### PR TITLE
feat(backend): multi-window foundation — window ownership map + view re-parenting seam (Closes #1900)

### DIFF
--- a/docs/changes/dev4/feature/1900-multiwindow-foundation.md
+++ b/docs/changes/dev4/feature/1900-multiwindow-foundation.md
@@ -1,0 +1,24 @@
+### Added
+
+- Multi-window foundation (#1900, epic #1899): the backend can now create a
+  second native window and a live session tab can be moved between windows
+  without restarting its backend session (PTY / SSH / serial keeps running).
+  This lands the core seam the rest of the epic builds on:
+  - A backend `session_id → owning_window` ownership map with a claim/release
+    handshake, so a session renders in exactly one window at a time, plus resize
+    ownership so only the displaying window drives a PTY's size.
+  - Window creation/labelling (`win-N`) and a per-window tab hand-off queue, via
+    new commands `open_window`, `claim_session`, `release_session`,
+    `get_session_owner`, `list_windows`, `take_pending_handoffs`,
+    `send_handoff_to_window`, and `replay_session_scrollback`.
+  - Per-session 1 MiB scrollback capture so a re-parented view repaints history
+    in the destination window (works for any session type, including plain local
+    shells which have no backend replay buffer of their own).
+  - A frontend `moveTabToWindow` store seam (new or existing window), hand-off
+    hydration on window boot / on a live `window-handoff` nudge, and destination
+    scrollback replay into a fresh xterm.
+
+  The "Move to Window" commands/menus (#1901), empty-window state (#1902),
+  close-with-live-tabs decision (#1903), graphical-tab move (#1904), and
+  window-dimension persistence (#1905) are separate follow-up children and are
+  not part of this foundation.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2172,24 +2172,25 @@ Foundation smoke test (all platforms; **required on macOS**):
 
 1. Launch via `./scripts/dev.sh`. Open a **local shell** tab in the main window
    and run a few commands so it has visible scrollback (e.g. `ls -la`, `pwd`).
-2. Open the DevTools console and note the tab/panel ids:
-   `const s = window` — instead use the app store:
-   ```js
-   const store = (await import("/src/store/appStore.ts")).useAppStore;
-   const leaf = store.getState().rootPanel; // inspect to find the leaf + tab id
-   ```
-   (Or read the tab id off the active leaf via `getAllLeaves`.)
-3. Move the tab into a **new** window:
-   ```js
-   store.getState().moveTabToWindow("<tabId>", "<panelId>", { kind: "new" });
-   ```
-4. Verify: a second native window opens; the tab appears in it with its
-   **scrollback repainted**; the tab disappears from the main window; the shell
-   is **still live** (type a command in the moved tab — it responds, the backend
-   PTY never restarted).
-5. In the new (empty) main-window leaf, confirm no orphaned/blank terminal is
+2. Open the DevTools console. Grab the store, find the active leaf/tab ids, and
+   move the tab into a **new** window:
+
+```js
+const store = (await import("/src/store/appStore.ts")).useAppStore;
+const { getAllLeaves } = await import("/src/utils/panelTree.ts");
+const leaf = getAllLeaves(store.getState().rootPanel)[0];
+store.getState().moveTabToWindow(leaf.tabs[0].id, leaf.id, { kind: "new" });
+```
+
+Then verify:
+
+1. A second native window opens; the tab appears in it with its **scrollback
+   repainted**; the tab disappears from the main window; the shell is **still
+   live** (type a command in the moved tab — it responds, the backend PTY never
+   restarted).
+2. In the new (empty) main-window leaf, confirm no orphaned/blank terminal is
    left behind and the source session was not killed.
-6. Close the second window → confirm the main window's other sessions, tunnels,
+3. Close the second window → confirm the main window's other sessions, tunnels,
    and embedded/X servers are untouched (app-wide teardown only runs when the
    last window closes; full close policy is #1903).
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2160,6 +2160,39 @@ connection (no exec channel, so no `sudo` path). See PR #1525 (#1330).
    connection → the **Edit with sudo** action is shown (not the fallback), and no
    "Save a copy…" / "Download" actions appear in the banner (see #1329).
 
+### Multi-window: move a live tab between windows (#1900)
+
+Multi-window behavior cannot be automated on macOS (`tauri-driver` has no
+WKWebView driver, ADR-5) and the Python bridge harness is not yet multi-window
+aware, so the foundation's end-to-end path is verified manually. The UI to
+trigger a move (context-menu "Move to Window") is #1901; until it lands, drive
+the store seam from the DevTools console.
+
+Foundation smoke test (all platforms; **required on macOS**):
+
+1. Launch via `./scripts/dev.sh`. Open a **local shell** tab in the main window
+   and run a few commands so it has visible scrollback (e.g. `ls -la`, `pwd`).
+2. Open the DevTools console and note the tab/panel ids:
+   `const s = window` — instead use the app store:
+   ```js
+   const store = (await import("/src/store/appStore.ts")).useAppStore;
+   const leaf = store.getState().rootPanel; // inspect to find the leaf + tab id
+   ```
+   (Or read the tab id off the active leaf via `getAllLeaves`.)
+3. Move the tab into a **new** window:
+   ```js
+   store.getState().moveTabToWindow("<tabId>", "<panelId>", { kind: "new" });
+   ```
+4. Verify: a second native window opens; the tab appears in it with its
+   **scrollback repainted**; the tab disappears from the main window; the shell
+   is **still live** (type a command in the moved tab — it responds, the backend
+   PTY never restarted).
+5. In the new (empty) main-window leaf, confirm no orphaned/blank terminal is
+   left behind and the source session was not killed.
+6. Close the second window → confirm the main window's other sessions, tunnels,
+   and embedded/X servers are untouched (app-wide teardown only runs when the
+   last window closes; full close policy is #1903).
+
 ### Guided-Manual Tests in the Python Harness (preferred)
 
 Guided-manual tests are **first-class `pytest` tests** in the Python system-test harness (`tests/system/`). Each one does all the automatable setup through the existing mixins — launch the app, build connections/state — and then prompts the operator for only the irreducibly-manual step (a native OS dialog, xterm-canvas color fidelity, cursor blink). This is the key difference from the legacy YAML runner: the operator does just the un-automatable bit, and the test shares the harness's app/agent orchestration, fixtures, and reporting.

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod ssh_config_import;
 pub mod transfer;
 pub mod tunnel;
 pub mod update;
+pub mod window;
 pub mod workflows;
 pub mod workspace;
 pub mod xserver;

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -17,6 +17,7 @@ use crate::session::line_ending::LineEnding;
 use crate::session::manager::{PersistentSessionSummary, SessionInfo, SessionManager};
 use crate::utils::errors::TerminalError;
 use crate::utils::shell_detect;
+use crate::window::WindowManager;
 
 /// Create a new connection session.
 ///
@@ -112,13 +113,29 @@ pub async fn set_session_line_ending(
 }
 
 /// Resize a session's terminal.
+///
+/// Multi-window resize ownership (#1900): a PTY has exactly one size, so only the
+/// window currently displaying a session may drive its resize. An **unclaimed**
+/// session (the single-window case, or before any move) resizes from any window;
+/// once a session is owned, a resize from a non-owning window is ignored so two
+/// windows never race the backend size.
 #[tauri::command]
 pub async fn resize_terminal(
     session_id: String,
     cols: u16,
     rows: u16,
+    window: tauri::WebviewWindow,
     manager: State<'_, SessionManager>,
+    window_manager: State<'_, WindowManager>,
 ) -> Result<(), TerminalError> {
+    if !window_manager.may_resize(&session_id, window.label()) {
+        debug!(
+            session_id,
+            window = window.label(),
+            "Ignoring resize from non-owning window (#1900)"
+        );
+        return Ok(());
+    }
     debug!(session_id, cols, rows, "Resizing terminal");
     manager.resize(&session_id, cols, rows).await
 }

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -1,0 +1,149 @@
+//! Multi-window Tauri commands (#1900).
+//!
+//! The frontend seam for the multi-window foundation: create native windows,
+//! broker the `session_id → owning_window` ownership handshake, ferry tab
+//! hand-off records between windows, and replay a session's scrollback into a
+//! freshly re-parented view. See [`crate::window`] for the coordinator.
+
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, Manager, State, WebviewUrl, WebviewWindow, WebviewWindowBuilder};
+
+use crate::session::manager::SessionManager;
+use crate::utils::errors::TerminalError;
+use crate::window::{HandoffRecord, WindowManager};
+
+/// A window known to the app, as reported to the frontend window picker.
+///
+/// Kept intentionally minimal for the foundation — tab counts and display
+/// names are frontend concerns layered on by the "Move to Window" UI (#1901)
+/// and the status-bar affordance (#1902).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowInfo {
+    /// The window's runtime label (`main`, `win-1`, …).
+    pub label: String,
+}
+
+/// Open a new native window loading the same frontend bundle.
+///
+/// If a hand-off record is supplied it is queued for the new window, which
+/// drains it on boot via [`take_pending_handoffs`]. Returns the new window's
+/// unique label so the caller can address it.
+///
+/// Window creation is dispatched onto the main thread because some platforms
+/// (notably Linux/GTK) require it there.
+#[tauri::command]
+pub fn open_window(
+    app: AppHandle,
+    window_manager: State<'_, WindowManager>,
+    handoff: Option<HandoffRecord>,
+) -> Result<String, String> {
+    let label = window_manager.next_label();
+    if let Some(record) = handoff {
+        window_manager.queue_handoff(&label, record);
+    }
+
+    let app_for_build = app.clone();
+    let label_for_build = label.clone();
+    app.run_on_main_thread(move || {
+        if let Err(e) = WebviewWindowBuilder::new(
+            &app_for_build,
+            &label_for_build,
+            WebviewUrl::App("index.html".into()),
+        )
+        .title("termiHub")
+        .inner_size(1280.0, 800.0)
+        .min_inner_size(800.0, 600.0)
+        .build()
+        {
+            tracing::error!("Failed to create window {label_for_build}: {e}");
+        }
+    })
+    .map_err(|e| e.to_string())?;
+
+    Ok(label)
+}
+
+/// Claim `session_id` for the **calling** window (the grant side of the
+/// ownership handshake). Returns the previous owner, if any.
+#[tauri::command]
+pub fn claim_session(
+    session_id: String,
+    window: WebviewWindow,
+    window_manager: State<'_, WindowManager>,
+) -> Option<String> {
+    window_manager.claim(&session_id, window.label())
+}
+
+/// Release `session_id` from the **calling** window. No-op unless the calling
+/// window is the current owner. Returns `true` if an entry was removed.
+#[tauri::command]
+pub fn release_session(
+    session_id: String,
+    window: WebviewWindow,
+    window_manager: State<'_, WindowManager>,
+) -> bool {
+    window_manager.release(&session_id, window.label())
+}
+
+/// The window label currently rendering `session_id`, if any.
+#[tauri::command]
+pub fn get_session_owner(
+    session_id: String,
+    window_manager: State<'_, WindowManager>,
+) -> Option<String> {
+    window_manager.owner_of(&session_id)
+}
+
+/// List all currently open windows (label only).
+#[tauri::command]
+pub fn list_windows(app: AppHandle) -> Vec<WindowInfo> {
+    app.webview_windows()
+        .into_keys()
+        .map(|label| WindowInfo { label })
+        .collect()
+}
+
+/// Take (and clear) the hand-off records queued for the **calling** window.
+///
+/// A destination window calls this on boot and on a `window-handoff` nudge to
+/// hydrate incoming tabs. Mirrors [`take_pending_spawn`](crate::commands::spawn::take_pending_spawn).
+#[tauri::command]
+pub fn take_pending_handoffs(
+    window: WebviewWindow,
+    window_manager: State<'_, WindowManager>,
+) -> Vec<HandoffRecord> {
+    window_manager.take_handoffs(window.label())
+}
+
+/// Queue a hand-off record for an already-open window and nudge every window to
+/// drain its queue.
+///
+/// The nudge is a global `window-handoff` event; only the target window has a
+/// queued record, so every other window's drain is a cheap no-op. This avoids
+/// coupling to per-window event targeting for the foundation.
+#[tauri::command]
+pub fn send_handoff_to_window(
+    app: AppHandle,
+    target_label: String,
+    handoff: HandoffRecord,
+    window_manager: State<'_, WindowManager>,
+) -> Result<(), String> {
+    window_manager.queue_handoff(&target_label, handoff);
+    app.emit("window-handoff", ()).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Replay a session's ring-buffered scrollback so a freshly-created xterm in a
+/// destination window can repaint history after a re-parent.
+///
+/// Returns the buffered bytes (empty when nothing has been captured yet or the
+/// session is unknown). The backend session is never touched — this is a pure
+/// read of the capture buffer.
+#[tauri::command]
+pub async fn replay_session_scrollback(
+    session_id: String,
+    manager: State<'_, SessionManager>,
+) -> Result<Vec<u8>, TerminalError> {
+    Ok(manager.replay_scrollback(&session_id).await)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,9 @@ mod spawn;
 mod terminal;
 mod tunnel;
 mod utils;
+/// Multi-window foundation (#1900): window creation/labelling, the
+/// `session_id → owning_window` ownership map, and the tab hand-off queue.
+mod window;
 /// Native Windows clipboard binding for pasting remote-copied RDP clipboard files
 /// into local apps with delayed rendering (`CF_HDROP`, #1814). Windows-only.
 #[cfg(windows)]
@@ -232,6 +235,7 @@ pub fn run() {
         .manage(x_server_manager.clone())
         .manage(x_server_consent_registry.clone())
         .manage(spawn::handler::PendingSpawn::default())
+        .manage(window::WindowManager::new())
         .manage(commands::connection_path::ProbeRegistry::default())
         .manage(commands::local_process::LocalProcessRegistry::default())
         .manage(crate::terminal::agent_cancel::AgentDeployCancellation::default())
@@ -892,6 +896,15 @@ pub fn run() {
             commands::workspace::save_last_session,
             commands::workspace::load_last_session,
             commands::workspace::clear_last_session,
+            // Multi-window foundation (#1900)
+            commands::window::open_window,
+            commands::window::claim_session,
+            commands::window::release_session,
+            commands::window::get_session_owner,
+            commands::window::list_windows,
+            commands::window::take_pending_handoffs,
+            commands::window::send_handoff_to_window,
+            commands::window::replay_session_scrollback,
             // Macros
             commands::macros::list_macros,
             commands::macros::get_macro,
@@ -993,10 +1006,40 @@ pub fn run() {
             }
 
             if let RunEvent::WindowEvent {
+                label,
                 event: WindowEvent::Destroyed,
                 ..
             } = &event
             {
+                // Release any session ownership held by the destroyed window so the
+                // `session_id → window` map never points at a window that no longer
+                // exists (#1900). Cheap, synchronous, safe on the event-loop thread.
+                if let Some(wm) = app_handle.try_state::<window::WindowManager>() {
+                    let released = wm.release_all_for_window(label);
+                    if !released.is_empty() {
+                        info!(
+                            window = %label,
+                            count = released.len(),
+                            "Released session ownership for destroyed window (#1900)"
+                        );
+                    }
+                }
+
+                // App-wide teardown (tunnels, embedded/X servers, transfers, SFTP)
+                // must only run when the *last* window closes — i.e. the app is
+                // actually going away. With multi-window (#1900) a secondary window
+                // closing must not tear down resources the remaining windows still
+                // use. The detach-vs-terminate close policy is #1903; this guard is
+                // the minimal correctness floor the foundation needs.
+                let is_last_window = app_handle.webview_windows().is_empty();
+                if !is_last_window {
+                    info!(
+                        window = %label,
+                        "Secondary window destroyed; skipping app-wide teardown (#1900)"
+                    );
+                    return;
+                }
+
                 // Spawn cleanup off the event-loop thread.  Calling emit() directly
                 // inside this handler would re-enter a RefCell that Tauri already
                 // holds mutably, causing a panic.  Running the work on the async

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -189,6 +189,13 @@ async fn recv_optional(rx: &mut Option<MonitorStatusReceiver>) -> Option<Monitor
     }
 }
 
+/// Per-session scrollback capture buffers, keyed by `session_id` (#1900).
+///
+/// The outer lock guards the map (held only at create/replay/cleanup); each
+/// inner lock guards one session's [`RingBuffer`], written on the hot output
+/// path and read on replay.
+type OutputBuffers = Arc<StdMutex<HashMap<String, Arc<StdMutex<RingBuffer>>>>>;
+
 /// Manages all active connection sessions.
 ///
 /// Holds a [`ConnectionTypeRegistry`] for creating local connections and
@@ -217,7 +224,7 @@ pub struct SessionManager {
     /// scrollback — the multi-window foundation's "detach a view and re-attach it
     /// later with replay" primitive. The outer lock is held only briefly at
     /// create/replay/cleanup; the hot output path writes through the inner lock.
-    output_buffers: Arc<StdMutex<HashMap<String, Arc<StdMutex<RingBuffer>>>>>,
+    output_buffers: OutputBuffers,
 }
 
 /// Removes a `connect_id` from the [`SessionManager::connecting`] map when the
@@ -1406,7 +1413,7 @@ impl SessionManager {
         sessions: Arc<Mutex<HashMap<String, SessionEntry>>>,
         wait_for_clear: bool,
         capture: Arc<StdMutex<RingBuffer>>,
-        output_buffers: Arc<StdMutex<HashMap<String, Arc<StdMutex<RingBuffer>>>>>,
+        output_buffers: OutputBuffers,
     ) {
         // Phase 1: optionally buffer until the screen-clear sequence.
         if wait_for_clear {
@@ -1486,7 +1493,14 @@ impl SessionManager {
             }
         }
 
-        Self::emit_and_cleanup(&session_id, Vec::new(), &emitter, &sessions, &output_buffers).await;
+        Self::emit_and_cleanup(
+            &session_id,
+            Vec::new(),
+            &emitter,
+            &sessions,
+            &output_buffers,
+        )
+        .await;
     }
 
     /// Mirror emitted output into a session's scrollback capture buffer (#1900).
@@ -1512,7 +1526,7 @@ impl SessionManager {
         data: Vec<u8>,
         emitter: &E,
         sessions: &Arc<Mutex<HashMap<String, SessionEntry>>>,
-        output_buffers: &Arc<StdMutex<HashMap<String, Arc<StdMutex<RingBuffer>>>>>,
+        output_buffers: &OutputBuffers,
     ) {
         if !data.is_empty() {
             let event = TerminalOutputEvent {
@@ -1631,7 +1645,7 @@ mod tests {
     }
 
     /// A fresh, empty `output_buffers` map for the cleanup path (#1900).
-    fn new_output_buffers() -> Arc<StdMutex<HashMap<String, Arc<StdMutex<RingBuffer>>>>> {
+    fn new_output_buffers() -> OutputBuffers {
         Arc::new(StdMutex::new(HashMap::new()))
     }
 
@@ -1801,7 +1815,10 @@ mod tests {
         assert!(manager.sessions.lock().await.contains_key("sess-move"));
 
         // An unknown session replays empty rather than erroring.
-        assert!(manager.replay_scrollback("no-such-session").await.is_empty());
+        assert!(manager
+            .replay_scrollback("no-such-session")
+            .await
+            .is_empty());
     }
 
     /// Regression test for #792: the settings-driven initial command must honor

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -14,6 +14,7 @@ use tokio_util::sync::CancellationToken;
 
 use serde::Serialize;
 use tauri::Emitter;
+use termihub_core::buffer::{RingBuffer, DEFAULT_BUFFER_CAPACITY};
 use termihub_core::connection::{
     Capabilities, ConnectionType, ConnectionTypeInfo, ConnectionTypeRegistry,
 };
@@ -206,6 +207,17 @@ pub struct SessionManager {
     /// by the caller-supplied `connect_id`. Lets a Stop/close while connecting
     /// abort the handshake promptly instead of waiting out the timeout (#952).
     connecting: Arc<StdMutex<HashMap<String, CancellationToken>>>,
+    /// Per-session 1 MiB scrollback capture (#1900), keyed by `session_id`.
+    ///
+    /// Every session's emitted output is mirrored into a [`RingBuffer`] so that a
+    /// re-parented view in another window can repaint history via
+    /// [`SessionManager::replay_scrollback`]. Plain local shells have no backend
+    /// replay buffer of their own (unlike serial/agent sessions), so this is the
+    /// general substrate that makes *any* session type re-parentable with
+    /// scrollback — the multi-window foundation's "detach a view and re-attach it
+    /// later with replay" primitive. The outer lock is held only briefly at
+    /// create/replay/cleanup; the hot output path writes through the inner lock.
+    output_buffers: Arc<StdMutex<HashMap<String, Arc<StdMutex<RingBuffer>>>>>,
 }
 
 /// Removes a `connect_id` from the [`SessionManager::connecting`] map when the
@@ -234,6 +246,44 @@ impl SessionManager {
             monitoring_tasks: Arc::new(Mutex::new(HashMap::new())),
             persistent_sessions: Arc::new(Mutex::new(HashMap::new())),
             connecting: Arc::new(StdMutex::new(HashMap::new())),
+            output_buffers: Arc::new(StdMutex::new(HashMap::new())),
+        }
+    }
+
+    /// Get-or-create the scrollback capture buffer for `session_id` (#1900).
+    ///
+    /// Returns a handle the output reader writes through and
+    /// [`Self::replay_scrollback`] reads from.
+    fn ensure_output_buffer(&self, session_id: &str) -> Arc<StdMutex<RingBuffer>> {
+        let mut map = self
+            .output_buffers
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        map.entry(session_id.to_string())
+            .or_insert_with(|| Arc::new(StdMutex::new(RingBuffer::new(DEFAULT_BUFFER_CAPACITY))))
+            .clone()
+    }
+
+    /// Replay a session's captured scrollback (#1900).
+    ///
+    /// Returns the ring-buffered bytes so a freshly-created xterm in a
+    /// destination window can repaint history after a re-parent. Empty when the
+    /// session is unknown or nothing has been captured yet. The backend session
+    /// is never touched — this is a pure read of the capture buffer.
+    pub async fn replay_scrollback(&self, session_id: &str) -> Vec<u8> {
+        let buffer = {
+            let map = self
+                .output_buffers
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            map.get(session_id).cloned()
+        };
+        match buffer {
+            Some(buffer) => buffer
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .read_all(),
+            None => Vec::new(),
         }
     }
 
@@ -373,10 +423,20 @@ impl SessionManager {
 
         // Spawn output streaming task.
         let sessions_clone = self.sessions.clone();
+        let capture = self.ensure_output_buffer(&session_id);
+        let output_buffers = self.output_buffers.clone();
         let sid = session_id.clone();
         tokio::spawn(async move {
-            Self::run_output_reader(sid, output_rx, emitter, sessions_clone, has_initial_command)
-                .await;
+            Self::run_output_reader(
+                sid,
+                output_rx,
+                emitter,
+                sessions_clone,
+                has_initial_command,
+                capture,
+                output_buffers,
+            )
+            .await;
         });
 
         // Send initial command after a short delay.
@@ -1091,6 +1151,8 @@ impl SessionManager {
                     // Spawn output reader for the re-created session.
                     let sessions_clone = self.sessions.clone();
                     let emitter_clone = emitter.clone();
+                    let capture = self.ensure_output_buffer(&session_id);
+                    let output_buffers = self.output_buffers.clone();
                     let sid = session_id.clone();
                     tokio::spawn(async move {
                         Self::run_output_reader(
@@ -1099,6 +1161,8 @@ impl SessionManager {
                             emitter_clone,
                             sessions_clone,
                             false,
+                            capture,
+                            output_buffers,
                         )
                         .await;
                     });
@@ -1334,12 +1398,15 @@ impl SessionManager {
     ///
     /// Coalesces pending output chunks into a single event (up to
     /// `MAX_COALESCE_BYTES`) to reduce IPC overhead.
+    #[allow(clippy::too_many_arguments)]
     async fn run_output_reader<E: EventEmitter>(
         session_id: String,
         mut output_rx: tokio::sync::mpsc::Receiver<Vec<u8>>,
         emitter: E,
         sessions: Arc<Mutex<HashMap<String, SessionEntry>>>,
         wait_for_clear: bool,
+        capture: Arc<StdMutex<RingBuffer>>,
+        output_buffers: Arc<StdMutex<HashMap<String, Arc<StdMutex<RingBuffer>>>>>,
     ) {
         // Phase 1: optionally buffer until the screen-clear sequence.
         if wait_for_clear {
@@ -1363,7 +1430,15 @@ impl SessionManager {
                     }
                     Ok(None) => {
                         // Channel closed during startup.
-                        Self::emit_and_cleanup(&session_id, buffer, &emitter, &sessions).await;
+                        Self::capture_bytes(&capture, &buffer);
+                        Self::emit_and_cleanup(
+                            &session_id,
+                            buffer,
+                            &emitter,
+                            &sessions,
+                            &output_buffers,
+                        )
+                        .await;
                         return;
                     }
                     Err(_) => break, // Timeout
@@ -1372,6 +1447,7 @@ impl SessionManager {
 
             // Flush the buffered output as a single event.
             if !buffer.is_empty() {
+                Self::capture_bytes(&capture, &buffer);
                 let event = TerminalOutputEvent {
                     session_id: session_id.clone(),
                     data: buffer,
@@ -1398,6 +1474,7 @@ impl SessionManager {
             }
 
             if let Some(data) = coalescer.flush() {
+                Self::capture_bytes(&capture, &data);
                 let event = TerminalOutputEvent {
                     session_id: session_id.clone(),
                     data,
@@ -1409,7 +1486,19 @@ impl SessionManager {
             }
         }
 
-        Self::emit_and_cleanup(&session_id, Vec::new(), &emitter, &sessions).await;
+        Self::emit_and_cleanup(&session_id, Vec::new(), &emitter, &sessions, &output_buffers).await;
+    }
+
+    /// Mirror emitted output into a session's scrollback capture buffer (#1900).
+    ///
+    /// The write is bounded by the [`RingBuffer`]'s 1 MiB capacity, so long
+    /// histories are truncated to the most recent bytes — matching the concept's
+    /// stated scrollback-fidelity limit.
+    fn capture_bytes(capture: &StdMutex<RingBuffer>, data: &[u8]) {
+        capture
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .write(data);
     }
 
     /// Emit remaining data (if any), send the exit event, and remove the session.
@@ -1423,6 +1512,7 @@ impl SessionManager {
         data: Vec<u8>,
         emitter: &E,
         sessions: &Arc<Mutex<HashMap<String, SessionEntry>>>,
+        output_buffers: &Arc<StdMutex<HashMap<String, Arc<StdMutex<RingBuffer>>>>>,
     ) {
         if !data.is_empty() {
             let event = TerminalOutputEvent {
@@ -1442,6 +1532,13 @@ impl SessionManager {
             let mut sessions = sessions.lock().await;
             sessions.remove(session_id);
         }
+
+        // Drop the session's scrollback capture buffer (#1900) so a dead
+        // session's 1 MiB ring does not linger.
+        output_buffers
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(session_id);
 
         info!("Session ended: {session_id}");
     }
@@ -1528,6 +1625,16 @@ mod tests {
     }
 
     /// Helper to create a sessions map and insert a mock session.
+    /// A fresh, empty scrollback capture buffer for `run_output_reader` tests (#1900).
+    fn new_capture() -> Arc<StdMutex<RingBuffer>> {
+        Arc::new(StdMutex::new(RingBuffer::new(DEFAULT_BUFFER_CAPACITY)))
+    }
+
+    /// A fresh, empty `output_buffers` map for the cleanup path (#1900).
+    fn new_output_buffers() -> Arc<StdMutex<HashMap<String, Arc<StdMutex<RingBuffer>>>>> {
+        Arc::new(StdMutex::new(HashMap::new()))
+    }
+
     async fn sessions_with_mock(session_id: &str) -> Arc<Mutex<HashMap<String, SessionEntry>>> {
         let sessions = Arc::new(Mutex::new(HashMap::new()));
         let mut map = sessions.lock().await;
@@ -1668,6 +1775,35 @@ mod tests {
         assert_eq!(writes.lock().unwrap().as_slice(), b"a\nb\n");
     }
 
+    /// Multi-window (#1900): re-parenting a tab is a pure view operation. The
+    /// destination window repaints history from the session's captured
+    /// scrollback while the backend session stays untouched in the `sessions`
+    /// map. This proves the replay substrate that makes any session type
+    /// re-parentable with scrollback.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn replay_scrollback_returns_captured_history_without_touching_session() {
+        let manager = SessionManager::new(ConnectionTypeRegistry::new(), Arc::new(NullAgent));
+        manager
+            .insert_test_session("sess-move", Box::new(MockConnection::default()))
+            .await;
+
+        // Simulate output having streamed through the reader into the capture.
+        manager
+            .ensure_output_buffer("sess-move")
+            .lock()
+            .unwrap()
+            .write(b"line-1\r\nline-2\r\n");
+
+        // A move: the destination replays the history verbatim...
+        let replayed = manager.replay_scrollback("sess-move").await;
+        assert_eq!(replayed, b"line-1\r\nline-2\r\n");
+        // ...and the backend session survives the move entirely.
+        assert!(manager.sessions.lock().await.contains_key("sess-move"));
+
+        // An unknown session replays empty rather than erroring.
+        assert!(manager.replay_scrollback("no-such-session").await.is_empty());
+    }
+
     /// Regression test for #792: the settings-driven initial command must honor
     /// the session's configured line ending instead of a hardcoded `\n`. A CRLF
     /// session must receive the command terminated with `\r\n` so it executes on
@@ -1761,7 +1897,15 @@ mod tests {
         let emitter = MockEventEmitter::new();
         let sessions = sessions_with_mock("sess-exit").await;
 
-        SessionManager::emit_and_cleanup("sess-exit", Vec::new(), &emitter, &sessions).await;
+        let output_buffers = new_output_buffers();
+        SessionManager::emit_and_cleanup(
+            "sess-exit",
+            Vec::new(),
+            &emitter,
+            &sessions,
+            &output_buffers,
+        )
+        .await;
 
         {
             let exits = emitter.exits.lock().unwrap();
@@ -1777,8 +1921,15 @@ mod tests {
         let emitter = MockEventEmitter::new();
         let sessions = sessions_with_mock("sess-data").await;
 
-        SessionManager::emit_and_cleanup("sess-data", b"final bytes".to_vec(), &emitter, &sessions)
-            .await;
+        let output_buffers = new_output_buffers();
+        SessionManager::emit_and_cleanup(
+            "sess-data",
+            b"final bytes".to_vec(),
+            &emitter,
+            &sessions,
+            &output_buffers,
+        )
+        .await;
 
         {
             let outputs = emitter.outputs.lock().unwrap();
@@ -1797,14 +1948,30 @@ mod tests {
         tx.send(b"world".to_vec()).await.unwrap();
         drop(tx); // signal EOF
 
+        let capture = new_capture();
+        let output_buffers = new_output_buffers();
         SessionManager::run_output_reader(
             "sess-stream".to_string(),
             rx,
             emitter.clone(),
             sessions.clone(),
             false,
+            capture.clone(),
+            output_buffers,
         )
         .await;
+
+        // The scrollback capture buffer (#1900) mirrors the streamed output.
+        {
+            let captured = capture
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .read_all();
+            assert!(
+                captured.windows(5).any(|w| w == b"hello"),
+                "expected streamed output to be captured for replay"
+            );
+        }
 
         {
             let outputs = emitter.outputs.lock().unwrap();
@@ -1838,6 +2005,8 @@ mod tests {
             emitter.clone(),
             sessions,
             false,
+            new_capture(),
+            new_output_buffers(),
         )
         .await;
 
@@ -1870,7 +2039,14 @@ mod tests {
             );
         }
 
-        SessionManager::emit_and_cleanup("sess-ps", Vec::new(), &emitter, &sessions).await;
+        SessionManager::emit_and_cleanup(
+            "sess-ps",
+            Vec::new(),
+            &emitter,
+            &sessions,
+            &new_output_buffers(),
+        )
+        .await;
 
         // The persistent record must still be present — the daemon is alive.
         assert!(

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -39,10 +39,6 @@ use std::sync::{Mutex, PoisonError};
 
 use serde::{Deserialize, Serialize};
 
-/// Runtime label of the primary application window (declared in
-/// `tauri.conf.json` → `app.windows[]`).
-pub const MAIN_WINDOW_LABEL: &str = "main";
-
 /// A serialized tab view-model handed from one window to another during a
 /// re-parent ("move to window") operation.
 ///

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -1,0 +1,277 @@
+//! Multi-window foundation (#1900, epic #1899).
+//!
+//! Backend authority for multi-window state. Separate native windows are
+//! separate JavaScript contexts with no shared store, so the backend — which
+//! already owns session state keyed by `session_id` — is the natural home for
+//! the cross-window coordination the frontend cannot do itself (concept:
+//! `docs/concepts/backlog/multi-window.html` → "State Ownership & Event
+//! Retargeting").
+//!
+//! [`WindowManager`] coordinates three things:
+//!
+//! * **window labelling** — hands out `win-1`, `win-2`, … labels for new
+//!   [`tauri::WebviewWindow`]s. The primary window keeps its declared `"main"`
+//!   label.
+//! * the **`session_id → owning_window` ownership map** — the single source of
+//!   truth for which window renders a session, so a tab is shown in exactly one
+//!   window at a time (the claim/release handshake). Ownership is a single
+//!   [`HashMap`] entry per session, which makes *two simultaneous owners*
+//!   structurally impossible; a session with no entry is simply *unclaimed*
+//!   (the legacy single-window case).
+//! * a **pending hand-off queue** per window label — a destination window
+//!   drains its queued records on boot (`take_pending_handoffs`), mirroring the
+//!   existing [`PendingSpawn`](crate::spawn::handler::PendingSpawn) pattern.
+//!
+//! # Windows vs tab groups (maintainer decision, #1900 / #1899)
+//!
+//! The concept flags "do windows map onto tab groups?" as an open product
+//! question. This foundation proceeds on the concept's **recommended** model: a
+//! **window owns sessions** (via this `session_id → window` map), orthogonal to
+//! tab groups — a window's frontend store still holds its own `tabGroups[]`, and
+//! the backend neither knows nor cares about groups. The ownership map is kept
+//! deliberately session-keyed (not group-keyed) so that if the product later
+//! decides "a window owns whole tab groups", that layer can be added on top
+//! without reshaping this map.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Mutex, PoisonError};
+
+use serde::{Deserialize, Serialize};
+
+/// Runtime label of the primary application window (declared in
+/// `tauri.conf.json` → `app.windows[]`).
+pub const MAIN_WINDOW_LABEL: &str = "main";
+
+/// A serialized tab view-model handed from one window to another during a
+/// re-parent ("move to window") operation.
+///
+/// The `tab` payload is an **opaque JSON envelope owned by the frontend** so the
+/// tab schema can evolve (child issues #1901–#1905) without touching this
+/// backend seam. The backend only ferries it from the source window to the
+/// destination window's pending queue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandoffRecord {
+    /// The frontend `TerminalTab` view-model (title, config, `contentType`,
+    /// `sessionId`, placement). Opaque to the backend.
+    pub tab: serde_json::Value,
+}
+
+/// Backend coordinator for windows, session ownership, and tab hand-offs.
+#[derive(Default)]
+pub struct WindowManager {
+    /// Monotonic counter feeding unique `win-N` labels.
+    seq: AtomicU32,
+    /// `session_id → owning_window_label`. At most one entry per session.
+    ownership: Mutex<HashMap<String, String>>,
+    /// `window_label → queued hand-off records` awaiting the window's boot/claim.
+    pending: Mutex<HashMap<String, Vec<HandoffRecord>>>,
+}
+
+/// Recover a lock guard even if a previous holder panicked. Multi-window
+/// coordination must never wedge because one operation poisoned a mutex.
+fn recover<T>(result: Result<T, PoisonError<T>>) -> T {
+    result.unwrap_or_else(PoisonError::into_inner)
+}
+
+impl WindowManager {
+    /// Create an empty manager (no extra windows, nothing claimed).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocate the next unique window label (`win-1`, `win-2`, …).
+    pub fn next_label(&self) -> String {
+        let n = self.seq.fetch_add(1, Ordering::SeqCst) + 1;
+        format!("win-{n}")
+    }
+
+    // ── Ownership map ────────────────────────────────────────────────────
+
+    /// Grant `session_id` to `window_label` (the *grant* side of the handshake).
+    ///
+    /// Returns the previous owner, if any. Because ownership is a single map
+    /// entry, claiming atomically supersedes any prior owner — there is never a
+    /// window in which the session is owned by two windows at once.
+    pub fn claim(&self, session_id: &str, window_label: &str) -> Option<String> {
+        let mut map = recover(self.ownership.lock());
+        map.insert(session_id.to_string(), window_label.to_string())
+    }
+
+    /// Release `session_id` **only if** it is currently owned by `window_label`.
+    ///
+    /// Returns `true` if an entry was removed. A release from a non-owner is a
+    /// no-op, so a stale/late window cannot orphan a session that another
+    /// window has already claimed.
+    pub fn release(&self, session_id: &str, window_label: &str) -> bool {
+        let mut map = recover(self.ownership.lock());
+        match map.get(session_id) {
+            Some(owner) if owner == window_label => {
+                map.remove(session_id);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Drop every ownership entry held by `window_label` (e.g. the window was
+    /// destroyed). Returns the session ids that were owned by it.
+    pub fn release_all_for_window(&self, window_label: &str) -> Vec<String> {
+        let mut map = recover(self.ownership.lock());
+        let owned: Vec<String> = map
+            .iter()
+            .filter(|(_, w)| w.as_str() == window_label)
+            .map(|(s, _)| s.clone())
+            .collect();
+        for s in &owned {
+            map.remove(s);
+        }
+        owned
+    }
+
+    /// The window currently rendering `session_id`, if any.
+    pub fn owner_of(&self, session_id: &str) -> Option<String> {
+        recover(self.ownership.lock()).get(session_id).cloned()
+    }
+
+    /// Whether `window_label` may issue `resize` for `session_id`.
+    ///
+    /// `true` when the session is **unclaimed** (legacy single-window: any
+    /// window may size it) or owned by exactly this window. This is the guard
+    /// that keeps a PTY's single size driven by exactly one window so two
+    /// windows never race the backend resize (concept: "Resize is a real
+    /// subtlety").
+    pub fn may_resize(&self, session_id: &str, window_label: &str) -> bool {
+        match self.owner_of(session_id) {
+            None => true,
+            Some(owner) => owner == window_label,
+        }
+    }
+
+    // ── Hand-off queue ───────────────────────────────────────────────────
+
+    /// Queue a hand-off record for `window_label` to drain later.
+    pub fn queue_handoff(&self, window_label: &str, record: HandoffRecord) {
+        recover(self.pending.lock())
+            .entry(window_label.to_string())
+            .or_default()
+            .push(record);
+    }
+
+    /// Take (and clear) all hand-off records queued for `window_label`.
+    pub fn take_handoffs(&self, window_label: &str) -> Vec<HandoffRecord> {
+        recover(self.pending.lock())
+            .remove(window_label)
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(session_id: &str) -> HandoffRecord {
+        HandoffRecord {
+            tab: serde_json::json!({ "sessionId": session_id }),
+        }
+    }
+
+    #[test]
+    fn next_label_is_monotonic_and_unique() {
+        let wm = WindowManager::new();
+        let a = wm.next_label();
+        let b = wm.next_label();
+        let c = wm.next_label();
+        assert_eq!(a, "win-1");
+        assert_eq!(b, "win-2");
+        assert_eq!(c, "win-3");
+    }
+
+    #[test]
+    fn claim_records_owner_and_returns_previous() {
+        let wm = WindowManager::new();
+        assert_eq!(wm.owner_of("s1"), None, "unclaimed session has no owner");
+        assert_eq!(wm.claim("s1", "main"), None, "first claim has no previous");
+        assert_eq!(wm.owner_of("s1"), Some("main".to_string()));
+    }
+
+    #[test]
+    fn claim_supersedes_previous_owner_never_two_owners() {
+        let wm = WindowManager::new();
+        wm.claim("s1", "main");
+        // Re-parenting: window win-1 grabs the session.
+        let previous = wm.claim("s1", "win-1");
+        assert_eq!(previous, Some("main".to_string()));
+        // Exactly one owner at all times — the map has a single entry.
+        assert_eq!(wm.owner_of("s1"), Some("win-1".to_string()));
+    }
+
+    #[test]
+    fn claim_release_handshake_never_leaves_zero_owners_mid_move() {
+        let wm = WindowManager::new();
+        wm.claim("s1", "main");
+        // Destination grants first (per the handshake), so the session always
+        // has exactly one owner across the move — never zero.
+        assert_eq!(wm.owner_of("s1"), Some("main".to_string()));
+        wm.claim("s1", "win-1");
+        assert_eq!(wm.owner_of("s1"), Some("win-1".to_string()));
+        // The source's late release for its old ownership is now a no-op —
+        // it does not own the session any more, so it cannot orphan it.
+        assert!(!wm.release("s1", "main"));
+        assert_eq!(wm.owner_of("s1"), Some("win-1".to_string()));
+    }
+
+    #[test]
+    fn release_by_owner_clears_but_non_owner_is_noop() {
+        let wm = WindowManager::new();
+        wm.claim("s1", "win-1");
+        assert!(!wm.release("s1", "win-2"), "non-owner release is a no-op");
+        assert_eq!(wm.owner_of("s1"), Some("win-1".to_string()));
+        assert!(wm.release("s1", "win-1"), "owner release clears");
+        assert_eq!(wm.owner_of("s1"), None);
+        assert!(!wm.release("s1", "win-1"), "double release is a no-op");
+    }
+
+    #[test]
+    fn release_all_for_window_drops_only_that_windows_sessions() {
+        let wm = WindowManager::new();
+        wm.claim("s1", "win-1");
+        wm.claim("s2", "win-1");
+        wm.claim("s3", "main");
+        let mut dropped = wm.release_all_for_window("win-1");
+        dropped.sort();
+        assert_eq!(dropped, vec!["s1".to_string(), "s2".to_string()]);
+        assert_eq!(wm.owner_of("s1"), None);
+        assert_eq!(wm.owner_of("s2"), None);
+        assert_eq!(wm.owner_of("s3"), Some("main".to_string()));
+    }
+
+    #[test]
+    fn may_resize_allows_unclaimed_and_owner_only() {
+        let wm = WindowManager::new();
+        // Unclaimed: any window may size it (legacy single-window behaviour).
+        assert!(wm.may_resize("s1", "main"));
+        assert!(wm.may_resize("s1", "win-1"));
+        // Once claimed, only the owner may size it — no two-window race.
+        wm.claim("s1", "win-1");
+        assert!(wm.may_resize("s1", "win-1"));
+        assert!(!wm.may_resize("s1", "main"));
+    }
+
+    #[test]
+    fn handoff_queue_is_drained_once_per_window() {
+        let wm = WindowManager::new();
+        wm.queue_handoff("win-1", record("s1"));
+        wm.queue_handoff("win-1", record("s2"));
+        wm.queue_handoff("win-2", record("s3"));
+
+        let taken = wm.take_handoffs("win-1");
+        assert_eq!(taken.len(), 2);
+        // A second drain yields nothing — records are taken, not copied.
+        assert!(wm.take_handoffs("win-1").is_empty());
+        // A different window's queue is untouched.
+        assert_eq!(wm.take_handoffs("win-2").len(), 1);
+        // An unknown window simply has an empty queue.
+        assert!(wm.take_handoffs("win-99").is_empty());
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import { useSidebarResize } from "@/hooks/useSidebarResize";
 import { useAppStore } from "@/store/appStore";
 import { getCliWorkspace } from "@/services/workspaceApi";
 import { resolveRestoreMode } from "@/utils/restoreMode";
+import { MAIN_WINDOW_LABEL } from "@/types/window";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { listen } from "@tauri-apps/api/event";
 import "./App.css";
@@ -166,6 +167,16 @@ function App() {
     (async () => {
       await loadFromBackend();
 
+      // Secondary windows (#1900) boot empty: they never restore the main
+      // window's last session and never auto-save (window-dimension persistence
+      // is #1905). Instead they drain any tabs handed off to them. Live moves to
+      // an already-open window arrive via the `window-handoff` listener below.
+      const isMainWindow = getCurrentWindow().label === MAIN_WINDOW_LABEL;
+      if (!isMainWindow) {
+        await useAppStore.getState().receivePendingHandoffs();
+        return;
+      }
+
       // A workspace launched from the CLI takes precedence over the last session.
       let handledByCli = false;
       try {
@@ -228,6 +239,18 @@ function App() {
   useEffect(() => {
     const unlistenPromise = listen<void>("connections-changed", () => {
       useAppStore.getState().reloadConnectionsFromBackend();
+    });
+    return () => {
+      void unlistenPromise.then((fn) => fn());
+    };
+  }, []);
+
+  // Multi-window (#1900): a tab moved into an already-open window arrives as a
+  // queued hand-off plus a global `window-handoff` nudge. Every window drains
+  // its own queue; only the targeted window has a record, so the rest no-op.
+  useEffect(() => {
+    const unlistenPromise = listen<void>("window-handoff", () => {
+      void useAppStore.getState().receivePendingHandoffs();
     });
     return () => {
       void unlistenPromise.then((fn) => fn());

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -16,6 +16,7 @@ import {
   closeTerminal,
   detachPersistentTab,
   getAgentSessionBuffer,
+  replaySessionScrollback,
 } from "@/services/api";
 import { terminalDispatcher } from "@/services/events";
 import { useTerminalRegistry } from "./TerminalRegistry";
@@ -228,6 +229,13 @@ interface TerminalProps {
    * panel groups "Spawned Containers" from, surviving this tab's close.
    */
   spawned?: boolean;
+  /**
+   * `true` when this tab was hydrated into a destination window by a "move to
+   * window" re-parent (#1900). On (re)attach the terminal fetches and replays
+   * the session's ring-buffered scrollback once so the fresh xterm repaints
+   * history. Ignored for persistent tabs (they replay via the agent buffer).
+   */
+  replayScrollbackOnAttach?: boolean;
 }
 
 /**
@@ -243,6 +251,7 @@ export function Terminal({
   initialCommand,
   persistentConnectionId,
   spawned,
+  replayScrollbackOnAttach,
 }: TerminalProps) {
   const retryCount = useAppStore((s) => s.terminalRetryCounters[tabId] ?? 0);
   const terminalElRef = useRef<HTMLDivElement | null>(null);
@@ -285,6 +294,10 @@ export function Terminal({
   // destroying the live xterm and leaving a blank terminal. Using a mount-time
   // ref keeps setupTerminal stable after the initial connect.
   const initialSessionIdRef = useRef(existingSessionId);
+  // One-shot: replay the moved session's scrollback on the first attach after a
+  // cross-window re-parent (#1900). Captured at mount so a later store write does
+  // not re-trigger it; cleared once consumed.
+  const replayScrollbackRef = useRef(replayScrollbackOnAttach);
   // Keep the latest persistentConnectionId in a ref so the terminal-creation
   // effect below can read it without listing it as a dependency. Adding it to
   // that effect's deps would dispose and recreate the live xterm instance and
@@ -459,6 +472,33 @@ export function Terminal({
               if (!isCanceled()) {
                 useAppStore.getState().setTerminalReattaching(tabId, false);
               }
+            }
+            if (isCanceled()) return;
+          } else if (replayScrollbackRef.current) {
+            // Cross-window re-parent (#1900): the backend session kept running,
+            // so repaint history from its 1 MiB ring buffer into this fresh
+            // xterm. Mirrors the persistent-reattach replay dance above.
+            useAppStore.getState().setTerminalReattaching(tabId, true);
+            frontendLog("terminal", `Replaying scrollback for moved session ${sessionId}`);
+            try {
+              const buffer = await replaySessionScrollback(sessionId);
+              if (isCanceled()) return;
+              if (buffer.length > 0) {
+                useAppStore.getState().setTerminalReattaching(tabId, false);
+                await waitForUsableDimensions(xterm, fitAddon, terminalElRef.current, isCanceled);
+                if (isCanceled()) return;
+                xterm.reset();
+                await new Promise<void>((resolve) => xterm.write(buffer, resolve));
+              }
+            } catch (err) {
+              frontendLog("terminal", `Failed to replay moved-session scrollback: ${err}`);
+            } finally {
+              if (!isCanceled()) {
+                useAppStore.getState().setTerminalReattaching(tabId, false);
+              }
+              // One-shot: clear the tab flag so a later render never replays again.
+              replayScrollbackRef.current = false;
+              useAppStore.getState().clearPendingScrollbackReplay(tabId);
             }
             if (isCanceled()) return;
           }
@@ -791,6 +831,13 @@ export function Terminal({
               }, 50);
             } else {
               pendingCloseTimerRef.current = setTimeout(() => {
+                // Multi-window (#1900): if this session is being re-parented to
+                // another window, the destination adopts it — do NOT close the
+                // backend session. Consume the moving flag once.
+                if (useAppStore.getState().isSessionMoving(sid)) {
+                  useAppStore.getState().clearMovingSession(sid);
+                  return;
+                }
                 closeTerminal(sid);
               }, 50);
             }

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -453,6 +453,7 @@ function TerminalHost() {
           initialCommand={tab.initialCommand}
           persistentConnectionId={tab.persistentConnectionId}
           spawned={tab.spawned}
+          replayScrollbackOnAttach={tab.pendingScrollbackReplay}
         />
       ))}
     </>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -16,6 +16,7 @@ import type { RemoteClipboardFile, RemoteDesktopInput } from "@/types/remoteDesk
 import { CredentialStoreStatusInfo, SwitchCredentialStoreResult } from "@/types/credential";
 import type { SpawnRequestPayload } from "@/services/events";
 import type { ContainerRuntime, SpawnTarget } from "@/types/spawn";
+import type { TabHandoffRecord, WindowInfo } from "@/types/window";
 import {
   SavedConnection,
   ConnectionFolder,
@@ -275,6 +276,69 @@ export async function resolveShellSpawn(
  */
 export async function takePendingSpawn(): Promise<SpawnRequestPayload | null> {
   return await invoke<SpawnRequestPayload | null>("take_pending_spawn");
+}
+
+// ── Multi-window foundation (#1900) ───────────────────────────────────────
+
+/**
+ * Open a new native window loading the same frontend bundle. When a hand-off
+ * record is supplied, it is queued for the new window to drain on boot. Returns
+ * the new window's unique label.
+ */
+export async function openWindow(handoff?: TabHandoffRecord): Promise<string> {
+  return await invoke<string>("open_window", { handoff: handoff ?? null });
+}
+
+/**
+ * Claim a session for the *calling* window (grant side of the ownership
+ * handshake). Returns the previous owner's label, if any.
+ */
+export async function claimSession(sessionId: string): Promise<string | null> {
+  return await invoke<string | null>("claim_session", { sessionId });
+}
+
+/** Release a session from the *calling* window. No-op unless it is the owner. */
+export async function releaseSession(sessionId: string): Promise<boolean> {
+  return await invoke<boolean>("release_session", { sessionId });
+}
+
+/** The window label currently rendering a session, if any. */
+export async function getSessionOwner(sessionId: string): Promise<string | null> {
+  return await invoke<string | null>("get_session_owner", { sessionId });
+}
+
+/** List all currently open windows (label only). */
+export async function listWindows(): Promise<WindowInfo[]> {
+  return await invoke<WindowInfo[]>("list_windows");
+}
+
+/**
+ * Take (and clear) the hand-off records queued for the *calling* window — the
+ * destination window's drain on boot / on a `window-handoff` nudge.
+ */
+export async function takePendingHandoffs(): Promise<TabHandoffRecord[]> {
+  return await invoke<TabHandoffRecord[]>("take_pending_handoffs");
+}
+
+/**
+ * Queue a hand-off record for an already-open window and nudge every window to
+ * drain its queue (global `window-handoff` event).
+ */
+export async function sendHandoffToWindow(
+  targetLabel: string,
+  handoff: TabHandoffRecord
+): Promise<void> {
+  await invoke("send_handoff_to_window", { targetLabel, handoff });
+}
+
+/**
+ * Fetch a session's captured scrollback so a freshly-created xterm in a
+ * destination window can repaint history after a re-parent. Empty when nothing
+ * has been captured or the session is unknown.
+ */
+export async function replaySessionScrollback(sessionId: string): Promise<Uint8Array> {
+  const bytes = await invoke<number[]>("replay_session_scrollback", { sessionId });
+  return new Uint8Array(bytes);
 }
 
 /**

--- a/src/store/appStore.multiWindow.test.ts
+++ b/src/store/appStore.multiWindow.test.ts
@@ -23,10 +23,12 @@ vi.mock("@/services/storage", () => ({
   getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
 }));
 
-const openWindow = vi.fn(() => Promise.resolve("win-1"));
-const sendHandoffToWindow = vi.fn(() => Promise.resolve());
-const claimSession = vi.fn(() => Promise.resolve(null));
-const takePendingHandoffs = vi.fn(() => Promise.resolve([]));
+// Untyped mocks so their call signatures accept any args (the spread wrappers
+// below forward `unknown[]`) and their resolved values are set per-test.
+const openWindow = vi.fn();
+const sendHandoffToWindow = vi.fn();
+const claimSession = vi.fn();
+const takePendingHandoffs = vi.fn();
 
 vi.mock("@/services/api", () => ({
   sftpOpen: vi.fn(),
@@ -56,10 +58,13 @@ function seedLiveTab(sessionId: string): { tabId: string; panelId: string } {
 describe("appStore — multi-window re-parenting seam (#1900)", () => {
   beforeEach(() => {
     useAppStore.setState(useAppStore.getInitialState());
-    openWindow.mockClear();
-    sendHandoffToWindow.mockClear();
-    claimSession.mockClear();
-    takePendingHandoffs.mockClear();
+    openWindow.mockReset();
+    sendHandoffToWindow.mockReset();
+    claimSession.mockReset();
+    takePendingHandoffs.mockReset();
+    openWindow.mockResolvedValue("win-1");
+    sendHandoffToWindow.mockResolvedValue(undefined);
+    claimSession.mockResolvedValue(null);
     takePendingHandoffs.mockResolvedValue([]);
   });
 

--- a/src/store/appStore.multiWindow.test.ts
+++ b/src/store/appStore.multiWindow.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock service modules before importing the store.
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+const openWindow = vi.fn(() => Promise.resolve("win-1"));
+const sendHandoffToWindow = vi.fn(() => Promise.resolve());
+const claimSession = vi.fn(() => Promise.resolve(null));
+const takePendingHandoffs = vi.fn(() => Promise.resolve([]));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  openWindow: (...args: unknown[]) => openWindow(...args),
+  sendHandoffToWindow: (...args: unknown[]) => sendHandoffToWindow(...args),
+  claimSession: (...args: unknown[]) => claimSession(...args),
+  takePendingHandoffs: (...args: unknown[]) => takePendingHandoffs(...args),
+}));
+
+import { useAppStore } from "./appStore";
+import { getAllLeaves } from "@/utils/panelTree";
+import type { TabHandoffRecord } from "@/types/window";
+
+/** Seed one live terminal tab (with a backend session id) and return its ids. */
+function seedLiveTab(sessionId: string): { tabId: string; panelId: string } {
+  useAppStore.getState().addTab("bash", "local");
+  const leaf = getAllLeaves(useAppStore.getState().rootPanel)[0];
+  const tabId = leaf.tabs[0].id;
+  useAppStore.getState().setTabSessionId(tabId, sessionId);
+  return { tabId, panelId: leaf.id };
+}
+
+describe("appStore — multi-window re-parenting seam (#1900)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    openWindow.mockClear();
+    sendHandoffToWindow.mockClear();
+    claimSession.mockClear();
+    takePendingHandoffs.mockClear();
+    takePendingHandoffs.mockResolvedValue([]);
+  });
+
+  describe("moveTabToWindow → new window", () => {
+    it("opens a window with a hand-off record and removes the tab from the source", async () => {
+      const { tabId, panelId } = seedLiveTab("sess-1");
+
+      await useAppStore.getState().moveTabToWindow(tabId, panelId, { kind: "new" });
+
+      // Handed off to a brand-new window with the session anchored.
+      expect(openWindow).toHaveBeenCalledTimes(1);
+      const record = openWindow.mock.calls[0][0] as TabHandoffRecord;
+      expect(record.tab.sessionId).toBe("sess-1");
+      expect(record.tab.contentType).toBe("terminal");
+
+      // Removed from the source window's tree.
+      const tabs = getAllLeaves(useAppStore.getState().rootPanel).flatMap((l) => l.tabs);
+      expect(tabs).toHaveLength(0);
+    });
+
+    it("marks the session as moving so the source view does not kill it", async () => {
+      const { tabId, panelId } = seedLiveTab("sess-keep");
+
+      await useAppStore.getState().moveTabToWindow(tabId, panelId, { kind: "new" });
+
+      // The moving flag is what the source Terminal's unmount consults to skip
+      // closeTerminal — the backend session must survive the move.
+      expect(useAppStore.getState().isSessionMoving("sess-keep")).toBe(true);
+    });
+  });
+
+  describe("moveTabToWindow → existing window", () => {
+    it("queues a hand-off for the target window and removes the tab", async () => {
+      const { tabId, panelId } = seedLiveTab("sess-2");
+
+      await useAppStore
+        .getState()
+        .moveTabToWindow(tabId, panelId, { kind: "existing", label: "win-3" });
+
+      expect(sendHandoffToWindow).toHaveBeenCalledTimes(1);
+      expect(sendHandoffToWindow.mock.calls[0][0]).toBe("win-3");
+      expect(openWindow).not.toHaveBeenCalled();
+
+      const tabs = getAllLeaves(useAppStore.getState().rootPanel).flatMap((l) => l.tabs);
+      expect(tabs).toHaveLength(0);
+    });
+  });
+
+  describe("hydrateHandoffTab (destination side)", () => {
+    it("adds the handed-off tab and flags it for scrollback replay", () => {
+      const record: TabHandoffRecord = {
+        tab: {
+          sessionId: "sess-9",
+          title: "moved",
+          connectionType: "local",
+          contentType: "terminal",
+          config: { type: "shell", config: {} },
+        },
+      };
+
+      useAppStore.getState().hydrateHandoffTab(record);
+
+      const tabs = getAllLeaves(useAppStore.getState().rootPanel).flatMap((l) => l.tabs);
+      expect(tabs).toHaveLength(1);
+      expect(tabs[0].sessionId).toBe("sess-9");
+      expect(tabs[0].title).toBe("moved");
+      // The fresh xterm repaints history from the ring buffer on attach.
+      expect(tabs[0].pendingScrollbackReplay).toBe(true);
+    });
+  });
+
+  describe("receivePendingHandoffs (boot / nudge drain)", () => {
+    it("claims ownership and hydrates each queued record", async () => {
+      takePendingHandoffs.mockResolvedValue([
+        {
+          tab: {
+            sessionId: "sess-drain",
+            title: "drained",
+            connectionType: "local",
+            contentType: "terminal",
+            config: { type: "shell", config: {} },
+          },
+        },
+      ]);
+
+      await useAppStore.getState().receivePendingHandoffs();
+
+      expect(claimSession).toHaveBeenCalledWith("sess-drain");
+      const tabs = getAllLeaves(useAppStore.getState().rootPanel).flatMap((l) => l.tabs);
+      expect(tabs.some((t) => t.sessionId === "sess-drain")).toBe(true);
+    });
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -114,7 +114,12 @@ import {
   detachPersistentTab as apiDetachPersistentTab,
   saveShellIntegrationSettings,
   localReadFile,
+  openWindow,
+  sendHandoffToWindow,
+  claimSession,
+  takePendingHandoffs,
 } from "@/services/api";
+import type { MoveWindowTarget, TabHandoffRecord, HandoffTab } from "@/types/window";
 import type {
   ConnectionTypeInfo,
   ContainerSpawn,
@@ -658,6 +663,39 @@ interface AppState {
   getAllPanels: () => LeafPanel[];
   /** Update the backend session ID on a tab (called after the terminal session is created). */
   setTabSessionId: (tabId: string, sessionId: string | null) => void;
+  /** Clear a tab's one-shot scrollback-replay flag after a re-parent (#1900). */
+  clearPendingScrollbackReplay: (tabId: string) => void;
+
+  // ── Multi-window foundation (#1900) ──
+  /**
+   * Session ids currently being re-parented to another window. While a session
+   * is in this set, the source window's {@link Terminal} must NOT close the
+   * backend session on unmount — the destination window is adopting it. The flag
+   * is consumed once by the source's deferred close.
+   */
+  movingSessionIds: string[];
+  /** Whether a session is mid-move (read by the source Terminal's unmount cleanup). */
+  isSessionMoving: (sessionId: string) => boolean;
+  /** Clear a session's moving flag once the source has released its view. */
+  clearMovingSession: (sessionId: string) => void;
+  /**
+   * Re-parent a session-bearing tab into another window (a brand-new window or
+   * an existing one). The backend session keeps running; the source view is
+   * disposed and the destination re-attaches with scrollback replay. This is the
+   * store seam the "Move to Window" UI (#1901) builds on.
+   */
+  moveTabToWindow: (
+    tabId: string,
+    fromPanelId: string,
+    target: MoveWindowTarget
+  ) => Promise<void>;
+  /**
+   * Hydrate a handed-off tab into this window's active group (destination side).
+   * The tab re-attaches to its live backend session and replays scrollback.
+   */
+  hydrateHandoffTab: (record: TabHandoffRecord) => void;
+  /** Drain and hydrate any hand-off records queued for this window. */
+  receivePendingHandoffs: () => Promise<void>;
 
   // Connections
   folders: ConnectionFolder[];
@@ -1868,6 +1906,26 @@ function createTab(
 }
 
 /**
+ * Serialize a tab into the view-model carried across a native-window boundary
+ * (#1900). Placement (`panelId`/`isActive`) is dropped — the destination window
+ * re-assigns it on hydrate — while `sessionId` anchors the re-attach to the same
+ * live backend session.
+ */
+function serializeHandoffTab(tab: TerminalTab): HandoffTab {
+  return {
+    sessionId: tab.sessionId,
+    title: tab.title,
+    connectionType: tab.connectionType,
+    contentType: tab.contentType,
+    config: tab.config,
+    ...(tab.initialCommand ? { initialCommand: tab.initialCommand } : {}),
+    ...(tab.persistentConnectionId ? { persistentConnectionId: tab.persistentConnectionId } : {}),
+    ...(tab.connectionId ? { connectionId: tab.connectionId } : {}),
+    ...(tab.spawned ? { spawned: true } : {}),
+  };
+}
+
+/**
  * Remove a tab from a leaf panel, choosing a new active tab if needed.
  * Returns the updated leaf (may have empty tabs).
  */
@@ -2290,6 +2348,133 @@ export const useAppStore = create<AppState>((set, get) => {
         };
       }),
 
+    // ── Multi-window foundation (#1900) ──
+    movingSessionIds: [],
+    isSessionMoving: (sessionId) => get().movingSessionIds.includes(sessionId),
+    clearMovingSession: (sessionId) =>
+      set((state) => ({
+        movingSessionIds: state.movingSessionIds.filter((id) => id !== sessionId),
+      })),
+
+    moveTabToWindow: async (tabId, fromPanelId, target) => {
+      // Locate the tab in the active group's live rootPanel.
+      const sourceLeaf = getAllLeaves(get().rootPanel).find((l) => l.id === fromPanelId);
+      const tab = sourceLeaf?.tabs.find((t) => t.id === tabId);
+      if (!tab) return;
+
+      const record: TabHandoffRecord = { tab: serializeHandoffTab(tab) };
+      const sessionId = tab.sessionId;
+
+      // Mark the live session as moving so the source window's Terminal does NOT
+      // close the backend session when its view unmounts — the destination
+      // window adopts the still-running session.
+      if (sessionId) {
+        set((state) => ({
+          movingSessionIds: state.movingSessionIds.includes(sessionId)
+            ? state.movingSessionIds
+            : [...state.movingSessionIds, sessionId],
+        }));
+      }
+
+      // Hand the tab off to the destination window (create it, or queue + nudge).
+      try {
+        if (target.kind === "new") {
+          await openWindow(record);
+        } else {
+          await sendHandoffToWindow(target.label, record);
+        }
+      } catch (err) {
+        // Hand-off failed: clear the moving flag so a later close still tears the
+        // session down rather than leaking it.
+        if (sessionId) get().clearMovingSession(sessionId);
+        frontendLog("multi_window", `move tab to window failed: ${String(err)}`);
+        return;
+      }
+
+      // Remove the tab from the source window's tree. The Terminal unmount sees
+      // the moving flag and skips closeTerminal, keeping the backend session
+      // alive for the destination to re-attach and replay.
+      set((state) => {
+        let newRootPanel = updateLeaf(state.rootPanel, fromPanelId, (leaf) =>
+          removeTabFromLeaf(leaf, tabId)
+        );
+        const updatedSource = findLeaf(newRootPanel, fromPanelId);
+        const allLeaves = getAllLeaves(newRootPanel);
+        if (updatedSource && updatedSource.tabs.length === 0 && allLeaves.length > 1) {
+          const removed = removeLeaf(newRootPanel, fromPanelId);
+          newRootPanel = removed ? simplifyTree(removed) : newRootPanel;
+        }
+        const newActivePanelId =
+          state.activePanelId === fromPanelId
+            ? (getAllLeaves(newRootPanel)[0]?.id ?? null)
+            : state.activePanelId;
+        const tabGroups = state.tabGroups.map((g) =>
+          g.id === state.activeTabGroupId
+            ? { ...g, rootPanel: newRootPanel, activePanelId: newActivePanelId }
+            : g
+        );
+        return { rootPanel: newRootPanel, tabGroups, activePanelId: newActivePanelId };
+      });
+    },
+
+    hydrateHandoffTab: (record) =>
+      set((state) => {
+        const h = record.tab;
+        const targetLeaf = getAllLeaves(state.rootPanel)[0];
+        if (!targetLeaf) return state;
+
+        tabCounter++;
+        const newTab: TerminalTab = {
+          id: `tab-${tabCounter}`,
+          sessionId: h.sessionId,
+          title: h.title,
+          connectionType: h.connectionType,
+          contentType: h.contentType,
+          config: h.config,
+          panelId: targetLeaf.id,
+          isActive: true,
+          ...(h.initialCommand ? { initialCommand: h.initialCommand } : {}),
+          ...(h.persistentConnectionId ? { persistentConnectionId: h.persistentConnectionId } : {}),
+          ...(h.connectionId ? { connectionId: h.connectionId } : {}),
+          ...(h.spawned ? { spawned: true } : {}),
+          // Repaint history from the backend ring buffer once the fresh xterm
+          // (re)attaches to the live session.
+          ...(h.sessionId ? { pendingScrollbackReplay: true } : {}),
+        };
+
+        const newRootPanel = updateLeaf(state.rootPanel, targetLeaf.id, (leaf) => ({
+          ...leaf,
+          tabs: [...leaf.tabs.map((t) => ({ ...t, isActive: false })), newTab],
+          activeTabId: newTab.id,
+        }));
+        const tabGroups = state.tabGroups.map((g) =>
+          g.id === state.activeTabGroupId ? { ...g, rootPanel: newRootPanel } : g
+        );
+        return { rootPanel: newRootPanel, tabGroups, activePanelId: targetLeaf.id };
+      }),
+
+    receivePendingHandoffs: async () => {
+      let records: TabHandoffRecord[];
+      try {
+        records = await takePendingHandoffs();
+      } catch (err) {
+        frontendLog("multi_window", `takePendingHandoffs failed: ${String(err)}`);
+        return;
+      }
+      for (const record of records) {
+        // Claim ownership for this window so the backend `session → window` map
+        // points here (single-owner invariant + resize gating).
+        if (record.tab.sessionId) {
+          try {
+            await claimSession(record.tab.sessionId);
+          } catch (err) {
+            frontendLog("multi_window", `claimSession failed: ${String(err)}`);
+          }
+        }
+        get().hydrateHandoffTab(record);
+      }
+    },
+
     draggingTabId: null,
     setDraggingTabId: (id) => set({ draggingTabId: id }),
 
@@ -2654,6 +2839,24 @@ export const useAppStore = create<AppState>((set, get) => {
     activePanelId: initialPanel.id,
 
     getAllPanels: () => getAllLeaves(get().rootPanel),
+
+    clearPendingScrollbackReplay: (tabId) =>
+      set((state) => {
+        const leaf = findLeafByTab(state.rootPanel, tabId);
+        if (!leaf) return state;
+        const rootPanel = updateLeaf(state.rootPanel, leaf.id, (l) => ({
+          ...l,
+          tabs: l.tabs.map((t) =>
+            t.id === tabId && t.pendingScrollbackReplay
+              ? { ...t, pendingScrollbackReplay: false }
+              : t
+          ),
+        }));
+        const tabGroups = state.tabGroups.map((g) =>
+          g.id === state.activeTabGroupId ? { ...g, rootPanel } : g
+        );
+        return { rootPanel, tabGroups };
+      }),
 
     setTabSessionId: (tabId, sessionId) => {
       // For remote-session tabs gaining a session ID, fetch capabilities so

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -684,11 +684,7 @@ interface AppState {
    * disposed and the destination re-attaches with scrollback replay. This is the
    * store seam the "Move to Window" UI (#1901) builds on.
    */
-  moveTabToWindow: (
-    tabId: string,
-    fromPanelId: string,
-    target: MoveWindowTarget
-  ) => Promise<void>;
+  moveTabToWindow: (tabId: string, fromPanelId: string, target: MoveWindowTarget) => Promise<void>;
   /**
    * Hydrate a handed-off tab into this window's active group (destination side).
    * The tab re-attaches to its live backend session and replays scrollback.

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -316,6 +316,13 @@ export interface TerminalTab {
    * Open Connections panel.
    */
   spawned?: boolean;
+  /**
+   * Set on a tab hydrated into a destination window by a "move to window"
+   * re-parent (#1900). Signals the {@link Terminal} to fetch and replay the
+   * session's ring-buffered scrollback once, so the fresh xterm repaints
+   * history. Cleared after the first (re)attach.
+   */
+  pendingScrollbackReplay?: boolean;
 }
 
 /**

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -1,0 +1,56 @@
+/**
+ * Multi-window foundation types (#1900, epic #1899).
+ *
+ * termiHub can host multiple native windows and move a live session tab between
+ * them without tearing down the backend session. These types describe the
+ * frontend seam the backend `session_id → owning_window` ownership map and the
+ * tab hand-off queue expose. See `docs/concepts/backlog/multi-window.html`.
+ */
+
+import type { ConnectionConfig, TabContentType } from "@/types/terminal";
+
+/** Runtime label of the primary application window. */
+export const MAIN_WINDOW_LABEL = "main";
+
+/** A native window known to the app, for the window picker (#1901/#1902). */
+export interface WindowInfo {
+  /** The window's runtime label (`main`, `win-1`, …). */
+  label: string;
+}
+
+/**
+ * The subset of a `TerminalTab` view-model carried across a native-window
+ * boundary during a re-parent.
+ *
+ * Placement (`panelId`, `isActive`) is deliberately excluded — it is re-assigned
+ * by the destination window's store when the tab is hydrated. `sessionId` is the
+ * anchor: the backend session keyed by it keeps running, so the destination
+ * re-attaches to the same live session rather than starting a new one.
+ */
+export interface HandoffTab {
+  sessionId: string | null;
+  title: string;
+  connectionType: string;
+  contentType: TabContentType;
+  config: ConnectionConfig;
+  initialCommand?: string;
+  persistentConnectionId?: string;
+  connectionId?: string;
+  spawned?: boolean;
+}
+
+/**
+ * A serialized tab hand-off, queued by the backend for a destination window to
+ * drain on boot or on a `window-handoff` nudge. The `tab` payload is opaque to
+ * the backend (`serde_json::Value`).
+ */
+export interface TabHandoffRecord {
+  tab: HandoffTab;
+}
+
+/**
+ * Where a "move tab to window" targets: a brand-new window, or an existing one
+ * addressed by its label. The command/menu UI that picks the target is #1901;
+ * the foundation only provides the store action and the seam.
+ */
+export type MoveWindowTarget = { kind: "new" } | { kind: "existing"; label: string };


### PR DESCRIPTION
## Summary

Lands the **multi-window foundation** (#1900) — the single serializing issue of the Multi-window epic (#1899) that every other child (#1901–#1905) depends on. A second native window can be created and a live session tab moved into it **without restarting the backend session** (PTY / SSH / serial keeps running); the destination repaints scrollback from a backend ring buffer.

Closes #1900

Source of truth: `docs/concepts/backlog/multi-window.html`. Proceeds on the concept's **recommended ownership model** — a window owns *sessions* (via the `session_id → window` map), orthogonal to tab groups. The map is kept session-keyed (not group-keyed) so the deferred "do windows own tab groups?" product question can be layered on later without reshaping it.

## What landed

**Backend**
- `WindowManager` (`src-tauri/src/window/mod.rs`): window labelling (`win-N`), the authoritative `session_id → owning_window` ownership map (claim/release handshake — single-owner invariant is structural; never-zero across a move), resize gating (`may_resize`), and a per-window tab hand-off queue.
- Commands (`src-tauri/src/commands/window.rs`): `open_window`, `claim_session`, `release_session`, `get_session_owner`, `list_windows`, `take_pending_handoffs`, `send_handoff_to_window`, `replay_session_scrollback`.
- Per-session **1 MiB scrollback capture** in `SessionManager` so any session type (incl. plain local shells, which have no backend replay buffer of their own) can replay history on re-parent.
- Window-destroy releases that window's ownership; app-wide teardown (tunnels/servers/transfers/SFTP) now only runs when the **last** window closes, so closing a secondary window doesn't tear down shared resources (full close policy is #1903).

**Frontend**
- `moveTabToWindow(tabId, fromPanelId, target)` store seam (`new` or `existing` window): serializes a tab hand-off record, marks the session "moving" so the source `Terminal` unmount **skips** `closeTerminal` (backend session survives), removes the tab from the source tree.
- Hand-off hydration on secondary-window boot and on a live `window-handoff` nudge — claims ownership, hydrates the tab, and replays scrollback into a fresh xterm (`replayScrollbackOnAttach`). Secondary windows do not restore/save the last session (window-dimension persistence is #1905).
- `api.ts` wrappers + `src/types/window.ts` types.

## The seam wave-1 children build on

- **Ownership map:** `claim_session(sessionId) -> prevOwner?` / `release_session(sessionId) -> bool` / `get_session_owner(sessionId) -> label?` (calling window inferred backend-side); `list_windows() -> {label}[]`.
- **`moveTabToWindow(tabId, fromPanelId, target)`** where `target = { kind: "new" } | { kind: "existing"; label }`. #1901 just calls this from the tab context menu; #1902 adds the empty-window CTA + `open_window`; #1903 owns the close/quit decision surface.
- **Hand-off record:** `{ tab: HandoffTab }` — an opaque frontend-owned envelope, so children can extend the tab schema without touching the backend.

## Tests
- Backend: `WindowManager` ownership invariants (claim/release, never-two-owners, never-zero-mid-move, resize gating, hand-off drain) + a `SessionManager` test proving replay returns captured history while the session survives.
- Frontend: `appStore.multiWindow.test.ts` — move-to-new/existing removes the source tab + marks moving; hydrate flags scrollback replay; `receivePendingHandoffs` claims + hydrates.
- Manual macOS steps documented in `docs/testing.md` (ADR-5: no WKWebView driver; harness isn't multi-window aware yet).

## Notes / divergence from the concept
The concept said to "reuse the existing persistent/agent replay path" for scrollback. In reality plain local shells have **no** backend replay buffer, so this adds a general per-session 1 MiB capture ring (bounded; dropped on session end) — the substrate that makes *any* session type re-parentable with scrollback. Worth a concept re-sync. Scrollback replay may show a small seam artifact if heavy output lands exactly during a move; the common (idle/moderate) case is clean.

## Out of scope (later children)
"Move to Window" menus/commands (#1901), empty-window state UI (#1902), close-with-live-tabs decision (#1903), graphical (RDP/VNC) move (#1904), window-dimension persistence (#1905), and the `emit_to` efficiency optimization. The seams they need are exposed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)