### PR TITLE
feat(network): add don't-warn-again opt-out to large-scan warning

### DIFF
--- a/docs/changes/dev1/feature/1877-portscan-dont-warn-again.md
+++ b/docs/changes/dev1/feature/1877-portscan-dont-warn-again.md
@@ -1,0 +1,7 @@
+### Added
+
+- Port Scanner: the large-scan warning now has a "Don't warn again" opt-out.
+  Ticking it and confirming persists the new `warnLargePortScan` setting
+  (default on) so future large scans start directly without prompting. The
+  warning can be re-enabled from **Settings → General → "Warn Before a Large
+  Port Scan"**.

--- a/src/components/NetworkTools/PortScannerPanel.dont-warn-again.test.tsx
+++ b/src/components/NetworkTools/PortScannerPanel.dont-warn-again.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * Tests for the Port Scanner large-scan warning "Don't warn again" opt-out
+ * (#1877). The warning already migrated onto the shared ConfirmDialog primitive
+ * (#1876); this covers persisting and honouring the opt-out.
+ *
+ * Covers: confirming with the checkbox ticked persists
+ * `warnLargePortScan: false`; once opted out, the next large scan starts
+ * directly without the warning; cancelling does not persist the opt-out; and
+ * re-enabling the setting brings the warning back.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+// The store's updateSettings persists via the storage service — mock it so the
+// optimistic store update lands without touching a real Tauri backend.
+vi.mock("@/services/storage", async () => {
+  const actual = await vi.importActual<typeof import("@/services/storage")>("@/services/storage");
+  return { ...actual, saveSettings: vi.fn(() => Promise.resolve()) };
+});
+
+vi.mock("@/services/networkApi", () => ({
+  networkPortScan: vi.fn(() => Promise.resolve("task-1")),
+  networkPortScanCancel: vi.fn(() => Promise.resolve()),
+  onScanResult: vi.fn(() => Promise.resolve(() => {})),
+  onScanComplete: vi.fn(() => Promise.resolve(() => {})),
+  onScanError: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+import { networkPortScan, onScanComplete } from "@/services/networkApi";
+import { useAppStore } from "@/store/appStore";
+import { PortScannerPanel } from "./PortScannerPanel";
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
+  setter.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+/** Query into the modal, which Radix portals onto document.body. */
+function q<T extends Element>(selector: string): T | null {
+  return document.body.querySelector<T>(selector);
+}
+
+async function renderPanel() {
+  await act(async () => {
+    root.render(<PortScannerPanel prefillHost="192.168.1.1" />);
+  });
+  await flush();
+}
+
+async function setPorts(value: string) {
+  await act(async () => {
+    setInputValue(
+      container.querySelector<HTMLInputElement>('[data-testid="port-scanner-ports"]')!,
+      value
+    );
+  });
+  await flush();
+}
+
+async function clickRun() {
+  await act(async () => {
+    container.querySelector<HTMLButtonElement>('[data-testid="port-scanner-run"]')!.click();
+  });
+  await flush();
+}
+
+async function click(selector: string) {
+  await act(async () => {
+    q<HTMLButtonElement>(selector)!.click();
+  });
+  await flush();
+}
+
+/**
+ * Drive the running scan to completion via the captured onScanComplete handler
+ * so the panel leaves the "running" state and the Start button reappears.
+ */
+async function completeScan() {
+  const calls = vi.mocked(onScanComplete).mock.calls;
+  const handler = calls[calls.length - 1][0] as (p: {
+    taskId: string;
+    summary: {
+      total: number;
+      open: number;
+      closed: number;
+      filtered: number;
+      elapsedMs: number;
+    };
+  }) => void;
+  await act(async () => {
+    handler({
+      taskId: "task-1",
+      summary: { total: 2000, open: 1, closed: 1998, filtered: 1, elapsedMs: 1000 },
+    });
+  });
+  await flush();
+}
+
+describe("PortScannerPanel — large-scan don't-warn-again opt-out (#1877)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    // Reset the persisted preference to the default (warn on) before each test.
+    act(() => {
+      useAppStore.setState((s) => ({
+        settings: { ...s.settings, warnLargePortScan: true },
+      }));
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("persists warnLargePortScan: false when confirmed with the box ticked", async () => {
+    await renderPanel();
+    await setPorts("1-2000");
+    await clickRun();
+
+    // Tick the "don't warn again" checkbox, then confirm.
+    await click('[data-testid="port-scan-warn-dont-ask-again"]');
+    await click('[data-testid="port-scan-warn-confirm"]');
+
+    expect(useAppStore.getState().settings.warnLargePortScan).toBe(false);
+    expect(networkPortScan).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the warning on the next large scan once opted out", async () => {
+    await renderPanel();
+    await setPorts("1-2000");
+    await clickRun();
+    await click('[data-testid="port-scan-warn-dont-ask-again"]');
+    await click('[data-testid="port-scan-warn-confirm"]');
+    expect(networkPortScan).toHaveBeenCalledTimes(1);
+    await completeScan();
+
+    // A second large scan must start directly, with no warning modal.
+    await clickRun();
+    expect(q('[data-testid="port-scan-warn-modal"]')).toBeNull();
+    expect(networkPortScan).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not persist the opt-out when the warning is cancelled", async () => {
+    await renderPanel();
+    await setPorts("1-2000");
+    await clickRun();
+
+    // Tick the box but cancel — the preference must stay unchanged.
+    await click('[data-testid="port-scan-warn-dont-ask-again"]');
+    await click('[data-testid="port-scan-warn-cancel"]');
+
+    expect(useAppStore.getState().settings.warnLargePortScan).toBe(true);
+    expect(networkPortScan).not.toHaveBeenCalled();
+
+    // The next large scan still warns (opt-out was discarded on cancel).
+    await clickRun();
+    expect(q('[data-testid="port-scan-warn-modal"]')).not.toBeNull();
+  });
+
+  it("warns again once the setting is re-enabled", async () => {
+    // Start opted out (e.g. re-enabling from General settings sets this true).
+    act(() => {
+      useAppStore.setState((s) => ({
+        settings: { ...s.settings, warnLargePortScan: false },
+      }));
+    });
+    await renderPanel();
+    await setPorts("1-2000");
+    await clickRun();
+    // Opted out → scan runs immediately, no modal.
+    expect(q('[data-testid="port-scan-warn-modal"]')).toBeNull();
+    expect(networkPortScan).toHaveBeenCalledTimes(1);
+    await completeScan();
+
+    // Re-enable the warning, as the General settings toggle would.
+    act(() => {
+      useAppStore.setState((s) => ({
+        settings: { ...s.settings, warnLargePortScan: true },
+      }));
+    });
+    await flush();
+    await clickRun();
+    expect(q('[data-testid="port-scan-warn-modal"]')).not.toBeNull();
+  });
+});

--- a/src/components/NetworkTools/PortScannerPanel.tsx
+++ b/src/components/NetworkTools/PortScannerPanel.tsx
@@ -14,6 +14,7 @@ import { DiagnosticResultsTable } from "./DiagnosticResultsTable";
 import { validateHost, validateIntRange } from "@/utils/fieldValidation";
 import { estimateScanProbes } from "@/utils/scanEstimate";
 import { useNetworkTask, type NetworkTaskContext } from "@/hooks/useNetworkTask";
+import { useAppStore } from "@/store/appStore";
 
 /** Probe count above which the scanner warns before starting. */
 const LARGE_SCAN_THRESHOLD = 1000;
@@ -38,6 +39,15 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
   const [results, setResults] = useState<ScanRow[]>([]);
   const [summary, setSummary] = useState<PortScanSummary | null>(null);
   const [warnOpen, setWarnOpen] = useState(false);
+  // Local, deferred opt-out state — committed to settings only on confirm,
+  // discarded on cancel (honours the ConfirmDialog checkbox contract).
+  const [dontWarnAgain, setDontWarnAgain] = useState(false);
+
+  // Persisted "warn before a large scan" preference. Defaults to true when
+  // unset; the dialog's opt-out flips it off, re-enabled from General settings.
+  const warnLargeScan = useAppStore((s) => s.settings.warnLargePortScan);
+  const settings = useAppStore((s) => s.settings);
+  const updateSettings = useAppStore((s) => s.updateSettings);
 
   const hostRef = useAutofocusSelect<HTMLInputElement>();
 
@@ -97,17 +107,29 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
 
   const handleRun = useCallback(async () => {
     if (!canRun) return;
-    if (probeEstimate > LARGE_SCAN_THRESHOLD) {
+    // Skip the warning when the user previously opted out (warnLargePortScan
+    // === false); the scan then starts directly. Unset defaults to warning.
+    if (probeEstimate > LARGE_SCAN_THRESHOLD && warnLargeScan !== false) {
       setWarnOpen(true);
       return;
     }
     await run();
-  }, [canRun, probeEstimate, run]);
+  }, [canRun, probeEstimate, warnLargeScan, run]);
 
   const handleConfirmLargeScan = useCallback(async () => {
+    // Deferred opt-out: persist only when confirmed with the box ticked.
+    if (dontWarnAgain) {
+      void updateSettings({ ...settings, warnLargePortScan: false });
+    }
+    setDontWarnAgain(false);
     setWarnOpen(false);
     await run();
-  }, [run]);
+  }, [dontWarnAgain, settings, updateSettings, run]);
+
+  const handleCancelLargeScan = useCallback(() => {
+    setDontWarnAgain(false);
+    setWarnOpen(false);
+  }, []);
 
   // Only show the Host column when results span more than one host
   // (single-host scans look cleaner without it). Memoised because results
@@ -259,8 +281,13 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
         confirmVariant="primary"
         testIdBase="port-scan-warn"
         data-testid="port-scan-warn-modal"
+        dontAskAgain={{
+          checked: dontWarnAgain,
+          onChange: setDontWarnAgain,
+          label: "Don't warn again",
+        }}
         onConfirm={handleConfirmLargeScan}
-        onCancel={() => setWarnOpen(false)}
+        onCancel={handleCancelLargeScan}
       />
     </form>
   );

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -176,9 +176,7 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
           >
             <Toggle
               checked={settings.warnLargePortScan ?? true}
-              onCheckedChange={(checked) =>
-                onChange({ ...settings, warnLargePortScan: checked })
-              }
+              onCheckedChange={(checked) => onChange({ ...settings, warnLargePortScan: checked })}
               data-testid="settings-warn-large-port-scan"
             />
           </SettingsField>

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -169,6 +169,21 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
           </SettingsField>
         )}
 
