### PR TITLE
feat(workspace): spawn and hydrate secondary windows on restore (#1925)

### DIFF
--- a/docs/changes/dev1/feature/1925-restore-secondary-windows.md
+++ b/docs/changes/dev1/feature/1925-restore-secondary-windows.md
@@ -1,0 +1,18 @@
+# Changes
+
+## Added
+
+- **Multi-window restore now recreates the saved window arrangement** (#1925,
+  epic #1899). Saving a workspace or the last session with tabs spread across two
+  or more windows, then restarting (or launching that workspace), now spawns each
+  saved secondary window and hydrates it with its own tab groups — instead of
+  collapsing every window's tabs into the main window. Empty secondary windows
+  round-trip too. The main window aggregates every open window's layout when it
+  saves, so the persisted document spans all windows even though each window is a
+  separate JS context.
+
+## Notes
+
+- Single-window saves are unchanged and remain byte-identical to the legacy
+  shape; the aggregation falls back to the current window if the cross-window
+  commands are unavailable (e.g. browser dev mode).

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -190,9 +190,7 @@ pub fn report_window_layout(
 /// Every open window's reported layout slice, main-window-first, for the main
 /// window to assemble the full multi-window persisted document (#1925).
 #[tauri::command]
-pub fn collect_window_layouts(
-    window_manager: State<'_, WindowManager>,
-) -> Vec<WindowLayoutReport> {
+pub fn collect_window_layouts(window_manager: State<'_, WindowManager>) -> Vec<WindowLayoutReport> {
     window_manager.collect_layouts()
 }
 

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -10,7 +10,7 @@ use tauri::{AppHandle, Emitter, Manager, State, WebviewUrl, WebviewWindow, Webvi
 
 use crate::session::manager::SessionManager;
 use crate::utils::errors::TerminalError;
-use crate::window::{HandoffRecord, WindowManager};
+use crate::window::{HandoffRecord, WindowLayoutReport, WindowManager, MAIN_WINDOW_LABEL};
 
 /// A window known to the app, as reported to the frontend window picker.
 ///
@@ -41,10 +41,16 @@ pub fn open_window(
     app: AppHandle,
     window_manager: State<'_, WindowManager>,
     handoff: Option<HandoffRecord>,
+    restore: Option<serde_json::Value>,
 ) -> Result<String, String> {
     let label = window_manager.next_label();
     if let Some(record) = handoff {
         window_manager.queue_handoff(&label, record);
+    }
+    // A restore-spawned window carries the tab groups it should hydrate on boot
+    // (#1925), drained via `take_pending_window_restore`.
+    if let Some(groups) = restore {
+        window_manager.queue_restore(&label, groups);
     }
 
     let app_for_build = app.clone();
@@ -153,6 +159,55 @@ pub fn take_pending_handoffs(
     window_manager: State<'_, WindowManager>,
 ) -> Vec<HandoffRecord> {
     window_manager.take_handoffs(window.label())
+}
+
+/// Report the **calling** window's captured layout slice for multi-window
+/// persistence aggregation (#1925).
+///
+/// Each window's tab groups live in its own JS context, so the main window
+/// cannot see another window's layout. Every window reports its own slice here;
+/// the main window assembles the full last-session / workspace document from
+/// [`collect_window_layouts`]. A report from a **secondary** window whose layout
+/// actually changed nudges every window with `window-layout-changed` so the main
+/// window re-persists. The main window's own reports never nudge — it persists
+/// from its own layout subscription — which prevents a self-triggering save loop.
+#[tauri::command]
+pub fn report_window_layout(
+    app: AppHandle,
+    window: WebviewWindow,
+    tab_groups: serde_json::Value,
+    active_group_index: usize,
+    window_manager: State<'_, WindowManager>,
+) -> Result<(), String> {
+    let changed = window_manager.report_layout(window.label(), tab_groups, active_group_index);
+    if changed && window.label() != MAIN_WINDOW_LABEL {
+        app.emit("window-layout-changed", ())
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Every open window's reported layout slice, main-window-first, for the main
+/// window to assemble the full multi-window persisted document (#1925).
+#[tauri::command]
+pub fn collect_window_layouts(
+    window_manager: State<'_, WindowManager>,
+) -> Vec<WindowLayoutReport> {
+    window_manager.collect_layouts()
+}
+
+/// Take (and clear) the tab groups the **calling** window should hydrate on boot
+/// when it was spawned by a multi-window restore (#1925).
+///
+/// Mirrors [`take_pending_handoffs`] but carries whole tab groups seeded by the
+/// restore rather than a single moved tab. Returns `None` for a window that was
+/// not restore-spawned (e.g. the empty-window or move-to-window paths).
+#[tauri::command]
+pub fn take_pending_window_restore(
+    window: WebviewWindow,
+    window_manager: State<'_, WindowManager>,
+) -> Option<serde_json::Value> {
+    window_manager.take_restore(window.label())
 }
 
 /// Queue a hand-off record for an already-open window and nudge every window to

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -950,6 +950,9 @@ pub fn run() {
             commands::window::get_session_owner,
             commands::window::list_windows,
             commands::window::report_window_tab_count,
+            commands::window::report_window_layout,
+            commands::window::collect_window_layouts,
+            commands::window::take_pending_window_restore,
             commands::window::take_pending_handoffs,
             commands::window::send_handoff_to_window,
             commands::window::replay_session_scrollback,
@@ -1123,6 +1126,11 @@ pub fn run() {
                     // "Move to Window ▸" picker never lists a stale count for a
                     // window that no longer exists.
                     wm.forget_tab_count(label);
+                    // Drop the window's reported layout slice (#1925) so an
+                    // assembled last-session / workspace document never carries a
+                    // window that no longer exists. A surviving window's next
+                    // layout change re-persists without it.
+                    wm.forget_layout(label);
                 }
 
                 // App-wide teardown (tunnels, embedded/X servers, transfers, SFTP)

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -531,7 +531,11 @@ mod tests {
     fn pending_restore_is_queued_and_drained_once() {
         let wm = WindowManager::new();
         let payload = serde_json::json!({ "tabGroups": [{ "name": "g" }] });
-        assert_eq!(wm.take_restore("win-1"), None, "unseeded window has nothing");
+        assert_eq!(
+            wm.take_restore("win-1"),
+            None,
+            "unseeded window has nothing"
+        );
 
         wm.queue_restore("win-1", payload.clone());
         assert_eq!(wm.take_restore("win-1"), Some(payload));

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -39,6 +39,12 @@ use std::sync::{Mutex, PoisonError};
 
 use serde::{Deserialize, Serialize};
 
+/// Runtime label of the primary application window (mirrors the frontend
+/// `MAIN_WINDOW_LABEL`). Used to order the primary window first when assembling a
+/// multi-window persisted layout, and to gate the "layout changed" nudge so the
+/// main window never nudges itself into a re-save loop (#1925).
+pub const MAIN_WINDOW_LABEL: &str = "main";
+
 /// A serialized tab view-model handed from one window to another during a
 /// re-parent ("move to window") operation.
 ///
@@ -69,6 +75,45 @@ pub struct WindowManager {
     /// hint sourced from real state rather than a placeholder. Absent until a
     /// window first reports (a freshly-booted window that has not yet reported).
     tab_counts: Mutex<HashMap<String, usize>>,
+    /// `window_label → the window's last-reported captured layout slice` — the
+    /// aggregation authority for multi-window persistence (#1925). Each window's
+    /// tab groups live in its own JS context, so the main window cannot see
+    /// another window's layout; every window reports its own slice here and the
+    /// main window assembles the full last-session / workspace document from
+    /// [`Self::collect_layouts`].
+    layouts: Mutex<HashMap<String, StoredLayout>>,
+    /// Monotonic counter giving each first-seen window a stable collect order so
+    /// [`Self::collect_layouts`] returns windows deterministically.
+    layout_seq: AtomicU32,
+    /// `window_label → tab groups to hydrate on boot` for a window spawned by a
+    /// multi-window restore (#1925). Mirrors [`Self::pending`] (hand-offs) but
+    /// carries whole tab groups seeded by the restore rather than one moved tab.
+    pending_restores: Mutex<HashMap<String, serde_json::Value>>,
+}
+
+/// One window's reported layout slice, held by [`WindowManager`] for the main
+/// window to assemble into the full multi-window persisted document (#1925).
+#[derive(Debug, Clone)]
+struct StoredLayout {
+    /// The window's captured `WorkspaceTabGroupDef[]` (opaque frontend JSON).
+    tab_groups: serde_json::Value,
+    /// Index of the active group within this window's own groups.
+    active_group_index: usize,
+    /// First-report order, for a deterministic secondary-window ordering.
+    order: u32,
+}
+
+/// One window's reported layout slice as returned to the frontend for assembly
+/// (#1925). The `tab_groups` payload is opaque frontend JSON.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowLayoutReport {
+    /// The reporting window's runtime label (`main`, `win-1`, …).
+    pub label: String,
+    /// That window's captured `WorkspaceTabGroupDef[]` (opaque frontend JSON).
+    pub tab_groups: serde_json::Value,
+    /// Index of the active group within this window's own groups.
+    pub active_group_index: usize,
 }
 
 /// Recover a lock guard even if a previous holder panicked. Multi-window
@@ -203,6 +248,85 @@ impl WindowManager {
     /// map never grows a stale entry for a window that no longer exists.
     pub fn forget_tab_count(&self, window_label: &str) {
         recover(self.tab_counts.lock()).remove(window_label);
+    }
+
+    // ── Per-window layout aggregation for persistence (#1925) ─────────────
+
+    /// Record `window_label`'s current captured layout slice for the main window
+    /// to aggregate into a multi-window persisted document.
+    ///
+    /// Returns whether the stored slice actually *changed*. The caller uses this
+    /// to nudge the main window to re-persist only on a real change — never on a
+    /// redundant re-report of an unchanged layout, which would otherwise loop the
+    /// main window's re-save.
+    pub fn report_layout(
+        &self,
+        window_label: &str,
+        tab_groups: serde_json::Value,
+        active_group_index: usize,
+    ) -> bool {
+        let mut map = recover(self.layouts.lock());
+        let changed = match map.get(window_label) {
+            Some(existing) => {
+                existing.tab_groups != tab_groups
+                    || existing.active_group_index != active_group_index
+            }
+            None => true,
+        };
+        // Preserve a window's first-seen order across re-reports so the collect
+        // order is stable while it stays open.
+        let order = map
+            .get(window_label)
+            .map(|l| l.order)
+            .unwrap_or_else(|| self.layout_seq.fetch_add(1, Ordering::SeqCst));
+        map.insert(
+            window_label.to_string(),
+            StoredLayout {
+                tab_groups,
+                active_group_index,
+                order,
+            },
+        );
+        changed
+    }
+
+    /// Forget a window's reported layout slice (the window was destroyed) so an
+    /// assembled document never carries a window that no longer exists.
+    pub fn forget_layout(&self, window_label: &str) {
+        recover(self.layouts.lock()).remove(window_label);
+    }
+
+    /// Every window's reported layout slice, ordered main-window-first then by
+    /// first-report order, for the main window to assemble the full document.
+    pub fn collect_layouts(&self) -> Vec<WindowLayoutReport> {
+        let map = recover(self.layouts.lock());
+        let mut entries: Vec<(&String, &StoredLayout)> = map.iter().collect();
+        entries.sort_by(|(la, a), (lb, b)| {
+            let a_main = la.as_str() == MAIN_WINDOW_LABEL;
+            let b_main = lb.as_str() == MAIN_WINDOW_LABEL;
+            // Main first (a_main "greater"), then by first-report order.
+            b_main.cmp(&a_main).then_with(|| a.order.cmp(&b.order))
+        });
+        entries
+            .into_iter()
+            .map(|(label, l)| WindowLayoutReport {
+                label: label.clone(),
+                tab_groups: l.tab_groups.clone(),
+                active_group_index: l.active_group_index,
+            })
+            .collect()
+    }
+
+    // ── Pending window-restore queue (#1925) ─────────────────────────────
+
+    /// Queue the tab groups a restore-spawned window should hydrate on boot.
+    pub fn queue_restore(&self, window_label: &str, groups: serde_json::Value) {
+        recover(self.pending_restores.lock()).insert(window_label.to_string(), groups);
+    }
+
+    /// Take (and clear) the restore payload queued for `window_label`, if any.
+    pub fn take_restore(&self, window_label: &str) -> Option<serde_json::Value> {
+        recover(self.pending_restores.lock()).remove(window_label)
     }
 
     // ── Hand-off queue ───────────────────────────────────────────────────
@@ -363,6 +487,56 @@ mod tests {
         wm.forget_tab_count("win-1");
         assert_eq!(wm.tab_count_of("win-1"), None);
         assert_eq!(wm.tab_count_of("main"), Some(0));
+    }
+
+    #[test]
+    fn report_layout_reports_signals_change_and_forgets() {
+        let wm = WindowManager::new();
+        let groups = |n: &str| serde_json::json!([{ "name": n }]);
+
+        // First report of a window is always a change.
+        assert!(wm.report_layout("main", groups("a"), 0));
+        // Re-reporting the identical slice is not a change (prevents re-save loop).
+        assert!(!wm.report_layout("main", groups("a"), 0));
+        // A different slice — or a different active index — is a change.
+        assert!(wm.report_layout("main", groups("b"), 0));
+        assert!(wm.report_layout("main", groups("b"), 1));
+
+        // Forgetting a destroyed window drops its slice; a later report is "new".
+        wm.forget_layout("main");
+        assert!(wm.report_layout("main", groups("b"), 1));
+    }
+
+    #[test]
+    fn collect_layouts_orders_main_first_then_first_report_order() {
+        let wm = WindowManager::new();
+        let groups = |n: &str| serde_json::json!([{ "name": n }]);
+
+        // Report secondaries before main to prove main is floated to the front.
+        wm.report_layout("win-2", groups("b"), 0);
+        wm.report_layout("win-1", groups("c"), 0);
+        wm.report_layout("main", groups("a"), 0);
+
+        let collected: Vec<String> = wm.collect_layouts().into_iter().map(|r| r.label).collect();
+        // Main first, then secondaries in first-report order (win-2 before win-1).
+        assert_eq!(collected, vec!["main", "win-2", "win-1"]);
+
+        // A window keeps its order across re-reports.
+        wm.report_layout("win-2", groups("b2"), 0);
+        let collected: Vec<String> = wm.collect_layouts().into_iter().map(|r| r.label).collect();
+        assert_eq!(collected, vec!["main", "win-2", "win-1"]);
+    }
+
+    #[test]
+    fn pending_restore_is_queued_and_drained_once() {
+        let wm = WindowManager::new();
+        let payload = serde_json::json!({ "tabGroups": [{ "name": "g" }] });
+        assert_eq!(wm.take_restore("win-1"), None, "unseeded window has nothing");
+
+        wm.queue_restore("win-1", payload.clone());
+        assert_eq!(wm.take_restore("win-1"), Some(payload));
+        // Drained, not copied — a second take is empty.
+        assert_eq!(wm.take_restore("win-1"), None);
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -192,6 +192,11 @@ function App() {
         await useAppStore.getState().receivePendingWindowRestore();
         await useAppStore.getState().receivePendingHandoffs();
         enableSecondaryLayoutReport();
+        // Report the current slice once now (#1925): the subscription above only
+        // fires on a *later* change, so without this the window's initial layout —
+        // a restored/handed-off tree, or the empty-window state — would be missing
+        // from the aggregation authority and dropped from the main window's save.
+        void useAppStore.getState().reportOwnWindowLayout();
         return;
       }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -151,33 +151,47 @@ function App() {
 
   useEffect(() => {
     let unsubscribe: (() => void) | null = null;
+    let unlistenLayoutChanged: (() => void) | null = null;
 
-    // Auto-save the open tabs/layout whenever the panel tree changes, so the
-    // session can be restored after a reload or restart. Attached only after the
-    // initial restore so restoring does not immediately re-save.
+    type StoreState = ReturnType<typeof useAppStore.getState>;
+    const layoutChanged = (state: StoreState, prevState: StoreState): boolean =>
+      state.tabGroups !== prevState.tabGroups ||
+      state.rootPanel !== prevState.rootPanel ||
+      state.activePanelId !== prevState.activePanelId ||
+      state.activeTabGroupId !== prevState.activeTabGroupId;
+
+    // Main window: auto-save the open tabs/layout whenever the panel tree
+    // changes, so the session can be restored after a reload or restart.
+    // Attached only after the initial restore so restoring does not immediately
+    // re-save. The save aggregates every open window's slice (#1925).
     const enableAutoSave = () => {
       unsubscribe = useAppStore.subscribe((state, prevState) => {
-        if (
-          state.tabGroups !== prevState.tabGroups ||
-          state.rootPanel !== prevState.rootPanel ||
-          state.activePanelId !== prevState.activePanelId ||
-          state.activeTabGroupId !== prevState.activeTabGroupId
-        ) {
-          state.scheduleLastSessionSave();
-        }
+        if (layoutChanged(state, prevState)) state.scheduleLastSessionSave();
+      });
+    };
+
+    // Secondary window: report this window's captured layout slice to the
+    // backend aggregation authority on every layout change (#1925), so the main
+    // window's save spans every window it cannot see across the JS boundary.
+    const enableSecondaryLayoutReport = () => {
+      unsubscribe = useAppStore.subscribe((state, prevState) => {
+        if (layoutChanged(state, prevState)) state.scheduleWindowLayoutReport();
       });
     };
 
     (async () => {
       await loadFromBackend();
 
-      // Secondary windows (#1900) boot empty: they never restore the main
-      // window's last session and never auto-save (window-dimension persistence
-      // is #1905). Instead they drain any tabs handed off to them. Live moves to
-      // an already-open window arrive via the `window-handoff` listener below.
+      // Secondary windows (#1900) never restore the main window's last session.
+      // A restore-spawned window (#1925) first hydrates the tab groups it was
+      // seeded with, then drains any live hand-offs; it reports its layout slice
+      // so the main window's save includes it. Live moves to an already-open
+      // window arrive via the `window-handoff` listener below.
       const isMainWindow = getCurrentWindow().label === MAIN_WINDOW_LABEL;
       if (!isMainWindow) {
+        await useAppStore.getState().receivePendingWindowRestore();
         await useAppStore.getState().receivePendingHandoffs();
+        enableSecondaryLayoutReport();
         return;
       }
 
@@ -216,10 +230,18 @@ function App() {
       // Always observe layout changes; saveLastSession itself honors the current
       // setting, so toggling it at runtime takes effect without a restart.
       enableAutoSave();
+
+      // Multi-window (#1925): a secondary window reporting a layout change nudges
+      // the main window here so the aggregated session is re-persisted with that
+      // window's latest slice.
+      unlistenLayoutChanged = await listen<void>("window-layout-changed", () => {
+        useAppStore.getState().scheduleLastSessionSave();
+      });
     })();
 
     return () => {
       if (unsubscribe) unsubscribe();
+      if (unlistenLayoutChanged) unlistenLayoutChanged();
     };
   }, [loadFromBackend]);
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -16,7 +16,13 @@ import type { RemoteClipboardFile, RemoteDesktopInput } from "@/types/remoteDesk
 import { CredentialStoreStatusInfo, SwitchCredentialStoreResult } from "@/types/credential";
 import type { SpawnRequestPayload } from "@/services/events";
 import type { ContainerRuntime, SpawnTarget } from "@/types/spawn";
-import type { TabHandoffRecord, WindowInfo } from "@/types/window";
+import type {
+  TabHandoffRecord,
+  WindowInfo,
+  WindowLayoutReport,
+  WindowRestorePayload,
+} from "@/types/window";
+import type { WorkspaceTabGroupDef } from "@/types/workspace";
 import {
   SavedConnection,
   ConnectionFolder,
@@ -282,11 +288,19 @@ export async function takePendingSpawn(): Promise<SpawnRequestPayload | null> {
 
 /**
  * Open a new native window loading the same frontend bundle. When a hand-off
- * record is supplied, it is queued for the new window to drain on boot. Returns
- * the new window's unique label.
+ * record is supplied, it is queued for the new window to drain on boot; when a
+ * restore payload is supplied, its tab groups are queued for the new window to
+ * hydrate on boot (multi-window restore, #1925). Returns the new window's unique
+ * label.
  */
-export async function openWindow(handoff?: TabHandoffRecord): Promise<string> {
-  return await invoke<string>("open_window", { handoff: handoff ?? null });
+export async function openWindow(
+  handoff?: TabHandoffRecord,
+  restore?: WindowRestorePayload
+): Promise<string> {
+  return await invoke<string>("open_window", {
+    handoff: handoff ?? null,
+    restore: restore ?? null,
+  });
 }
 
 /**
@@ -338,6 +352,36 @@ export async function sendHandoffToWindow(
   handoff: TabHandoffRecord
 ): Promise<void> {
   await invoke("send_handoff_to_window", { targetLabel, handoff });
+}
+
+/**
+ * Report this window's captured layout slice to the multi-window aggregation
+ * authority (#1925) so the main window can assemble the full persisted document
+ * it cannot see across the JS-context boundary.
+ */
+export async function reportWindowLayout(
+  tabGroups: WorkspaceTabGroupDef[],
+  activeGroupIndex: number
+): Promise<void> {
+  await invoke("report_window_layout", { tabGroups, activeGroupIndex });
+}
+
+/**
+ * Every open window's reported layout slice, main-window-first — the main window
+ * assembles the full multi-window last-session / workspace document from these
+ * (#1925).
+ */
+export async function collectWindowLayouts(): Promise<WindowLayoutReport[]> {
+  return await invoke<WindowLayoutReport[]>("collect_window_layouts");
+}
+
+/**
+ * Take (and clear) the tab groups this window should hydrate on boot when it was
+ * spawned by a multi-window restore (#1925). `null` for a window that was not
+ * restore-spawned.
+ */
+export async function takePendingWindowRestore(): Promise<WindowRestorePayload | null> {
+  return await invoke<WindowRestorePayload | null>("take_pending_window_restore");
 }
 
 /**

--- a/src/store/appStore.lastSession.test.ts
+++ b/src/store/appStore.lastSession.test.ts
@@ -23,12 +23,23 @@ vi.mock("@/services/storage", () => ({
   getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
 }));
 
+// Multi-window aggregation/restore commands (#1925). Untyped wrappers so the
+// resolved values can be set per-test.
+const openWindow = vi.fn();
+const reportWindowLayout = vi.fn();
+const collectWindowLayouts = vi.fn();
+const takePendingWindowRestore = vi.fn();
+
 vi.mock("@/services/api", () => ({
   sftpOpen: vi.fn(),
   sftpClose: vi.fn(),
   sftpListDir: vi.fn(),
   localListDir: vi.fn(),
   vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  openWindow: (...args: unknown[]) => openWindow(...args),
+  reportWindowLayout: (...args: unknown[]) => reportWindowLayout(...args),
+  collectWindowLayouts: (...args: unknown[]) => collectWindowLayouts(...args),
+  takePendingWindowRestore: (...args: unknown[]) => takePendingWindowRestore(...args),
 }));
 
 vi.mock("@/services/lastSessionApi", () => ({
@@ -66,6 +77,12 @@ describe("last session persistence", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLoad.mockResolvedValue(null);
+    // Default: aggregation unavailable → each save/restore falls back to this
+    // window only (byte-identical legacy shape); overridden per multi-window test.
+    reportWindowLayout.mockResolvedValue(undefined);
+    collectWindowLayouts.mockResolvedValue([]);
+    takePendingWindowRestore.mockResolvedValue(null);
+    openWindow.mockResolvedValue("win-1");
     // Reset to a clean single empty terminal group.
     useAppStore.setState({
       connections: [],
@@ -117,8 +134,8 @@ describe("last session persistence", () => {
     });
   });
 
-  // Window dimension (#1905): the save path stamps the capturing window and the
-  // restore path is non-lossy for a multi-window session.
+  // Window dimension (#1905/#1925): the save path stamps the capturing window and
+  // the restore path spawns + hydrates the saved secondary windows.
   describe("window dimension", () => {
     it("omits windowId and windows for the main window (legacy shape)", async () => {
       await useAppStore.getState().saveLastSession();
@@ -140,7 +157,7 @@ describe("last session persistence", () => {
       expect(payload.windows).toEqual([{ id: "win-2" }]);
     });
 
-    it("restores a multi-window session non-lossily (all groups, main first)", async () => {
+    it("spawns the saved secondary windows and restores only the main groups here (#1925)", async () => {
       // A saved session spanning main (group A) + win-1 (group B).
       const leaf = (title: string) => ({
         type: "leaf" as const,
@@ -159,8 +176,101 @@ describe("last session persistence", () => {
       const ok = await useAppStore.getState().restoreLastSession();
 
       expect(ok).toBe(true);
+      // This (main) window holds only its own group; the secondary window is
+      // spawned to hold group B rather than collapsed into main.
       const groups = useAppStore.getState().tabGroups;
-      expect(groups.map((g) => g.name)).toEqual(["A", "B"]);
+      expect(groups.map((g) => g.name)).toEqual(["A"]);
+      // One secondary window is spawned, seeded with win-1's group B.
+      expect(openWindow).toHaveBeenCalledTimes(1);
+      const [handoffArg, restoreArg] = openWindow.mock.calls[0];
+      expect(handoffArg).toBeUndefined();
+      // The seeded group keeps its saved windowId (hydration ignores it).
+      expect(restoreArg).toEqual({
+        tabGroups: [{ name: "B", layout: leaf("b"), windowId: "win-1" }],
+      });
+    });
+
+    it("spawns an empty window for a saved empty secondary window (#1902/#1925)", async () => {
+      mockLoad.mockResolvedValue({
+        version: "1",
+        activeGroupIndex: 0,
+        tabGroups: [
+          {
+            name: "A",
+            layout: {
+              type: "leaf",
+              tabs: [{ inlineConfig: { type: "local", config: { shell: "bash" } }, title: "a" }],
+            },
+          },
+        ],
+        windows: [{ id: "main" }, { id: "win-1" }],
+      });
+
+      const ok = await useAppStore.getState().restoreLastSession();
+
+      expect(ok).toBe(true);
+      // win-1 owns no groups → spawn a plain empty window (no restore payload).
+      expect(openWindow).toHaveBeenCalledTimes(1);
+      expect(openWindow.mock.calls[0]).toEqual([]);
+    });
+  });
+
+  // Multi-window aggregation on save (#1925): the main window persists a document
+  // spanning every open window from the backend-reported slices it cannot see.
+  describe("multi-window aggregation (#1925)", () => {
+    it("assembles every window's reported slice into one saved document", async () => {
+      // The backend authority reports main (its live group) + win-1 (group B).
+      const leafB = {
+        type: "leaf" as const,
+        tabs: [{ inlineConfig: { type: "local", config: { shell: "bash" } }, title: "b" }],
+      };
+      collectWindowLayouts.mockResolvedValue([
+        {
+          label: "main",
+          tabGroups: [{ name: "Main", layout: { type: "leaf", tabs: [] } }],
+          activeGroupIndex: 0,
+        },
+        { label: "win-1", tabGroups: [{ name: "B", layout: leafB }], activeGroupIndex: 0 },
+      ]);
+
+      await useAppStore.getState().saveLastSession();
+
+      expect(reportWindowLayout).toHaveBeenCalledTimes(1);
+      const payload = mockSave.mock.calls[0][0] as LastSession;
+      // Both windows recorded; win-1's group carries its windowId, main's does not.
+      expect(payload.windows).toEqual([{ id: "main" }, { id: "win-1" }]);
+      const winIds = payload.tabGroups.map((g) => g.windowId);
+      expect(winIds).toEqual([undefined, "win-1"]);
+    });
+
+    it("hydrates a restore-spawned window from its seeded groups (#1925)", async () => {
+      takePendingWindowRestore.mockResolvedValue({
+        tabGroups: [
+          {
+            name: "Seeded",
+            layout: {
+              type: "leaf",
+              tabs: [{ inlineConfig: { type: "local", config: { shell: "bash" } }, title: "S" }],
+            },
+          },
+        ],
+      });
+
+      await useAppStore.getState().receivePendingWindowRestore();
+
+      const state = useAppStore.getState();
+      expect(state.tabGroups.map((g) => g.name)).toEqual(["Seeded"]);
+      const tabs = getAllLeaves(state.rootPanel).flatMap((l) => l.tabs);
+      expect(tabs.map((t) => t.title)).toEqual(["S"]);
+    });
+
+    it("is a no-op when there is no seeded restore payload", async () => {
+      takePendingWindowRestore.mockResolvedValue(null);
+      const before = useAppStore.getState().tabGroups;
+
+      await useAppStore.getState().receivePendingWindowRestore();
+
+      expect(useAppStore.getState().tabGroups).toBe(before);
     });
   });
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -118,6 +118,9 @@ import {
   sendHandoffToWindow,
   claimSession,
   takePendingHandoffs,
+  reportWindowLayout,
+  collectWindowLayouts,
+  takePendingWindowRestore,
 } from "@/services/api";
 import type {
   MoveWindowTarget,
@@ -125,6 +128,7 @@ import type {
   HandoffTab,
   WindowInfo,
   WindowCloseRequest,
+  WindowRestorePayload,
 } from "@/types/window";
 import { MAIN_WINDOW_LABEL } from "@/types/window";
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -133,6 +137,11 @@ import {
   buildWindowsMeta,
   planWindowRestore,
   hasWindowDimension,
+  assembleWindowedGroups,
+} from "@/utils/windowPersistence";
+import type {
+  CapturedWindowLayout,
+  WindowRestorePlanEntry,
 } from "@/utils/windowPersistence";
 import { classifyWindowCloseSessions, windowCloseWouldLoseData } from "@/utils/windowClose";
 import type {
@@ -1724,7 +1733,68 @@ function currentWindowLabel(): string {
     return MAIN_WINDOW_LABEL;
   }
 }
+
+/**
+ * Capture the full multi-window layout for persistence (#1925): refresh this
+ * window's slice in the backend aggregation authority, pull every window's
+ * reported slice, and assemble the windowId-stamped groups + `windows[]` set.
+ *
+ * Falls back to **this window's groups only** if the cross-window commands are
+ * unavailable (e.g. browser dev mode, or an IPC error) so a save never throws —
+ * a single-window app then produces the byte-identical legacy shape.
+ */
+async function captureAllWindows(
+  ownGroups: WorkspaceTabGroupDef[],
+  activeGroupIndex: number
+): Promise<{ tabGroups: WorkspaceTabGroupDef[]; windows?: WorkspaceWindowDef[] }> {
+  let layouts: CapturedWindowLayout[] = [
+    { windowId: currentWindowLabel(), tabGroups: ownGroups },
+  ];
+  try {
+    await reportWindowLayout(ownGroups, activeGroupIndex);
+    const reports = await collectWindowLayouts();
+    if (reports.length > 0) {
+      layouts = reports.map((r) => ({ windowId: r.label, tabGroups: r.tabGroups }));
+    }
+  } catch (err) {
+    frontendLog(
+      "multi_window",
+      `window layout aggregation unavailable, saving own window only: ${String(err)}`
+    );
+  }
+  return assembleWindowedGroups(layouts);
+}
+
+/**
+ * Spawn a native window for each non-main entry of a restore plan and seed it
+ * with its assigned tab groups (#1925). Each spawned window hydrates its layout
+ * on boot from the backend pending-restore queue; an entry that owns no groups
+ * spawns an empty window so the #1902 empty-window state round-trips.
+ *
+ * Best-effort per window: a single window's spawn failure is logged and skipped
+ * rather than aborting the whole restore.
+ */
+async function spawnPlanSecondaryWindows(plan: WindowRestorePlanEntry[]): Promise<void> {
+  for (const entry of plan) {
+    if (entry.isMain) continue;
+    try {
+      if (entry.tabGroups.length > 0) {
+        await openWindow(undefined, { tabGroups: entry.tabGroups });
+      } else {
+        await openWindow();
+      }
+    } catch (err) {
+      frontendLog(
+        "multi_window",
+        `spawn restore window ${entry.windowId} failed: ${String(err)}`
+      );
+    }
+  }
+}
+
 const LAST_SESSION_SAVE_DEBOUNCE_MS = 500;
+/** Debounce timer for reporting a secondary window's layout slice (#1925). */
+let windowLayoutReportTimer: ReturnType<typeof setTimeout> | null = null;
 /**
  * Settle timer for the restore-in-progress guard (GAP G5, #1146). After a
  * restore/launch places its layout, per-tab connects keep mutating the tree for

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -139,10 +139,7 @@ import {
   hasWindowDimension,
   assembleWindowedGroups,
 } from "@/utils/windowPersistence";
-import type {
-  CapturedWindowLayout,
-  WindowRestorePlanEntry,
-} from "@/utils/windowPersistence";
+import type { CapturedWindowLayout, WindowRestorePlanEntry } from "@/utils/windowPersistence";
 import { classifyWindowCloseSessions, windowCloseWouldLoseData } from "@/utils/windowClose";
 import type {
   ConnectionTypeInfo,
@@ -181,7 +178,12 @@ import {
   stopTunnel as apiStopTunnel,
   getTunnelStatuses,
 } from "@/services/tunnelApi";
-import { WorkspaceSummary, WorkspaceDefinition } from "@/types/workspace";
+import {
+  WorkspaceSummary,
+  WorkspaceDefinition,
+  type WorkspaceTabGroupDef,
+  type WorkspaceWindowDef,
+} from "@/types/workspace";
 import {
   getWorkspaces as apiGetWorkspaces,
   loadWorkspace as apiLoadWorkspace,
@@ -716,6 +718,21 @@ interface AppState {
   hydrateHandoffTab: (record: TabHandoffRecord) => void;
   /** Drain and hydrate any hand-off records queued for this window. */
   receivePendingHandoffs: () => Promise<void>;
+  /**
+   * Drain and hydrate the tab groups a restore-spawned secondary window was
+   * seeded with (#1925). A no-op for a window not spawned by a multi-window
+   * restore. Rebuilds this window's layout from the saved groups just as the
+   * main window rebuilds its own in {@link restoreLastSession}.
+   */
+  receivePendingWindowRestore: () => Promise<void>;
+  /**
+   * Report this (secondary) window's captured layout slice to the backend
+   * aggregation authority (#1925) so the main window can persist a document that
+   * spans every window. Debounced via {@link scheduleWindowLayoutReport}.
+   */
+  reportOwnWindowLayout: () => Promise<void>;
+  /** Debounced trigger for {@link reportOwnWindowLayout} on a layout change. */
+  scheduleWindowLayoutReport: () => void;
   /**
    * Open a brand-new, empty native window (no hand-off) — the top-level "New
    * Window" command (#1902). The window boots into the empty-window CTA state.
@@ -1747,9 +1764,7 @@ async function captureAllWindows(
   ownGroups: WorkspaceTabGroupDef[],
   activeGroupIndex: number
 ): Promise<{ tabGroups: WorkspaceTabGroupDef[]; windows?: WorkspaceWindowDef[] }> {
-  let layouts: CapturedWindowLayout[] = [
-    { windowId: currentWindowLabel(), tabGroups: ownGroups },
-  ];
+  let layouts: CapturedWindowLayout[] = [{ windowId: currentWindowLabel(), tabGroups: ownGroups }];
   try {
     await reportWindowLayout(ownGroups, activeGroupIndex);
     const reports = await collectWindowLayouts();
@@ -1784,12 +1799,23 @@ async function spawnPlanSecondaryWindows(plan: WindowRestorePlanEntry[]): Promis
         await openWindow();
       }
     } catch (err) {
-      frontendLog(
-        "multi_window",
-        `spawn restore window ${entry.windowId} failed: ${String(err)}`
-      );
+      frontendLog("multi_window", `spawn restore window ${entry.windowId} failed: ${String(err)}`);
     }
   }
+}
+
+/**
+ * Restore a windowed layout (#1925): spawn + hydrate the saved secondary windows
+ * and return the tab group defs that belong in **this** (main) window, in saved
+ * order. A legacy save with no window dimension yields a single main entry, so
+ * this returns every group and spawns nothing — the back-compat path.
+ */
+async function restoreWindowedLayout(
+  plan: WindowRestorePlanEntry[]
+): Promise<WorkspaceTabGroupDef[]> {
+  await spawnPlanSecondaryWindows(plan);
+  const mainEntry = plan.find((entry) => entry.isMain);
+  return mainEntry ? mainEntry.tabGroups : plan.flatMap((entry) => entry.tabGroups);
 }
 
 const LAST_SESSION_SAVE_DEBOUNCE_MS = 500;
@@ -2619,6 +2645,88 @@ export const useAppStore = create<AppState>((set, get) => {
         }
         get().hydrateHandoffTab(record);
       }
+    },
+
+    receivePendingWindowRestore: async () => {
+      let payload: WindowRestorePayload | null;
+      try {
+        payload = await takePendingWindowRestore();
+      } catch (err) {
+        frontendLog("multi_window", `takePendingWindowRestore failed: ${String(err)}`);
+        return;
+      }
+      if (!payload || payload.tabGroups.length === 0) return;
+      const state = get();
+      // Agents are all disconnected at startup, so agentRef tabs resolve to
+      // agent-error tabs rather than silently disappearing (mirrors restore).
+      const agentContext = {
+        agents: state.remoteAgents.map((a) => ({
+          id: a.id,
+          name: a.name,
+          connected: a.connectionState === "connected",
+        })),
+        definitions: state.agentDefinitions,
+      };
+      const builtGroups = buildTabGroupsFromWorkspace(
+        payload.tabGroups,
+        state.connections,
+        state.defaultShell,
+        agentContext
+      );
+      const builtTabCount = builtGroups.reduce(
+        (n, g) => n + getAllLeaves(g.rootPanel).reduce((m, leaf) => m + leaf.tabs.length, 0),
+        0
+      );
+      if (builtGroups.length === 0 || builtTabCount === 0) {
+        frontendLog(
+          "multi_window",
+          "receivePendingWindowRestore: seeded groups produced no launchable tabs"
+        );
+        return;
+      }
+      const firstGroup = builtGroups[0];
+      // GAP G5 (#1146): raise the guard before placing the layout so this
+      // window's auto-report subscription does not report a mid-hydrate tree.
+      beginRestoreGuard(set);
+      set({
+        tabGroups: builtGroups,
+        activeTabGroupId: firstGroup.id,
+        rootPanel: firstGroup.rootPanel,
+        activePanelId: firstGroup.activePanelId,
+      });
+      const { pendingTabIds, preFailedCount } = collectRestoreCohort(builtGroups);
+      get().beginRestoreCohort(pendingTabIds, preFailedCount);
+    },
+
+    reportOwnWindowLayout: async () => {
+      const state = get();
+      const tabGroups = captureAllTabGroups(
+        state.tabGroups,
+        state.activeTabGroupId,
+        state.rootPanel,
+        state.connections
+      );
+      const activeGroupIndex = Math.max(
+        0,
+        state.tabGroups.findIndex((g) => g.id === state.activeTabGroupId)
+      );
+      try {
+        await reportWindowLayout(tabGroups, activeGroupIndex);
+      } catch (err) {
+        frontendLog("multi_window", `reportWindowLayout failed: ${String(err)}`);
+      }
+    },
+
+    scheduleWindowLayoutReport: () => {
+      // While a restore/hydrate is settling, the layout tree is mid-flight; a
+      // report now would push a transient slice to the aggregation authority and
+      // nudge the main window to persist it (GAP G5, #1146). Hold until settled.
+      if (get().restoreInProgress) return;
+      if (windowLayoutReportTimer) clearTimeout(windowLayoutReportTimer);
+      windowLayoutReportTimer = setTimeout(() => {
+        windowLayoutReportTimer = null;
+        void get().reportOwnWindowLayout();
+      }, LAST_SESSION_SAVE_DEBOUNCE_MS);
     },
 
     openNewWindow: async () => {
@@ -7210,8 +7318,13 @@ export const useAppStore = create<AppState>((set, get) => {
           definitions: freshState.agentDefinitions,
         };
 
+        // Window dimension (#1925): spawn + hydrate the workspace's saved
+        // secondary windows and build only the main window's groups here. A
+        // legacy single-window workspace spawns nothing and builds every group.
+        const plan = planWindowRestore(definition.tabGroups, definition.windows);
+        const mainGroups = await restoreWindowedLayout(plan);
         const builtGroups = buildTabGroupsFromWorkspace(
-          definition.tabGroups,
+          mainGroups,
           resolvedConnections,
           state.defaultShell,
           agentContext
@@ -7268,25 +7381,37 @@ export const useAppStore = create<AppState>((set, get) => {
       try {
         const state = get();
         const activeGroup = state.tabGroups.find((g) => g.id === state.activeTabGroupId);
-        const tabGroups =
-          scope === "active" && activeGroup
-            ? captureAllTabGroups(
-                [activeGroup],
-                state.activeTabGroupId,
-                state.rootPanel,
-                state.connections
-              )
-            : captureAllTabGroups(
-                state.tabGroups,
-                state.activeTabGroupId,
-                state.rootPanel,
-                state.connections
-              );
-        // Window dimension (#1905): record which window owns each group so a
-        // saved multi-window layout restores its window arrangement. For the
-        // single main-window store this omits the dimension (legacy shape).
-        const stampedGroups = stampWindowId(tabGroups, currentWindowLabel());
-        const windows = buildWindowsMeta(stampedGroups);
+        // "active" scope saves only this window's active group — inherently a
+        // single-window layout, so stamp it directly (legacy shape when it is the
+        // main window). Full scope aggregates every open window (#1905/#1925) so a
+        // saved multi-window layout restores its window arrangement.
+        let stampedGroups: WorkspaceTabGroupDef[];
+        let windows: WorkspaceWindowDef[] | undefined;
+        if (scope === "active" && activeGroup) {
+          const tabGroups = captureAllTabGroups(
+            [activeGroup],
+            state.activeTabGroupId,
+            state.rootPanel,
+            state.connections
+          );
+          stampedGroups = stampWindowId(tabGroups, currentWindowLabel());
+          windows = buildWindowsMeta(stampedGroups);
+        } else {
+          const tabGroups = captureAllTabGroups(
+            state.tabGroups,
+            state.activeTabGroupId,
+            state.rootPanel,
+            state.connections
+          );
+          const activeGroupIndex = Math.max(
+            0,
+            state.tabGroups.findIndex((g) => g.id === state.activeTabGroupId)
+          );
+          ({ tabGroups: stampedGroups, windows } = await captureAllWindows(
+            tabGroups,
+            activeGroupIndex
+          ));
+        }
         const id = `ws-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
         await apiSaveWorkspace({
           id,
@@ -7310,28 +7435,32 @@ export const useAppStore = create<AppState>((set, get) => {
       // Respect the setting at save time so toggling it takes effect immediately.
       // "never" means the user does not want a session kept, so skip the write.
       if (resolveRestoreMode(state.settings) === "never") return;
-      const tabGroups = captureAllTabGroups(
+      const ownGroups = captureAllTabGroups(
         state.tabGroups,
         state.activeTabGroupId,
         state.rootPanel,
         state.connections
       );
-      // Only persist when there is at least one real tab to restore. An empty
-      // payload tells the backend to clear the stored session instead.
-      const totalTabs = tabGroups.reduce(
-        (n, g) => n + getWorkspaceLeaves(g.layout).reduce((m, leaf) => m + leaf.tabs.length, 0),
-        0
-      );
       const activeGroupIndex = Math.max(
         0,
         state.tabGroups.findIndex((g) => g.id === state.activeTabGroupId)
       );
-      // Window dimension (#1905): stamp which window owns each captured group so
-      // a multi-window session restores its window arrangement. For the main
-      // window (the only store today) this omits windowId and the windows set,
-      // keeping the payload identical to the legacy single-window shape.
-      const stampedGroups = stampWindowId(tabGroups, currentWindowLabel());
-      const windows = buildWindowsMeta(stampedGroups);
+      // Window dimension (#1905/#1925): aggregate every open window's reported
+      // layout slice into one windowId-stamped document so a multi-window session
+      // restores its window arrangement. This also refreshes the main window's own
+      // slice in the backend authority. Falls back to this window's groups only if
+      // aggregation is unavailable — a single-window app then produces the
+      // byte-identical legacy shape (no windowId, no windows set).
+      const { tabGroups: stampedGroups, windows } = await captureAllWindows(
+        ownGroups,
+        activeGroupIndex
+      );
+      // Only persist when there is at least one real tab to restore across every
+      // window. An empty payload tells the backend to clear the stored session.
+      const totalTabs = stampedGroups.reduce(
+        (n, g) => n + getWorkspaceLeaves(g.layout).reduce((m, leaf) => m + leaf.tabs.length, 0),
+        0
+      );
       try {
         await apiSaveLastSession({
           version: "1",
@@ -7378,21 +7507,15 @@ export const useAppStore = create<AppState>((set, get) => {
           })),
           definitions: state.agentDefinitions,
         };
-        // Window dimension (#1905): partition the saved groups by window. Spawning
-        // and hydrating the secondary native windows is cross-window runtime owned
-        // by the epic's runtime work; until it lands, restore is deliberately
-        // NON-LOSSY — every window's groups are restored (plan order, main first)
-        // into this main window rather than dropped. A legacy session has a single
-        // main entry, so this is a no-op there.
+        // Window dimension (#1925): partition the saved groups by window, spawn +
+        // hydrate the saved secondary windows, and build only the main window's
+        // groups into THIS window. A legacy session has a single main entry, so
+        // this spawns nothing and restores every group here (back-compat path).
         const plan = planWindowRestore(session.tabGroups, session.windows);
         if (hasWindowDimension(session.tabGroups, session.windows)) {
-          frontendLog(
-            "multi_window",
-            `restoreLastSession: ${plan.length} saved windows collapsed into the main ` +
-              `window (multi-window spawn-on-restore not yet wired)`
-          );
+          frontendLog("multi_window", `restoreLastSession: restoring ${plan.length} saved windows`);
         }
-        const orderedGroups = plan.flatMap((entry) => entry.tabGroups);
+        const orderedGroups = await restoreWindowedLayout(plan);
         const builtGroups = buildTabGroupsFromWorkspace(
           orderedGroups,
           state.connections,

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ConnectionConfig, TabContentType } from "@/types/terminal";
+import type { WorkspaceTabGroupDef } from "@/types/workspace";
 
 /** Runtime label of the primary application window. */
 export const MAIN_WINDOW_LABEL = "main";
@@ -60,6 +61,37 @@ export interface TabHandoffRecord {
  * the foundation only provides the store action and the seam.
  */
 export type MoveWindowTarget = { kind: "new" } | { kind: "existing"; label: string };
+
+/**
+ * One window's captured layout slice, reported to the backend aggregation
+ * authority and read back when the main window assembles the full multi-window
+ * last-session / workspace document (#1925).
+ *
+ * Each window's tab groups live in its own JS context, so the main window cannot
+ * see another window's layout directly — it collects every window's reported
+ * slice from the backend (`collect_window_layouts`) and stamps + concatenates
+ * them (see `src/utils/windowPersistence.ts`).
+ */
+export interface WindowLayoutReport {
+  /** The reporting window's runtime label (`main`, `win-1`, …). */
+  label: string;
+  /** That window's captured tab groups (its panel trees). */
+  tabGroups: WorkspaceTabGroupDef[];
+  /** Index of the active group within this window's own groups. */
+  activeGroupIndex: number;
+}
+
+/**
+ * The tab groups a restore-spawned secondary window hydrates on boot (#1925).
+ *
+ * A multi-window restore spawns one native window per saved secondary window and
+ * seeds each with its assigned groups via the backend pending-restore queue; the
+ * new window drains this payload (`take_pending_window_restore`) and rebuilds its
+ * layout from it, exactly as the main window rebuilds its own on restore.
+ */
+export interface WindowRestorePayload {
+  tabGroups: WorkspaceTabGroupDef[];
+}
 
 /**
  * What would happen to one live session owned by a window being closed (#1903):

--- a/src/utils/windowPersistence.test.ts
+++ b/src/utils/windowPersistence.test.ts
@@ -5,6 +5,7 @@ import {
   collectWindowIds,
   hasWindowDimension,
   planWindowRestore,
+  assembleWindowedGroups,
 } from "./windowPersistence";
 import { MAIN_WINDOW_LABEL } from "@/types/window";
 import type { WorkspaceTabGroupDef } from "@/types/workspace";
@@ -169,5 +170,40 @@ describe("planWindowRestore", () => {
     expect(plan.map((e) => e.windowId)).toEqual([MAIN_WINDOW_LABEL, "win-1"]);
     expect(plan[0].tabGroups.map((g) => g.name)).toEqual(["A", "B"]);
     expect(plan[1].tabGroups.map((g) => g.name)).toEqual(["C"]);
+  });
+});
+
+describe("assembleWindowedGroups (#1925)", () => {
+  it("produces the legacy shape for a single main window", () => {
+    const result = assembleWindowedGroups([
+      { windowId: MAIN_WINDOW_LABEL, tabGroups: [group("A"), group("B")] },
+    ]);
+    expect(result.windows).toBeUndefined();
+    expect(result.tabGroups.every((g) => g.windowId === undefined)).toBe(true);
+  });
+
+  it("stamps each window's groups and records windows[] main-first", () => {
+    const result = assembleWindowedGroups([
+      { windowId: MAIN_WINDOW_LABEL, tabGroups: [group("A")] },
+      { windowId: "win-1", tabGroups: [group("B")] },
+    ]);
+    expect(result.windows).toEqual([{ id: MAIN_WINDOW_LABEL }, { id: "win-1" }]);
+    expect(result.tabGroups.map((g) => g.windowId)).toEqual([undefined, "win-1"]);
+    // Round-trips: assembling then planning recovers the per-window partition.
+    const plan = planWindowRestore(result.tabGroups, result.windows);
+    expect(plan.map((e) => e.windowId)).toEqual([MAIN_WINDOW_LABEL, "win-1"]);
+    expect(plan[1].tabGroups.map((g) => g.name)).toEqual(["B"]);
+  });
+
+  it("records a secondary window that owns no groups as an empty window", () => {
+    const result = assembleWindowedGroups([
+      { windowId: MAIN_WINDOW_LABEL, tabGroups: [group("A")] },
+      { windowId: "win-1", tabGroups: [] },
+    ]);
+    // win-1 carries no group, so it survives only via the explicit windows[] entry.
+    expect(result.windows).toEqual([{ id: MAIN_WINDOW_LABEL }, { id: "win-1" }]);
+    expect(result.tabGroups.map((g) => g.name)).toEqual(["A"]);
+    const plan = planWindowRestore(result.tabGroups, result.windows);
+    expect(plan.find((e) => e.windowId === "win-1")?.tabGroups).toEqual([]);
   });
 });

--- a/src/utils/windowPersistence.ts
+++ b/src/utils/windowPersistence.ts
@@ -22,6 +22,14 @@
 import { MAIN_WINDOW_LABEL } from "@/types/window";
 import type { WorkspaceTabGroupDef, WorkspaceWindowDef } from "@/types/workspace";
 
+/** One native window's captured layout slice, for assembly on save (#1925). */
+export interface CapturedWindowLayout {
+  /** Runtime window label (`MAIN_WINDOW_LABEL` for the primary window). */
+  windowId: string;
+  /** The tab groups captured from that window, in order. */
+  tabGroups: WorkspaceTabGroupDef[];
+}
+
 /** One native window's slice of a restored layout. */
 export interface WindowRestorePlanEntry {
   /** Logical window id (`MAIN_WINDOW_LABEL` for the primary window). */
@@ -116,6 +124,39 @@ export function hasWindowDimension(
 ): boolean {
   if (windows && windows.some((w) => w.id !== MAIN_WINDOW_LABEL)) return true;
   return groups.some((g) => g.windowId != null && g.windowId !== MAIN_WINDOW_LABEL);
+}
+
+/**
+ * Assemble every open window's captured layout slice into the single windowed
+ * document persisted to a workspace / last session (#1925).
+ *
+ * Each slice's groups are stamped with its window's logical id (the main
+ * window's id is omitted, keeping a single-window save byte-identical to the
+ * legacy schema), then concatenated in the given order — which the backend
+ * authority returns main-window-first. A window that reports **no** groups is
+ * still recorded in `windows[]` (an empty secondary window, #1902), so the
+ * empty-window state round-trips. When only the main window is present with no
+ * secondary windows, `windows` is `undefined` (the legacy shape).
+ */
+export function assembleWindowedGroups(layouts: CapturedWindowLayout[]): {
+  tabGroups: WorkspaceTabGroupDef[];
+  windows: WorkspaceWindowDef[] | undefined;
+} {
+  const stampedGroups: WorkspaceTabGroupDef[] = [];
+  const emptyWindowIds: string[] = [];
+  for (const layout of layouts) {
+    const stamped = stampWindowId(layout.tabGroups, layout.windowId);
+    stampedGroups.push(...stamped);
+    // A secondary window that owns no groups would otherwise vanish (no group
+    // carries its id), so record it as an explicit empty window.
+    if (stamped.length === 0 && layout.windowId !== MAIN_WINDOW_LABEL) {
+      emptyWindowIds.push(layout.windowId);
+    }
+  }
+  return {
+    tabGroups: stampedGroups,
+    windows: buildWindowsMeta(stampedGroups, emptyWindowIds),
+  };
 }
 
 /**


### PR DESCRIPTION
Completes the multi-window persistence epic (#1899) by re-creating secondary
windows on startup / workspace launch and re-attaching their tab groups, building
on the #1905 schema + pure helpers, the #1900 window manager / ownership seam, and
the #1902 empty-window boot.

## What changed

**Backend (`src-tauri/src/window`, `commands/window.rs`)** — the aggregation
authority and restore queue (landed as WIP, now wired):
- `report_window_layout` / `collect_window_layouts`: each window reports its own
  captured layout slice; the main window collects every slice (main-first) to
  assemble a document it cannot see across the JS-context boundary. A changed
  secondary slice nudges `window-layout-changed`; the main window's own report
  never nudges (no re-save loop).
- `take_pending_window_restore` + `open_window(restore)`: a restore-spawned window
  drains the tab groups it was seeded with on boot. Slices are forgotten on window
  destroy so a saved document never carries a dead window.

**Frontend (`appStore.ts`, `App.tsx`, `windowPersistence.ts`)**:
- **Save** aggregates every open window via `captureAllWindows` →
  `assembleWindowedGroups` for both `saveLastSession` and full-scope
  `saveCurrentAsWorkspace`. Secondary windows report their slice on layout change
  (debounced); the main window re-persists on the `window-layout-changed` nudge.
- **Restore** (`restoreLastSession` and `launchWorkspace`) partitions the saved
  layout with `planWindowRestore`, spawns + hydrates each saved secondary window,
  and builds only the main window's groups into the main window — replacing the
  previous non-lossy collapse-into-main path. Empty secondary windows round-trip.
- A restore-spawned window hydrates its seeded groups on boot before draining
  live hand-offs.

Single-window saves remain byte-identical to the legacy shape; aggregation falls
back to the current window if the cross-window commands are unavailable.

## Tests

- Rust: `WindowManager` layout report/collect ordering + pending-restore drain
  (in the WIP commit).
- Frontend: `assembleWindowedGroups` (legacy shape, main-first stamping with a
  planWindowRestore round-trip, empty-window recording); `restoreLastSession`
  spawns seeded and empty secondary windows and keeps only main groups; save
  aggregates reported slices; `receivePendingWindowRestore` hydrates / no-ops.
- `./scripts/check.sh` and the full frontend suite (4242 tests) pass.

## Notes

- Multi-window layouts can only be exercised end-to-end outside the jsdom
  per-PR lane; the unit tests drive the aggregation/plan seams directly.

Closes #1925