### PR TITLE
feat(ui): tear-out — Move to New Window / Move to Window commands (Closes #1901)

### DIFF
--- a/docs/changes/dev1/feature/1901-move-to-window-commands.md
+++ b/docs/changes/dev1/feature/1901-move-to-window-commands.md
@@ -1,0 +1,11 @@
+### Added
+
+- Move a session tab to another window from its context menu (#1901, epic
+  #1899): a session tab's right-click menu now has a **Move to New Window**
+  command that tears the tab out into a fresh window, and a **Move to Window ▸**
+  submenu listing the other open windows (with **New Window** on top and the
+  current window shown disabled) for moving the tab into an existing window. The
+  move re-parents the live session through the #1900 hand-off seam, so the
+  backend session (PTY / SSH / serial) keeps running. **Move Tab to New Window**
+  is also reachable from the command palette. Only session-bearing tabs offer
+  the commands; graphical (RDP/VNC) tab moves remain a follow-up (#1904).

--- a/src/components/Sidebar/ConnectionList.css
+++ b/src/components/Sidebar/ConnectionList.css
@@ -217,6 +217,34 @@
   width: 14px;
 }
 
+/* Submenu trigger (e.g. "Move to Window ▸") and its trailing chevron. */
+.context-menu__sub-trigger[data-state="open"] {
+  background-color: var(--bg-hover);
+}
+
+.context-menu__sub-arrow {
+  margin-left: auto;
+  color: var(--text-secondary);
+}
+
+/* Trailing hint on a submenu row (e.g. "current"). */
+.context-menu__sub-label {
+  margin-left: auto;
+  padding-left: var(--spacing-sm);
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+.context-menu__item[data-disabled] {
+  color: var(--text-secondary);
+  cursor: default;
+  opacity: 0.6;
+}
+
+.context-menu__item[data-disabled]:hover {
+  background-color: transparent;
+}
+
 /* Inline folder editing */
 .connection-tree__folder--editing {
   display: flex;

--- a/src/components/Terminal/Tab.move-window.test.tsx
+++ b/src/components/Terminal/Tab.move-window.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Tests for the "Move to Window" tab context-menu commands (#1901).
+ *
+ * Covers that a session tab's context menu exposes "Move to New Window" and,
+ * when other windows exist, a "Move to Window ▸" submenu, and that picking an
+ * entry invokes the matching move handler with the right target.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Tab } from "./Tab";
+import { TooltipProvider } from "@/components/ui";
+import { TerminalTab } from "@/types/terminal";
+import type { WindowInfo } from "@/types/window";
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => {},
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+const PANEL_ID = "panel-1";
+
+function makeTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: "t1",
+    sessionId: "sess-1",
+    title: "bash",
+    connectionType: "local",
+    contentType: "terminal",
+    config: { type: "local", config: {} },
+    panelId: PANEL_ID,
+    isActive: true,
+    ...overrides,
+  };
+}
+
+interface RenderOpts {
+  tab?: TerminalTab;
+  windows?: WindowInfo[];
+  currentWindowLabel?: string | null;
+  onMoveToNewWindow?: () => void;
+  onMoveToWindow?: (label: string) => void;
+}
+
+function renderTab(opts: RenderOpts = {}) {
+  const root = createRoot(document.body.appendChild(document.createElement("div")));
+  act(() => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <Tab
+          tab={opts.tab ?? makeTab()}
+          onActivate={() => {}}
+          onClose={() => {}}
+          windows={opts.windows ?? []}
+          currentWindowLabel={opts.currentWindowLabel ?? "main"}
+          onMoveToNewWindow={opts.onMoveToNewWindow}
+          onMoveToWindow={opts.onMoveToWindow}
+        />
+      </TooltipProvider>
+    );
+  });
+  return root;
+}
+
+/** Open the tab's context menu by dispatching a contextmenu event. */
+function openMenu() {
+  const trigger = document.querySelector('[data-testid="tab-t1"]');
+  act(() => {
+    trigger!.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true }));
+  });
+}
+
+describe("Tab — Move to Window commands (#1901)", () => {
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    if (root) act(() => root!.unmount());
+    root = null;
+    document.body.innerHTML = "";
+  });
+
+  it("shows 'Move to New Window' in a session tab's context menu", () => {
+    root = renderTab();
+    openMenu();
+    expect(document.querySelector('[data-testid="tab-context-move-new-window"]')).not.toBeNull();
+  });
+
+  it("invokes onMoveToNewWindow when 'Move to New Window' is picked", () => {
+    const onMoveToNewWindow = vi.fn();
+    root = renderTab({ onMoveToNewWindow });
+    openMenu();
+    const item = document.querySelector(
+      '[data-testid="tab-context-move-new-window"]'
+    ) as HTMLElement;
+    act(() => item.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(onMoveToNewWindow).toHaveBeenCalledOnce();
+  });
+
+  it("hides the 'Move to Window ▸' submenu when only the current window exists", () => {
+    root = renderTab({ windows: [{ label: "main" }], currentWindowLabel: "main" });
+    openMenu();
+    expect(document.querySelector('[data-testid="tab-context-move-window"]')).toBeNull();
+    // The direct tear-out command is still present.
+    expect(document.querySelector('[data-testid="tab-context-move-new-window"]')).not.toBeNull();
+  });
+
+  it("shows the 'Move to Window ▸' submenu trigger once another window exists", () => {
+    root = renderTab({
+      windows: [{ label: "main" }, { label: "win-1" }],
+      currentWindowLabel: "main",
+    });
+    openMenu();
+    expect(document.querySelector('[data-testid="tab-context-move-window"]')).not.toBeNull();
+  });
+
+  it("does not add Move commands to a non-session (settings) tab", () => {
+    root = renderTab({
+      tab: makeTab({ contentType: "settings", sessionId: null }),
+      windows: [{ label: "main" }, { label: "win-1" }],
+    });
+    openMenu();
+    expect(document.querySelector('[data-testid="tab-context-move-new-window"]')).toBeNull();
+    expect(document.querySelector('[data-testid="tab-context-move-window"]')).toBeNull();
+  });
+});

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -16,11 +16,17 @@ import {
   Palette,
   Pencil,
   FileSearch,
+  ExternalLink,
+  AppWindow,
+  Plus,
+  ChevronRight,
 } from "lucide-react";
 import { TerminalTab } from "@/types/terminal";
 import { TabStatus } from "@/utils/tabStatus";
 import { ConnectionIcon } from "@/utils/connectionIcons";
 import { Tooltip } from "@/components/ui";
