### PR TITLE
feat(ui): custom theme import/export

### DIFF
--- a/docs/changes/dev3/feature/1880-theme-import-export.md
+++ b/docs/changes/dev3/feature/1880-theme-import-export.md
@@ -1,0 +1,9 @@
+### Added
+
+- Appearance: import and export custom themes as `.json` files. New **Export**
+  and **Import** actions in Appearance settings let you save the selected custom
+  theme to a file and load a theme file back in. Imported themes are validated,
+  get a `(2)` suffix if their name collides with an existing one, and become the
+  active theme; missing or invalid color values fall back to the base theme's
+  defaults with a heads-up, and unreadable or malformed files surface a clear
+  error instead of failing silently (#1880).

--- a/src/components/Settings/AppearanceSettings.test.tsx
+++ b/src/components/Settings/AppearanceSettings.test.tsx
@@ -1,14 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
+import { open, save } from "@tauri-apps/plugin-dialog";
+import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 import { AppSettings } from "@/types/connection";
 import type { ThemeDefinition } from "@/themes/types";
 import { AppearanceSettings } from "./AppearanceSettings";
 
 const toastSuccess = vi.fn();
+const toastError = vi.fn();
 
-// Keep the real theme helpers (createCustomTheme, resolve, encode) but stub the
-// applyTheme/previewTheme side effects so the tests don't mutate global CSS.
+vi.mock("@tauri-apps/plugin-dialog", () => ({ save: vi.fn(), open: vi.fn() }));
+vi.mock("@tauri-apps/plugin-fs", () => ({ writeTextFile: vi.fn(), readTextFile: vi.fn() }));
+
+// Keep the real theme helpers (createCustomTheme, resolve, encode, IO) but stub
+// the applyTheme/previewTheme side effects so the tests don't mutate global CSS.
 vi.mock("@/themes", async (orig) => ({
   ...(await orig<typeof import("@/themes")>()),
   applyTheme: vi.fn(),
@@ -18,8 +24,25 @@ vi.mock("@/themes", async (orig) => ({
 
 vi.mock("@/components/ui", async (orig) => ({
   ...(await orig<typeof import("@/components/ui")>()),
-  toast: { success: (...a: unknown[]) => toastSuccess(...a), error: vi.fn(), loading: vi.fn() },
+  toast: {
+    success: (...a: unknown[]) => toastSuccess(...a),
+    error: (...a: unknown[]) => toastError(...a),
+    loading: vi.fn(),
+  },
 }));
+
+const mockedSave = vi.mocked(save);
+const mockedOpen = vi.mocked(open);
+const mockedWriteTextFile = vi.mocked(writeTextFile);
+const mockedReadTextFile = vi.mocked(readTextFile);
+
+/** Flush pending microtasks so async dialog handlers settle. */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
 
 /** A minimal but valid custom theme for option/select tests. */
 function customTheme(id: string, name: string): ThemeDefinition {
@@ -188,5 +211,114 @@ describe("AppearanceSettings — custom themes", () => {
     expect(next.customThemes![0].name).toBe("Sunset");
     expect(next.theme).toBe(`custom:${next.customThemes![0].id}`);
     expect(toastSuccess).toHaveBeenCalled();
+  });
+});
+
+describe("AppearanceSettings — theme import/export (#1880)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    toastSuccess.mockReset();
+    toastError.mockReset();
+    mockedSave.mockReset();
+    mockedOpen.mockReset();
+    mockedWriteTextFile.mockReset();
+    mockedReadTextFile.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const withOcean: AppSettings = {
+    ...defaultSettings,
+    theme: "custom:t1",
+    customThemes: [customTheme("t1", "Ocean")],
+  };
+
+  it("disables Export with no custom theme selected, enables it for one", () => {
+    renderWith({ ...defaultSettings, theme: "dark" });
+    expect((byId("appearance-theme-export") as HTMLButtonElement).disabled).toBe(true);
+    // Import is always available.
+    expect((byId("appearance-theme-import") as HTMLButtonElement).disabled).toBe(false);
+
+    act(() => root.render(<AppearanceSettings settings={withOcean} onChange={vi.fn()} />));
+    expect((byId("appearance-theme-export") as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("serializes the selected theme and writes it to the chosen file", async () => {
+    mockedSave.mockResolvedValue("/tmp/ocean.json");
+    mockedWriteTextFile.mockResolvedValue(undefined);
+    renderWith(withOcean);
+
+    act(() => (byId("appearance-theme-export") as HTMLButtonElement).click());
+    await flush();
+
+    expect(mockedWriteTextFile).toHaveBeenCalledTimes(1);
+    const [path, contents] = mockedWriteTextFile.mock.calls[0] as [string, string];
+    expect(path).toBe("/tmp/ocean.json");
+    const parsed = JSON.parse(contents) as Record<string, unknown>;
+    expect(parsed.$schema).toBe("termihub-theme-v1");
+    expect(parsed.name).toBe("Ocean");
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+
+  it("does nothing when the export dialog is cancelled", async () => {
+    mockedSave.mockResolvedValue(null);
+    renderWith(withOcean);
+
+    act(() => (byId("appearance-theme-export") as HTMLButtonElement).click());
+    await flush();
+
+    expect(mockedWriteTextFile).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("validates a file, adds and selects it, and de-dupes a colliding name", async () => {
+    mockedOpen.mockResolvedValue("/tmp/import.json");
+    mockedReadTextFile.mockResolvedValue(
+      JSON.stringify({ name: "Ocean", baseTheme: "dark", colors: { bgPrimary: "#010203" } })
+    );
+    const onChange = renderWith(withOcean);
+
+    act(() => (byId("appearance-theme-import") as HTMLButtonElement).click());
+    await flush();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const next = onChange.mock.calls[0][0] as AppSettings;
+    expect(next.customThemes).toHaveLength(2);
+    const imported = next.customThemes![1];
+    expect(imported.name).toBe("Ocean (2)"); // de-duped against the existing "Ocean"
+    expect(imported.colors.bgPrimary).toBe("#010203");
+    expect(next.theme).toBe(`custom:${imported.id}`);
+    expect(toastSuccess).toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a recoverable error toast for a malformed file", async () => {
+    mockedOpen.mockResolvedValue("/tmp/bad.json");
+    mockedReadTextFile.mockResolvedValue("this is not json {");
+    const onChange = renderWith(withOcean);
+
+    act(() => (byId("appearance-theme-import") as HTMLButtonElement).click());
+    await flush();
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledTimes(1);
+    expect(String(toastError.mock.calls[0][0])).toMatch(/Invalid theme file/);
+  });
+
+  it("does nothing when the import dialog is cancelled", async () => {
+    mockedOpen.mockResolvedValue(null);
+    const onChange = renderWith(withOcean);
+
+    act(() => (byId("appearance-theme-import") as HTMLButtonElement).click());
+    await flush();
+
+    expect(mockedReadTextFile).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Settings/AppearanceSettings.tsx
+++ b/src/components/Settings/AppearanceSettings.tsx
@@ -1,4 +1,6 @@
 import { useState } from "react";
+import { open, save } from "@tauri-apps/plugin-dialog";
+import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 import { AppSettings } from "@/types/connection";
 import { Button, NumberInput, Select, toast } from "@/components/ui";
 import type { SelectOption } from "@/components/ui";
@@ -10,8 +12,11 @@ import {
   dedupeThemeName,
   findCustomTheme,
   isCustomThemeSetting,
+  parseThemeFile,
+  serializeTheme,
+  themeFileName,
 } from "@/themes";
-import type { ThemeDefinition } from "@/themes/types";
+import type { ThemeDefinition, ThemeImportResult } from "@/themes";
 import { ThemeEditor } from "@/components/ThemeEditor/ThemeEditor";
 import { SettingsField } from "./SettingsField";
 import "./AppearanceSettings.css";
@@ -94,6 +99,69 @@ export function AppearanceSettings({ settings, onChange, visibleFields }: Appear
     toast.success(`Theme "${deleted.name}" deleted`);
   };
 
+  const handleExportTheme = async () => {
+    if (!selectedCustom) return;
+    try {
+      const filePath = await save({
+        title: "Export Theme",
+        defaultPath: themeFileName(selectedCustom.name),
+        filters: [{ name: "JSON", extensions: ["json"] }],
+      });
+      if (!filePath) return; // dialog cancelled
+      await writeTextFile(filePath, serializeTheme(selectedCustom));
+      toast.success(`Theme "${selectedCustom.name}" exported`);
+    } catch (err) {
+      toast.error(`Failed to export theme: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+
+  const handleImportTheme = async () => {
+    let filePath: string | string[] | null;
+    try {
+      filePath = await open({
+        multiple: false,
+        title: "Import Theme",
+        filters: [{ name: "JSON", extensions: ["json"] }],
+      });
+    } catch {
+      return; // dialog cancelled / unavailable
+    }
+    if (!filePath || Array.isArray(filePath)) return;
+
+    let text: string;
+    try {
+      text = await readTextFile(filePath);
+    } catch (err) {
+      toast.error(`Could not read theme file: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+
+    let result: ThemeImportResult;
+    try {
+      result = parseThemeFile(text);
+    } catch (err) {
+      toast.error(`Invalid theme file: ${err instanceof Error ? err.message : String(err)}`);
+      return;
+    }
+
+    // Regenerate id-free name collisions with a "(2)" suffix, matching the
+    // concept's import-rename behavior, then add and select the new theme.
+    const name = dedupeThemeName(result.theme.name, customThemes);
+    const imported: ThemeDefinition = { ...result.theme, name };
+    onChange({
+      ...settings,
+      customThemes: [...customThemes, imported],
+      theme: customThemeSetting(imported.id),
+    });
+    if (result.hadInvalidColors) {
+      toast.success(`Theme "${name}" imported`, {
+        description: "Some colors were invalid and fell back to the base theme's defaults.",
+      });
+    } else {
+      toast.success(`Theme "${name}" imported`);
+    }
+  };
+
   return (
     <div className="settings-panel__category">
       <h3 className="settings-panel__category-title">Appearance</h3>
@@ -124,6 +192,23 @@ export function AppearanceSettings({ settings, onChange, visibleFields }: Appear
               data-testid="appearance-theme-edit"
             >
               Edit
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleImportTheme}
+              data-testid="appearance-theme-import"
+            >
+              Import
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleExportTheme}
+              disabled={!selectedCustom}
+              data-testid="appearance-theme-export"
+            >
+              Export
             </Button>
             <Button
               variant="danger"

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -27,10 +27,5 @@ export {
   findCustomTheme,
   resolveCustomTheme,
 } from "./customThemes";
-export {
-  THEME_FILE_SCHEMA,
-  serializeTheme,
-  parseThemeFile,
-  themeFileName,
-} from "./themeIO";
+export { THEME_FILE_SCHEMA, serializeTheme, parseThemeFile, themeFileName } from "./themeIO";
 export type { ThemeFile, ThemeImportResult } from "./themeIO";

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -27,3 +27,10 @@ export {
   findCustomTheme,
   resolveCustomTheme,
 } from "./customThemes";
+export {
+  THEME_FILE_SCHEMA,
+  serializeTheme,
+  parseThemeFile,
+  themeFileName,
+} from "./themeIO";
+export type { ThemeFile, ThemeImportResult } from "./themeIO";

--- a/src/themes/themeIO.test.ts
+++ b/src/themes/themeIO.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { THEME_FILE_SCHEMA, serializeTheme, parseThemeFile, themeFileName } from "./themeIO";
+import { COLOR_TOKEN_KEYS } from "./colorTokens";
+import { darkTheme } from "./dark";
+import { lightTheme } from "./light";
+import type { ThemeColors, ThemeDefinition } from "./types";
+
+/** A full, valid custom theme derived from a base for round-trip tests. */
+function fullTheme(overrides: Partial<ThemeDefinition> = {}): ThemeDefinition {
+  return {
+    id: "src-id",
+    name: "My Custom Theme",
+    colorScheme: "dark",
+    baseTheme: "dark",
+    colors: { ...darkTheme.colors },
+    ...overrides,
+  };
+}
+
+describe("serializeTheme", () => {
+  it("writes the versioned on-disk shape, dropping the runtime id", () => {
+    const json = serializeTheme(fullTheme());
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    expect(parsed.$schema).toBe(THEME_FILE_SCHEMA);
+    expect(parsed.name).toBe("My Custom Theme");
+    expect(parsed.baseTheme).toBe("dark");
+    expect(parsed.colorScheme).toBe("dark");
+    expect(parsed).not.toHaveProperty("id");
+    expect((parsed.colors as ThemeColors).bgPrimary).toBe(darkTheme.colors.bgPrimary);
+  });
+
+  it("defaults a missing baseTheme to dark and pretty-prints with a trailing newline", () => {
+    const json = serializeTheme(fullTheme({ baseTheme: undefined }));
+    expect(json.endsWith("\n")).toBe(true);
+    expect(json).toContain("\n  ");
+    expect((JSON.parse(json) as { baseTheme: string }).baseTheme).toBe("dark");
+  });
+});
+
+describe("parseThemeFile — validation errors", () => {
+  it("rejects non-JSON input", () => {
+    expect(() => parseThemeFile("not json{")).toThrow(/valid JSON/);
+  });
+
+  it("rejects a JSON array or primitive", () => {
+    expect(() => parseThemeFile("[]")).toThrow(/JSON object/);
+    expect(() => parseThemeFile("42")).toThrow(/JSON object/);
+  });
+
+  it("rejects an unknown $schema version", () => {
+    const json = JSON.stringify({ $schema: "termihub-theme-v99", name: "x" });
+    expect(() => parseThemeFile(json)).toThrow(/Unsupported theme file version/);
+  });
+
+  it("rejects a missing or blank name", () => {
+    expect(() => parseThemeFile(JSON.stringify({ baseTheme: "dark" }))).toThrow(/missing a name/);
+    expect(() => parseThemeFile(JSON.stringify({ name: "   " }))).toThrow(/missing a name/);
+  });
+});
+
+describe("parseThemeFile — success and tolerance", () => {
+  it("round-trips a full exported theme with a fresh id", () => {
+    const json = serializeTheme(fullTheme());
+    const { theme, hadInvalidColors } = parseThemeFile(json);
+    expect(hadInvalidColors).toBe(false);
+    expect(theme.name).toBe("My Custom Theme");
+    expect(theme.baseTheme).toBe("dark");
+    expect(theme.id).not.toBe("src-id");
+    expect(theme.id).toBeTruthy();
+    for (const key of COLOR_TOKEN_KEYS) {
+      expect(theme.colors[key]).toBe(darkTheme.colors[key]);
+    }
+  });
+
+  it("accepts a partial file with no $schema, inheriting absent colors silently", () => {
+    const json = JSON.stringify({
+      name: "Minimal",
+      baseTheme: "light",
+      colors: { bgPrimary: "#010203", accentColor: "#7aa2f7" },
+    });
+    const { theme, hadInvalidColors } = parseThemeFile(json);
+    expect(hadInvalidColors).toBe(false); // absent keys are the intended format, not a warning
+    expect(theme.colorScheme).toBe("light"); // derived from the light base
+    expect(theme.colors.bgPrimary).toBe("#010203");
+    expect(theme.colors.accentColor).toBe("#7aa2f7");
+    // An unspecified color falls back to the (light) base default.
+    expect(theme.colors.textPrimary).toBe(lightTheme.colors.textPrimary);
+  });
+
+  it("flags present-but-invalid color values and falls back to the base", () => {
+    const json = JSON.stringify({
+      name: "Corrupt",
+      baseTheme: "dark",
+      colors: { bgPrimary: 123, textPrimary: "" },
+    });
+    const { theme, hadInvalidColors } = parseThemeFile(json);
+    expect(hadInvalidColors).toBe(true);
+    expect(theme.colors.bgPrimary).toBe(darkTheme.colors.bgPrimary);
+    expect(theme.colors.textPrimary).toBe(darkTheme.colors.textPrimary);
+  });
+
+  it("defaults an unknown baseTheme to dark and drops unknown color keys", () => {
+    const json = JSON.stringify({
+      name: "Weird",
+      baseTheme: "nope",
+      colors: { notAToken: "#fff", bgPrimary: "#111111" },
+    });
+    const { theme } = parseThemeFile(json);
+    expect(theme.baseTheme).toBe("dark");
+    expect(theme.colors).not.toHaveProperty("notAToken");
+    expect(theme.colors.bgPrimary).toBe("#111111");
+  });
+});
+
+describe("themeFileName", () => {
+  it("slugs a name into a .json file name", () => {
+    expect(themeFileName("My Custom Theme")).toBe("my-custom-theme.json");
+    expect(themeFileName("Ocean (2)")).toBe("ocean-2.json");
+  });
+
+  it("falls back to theme.json for an unsluggable name", () => {
+    expect(themeFileName("   ")).toBe("theme.json");
+    expect(themeFileName("***")).toBe("theme.json");
+  });
+});

--- a/src/themes/themeIO.ts
+++ b/src/themes/themeIO.ts
@@ -1,0 +1,144 @@
+/**
+ * Import/export of custom themes as portable JSON files (#1880).
+ *
+ * These are pure, dependency-free helpers: serialising a custom theme into the
+ * versioned on-disk shape, and validating/parsing such a file back into a
+ * {@link ThemeDefinition}. File IO (the save/open dialogs) lives in the UI
+ * layer; keeping the serialise/validate logic here makes it unit-testable in
+ * isolation and mirrors `services/macroIo.ts`.
+ */
+
+import type { ThemeColors, ThemeDefinition } from "./types";
+import { COLOR_TOKEN_KEYS } from "./colorTokens";
+import { generateThemeId, resolveBaseTheme } from "./customThemes";
+
+/**
+ * `$schema` marker written to (and required-if-present on) exported theme
+ * files. It enables future format versioning: a file carrying a different,
+ * unknown schema is rejected rather than imported as a corrupt theme. Files
+ * with no `$schema` are accepted leniently.
+ */
+export const THEME_FILE_SCHEMA = "termihub-theme-v1";
+
+/**
+ * The stable, explicit on-disk shape for an exported theme — deliberately NOT
+ * the raw {@link ThemeDefinition} (no `id`, which is regenerated on import) so
+ * the file format can evolve independently of the runtime type. Per the
+ * concept, only overridden colors need to be present; missing ones inherit from
+ * `baseTheme`.
+ */
+export interface ThemeFile {
+  $schema: string;
+  name: string;
+  baseTheme?: string;
+  colorScheme?: "dark" | "light";
+  colors: Partial<ThemeColors>;
+}
+
+/** Result of parsing an imported theme file. */
+export interface ThemeImportResult {
+  /** The validated theme, with a fresh id and a full color palette. */
+  theme: ThemeDefinition;
+  /**
+   * True when the file carried one or more color values that were present but
+   * invalid (wrong type / empty) and had to fall back to the base theme's
+   * default. Absent keys inherit silently (the intended partial-file format);
+   * only genuinely corrupt values raise this so the UI can warn.
+   */
+  hadInvalidColors: boolean;
+}
+
+/** Type guard: a JSON value is a non-null, non-array object. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Serialise a custom theme into a pretty-printed export-file string ready to
+ * write to a `.json` file. The full stored palette is written so the file is
+ * self-contained even if the base theme later changes.
+ */
+export function serializeTheme(theme: ThemeDefinition): string {
+  const file: ThemeFile = {
+    $schema: THEME_FILE_SCHEMA,
+    name: theme.name,
+    baseTheme: theme.baseTheme ?? "dark",
+    colorScheme: theme.colorScheme,
+    colors: { ...theme.colors },
+  };
+  return `${JSON.stringify(file, null, 2)}\n`;
+}
+
+/**
+ * A filesystem-safe default file name for a theme export, e.g.
+ * `"My Custom Theme"` -> `"my-custom-theme.json"`. Falls back to `theme.json`
+ * for a name that slugs to nothing.
+ */
+export function themeFileName(name: string): string {
+  const slug = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `${slug || "theme"}.json`;
+}
+
+/**
+ * Validate and parse an imported theme-file string into a {@link ThemeDefinition}.
+ *
+ * Hard errors (thrown, surfaced as an error toast): not valid JSON, not an
+ * object, an unknown `$schema`, or a missing/blank `name`. Everything else is
+ * tolerant per the concept — an unknown `baseTheme` defaults to Dark, unknown
+ * color keys are dropped, and missing/invalid color values fall back to the
+ * base theme's defaults (with {@link ThemeImportResult.hadInvalidColors} flagged
+ * only for values that were present but corrupt).
+ */
+export function parseThemeFile(json: string): ThemeImportResult {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    throw new Error("File is not valid JSON.");
+  }
+  if (!isRecord(raw)) {
+    throw new Error("Theme file must be a JSON object.");
+  }
+
+  const schema = raw.$schema;
+  if (typeof schema === "string" && schema !== THEME_FILE_SCHEMA) {
+    throw new Error(`Unsupported theme file version "${schema}".`);
+  }
+  if (typeof raw.name !== "string" || raw.name.trim() === "") {
+    throw new Error("Theme file is missing a name.");
+  }
+
+  const baseId = typeof raw.baseTheme === "string" ? raw.baseTheme : undefined;
+  const base = resolveBaseTheme(baseId);
+  const stored = isRecord(raw.colors) ? (raw.colors as Partial<ThemeColors>) : {};
+
+  const colors = {} as ThemeColors;
+  let hadInvalidColors = false;
+  for (const key of COLOR_TOKEN_KEYS) {
+    const value = stored[key];
+    if (typeof value === "string" && value.trim() !== "") {
+      colors[key] = value;
+    } else {
+      if (key in stored) hadInvalidColors = true; // present but unusable
+      colors[key] = base.colors[key];
+    }
+  }
+
+  const colorScheme =
+    raw.colorScheme === "light" || raw.colorScheme === "dark" ? raw.colorScheme : base.colorScheme;
+
+  return {
+    theme: {
+      id: generateThemeId(),
+      name: raw.name.trim(),
+      colorScheme,
+      baseTheme: base.id,
+      colors,
+    },
+    hadInvalidColors,
+  };
+}


### PR DESCRIPTION
Custom theme import/export built on the #1879 customThemes field. Export a custom theme to a file and import/validate one back in via the Tauri file dialogs, with collision + parse-error handling.

Closes #1880

(PR opened by the coordinator — the implementing agent pushed the branch but stalled before opening the PR.)