### PR TITLE
feat(ui): add ask/never/always restore mode and a restore dialog (Closes #1884)

### DIFF
--- a/docs/changes/dev2/feature/1884-restore-mode-dialog.md
+++ b/docs/changes/dev2/feature/1884-restore-mode-dialog.md
@@ -1,0 +1,11 @@
+### Added
+
+- Session restore now has a three-way **restore mode** — Never, Ask, or Always —
+  replacing the previous on/off toggle (General settings → "Restore Last Session
+  on Startup"). When the mode is **Ask** and a previous session was stored, a
+  **"Restore Previous Session?"** dialog appears on startup listing the tabs that
+  were open, with **Restore** / **Start Fresh** and a **"Remember my choice"**
+  opt-out that saves the mode as Always or Never so the dialog is not shown again.
+  **Always** restores silently (the prior behavior) and **Never** starts fresh.
+  The legacy `restoreLastSessionOnStartup` setting is migrated automatically
+  (off → Never, otherwise Ask) (#1884).

--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -630,7 +630,10 @@ mod tests {
         let json = serde_json::to_string(&settings).unwrap();
         assert!(json.contains("restoreLastSessionMode"));
         let deserialized: AppSettings = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.restore_last_session_mode.as_deref(), Some("ask"));
+        assert_eq!(
+            deserialized.restore_last_session_mode.as_deref(),
+            Some("ask")
+        );
 
         // A legacy file without the field deserializes to None.
         let legacy = r#"{"version":"1","externalConnectionFiles":[]}"#;

--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -196,6 +196,13 @@ pub struct AppSettings {
     /// always starts with a fresh empty session.
     #[serde(default = "default_true")]
     pub restore_last_session_on_startup: bool,
+    /// How the previous session is restored on startup: `"never"`, `"ask"`, or
+    /// `"always"`. `None` migrates from `restore_last_session_on_startup`
+    /// (`false` → `"never"`, otherwise the frontend default `"ask"`). The
+    /// frontend owns the resolution (`resolveRestoreMode`); the backend only
+    /// persists the chosen value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub restore_last_session_mode: Option<String>,
     /// When true (default), every terminal session opened is recorded to the
     /// browsable session history (`session-history.json`). Turning it off stops
     /// all automatic recording (existing entries are kept).
@@ -314,6 +321,7 @@ impl Default for AppSettings {
             provide_x_server_automatically: None,
             stop_x_server_when_idle: true,
             restore_last_session_on_startup: true,
+            restore_last_session_mode: None,
             session_history_enabled: true,
             session_history_limit: default_session_history_limit(),
             show_recent_sessions: true,
@@ -604,6 +612,30 @@ mod tests {
         let json = serde_json::to_string(&settings).unwrap();
         let deserialized: AppSettings = serde_json::from_str(&json).unwrap();
         assert!(!deserialized.restore_last_session_on_startup);
+    }
+
+    #[test]
+    fn restore_last_session_mode_round_trips() {
+        // Unset by default and omitted from the serialized JSON.
+        let default = AppSettings::default();
+        assert!(default.restore_last_session_mode.is_none());
+        let default_json = serde_json::to_string(&default).unwrap();
+        assert!(!default_json.contains("restoreLastSessionMode"));
+
+        // A set value survives a serialize/deserialize round-trip.
+        let settings = AppSettings {
+            restore_last_session_mode: Some("ask".to_string()),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(json.contains("restoreLastSessionMode"));
+        let deserialized: AppSettings = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.restore_last_session_mode.as_deref(), Some("ask"));
+
+        // A legacy file without the field deserializes to None.
+        let legacy = r#"{"version":"1","externalConnectionFiles":[]}"#;
+        let legacy_settings: AppSettings = serde_json::from_str(legacy).unwrap();
+        assert!(legacy_settings.restore_last_session_mode.is_none());
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { LargePasteDialog } from "@/components/Terminal/LargePasteDialog";
 import { OpenSavedFileDialog } from "@/components/Terminal/OpenSavedFileDialog";
 import { ConfirmCloseTabDialog } from "@/components/Terminal/ConfirmCloseTabDialog";
 import { ConfirmSessionCloseDialog } from "@/components/Terminal/ConfirmSessionCloseDialog";
+import { SessionRestoreDialog } from "@/components/SessionRestoreDialog";
 import { UpdateNotification } from "@/components/UpdateNotification/UpdateNotification";
 import { XServerConnectConsent } from "@/components/OpenConnections/XServerConnectConsent";
 import { ToastProvider, TooltipProvider } from "@/components/ui";
@@ -37,6 +38,7 @@ import { useWebviewZoom } from "@/hooks/useWebviewZoom";
 import { useSidebarResize } from "@/hooks/useSidebarResize";
 import { useAppStore } from "@/store/appStore";
 import { getCliWorkspace } from "@/services/workspaceApi";
+import { resolveRestoreMode } from "@/utils/restoreMode";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { listen } from "@tauri-apps/api/event";
 import "./App.css";
@@ -183,13 +185,17 @@ function App() {
       }
 
       const store = useAppStore.getState();
-      if (store.settings.restoreLastSessionOnStartup !== false) {
-        if (!handledByCli) {
-          await store.restoreLastSession();
-        }
-      } else {
-        // Restore disabled: drop any stale stored session from a previous run.
+      const restoreMode = resolveRestoreMode(store.settings);
+      if (restoreMode === "never") {
+        // Never restore: drop any stale stored session from a previous run.
         await store.clearLastSession();
+      } else if (!handledByCli) {
+        if (restoreMode === "always") {
+          await store.restoreLastSession();
+        } else {
+          // "ask": raise the restore dialog when a session is stored.
+          await store.promptRestore();
+        }
       }
 
       // Always observe layout changes; saveLastSession itself honors the current
@@ -337,6 +343,7 @@ function App() {
           <UpdateNotification />
           <ConfirmCloseTabDialog />
           <ConfirmSessionCloseDialog />
+          <SessionRestoreDialog />
           <XServerConnectConsent />
           <ToastProvider />
         </div>

--- a/src/components/SessionRestoreDialog.css
+++ b/src/components/SessionRestoreDialog.css
@@ -1,0 +1,39 @@
+/* Tab list shown inside the "Restore Previous Session?" dialog. */
+
+.session-restore__tabs {
+  list-style: none;
+  margin: var(--spacing-md) 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.session-restore__tab {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: 1px solid var(--border-secondary);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+}
+
+.session-restore__tab-title {
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.session-restore__tab-type {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs);
+  letter-spacing: var(--letter-spacing-ui);
+  text-transform: uppercase;
+}

--- a/src/components/SessionRestoreDialog.test.tsx
+++ b/src/components/SessionRestoreDialog.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import type { RestorePrompt } from "@/utils/restoreMode";
+
+const confirmRestorePrompt = vi.fn(() => Promise.resolve());
+const dismissRestorePrompt = vi.fn(() => Promise.resolve());
+
+/** Mutable slice the mocked store selector reads from. */
+const storeState: {
+  restorePrompt: RestorePrompt | null;
+  confirmRestorePrompt: typeof confirmRestorePrompt;
+  dismissRestorePrompt: typeof dismissRestorePrompt;
+} = {
+  restorePrompt: null,
+  confirmRestorePrompt,
+  dismissRestorePrompt,
+};
+
+vi.mock("@/store/appStore", () => ({
+  useAppStore: <T,>(selector: (s: typeof storeState) => T): T => selector(storeState),
+}));
+
+import { SessionRestoreDialog } from "./SessionRestoreDialog";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render() {
+  act(() => {
+    root.render(<SessionRestoreDialog />);
+  });
+}
+
+function byTestId(id: string): HTMLElement | null {
+  return document.querySelector(`[data-testid="${id}"]`);
+}
+
+describe("SessionRestoreDialog", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    storeState.restorePrompt = null;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders nothing when there is no pending prompt", () => {
+    render();
+    expect(byTestId("session-restore-dialog")).toBeNull();
+  });
+
+  it("shows the tab count and lists each tab with its type", () => {
+    storeState.restorePrompt = {
+      tabCount: 2,
+      tabs: [
+        { title: "admin@prod-db", typeLabel: "SSH" },
+        { title: "Local", typeLabel: "Local" },
+      ],
+    };
+    render();
+
+    const dialog = byTestId("session-restore-dialog");
+    expect(dialog?.textContent).toContain("You had 2 tabs open");
+    const list = byTestId("session-restore-tabs");
+    expect(list?.textContent).toContain("admin@prod-db");
+    expect(list?.textContent).toContain("SSH");
+    expect(list?.textContent).toContain("Local");
+  });
+
+  it("uses the singular 'tab' for a single stored tab", () => {
+    storeState.restorePrompt = { tabCount: 1, tabs: [{ title: "Shell", typeLabel: "Local" }] };
+    render();
+    expect(byTestId("session-restore-dialog")?.textContent).toContain("You had 1 tab open");
+  });
+
+  it("restores (without remember) when Restore is clicked", () => {
+    storeState.restorePrompt = { tabCount: 1, tabs: [{ title: "Shell", typeLabel: "Local" }] };
+    render();
+
+    act(() => (byTestId("session-restore-confirm") as HTMLElement).click());
+
+    expect(confirmRestorePrompt).toHaveBeenCalledTimes(1);
+    expect(confirmRestorePrompt).toHaveBeenCalledWith(false);
+    expect(dismissRestorePrompt).not.toHaveBeenCalled();
+  });
+
+  it("starts fresh (without remember) when Start Fresh is clicked", () => {
+    storeState.restorePrompt = { tabCount: 1, tabs: [{ title: "Shell", typeLabel: "Local" }] };
+    render();
+
+    act(() => (byTestId("session-restore-cancel") as HTMLElement).click());
+
+    expect(dismissRestorePrompt).toHaveBeenCalledTimes(1);
+    expect(dismissRestorePrompt).toHaveBeenCalledWith(false);
+    expect(confirmRestorePrompt).not.toHaveBeenCalled();
+  });
+
+  it("passes remember=true to confirm after ticking 'Remember my choice'", () => {
+    storeState.restorePrompt = { tabCount: 1, tabs: [{ title: "Shell", typeLabel: "Local" }] };
+    render();
+
+    act(() => (byTestId("session-restore-remember") as HTMLElement).click());
+    act(() => (byTestId("session-restore-confirm") as HTMLElement).click());
+
+    expect(confirmRestorePrompt).toHaveBeenCalledWith(true);
+  });
+
+  it("passes remember=true to dismiss after ticking 'Remember my choice'", () => {
+    storeState.restorePrompt = { tabCount: 1, tabs: [{ title: "Shell", typeLabel: "Local" }] };
+    render();
+
+    act(() => (byTestId("session-restore-remember") as HTMLElement).click());
+    act(() => (byTestId("session-restore-cancel") as HTMLElement).click());
+
+    expect(dismissRestorePrompt).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/components/SessionRestoreDialog.test.tsx
+++ b/src/components/SessionRestoreDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import React, { act } from "react";
+import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import type { RestorePrompt } from "@/utils/restoreMode";
 

--- a/src/components/SessionRestoreDialog.tsx
+++ b/src/components/SessionRestoreDialog.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { ConfirmDialog } from "@/components/ui";
+import { useAppStore } from "@/store/appStore";
+import "./SessionRestoreDialog.css";
+
+/**
+ * Startup "Restore Previous Session?" dialog shown when the restore mode is
+ * `ask` and a previous session is stored (see `resolveRestoreMode`).
+ *
+ * Self-contained: it reads the pending {@link RestorePrompt} from the store and
+ * resolves it through `confirmRestorePrompt` / `dismissRestorePrompt`. The
+ * "Remember my choice" opt-out persists the mode (`always` on Restore, `never`
+ * on Start Fresh) so the dialog is not shown again.
+ *
+ * Composes the shared {@link ConfirmDialog}: "Restore" is the primary confirm,
+ * "Start Fresh" is the cancel, and the opt-out rides the `dontAskAgain` slot.
+ */
+export function SessionRestoreDialog(): React.ReactElement | null {
+  const restorePrompt = useAppStore((s) => s.restorePrompt);
+  const confirmRestorePrompt = useAppStore((s) => s.confirmRestorePrompt);
+  const dismissRestorePrompt = useAppStore((s) => s.dismissRestorePrompt);
+  const [remember, setRemember] = useState(false);
+
+  if (!restorePrompt) return null;
+
+  const { tabCount, tabs } = restorePrompt;
+  const tabWord = tabCount === 1 ? "tab" : "tabs";
+
+  return (
+    <ConfirmDialog
+      open
+      title="Restore Previous Session?"
+      description="Choose whether to reopen the tabs from your previous session."
+      message={`You had ${tabCount} ${tabWord} open when termiHub last closed:`}
+      confirmLabel="Restore"
+      cancelLabel="Start Fresh"
+      confirmVariant="primary"
+      confirmErrorToast={false}
+      dontAskAgain={{
+        checked: remember,
+        onChange: setRemember,
+        label: "Remember my choice",
+        "data-testid": "session-restore-remember",
+      }}
+      testIdBase="session-restore"
+      onConfirm={() => confirmRestorePrompt(remember)}
+      onCancel={() => dismissRestorePrompt(remember)}
+      data-testid="session-restore-dialog"
+    >
+      <ul className="session-restore__tabs" data-testid="session-restore-tabs">
+        {tabs.map((tab, index) => (
+          <li key={index} className="session-restore__tab">
+            <span className="session-restore__tab-title">{tab.title}</span>
+            <span className="session-restore__tab-type">{tab.typeLabel}</span>
+          </li>
+        ))}
+      </ul>
+    </ConfirmDialog>
+  );
+}

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -4,6 +4,7 @@ import { ShellType } from "@/types/terminal";
 import { detectAvailableShells } from "@/utils/shell-detection";
 import { getWslDistroName } from "@/utils/shell-detection";
 import { useAppStore } from "@/store/appStore";
+import { resolveRestoreMode } from "@/utils/restoreMode";
 import { isWindows } from "@/utils/platform";
 import { shouldOfferGitBashSetup } from "@/utils/gitBashSetup";
 import { Button, NumberInput, Select, SelectItem, Toggle, toast } from "@/components/ui";
@@ -203,14 +204,23 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
         {show("restoreLastSessionOnStartup") && (
           <SettingsField
             label="Restore Last Session on Startup"
-            hint="Reopen the tabs and panel layout from your previous session when the app starts. Sessions that can no longer reconnect are shown in a disconnected state."
+            hint="Choose how the tabs and panel layout from your previous session are handled when the app starts. Never starts fresh; Ask offers a restore dialog; Always restores silently. Sessions that can no longer reconnect are shown in a disconnected state."
           >
-            <Toggle
-              checked={settings.restoreLastSessionOnStartup ?? true}
-              onCheckedChange={(checked) =>
-                onChange({ ...settings, restoreLastSessionOnStartup: checked })
+            <Select
+              value={resolveRestoreMode(settings)}
+              onChange={(value) =>
+                onChange({
+                  ...settings,
+                  restoreLastSessionMode: value as "never" | "ask" | "always",
+                })
               }
-              data-testid="settings-restore-last-session"
+              options={[
+                { value: "never", label: "Never" },
+                { value: "ask", label: "Ask each time" },
+                { value: "always", label: "Always" },
+              ]}
+              aria-label="Restore last session on startup"
+              data-testid="settings-restore-last-session-mode"
             />
           </SettingsField>
         )}

--- a/src/components/Settings/settingsRegistry.ts
+++ b/src/components/Settings/settingsRegistry.ts
@@ -393,7 +393,8 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
   {
     id: "restoreLastSessionOnStartup",
     label: "Restore Last Session on Startup",
-    description: "Reopen the tabs and layout from your previous session when the app starts",
+    description:
+      "Never, ask, or always reopen the tabs and layout from your previous session when the app starts",
     category: "general",
     keywords: [
       "restore",
@@ -406,6 +407,10 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
       "remember",
       "last",
       "previous",
+      "ask",
+      "always",
+      "never",
+      "mode",
     ],
   },
   {

--- a/src/store/appStore.restoreMode.test.ts
+++ b/src/store/appStore.restoreMode.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock service modules before importing the store (mirrors appStore.lastSession.test.ts).
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() => Promise.resolve({ version: "1", externalConnectionFiles: [] })),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+vi.mock("@/services/lastSessionApi", () => ({
+  saveLastSession: vi.fn(() => Promise.resolve()),
+  loadLastSession: vi.fn(() => Promise.resolve(null)),
+  clearLastSession: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    promise: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+import { useAppStore } from "./appStore";
+import { saveLastSession, loadLastSession, clearLastSession } from "@/services/lastSessionApi";
+import { saveSettings } from "@/services/storage";
+import type { LastSession } from "@/types/lastSession";
+
+const mockSave = vi.mocked(saveLastSession);
+const mockLoad = vi.mocked(loadLastSession);
+const mockClear = vi.mocked(clearLastSession);
+const mockPersistSettings = vi.mocked(saveSettings);
+
+const storedSession: LastSession = {
+  version: "1",
+  activeGroupIndex: 0,
+  tabGroups: [
+    {
+      name: "Restored",
+      layout: {
+        type: "leaf",
+        tabs: [{ inlineConfig: { type: "local", config: { shell: "bash" } }, title: "Shell A" }],
+      },
+    },
+  ],
+};
+
+describe("startup restore mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoad.mockResolvedValue(null);
+    useAppStore.setState({
+      connections: [],
+      remoteAgents: [],
+      agentDefinitions: {},
+      defaultShell: "bash",
+      restorePrompt: null,
+      settings: {
+        ...useAppStore.getState().settings,
+        restoreLastSessionOnStartup: undefined,
+        restoreLastSessionMode: "ask",
+      },
+    });
+    useAppStore.getState().addTab("Shell", "local", { type: "local", config: { shell: "bash" } });
+  });
+
+  describe("saveLastSession honours the mode", () => {
+    it("skips persisting when the mode is never", async () => {
+      useAppStore.setState({
+        settings: { ...useAppStore.getState().settings, restoreLastSessionMode: "never" },
+      });
+
+      await useAppStore.getState().saveLastSession();
+
+      expect(mockSave).not.toHaveBeenCalled();
+    });
+
+    it("persists when the mode is ask", async () => {
+      await useAppStore.getState().saveLastSession();
+      expect(mockSave).toHaveBeenCalledTimes(1);
+    });
+
+    it("persists when the mode is always", async () => {
+      useAppStore.setState({
+        settings: { ...useAppStore.getState().settings, restoreLastSessionMode: "always" },
+      });
+      await useAppStore.getState().saveLastSession();
+      expect(mockSave).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("promptRestore", () => {
+    it("raises the prompt when a session with tabs is stored", async () => {
+      mockLoad.mockResolvedValue(storedSession);
+
+      await useAppStore.getState().promptRestore();
+
+      const prompt = useAppStore.getState().restorePrompt;
+      expect(prompt).not.toBeNull();
+      expect(prompt?.tabCount).toBe(1);
+      expect(prompt?.tabs[0].title).toBe("Shell A");
+    });
+
+    it("does not raise the prompt when nothing is stored", async () => {
+      mockLoad.mockResolvedValue(null);
+
+      await useAppStore.getState().promptRestore();
+
+      expect(useAppStore.getState().restorePrompt).toBeNull();
+    });
+
+    it("does not raise the prompt when the stored session has no tabs", async () => {
+      mockLoad.mockResolvedValue({
+        version: "1",
+        activeGroupIndex: 0,
+        tabGroups: [{ name: "Empty", layout: { type: "leaf", tabs: [] } }],
+      });
+
+      await useAppStore.getState().promptRestore();
+
+      expect(useAppStore.getState().restorePrompt).toBeNull();
+    });
+  });
+
+  describe("confirmRestorePrompt (Restore)", () => {
+    beforeEach(() => {
+      useAppStore.setState({
+        restorePrompt: { tabCount: 1, tabs: [{ title: "x", typeLabel: "Local" }] },
+      });
+      mockLoad.mockResolvedValue(storedSession);
+    });
+
+    it("restores the session and clears the prompt", async () => {
+      await useAppStore.getState().confirmRestorePrompt(false);
+
+      expect(useAppStore.getState().restorePrompt).toBeNull();
+      expect(useAppStore.getState().tabGroups[0].name).toBe("Restored");
+    });
+
+    it("persists mode=always when remember is set", async () => {
+      await useAppStore.getState().confirmRestorePrompt(true);
+
+      expect(useAppStore.getState().settings.restoreLastSessionMode).toBe("always");
+      expect(mockPersistSettings).toHaveBeenCalled();
+      expect(
+        (mockPersistSettings.mock.calls[0][0] as { restoreLastSessionMode?: string })
+          .restoreLastSessionMode
+      ).toBe("always");
+    });
+
+    it("does not change the mode when remember is not set", async () => {
+      await useAppStore.getState().confirmRestorePrompt(false);
+
+      expect(useAppStore.getState().settings.restoreLastSessionMode).toBe("ask");
+      expect(mockPersistSettings).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dismissRestorePrompt (Start Fresh)", () => {
+    beforeEach(() => {
+      useAppStore.setState({
+        restorePrompt: { tabCount: 1, tabs: [{ title: "x", typeLabel: "Local" }] },
+      });
+    });
+
+    it("clears the stored session and the prompt", async () => {
+      await useAppStore.getState().dismissRestorePrompt(false);
+
+      expect(useAppStore.getState().restorePrompt).toBeNull();
+      expect(mockClear).toHaveBeenCalledTimes(1);
+    });
+
+    it("persists mode=never when remember is set", async () => {
+      await useAppStore.getState().dismissRestorePrompt(true);
+
+      expect(useAppStore.getState().settings.restoreLastSessionMode).toBe("never");
+      expect(
+        (mockPersistSettings.mock.calls[0][0] as { restoreLastSessionMode?: string })
+          .restoreLastSessionMode
+      ).toBe("never");
+    });
+
+    it("does not change the mode when remember is not set", async () => {
+      await useAppStore.getState().dismissRestorePrompt(false);
+
+      expect(useAppStore.getState().settings.restoreLastSessionMode).toBe("ask");
+      expect(mockPersistSettings).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -165,6 +165,11 @@ import {
   captureAllTabGroups,
   getWorkspaceLeaves,
 } from "@/utils/workspaceLayout";
+import {
+  resolveRestoreMode,
+  summarizeLastSession,
+  type RestorePrompt,
+} from "@/utils/restoreMode";
 import { Macro, MacroStep } from "@/types/macro";
 import {
   listMacros as apiListMacros,
@@ -1398,6 +1403,30 @@ interface AppState {
   restoreLastSession: () => Promise<boolean>;
   /** Clear the persisted last session (e.g. when restore-on-startup is disabled). */
   clearLastSession: () => Promise<void>;
+  /**
+   * Pending "restore previous session?" prompt for `ask` mode: a summary of the
+   * stored last session shown by the {@link SessionRestoreDialog}. `null` when
+   * no prompt is showing.
+   */
+  restorePrompt: RestorePrompt | null;
+  /**
+   * `ask`-mode startup step: peek the stored last session and, when it has
+   * tabs, raise {@link restorePrompt} so the dialog can offer to restore. A
+   * no-op when nothing is stored.
+   */
+  promptRestore: () => Promise<void>;
+  /**
+   * Resolve the restore prompt with "Restore": optionally persist
+   * `restoreLastSessionMode: "always"` (when `remember`), then restore the
+   * stored session.
+   */
+  confirmRestorePrompt: (remember: boolean) => Promise<void>;
+  /**
+   * Resolve the restore prompt with "Start Fresh": optionally persist
+   * `restoreLastSessionMode: "never"` (when `remember`), then clear the stored
+   * session.
+   */
+  dismissRestorePrompt: (remember: boolean) => Promise<void>;
 
   // Credential store
   credentialStoreStatus: CredentialStoreStatusInfo | null;
@@ -6838,7 +6867,8 @@ export const useAppStore = create<AppState>((set, get) => {
     saveLastSession: async () => {
       const state = get();
       // Respect the setting at save time so toggling it takes effect immediately.
-      if (state.settings.restoreLastSessionOnStartup === false) return;
+      // "never" means the user does not want a session kept, so skip the write.
+      if (resolveRestoreMode(state.settings) === "never") return;
       const tabGroups = captureAllTabGroups(
         state.tabGroups,
         state.activeTabGroupId,
@@ -6967,6 +6997,48 @@ export const useAppStore = create<AppState>((set, get) => {
           `Failed to clear saved session: ${err instanceof Error ? err.message : String(err)}`
         );
       }
+    },
+
+    restorePrompt: null,
+
+    promptRestore: async () => {
+      try {
+        const session = await apiLoadLastSession();
+        if (!session || session.tabGroups.length === 0) return;
+        const summary = summarizeLastSession(session);
+        // Nothing launchable → treat as "no session" and stay silent.
+        if (summary.tabCount === 0) return;
+        set({ restorePrompt: summary });
+      } catch (err) {
+        // A corrupt/failed load must not wedge startup — surface it like a
+        // failed restore and start fresh.
+        frontendLog("workspace", `Failed to load last session for prompt: ${String(err)}`);
+        toast.error("Could not load previous session");
+      }
+    },
+
+    confirmRestorePrompt: async (remember) => {
+      const state = get();
+      if (remember) {
+        await state.updateSettings({
+          ...state.settings,
+          restoreLastSessionMode: "always",
+        });
+      }
+      set({ restorePrompt: null });
+      await get().restoreLastSession();
+    },
+
+    dismissRestorePrompt: async (remember) => {
+      const state = get();
+      if (remember) {
+        await state.updateSettings({
+          ...state.settings,
+          restoreLastSessionMode: "never",
+        });
+      }
+      set({ restorePrompt: null });
+      await get().clearLastSession();
     },
 
     // Credential store

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -165,11 +165,7 @@ import {
   captureAllTabGroups,
   getWorkspaceLeaves,
 } from "@/utils/workspaceLayout";
-import {
-  resolveRestoreMode,
-  summarizeLastSession,
-  type RestorePrompt,
-} from "@/utils/restoreMode";
+import { resolveRestoreMode, summarizeLastSession, type RestorePrompt } from "@/utils/restoreMode";
 import { Macro, MacroStep } from "@/types/macro";
 import {
   listMacros as apiListMacros,

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -513,11 +513,26 @@ export interface AppSettings {
   /** Stop the auto-provided X server once no connection is using it. */
   stopXServerWhenIdle?: boolean;
   /**
+   * @deprecated Superseded by {@link restoreLastSessionMode}. Retained for
+   * backward-compatible migration: `false` maps to `"never"`, otherwise the
+   * effective mode falls through to the `"ask"` default. New code should read
+   * the mode via `resolveRestoreMode` rather than this boolean.
+   *
    * When true (default), the open tab groups and layout are auto-saved on every
    * change and restored on the next startup. When false, the app always starts
    * with a fresh empty session.
    */
   restoreLastSessionOnStartup?: boolean;
+  /**
+   * How the previous session is restored on startup:
+   * - `"never"` — start fresh, never restore;
+   * - `"ask"` — show a dialog offering to restore (default);
+   * - `"always"` — restore silently.
+   *
+   * Unset migrates from the legacy {@link restoreLastSessionOnStartup} boolean
+   * (`false` → `"never"`, otherwise `"ask"`). Resolve via `resolveRestoreMode`.
+   */
+  restoreLastSessionMode?: "never" | "ask" | "always";
   /**
    * When true (default), every terminal session opened is recorded to the
    * browsable session history. Turning it off stops all automatic recording;

--- a/src/utils/restoreMode.test.ts
+++ b/src/utils/restoreMode.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { resolveRestoreMode, summarizeLastSession } from "./restoreMode";
+import type { AppSettings } from "@/types/connection";
+import type { LastSession } from "@/types/lastSession";
+
+function settings(partial: Partial<AppSettings>): AppSettings {
+  return { version: "1", externalConnectionFiles: [], ...partial } as AppSettings;
+}
+
+describe("resolveRestoreMode", () => {
+  it("returns the explicit mode when set", () => {
+    expect(resolveRestoreMode(settings({ restoreLastSessionMode: "never" }))).toBe("never");
+    expect(resolveRestoreMode(settings({ restoreLastSessionMode: "ask" }))).toBe("ask");
+    expect(resolveRestoreMode(settings({ restoreLastSessionMode: "always" }))).toBe("always");
+  });
+
+  it("prefers the explicit mode over the legacy boolean", () => {
+    expect(
+      resolveRestoreMode(
+        settings({ restoreLastSessionMode: "always", restoreLastSessionOnStartup: false })
+      )
+    ).toBe("always");
+  });
+
+  it("migrates the legacy boolean false to never", () => {
+    expect(resolveRestoreMode(settings({ restoreLastSessionOnStartup: false }))).toBe("never");
+  });
+
+  it("defaults to ask when nothing is set", () => {
+    expect(resolveRestoreMode(settings({}))).toBe("ask");
+  });
+
+  it("defaults to ask when the legacy boolean is true", () => {
+    expect(resolveRestoreMode(settings({ restoreLastSessionOnStartup: true }))).toBe("ask");
+  });
+
+  it("falls through to ask for an out-of-range mode value", () => {
+    expect(resolveRestoreMode(settings({ restoreLastSessionMode: "bogus" as "ask" }))).toBe("ask");
+  });
+});
+
+describe("summarizeLastSession", () => {
+  const session: LastSession = {
+    version: "1",
+    activeGroupIndex: 0,
+    tabGroups: [
+      {
+        name: "Group",
+        layout: {
+          type: "split",
+          direction: "horizontal",
+          children: [
+            {
+              type: "leaf",
+              tabs: [
+                { title: "prod-db", inlineConfig: { type: "ssh", config: { host: "prod-db" } } },
+                { inlineConfig: { type: "serial", config: { device: "/dev/ttyUSB0" } } },
+              ],
+            },
+            {
+              type: "leaf",
+              tabs: [{ inlineConfig: { type: "local", config: { shell: "bash" } } }],
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  it("counts every tab across nested leaves", () => {
+    expect(summarizeLastSession(session).tabCount).toBe(3);
+  });
+
+  it("uses the title override and derives type labels", () => {
+    const { tabs } = summarizeLastSession(session);
+    expect(tabs[0]).toEqual({ title: "prod-db", typeLabel: "SSH" });
+    // No title: falls back to the device path, Serial type badge.
+    expect(tabs[1]).toEqual({ title: "/dev/ttyUSB0", typeLabel: "Serial" });
+    expect(tabs[2]).toEqual({ title: "Local", typeLabel: "Local" });
+  });
+
+  it("reports zero tabs for an empty session", () => {
+    const empty: LastSession = {
+      version: "1",
+      activeGroupIndex: 0,
+      tabGroups: [{ name: "Empty", layout: { type: "leaf", tabs: [] } }],
+    };
+    expect(summarizeLastSession(empty)).toEqual({ tabCount: 0, tabs: [] });
+  });
+});

--- a/src/utils/restoreMode.ts
+++ b/src/utils/restoreMode.ts
@@ -1,0 +1,102 @@
+/**
+ * Startup session-restore mode: how the previously-open tabs are handled when
+ * the app launches.
+ *
+ * - `"never"` — never restore; start with a fresh empty session.
+ * - `"ask"` — show a dialog offering to restore the previous session.
+ * - `"always"` — restore the previous session silently.
+ */
+
+import type { AppSettings } from "@/types/connection";
+import type { LastSession } from "@/types/lastSession";
+import type { WorkspaceTabDef } from "@/types/workspace";
+import { getWorkspaceLeaves } from "@/utils/workspaceLayout";
+
+/** The three restore modes. */
+export type RestoreLastSessionMode = "never" | "ask" | "always";
+
+/** A single restorable tab, described for the restore dialog. */
+export interface RestoreTabInfo {
+  /** Human-readable tab title. */
+  title: string;
+  /** Short connection-type label (e.g. "SSH", "Serial", "Local"). */
+  typeLabel: string;
+}
+
+/** Summary of a stored last session for the restore dialog. */
+export interface RestorePrompt {
+  /** Total number of restorable tabs across all groups. */
+  tabCount: number;
+  /** Per-tab descriptors for display. */
+  tabs: RestoreTabInfo[];
+}
+
+const VALID_MODES: readonly RestoreLastSessionMode[] = ["never", "ask", "always"];
+
+/**
+ * Resolve the effective restore mode from settings, migrating the legacy
+ * boolean `restoreLastSessionOnStartup` when the explicit mode is unset.
+ *
+ * - explicit {@link AppSettings.restoreLastSessionMode} wins when valid;
+ * - otherwise the legacy boolean `=== false` maps to `"never"`;
+ * - otherwise the default is `"ask"` (the concept default).
+ */
+export function resolveRestoreMode(settings: AppSettings): RestoreLastSessionMode {
+  const explicit = settings.restoreLastSessionMode;
+  if (explicit && VALID_MODES.includes(explicit)) return explicit;
+  if (settings.restoreLastSessionOnStartup === false) return "never";
+  return "ask";
+}
+
+/** Map a stored tab definition's connection type to a short display label. */
+function tabTypeLabel(tab: WorkspaceTabDef): string {
+  if (tab.agentRef) return "Agent";
+  const type = tab.inlineConfig?.type;
+  switch (type) {
+    case "ssh":
+      return "SSH";
+    case "serial":
+      return "Serial";
+    case "telnet":
+      return "Telnet";
+    case "docker":
+      return "Docker";
+    case "wsl":
+      return "WSL";
+    case "local":
+      return "Local";
+    default:
+      return type ? type.charAt(0).toUpperCase() + type.slice(1) : "Terminal";
+  }
+}
+
+/** Best-effort title for a stored tab when no explicit title was captured. */
+function tabFallbackTitle(tab: WorkspaceTabDef): string {
+  const cfg = tab.inlineConfig?.config as Record<string, unknown> | undefined;
+  const host = typeof cfg?.host === "string" ? cfg.host : undefined;
+  const user = typeof cfg?.username === "string" ? cfg.username : undefined;
+  if (host) return user ? `${user}@${host}` : host;
+  const device = typeof cfg?.device === "string" ? cfg.device : undefined;
+  if (device) return device;
+  return tabTypeLabel(tab);
+}
+
+/**
+ * Flatten a stored {@link LastSession} into a per-tab summary for the restore
+ * dialog. Pure over the session — no connection lookup, so it can run before
+ * connections are loaded.
+ */
+export function summarizeLastSession(session: LastSession): RestorePrompt {
+  const tabs: RestoreTabInfo[] = [];
+  for (const group of session.tabGroups) {
+    for (const leaf of getWorkspaceLeaves(group.layout)) {
+      for (const tab of leaf.tabs) {
+        tabs.push({
+          title: tab.title?.trim() || tabFallbackTitle(tab),
+          typeLabel: tabTypeLabel(tab),
+        });
+      }
+    }
+  }
+  return { tabCount: tabs.length, tabs };
+}


### PR DESCRIPTION
## Summary

Extends session restore (shipped in #586) from a single silent-restore boolean into a **three-way restore mode** — `never` / `ask` / `always` — and adds a **"Restore Previous Session?" dialog** shown on startup when the mode is `ask`.

Completes part of the partial `session-auto-save` concept (`docs/concepts/partial/session-auto-save.html`, Sync Ledger row 3).

## What changed

- **Setting**: new `restoreLastSessionMode` (`never`/`ask`/`always`) on `AppSettings` (TS + Rust). The legacy boolean `restoreLastSessionOnStartup` is kept for backward-compatible migration and marked deprecated. `resolveRestoreMode()` (new `src/utils/restoreMode.ts`) resolves the effective mode: explicit mode wins; else legacy `false` -> `never`; else default `ask`.
- **Startup wiring** (`App.tsx`): `never` clears any stored session; `always` restores silently (previous behavior); `ask` peeks the stored session and raises a restore prompt when it has tabs.
- **Dialog**: `SessionRestoreDialog` composes the shared `ConfirmDialog` — "Restore" (primary) / "Start Fresh" (cancel), lists the previous tabs with type badges, and a "Remember my choice" opt-out (`dontAskAgain` slot) that persists the mode (`always` on Restore, `never` on Start Fresh).
- **Settings UI** (`GeneralSettings`): the restore Toggle becomes a 3-way `Select`.
- `saveLastSession` now skips persisting when the effective mode is `never`.

## Tests

- `restoreMode.test.ts` — mode resolution/migration + session summarization.
- `appStore.restoreMode.test.ts` — `promptRestore` raises the prompt only when tabs exist; `confirmRestorePrompt`/`dismissRestorePrompt` persist mode on remember and restore/clear; `saveLastSession` skips in `never`.
- `SessionRestoreDialog.test.tsx` — renders on prompt, Restore/Start Fresh + remember wiring.
- Rust `restore_last_session_mode_round_trips` — serde round-trip + legacy migration.

## Notes / follow-up

Scoped to the restore-mode preference + dialog + startup wiring per the concept's Sync Ledger row 3. The concept's per-tab restore **checkboxes** and **offline-target warnings** are deferred to a follow-up (#1897) (they require partial-restore plumbing and target reachability probing); the dialog currently lists tabs read-only.

Closes #1884