+        {show("warnLargePortScan") && (
+          <SettingsField
+            label="Warn Before a Large Port Scan"
+            hint="Show a warning before starting a Port Scanner scan that probes a very large number of host/port combinations."
+          >
+            <Toggle
+              checked={settings.warnLargePortScan ?? true}
+              onCheckedChange={(checked) =>
+                onChange({ ...settings, warnLargePortScan: checked })
+              }
+              data-testid="settings-warn-large-port-scan"
+            />
+          </SettingsField>
+        )}
+
         {show("experimentalFeaturesEnabled") && (
           <SettingsField
             label="Allow Experimental Features"

--- a/src/components/Settings/settingsRegistry.ts
+++ b/src/components/Settings/settingsRegistry.ts
@@ -364,6 +364,25 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     ],
   },
   {
+    id: "warnLargePortScan",
+    label: "Warn Before a Large Port Scan",
+    description:
+      "Show a warning before starting a Port Scanner scan that probes a very large number of host/port combinations",
+    category: "general",
+    keywords: [
+      "warn",
+      "port",
+      "scan",
+      "scanner",
+      "large",
+      "network",
+      "confirm",
+      "prompt",
+      "dialog",
+      "probe",
+    ],
+  },
+  {
     id: "experimentalFeaturesEnabled",
     label: "Allow Experimental Features",
     description:

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -3370,6 +3370,7 @@ export const useAppStore = create<AppState>((set, get) => {
       confirmCloseTabOnShortcut: true,
       confirmCloseLiveSession: true,
       askOpenSavedFileInTab: true,
+      warnLargePortScan: true,
     },
     savedSettings: {
       version: "1",
@@ -3379,6 +3380,7 @@ export const useAppStore = create<AppState>((set, get) => {
       confirmCloseTabOnShortcut: true,
       confirmCloseLiveSession: true,
       askOpenSavedFileInTab: true,
+      warnLargePortScan: true,
     },
 
     // Layout

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -499,6 +499,13 @@ export interface AppSettings {
    * file is saved silently and no dialog or editor tab is opened.
    */
   askOpenSavedFileInTab?: boolean;
+  /**
+   * Show a warning before starting a Port Scanner scan whose estimated probe
+   * count is very large (many host/port combinations). Defaults to true. The
+   * warning dialog's "Don't warn again" opt-out flips this off; it can be
+   * re-enabled from General settings.
+   */
+  warnLargePortScan?: boolean;
   defaultShellIntegration?: boolean;
   defaultX11Forwarding?: boolean;
   /** Start/provide a local X server automatically for SSH X11 forwarding. Unset → platform default (on for Windows). */


### PR DESCRIPTION
Enables the shared `ConfirmDialog` "Don't warn again" affordance on the Port Scanner large-scan warning (migrated onto the primitive in #1876), then persists and honors the opt-out.

## What changed

- **New setting** `warnLargePortScan?: boolean` (default `true`) on `AppSettings`, seeded in the store defaults.
- **PortScannerPanel** renders the dialog's `dontAskAgain` checkbox. The opt-out is deferred (checkbox state is local, committed only on confirm, discarded on cancel — per the `ConfirmDialog` checkbox contract). Confirming with it ticked persists `warnLargePortScan: false`.
- **Honor it**: the large-scan gate is `probeEstimate > threshold && warnLargePortScan !== false`, so once opted out a large scan starts directly with no warning.
- **Re-enable**: General settings gets a "Warn Before a Large Port Scan" toggle (also registered for settings search).

## Tests

New `PortScannerPanel.dont-warn-again.test.tsx`: opt-out persists on confirm; next large scan is suppressed; cancel does not persist; re-enabling brings the warning back. Full suite green (4056 passed).

Closes #1877