### PR TITLE
feat(ui): close-window-with-live-tabs decision surface (detach vs terminate) + per-OS quit policy (Closes #1903)

### DIFF
--- a/docs/changes/dev2/feature/1903-close-window-decision.md
+++ b/docs/changes/dev2/feature/1903-close-window-decision.md
@@ -1,0 +1,19 @@
+### Added
+
+- Multi-window: closing a window that still owns live sessions now presents a
+  detach-vs-terminate decision instead of silently killing sessions (#1903,
+  epic #1899). Persistent/agent sessions detach (the backend process keeps
+  running and can be re-attached later); non-persistent sessions (local shell,
+  serial, one-shot SSH) would be terminated. The dialog's primary action moves
+  the live tabs to another window (safe — nothing is lost), the red action ends
+  the sessions, and Cancel keeps the window open. A window whose sessions are
+  all persistent detaches them with just a toast (no dialog), and an empty
+  window closes with no prompt.
+
+### Changed
+
+- Multi-window: the last window closing now follows a per-OS quit policy. On
+  macOS the app stays alive in the Dock when its last window closes (WKWebView
+  convention) and recreates a window when the Dock icon is clicked; on
+  Windows/Linux closing the last window quits the app. A non-last window close
+  never quits the app (#1903).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -912,6 +912,42 @@ E2E test coverage: all WebdriverIO specs have been ported to the cross-platform 
 - For serial port tests: host-side virtual serial ports via `socat` + echo server, set up by `scripts/test-system-linux.sh` (see also `examples/serial/`)
 - Test on each target OS (macOS, Linux, Windows) for cross-platform items
 
+### Multi-window close-with-live-tabs & per-OS quit policy (#1903)
+
+The close decision surface and the classification/store branches are covered by
+unit tests (`src/utils/windowClose.test.ts`, `src/store/appStore.windowClose.test.ts`,
+`src/components/Terminal/CloseWindowDecisionDialog.test.tsx`) and the per-OS
+policy by Rust unit tests (`src-tauri/src/window/mod.rs`). The steps below verify
+the native-window behaviour, which cannot be automated — `tauri-driver` has no
+macOS WKWebView driver (ADR-5) and window-close/Dock behaviour is OS-native.
+
+1. **Detach-vs-terminate dialog.** Open a window with at least one persistent
+   session (SSH/agent) **and** one non-persistent session (local shell), e.g. via
+   "Move to New Window" (#1901). Close that window (title-bar X). **Expected:** a
+   "Close this window?" dialog lists each session — the persistent one as
+   "Detaches — keeps running", the local shell as "Would be terminated" — with
+   **Move tabs to …** as the primary (blue) action, **Close & end sessions** as
+   the red action, and **Cancel**.
+2. **Move (safe).** Click **Move tabs to Window N**. **Expected:** the window
+   closes and all its tabs reappear in the target window, sessions still live
+   (scrollback replays); nothing was terminated.
+3. **Close & end.** Reopen a similar window, close it, click **Close & end
+   sessions**. **Expected:** the window closes; the persistent session detaches
+   (still visible in the Open Connections panel), the local shell is terminated.
+4. **Cancel.** Close a window with a live local shell and click **Cancel**.
+   **Expected:** the window stays open, no session is touched.
+5. **All-persistent → no dialog.** Close a window whose sessions are all
+   persistent/agent. **Expected:** no dialog; a toast reads "N sessions detached
+   — still running" and the window closes.
+6. **Empty window → no prompt.** Close a window with no live sessions.
+   **Expected:** it closes immediately, no dialog.
+7. **Per-OS quit policy — macOS.** With multiple windows, close a non-last window
+   → only that window closes, the app keeps running. Close the **last** window →
+   the app **stays alive in the Dock**; clicking the Dock icon **recreates a
+   window**. Cmd+Q quits the app.
+8. **Per-OS quit policy — Windows/Linux.** Closing the **last** window **quits**
+   the app; closing a non-last window closes only that window and never quits.
+
 ### VNC VeNCrypt / TLS authentication (#1714)
 
 The VNC backend auto-negotiates **VeNCrypt** (RFB security type 19) when the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -147,6 +147,52 @@ fn handle_shell_integration_command(install: bool) -> ! {
     }
 }
 
+/// Run app-wide teardown (tunnels, embedded/X servers, HTTP monitors,
+/// transfers, SFTP) when the app is actually going away.
+///
+/// Spawned off the event-loop thread: calling `emit()` (or otherwise re-entering
+/// Tauri) directly inside a `RunEvent` handler re-borrows a `RefCell` Tauri
+/// already holds mutably and panics, so the cleanup runs on the async runtime.
+///
+/// Invoked when the last window closes on Windows/Linux, and on an explicit quit
+/// on macOS (where last-window-close instead keeps the app alive) — see the
+/// per-OS policy in [`window::should_teardown_on_last_window`] /
+/// [`window::should_prevent_exit`] (#1903).
+fn run_app_teardown(app_handle: &tauri::AppHandle) {
+    let handle = app_handle.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Some(mgr) = handle.try_state::<Arc<tunnel::tunnel_manager::TunnelManager>>() {
+            mgr.stop_all();
+        }
+        if let Some(mgr) =
+            handle.try_state::<embedded_servers::server_manager::EmbeddedServerManager>()
+        {
+            mgr.stop_all();
+        }
+        // Stop the managed X server so no orphan vcxsrv.exe is left behind
+        // (issue #1049). Adopted external servers are untouched.
+        if let Some(mgr) = handle.try_state::<Arc<terminal::xserver::XServerManager>>() {
+            mgr.stop();
+        }
+        // Cancel all HTTP monitor poll loops so in-flight reqwest requests are
+        // aborted rather than abandoned on exit (#1147).
+        if let Some(mgr) = handle.try_state::<NetworkManager>() {
+            mgr.stop_all_http_monitors();
+        }
+        // Cancel every in-flight transfer *before* closing sessions, so no
+        // half-written file keeps a dedicated channel open during teardown
+        // (#1245).
+        if let Some(reg) = handle.try_state::<TransferRegistry>() {
+            reg.cancel_all();
+        }
+        // Close every open SFTP session so no SSH+SFTP connection is left
+        // dangling on the server until it times out (#1244).
+        if let Some(mgr) = handle.try_state::<SftpManager>() {
+            mgr.close_all();
+        }
+    });
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Pre-init CLI routing: `spawn` / `(un)install-shell-integration` must be
@@ -1005,6 +1051,54 @@ pub fn run() {
                 _ => {}
             }
 
+            // Per-OS quit policy (#1903). On macOS, closing the last window does
+            // NOT quit the app (WKWebView convention: it stays in the Dock), so
+            // an `ExitRequested` triggered by that close is prevented; an
+            // explicit quit (menu Quit / `AppHandle::exit`, `code == Some`) runs
+            // teardown and proceeds. Windows/Linux fall through to the default
+            // (quit), tearing down when the last window is destroyed below.
+            if let RunEvent::ExitRequested { code, api, .. } = &event {
+                if window::should_prevent_exit(*code) {
+                    info!("Last window closed; keeping app alive (macOS Dock) (#1903)");
+                    api.prevent_exit();
+                } else if cfg!(target_os = "macos") {
+                    // Explicit quit on macOS: teardown was deferred from the
+                    // last window's Destroyed, so run it now before exiting.
+                    info!("Explicit quit; running app-wide teardown (#1903)");
+                    run_app_teardown(app_handle);
+                }
+            }
+
+            // On macOS the app can outlive its windows; a Dock-icon click with no
+            // open windows must recreate one so the app is reachable again. The
+            // richer restore-on-reopen behaviour is #1905; this creates a fresh
+            // empty window (as a "Move to Window" / "New Window" destination).
+            #[cfg(target_os = "macos")]
+            if let RunEvent::Reopen {
+                has_visible_windows: false,
+                ..
+            } = &event
+            {
+                if app_handle.webview_windows().is_empty() {
+                    info!("Reopen with no windows; recreating a window (#1903)");
+                    if let Some(wm) = app_handle.try_state::<window::WindowManager>() {
+                        let label = wm.next_label();
+                        if let Err(e) = tauri::WebviewWindowBuilder::new(
+                            app_handle,
+                            &label,
+                            tauri::WebviewUrl::App("index.html".into()),
+                        )
+                        .title("termiHub")
+                        .inner_size(1280.0, 800.0)
+                        .min_inner_size(800.0, 600.0)
+                        .build()
+                        {
+                            tracing::error!("Failed to recreate window on reopen: {e}");
+                        }
+                    }
+                }
+            }
+
             if let RunEvent::WindowEvent {
                 label,
                 event: WindowEvent::Destroyed,
@@ -1029,8 +1123,7 @@ pub fn run() {
                 // must only run when the *last* window closes — i.e. the app is
                 // actually going away. With multi-window (#1900) a secondary window
                 // closing must not tear down resources the remaining windows still
-                // use. The detach-vs-terminate close policy is #1903; this guard is
-                // the minimal correctness floor the foundation needs.
+                // use.
                 let is_last_window = app_handle.webview_windows().is_empty();
                 if !is_last_window {
                     info!(
@@ -1040,44 +1133,19 @@ pub fn run() {
                     return;
                 }
 
-                // Spawn cleanup off the event-loop thread.  Calling emit() directly
-                // inside this handler would re-enter a RefCell that Tauri already
-                // holds mutably, causing a panic.  Running the work on the async
-                // runtime avoids that borrow while still performing the cleanup.
-                let handle = app_handle.clone();
-                tauri::async_runtime::spawn(async move {
-                    if let Some(mgr) =
-                        handle.try_state::<Arc<tunnel::tunnel_manager::TunnelManager>>()
-                    {
-                        mgr.stop_all();
-                    }
-                    if let Some(mgr) = handle
-                        .try_state::<embedded_servers::server_manager::EmbeddedServerManager>()
-                    {
-                        mgr.stop_all();
-                    }
-                    // Stop the managed X server so no orphan vcxsrv.exe is left
-                    // behind (issue #1049). Adopted external servers are untouched.
-                    if let Some(mgr) = handle.try_state::<Arc<terminal::xserver::XServerManager>>() {
-                        mgr.stop();
-                    }
-                    // Cancel all HTTP monitor poll loops so in-flight reqwest
-                    // requests are aborted rather than abandoned on exit (#1147).
-                    if let Some(mgr) = handle.try_state::<NetworkManager>() {
-                        mgr.stop_all_http_monitors();
-                    }
-                    // Cancel every in-flight transfer *before* closing sessions,
-                    // so no half-written file keeps a dedicated channel open
-                    // during teardown (#1245).
-                    if let Some(reg) = handle.try_state::<TransferRegistry>() {
-                        reg.cancel_all();
-                    }
-                    // Close every open SFTP session so no SSH+SFTP connection is
-                    // left dangling on the server until it times out (#1244).
-                    if let Some(mgr) = handle.try_state::<SftpManager>() {
-                        mgr.close_all();
-                    }
-                });
+                // Last window closed. Per-OS policy (#1903): Windows/Linux quit
+                // now, so tear down here; macOS keeps the app alive in the Dock,
+                // deferring teardown to an explicit quit (handled above in
+                // `ExitRequested`) so a reopened window still has its resources.
+                if window::should_teardown_on_last_window() {
+                    info!(window = %label, "Last window closed; running app-wide teardown (#1903)");
+                    run_app_teardown(app_handle);
+                } else {
+                    info!(
+                        window = %label,
+                        "Last window closed on macOS; app stays alive, teardown deferred (#1903)"
+                    );
+                }
             }
         });
 }

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -70,6 +70,37 @@ fn recover<T>(result: Result<T, PoisonError<T>>) -> T {
     result.unwrap_or_else(PoisonError::into_inner)
 }
 
+// ── Per-OS window-close / quit policy (#1903) ────────────────────────────────
+//
+// With one window, "window closed" ≈ "app quit". Multi-window breaks that
+// identity, so the last-window-close behaviour must follow platform convention
+// (concept: `docs/concepts/backlog/multi-window.html` → "Per-Platform
+// Constraints"). These are pure, `#[cfg]`-gated decisions so the branches are
+// unit-testable without a running event loop; `lib.rs` calls them from the
+// `RunEvent` handler.
+
+/// Whether app-wide teardown (tunnels, embedded/X servers, transfers, SFTP)
+/// should run when the **last** window is destroyed.
+///
+/// - **Windows/Linux**: closing the last window quits the app, so tear down now.
+/// - **macOS**: the app stays alive in the Dock (WKWebView convention), so
+///   teardown is deferred to an actual quit ([`should_prevent_exit`] returns
+///   `false` for an explicit exit) rather than run on window close.
+pub fn should_teardown_on_last_window() -> bool {
+    cfg!(not(target_os = "macos"))
+}
+
+/// Whether an `ExitRequested` should be prevented to keep the app running.
+///
+/// - **macOS**: a user-triggered exit (last window closed → `code == None`)
+///   keeps the app alive in the Dock; an explicit programmatic quit
+///   (`code == Some`, e.g. the app menu's Quit / `AppHandle::exit`) always
+///   proceeds.
+/// - **Windows/Linux**: never stays alive — the exit always proceeds.
+pub fn should_prevent_exit(code: Option<i32>) -> bool {
+    cfg!(target_os = "macos") && code.is_none()
+}
+
 impl WindowManager {
     /// Create an empty manager (no extra windows, nothing claimed).
     pub fn new() -> Self {
@@ -252,6 +283,31 @@ mod tests {
         wm.claim("s1", "win-1");
         assert!(wm.may_resize("s1", "win-1"));
         assert!(!wm.may_resize("s1", "main"));
+    }
+
+    #[test]
+    fn last_window_teardown_policy_is_per_os() {
+        // macOS keeps the app alive on last-window-close, so teardown is
+        // deferred; every other platform tears down when the last window goes.
+        if cfg!(target_os = "macos") {
+            assert!(!should_teardown_on_last_window());
+        } else {
+            assert!(should_teardown_on_last_window());
+        }
+    }
+
+    #[test]
+    fn prevent_exit_only_on_macos_user_triggered_close() {
+        if cfg!(target_os = "macos") {
+            // Last window closed (no explicit code) → stay alive in the Dock.
+            assert!(should_prevent_exit(None));
+            // Explicit quit (menu Quit / AppHandle::exit) → proceed.
+            assert!(!should_prevent_exit(Some(0)));
+        } else {
+            // Windows/Linux never stay alive.
+            assert!(!should_prevent_exit(None));
+            assert!(!should_prevent_exit(Some(0)));
+        }
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { LargePasteDialog } from "@/components/Terminal/LargePasteDialog";
 import { OpenSavedFileDialog } from "@/components/Terminal/OpenSavedFileDialog";
 import { ConfirmCloseTabDialog } from "@/components/Terminal/ConfirmCloseTabDialog";
 import { ConfirmSessionCloseDialog } from "@/components/Terminal/ConfirmSessionCloseDialog";
+import { CloseWindowDecisionDialog } from "@/components/Terminal/CloseWindowDecisionDialog";
 import { SessionRestoreDialog } from "@/components/SessionRestoreDialog";
 import { UpdateNotification } from "@/components/UpdateNotification/UpdateNotification";
 import { XServerConnectConsent } from "@/components/OpenConnections/XServerConnectConsent";
@@ -40,6 +41,7 @@ import { useAppStore } from "@/store/appStore";
 import { getCliWorkspace } from "@/services/workspaceApi";
 import { resolveRestoreMode } from "@/utils/restoreMode";
 import { MAIN_WINDOW_LABEL } from "@/types/window";
+import { listWindows } from "@/services/api";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { listen } from "@tauri-apps/api/event";
 import "./App.css";
@@ -257,6 +259,36 @@ function App() {
     };
   }, []);
 
+  // Multi-window (#1903): intercept this window's close so live sessions are not
+  // silently killed. `prepareWindowClose` decides: an empty or all-persistent
+  // window closes straight away (persistent sessions detach, with a toast),
+  // while a window that would lose a non-persistent session raises the
+  // detach-vs-terminate decision dialog, which destroys the window itself once
+  // the user resolves it. The backend applies the per-OS quit policy when the
+  // window is actually destroyed.
+  useEffect(() => {
+    const win = getCurrentWindow();
+    const unlistenPromise = win.onCloseRequested(async (event) => {
+      event.preventDefault();
+      let others: Awaited<ReturnType<typeof listWindows>> = [];
+      try {
+        others = (await listWindows()).filter((w) => w.label !== win.label);
+      } catch {
+        // Window listing unavailable (e.g. browser dev mode) — fall back to the
+        // no-other-windows case, which still classifies and prompts correctly.
+      }
+      const decision = await useAppStore.getState().prepareWindowClose(others);
+      if (decision === "proceed") {
+        await win.destroy();
+      }
+      // "prompt": the decision dialog is up and will destroy the window on
+      // resolve — do nothing here.
+    });
+    return () => {
+      void unlistenPromise.then((fn) => fn());
+    };
+  }, []);
+
   // Schedule update check: 5-second delay on startup, then every 24 hours.
   useEffect(() => {
     if (!settings.updates?.autoCheck && settings.updates?.autoCheck !== undefined) return;
@@ -366,6 +398,7 @@ function App() {
           <UpdateNotification />
           <ConfirmCloseTabDialog />
           <ConfirmSessionCloseDialog />
+          <CloseWindowDecisionDialog />
           <SessionRestoreDialog />
           <XServerConnectConsent />
           <ToastProvider />

--- a/src/components/Terminal/CloseWindowDecisionDialog.css
+++ b/src/components/Terminal/CloseWindowDecisionDialog.css
@@ -1,0 +1,98 @@
+/* Close-with-live-tabs decision dialog (#1903). Token-only styling; composes
+   the shared Modal + Button primitives. */
+
+.close-window-decision__lead {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: flex-start;
+  margin-bottom: var(--spacing-md);
+  color: var(--text-primary);
+}
+
+.close-window-decision__lead-icon {
+  flex: 0 0 auto;
+  width: 18px;
+  height: 18px;
+  margin-top: 1px;
+  color: var(--color-warning);
+}
+
+.close-window-decision__target {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  margin-bottom: var(--spacing-md);
+}
+
+.close-window-decision__target-label {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+}
+
+.close-window-decision__rows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.close-window-decision__row {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+  padding: var(--spacing-sm);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+}
+
+.close-window-decision__row-icon {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  color: var(--text-secondary);
+}
+
+.close-window-decision__row-name {
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.close-window-decision__row-type {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.close-window-decision__pill {
+  flex: 0 0 auto;
+  display: inline-flex;
+  gap: var(--spacing-xs);
+  align-items: center;
+  padding: 2px var(--spacing-sm);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-xs);
+  white-space: nowrap;
+}
+
+.close-window-decision__pill .li,
+.close-window-decision__row-icon.li,
+.close-window-decision__lead-icon.li {
+  width: 14px;
+  height: 14px;
+}
+
+.close-window-decision__pill--detach {
+  color: var(--color-success);
+  background: color-mix(in srgb, var(--color-success) 16%, transparent);
+}
+
+.close-window-decision__pill--terminate {
+  color: var(--color-error);
+  background: color-mix(in srgb, var(--color-error) 16%, transparent);
+}

--- a/src/components/Terminal/CloseWindowDecisionDialog.test.tsx
+++ b/src/components/Terminal/CloseWindowDecisionDialog.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import type { WindowCloseRequest } from "@/types/window";
+import { CloseWindowDecisionDialog } from "./CloseWindowDecisionDialog";
+
+const destroy = vi.fn(() => Promise.resolve());
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ destroy, label: "win-2" }),
+}));
+
+const endWindowSessions = vi.fn(() => Promise.resolve());
+const moveWindowSessionsToWindow = vi.fn(() => Promise.resolve());
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render() {
+  act(() => root.render(<CloseWindowDecisionDialog />));
+}
+
+const q = (testId: string) => document.querySelector(`[data-testid="${testId}"]`) as HTMLElement;
+const qa = (testId: string) =>
+  Array.from(document.querySelectorAll(`[data-testid="${testId}"]`)) as HTMLElement[];
+
+function request(overrides: Partial<WindowCloseRequest> = {}): WindowCloseRequest {
+  return {
+    sessions: [
+      {
+        tabId: "t1",
+        sessionId: "s1",
+        title: "server-1",
+        connectionType: "ssh",
+        contentType: "terminal",
+        outcome: "detach",
+      },
+      {
+        tabId: "t2",
+        sessionId: "s2",
+        title: "build",
+        connectionType: "local",
+        contentType: "terminal",
+        outcome: "terminate",
+      },
+    ],
+    otherWindows: [{ label: "win-1" }],
+    ...overrides,
+  };
+}
+
+describe("CloseWindowDecisionDialog (#1903)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ endWindowSessions, moveWindowSessionsToWindow });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when no close is pending", () => {
+    render();
+    expect(q("close-window-decision-dialog")).toBeNull();
+  });
+
+  it("lists per-session outcomes (detach vs terminate)", () => {
+    render();
+    act(() => useAppStore.getState().setPendingWindowClose(request()));
+
+    expect(qa("close-window-decision-row")).toHaveLength(2);
+    expect(q("close-window-decision-outcome-detach")).not.toBeNull();
+    expect(q("close-window-decision-outcome-terminate")).not.toBeNull();
+  });
+
+  it("shows Move-to-window as the primary action when another window exists", () => {
+    render();
+    act(() => useAppStore.getState().setPendingWindowClose(request()));
+
+    const move = q("close-window-decision-move");
+    expect(move).not.toBeNull();
+    // Single other window → the button names it directly.
+    expect(move.textContent).toContain("Move tabs to Window 1");
+  });
+
+  it("hides the Move action when there is no other window to move to", () => {
+    render();
+    act(() => useAppStore.getState().setPendingWindowClose(request({ otherWindows: [] })));
+
+    expect(q("close-window-decision-move")).toBeNull();
+    // The destructive action is still available.
+    expect(q("close-window-decision-end")).not.toBeNull();
+  });
+
+  it("Close & end sessions ends sessions and destroys the window", async () => {
+    render();
+    act(() => useAppStore.getState().setPendingWindowClose(request()));
+
+    await act(async () => {
+      q("close-window-decision-end").click();
+    });
+
+    expect(endWindowSessions).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().pendingWindowClose).toBeNull();
+  });
+
+  it("Move tabs re-parents sessions to the chosen window and destroys this one", async () => {
+    render();
+    act(() => useAppStore.getState().setPendingWindowClose(request()));
+
+    await act(async () => {
+      q("close-window-decision-move").click();
+    });
+
+    expect(moveWindowSessionsToWindow).toHaveBeenCalledWith({ kind: "existing", label: "win-1" });
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().pendingWindowClose).toBeNull();
+  });
+
+  it("Cancel keeps the window open (no destroy, no session teardown)", () => {
+    render();
+    act(() => useAppStore.getState().setPendingWindowClose(request()));
+
+    act(() => q("close-window-decision-cancel").click());
+
+    expect(destroy).not.toHaveBeenCalled();
+    expect(endWindowSessions).not.toHaveBeenCalled();
+    expect(useAppStore.getState().pendingWindowClose).toBeNull();
+  });
+});

