### PR TITLE
feat(ui): empty-window first-class state — CTA, New Window command, status-bar affordance

### DIFF
--- a/docs/changes/dev1/feature/1902-empty-window-state.md
+++ b/docs/changes/dev1/feature/1902-empty-window-state.md
@@ -1,0 +1,13 @@
+### Added
+
+- Multi-window: the empty window is now a first-class state (epic #1899). A
+  native window that holds zero tabs — right after **New Window**, or once its
+  last tab is moved or closed — shows a deliberate call-to-action ("This window
+  is empty" with **New Terminal** and **Open Connection…** actions) instead of a
+  blank pane. The activity bar and sidebar stay mounted so a session can launch
+  straight into the window.
+- Multi-window: a top-level **New Window** command opens a fresh empty window,
+  bound to **Ctrl/Cmd+Shift+N** and reachable from the command palette.
+- Multi-window: the status bar shows the current window's name (e.g. "Window 2")
+  when more than one window is open, so windows are distinguishable at a glance
+  (#1902).

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -46,7 +46,7 @@ pub fn open_window(
     let app_for_build = app.clone();
     let label_for_build = label.clone();
     app.run_on_main_thread(move || {
-        if let Err(e) = WebviewWindowBuilder::new(
+        match WebviewWindowBuilder::new(
             &app_for_build,
             &label_for_build,
             WebviewUrl::App("index.html".into()),
@@ -56,7 +56,16 @@ pub fn open_window(
         .min_inner_size(800.0, 600.0)
         .build()
         {
-            tracing::error!("Failed to create window {label_for_build}: {e}");
+            Ok(_) => {
+                // Notify every open window that the window set changed so the
+                // status-bar affordance (#1902) can refresh its count. The
+                // matching close-side emit lives in the `Destroyed` RunEvent
+                // handler in `lib.rs`.
+                if let Err(e) = app_for_build.emit("windows-changed", ()) {
+                    tracing::warn!("Failed to emit windows-changed for {label_for_build}: {e}");
+                }
+            }
+            Err(e) => tracing::error!("Failed to create window {label_for_build}: {e}"),
         }
     })
     .map_err(|e| e.to_string())?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1037,6 +1037,16 @@ pub fn run() {
                         window = %label,
                         "Secondary window destroyed; skipping app-wide teardown (#1900)"
                     );
+                    // Notify the remaining windows that the window set shrank so
+                    // the status-bar affordance (#1902) refreshes its count.
+                    // emit() must run off the event-loop thread: calling it
+                    // directly here re-enters a RefCell Tauri already holds.
+                    let handle = app_handle.clone();
+                    tauri::async_runtime::spawn(async move {
+                        if let Err(e) = handle.emit("windows-changed", ()) {
+                            tracing::warn!("Failed to emit windows-changed on destroy: {e}");
+                        }
+                    });
                     return;
                 }
 

--- a/src/components/SplitView/EmptyWindowState.css
+++ b/src/components/SplitView/EmptyWindowState.css
@@ -1,0 +1,49 @@
+/* Empty-window first-class state (#1902). Fills the SplitView content area when
+   the window holds zero tabs, replacing the tab-bar/panel tree with a centred
+   call-to-action. */
+.empty-window {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+}
+
+.empty-window__card {
+  max-width: 380px;
+  padding: var(--spacing-xl);
+  text-align: center;
+}
+
+.empty-window__icon {
+  width: 56px;
+  height: 56px;
+  margin: 0 auto var(--spacing-md);
+  border-radius: var(--radius-lg);
+  display: grid;
+  place-items: center;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+}
+
+.empty-window__title {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  margin: 0 0 var(--spacing-xs);
+}
+
+.empty-window__sub {
+  color: var(--text-secondary);
+  margin: 0 0 var(--spacing-lg);
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+}
+
+.empty-window__actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  justify-content: center;
+  flex-wrap: wrap;
+}

--- a/src/components/SplitView/EmptyWindowState.test.tsx
+++ b/src/components/SplitView/EmptyWindowState.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { EmptyWindowState } from "./EmptyWindowState";
+
+// Standard mocks required when importing useAppStore.
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+/** Click the button carrying the given test id. */
+function clickTestId(container: HTMLElement, testid: string): void {
+  const btn = container.querySelector(`[data-testid="${testid}"]`) as HTMLButtonElement;
+  act(() => {
+    btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("EmptyWindowState (#1902)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders the empty-window call-to-action", () => {
+    act(() => root.render(<EmptyWindowState />));
+    expect(container.querySelector('[data-testid="empty-window-state"]')).not.toBeNull();
+    expect(container.textContent).toContain("This window is empty");
+    expect(container.querySelector('[data-testid="empty-window-new-terminal"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="empty-window-open-connection"]')).not.toBeNull();
+  });
+
+  it("launches a local shell into this window via New Terminal", () => {
+    const addTab = vi.fn();
+    useAppStore.setState({ addTab });
+    act(() => root.render(<EmptyWindowState />));
+
+    clickTestId(container, "empty-window-new-terminal");
+
+    expect(addTab).toHaveBeenCalledWith("Terminal", "local");
+  });
+
+  it("reveals the Connections sidebar when Open Connection is clicked", () => {
+    const setSidebarView = vi.fn();
+    // A non-connections view so the CTA action switches to Connections rather
+    // than toggling an already-open panel closed.
+    useAppStore.setState({ setSidebarView, sidebarView: "files", sidebarCollapsed: false });
+    act(() => root.render(<EmptyWindowState />));
+
+    clickTestId(container, "empty-window-open-connection");
+
+    expect(setSidebarView).toHaveBeenCalledWith("connections");
+  });
+
+  it("expands a collapsed Connections sidebar rather than toggling it shut", () => {
+    const setSidebarView = vi.fn();
+    useAppStore.setState({ setSidebarView, sidebarView: "connections", sidebarCollapsed: true });
+    act(() => root.render(<EmptyWindowState />));
+
+    clickTestId(container, "empty-window-open-connection");
+
+    // Already the active view but collapsed → still call to expand it.
+    expect(setSidebarView).toHaveBeenCalledWith("connections");
+  });
+
+  it("does not collapse the Connections sidebar when it is already open", () => {
+    const setSidebarView = vi.fn();
+    useAppStore.setState({ setSidebarView, sidebarView: "connections", sidebarCollapsed: false });
+    act(() => root.render(<EmptyWindowState />));
+
+    clickTestId(container, "empty-window-open-connection");
+
+    // Already showing Connections → do nothing (calling would toggle it shut).
+    expect(setSidebarView).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/SplitView/EmptyWindowState.tsx
+++ b/src/components/SplitView/EmptyWindowState.tsx
@@ -1,0 +1,74 @@
+import { AppWindow, Plus, Network } from "lucide-react";
+import { useAppStore } from "@/store/appStore";
+import { Button } from "@/components/ui";
+import "./EmptyWindowState.css";
+
+/**
+ * First-class empty-window call-to-action (#1902, epic #1899).
+ *
+ * A native window can exist with **zero tabs** — right after *New Window*, or
+ * after its last tab is moved or closed. Rather than an accidental blank pane,
+ * the content area shows a deliberate CTA so the window is immediately useful:
+ * start a local shell here, or open a saved connection into this window. The
+ * activity bar and sidebar stay mounted (they live outside this component), so a
+ * connection can be launched straight into the empty window.
+ *
+ * Rendered by {@link SplitView} in place of the tab-group/tab-bar tree while the
+ * window holds no tabs; both actions run against *this* window's store, so a
+ * launched session (or a tab moved in via "Move to Window") replaces the CTA
+ * with the normal tab UI.
+ */
+export function EmptyWindowState() {
+  const addTab = useAppStore((s) => s.addTab);
+
+  /** Launch a local shell into this window. */
+  const handleNewTerminal = () => {
+    addTab("Terminal", "local");
+  };
+
+  /** Reveal the Connections sidebar so a saved connection can be opened here. */
+  const handleOpenConnection = () => {
+    const { sidebarView, sidebarCollapsed, setSidebarView } = useAppStore.getState();
+    // setSidebarView toggles the sidebar closed when the view is already the
+    // active, expanded one — so only call it when it would actually reveal the
+    // Connections panel rather than collapse it.
+    if (sidebarView !== "connections" || sidebarCollapsed) {
+      setSidebarView("connections");
+    }
+  };
+
+  return (
+    <div className="empty-window" data-testid="empty-window-state">
+      <div className="empty-window__card">
+        <div className="empty-window__icon">
+          <AppWindow size={28} strokeWidth={1.5} />
+        </div>
+        <p className="empty-window__title">This window is empty</p>
+        <p className="empty-window__sub">
+          Start a session here, or move a tab in from another window with{" "}
+          <strong>Tab ▸ Move to Window</strong>.
+        </p>
+        <div className="empty-window__actions">
+          <Button
+            variant="primary"
+            size="sm"
+            icon={<Plus size={14} />}
+            onClick={handleNewTerminal}
+            data-testid="empty-window-new-terminal"
+          >
+            New Terminal
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            icon={<Network size={14} />}
+            onClick={handleOpenConnection}
+            data-testid="empty-window-open-connection"
+          >
+            Open Connection…
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -33,7 +33,7 @@ import {
 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { PanelNode, LeafPanel, TerminalTab, DropEdge } from "@/types/terminal";
-import { getAllLeaves, findLeafByTab } from "@/utils/panelTree";
+import { getAllLeaves, findLeafByTab, isWindowEmpty } from "@/utils/panelTree";
 import { getEditorTabDisplayTitle } from "@/utils/editorTabTitle";
 import { isWindows, isMac } from "@/utils/platform";
 import { usePaneFileDrop } from "@/hooks/usePaneFileDrop";
@@ -59,6 +59,7 @@ import { TerminalDisconnectOverlay } from "@/components/Terminal/TerminalDisconn
 import { TerminalViewModeBanner } from "@/components/Terminal/TerminalViewModeBanner";
 import { TerminalReconnectPrompt } from "@/components/Terminal/TerminalReconnectPrompt";
 import { PanelDropZone } from "./PanelDropZone";
+import { EmptyWindowState } from "./EmptyWindowState";
 import "./SplitView.css";
 
 export function SplitView() {
@@ -106,6 +107,15 @@ export function SplitView() {
     const allTabs = getAllLeaves(rootPanel).flatMap((leaf) => leaf.tabs);
     return getEditorTabDisplayTitle(zoomedTab, allTabs);
   }, [zoomedTab, rootPanel]);
+
+  // Empty-window first-class state (#1902): the window holds zero tabs across
+  // every tab group — right after "New Window", or after its last tab was moved
+  // or closed. When empty we render the CTA in place of the tab-bar/panel tree
+  // (see below).
+  const windowEmpty = useMemo(
+    () => isWindowEmpty(rootPanel, tabGroups, activeTabGroupId),
+    [rootPanel, tabGroups, activeTabGroupId]
+  );
 
   const dismissZoom = useCallback(() => setZoomedTabId(null), [setZoomedTabId]);
 
@@ -231,6 +241,14 @@ export function SplitView() {
       setDraggingTabId,
     ]
   );
+
+  if (windowEmpty) {
+    return (
+      <div className="split-view-groups">
+        <EmptyWindowState />
+      </div>
+    );
+  }
 
   return (
     <div className="split-view-groups">

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -15,12 +15,14 @@ import {
   ArrowUpCircle,
   Monitor,
   Highlighter,
+  AppWindow,
   Infinity as InfinityIcon,
 } from "lucide-react";
 import { useAppStore, getActiveTab, monitorKeyForTab, selectMonitor } from "@/store/appStore";
 import { resolveHighlightingConfig } from "@/services/syntaxHighlightingConfig";
 import { frontendLog } from "@/utils/frontendLog";
 import { useDesktopVersion } from "@/hooks/useDesktopVersion";
+import { useWindowInfo } from "@/hooks/useWindowInfo";
 import { summarizeAgentUpdates } from "@/utils/agentVersion";
 import { jumpHostStatusLabel } from "@/utils/jumpHost";
 import type { ConnectionTypeInfo } from "@/services/api";
@@ -105,6 +107,7 @@ export function StatusBar() {
   return (
     <div className="status-bar" data-testid="status-bar">
       <div className="status-bar__section status-bar__section--left">
+        <WindowIndicator />
         <PortableBadge />
         <JumpHostStatus />
         <RemoteDesktopStatus />
@@ -199,6 +202,28 @@ export function StatusBar() {
         )}
       </div>
     </div>
+  );
+}
+
+/**
+ * Status-bar window affordance (#1902, epic #1899).
+ *
+ * When more than one native window is open, the status bar shows this window's
+ * name (e.g. "Window 2") so windows are distinguishable at a glance. With a
+ * single window it renders nothing — there is nothing to disambiguate. The count
+ * and label come from the backend window registry (#1900), since stores are not
+ * shared across windows.
+ */
+function WindowIndicator() {
+  const { name, count } = useWindowInfo();
+
+  if (count <= 1) return null;
+
+  return (
+    <span className="status-bar__item" data-testid="status-bar-window" title={name}>
+      <AppWindow size={13} />
+      {name}
+    </span>
   );
 }
 

--- a/src/components/StatusBar/StatusBar.window.test.tsx
+++ b/src/components/StatusBar/StatusBar.window.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Tests for the status-bar window affordance (#1902).
+ *
+ * When more than one native window is open, the status bar shows the current
+ * window's name so windows are distinguishable at a glance. With a single window
+ * open it renders nothing.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { StatusBar } from "./StatusBar";
+import type { WindowInfoState } from "@/hooks/useWindowInfo";
+
+// Stub the unrelated status-bar children so the test isolates the window item.
+vi.mock("@/components/CredentialStoreIndicator", () => ({ CredentialStoreIndicator: () => null }));
+vi.mock("./PortableBadge", () => ({ PortableBadge: () => null }));
+vi.mock("./UpdateIndicator", () => ({ UpdateIndicator: () => null }));
+
+// The window registry is backend-sourced; drive it directly in the test.
+let windowInfo: WindowInfoState = { label: "main", name: "Main Window", count: 1 };
+vi.mock("@/hooks/useWindowInfo", () => ({
+  useWindowInfo: () => windowInfo,
+}));
+
+describe("StatusBar — window affordance", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    windowInfo = { label: "main", name: "Main Window", count: 1 };
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("shows nothing when only one window is open", () => {
+    windowInfo = { label: "main", name: "Main Window", count: 1 };
+    act(() => root.render(React.createElement(StatusBar)));
+    expect(container.querySelector('[data-testid="status-bar-window"]')).toBeNull();
+  });
+
+  it("shows the window name when more than one window is open", () => {
+    windowInfo = { label: "win-1", name: "Window 1", count: 2 };
+    act(() => root.render(React.createElement(StatusBar)));
+    const item = container.querySelector('[data-testid="status-bar-window"]');
+    expect(item).not.toBeNull();
+    expect(item!.textContent).toContain("Window 1");
+  });
+});

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -110,6 +110,11 @@ export function useKeyboardShortcuts() {
           useAppStore.getState().addTab("Terminal", "local");
           break;
 
+        case "new-window":
+          e.preventDefault();
+          void useAppStore.getState().openNewWindow();
+          break;
+
         case "show-shortcuts":
           e.preventDefault();
           useAppStore.getState().setShortcutsOverlayOpen(true);

--- a/src/hooks/useWindowInfo.test.tsx
+++ b/src/hooks/useWindowInfo.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Tests for {@link useWindowInfo} (#1902) — the hook that sources the current
+ * window's identity and the live count of open windows from the backend window
+ * registry (#1900), since stores are not shared across native windows.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useWindowInfo, type WindowInfoState } from "./useWindowInfo";
+
+const listWindows = vi.fn();
+vi.mock("@/services/api", () => ({
+  listWindows: (...args: unknown[]) => listWindows(...args),
+}));
+
+// getCurrentWindow / listen are stubbed globally in src/test/setup.ts.
+
+function Probe({ onState }: { onState: (s: WindowInfoState) => void }) {
+  onState(useWindowInfo());
+  return null;
+}
+
+describe("useWindowInfo", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latest: WindowInfoState;
+
+  beforeEach(() => {
+    listWindows.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("reports the current window name and a count of one before the registry resolves", async () => {
+    listWindows.mockResolvedValue([{ label: "main" }]);
+    await act(async () => {
+      root.render(<Probe onState={(s) => (latest = s)} />);
+    });
+    expect(latest.label).toBe("main");
+    expect(latest.name).toBe("Main Window");
+    expect(latest.count).toBe(1);
+  });
+
+  it("reflects the number of open windows from the registry", async () => {
+    listWindows.mockResolvedValue([{ label: "main" }, { label: "win-1" }, { label: "win-2" }]);
+    await act(async () => {
+      root.render(<Probe onState={(s) => (latest = s)} />);
+    });
+    // Flush the async refresh microtask.
+    await act(async () => {});
+    expect(latest.count).toBe(3);
+  });
+
+  it("leaves the count at one when the registry read fails", async () => {
+    listWindows.mockRejectedValue(new Error("no backend"));
+    await act(async () => {
+      root.render(<Probe onState={(s) => (latest = s)} />);
+    });
+    await act(async () => {});
+    expect(latest.count).toBe(1);
+  });
+});

--- a/src/hooks/useWindowInfo.ts
+++ b/src/hooks/useWindowInfo.ts
@@ -1,0 +1,66 @@
+import { useEffect, useMemo, useState } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { listen } from "@tauri-apps/api/event";
+import { listWindows } from "@/services/api";
+import { windowDisplayName } from "@/utils/windowPicker";
+import { MAIN_WINDOW_LABEL } from "@/types/window";
+import { frontendLog } from "@/utils/frontendLog";
+
+/** The current window's identity and the live count of open windows (#1902). */
+export interface WindowInfoState {
+  /** This window's runtime label (`main`, `win-1`, …). */
+  label: string;
+  /** Human-readable name, e.g. "Main Window" / "Window 2". */
+  name: string;
+  /** Number of native windows currently open (>= 1). */
+  count: number;
+}
+
+/**
+ * Track this window's identity and how many windows are open, sourced from the
+ * backend window registry (#1900) — stores are not shared across native windows,
+ * so the count cannot come from the frontend store.
+ *
+ * Refreshes on the backend `windows-changed` event (emitted when a window opens
+ * or is destroyed) and once on mount. Failures leave the count at its last known
+ * value; the status-bar affordance simply stays hidden until a successful read.
+ */
+export function useWindowInfo(): WindowInfoState {
+  const label = useMemo(() => {
+    try {
+      return getCurrentWindow().label;
+    } catch {
+      return MAIN_WINDOW_LABEL;
+    }
+  }, []);
+
+  const [count, setCount] = useState(1);
+
+  useEffect(() => {
+    let active = true;
+
+    const refresh = async () => {
+      try {
+        const windows = await listWindows();
+        if (active && Array.isArray(windows) && windows.length > 0) {
+          setCount(windows.length);
+        }
+      } catch (err) {
+        frontendLog("multi_window", `useWindowInfo listWindows failed: ${String(err)}`);
+      }
+    };
+
+    void refresh();
+
+    const unlistenPromise = listen<void>("windows-changed", () => {
+      void refresh();
+    });
+
+    return () => {
+      active = false;
+      void unlistenPromise.then((fn) => fn());
+    };
+  }, []);
+
+  return { label, name: windowDisplayName(label), count };
+}

--- a/src/services/commands.test.ts
+++ b/src/services/commands.test.ts
@@ -40,6 +40,8 @@ describe("buildCommands", () => {
     expect(ids).toContain("find-in-terminal");
     // …including the multi-window tear-out command (#1901)…
     expect(ids).toContain("move-tab-to-new-window");
+    // …and the top-level New Window command (#1902)…
+    expect(ids).toContain("new-window");
     // …while the palette's own shortcut has no runner and stays out.
     expect(ids).not.toContain("command-palette");
   });
@@ -50,6 +52,16 @@ describe("buildCommands", () => {
     const cmd = buildCommands().find((c) => c.id === "toggle-sidebar");
     cmd!.run();
     expect(toggleSidebar).toHaveBeenCalledOnce();
+  });
+
+  it("runs openNewWindow for the New Window command (#1902)", () => {
+    const openNewWindow = vi.fn();
+    useAppStore.setState({ openNewWindow });
+    const cmd = buildCommands().find((c) => c.id === "new-window");
+    expect(cmd).toBeDefined();
+    expect(cmd!.label).toBe("New Window");
+    cmd!.run();
+    expect(openNewWindow).toHaveBeenCalledOnce();
   });
 
   it("marks store-only commands as always available", () => {

--- a/src/services/commands.ts
+++ b/src/services/commands.ts
@@ -40,6 +40,9 @@ const STORE_RUNNERS: Record<string, () => void> = {
   "new-terminal": () => {
     useAppStore.getState().addTab("Terminal", "local");
   },
+  "new-window": () => {
+    void useAppStore.getState().openNewWindow();
+  },
   "split-right": () => useAppStore.getState().splitPanel("horizontal"),
   "split-down": () => useAppStore.getState().splitPanel("vertical"),
   "zoom-panel": () => useAppStore.getState().toggleZoomActiveTab(),

--- a/src/services/keybindings.ts
+++ b/src/services/keybindings.ts
@@ -47,6 +47,16 @@ export const DEFAULT_BINDINGS: KeyBinding[] = [
     configurable: true,
   },
   {
+    action: "new-window",
+    label: "New Window",
+    category: "general",
+    // Opens a new empty native window (#1902). Ctrl/Cmd+Shift+N does not collide
+    // with the shell key map and mirrors the familiar "new window" convention.
+    macDefault: { key: "N", meta: true, shift: true },
+    winLinuxDefault: { key: "N", ctrl: true, shift: true },
+    configurable: true,
+  },
+  {
     action: "show-shortcuts",
     label: "Keyboard Shortcuts",
     category: "general",

--- a/src/store/appStore.multiWindow.test.ts
+++ b/src/store/appStore.multiWindow.test.ts
@@ -136,6 +136,20 @@ describe("appStore — multi-window re-parenting seam (#1900)", () => {
     });
   });
 
+  describe("openNewWindow (top-level New Window command #1902)", () => {
+    it("opens an empty window with no hand-off record", async () => {
+      await useAppStore.getState().openNewWindow();
+      expect(openWindow).toHaveBeenCalledTimes(1);
+      // No hand-off: the new window boots into the empty-window CTA state.
+      expect(openWindow.mock.calls[0][0]).toBeUndefined();
+    });
+
+    it("does not throw when window creation fails", async () => {
+      openWindow.mockRejectedValueOnce(new Error("no backend"));
+      await expect(useAppStore.getState().openNewWindow()).resolves.toBeUndefined();
+    });
+  });
+
   describe("receivePendingHandoffs (boot / nudge drain)", () => {
     it("claims ownership and hydrates each queued record", async () => {
       takePendingHandoffs.mockResolvedValue([

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -692,6 +692,12 @@ interface AppState {
   hydrateHandoffTab: (record: TabHandoffRecord) => void;
   /** Drain and hydrate any hand-off records queued for this window. */
   receivePendingHandoffs: () => Promise<void>;
+  /**
+   * Open a brand-new, empty native window (no hand-off) — the top-level "New
+   * Window" command (#1902). The window boots into the empty-window CTA state.
+   * Failures are surfaced as a recoverable toast rather than thrown.
+   */
+  openNewWindow: () => Promise<void>;
 
   // Connections
   folders: ConnectionFolder[];
@@ -2468,6 +2474,18 @@ export const useAppStore = create<AppState>((set, get) => {
           }
         }
         get().hydrateHandoffTab(record);
+      }
+    },
+
+    openNewWindow: async () => {
+      // No hand-off record: the new window boots empty and shows the
+      // empty-window CTA (#1902). Window creation is a fast native op, so no
+      // pending toast — only a recoverable error toast if it fails.
+      try {
+        await openWindow();
+      } catch (err) {
+        frontendLog("multi_window", `openNewWindow failed: ${String(err)}`);
+        toast.error("Could not open a new window");
       }
     },
 

--- a/src/utils/panelTree.test.ts
+++ b/src/utils/panelTree.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import type { LeafPanel, SplitContainer, TerminalTab, PanelNode } from "@/types/terminal";
+import type {
+  LeafPanel,
+  SplitContainer,
+  TerminalTab,
+  PanelNode,
+  TabGroup,
+} from "@/types/terminal";
 import {
   createLeafPanel,
   findLeaf,
@@ -13,6 +19,8 @@ import {
   findAdjacentLeaf,
   markActiveLeaf,
   normalizeSizes,
+  countTabsInTree,
+  isWindowEmpty,
 } from "./panelTree";
 
 /** Create a minimal tab for testing. */
@@ -570,5 +578,60 @@ describe("removeLeaf with sized parent", () => {
     };
     const result = removeLeaf(root, "leaf-1");
     expect(result).toBe(leaf2);
+  });
+});
+
+/** Wrap a panel tree in a minimal TabGroup for the empty-window helpers. */
+function makeGroup(id: string, rootPanel: PanelNode): TabGroup {
+  return { id, name: id, rootPanel, activePanelId: null };
+}
+
+describe("countTabsInTree", () => {
+  it("counts zero for an empty leaf", () => {
+    expect(countTabsInTree(makeLeaf("leaf-1"))).toBe(0);
+  });
+
+  it("sums tabs across every leaf in a split tree", () => {
+    const tree = makeSplit("split-1", "horizontal", [
+      makeLeaf("leaf-1", ["a", "b"]),
+      makeLeaf("leaf-2", ["c"]),
+    ]);
+    expect(countTabsInTree(tree)).toBe(3);
+  });
+});
+
+describe("isWindowEmpty (#1902)", () => {
+  it("is empty when the active group's tree has no tabs and it is the only group", () => {
+    const active = makeLeaf("leaf-1");
+    const groups = [makeGroup("g1", active)];
+    expect(isWindowEmpty(active, groups, "g1")).toBe(true);
+  });
+
+  it("is not empty when the active group holds a tab", () => {
+    const active = makeLeaf("leaf-1", ["a"]);
+    const groups = [makeGroup("g1", active)];
+    expect(isWindowEmpty(active, groups, "g1")).toBe(false);
+  });
+
+  it("is not empty when an inactive group still holds tabs", () => {
+    const active = makeLeaf("leaf-1");
+    const inactive = makeLeaf("leaf-2", ["a"]);
+    const groups = [makeGroup("g1", active), makeGroup("g2", inactive)];
+    expect(isWindowEmpty(active, groups, "g1")).toBe(false);
+  });
+
+  it("is empty when every group across the window is empty", () => {
+    const active = makeLeaf("leaf-1");
+    const groups = [makeGroup("g1", active), makeGroup("g2", makeLeaf("leaf-2"))];
+    expect(isWindowEmpty(active, groups, "g1")).toBe(true);
+  });
+
+  it("uses the live active tree, not the stale copy stored in tabGroups", () => {
+    // The active group's stored rootPanel is stale (empty) but the live tree
+    // passed separately holds a tab — the window is not empty.
+    const liveActive = makeLeaf("leaf-1", ["a"]);
+    const staleStored = makeLeaf("leaf-1");
+    const groups = [makeGroup("g1", staleStored)];
+    expect(isWindowEmpty(liveActive, groups, "g1")).toBe(false);
   });
 });

--- a/src/utils/panelTree.test.ts
+++ b/src/utils/panelTree.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type {
-  LeafPanel,
-  SplitContainer,
-  TerminalTab,
-  PanelNode,
-  TabGroup,
-} from "@/types/terminal";
+import type { LeafPanel, SplitContainer, TerminalTab, PanelNode, TabGroup } from "@/types/terminal";
 import {
   createLeafPanel,
   findLeaf,

--- a/src/utils/panelTree.ts
+++ b/src/utils/panelTree.ts
@@ -1,6 +1,28 @@
-import { LeafPanel, PanelNode, SplitContainer, DropEdge } from "@/types/terminal";
+import { LeafPanel, PanelNode, SplitContainer, DropEdge, TabGroup } from "@/types/terminal";
 
 export type FocusDirection = "up" | "down" | "left" | "right";
+
+/** Total number of tabs across every leaf of a panel tree. */
+export function countTabsInTree(root: PanelNode): number {
+  return getAllLeaves(root).reduce((n, leaf) => n + leaf.tabs.length, 0);
+}
+
+/**
+ * Whether a native window holds zero tabs across every tab group — the
+ * empty-window first-class state (#1902). The active group's live tree is passed
+ * separately (it is authoritative over the stale copy stored in `tabGroups`);
+ * inactive groups use their stored `rootPanel`.
+ */
+export function isWindowEmpty(
+  activeRootPanel: PanelNode,
+  tabGroups: TabGroup[],
+  activeTabGroupId: string | null
+): boolean {
+  if (countTabsInTree(activeRootPanel) > 0) return false;
+  return tabGroups
+    .filter((g) => g.id !== activeTabGroupId)
+    .every((g) => countTabsInTree(g.rootPanel) === 0);
+}
 
 /** Normalize an array of sizes so they sum to exactly 100. */
 export function normalizeSizes(sizes: number[]): number[] {


### PR DESCRIPTION
Part of epic #1899 (multi-window support). Builds on the foundation #1900 and stacks additively on #1901.

## What changed

Make the **empty window a first-class state**: a native window can exist with zero tabs (right after *New Window*, or once its last tab is moved/closed) and now shows a deliberate call-to-action instead of a blank pane.

- **Empty-window CTA** — when a window holds zero tabs across every tab group, `SplitView` renders a centred "This window is empty" card with **New Terminal** (launches a local shell here) and **Open Connection…** (reveals the Connections sidebar) actions, composed from the shared `ui/Button` primitive and design tokens. The tab bar is dropped while empty; the activity bar + sidebar stay mounted so a session can launch straight into the window. The empty/non-empty transition is derived from live store state, so launching a session or moving a tab in replaces the CTA with the normal tab UI.
- **New Window command** — a top-level `new-window` keybinding action (label "New Window", **Ctrl/Cmd+Shift+N**), surfaced in the command palette and wired through a new `openNewWindow` store action that opens an empty window via the #1900 `open_window` command (no hand-off). Failures surface a recoverable toast.
- **Status-bar window affordance** — when more than one window is open, the status bar shows this window's name (e.g. "Window 2"). The count/label come from the backend window registry (#1900) via a new `useWindowInfo` hook, since stores are not shared across native windows.
- **Backend `windows-changed` event** — emitted from `open_window` (on successful build) and from the `Destroyed` `RunEvent` handler (off the event-loop thread) so the status-bar affordance refreshes its count when the window set changes.

The empty-window render condition is extracted to a pure `isWindowEmpty` helper in `panelTree.ts` for direct unit testing.

## Tests

- `panelTree.test.ts` — `countTabsInTree` + `isWindowEmpty` (zero tabs → empty, tabs in active/inactive group → not empty, live-vs-stale active tree).
- `EmptyWindowState.test.tsx` — renders the CTA; New Terminal calls `addTab`; Open Connection reveals/expands the Connections sidebar without toggling an already-open panel shut.
- `commands.test.ts` — the New Window palette command exists and runs `openNewWindow`.
- `appStore.multiWindow.test.ts` — `openNewWindow` opens an empty window (no hand-off) and swallows creation errors.
- `StatusBar.window.test.tsx` — the affordance appears only with >1 window.
- `useWindowInfo.test.tsx` — count sourced from the registry; stays 1 on read failure.

Full frontend suite (4182 tests) green; `./scripts/check.sh` passes; Rust workspace builds.

## Scope

Empty-state UI + New Window wiring + status-bar affordance only. Close/quit policy (#1903) and graphical-move (#1904) are out of scope.

Closes #1902

🤖 Generated with [Claude Code](https://claude.com/claude-code)