### PR TITLE
feat(ui): show background persistent-session count in the status bar

### DIFF
--- a/docs/changes/dev4/feature/1882-statusbar-session-count.md
+++ b/docs/changes/dev4/feature/1882-statusbar-session-count.md
@@ -1,0 +1,8 @@
+### Added
+
+- Status bar: a new segment shows how many persistent connections are currently
+  running in the background (state `running` or `attached`), giving at-a-glance
+  awareness of sessions that have no tab in front of them. It counts both
+  desktop-local and agent-hosted persistent sessions, renders an infinity icon
+  plus the count with a tooltip, is hidden when none are running, and opens the
+  Connections sidebar (where sessions can be attached or stopped) when clicked.

--- a/src/components/StatusBar/StatusBar.persistent-sessions.test.tsx
+++ b/src/components/StatusBar/StatusBar.persistent-sessions.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Tests for the background persistent-session count segment (#1882).
+ *
+ * The status bar shows an infinity-icon segment with the number of persistent
+ * connections whose background process is currently running (state `running`
+ * or `attached`). It counts across desktop-local and agent-hosted sessions
+ * (both live in the store's `persistentSessions` map), is hidden when none are
+ * running, and opens the Connections sidebar when clicked.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+import { StatusBar } from "./StatusBar";
+import type { PersistentRunState, PersistentSessionEntry } from "@/types/connection";
+
+function renderStatusBar(root: Root) {
+  root.render(React.createElement(TooltipProvider, null, React.createElement(StatusBar)));
+}
+
+function entry(connectionId: string, state: PersistentRunState): PersistentSessionEntry {
+  return { connectionId, sessionId: "s1", state, attachedTabIds: [] };
+}
+
+function setSessions(sessions: Record<string, PersistentSessionEntry>) {
+  useAppStore.setState({ persistentSessions: sessions });
+}
+
+describe("StatusBar — persistent-session count segment", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const query = () => container.querySelector('[data-testid="persistent-sessions-indicator"]');
+
+  it("is hidden when no persistent sessions are running", () => {
+    setSessions({
+      a: entry("a", "stopped"),
+      b: entry("b", "starting"),
+      c: entry("c", "error"),
+    });
+
+    act(() => renderStatusBar(root));
+
+    expect(query()).toBeNull();
+  });
+
+  it("counts only running and attached sessions", () => {
+    setSessions({
+      a: entry("a", "running"),
+      b: entry("b", "attached"),
+      c: entry("c", "starting"),
+      d: entry("d", "stopping"),
+      e: entry("e", "stopped"),
+      f: entry("f", "error"),
+    });
+
+    act(() => renderStatusBar(root));
+
+    const item = query();
+    expect(item).not.toBeNull();
+    expect(item!.textContent).toContain("2");
+    expect(item!.getAttribute("aria-label")).toContain("2 background sessions running");
+  });
+
+  it("uses the singular label for a single running session", () => {
+    setSessions({ a: entry("a", "running") });
+
+    act(() => renderStatusBar(root));
+
+    const item = query();
+    expect(item).not.toBeNull();
+    expect(item!.textContent).toContain("1");
+    expect(item!.getAttribute("aria-label")).toContain("1 background session running");
+    expect(item!.getAttribute("aria-label")).not.toContain("sessions");
+  });
+
+  it("opens the Connections sidebar when clicked", () => {
+    useAppStore.setState({ sidebarView: "services" });
+    setSessions({ a: entry("a", "running") });
+
+    act(() => renderStatusBar(root));
+
+    act(() => {
+      query()!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(useAppStore.getState().sidebarView).toBe("connections");
+  });
+});

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -15,6 +15,7 @@ import {
   ArrowUpCircle,
   Monitor,
   Highlighter,
+  Infinity as InfinityIcon,
 } from "lucide-react";
 import { useAppStore, getActiveTab, monitorKeyForTab, selectMonitor } from "@/store/appStore";
 import { resolveHighlightingConfig } from "@/services/syntaxHighlightingConfig";
@@ -108,6 +109,7 @@ export function StatusBar() {
         <JumpHostStatus />
         <RemoteDesktopStatus />
         <MonitoringStatus />
+        <PersistentSessionsIndicator />
         <ServicesIndicator />
         <AgentUpdatesIndicator />
         <TransferQueueIndicator />
@@ -353,6 +355,48 @@ function ServicesIndicator() {
         onClick={() => setSidebarView("services")}
       >
         <Server size={12} />
+        {runningCount}
+      </button>
+    </Tooltip>
+  );
+}
+
+/**
+ * Background persistent-session count in the status bar (#1882).
+ *
+ * Counts the persistent connections whose background process is currently
+ * running — state `running` or `attached`, matching the sidebar's
+ * `isPersistentRunning` classification (ConnectionList / AgentNode). Both
+ * desktop-local and agent-hosted persistent sessions share the store's
+ * `persistentSessions` map, so a single count covers every background session.
+ *
+ * Gives at-a-glance awareness that processes are alive with no tab in front of
+ * them; clicking opens the Connections sidebar where they can be attached or
+ * stopped. Renders nothing when none are running, keeping the bar uncluttered.
+ */
+function PersistentSessionsIndicator() {
+  const persistentSessions = useAppStore((s) => s.persistentSessions);
+  const setSidebarView = useAppStore((s) => s.setSidebarView);
+
+  const runningCount = Object.values(persistentSessions).filter(
+    (entry) => entry.state === "running" || entry.state === "attached"
+  ).length;
+
+  if (runningCount === 0) return null;
+
+  const sessionsLabel = `${runningCount} background session${
+    runningCount !== 1 ? "s" : ""
+  } running — click to open Connections`;
+
+  return (
+    <Tooltip content={sessionsLabel} side="top">
+      <button
+        className="status-bar__item status-bar__item--interactive"
+        aria-label={sessionsLabel}
+        data-testid="persistent-sessions-indicator"
+        onClick={() => setSidebarView("connections")}
+      >
+        <InfinityIcon size={12} />
         {runningCount}
       </button>
     </Tooltip>


### PR DESCRIPTION
## Summary

Adds a status-bar segment showing how many persistent connections are currently running in the background, so the user has at-a-glance awareness of sessions that have no tab in front of them.

- New `PersistentSessionsIndicator` in `StatusBar` reads the store's `persistentSessions` map and counts entries whose state is `running` or `attached` — matching the sidebar's `isPersistentRunning` classification (ConnectionList / AgentNode). Both desktop-local and agent-hosted persistent sessions share that map, so one count covers every background session.
- Renders an infinity icon (matching the concept's persistence badge theme) plus the count, wrapped in a `Tooltip`, composed from the existing `status-bar__item--interactive` pattern used by the Services and Agent indicators.
- Hidden when the count is zero, consistent with the other running-count segments.
- Clicking opens the Connections sidebar (`setSidebarView("connections")`) where sessions can be attached or stopped.

Builds on the persistent-session model from #1881 (start/attach/stop controls).

## Tests

`StatusBar.persistent-sessions.test.tsx` covers: hidden when nothing is running, counts only running/attached (ignores starting/stopping/stopped/error), singular vs plural label, and click opens the Connections sidebar. Full suite green (4056 tests).

Closes #1882