### PR TITLE
feat(workspace): add a window dimension to workspace / last-session persistence (Closes #1905)

### DIFF
--- a/docs/changes/dev1/feature/1905-window-persistence.md
+++ b/docs/changes/dev1/feature/1905-window-persistence.md
@@ -1,0 +1,16 @@
+# Changes
+
+## Added
+
+- **Window dimension in workspace and last-session persistence** (#1905, epic
+  #1899). Saved workspaces and the auto-saved last session now record which
+  native window owns each tab group, so a multi-window layout can survive a
+  restart. The schema addition (`windowId` per tab group and a `windows[]` set)
+  is optional and back-compatible: existing single-window saves are unchanged and
+  load into the main window exactly as before.
+
+## Notes
+
+- Restore of a multi-window session is currently non-lossy but collapses into the
+  main window; spawning and hydrating the secondary windows on restore is
+  follow-up runtime work.

--- a/src-tauri/src/workspace/config.rs
+++ b/src-tauri/src/workspace/config.rs
@@ -633,4 +633,75 @@ mod tests {
         let json = serde_json::to_string(&split).unwrap();
         assert!(!json.contains("sizes"));
     }
+
+    // ── Window dimension (#1905) ─────────────────────────────────────────
+
+    #[test]
+    fn tab_group_window_id_omitted_when_none() {
+        let group = sample_tab_group("Main", "conn-1");
+        let json = serde_json::to_string(&group).unwrap();
+        assert!(
+            !json.contains("windowId"),
+            "a main-window/legacy group omits windowId"
+        );
+    }
+
+    #[test]
+    fn tab_group_window_id_round_trips() {
+        let group = WorkspaceTabGroupDef {
+            name: "Logs".to_string(),
+            color: None,
+            layout: WorkspaceLayoutNode::Leaf { tabs: vec![] },
+            window_id: Some("win-2".to_string()),
+        };
+        let json = serde_json::to_string(&group).unwrap();
+        assert!(json.contains("\"windowId\":\"win-2\""));
+        let back: WorkspaceTabGroupDef = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.window_id.as_deref(), Some("win-2"));
+    }
+
+    #[test]
+    fn workspace_windows_round_trips() {
+        let mut ws = sample_workspace();
+        ws.windows = Some(vec![
+            WorkspaceWindowDef {
+                id: "main".to_string(),
+            },
+            WorkspaceWindowDef {
+                id: "win-1".to_string(),
+            },
+        ]);
+        ws.tab_groups[1].window_id = Some("win-1".to_string());
+        let json = serde_json::to_string(&ws).unwrap();
+        let back: WorkspaceDefinition = serde_json::from_str(&json).unwrap();
+        let windows = back.windows.expect("windows preserved");
+        assert_eq!(windows.len(), 2);
+        assert_eq!(windows[1].id, "win-1");
+        assert_eq!(back.tab_groups[1].window_id.as_deref(), Some("win-1"));
+    }
+
+    #[test]
+    fn workspace_windows_omitted_when_none() {
+        let ws = sample_workspace();
+        let json = serde_json::to_string(&ws).unwrap();
+        assert!(
+            !json.contains("\"windows\""),
+            "a single-window layout omits the windows set"
+        );
+    }
+
+    #[test]
+    fn legacy_workspace_without_window_dimension_deserializes() {
+        // A pre-multi-window save: no windowId on groups, no windows set.
+        let json = r#"{
+            "id": "ws-legacy",
+            "name": "Legacy",
+            "tabGroups": [
+                { "name": "Main", "layout": { "type": "leaf", "tabs": [] } }
+            ]
+        }"#;
+        let ws: WorkspaceDefinition = serde_json::from_str(json).unwrap();
+        assert!(ws.windows.is_none());
+        assert!(ws.tab_groups[0].window_id.is_none());
+    }
 }

--- a/src-tauri/src/workspace/config.rs
+++ b/src-tauri/src/workspace/config.rs
@@ -66,6 +66,29 @@ pub struct WorkspaceTabGroupDef {
     pub color: Option<String>,
     /// The panel layout tree for this group.
     pub layout: WorkspaceLayoutNode,
+    /// Logical id of the native window this group belongs to (multi-window
+    /// persistence, #1905), referencing a [`WorkspaceWindowDef::id`]. Omitted for
+    /// the primary window and for legacy single-window saves; an absent value
+    /// restores into the main window.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_id: Option<String>,
+}
+
+/// A native window recorded in a saved layout (multi-window persistence, #1905).
+///
+/// Windows are identified by a **logical** id referenced from
+/// [`WorkspaceTabGroupDef::window_id`]; the primary window uses the `"main"`
+/// sentinel. The id is a grouping key, not a runtime window label — restore
+/// recreates the secondary windows and maps each logical id onto a freshly
+/// allocated `win-N`. Recorded explicitly (rather than inferred from the groups)
+/// so an **empty** window — one holding zero tab groups — still survives a
+/// save/restore round trip. Legacy single-window saves omit the window
+/// dimension entirely.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceWindowDef {
+    /// Logical window id referenced by tab groups. `"main"` is the primary window.
+    pub id: String,
 }
 
 /// A complete workspace definition.
@@ -81,6 +104,11 @@ pub struct WorkspaceDefinition {
     pub description: Option<String>,
     /// The tab groups in this workspace (always at least one).
     pub tab_groups: Vec<WorkspaceTabGroupDef>,
+    /// The set of windows this layout spans, in restore order (multi-window
+    /// persistence, #1905). Absent/empty on legacy single-window saves, which
+    /// restore entirely into the main window.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub windows: Option<Vec<WorkspaceWindowDef>>,
 }
 
 /// Summary of a workspace for list display (without full layout details).
