### PR TITLE
feat(ui): show per-window name + tab count in Move to Window picker (Closes #1910)

### DIFF
--- a/docs/changes/dev2/feature/1910-picker-window-info.md
+++ b/docs/changes/dev2/feature/1910-picker-window-info.md
@@ -1,0 +1,9 @@
+### Changed
+
+- Multi-window: the tab context menu's **Move to Window ▸** picker now shows each
+  other window's live **tab count** next to its name ("2 tabs" / "1 tab" /
+  "empty"), matching the concept mockup — the current window still reads
+  "current". The count comes from real per-window state: each window reports its
+  own tab count to the backend window registry (tabs live in separate JS
+  contexts, so a window cannot see another's directly), and the picker reads the
+  reported counts back (#1910, epic #1899).

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -114,10 +114,7 @@ pub fn get_session_owner(
 /// [`report_window_tab_count`] (#1910); a window that has not reported yet
 /// carries `None`, which the picker renders as no hint until its first report.
 #[tauri::command]
-pub fn list_windows(
-    app: AppHandle,
-    window_manager: State<'_, WindowManager>,
-) -> Vec<WindowInfo> {
+pub fn list_windows(app: AppHandle, window_manager: State<'_, WindowManager>) -> Vec<WindowInfo> {
     app.webview_windows()
         .into_keys()
         .map(|label| {

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -14,14 +14,18 @@ use crate::window::{HandoffRecord, WindowManager};
 
 /// A window known to the app, as reported to the frontend window picker.
 ///
-/// Kept intentionally minimal for the foundation — tab counts and display
-/// names are frontend concerns layered on by the "Move to Window" UI (#1901)
-/// and the status-bar affordance (#1902).
+/// The display name is derived from the label by the frontend; the tab count is
+/// the value the window last reported via [`report_window_tab_count`] (#1910),
+/// so the "Move to Window ▸" picker can show a live "N tabs" / "empty" hint
+/// sourced from real per-window state rather than a placeholder.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WindowInfo {
     /// The window's runtime label (`main`, `win-1`, …).
     pub label: String,
+    /// The window's live tab count, or `None` if it has not reported one yet
+    /// (a window that just booted and has not drawn its tabs).
+    pub tab_count: Option<usize>,
 }
 
 /// Open a new native window loading the same frontend bundle.
@@ -104,13 +108,42 @@ pub fn get_session_owner(
     window_manager.owner_of(&session_id)
 }
 
-/// List all currently open windows (label only).
+/// List all currently open windows, each with its last-reported tab count.
+///
+/// The tab count is whatever the owning window last pushed via
+/// [`report_window_tab_count`] (#1910); a window that has not reported yet
+/// carries `None`, which the picker renders as no hint until its first report.
 #[tauri::command]
-pub fn list_windows(app: AppHandle) -> Vec<WindowInfo> {
+pub fn list_windows(
+    app: AppHandle,
+    window_manager: State<'_, WindowManager>,
+) -> Vec<WindowInfo> {
     app.webview_windows()
         .into_keys()
-        .map(|label| WindowInfo { label })
+        .map(|label| {
+            let tab_count = window_manager.tab_count_of(&label);
+            WindowInfo { label, tab_count }
+        })
         .collect()
+}
+
+/// Record the **calling** window's current tab count so other windows'
+/// "Move to Window ▸" pickers can show a live "N tabs" hint (#1910).
+///
+/// The window calls this whenever its tab set changes. Every open window is then
+/// nudged with `windows-changed` so an open picker / the status-bar affordance
+/// (#1902) refreshes; a window reads the fresh counts back through
+/// [`list_windows`].
+#[tauri::command]
+pub fn report_window_tab_count(
+    app: AppHandle,
+    window: WebviewWindow,
+    count: usize,
+    window_manager: State<'_, WindowManager>,
+) -> Result<(), String> {
+    window_manager.set_tab_count(window.label(), count);
+    app.emit("windows-changed", ()).map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 /// Take (and clear) the hand-off records queued for the **calling** window.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -949,6 +949,7 @@ pub fn run() {
             commands::window::release_session,
             commands::window::get_session_owner,
             commands::window::list_windows,
+            commands::window::report_window_tab_count,
             commands::window::take_pending_handoffs,
             commands::window::send_handoff_to_window,
             commands::window::replay_session_scrollback,
@@ -1118,6 +1119,10 @@ pub fn run() {
                             "Released session ownership for destroyed window (#1900)"
                         );
                     }
+                    // Drop the window's reported tab count (#1910) so the
+                    // "Move to Window ▸" picker never lists a stale count for a
+                    // window that no longer exists.
+                    wm.forget_tab_count(label);
                 }
 
                 // App-wide teardown (tunnels, embedded/X servers, transfers, SFTP)

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -349,7 +349,11 @@ mod tests {
         wm.set_tab_count("win-1", 2);
         wm.set_tab_count("main", 0);
         assert_eq!(wm.tab_count_of("win-1"), Some(2));
-        assert_eq!(wm.tab_count_of("main"), Some(0), "zero is 'empty', not absent");
+        assert_eq!(
+            wm.tab_count_of("main"),
+            Some(0),
+            "zero is 'empty', not absent"
+        );
 
         // A re-report overwrites the previous value.
         wm.set_tab_count("win-1", 5);

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -62,6 +62,13 @@ pub struct WindowManager {
     ownership: Mutex<HashMap<String, String>>,
     /// `window_label → queued hand-off records` awaiting the window's boot/claim.
     pending: Mutex<HashMap<String, Vec<HandoffRecord>>>,
+    /// `window_label → the window's live tab count`, last reported by that
+    /// window (#1910). Tabs live in a window's own JS context, so a window
+    /// cannot see another window's count; each window reports its own here and
+    /// the "Move to Window ▸" picker reads the map to show a per-window "N tabs"
+    /// hint sourced from real state rather than a placeholder. Absent until a
+    /// window first reports (a freshly-booted window that has not yet reported).
+    tab_counts: Mutex<HashMap<String, usize>>,
 }
 
 /// Recover a lock guard even if a previous holder panicked. Multi-window
@@ -173,6 +180,29 @@ impl WindowManager {
             None => true,
             Some(owner) => owner == window_label,
         }
+    }
+
+    // ── Per-window tab count (#1910) ─────────────────────────────────────
+
+    /// Record `window_label`'s current tab count, as reported by that window.
+    ///
+    /// Each window owns its own tab set in a separate JS context, so it reports
+    /// its count here whenever the count changes; the "Move to Window ▸" picker
+    /// in every *other* window reads it back via [`Self::tab_count_of`].
+    pub fn set_tab_count(&self, window_label: &str, count: usize) {
+        recover(self.tab_counts.lock()).insert(window_label.to_string(), count);
+    }
+
+    /// The last tab count reported by `window_label`, or `None` if it has not
+    /// reported yet (a window that just booted and has not drawn its tabs).
+    pub fn tab_count_of(&self, window_label: &str) -> Option<usize> {
+        recover(self.tab_counts.lock()).get(window_label).copied()
+    }
+
+    /// Forget a window's reported tab count (the window was destroyed), so the
+    /// map never grows a stale entry for a window that no longer exists.
+    pub fn forget_tab_count(&self, window_label: &str) {
+        recover(self.tab_counts.lock()).remove(window_label);
     }
 
     // ── Hand-off queue ───────────────────────────────────────────────────
@@ -308,6 +338,27 @@ mod tests {
             assert!(!should_prevent_exit(None));
             assert!(!should_prevent_exit(Some(0)));
         }
+    }
+
+    #[test]
+    fn tab_count_is_reported_read_back_and_forgotten() {
+        let wm = WindowManager::new();
+        // Unreported window has no count (freshly booted, tabs not yet drawn).
+        assert_eq!(wm.tab_count_of("win-1"), None);
+
+        wm.set_tab_count("win-1", 2);
+        wm.set_tab_count("main", 0);
+        assert_eq!(wm.tab_count_of("win-1"), Some(2));
+        assert_eq!(wm.tab_count_of("main"), Some(0), "zero is 'empty', not absent");
+
+        // A re-report overwrites the previous value.
+        wm.set_tab_count("win-1", 5);
+        assert_eq!(wm.tab_count_of("win-1"), Some(5));
+
+        // Forgetting a destroyed window drops only its entry.
+        wm.forget_tab_count("win-1");
+        assert_eq!(wm.tab_count_of("win-1"), None);
+        assert_eq!(wm.tab_count_of("main"), Some(0));
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import { useAgentUpdatePendingEvents } from "@/hooks/useAgentUpdatePendingEvents
 import { useSpawnChoiceHandler, useSpawnRequests } from "@/hooks/useSpawnRequests";
 import { useHttpMonitorNotifications } from "@/hooks/useHttpMonitorNotifications";
 import { useWebviewZoom } from "@/hooks/useWebviewZoom";
+import { useReportWindowTabCount } from "@/hooks/useReportWindowTabCount";
 import { useSidebarResize } from "@/hooks/useSidebarResize";
 import { useAppStore } from "@/store/appStore";
 import { getCliWorkspace } from "@/services/workspaceApi";
@@ -123,6 +124,7 @@ function App() {
   useSpawnRequests();
   useHttpMonitorNotifications();
   useWebviewZoom();
+  useReportWindowTabCount();
   const loadFromBackend = useAppStore((s) => s.loadFromBackend);
   const checkForUpdates = useAppStore((s) => s.checkForUpdates);
   const settings = useAppStore((s) => s.settings);

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -26,7 +26,7 @@ import { TabStatus } from "@/utils/tabStatus";
 import { ConnectionIcon } from "@/utils/connectionIcons";
 import { Tooltip } from "@/components/ui";
 import type { WindowInfo } from "@/types/window";
-import { buildWindowPickerEntries, hasOtherWindows } from "@/utils/windowPicker";
+import { buildWindowPickerEntries, hasOtherWindows, tabCountHint } from "@/utils/windowPicker";
 
 /** Human-readable label for each connection status, used as the dot's tooltip. */
 const STATUS_LABELS: Record<TabStatus, string> = {
@@ -254,7 +254,15 @@ export function Tab({
                       data-testid={`tab-context-move-window-${entry.label}`}
                     >
                       <AppWindow size={14} /> {entry.name}
-                      {entry.isCurrent && <span className="context-menu__sub-label">current</span>}
+                      {entry.isCurrent ? (
+                        <span className="context-menu__sub-label">current</span>
+                      ) : (
+                        tabCountHint(entry.tabCount) && (
+                          <span className="context-menu__sub-label">
+                            {tabCountHint(entry.tabCount)}
+                          </span>
+                        )
+                      )}
                     </ContextMenu.Item>
                   ))}
                 </ContextMenu.SubContent>

--- a/src/hooks/useReportWindowTabCount.ts
+++ b/src/hooks/useReportWindowTabCount.ts
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { getAllLeaves } from "@/utils/panelTree";
+import { reportWindowTabCount } from "@/services/api";
+import { useAppStore } from "@/store/appStore";
+import { frontendLog } from "@/utils/frontendLog";
+
+/**
+ * Report this window's live tab count to the backend window registry whenever it
+ * changes (#1910).
+ *
+ * Tabs live in each window's own JS context, so a window cannot see another
+ * window's count. Each window reports its own count here; the "Move to Window ▸"
+ * picker in every *other* window reads the reported counts back (via
+ * `list_windows`) to show a "N tabs" / "empty" hint sourced from real state.
+ *
+ * Mounted once at the app root. The count spans all of this window's tab groups
+ * — the active group's live `rootPanel` plus the stored trees of the inactive
+ * groups — matching how the window's own tabs are enumerated elsewhere.
+ */
+export function useReportWindowTabCount(): void {
+  const tabCount = useAppStore((s) => {
+    const trees = s.tabGroups.map((g) => (g.id === s.activeTabGroupId ? s.rootPanel : g.rootPanel));
+    return trees.reduce(
+      (n, tree) => n + getAllLeaves(tree).reduce((m, leaf) => m + leaf.tabs.length, 0),
+      0
+    );
+  });
+
+  useEffect(() => {
+    reportWindowTabCount(tabCount).catch((err) => {
+      frontendLog("multi_window", `reportWindowTabCount failed: ${String(err)}`);
+    });
+  }, [tabCount]);
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -307,9 +307,18 @@ export async function getSessionOwner(sessionId: string): Promise<string | null>
   return await invoke<string | null>("get_session_owner", { sessionId });
 }
 
-/** List all currently open windows (label only). */
+/** List all currently open windows, each with its last-reported tab count. */
 export async function listWindows(): Promise<WindowInfo[]> {
   return await invoke<WindowInfo[]>("list_windows");
+}
+
+/**
+ * Report the *calling* window's current tab count so other windows'
+ * "Move to Window ▸" pickers can show a live "N tabs" hint (#1910). Nudges every
+ * window with `windows-changed` so an open picker refreshes.
+ */
+export async function reportWindowTabCount(count: number): Promise<void> {
+  await invoke("report_window_tab_count", { count });
 }
 
 /**

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -16,6 +16,12 @@ export const MAIN_WINDOW_LABEL = "main";
 export interface WindowInfo {
   /** The window's runtime label (`main`, `win-1`, …). */
   label: string;
+  /**
+   * The window's live tab count, sourced from that window's own store via the
+   * backend registry (#1910). `null`/absent when the window has not reported a
+   * count yet — the picker then shows no "N tabs" hint for it.
+   */
+  tabCount?: number | null;
 }
 
 /**

--- a/src/utils/windowPicker.test.ts
+++ b/src/utils/windowPicker.test.ts
@@ -5,10 +5,15 @@
  * named, current-flagged entries the tab context menu renders.
  */
 import { describe, it, expect } from "vitest";
-import { windowDisplayName, buildWindowPickerEntries, hasOtherWindows } from "./windowPicker";
+import {
+  windowDisplayName,
+  buildWindowPickerEntries,
+  hasOtherWindows,
+  tabCountHint,
+} from "./windowPicker";
 import type { WindowInfo } from "@/types/window";
 
-const w = (label: string): WindowInfo => ({ label });
+const w = (label: string, tabCount?: number | null): WindowInfo => ({ label, tabCount });
 
 describe("windowDisplayName", () => {
   it("names the primary window", () => {
@@ -26,12 +31,17 @@ describe("windowDisplayName", () => {
 });
 
 describe("buildWindowPickerEntries", () => {
-  it("returns an entry per window with display name and current flag", () => {
-    const entries = buildWindowPickerEntries([w("main"), w("win-1")], "main");
+  it("returns an entry per window with display name, current flag and tab count", () => {
+    const entries = buildWindowPickerEntries([w("main", 3), w("win-1", 0)], "main");
     expect(entries).toEqual([
-      { label: "main", name: "Main Window", isCurrent: true },
-      { label: "win-1", name: "Window 1", isCurrent: false },
+      { label: "main", name: "Main Window", isCurrent: true, tabCount: 3 },
+      { label: "win-1", name: "Window 1", isCurrent: false, tabCount: 0 },
     ]);
+  });
+
+  it("defaults an unreported tab count to null", () => {
+    const entries = buildWindowPickerEntries([w("win-1")], "main");
+    expect(entries[0].tabCount).toBeNull();
   });
 
   it("orders main first, then win-N ascending regardless of input order", () => {
@@ -51,6 +61,25 @@ describe("buildWindowPickerEntries", () => {
   it("flags none when the current label is unknown/null", () => {
     const entries = buildWindowPickerEntries([w("main"), w("win-1")], null);
     expect(entries.every((e) => !e.isCurrent)).toBe(true);
+  });
+});
+
+describe("tabCountHint", () => {
+  it("has no hint for an unreported count", () => {
+    expect(tabCountHint(null)).toBeNull();
+  });
+
+  it("renders zero as 'empty'", () => {
+    expect(tabCountHint(0)).toBe("empty");
+  });
+
+  it("singularises one tab", () => {
+    expect(tabCountHint(1)).toBe("1 tab");
+  });
+
+  it("pluralises more than one tab", () => {
+    expect(tabCountHint(2)).toBe("2 tabs");
+    expect(tabCountHint(42)).toBe("42 tabs");
   });
 });
 

--- a/src/utils/windowPicker.ts
+++ b/src/utils/windowPicker.ts
@@ -4,10 +4,10 @@
  * The backend window registry (`list_windows`, #1900) reports each open window
  * by its runtime label only (`main`, `win-1`, …). These helpers turn that flat
  * label list into the human-readable picker the tab context menu renders: a
- * display name per window and a flag marking the window the menu is opened in
- * (shown disabled, "current"). Tab counts and richer per-window metadata live in
- * separate JS contexts and are not exposed by the foundation, so they are
- * intentionally omitted here.
+ * display name per window, its live tab count (#1910), and a flag marking the
+ * window the menu is opened in (shown disabled, "current"). Tabs live in each
+ * window's own JS context, so the count is sourced from the backend window
+ * registry — every window reports its own count, which the picker reads back.
  */
 
 import { MAIN_WINDOW_LABEL, type WindowInfo } from "@/types/window";
@@ -20,6 +20,11 @@ export interface WindowPickerEntry {
   name: string;
   /** Whether this is the window the picker was opened from (rendered disabled). */
   isCurrent: boolean;
+  /**
+   * The window's live tab count (#1910), or `null` when it has not been reported
+   * yet. Rendered as a "N tabs" / "empty" hint next to the name.
+   */
+  tabCount: number | null;
 }
 
 /**
@@ -32,6 +37,17 @@ export function windowDisplayName(label: string): string {
   const match = /^win-(\d+)$/.exec(label);
   if (match) return `Window ${match[1]}`;
   return label;
+}
+
+/**
+ * The short hint shown next to a window in the picker, matching the concept's
+ * `move-menu` mockup: `null` (unknown, no hint yet) → `null`; `0` → "empty";
+ * `1` → "1 tab"; `n` → "n tabs".
+ */
+export function tabCountHint(tabCount: number | null): string | null {
+  if (tabCount == null) return null;
+  if (tabCount <= 0) return "empty";
+  return tabCount === 1 ? "1 tab" : `${tabCount} tabs`;
 }
 
 /** Numeric sort key for a window label: main first, then `win-N` ascending. */
@@ -57,6 +73,7 @@ export function buildWindowPickerEntries(
       label: w.label,
       name: windowDisplayName(w.label),
       isCurrent: w.label === currentWindowLabel,
+      tabCount: w.tabCount ?? null,
     }));
 }
 


### PR DESCRIPTION
## What

Enrich the multi-window **Move to Window ▸** picker (from #1901) so each target
window shows its **name** *and* its live **tab count** — "2 tabs" / "1 tab" /
"empty" — matching the `move-menu` mockup in
`docs/concepts/backlog/multi-window.html`. The current window keeps its
"current" hint.

Part of epic #1899; builds on the #1900 foundation, the #1901 picker, and the
#1902 registry / `windows-changed` event.

## How

Tabs live in each window's **own JS context**, so a window cannot read another
window's tab count directly. The count is therefore sourced from real
per-window state via the backend:

- **Backend** — `WindowManager` gains a `window_label → tab_count` map. A new
  `report_window_tab_count` command lets the calling window record its count and
  nudges every window with `windows-changed`. `list_windows` now returns the
  count on `WindowInfo.tabCount`; the entry is dropped when the window is
  destroyed.
- **Frontend** — a mounted `useReportWindowTabCount` hook reports this window's
  total tab count (across all its tab groups) whenever it changes. The picker
  (`buildWindowPickerEntries`) carries `tabCount` through, `tabCountHint`
  formats it ("empty" / "1 tab" / "N tabs"), and `Tab.tsx` renders it as the
  submenu sub-label for every non-current window.

## Tests

- Rust: `tab_count_is_reported_read_back_and_forgotten` on `WindowManager`.
- Frontend: `windowPicker.test.ts` — enriched entry construction (tab count
  pass-through, null default) and `tabCountHint` (null/empty/singular/plural).

Closes #1910