--- a/src/components/Terminal/CloseWindowDecisionDialog.tsx
+++ b/src/components/Terminal/CloseWindowDecisionDialog.tsx
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { ArrowRight, Network, Plug, Power, Terminal, TriangleAlert } from "lucide-react";
+import { Button, Modal, Select } from "@/components/ui";
+import { useAppStore } from "@/store/appStore";
+import { windowDisplayName } from "@/types/window";
+import type { WindowCloseSessionRow } from "@/types/window";
+import "./CloseWindowDecisionDialog.css";
+
+/**
+ * The close-with-live-tabs decision surface (#1903, epic #1899).
+ *
+ * When the OS requests a window's close and that window still owns a
+ * non-persistent live session, {@link AppState.prepareWindowClose} raises this
+ * dialog instead of silently killing sessions. It lists each owned session with
+ * its outcome — persistent/agent sessions **detach** (keep running),
+ * non-persistent ones **would be terminated** — and offers three choices:
+ *
+ * - **Move tabs to another window** (safe primary) — re-parents every owned live
+ *   tab so nothing is lost, then closes the now-empty window. Shown only when
+ *   another window exists.
+ * - **Close & end sessions** (destructive, red) — detaches persistent sessions,
+ *   terminates non-persistent ones, then closes.
+ * - **Cancel** — keep the window open.
+ *
+ * All-persistent and empty windows never reach this dialog; they close with a
+ * toast (or silently) from {@link AppState.prepareWindowClose}.
+ */
+export function CloseWindowDecisionDialog() {
+  const request = useAppStore((s) => s.pendingWindowClose);
+  const setRequest = useAppStore((s) => s.setPendingWindowClose);
+  const endWindowSessions = useAppStore((s) => s.endWindowSessions);
+  const moveWindowSessionsToWindow = useAppStore((s) => s.moveWindowSessionsToWindow);
+  const [targetLabel, setTargetLabel] = useState<string | undefined>(undefined);
+
+  if (!request) return null;
+
+  const others = request.otherWindows;
+  const selected = targetLabel ?? others[0]?.label;
+  const canMove = others.length > 0 && Boolean(selected);
+
+  const handleCancel = () => setRequest(null);
+
+  const handleEnd = async () => {
+    await endWindowSessions();
+    setRequest(null);
+    await getCurrentWindow().destroy();
+  };
+
+  const handleMove = async () => {
+    if (!selected) return;
+    await moveWindowSessionsToWindow({ kind: "existing", label: selected });
+    setRequest(null);
+    await getCurrentWindow().destroy();
+  };
+
+  const count = request.sessions.length;
+  const moveLabel =
+    others.length === 1 && selected
+      ? `Move tabs to ${windowDisplayName(selected)}`
+      : "Move tabs";
+
+  return (
+    <Modal
+      open
+      onOpenChange={(isOpen) => !isOpen && handleCancel()}
+      title="Close this window?"
+      description="Choose what happens to this window's live sessions before it closes."
+      data-testid="close-window-decision-dialog"
+      footer={
+        <>
+          <Button
+            variant="secondary"
+            onClick={handleCancel}
+            data-testid="close-window-decision-cancel"
+          >
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={handleEnd} data-testid="close-window-decision-end">
+            <Power className="li" aria-hidden="true" /> Close &amp; end sessions
+          </Button>
+          {canMove && (
+            <Button variant="primary" onClick={handleMove} data-testid="close-window-decision-move">
+              <ArrowRight className="li" aria-hidden="true" /> {moveLabel}
+            </Button>
+          )}
+        </>
+      }
+    >
+      <div className="close-window-decision__lead">
+        <TriangleAlert className="li close-window-decision__lead-icon" aria-hidden="true" />
+        <p>
+          This window owns {count} open session{count === 1 ? "" : "s"}. Choose what happens to{" "}
+          {count === 1 ? "it" : "them"} before it closes.
+        </p>
+      </div>
+
+      {others.length > 1 && (
+        <div className="close-window-decision__target">
+          <label className="close-window-decision__target-label" htmlFor="close-window-move-target">
+            Move to
+          </label>
+          <Select
+            value={selected}
+            onChange={setTargetLabel}
+            options={others.map((w) => ({ value: w.label, label: windowDisplayName(w.label) }))}
+            aria-label="Destination window"
+            data-testid="close-window-decision-target"
+          />
+        </div>
+      )}
+
+      <div className="close-window-decision__rows">
+        {request.sessions.map((session) => (
+          <SessionRow key={session.tabId} session={session} />
+        ))}
+      </div>
+    </Modal>
+  );
+}
+
+/** One per-session row: icon, name, connection type, and the outcome pill. */
+function SessionRow({ session }: { session: WindowCloseSessionRow }) {
+  const Icon = session.connectionType === "ssh" ? Network : Terminal;
+  return (
+    <div className="close-window-decision__row" data-testid="close-window-decision-row">
+      <Icon className="li close-window-decision__row-icon" aria-hidden="true" />
+      <span className="close-window-decision__row-name">{session.title}</span>
+      <span className="close-window-decision__row-type">{session.connectionType}</span>
+      {session.outcome === "detach" ? (
+        <span
+          className="close-window-decision__pill close-window-decision__pill--detach"
+          data-testid="close-window-decision-outcome-detach"
+        >
+          <Plug className="li" aria-hidden="true" /> Detaches — keeps running
+        </span>
+      ) : (
+        <span
+          className="close-window-decision__pill close-window-decision__pill--terminate"
+          data-testid="close-window-decision-outcome-terminate"
+        >
+          <Power className="li" aria-hidden="true" /> Would be terminated
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/Terminal/CloseWindowDecisionDialog.tsx
+++ b/src/components/Terminal/CloseWindowDecisionDialog.tsx
@@ -56,9 +56,7 @@ export function CloseWindowDecisionDialog() {
 
   const count = request.sessions.length;
   const moveLabel =
-    others.length === 1 && selected
-      ? `Move tabs to ${windowDisplayName(selected)}`
-      : "Move tabs";
+    others.length === 1 && selected ? `Move tabs to ${windowDisplayName(selected)}` : "Move tabs";
 
   return (
     <Modal
@@ -97,9 +95,7 @@ export function CloseWindowDecisionDialog() {
 
       {others.length > 1 && (
         <div className="close-window-decision__target">
-          <label className="close-window-decision__target-label" htmlFor="close-window-move-target">
-            Move to
-          </label>
+          <span className="close-window-decision__target-label">Move to</span>
           <Select
             value={selected}
             onChange={setTargetLabel}

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -119,7 +119,14 @@ import {
   claimSession,
   takePendingHandoffs,
 } from "@/services/api";
-import type { MoveWindowTarget, TabHandoffRecord, HandoffTab } from "@/types/window";
+import type {
+  MoveWindowTarget,
+  TabHandoffRecord,
+  HandoffTab,
+  WindowInfo,
+  WindowCloseRequest,
+} from "@/types/window";
+import { classifyWindowCloseSessions, windowCloseWouldLoseData } from "@/utils/windowClose";
 import type {
   ConnectionTypeInfo,
   ContainerSpawn,
@@ -692,6 +699,37 @@ interface AppState {
   hydrateHandoffTab: (record: TabHandoffRecord) => void;
   /** Drain and hydrate any hand-off records queued for this window. */
   receivePendingHandoffs: () => Promise<void>;
+
+  /**
+   * Pending close-with-live-tabs decision (#1903). Non-null while the
+   * detach-vs-terminate dialog is open for this window; set by
+   * {@link prepareWindowClose} and cleared when the dialog resolves.
+   */
+  pendingWindowClose: WindowCloseRequest | null;
+  /** Set or clear the pending close-with-live-tabs decision (#1903). */
+  setPendingWindowClose: (request: WindowCloseRequest | null) => void;
+  /**
+   * Assess this window's owned live sessions when the OS requests its close
+   * (#1903) and pick the next step:
+   *
+   * - `"proceed"` — nothing would be lost: the window is empty, or every live
+   *   session is persistent/agent and is detached here (kept running) with a
+   *   toast. The caller may destroy the window.
+   * - `"prompt"` — at least one non-persistent session would be terminated, so
+   *   the decision dialog is raised ({@link pendingWindowClose}); the caller
+   *   must NOT destroy the window — the dialog resolves it.
+   */
+  prepareWindowClose: (otherWindows: WindowInfo[]) => Promise<"proceed" | "prompt">;
+  /**
+   * Destructive close outcome (#1903): detach every persistent/agent session
+   * and terminate every non-persistent one owned by this window.
+   */
+  endWindowSessions: () => Promise<void>;
+  /**
+   * Safe close outcome (#1903): re-parent every owned live session tab into
+   * another window so nothing is lost, reusing the #1900 hand-off seam.
+   */
+  moveWindowSessionsToWindow: (target: MoveWindowTarget) => Promise<void>;
 
   // Connections
   folders: ConnectionFolder[];
@@ -1700,15 +1738,29 @@ function beginRestoreGuard(setState: (partial: Partial<AppState>) => void): void
  * makes. Failures are swallowed: a best-effort close must never block the
  * launch/restore that follows.
  */
+/**
+ * Every tab across all of this window's tab groups, with the active group read
+ * from the live `rootPanel` (the inactive groups keep their snapshot tree).
+ * Used wherever a "whole window" operation must span groups — session teardown
+ * on restore/launch and the close-with-live-tabs decision (#1903).
+ */
+function collectWindowTabs(state: {
+  tabGroups: TabGroup[];
+  activeTabGroupId: string;
+  rootPanel: PanelNode;
+}): TerminalTab[] {
+  const trees = state.tabGroups.map((g) =>
+    g.id === state.activeTabGroupId ? state.rootPanel : g.rootPanel
+  );
+  return trees.flatMap((tree) => getAllLeaves(tree).flatMap((leaf) => leaf.tabs));
+}
+
 function teardownAllSessions(state: {
   tabGroups: TabGroup[];
   activeTabGroupId: string;
   rootPanel: PanelNode;
 }): void {
-  const trees = state.tabGroups.map((g) =>
-    g.id === state.activeTabGroupId ? state.rootPanel : g.rootPanel
-  );
-  const tabs = trees.flatMap((tree) => getAllLeaves(tree).flatMap((leaf) => leaf.tabs));
+  const tabs = collectWindowTabs(state);
   let closed = 0;
   for (const tab of tabs) {
     if (!tab.sessionId) continue;
@@ -2468,6 +2520,79 @@ export const useAppStore = create<AppState>((set, get) => {
           }
         }
         get().hydrateHandoffTab(record);
+      }
+    },
+
+    // ── Close-with-live-tabs decision surface (#1903) ────────────────────
+    pendingWindowClose: null,
+    setPendingWindowClose: (request) => set({ pendingWindowClose: request }),
+
+    prepareWindowClose: async (otherWindows) => {
+      const sessions = classifyWindowCloseSessions(collectWindowTabs(get()));
+      if (sessions.length === 0) {
+        // Empty window (no live sessions) — nothing to decide, just close.
+        return "proceed";
+      }
+      if (!windowCloseWouldLoseData(sessions)) {
+        // Every owned session detaches cleanly — no data is lost, so close with
+        // just a toast instead of a dialog (concept: "All-persistent → no
+        // dialog").
+        await get().endWindowSessions();
+        toast.success(
+          `${sessions.length} session${sessions.length === 1 ? "" : "s"} detached — still running`
+        );
+        return "proceed";
+      }
+      // At least one non-persistent session would be terminated — raise the
+      // detach-vs-terminate decision surface.
+      set({ pendingWindowClose: { sessions, otherWindows } });
+      return "prompt";
+    },
+
+    endWindowSessions: async () => {
+      const tabs = collectWindowTabs(get()).filter((tab) => tab.sessionId);
+      await Promise.all(
+        tabs.map((tab) => {
+          const sessionId = tab.sessionId as string;
+          return tab.persistentConnectionId
+            ? apiDetachPersistentTab(sessionId, tab.id).catch(() => {})
+            : apiCloseTerminal(sessionId).catch(() => {});
+        })
+      );
+    },
+
+    moveWindowSessionsToWindow: async (target) => {
+      const tabs = collectWindowTabs(get()).filter((tab) => tab.sessionId);
+      if (tabs.length === 0) return;
+
+      // Mark every session as moving up front so a source Terminal unmounting
+      // during the window teardown does NOT tear down the backend session — the
+      // destination window adopts each still-running session (#1900 seam).
+      const sessionIds = tabs.map((tab) => tab.sessionId as string);
+      set((state) => ({
+        movingSessionIds: Array.from(new Set([...state.movingSessionIds, ...sessionIds])),
+      }));
+
+      const records: TabHandoffRecord[] = tabs.map((tab) => ({ tab: serializeHandoffTab(tab) }));
+      try {
+        if (target.kind === "new") {
+          // Create the destination window seeded with the first tab, then queue
+          // the rest for it to drain on boot / on the nudge.
+          const label = await openWindow(records[0]);
+          for (const record of records.slice(1)) {
+            await sendHandoffToWindow(label, record);
+          }
+        } else {
+          for (const record of records) {
+            await sendHandoffToWindow(target.label, record);
+          }
+        }
+      } catch (err) {
+        // Hand-off failed: clear the moving flags so a later close still tears
+        // the sessions down rather than leaking them.
+        for (const sessionId of sessionIds) get().clearMovingSession(sessionId);
+        frontendLog("multi_window", `move window sessions failed: ${String(err)}`);
+        throw err;
       }
     },
 

--- a/src/store/appStore.windowClose.test.ts
+++ b/src/store/appStore.windowClose.test.ts
@@ -52,9 +52,7 @@ function seedLiveTab(opts: {
 }): string {
   return useAppStore.getState().addTab(opts.title, opts.connectionType, undefined, {
     sessionId: opts.sessionId,
-    ...(opts.persistentConnectionId
-      ? { persistentConnectionId: opts.persistentConnectionId }
-      : {}),
+    ...(opts.persistentConnectionId ? { persistentConnectionId: opts.persistentConnectionId } : {}),
   });
 }
 
@@ -139,18 +137,14 @@ describe("appStore — close-with-live-tabs decision (#1903)", () => {
       seedLiveTab({ title: "server-1", connectionType: "ssh", sessionId: "s1" });
       seedLiveTab({ title: "build", connectionType: "local", sessionId: "s2" });
 
-      await useAppStore
-        .getState()
-        .moveWindowSessionsToWindow({ kind: "existing", label: "win-1" });
+      await useAppStore.getState().moveWindowSessionsToWindow({ kind: "existing", label: "win-1" });
 
       expect(sendHandoffToWindow).toHaveBeenCalledTimes(2);
       const targets = sendHandoffToWindow.mock.calls.map((c) => c[0]);
       expect(targets).toEqual(["win-1", "win-1"]);
       // Both sessions are flagged moving so the source Terminals do not tear
       // them down on unmount.
-      expect(useAppStore.getState().movingSessionIds).toEqual(
-        expect.arrayContaining(["s1", "s2"])
-      );
+      expect(useAppStore.getState().movingSessionIds).toEqual(expect.arrayContaining(["s1", "s2"]));
       expect(openWindow).not.toHaveBeenCalled();
     });
 

--- a/src/store/appStore.windowClose.test.ts
+++ b/src/store/appStore.windowClose.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+// Untyped mocks so their call signatures accept any args and resolve per-test.
+const openWindow = vi.fn();
+const sendHandoffToWindow = vi.fn();
+const closeTerminal = vi.fn();
+const detachPersistentTab = vi.fn();
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  openWindow: (...args: unknown[]) => openWindow(...args),
+  sendHandoffToWindow: (...args: unknown[]) => sendHandoffToWindow(...args),
+  closeTerminal: (...args: unknown[]) => closeTerminal(...args),
+  detachPersistentTab: (...args: unknown[]) => detachPersistentTab(...args),
+}));
+
+import { useAppStore } from "./appStore";
+import type { WindowInfo } from "@/types/window";
+
+/** Seed a live tab (with a backend session) and return its tab id. */
+function seedLiveTab(opts: {
+  title: string;
+  connectionType: string;
+  sessionId: string;
+  persistentConnectionId?: string;
+}): string {
+  return useAppStore.getState().addTab(opts.title, opts.connectionType, undefined, {
+    sessionId: opts.sessionId,
+    ...(opts.persistentConnectionId
+      ? { persistentConnectionId: opts.persistentConnectionId }
+      : {}),
+  });
+}
+
+const OTHERS: WindowInfo[] = [{ label: "win-1" }];
+
+describe("appStore — close-with-live-tabs decision (#1903)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    openWindow.mockReset().mockResolvedValue("win-9");
+    sendHandoffToWindow.mockReset().mockResolvedValue(undefined);
+    closeTerminal.mockReset().mockResolvedValue(undefined);
+    detachPersistentTab.mockReset().mockResolvedValue(undefined);
+  });
+
+  describe("prepareWindowClose", () => {
+    it("proceeds with no dialog when the window has no live sessions", async () => {
+      const decision = await useAppStore.getState().prepareWindowClose(OTHERS);
+      expect(decision).toBe("proceed");
+      expect(useAppStore.getState().pendingWindowClose).toBeNull();
+    });
+
+    it("detaches silently (no dialog) when every session is persistent", async () => {
+      seedLiveTab({
+        title: "server-1",
+        connectionType: "ssh",
+        sessionId: "s1",
+        persistentConnectionId: "conn-1",
+      });
+
+      const decision = await useAppStore.getState().prepareWindowClose(OTHERS);
+
+      expect(decision).toBe("proceed");
+      expect(useAppStore.getState().pendingWindowClose).toBeNull();
+      // Persistent session detached (kept running), never terminated.
+      expect(detachPersistentTab).toHaveBeenCalledWith("s1", expect.any(String));
+      expect(closeTerminal).not.toHaveBeenCalled();
+    });
+
+    it("raises the decision dialog when a non-persistent session would be lost", async () => {
+      seedLiveTab({
+        title: "server-1",
+        connectionType: "ssh",
+        sessionId: "s1",
+        persistentConnectionId: "conn-1",
+      });
+      seedLiveTab({ title: "build", connectionType: "local", sessionId: "s2" });
+
+      const decision = await useAppStore.getState().prepareWindowClose(OTHERS);
+
+      expect(decision).toBe("prompt");
+      const pending = useAppStore.getState().pendingWindowClose;
+      expect(pending).not.toBeNull();
+      expect(pending?.otherWindows).toEqual(OTHERS);
+      const outcomes = pending?.sessions.map((s) => `${s.sessionId}:${s.outcome}`);
+      expect(outcomes).toContain("s1:detach");
+      expect(outcomes).toContain("s2:terminate");
+      // No side effects yet — the user has not decided.
+      expect(detachPersistentTab).not.toHaveBeenCalled();
+      expect(closeTerminal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("endWindowSessions", () => {
+    it("detaches persistent sessions and terminates non-persistent ones", async () => {
+      seedLiveTab({
+        title: "server-1",
+        connectionType: "ssh",
+        sessionId: "s1",
+        persistentConnectionId: "conn-1",
+      });
+      seedLiveTab({ title: "build", connectionType: "local", sessionId: "s2" });
+
+      await useAppStore.getState().endWindowSessions();
+
+      expect(detachPersistentTab).toHaveBeenCalledWith("s1", expect.any(String));
+      expect(closeTerminal).toHaveBeenCalledWith("s2");
+    });
+  });
+
+  describe("moveWindowSessionsToWindow", () => {
+    it("hands every live session off to an existing window and marks them moving", async () => {
+      seedLiveTab({ title: "server-1", connectionType: "ssh", sessionId: "s1" });
+      seedLiveTab({ title: "build", connectionType: "local", sessionId: "s2" });
+
+      await useAppStore
+        .getState()
+        .moveWindowSessionsToWindow({ kind: "existing", label: "win-1" });
+
+      expect(sendHandoffToWindow).toHaveBeenCalledTimes(2);
+      const targets = sendHandoffToWindow.mock.calls.map((c) => c[0]);
+      expect(targets).toEqual(["win-1", "win-1"]);
+      // Both sessions are flagged moving so the source Terminals do not tear
+      // them down on unmount.
+      expect(useAppStore.getState().movingSessionIds).toEqual(
+        expect.arrayContaining(["s1", "s2"])
+      );
+      expect(openWindow).not.toHaveBeenCalled();
+    });
+
+    it("creates a new window seeded with the first tab when target is new", async () => {
+      seedLiveTab({ title: "server-1", connectionType: "ssh", sessionId: "s1" });
+      seedLiveTab({ title: "build", connectionType: "local", sessionId: "s2" });
+
+      await useAppStore.getState().moveWindowSessionsToWindow({ kind: "new" });
+
+      expect(openWindow).toHaveBeenCalledTimes(1);
+      // First tab seeds the new window; the remaining tab is queued to it.
+      expect(sendHandoffToWindow).toHaveBeenCalledTimes(1);
+      expect(sendHandoffToWindow.mock.calls[0][0]).toBe("win-9");
+    });
+  });
+});

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -54,3 +54,53 @@ export interface TabHandoffRecord {
  * the foundation only provides the store action and the seam.
  */
 export type MoveWindowTarget = { kind: "new" } | { kind: "existing"; label: string };
+
+/**
+ * What would happen to one live session owned by a window being closed (#1903):
+ * a persistent/agent session `detach`es (its backend process keeps running and
+ * can be re-attached later), while a non-persistent one would be `terminate`d.
+ */
+export type WindowCloseOutcome = "detach" | "terminate";
+
+/**
+ * One live session owned by a closing window, with the outcome its close would
+ * have — the per-session row rendered in the detach-vs-terminate decision
+ * dialog (#1903).
+ */
+export interface WindowCloseSessionRow {
+  /** Owning tab id (used to detach/move the exact tab). */
+  tabId: string;
+  /** The live backend session id. */
+  sessionId: string;
+  /** Tab title, for display. */
+  title: string;
+  /** Connection type (`local`, `ssh`, `serial`, …), for display/icon. */
+  connectionType: string;
+  /** The tab's content type, for the row icon. */
+  contentType: TabContentType;
+  /** Whether this session detaches (survives) or would be terminated. */
+  outcome: WindowCloseOutcome;
+}
+
+/**
+ * A pending close-with-live-tabs decision (#1903). Raised only when at least one
+ * owned session would actually be lost (a non-persistent `terminate`); an empty
+ * or all-persistent window closes without a dialog.
+ */
+export interface WindowCloseRequest {
+  /** The live sessions owned by the window being closed, and their outcomes. */
+  sessions: WindowCloseSessionRow[];
+  /** Other open windows this window's tabs could be moved to (excludes self). */
+  otherWindows: WindowInfo[];
+}
+
+/**
+ * A friendly display name for a window label (`main` → "Main window",
+ * `win-3` → "Window 3"). The richer window picker is #1901/#1902; this is the
+ * minimal label formatter the close-decision dialog needs.
+ */
+export function windowDisplayName(label: string): string {
+  if (label === MAIN_WINDOW_LABEL) return "Main window";
+  const match = /^win-(\d+)$/.exec(label);
+  return match ? `Window ${match[1]}` : label;
+}

--- a/src/utils/windowClose.test.ts
+++ b/src/utils/windowClose.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { classifyWindowCloseSessions, windowCloseWouldLoseData } from "./windowClose";
+import type { TerminalTab } from "@/types/terminal";
+
+/** Build a minimal terminal tab for classification tests. */
+function tab(overrides: Partial<TerminalTab>): TerminalTab {
+  return {
+    id: "tab-1",
+    sessionId: "sess-1",
+    title: "shell",
+    connectionType: "local",
+    contentType: "terminal",
+    config: {} as TerminalTab["config"],
+    panelId: "panel-1",
+    isActive: true,
+    ...overrides,
+  };
+}
+
+describe("classifyWindowCloseSessions (#1903)", () => {
+  it("ignores tabs with no backend session", () => {
+    const rows = classifyWindowCloseSessions([
+      tab({ id: "t1", sessionId: null }),
+      tab({ id: "t2", sessionId: "sess-2" }),
+    ]);
+    expect(rows.map((r) => r.tabId)).toEqual(["t2"]);
+  });
+
+  it("classifies a persistent tab as detach and a non-persistent tab as terminate", () => {
+    const rows = classifyWindowCloseSessions([
+      tab({ id: "t1", sessionId: "s1", persistentConnectionId: "conn-a" }),
+      tab({ id: "t2", sessionId: "s2" }),
+    ]);
+    expect(rows.find((r) => r.tabId === "t1")?.outcome).toBe("detach");
+    expect(rows.find((r) => r.tabId === "t2")?.outcome).toBe("terminate");
+  });
+
+  it("carries display fields (title, connection type, content type) for each row", () => {
+    const [row] = classifyWindowCloseSessions([
+      tab({ id: "t1", sessionId: "s1", title: "server-1", connectionType: "ssh" }),
+    ]);
+    expect(row).toMatchObject({
+      tabId: "t1",
+      sessionId: "s1",
+      title: "server-1",
+      connectionType: "ssh",
+      contentType: "terminal",
+    });
+  });
+});
+
+describe("windowCloseWouldLoseData (#1903)", () => {
+  it("is false when there are no sessions (empty window)", () => {
+    expect(windowCloseWouldLoseData([])).toBe(false);
+  });
+
+  it("is false when every session detaches (all persistent)", () => {
+    const rows = classifyWindowCloseSessions([
+      tab({ id: "t1", sessionId: "s1", persistentConnectionId: "a" }),
+      tab({ id: "t2", sessionId: "s2", persistentConnectionId: "b" }),
+    ]);
+    expect(windowCloseWouldLoseData(rows)).toBe(false);
+  });
+
+  it("is true when at least one session would be terminated", () => {
+    const rows = classifyWindowCloseSessions([
+      tab({ id: "t1", sessionId: "s1", persistentConnectionId: "a" }),
+      tab({ id: "t2", sessionId: "s2" }),
+    ]);
+    expect(windowCloseWouldLoseData(rows)).toBe(true);
+  });
+});

--- a/src/utils/windowClose.ts
+++ b/src/utils/windowClose.ts
@@ -1,0 +1,52 @@
+/**
+ * Close-with-live-tabs classification (#1903, epic #1899).
+ *
+ * When a native window that still owns live sessions is closed, termiHub must
+ * not silently kill those sessions. Each owned session is classified by whether
+ * closing would lose it:
+ *
+ * - **persistent / agent** sessions (`persistentConnectionId` set) **detach** —
+ *   the backend process keeps running and can be re-attached later, so nothing
+ *   is lost;
+ * - **non-persistent** sessions (local shell, serial, one-shot SSH, …) would be
+ *   **terminated**.
+ *
+ * The decision surface (`CloseWindowDecisionDialog`) appears only when something
+ * would actually be lost — i.e. at least one `terminate`. See
+ * `docs/concepts/backlog/multi-window.html` → "Closing a window that owns live
+ * tabs".
+ */
+
+import type { TerminalTab } from "@/types/terminal";
+import type { WindowCloseSessionRow } from "@/types/window";
+
+/**
+ * Classify the live (session-bearing) tabs of a window into per-session close
+ * outcomes. Tabs without a backend `sessionId` are ignored (nothing to lose).
+ *
+ * Mirrors the teardown rule used when the app closes all sessions: a tab with a
+ * `persistentConnectionId` detaches (keeps running); every other live tab would
+ * be terminated.
+ */
+export function classifyWindowCloseSessions(tabs: TerminalTab[]): WindowCloseSessionRow[] {
+  return tabs
+    .filter((tab): tab is TerminalTab & { sessionId: string } => Boolean(tab.sessionId))
+    .map((tab) => ({
+      tabId: tab.id,
+      sessionId: tab.sessionId,
+      title: tab.title,
+      connectionType: tab.connectionType,
+      contentType: tab.contentType,
+      outcome: tab.persistentConnectionId ? "detach" : "terminate",
+    }));
+}
+
+/**
+ * Whether closing a window with these classified sessions would lose data —
+ * true when at least one session would be terminated. Drives the "raise the
+ * dialog only when something is lost" branch: an empty or all-persistent window
+ * closes without a prompt.
+ */
+export function windowCloseWouldLoseData(sessions: WindowCloseSessionRow[]): boolean {
+  return sessions.some((session) => session.outcome === "terminate");
+}


### PR DESCRIPTION
Part of the Multi-window epic #1899 (wave 1). Builds on the merged foundation #1900; disjoint from #1901/#1902 (this is backend `lib.rs` + a new dialog).

Closes #1903

## What

When a native window that still owns live sessions is closed, termiHub no longer silently kills those sessions — it presents a **detach-vs-terminate decision** and applies a correct **per-OS quit policy**.

### Close-with-live-tabs decision surface

- **Intercept** each window's close (`onCloseRequested` in `App.tsx`) and classify the owned live sessions: persistent/agent (`persistentConnectionId`) → **detach** (backend process keeps running, re-attachable); non-persistent (local shell, serial, one-shot SSH) → **would be terminated**.
- **Empty window** → closes with no prompt. **All-persistent** → detaches silently with a toast (`"N sessions detached — still running"`), no dialog. The decision dialog appears **only when something would actually be lost**.
- **`CloseWindowDecisionDialog`** (composed from `ui/` Modal + Button + Select) lists each session with its outcome and offers: **Move tabs to another window** (safe primary — reuses the #1900 hand-off seam so nothing is lost), **Close & end sessions** (red, destructive), **Cancel**. When multiple other windows exist a Select picks the destination; when none exist the Move action is hidden.

### Per-OS quit policy (`src-tauri/src/lib.rs` `RunEvent`)

- A **non-last** window close closes just that window and never quits the app (unchanged #1900 guard).
- **Last** window close: Windows/Linux quit (teardown runs on `Destroyed`); **macOS** stays alive in the Dock (`ExitRequested` with no code → `prevent_exit`), deferring app-wide teardown to an explicit quit, and **recreates a window on Dock reopen**. The platform branches are `#[cfg]`-gated behind two pure, unit-tested helpers (`should_teardown_on_last_window`, `should_prevent_exit`).

## Maintainer decision settled here

Per the concept, the **detach-vs-terminate default** makes **Move (safe)** the primary action and **terminate** the explicit red action — implemented as recommended.

## Tests

- `src/utils/windowClose.test.ts` — classifier (detach vs terminate; would-lose-data).
- `src/store/appStore.windowClose.test.ts` — `prepareWindowClose` (empty / all-persistent / mixed), `endWindowSessions`, `moveWindowSessionsToWindow` (existing + new window).
- `src/components/Terminal/CloseWindowDecisionDialog.test.tsx` — rows, actions, move/end/cancel wiring.
- `src-tauri/src/window/mod.rs` — per-OS teardown + prevent-exit policy gates.
- macOS is E2E-unautomatable (ADR-5): manual steps added to `docs/testing.md`.

## Notes / follow-ups

- macOS quit-policy paths are verified by manual test steps (`tauri-driver` has no WKWebView driver, ADR-5).
- Integration/native-window behaviour is not exercised in per-PR CI; verified via unit tests + documented manual steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)