+import type { WindowInfo } from "@/types/window";
+import { buildWindowPickerEntries, hasOtherWindows } from "@/utils/windowPicker";
 
 /** Human-readable label for each connection status, used as the dot's tooltip. */
 const STATUS_LABELS: Record<TabStatus, string> = {
@@ -51,6 +57,20 @@ interface TabProps {
    * (#1640). Falls back to `tab.title` when omitted.
    */
   displayTitle?: string;
+  /**
+   * All currently-open native windows (#1901), used to populate the
+   * "Move to Window ▸" picker. Empty until the context menu opens and the list
+   * is fetched.
+   */
+  windows?: WindowInfo[];
+  /** Runtime label of the window this tab renders in (the "current" window). */
+  currentWindowLabel?: string | null;
+  /** Refresh the window list — fired when the tab context menu opens (#1901). */
+  onContextMenuOpenChange?: (open: boolean) => void;
+  /** Tear this tab out into a brand-new window (#1901). */
+  onMoveToNewWindow?: () => void;
+  /** Move this tab into an existing window addressed by `label` (#1901). */
+  onMoveToWindow?: (label: string) => void;
 }
 
 export function Tab({
@@ -69,8 +89,15 @@ export function Tab({
   onSetColor,
   status,
   displayTitle,
+  windows = [],
+  currentWindowLabel = null,
+  onContextMenuOpenChange,
+  onMoveToNewWindow,
+  onMoveToWindow,
 }: TabProps) {
   const shownTitle = displayTitle ?? tab.title;
+  const pickerEntries = buildWindowPickerEntries(windows, currentWindowLabel);
+  const showMoveToExisting = hasOtherWindows(windows, currentWindowLabel);
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: tab.id,
     data: { panelId: tab.panelId, type: "tab" },
@@ -175,7 +202,7 @@ export function Tab({
   }
 
   return (
-    <ContextMenu.Root>
+    <ContextMenu.Root onOpenChange={(open) => onContextMenuOpenChange?.(open)}>
       <ContextMenu.Trigger asChild>{tabElement}</ContextMenu.Trigger>
       <ContextMenu.Portal>
         <ContextMenu.Content className="context-menu__content">
@@ -186,6 +213,56 @@ export function Tab({
           >
             <Pencil size={14} /> Rename
           </ContextMenu.Item>
+          <ContextMenu.Separator className="context-menu__separator" />
+          <ContextMenu.Item
+            className="context-menu__item"
+            onSelect={() => onMoveToNewWindow?.()}
+            data-testid="tab-context-move-new-window"
+          >
+            <ExternalLink size={14} /> Move to New Window
+          </ContextMenu.Item>
+          {showMoveToExisting && (
+            <ContextMenu.Sub>
+              <ContextMenu.SubTrigger
+                className="context-menu__item context-menu__sub-trigger"
+                data-testid="tab-context-move-window"
+              >
+                <AppWindow size={14} /> Move to Window
+                <ChevronRight size={14} className="context-menu__sub-arrow" />
+              </ContextMenu.SubTrigger>
+              <ContextMenu.Portal>
+                <ContextMenu.SubContent
+                  className="context-menu__content"
+                  data-testid="tab-context-move-window-submenu"
+                >
+                  <ContextMenu.Item
+                    className="context-menu__item"
+                    onSelect={() => onMoveToNewWindow?.()}
+                    data-testid="tab-context-move-window-new"
+                  >
+                    <Plus size={14} /> New Window
+                  </ContextMenu.Item>
+                  <ContextMenu.Separator className="context-menu__separator" />
+                  {pickerEntries.map((entry) => (
+                    <ContextMenu.Item
+                      key={entry.label}
+                      className="context-menu__item"
+                      disabled={entry.isCurrent}
+                      onSelect={() => {
+                        if (!entry.isCurrent) onMoveToWindow?.(entry.label);
+                      }}
+                      data-testid={`tab-context-move-window-${entry.label}`}
+                    >
+                      <AppWindow size={14} /> {entry.name}
+                      {entry.isCurrent && (
+                        <span className="context-menu__sub-label">current</span>
+                      )}
+                    </ContextMenu.Item>
+                  ))}
+                </ContextMenu.SubContent>
+              </ContextMenu.Portal>
+            </ContextMenu.Sub>
+          )}
           <ContextMenu.Separator className="context-menu__separator" />
           <ContextMenu.Item
             className="context-menu__item"

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -254,9 +254,7 @@ export function Tab({
                       data-testid={`tab-context-move-window-${entry.label}`}
                     >
                       <AppWindow size={14} /> {entry.name}
-                      {entry.isCurrent && (
-                        <span className="context-menu__sub-label">current</span>
-                      )}
+                      {entry.isCurrent && <span className="context-menu__sub-label">current</span>}
                     </ContextMenu.Item>
                   ))}
                 </ContextMenu.SubContent>

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -70,7 +70,10 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
   };
 
   // Move a tab to a new or existing window through the #1900 handoff seam.
-  const handleMoveTabToWindow = (tabId: string, target: { kind: "new" } | { kind: "existing"; label: string }) => {
+  const handleMoveTabToWindow = (
+    tabId: string,
+    target: { kind: "new" } | { kind: "existing"; label: string }
+  ) => {
     void moveTabToWindow(tabId, panelId, target);
   };
   // Tab awaiting confirmation in the shared unsaved-changes dialog (fallback for
@@ -168,9 +171,7 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
               currentWindowLabel={currentWindowLabel}
               onContextMenuOpenChange={refreshWindowsOnOpen}
               onMoveToNewWindow={() => handleMoveTabToWindow(tab.id, { kind: "new" })}
-              onMoveToWindow={(label) =>
-                handleMoveTabToWindow(tab.id, { kind: "existing", label })
-              }
+              onMoveToWindow={(label) => handleMoveTabToWindow(tab.id, { kind: "existing", label })}
               displayTitle={getEditorTabDisplayTitle(tab, allTabs)}
               status={
                 tab.contentType === "terminal"

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -1,7 +1,11 @@
 import { useMemo, useState } from "react";
 import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortable";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useAppStore } from "@/store/appStore";
 import { TerminalTab } from "@/types/terminal";
+import type { WindowInfo } from "@/types/window";
+import { listWindows } from "@/services/api";
+import { frontendLog } from "@/utils/frontendLog";
 import { getAllLeaves } from "@/utils/panelTree";
 import { getEditorTabDisplayTitle } from "@/utils/editorTabTitle";
 import { deriveTabStatus } from "@/utils/tabStatus";
@@ -29,6 +33,7 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
   const tabColors = useAppStore((s) => s.tabColors);
   const setTabColor = useAppStore((s) => s.setTabColor);
   const renameTab = useAppStore((s) => s.renameTab);
+  const moveTabToWindow = useAppStore((s) => s.moveTabToWindow);
   const editorDirtyTabs = useAppStore((s) => s.editorDirtyTabs);
   const setPendingCloseRequest = useAppStore((s) => s.setPendingCloseRequest);
   const setPendingSessionCloseConfirm = useAppStore((s) => s.setPendingSessionCloseConfirm);
@@ -43,6 +48,31 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
 
   const [colorPickerTabId, setColorPickerTabId] = useState<string | null>(null);
   const [renameTabId, setRenameTabId] = useState<string | null>(null);
+  // Open native windows for the "Move to Window ▸" picker (#1901). Refreshed
+  // each time a tab context menu opens, since windows live in separate JS
+  // contexts and can open/close without notifying this one.
+  const [windows, setWindows] = useState<WindowInfo[]>([]);
+  const currentWindowLabel = useMemo(() => {
+    try {
+      return getCurrentWindow().label;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  // Refresh the window list when a tab context menu opens, so "Move to Window ▸"
+  // always reflects the live set of windows.
+  const refreshWindowsOnOpen = (open: boolean) => {
+    if (!open) return;
+    listWindows()
+      .then(setWindows)
+      .catch((err) => frontendLog("multi_window", `listWindows failed: ${String(err)}`));
+  };
+
+  // Move a tab to a new or existing window through the #1900 handoff seam.
+  const handleMoveTabToWindow = (tabId: string, target: { kind: "new" } | { kind: "existing"; label: string }) => {
+    void moveTabToWindow(tabId, panelId, target);
+  };
   // Tab awaiting confirmation in the shared unsaved-changes dialog (fallback for
   // dirty tabs whose editor does not route through `setPendingCloseRequest`).
   const [unsavedCloseTabId, setUnsavedCloseTabId] = useState<string | null>(null);
@@ -134,6 +164,13 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
               tabColor={tabColors[tab.id]}
               onRename={() => setRenameTabId(tab.id)}
               onSetColor={() => setColorPickerTabId(tab.id)}
+              windows={windows}
+              currentWindowLabel={currentWindowLabel}
+              onContextMenuOpenChange={refreshWindowsOnOpen}
+              onMoveToNewWindow={() => handleMoveTabToWindow(tab.id, { kind: "new" })}
+              onMoveToWindow={(label) =>
+                handleMoveTabToWindow(tab.id, { kind: "existing", label })
+              }
               displayTitle={getEditorTabDisplayTitle(tab, allTabs)}
               status={
                 tab.contentType === "terminal"

--- a/src/services/commands.test.ts
+++ b/src/services/commands.test.ts
@@ -38,6 +38,8 @@ describe("buildCommands", () => {
     expect(ids).toContain("focus-up");
     expect(ids).toContain("clear-terminal");
     expect(ids).toContain("find-in-terminal");
+    // …including the multi-window tear-out command (#1901)…
+    expect(ids).toContain("move-tab-to-new-window");
     // …while the palette's own shortcut has no runner and stays out.
     expect(ids).not.toContain("command-palette");
   });

--- a/src/services/contextCommands.test.ts
+++ b/src/services/contextCommands.test.ts
@@ -43,10 +43,38 @@ describe("CONTEXT_COMMANDS registry", () => {
         "focus-left",
         "focus-right",
         "focus-up",
+        "move-tab-to-new-window",
         "next-tab",
         "prev-tab",
       ].sort()
     );
+  });
+});
+
+describe("move-tab-to-new-window", () => {
+  const cmd = CONTEXT_COMMANDS["move-tab-to-new-window"];
+
+  it("is available only when the active tab is a terminal", () => {
+    expect(cmd.isAvailable()).toBe(false);
+    addActiveTab("editor");
+    expect(cmd.isAvailable()).toBe(false);
+    addActiveTab("terminal");
+    expect(cmd.isAvailable()).toBe(true);
+  });
+
+  it("tears the active terminal tab out through moveTabToWindow with kind:new", () => {
+    const tabId = addActiveTab("terminal");
+    const panelId = activeLeaf()!.id;
+    const spy = vi.spyOn(useAppStore.getState(), "moveTabToWindow").mockResolvedValue(undefined);
+    cmd.run();
+    expect(spy).toHaveBeenCalledWith(tabId, panelId, { kind: "new" });
+  });
+
+  it("run() is inert on a non-terminal tab", () => {
+    addActiveTab("editor");
+    const spy = vi.spyOn(useAppStore.getState(), "moveTabToWindow").mockResolvedValue(undefined);
+    cmd.run();
+    expect(spy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/contextCommands.ts
+++ b/src/services/contextCommands.ts
@@ -113,6 +113,17 @@ function findInActiveTerminal(): void {
 }
 
 /**
+ * Tear the active session tab out into a brand-new window (#1901), routed
+ * through the same `moveTabToWindow` handoff seam as the tab context menu.
+ */
+function moveActiveTabToNewWindow(): void {
+  const panel = activeLeaf();
+  const tab = activeTerminalTab();
+  if (!panel || !tab) return;
+  void useAppStore.getState().moveTabToWindow(tab.id, panel.id, { kind: "new" });
+}
+
+/**
  * Registry of context-bound commands, keyed by keybinding action id. Consumed by
  * both the keyboard handler and the command palette so the two never diverge.
  */
@@ -128,5 +139,9 @@ export const CONTEXT_COMMANDS: Record<string, ContextCommand> = {
   "find-in-terminal": {
     isAvailable: () => activeTerminalTab() !== null,
     run: findInActiveTerminal,
+  },
+  "move-tab-to-new-window": {
+    isAvailable: () => activeTerminalTab() !== null,
+    run: moveActiveTabToNewWindow,
   },
 };

--- a/src/services/keybindings.ts
+++ b/src/services/keybindings.ts
@@ -113,6 +113,16 @@ export const DEFAULT_BINDINGS: KeyBinding[] = [
     scope: "terminal",
   },
   {
+    action: "move-tab-to-new-window",
+    label: "Move Tab to New Window",
+    category: "terminal",
+    // Ships unbound: the primary surface is the tab context menu (#1901); this
+    // entry exists so the action is command-palette reachable.
+    macDefault: null,
+    winLinuxDefault: null,
+    configurable: true,
+  },
+  {
     action: "toggle-macro-recording",
     label: "Record Macro (Start/Stop)",
     category: "terminal",

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -201,6 +201,20 @@ vi.mock("@tauri-apps/api/event", () => ({
   emit: vi.fn(),
 }));
 
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: vi.fn(() => ({
+    label: "main",
+    onFocusChanged: vi.fn(() => Promise.resolve(() => {})),
+    setSize: vi.fn(() => Promise.resolve()),
+  })),
+  LogicalSize: class {
+    constructor(
+      public width: number,
+      public height: number
+    ) {}
+  },
+}));
+
 vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(),
   save: vi.fn(),

--- a/src/utils/windowPicker.test.ts
+++ b/src/utils/windowPicker.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the "Move to Window" picker construction (#1901).
+ *
+ * The picker turns the backend's flat window-label list into the ordered,
+ * named, current-flagged entries the tab context menu renders.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  windowDisplayName,
+  buildWindowPickerEntries,
+  hasOtherWindows,
+} from "./windowPicker";
+import type { WindowInfo } from "@/types/window";
+
+const w = (label: string): WindowInfo => ({ label });
+
+describe("windowDisplayName", () => {
+  it("names the primary window", () => {
+    expect(windowDisplayName("main")).toBe("Main Window");
+  });
+
+  it("numbers spawned windows", () => {
+    expect(windowDisplayName("win-1")).toBe("Window 1");
+    expect(windowDisplayName("win-42")).toBe("Window 42");
+  });
+
+  it("falls back to the raw label for unexpected labels", () => {
+    expect(windowDisplayName("popout")).toBe("popout");
+  });
+});
+
+describe("buildWindowPickerEntries", () => {
+  it("returns an entry per window with display name and current flag", () => {
+    const entries = buildWindowPickerEntries([w("main"), w("win-1")], "main");
+    expect(entries).toEqual([
+      { label: "main", name: "Main Window", isCurrent: true },
+      { label: "win-1", name: "Window 1", isCurrent: false },
+    ]);
+  });
+
+  it("orders main first, then win-N ascending regardless of input order", () => {
+    const entries = buildWindowPickerEntries([w("win-2"), w("win-10"), w("win-1"), w("main")], "win-2");
+    expect(entries.map((e) => e.label)).toEqual(["main", "win-1", "win-2", "win-10"]);
+  });
+
+  it("marks exactly the current window when it is a spawned window", () => {
+    const entries = buildWindowPickerEntries([w("main"), w("win-1")], "win-1");
+    expect(entries.find((e) => e.label === "win-1")!.isCurrent).toBe(true);
+    expect(entries.find((e) => e.label === "main")!.isCurrent).toBe(false);
+  });
+
+  it("flags none when the current label is unknown/null", () => {
+    const entries = buildWindowPickerEntries([w("main"), w("win-1")], null);
+    expect(entries.every((e) => !e.isCurrent)).toBe(true);
+  });
+});
+
+describe("hasOtherWindows", () => {
+  it("is false when only the current window is open", () => {
+    expect(hasOtherWindows([w("main")], "main")).toBe(false);
+  });
+
+  it("is true once another window exists", () => {
+    expect(hasOtherWindows([w("main"), w("win-1")], "main")).toBe(true);
+  });
+
+  it("is true when the current label is unknown but windows exist", () => {
+    expect(hasOtherWindows([w("main")], null)).toBe(true);
+  });
+});

--- a/src/utils/windowPicker.test.ts
+++ b/src/utils/windowPicker.test.ts
@@ -5,11 +5,7 @@
  * named, current-flagged entries the tab context menu renders.
  */
 import { describe, it, expect } from "vitest";
-import {
-  windowDisplayName,
-  buildWindowPickerEntries,
-  hasOtherWindows,
-} from "./windowPicker";
+import { windowDisplayName, buildWindowPickerEntries, hasOtherWindows } from "./windowPicker";
 import type { WindowInfo } from "@/types/window";
 
 const w = (label: string): WindowInfo => ({ label });
@@ -39,7 +35,10 @@ describe("buildWindowPickerEntries", () => {
   });
 
   it("orders main first, then win-N ascending regardless of input order", () => {
-    const entries = buildWindowPickerEntries([w("win-2"), w("win-10"), w("win-1"), w("main")], "win-2");
+    const entries = buildWindowPickerEntries(
+      [w("win-2"), w("win-10"), w("win-1"), w("main")],
+      "win-2"
+    );
     expect(entries.map((e) => e.label)).toEqual(["main", "win-1", "win-2", "win-10"]);
   });
 

--- a/src/utils/windowPicker.ts
+++ b/src/utils/windowPicker.ts
@@ -1,0 +1,70 @@
+/**
+ * Window-picker helpers for the "Move to Window" tab command surface (#1901).
+ *
+ * The backend window registry (`list_windows`, #1900) reports each open window
+ * by its runtime label only (`main`, `win-1`, …). These helpers turn that flat
+ * label list into the human-readable picker the tab context menu renders: a
+ * display name per window and a flag marking the window the menu is opened in
+ * (shown disabled, "current"). Tab counts and richer per-window metadata live in
+ * separate JS contexts and are not exposed by the foundation, so they are
+ * intentionally omitted here.
+ */
+
+import { MAIN_WINDOW_LABEL, type WindowInfo } from "@/types/window";
+
+/** A window as presented in the "Move to Window ▸" picker. */
+export interface WindowPickerEntry {
+  /** The window's runtime label — the move target address. */
+  label: string;
+  /** Human-readable name shown in the menu. */
+  name: string;
+  /** Whether this is the window the picker was opened from (rendered disabled). */
+  isCurrent: boolean;
+}
+
+/**
+ * A human-readable name for a window label. The primary window is "Main Window";
+ * spawned windows (`win-N`) become "Window N"; anything else falls back to its
+ * raw label so an unexpected label is still addressable.
+ */
+export function windowDisplayName(label: string): string {
+  if (label === MAIN_WINDOW_LABEL) return "Main Window";
+  const match = /^win-(\d+)$/.exec(label);
+  if (match) return `Window ${match[1]}`;
+  return label;
+}
+
+/** Numeric sort key for a window label: main first, then `win-N` ascending. */
+function labelSortKey(label: string): number {
+  if (label === MAIN_WINDOW_LABEL) return -1;
+  const match = /^win-(\d+)$/.exec(label);
+  return match ? Number(match[1]) : Number.MAX_SAFE_INTEGER;
+}
+
+/**
+ * Build the ordered picker entries for the "Move to Window ▸" submenu from the
+ * backend window list and the label of the window the menu was opened in. The
+ * current window is included but flagged {@link WindowPickerEntry.isCurrent} so
+ * the caller can render it disabled; every other window is a live move target.
+ */
+export function buildWindowPickerEntries(
+  windows: WindowInfo[],
+  currentWindowLabel: string | null
+): WindowPickerEntry[] {
+  return [...windows]
+    .sort((a, b) => labelSortKey(a.label) - labelSortKey(b.label))
+    .map((w) => ({
+      label: w.label,
+      name: windowDisplayName(w.label),
+      isCurrent: w.label === currentWindowLabel,
+    }));
+}
+
+/**
+ * Whether any window other than the current one is open — i.e. whether moving a
+ * tab into an *existing* window is possible. When false the "Move to Window ▸"
+ * submenu is redundant with "Move to New Window" and the caller hides it.
+ */
+export function hasOtherWindows(windows: WindowInfo[], currentWindowLabel: string | null): boolean {
+  return windows.some((w) => w.label !== currentWindowLabel);
+}


### PR DESCRIPTION
Wave 1 of the multi-window epic (#1899), built on the merged foundation #1900.

Adds the v1 tear-out / move mechanism as **commands + menus** (not live cross-window drag — @dnd-kit is single-document and Tauri exposes no webview→webview drag).

## What changed

- **Tab context menu** (`src/components/Terminal/Tab.tsx`) — session tabs gain a Move group just below Rename:
  - **Move to New Window** — one-click tear-out into a fresh window seeded with the tab.
  - **Move to Window ▸** submenu — lists the other open windows (New Window on top, current window shown disabled "current"). Hidden when only the current window is open, so only "Move to New Window" applies.
- **Command palette** — a `Move Tab to New Window` command (ships unbound, keyboard-rebindable) tears the active session tab out via the same seam.
- **Wiring** — both surfaces invoke the #1900 `moveTabToWindow(tabId, fromPanelId, target)` store seam: `{ kind: "new" }` for new-window, `{ kind: "existing", label }` for an existing window. The backend release-in-A → grant-to-B handshake keeps the live session running (PTY / SSH / serial).
- **Window picker** (`src/utils/windowPicker.ts`) — pure helpers turn the backend `list_windows()` label list into ordered, named, current-flagged entries. Windows are separate JS contexts, so the list is fetched from the backend registry each time a tab menu opens.

Only session-bearing (terminal) tabs offer the commands; non-session/singleton tabs (Settings, Log Viewer, editors) are excluded. Graphical (RDP/VNC) tab moves remain a follow-up (#1904). Tab counts in the picker need cross-window state the foundation does not expose — deferred (see below).

## Tests

- `src/utils/windowPicker.test.ts` — display names, ordering (main first, win-N ascending), current-flagging, "has other windows".
- `src/components/Terminal/Tab.move-window.test.tsx` — menu shows the commands; "Move to New Window" dispatches; submenu hidden with one window / shown with more; excluded on non-session tabs.
- `src/services/contextCommands.test.ts` + `commands.test.ts` — palette command availability and dispatch through `moveTabToWindow` with `{ kind: "new" }`.

Full suite green (4162 tests), `./scripts/check.sh` passes.

## Follow-ups filed

- Per-window tab counts / richer labels in the picker — see filed issue.

Closes #1901