@@ -152,6 +180,10 @@ pub struct WorkspaceExportEntry {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub tab_groups: Vec<WorkspaceTabGroupDef>,
+    /// The set of windows this layout spans (multi-window persistence, #1905).
+    /// Window ids are logical (`"main"`/synthetic) and portable across machines.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub windows: Option<Vec<WorkspaceWindowDef>>,
 }
 
 /// Preview of a workspace import file.
@@ -188,6 +220,7 @@ mod tests {
                     initial_command: None,
                 }],
             },
+            window_id: None,
         }
     }
 
@@ -196,10 +229,12 @@ mod tests {
             id: "ws-1".to_string(),
             name: "Dev Setup".to_string(),
             description: Some("My daily dev layout".to_string()),
+            windows: None,
             tab_groups: vec![
                 WorkspaceTabGroupDef {
                     name: "Dev".to_string(),
                     color: None,
+                    window_id: None,
                     layout: WorkspaceLayoutNode::Split {
                         direction: SplitDirection::Horizontal,
                         children: vec![
@@ -400,6 +435,7 @@ mod tests {
             name: "Simple".to_string(),
             description: None,
             tab_groups: vec![sample_tab_group("Main", "conn-1")],
+            windows: None,
         };
         let summary = ws.to_summary();
         assert_eq!(summary.id, "ws-1");
@@ -513,6 +549,7 @@ mod tests {
             name: "Simple".to_string(),
             description: None,
             tab_groups: vec![sample_tab_group("Main", "conn-1")],
+            windows: None,
         };
         let json = serde_json::to_string(&ws).unwrap();
         assert!(!json.contains("description"));
@@ -531,6 +568,7 @@ mod tests {
             name: "Dev".to_string(),
             color: Some("#ff6b6b".to_string()),
             layout: WorkspaceLayoutNode::Leaf { tabs: vec![] },
+            window_id: None,
         };
         let json = serde_json::to_string(&group).unwrap();
         let deserialized: WorkspaceTabGroupDef = serde_json::from_str(&json).unwrap();

--- a/src-tauri/src/workspace/last_session.rs
+++ b/src-tauri/src/workspace/last_session.rs
@@ -222,6 +222,45 @@ mod tests {
     }
 
     #[test]
+    fn window_dimension_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let storage = create_test_storage(&dir);
+        let mut session = sample_session();
+        session.tab_groups[0].window_id = Some("win-1".to_string());
+        session.windows = Some(vec![
+            WorkspaceWindowDef {
+                id: "main".to_string(),
+            },
+            WorkspaceWindowDef {
+                id: "win-1".to_string(),
+            },
+        ]);
+
+        storage.save(&session).unwrap();
+        let loaded = storage.load().unwrap().unwrap();
+
+        assert_eq!(loaded, session);
+        assert_eq!(loaded.windows.unwrap().len(), 2);
+        assert_eq!(loaded.tab_groups[0].window_id.as_deref(), Some("win-1"));
+    }
+
+    #[test]
+    fn legacy_session_without_window_dimension_deserializes() {
+        // A pre-multi-window last session: no windows set, no windowId.
+        let json =
+            r#"{"version":"1","tabGroups":[{"name":"Main","layout":{"type":"leaf","tabs":[]}}]}"#;
+        let session: LastSession = serde_json::from_str(json).unwrap();
+        assert!(session.windows.is_none());
+        assert!(session.tab_groups[0].window_id.is_none());
+    }
+
+    #[test]
+    fn windows_omitted_when_none_in_json() {
+        let json = serde_json::to_string(&sample_session()).unwrap();
+        assert!(!json.contains("\"windows\""));
+    }
+
+    #[test]
     fn manager_save_empty_session_clears_file() {
         let dir = TempDir::new().unwrap();
         let storage = LastSessionStorage {

--- a/src-tauri/src/workspace/last_session.rs
+++ b/src-tauri/src/workspace/last_session.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
 
-use super::config::WorkspaceTabGroupDef;
+use super::config::{WorkspaceTabGroupDef, WorkspaceWindowDef};
 use crate::utils::config_paths::resolve_config_dir;
 
 const FILE_NAME: &str = "last-session.json";
@@ -27,6 +27,11 @@ pub struct LastSession {
     /// Index into `tab_groups` of the group that was active.
     #[serde(default)]
     pub active_group_index: usize,
+    /// The set of windows the session spanned, in restore order (multi-window
+    /// persistence, #1905). Absent/empty for a legacy single-window session,
+    /// which restores entirely into the main window.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub windows: Option<Vec<WorkspaceWindowDef>>,
 }
 
 impl LastSession {
@@ -147,9 +152,11 @@ mod tests {
             tab_groups: vec![WorkspaceTabGroupDef {
                 name: "Group 1".to_string(),
                 color: None,
+                window_id: None,
                 layout: WorkspaceLayoutNode::Leaf { tabs: vec![] },
             }],
             active_group_index: 0,
+            windows: None,
         }
     }
 
@@ -231,6 +238,7 @@ mod tests {
                 version: "1".to_string(),
                 tab_groups: vec![],
                 active_group_index: 0,
+                windows: None,
             })
             .unwrap();
 

--- a/src-tauri/src/workspace/manager.rs
+++ b/src-tauri/src/workspace/manager.rs
@@ -556,6 +556,46 @@ mod tests {
     }
 
     #[test]
+    fn window_dimension_survives_duplicate_and_export_import() {
+        use crate::workspace::config::WorkspaceWindowDef;
+
+        let dir = TempDir::new().unwrap();
+        let mgr = create_test_manager(&dir);
+
+        // A multi-window layout: the second group lives in win-1.
+        let mut def = multi_group_definition("ws-1", "Multi Window");
+        def.tab_groups[1].window_id = Some("win-1".to_string());
+        def.windows = Some(vec![
+            WorkspaceWindowDef {
+                id: "main".to_string(),
+            },
+            WorkspaceWindowDef {
+                id: "win-1".to_string(),
+            },
+        ]);
+        mgr.save_workspace(def).unwrap();
+
+        // Duplicate preserves the window dimension.
+        let new_id = mgr.duplicate_workspace("ws-1").unwrap();
+        let dup = mgr.load_workspace(&new_id).unwrap();
+        assert_eq!(dup.windows.as_ref().unwrap().len(), 2);
+        assert_eq!(dup.tab_groups[1].window_id.as_deref(), Some("win-1"));
+
+        // Export then re-import into a fresh manager preserves it too.
+        let json = mgr.export_json(&HashMap::new()).unwrap();
+        assert!(json.contains("\"windowId\""));
+        assert!(json.contains("\"windows\""));
+
+        let dir2 = TempDir::new().unwrap();
+        let mgr2 = create_test_manager(&dir2);
+        mgr2.import_json(&json, &HashMap::new()).unwrap();
+        let imported = mgr2.get_workspaces().unwrap();
+        let ws = mgr2.load_workspace(&imported[0].id).unwrap();
+        assert_eq!(ws.windows.as_ref().unwrap().len(), 2);
+        assert_eq!(ws.tab_groups[1].window_id.as_deref(), Some("win-1"));
+    }
+
+    #[test]
     fn export_replaces_ids_with_names() {
         let dir = TempDir::new().unwrap();
         let mgr = create_test_manager(&dir);

--- a/src-tauri/src/workspace/manager.rs
+++ b/src-tauri/src/workspace/manager.rs
@@ -135,6 +135,7 @@ impl WorkspaceManager {
             name: format!("Copy of {}", original.name),
             description: original.description,
             tab_groups: original.tab_groups,
+            windows: original.windows,
         };
 
         store.workspaces.push(duplicate);
@@ -170,8 +171,10 @@ impl WorkspaceManager {
                         name: g.name.clone(),
                         color: g.color.clone(),
                         layout: replace_connection_ids_with_names(&g.layout, id_to_name),
+                        window_id: g.window_id.clone(),
                     })
                     .collect(),
+                windows: ws.windows.clone(),
             })
             .collect();
 
@@ -224,8 +227,10 @@ impl WorkspaceManager {
                         name: g.name,
                         color: g.color,
                         layout: resolve_connection_names_to_ids(&g.layout, name_to_id),
+                        window_id: g.window_id,
                     })
                     .collect(),
+                windows: entry.windows,
             };
 
             store.workspaces.push(definition);
@@ -348,9 +353,11 @@ mod tests {
             id: id.to_string(),
             name: name.to_string(),
             description: None,
+            windows: None,
             tab_groups: vec![WorkspaceTabGroupDef {
                 name: "Main".to_string(),
                 color: None,
+                window_id: None,
                 layout: WorkspaceLayoutNode::Leaf {
                     tabs: vec![WorkspaceTabDef {
                         connection_ref: Some("conn-1".to_string()),
@@ -369,10 +376,12 @@ mod tests {
             id: id.to_string(),
             name: name.to_string(),
             description: None,
+            windows: None,
             tab_groups: vec![
                 WorkspaceTabGroupDef {
                     name: "Dev".to_string(),
                     color: None,
+                    window_id: None,
                     layout: WorkspaceLayoutNode::Leaf {
                         tabs: vec![WorkspaceTabDef {
                             connection_ref: Some("conn-1".to_string()),
@@ -386,6 +395,7 @@ mod tests {
                 WorkspaceTabGroupDef {
                     name: "Deploy".to_string(),
                     color: Some("#ff6b6b".to_string()),
+                    window_id: None,
                     layout: WorkspaceLayoutNode::Leaf {
                         tabs: vec![WorkspaceTabDef {
                             connection_ref: Some("conn-2".to_string()),
@@ -448,9 +458,11 @@ mod tests {
             id: "ws-1".to_string(),
             name: "Test".to_string(),
             description: Some("desc".to_string()),
+            windows: None,
             tab_groups: vec![WorkspaceTabGroupDef {
                 name: "Main".to_string(),
                 color: None,
+                window_id: None,
                 layout: WorkspaceLayoutNode::Split {
                     direction: SplitDirection::Horizontal,
                     children: vec![

--- a/src/store/appStore.lastSession.test.ts
+++ b/src/store/appStore.lastSession.test.ts
@@ -52,6 +52,7 @@ vi.mock("@/components/ui", () => ({
 import { useAppStore } from "./appStore";
 import { saveLastSession, loadLastSession, clearLastSession } from "@/services/lastSessionApi";
 import { toast } from "@/components/ui";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { LastSession } from "@/types/lastSession";
 import { getAllLeaves } from "@/utils/panelTree";
 
@@ -59,6 +60,7 @@ const mockSave = vi.mocked(saveLastSession);
 const mockLoad = vi.mocked(loadLastSession);
 const mockClear = vi.mocked(clearLastSession);
 const mockToast = vi.mocked(toast);
+const mockCurrentWindow = vi.mocked(getCurrentWindow);
 
 describe("last session persistence", () => {
   beforeEach(() => {
@@ -112,6 +114,53 @@ describe("last session persistence", () => {
 
       const payload = mockSave.mock.calls[0][0] as LastSession;
       expect(payload.tabGroups).toHaveLength(0);
+    });
+  });
+
+  // Window dimension (#1905): the save path stamps the capturing window and the
+  // restore path is non-lossy for a multi-window session.
+  describe("window dimension", () => {
+    it("omits windowId and windows for the main window (legacy shape)", async () => {
+      await useAppStore.getState().saveLastSession();
+
+      const payload = mockSave.mock.calls[0][0] as LastSession;
+      expect(payload.windows).toBeUndefined();
+      expect(payload.tabGroups.every((g) => g.windowId === undefined)).toBe(true);
+    });
+
+    it("stamps the capturing window and records windows[] for a secondary window", async () => {
+      mockCurrentWindow.mockReturnValueOnce({
+        label: "win-2",
+      } as unknown as ReturnType<typeof getCurrentWindow>);
+
+      await useAppStore.getState().saveLastSession();
+
+      const payload = mockSave.mock.calls[0][0] as LastSession;
+      expect(payload.tabGroups.every((g) => g.windowId === "win-2")).toBe(true);
+      expect(payload.windows).toEqual([{ id: "win-2" }]);
+    });
+
+    it("restores a multi-window session non-lossily (all groups, main first)", async () => {
+      // A saved session spanning main (group A) + win-1 (group B).
+      const leaf = (title: string) => ({
+        type: "leaf" as const,
+        tabs: [{ inlineConfig: { type: "local", config: { shell: "bash" } }, title }],
+      });
+      mockLoad.mockResolvedValue({
+        version: "1",
+        activeGroupIndex: 0,
+        tabGroups: [
+          { name: "A", layout: leaf("a") },
+          { name: "B", layout: leaf("b"), windowId: "win-1" },
+        ],
+        windows: [{ id: "main" }, { id: "win-1" }],
+      });
+
+      const ok = await useAppStore.getState().restoreLastSession();
+
+      expect(ok).toBe(true);
+      const groups = useAppStore.getState().tabGroups;
+      expect(groups.map((g) => g.name)).toEqual(["A", "B"]);
     });
   });
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -126,6 +126,14 @@ import type {
   WindowInfo,
   WindowCloseRequest,
 } from "@/types/window";
+import { MAIN_WINDOW_LABEL } from "@/types/window";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import {
+  stampWindowId,
+  buildWindowsMeta,
+  planWindowRestore,
+  hasWindowDimension,
+} from "@/utils/windowPersistence";
 import { classifyWindowCloseSessions, windowCloseWouldLoseData } from "@/utils/windowClose";
 import type {
   ConnectionTypeInfo,
@@ -1702,6 +1710,20 @@ function generateWorkflowId(): string {
 let layoutPersistTimer: ReturnType<typeof setTimeout> | null = null;
 /** Debounce timer for auto-saving the last session on layout changes. */
 let lastSessionPersistTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * The runtime label of the window this store belongs to (multi-window
+ * persistence, #1905), used to stamp captured tab groups with their owning
+ * window. Falls back to {@link MAIN_WINDOW_LABEL} when the Tauri window API is
+ * unavailable (e.g. browser dev mode) so capture never throws.
+ */
+function currentWindowLabel(): string {
+  try {
+    return getCurrentWindow().label;
+  } catch {
+    return MAIN_WINDOW_LABEL;
+  }
+}
 const LAST_SESSION_SAVE_DEBOUNCE_MS = 500;
 /**
  * Settle timer for the restore-in-progress guard (GAP G5, #1146). After a
@@ -7190,8 +7212,19 @@ export const useAppStore = create<AppState>((set, get) => {
                 state.rootPanel,
                 state.connections
               );
+        // Window dimension (#1905): record which window owns each group so a
+        // saved multi-window layout restores its window arrangement. For the
+        // single main-window store this omits the dimension (legacy shape).
+        const stampedGroups = stampWindowId(tabGroups, currentWindowLabel());
+        const windows = buildWindowsMeta(stampedGroups);
         const id = `ws-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
-        await apiSaveWorkspace({ id, name, description, tabGroups });
+        await apiSaveWorkspace({
+          id,
+          name,
+          description,
+          tabGroups: stampedGroups,
+          ...(windows ? { windows } : {}),
+        });
         await get().loadWorkspaces();
         set({ activeWorkspaceName: name });
       } catch (err) {
@@ -7223,11 +7256,18 @@ export const useAppStore = create<AppState>((set, get) => {
         0,
         state.tabGroups.findIndex((g) => g.id === state.activeTabGroupId)
       );
+      // Window dimension (#1905): stamp which window owns each captured group so
+      // a multi-window session restores its window arrangement. For the main
+      // window (the only store today) this omits windowId and the windows set,
+      // keeping the payload identical to the legacy single-window shape.
+      const stampedGroups = stampWindowId(tabGroups, currentWindowLabel());
+      const windows = buildWindowsMeta(stampedGroups);
       try {
         await apiSaveLastSession({
           version: "1",
-          tabGroups: totalTabs > 0 ? tabGroups : [],
+          tabGroups: totalTabs > 0 ? stampedGroups : [],
           activeGroupIndex,
+          ...(totalTabs > 0 && windows ? { windows } : {}),
         });
       } catch (err) {
         console.error("Failed to save last session:", err);
@@ -7268,8 +7308,23 @@ export const useAppStore = create<AppState>((set, get) => {
           })),
           definitions: state.agentDefinitions,
         };
+        // Window dimension (#1905): partition the saved groups by window. Spawning
+        // and hydrating the secondary native windows is cross-window runtime owned
+        // by the epic's runtime work; until it lands, restore is deliberately
+        // NON-LOSSY — every window's groups are restored (plan order, main first)
+        // into this main window rather than dropped. A legacy session has a single
+        // main entry, so this is a no-op there.
+        const plan = planWindowRestore(session.tabGroups, session.windows);
+        if (hasWindowDimension(session.tabGroups, session.windows)) {
+          frontendLog(
+            "multi_window",
+            `restoreLastSession: ${plan.length} saved windows collapsed into the main ` +
+              `window (multi-window spawn-on-restore not yet wired)`
+          );
+        }
+        const orderedGroups = plan.flatMap((entry) => entry.tabGroups);
         const builtGroups = buildTabGroupsFromWorkspace(
-          session.tabGroups,
+          orderedGroups,
           state.connections,
           state.defaultShell,
           agentContext

--- a/src/types/lastSession.ts
+++ b/src/types/lastSession.ts
@@ -1,4 +1,4 @@
-import { WorkspaceTabGroupDef } from "@/types/workspace";
+import { WorkspaceTabGroupDef, WorkspaceWindowDef } from "@/types/workspace";
 
 /**
  * The automatically persisted "last session": the open tab groups and their
@@ -15,4 +15,10 @@ export interface LastSession {
   tabGroups: WorkspaceTabGroupDef[];
   /** Index into {@link tabGroups} of the group that was active. */
   activeGroupIndex: number;
+  /**
+   * The set of windows the session spanned, in restore order (multi-window
+   * persistence, #1905). Absent/empty for a legacy single-window session, which
+   * restores entirely into the main window.
+   */
+  windows?: WorkspaceWindowDef[];
 }

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -38,6 +38,30 @@ export interface WorkspaceTabGroupDef {
   color?: string;
   /** The panel layout tree for this group. */
   layout: WorkspaceLayoutNode;
+  /**
+   * Logical id of the native window this group belongs to (multi-window
+   * persistence, #1905), referencing a {@link WorkspaceWindowDef.id}. Omitted
+   * for the primary window and for legacy single-window saves — an absent value
+   * restores into the main window (see `MAIN_WINDOW_LABEL`).
+   */
+  windowId?: string;
+}
+
+/**
+ * A native window recorded in a saved layout (multi-window persistence, #1905).
+ *
+ * Windows are identified by a **logical** id referenced from
+ * {@link WorkspaceTabGroupDef.windowId}; the primary window uses the
+ * `MAIN_WINDOW_LABEL` sentinel (`"main"`). The id is a grouping key, not a
+ * runtime window label — restore recreates the secondary windows and maps each
+ * logical id onto a freshly allocated `win-N`. Recorded explicitly (rather than
+ * inferred from the groups) so that an **empty** window — one holding zero tab
+ * groups, the #1902 empty-window state — still survives a save/restore round
+ * trip. Legacy single-window saves omit the window dimension entirely.
+ */
+export interface WorkspaceWindowDef {
+  /** Logical window id referenced by tab groups. `"main"` is the primary window. */
+  id: string;
 }
 
 /** A complete workspace definition. */
@@ -47,6 +71,12 @@ export interface WorkspaceDefinition {
   description?: string;
   /** The tab groups in this workspace (always at least one). */
   tabGroups: WorkspaceTabGroupDef[];
+  /**
+   * The set of windows this layout spans, in restore order (multi-window
+   * persistence, #1905). Absent/empty on legacy single-window saves, which
+   * restore entirely into the main window.
+   */
+  windows?: WorkspaceWindowDef[];
 }
 
 /** Summary of a workspace for list display. */

--- a/src/utils/windowPersistence.test.ts
+++ b/src/utils/windowPersistence.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "vitest";
+import {
+  stampWindowId,
+  buildWindowsMeta,
+  collectWindowIds,
+  hasWindowDimension,
+  planWindowRestore,
+} from "./windowPersistence";
+import { MAIN_WINDOW_LABEL } from "@/types/window";
+import type { WorkspaceTabGroupDef } from "@/types/workspace";
+
+/** A minimal leaf group for tests. */
+function group(name: string, windowId?: string): WorkspaceTabGroupDef {
+  return {
+    name,
+    layout: { type: "leaf", tabs: [] },
+    ...(windowId ? { windowId } : {}),
+  };
+}
+
+describe("stampWindowId", () => {
+  it("omits windowId for the main window (legacy-compatible shape)", () => {
+    const stamped = stampWindowId([group("A"), group("B")], MAIN_WINDOW_LABEL);
+    expect(stamped.every((g) => g.windowId === undefined)).toBe(true);
+    expect("windowId" in stamped[0]).toBe(false);
+  });
+
+  it("stamps a secondary window id onto every group", () => {
+    const stamped = stampWindowId([group("A"), group("B")], "win-1");
+    expect(stamped.map((g) => g.windowId)).toEqual(["win-1", "win-1"]);
+  });
+
+  it("overwrites a stale windowId when re-stamping to main", () => {
+    const stamped = stampWindowId([group("A", "win-9")], MAIN_WINDOW_LABEL);
+    expect("windowId" in stamped[0]).toBe(false);
+  });
+
+  it("overwrites a stale windowId when re-stamping to another window", () => {
+    const stamped = stampWindowId([group("A", "win-1")], "win-2");
+    expect(stamped[0].windowId).toBe("win-2");
+  });
+
+  it("does not mutate the input groups", () => {
+    const input = [group("A")];
+    stampWindowId(input, "win-1");
+    expect(input[0].windowId).toBeUndefined();
+  });
+});
+
+describe("collectWindowIds", () => {
+  it("returns just main when every group is unassigned", () => {
+    expect(collectWindowIds([group("A"), group("B")])).toEqual([MAIN_WINDOW_LABEL]);
+  });
+
+  it("lists main first then secondary windows in first-appearance order", () => {
+    const groups = [group("A", "win-2"), group("B"), group("C", "win-1"), group("D", "win-2")];
+    expect(collectWindowIds(groups)).toEqual([MAIN_WINDOW_LABEL, "win-2", "win-1"]);
+  });
+
+  it("omits main when no group lives in it", () => {
+    expect(collectWindowIds([group("A", "win-1"), group("B", "win-1")])).toEqual(["win-1"]);
+  });
+
+  it("returns main for an empty group list", () => {
+    expect(collectWindowIds([])).toEqual([MAIN_WINDOW_LABEL]);
+  });
+});
+
+describe("buildWindowsMeta", () => {
+  it("is undefined for a single main window (legacy shape)", () => {
+    expect(buildWindowsMeta([group("A"), group("B")])).toBeUndefined();
+  });
+
+  it("lists every window when the layout spans more than one", () => {
+    const meta = buildWindowsMeta([group("A"), group("B", "win-1")]);
+    expect(meta).toEqual([{ id: MAIN_WINDOW_LABEL }, { id: "win-1" }]);
+  });
+
+  it("preserves an empty window (owns no groups) via extraWindowIds", () => {
+    // win-2 holds no tab group but must still round-trip (#1902 empty window).
+    const meta = buildWindowsMeta([group("A"), group("B", "win-1")], ["win-2"]);
+    expect(meta).toEqual([{ id: MAIN_WINDOW_LABEL }, { id: "win-1" }, { id: "win-2" }]);
+  });
+
+  it("ignores an extra id that already owns groups and drops an extra main", () => {
+    const meta = buildWindowsMeta([group("A", "win-1")], ["win-1", MAIN_WINDOW_LABEL]);
+    expect(meta).toEqual([{ id: "win-1" }]);
+  });
+});
+
+describe("hasWindowDimension", () => {
+  it("is false for a legacy layout", () => {
+    expect(hasWindowDimension([group("A"), group("B")])).toBe(false);
+  });
+
+  it("is true when a group carries a secondary windowId", () => {
+    expect(hasWindowDimension([group("A"), group("B", "win-1")])).toBe(true);
+  });
+
+  it("is true when windows[] declares a secondary window even with no assigned group", () => {
+    expect(hasWindowDimension([group("A")], [{ id: MAIN_WINDOW_LABEL }, { id: "win-3" }])).toBe(
+      true
+    );
+  });
+
+  it("is false when windows[] holds only main", () => {
+    expect(hasWindowDimension([group("A")], [{ id: MAIN_WINDOW_LABEL }])).toBe(false);
+  });
+});
+
+describe("planWindowRestore", () => {
+  it("puts every group into the main window for a legacy layout", () => {
+    const plan = planWindowRestore([group("A"), group("B")]);
+    expect(plan).toHaveLength(1);
+    expect(plan[0].windowId).toBe(MAIN_WINDOW_LABEL);
+    expect(plan[0].isMain).toBe(true);
+    expect(plan[0].tabGroups.map((g) => g.name)).toEqual(["A", "B"]);
+  });
+
+  it("partitions groups by window, main first", () => {
+    const groups = [group("A"), group("B", "win-1"), group("C", "win-1"), group("D", "win-2")];
+    const plan = planWindowRestore(groups, [
+      { id: MAIN_WINDOW_LABEL },
+      { id: "win-1" },
+      { id: "win-2" },
+    ]);
+    expect(plan.map((e) => e.windowId)).toEqual([MAIN_WINDOW_LABEL, "win-1", "win-2"]);
+    expect(plan[0].tabGroups.map((g) => g.name)).toEqual(["A"]);
+    expect(plan[1].tabGroups.map((g) => g.name)).toEqual(["B", "C"]);
+    expect(plan[2].tabGroups.map((g) => g.name)).toEqual(["D"]);
+    expect(plan.map((e) => e.isMain)).toEqual([true, false, false]);
+  });
+
+  it("preserves an empty declared window as an entry with no groups", () => {
+    const plan = planWindowRestore(
+      [group("A"), group("B", "win-1")],
+      [{ id: MAIN_WINDOW_LABEL }, { id: "win-1" }, { id: "win-2" }]
+    );
+    const empty = plan.find((e) => e.windowId === "win-2");
+    expect(empty).toBeDefined();
+    expect(empty?.tabGroups).toEqual([]);
+  });
+
+  it("honours the declared window order over first-appearance order", () => {
+    const groups = [group("A", "win-2"), group("B", "win-1")];
+    const plan = planWindowRestore(groups, [
+      { id: MAIN_WINDOW_LABEL },
+      { id: "win-1" },
+      { id: "win-2" },
+    ]);
+    expect(plan.map((e) => e.windowId)).toEqual([MAIN_WINDOW_LABEL, "win-1", "win-2"]);
+  });
+
+  it("falls back to first-appearance order for windows not declared", () => {
+    const groups = [group("A", "win-2"), group("B", "win-1")];
+    const plan = planWindowRestore(groups);
+    // main is always synthesised first even when it owns no groups.
+    expect(plan.map((e) => e.windowId)).toEqual([MAIN_WINDOW_LABEL, "win-2", "win-1"]);
+    expect(plan[0].tabGroups).toEqual([]);
+  });
+
+  it("round-trips a stamped capture back into the same partition", () => {
+    const captured = [
+      ...stampWindowId([group("A"), group("B")], MAIN_WINDOW_LABEL),
+      ...stampWindowId([group("C")], "win-1"),
+    ];
+    const windows = buildWindowsMeta(captured);
+    const plan = planWindowRestore(captured, windows);
+    expect(plan.map((e) => e.windowId)).toEqual([MAIN_WINDOW_LABEL, "win-1"]);
+    expect(plan[0].tabGroups.map((g) => g.name)).toEqual(["A", "B"]);
+    expect(plan[1].tabGroups.map((g) => g.name)).toEqual(["C"]);
+  });
+});

--- a/src/utils/windowPersistence.ts
+++ b/src/utils/windowPersistence.ts
@@ -1,0 +1,162 @@
+/**
+ * Window-dimension persistence helpers (#1905, epic #1899).
+ *
+ * Workspace save/restore and last-session restore capture `tabGroups[]` with a
+ * layout tree but historically had **no window field** — a restored layout had
+ * nowhere to record "this group is in window 2". These pure helpers add that
+ * dimension on top of the existing capture/restore utilities:
+ *
+ * - {@link stampWindowId} / {@link buildWindowsMeta} record which window owns
+ *   each captured group (the **save** side).
+ * - {@link planWindowRestore} partitions saved groups back into per-window
+ *   restore entries (the **restore** side).
+ *
+ * The persisted `windowId` is a **logical grouping key**, not a runtime window
+ * label: the primary window uses the {@link MAIN_WINDOW_LABEL} sentinel and its
+ * groups omit the field, so a single-window save is byte-identical to the legacy
+ * schema and a legacy save (no window dimension) restores entirely into the main
+ * window. See `docs/concepts/backlog/multi-window.html` → "Persistence &
+ * lifecycle have no window dimension".
+ */
+
+import { MAIN_WINDOW_LABEL } from "@/types/window";
+import type { WorkspaceTabGroupDef, WorkspaceWindowDef } from "@/types/workspace";
+
+/** One native window's slice of a restored layout. */
+export interface WindowRestorePlanEntry {
+  /** Logical window id (`MAIN_WINDOW_LABEL` for the primary window). */
+  windowId: string;
+  /** Whether this is the primary window (reused rather than spawned on restore). */
+  isMain: boolean;
+  /** The tab groups assigned to this window, in their saved order. */
+  tabGroups: WorkspaceTabGroupDef[];
+}
+
+/** The logical window a group is assigned to, defaulting an absent id to main. */
+function groupWindowId(group: WorkspaceTabGroupDef): string {
+  return group.windowId ?? MAIN_WINDOW_LABEL;
+}
+
+/**
+ * Stamp a `windowId` onto each captured group so a multi-window layout records
+ * which window owns it.
+ *
+ * The main window's id is deliberately **omitted** (left `undefined`): this
+ * keeps single-window and primary-window saves identical to the legacy schema,
+ * and pairs with {@link planWindowRestore} treating an absent id as the main
+ * window. Any existing `windowId` is overwritten so re-capturing a group after a
+ * cross-window move records its new owner.
+ */
+export function stampWindowId(
+  groups: WorkspaceTabGroupDef[],
+  windowId: string
+): WorkspaceTabGroupDef[] {
+  const isMain = windowId === MAIN_WINDOW_LABEL;
+  return groups.map((group) => {
+    if (isMain) {
+      // Drop any stale windowId so a group moved back to main serializes clean.
+      const { windowId: _omit, ...rest } = group;
+      return rest;
+    }
+    return { ...group, windowId };
+  });
+}
+
+/**
+ * The distinct logical window ids across a set of captured groups, in a stable
+ * order: the main window first, then every secondary window in first-appearance
+ * order. Groups with no `windowId` count as the main window.
+ */
+export function collectWindowIds(groups: WorkspaceTabGroupDef[]): string[] {
+  const ordered: string[] = [];
+  let sawMain = false;
+  for (const group of groups) {
+    const id = groupWindowId(group);
+    if (id === MAIN_WINDOW_LABEL) {
+      sawMain = true;
+      continue;
+    }
+    if (!ordered.includes(id)) ordered.push(id);
+  }
+  // Main is listed first whenever any group lives in it (or nothing is secondary).
+  if (sawMain || ordered.length === 0) return [MAIN_WINDOW_LABEL, ...ordered];
+  return ordered;
+}
+
+/**
+ * Build the `windows[]` metadata for a captured layout, or `undefined` when the
+ * layout is a single main window (the legacy shape — no window dimension is
+ * written).
+ *
+ * `extraWindowIds` records windows that own **no** tab groups (the #1902
+ * empty-window state); without it an empty window would vanish because no group
+ * carries its id. Empty windows are appended after the windows that do own
+ * groups, in the given order.
+ */
+export function buildWindowsMeta(
+  groups: WorkspaceTabGroupDef[],
+  extraWindowIds: string[] = []
+): WorkspaceWindowDef[] | undefined {
+  const ids = collectWindowIds(groups);
+  for (const id of extraWindowIds) {
+    if (id !== MAIN_WINDOW_LABEL && !ids.includes(id)) ids.push(id);
+  }
+  // Only main and nothing else → legacy single-window layout; omit the dimension.
+  if (ids.length === 1 && ids[0] === MAIN_WINDOW_LABEL) return undefined;
+  return ids.map((id) => ({ id }));
+}
+
+/**
+ * Whether a saved layout carries a window dimension worth acting on (more than
+ * the implicit main window).
+ */
+export function hasWindowDimension(
+  groups: WorkspaceTabGroupDef[],
+  windows?: WorkspaceWindowDef[]
+): boolean {
+  if (windows && windows.some((w) => w.id !== MAIN_WINDOW_LABEL)) return true;
+  return groups.some((g) => g.windowId != null && g.windowId !== MAIN_WINDOW_LABEL);
+}
+
+/**
+ * Partition saved tab groups into per-window restore entries so the restore
+ * lifecycle can recreate the saved windows and re-parent each group into its
+ * window.
+ *
+ * Ordering: the main window is always first; secondary windows follow the
+ * explicit `windows[]` order when present, then any window seen only on a group
+ * (not in `windows[]`) in first-appearance order. An entry from `windows[]` that
+ * owns no groups is preserved as an **empty** window so the #1902 empty-window
+ * state round-trips. A layout with no window dimension yields a single main
+ * entry holding every group — the legacy/back-compat path.
+ */
+export function planWindowRestore(
+  groups: WorkspaceTabGroupDef[],
+  windows?: WorkspaceWindowDef[]
+): WindowRestorePlanEntry[] {
+  // Group the saved tab groups by their logical window id.
+  const byWindow = new Map<string, WorkspaceTabGroupDef[]>();
+  for (const group of groups) {
+    const id = groupWindowId(group);
+    const bucket = byWindow.get(id);
+    if (bucket) bucket.push(group);
+    else byWindow.set(id, [group]);
+  }
+
+  // Establish the window order: main first, then declared windows, then any
+  // window that only appears on a group.
+  const order: string[] = [MAIN_WINDOW_LABEL];
+  const pushUnique = (id: string) => {
+    if (!order.includes(id)) order.push(id);
+  };
+  if (windows) {
+    for (const w of windows) pushUnique(w.id);
+  }
+  for (const id of byWindow.keys()) pushUnique(id);
+
+  return order.map((windowId) => ({
+    windowId,
+    isMain: windowId === MAIN_WINDOW_LABEL,
+    tabGroups: byWindow.get(windowId) ?? [],
+  }));
+}


### PR DESCRIPTION
## Summary

Gives workspace save/restore and last-session restore a **window dimension** so a
multi-window layout can be recorded and rebuilt (#1905, part of epic #1899). Builds
on the merged foundation: #1900's session↔window ownership map, #1902's window
registry / empty-window boot, and #1901's move seam.

Historically `WorkspaceDefinition` / `LastSession` captured `tabGroups[]` with a
layout tree but had **no window field** — a restored layout had nowhere to record
"this group is in window 2". This adds that dimension, kept fully optional and
back-compatible.

### Schema (net-new, TS + Rust)

- `WorkspaceTabGroupDef.windowId?` — the logical window a group belongs to.
- `WorkspaceWindowDef { id }` and a `windows?[]` set on `WorkspaceDefinition` and
  `LastSession` — records window identities, including an **empty** window (the
  #1902 empty-window state) that owns no group and would otherwise vanish.
- Mirrored in the Rust workspace types (`src-tauri/src/workspace/`) and carried
  through export / import / duplicate.
- **Back-compatible by construction**: the primary window uses the `main`
  sentinel and its groups omit `windowId`; the `windows[]` set is omitted for a
  single-window layout. So a single-window save is byte-identical to the legacy
  schema, and a legacy save (no window dimension) loads and restores entirely into
  the main window.

### Save / restore helpers (`src/utils/windowPersistence.ts`, pure + unit-tested)

- `stampWindowId` / `buildWindowsMeta` — the save side: stamp which window owns
  each captured group and build the `windows[]` meta (omitting the legacy shape).
- `planWindowRestore` — the restore side: partition saved groups into per-window
  restore entries (main first, declared window order preserved, empty windows
  kept), with the legacy no-window-dimension layout flattening into a single main
  entry.

### Wiring

`saveLastSession` / `saveCurrentAsWorkspace` stamp the capturing window's label
and attach `windows[]`; `restoreLastSession` routes through `planWindowRestore`.
In the current single-store runtime this is behaviourally identical to today
(everything is the main window) and **non-lossy** — see scope note below.

## Scope note (transparency)

This PR delivers the **persistence schema + capture/restore helpers + non-lossy
wiring** — the substrate the epic needs. The **cross-window runtime** that this
schema unlocks (each secondary native window is a separate JS context with its
own store, so *aggregating* every window's layout on save and *spawning +
hydrating* secondary windows on restore requires cross-window IPC) is owned by
the sibling runtime work and can't be exercised in the jsdom/per-PR CI lane.
Until it lands, restore is deliberately non-lossy: a multi-window layout restores
all groups into the main window rather than dropping any. Follow-ups filed below.

## Tests

- Rust: serde round-trip for `windowId` / `windows`, legacy no-window-field
  back-compat, export/import/duplicate preservation.
- Frontend: `windowPersistence` unit tests (stamp/omit-main, windows meta incl.
  empty windows, `planWindowRestore` partition/order/legacy-flatten round trip).

Closes #1905

## Follow-ups

- #1925 — spawn + hydrate secondary windows on restore (the cross-window runtime this schema unlocks).
- #1926 — decide whether the Open Connections panel becomes window-aware (deferred maintainer decision from the issue).
