### PR TITLE
feat(ui): variant-driven title accent icon in ConfirmDialog (Closes #1928)

### DIFF
--- a/docs/changes/dev4/feat/1928-confirmdialog-title-icon.md
+++ b/docs/changes/dev4/feat/1928-confirmdialog-title-icon.md
@@ -1,0 +1,8 @@
+### Added
+
+- Confirmation dialogs now show a tinted accent icon in the title, driven by a
+  new `variant` prop on the shared `ConfirmDialog` primitive: `danger` renders
+  an alert triangle in the error accent (file-browser delete), `warn` renders
+  one in the warning accent (Port Scanner large-scan warning), and a
+  caller-supplied `icon` shows on the default variant (a save glyph on the
+  Wake-on-LAN "save device" dialog) (#1928).

--- a/src/components/NetworkTools/PortScannerPanel.tsx
+++ b/src/components/NetworkTools/PortScannerPanel.tsx
@@ -275,6 +275,7 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
       <ConfirmDialog
         open={warnOpen}
         title="Large scan"
+        variant="warn"
         description="Confirm before starting a scan that may take a while."
         message={`This scan will probe about ${probeEstimate.toLocaleString()} host/port combinations and may take several minutes. Continue?`}
         confirmLabel="Start scan"

--- a/src/components/NetworkTools/WolPanel.tsx
+++ b/src/components/NetworkTools/WolPanel.tsx
@@ -239,6 +239,7 @@ export function WolPanel() {
       <ConfirmDialog
         open={saveModalOpen}
         title="Save Wake-on-LAN Device"
+        icon={<Save size={16} />}
         confirmLabel="Save"
         confirmVariant="primary"
         confirmDisabled={!canSaveDevice}

--- a/src/components/Sidebar/ConfirmDeleteDialog.tsx
+++ b/src/components/Sidebar/ConfirmDeleteDialog.tsx
@@ -18,6 +18,7 @@ export function ConfirmDeleteDialog({
     <ConfirmDialog
       open={open}
       title="Confirm Delete"
+      variant="danger"
       message={message}
       confirmLabel="Delete"
       confirmVariant="danger"

--- a/src/components/ui/ConfirmDialog.test.tsx
+++ b/src/components/ui/ConfirmDialog.test.tsx
@@ -219,6 +219,106 @@ describe("ConfirmDialog", () => {
     expect(onChange).toHaveBeenCalledWith(true);
   });
 
+  describe("title accent icon (per variant)", () => {
+    /** The title accent-icon wrapper, or null when the variant renders none. */
+    function titleIcon(base = "confirm-dialog"): HTMLElement | null {
+      return document.querySelector(`[data-testid="${base}-title-icon"]`);
+    }
+
+    it("renders no accent icon for the default variant", () => {
+      render(<ConfirmDialog open title="T" message="M" onConfirm={vi.fn()} onCancel={vi.fn()} />);
+      expect(titleIcon()).toBeNull();
+    });
+
+    it("renders a danger-tinted alert triangle for variant=danger", () => {
+      render(
+        <ConfirmDialog
+          open
+          variant="danger"
+          title="Delete"
+          message="M"
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+      const icon = titleIcon();
+      expect(icon).toBeTruthy();
+      expect(icon!.classList.contains("ui-confirm__title-icon--danger")).toBe(true);
+      expect(icon!.querySelector("svg")?.classList.contains("lucide-triangle-alert")).toBe(true);
+    });
+
+    it("renders a warning-tinted alert triangle for variant=warn", () => {
+      render(
+        <ConfirmDialog
+          open
+          variant="warn"
+          title="Large scan"
+          message="M"
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+      const icon = titleIcon();
+      expect(icon).toBeTruthy();
+      expect(icon!.classList.contains("ui-confirm__title-icon--warn")).toBe(true);
+      expect(icon!.querySelector("svg")?.classList.contains("lucide-triangle-alert")).toBe(true);
+    });
+
+    // The WoL "save device" case: a default-variant dialog with a caller icon.
+    it("renders a caller-supplied icon untinted on the default variant", () => {
+      render(
+        <ConfirmDialog
+          open
+          title="Save Wake-on-LAN Device"
+          icon={<svg data-testid="my-icon" />}
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+        >
+          <input data-testid="body-field" />
+        </ConfirmDialog>
+      );
+      const icon = titleIcon();
+      expect(icon).toBeTruthy();
+      expect(icon!.classList.contains("ui-confirm__title-icon--default")).toBe(true);
+      expect(icon!.querySelector('[data-testid="my-icon"]')).toBeTruthy();
+    });
+
+    // A caller icon overrides the variant's default glyph but keeps the tint.
+    it("lets a caller icon override the variant default icon while keeping the tint", () => {
+      render(
+        <ConfirmDialog
+          open
+          variant="danger"
+          title="Delete"
+          message="M"
+          icon={<svg data-testid="my-icon" />}
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+      const icon = titleIcon();
+      expect(icon!.classList.contains("ui-confirm__title-icon--danger")).toBe(true);
+      expect(icon!.querySelector('[data-testid="my-icon"]')).toBeTruthy();
+      expect(icon!.querySelector(".lucide-triangle-alert")).toBeNull();
+    });
+
+    it("derives the title-icon test id from testIdBase", () => {
+      render(
+        <ConfirmDialog
+          open
+          variant="danger"
+          title="Delete"
+          message="M"
+          testIdBase="confirm-delete"
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+        />
+      );
+      expect(titleIcon("confirm-delete")).toBeTruthy();
+      expect(titleIcon("confirm-dialog")).toBeNull();
+    });
+  });
+
   // WAI-ARIA: Space activates a checkbox, Enter does not. Enter inside the
   // dialog stays the confirm shortcut rather than ticking the opt-out.
   it("confirms rather than ticking the opt-out when Enter is pressed on it", () => {

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,8 +1,23 @@
 import React, { useEffect, useRef } from "react";
+import { AlertTriangle } from "lucide-react";
 import { Modal } from "./Modal";
 import { Button, ButtonVariant } from "./Button";
 import { Checkbox } from "./Checkbox";
 import "./ui.css";
+
+/**
+ * Intent of a {@link ConfirmDialog}, driving the tinted accent icon rendered in
+ * the Modal title:
+ *
+ * - `danger` — destructive/irreversible action: an alert triangle in
+ *   `--color-error` (the same token the danger confirm Button uses).
+ * - `warn` — a heads-up before a heavy/slow action: an alert triangle in
+ *   `--color-warning`.
+ * - `default` — no accent icon, unless the caller supplies one via
+ *   {@link ConfirmDialogProps.icon | icon} (e.g. a save glyph for the WoL
+ *   "save device" modal), which renders untinted.
+ */
+export type ConfirmDialogVariant = "default" | "warn" | "danger";
 
 /**
  * Optional "don't ask again" opt-out rendered below a confirmation message.
@@ -30,6 +45,22 @@ export interface ConfirmDialogProps {
   open: boolean;
   /** Heading text. */
   title: React.ReactNode;
+  /**
+   * Intent driving the tinted title accent icon (defaults to `"default"`, which
+   * shows no icon). `danger`/`warn` render an alert triangle tinted with
+   * `--color-error` / `--color-warning`; see {@link ConfirmDialogVariant}. This
+   * is presentational only — the confirm Button's colour is set independently
+   * via {@link ConfirmDialogProps.confirmVariant | confirmVariant}.
+   */
+  variant?: ConfirmDialogVariant;
+  /**
+   * Optional caller-supplied title accent icon. Overrides the
+   * {@link ConfirmDialogProps.variant | variant} default icon, so a
+   * `variant="default"` dialog can still show a glyph (e.g. `<Save />` for the
+   * WoL save modal). A caller icon on a `danger`/`warn` dialog is still tinted
+   * with that variant's accent colour.
+   */
+  icon?: React.ReactNode;
   /** Optional description for screen readers (rendered visually hidden). */
   description?: string;
   /**
@@ -95,6 +126,8 @@ export interface ConfirmDialogProps {
 export function ConfirmDialog({
   open,
   title,
+  variant = "default",
+  icon,
   description,
   message,
   children,
@@ -111,6 +144,24 @@ export function ConfirmDialog({
 }: ConfirmDialogProps): React.ReactElement {
   const cancelBtnRef = useRef<HTMLButtonElement>(null);
 
+  // Resolve the title accent icon: a caller-supplied `icon` wins, otherwise the
+  // danger/warn variants fall back to an alert triangle. `default` has no icon.
+  const accentIcon =
+    icon ?? (variant === "default" ? null : <AlertTriangle size={16} aria-hidden="true" />);
+  const titleNode = accentIcon ? (
+    <span className="ui-confirm__title">
+      <span
+        className={`ui-confirm__title-icon ui-confirm__title-icon--${variant}`}
+        data-testid={`${testIdBase}-title-icon`}
+      >
+        {accentIcon}
+      </span>
+      <span>{title}</span>
+    </span>
+  ) : (
+    title
+  );
+
   // Focus the safe (Cancel) button on open so an accidental Enter does not
   // trigger the destructive action.
   useEffect(() => {
@@ -123,7 +174,7 @@ export function ConfirmDialog({
     <Modal
       open={open}
       onOpenChange={(isOpen) => !isOpen && onCancel()}
-      title={title}
+      title={titleNode}
       description={description}
       data-testid={rest["data-testid"]}
       onKeyDown={(e) => {

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -27,7 +27,11 @@ export { Modal, useModalPortalContainer } from "./Modal";
 export type { ModalProps } from "./Modal";
 
 export { ConfirmDialog } from "./ConfirmDialog";
-export type { ConfirmDialogProps, ConfirmDontAskAgain } from "./ConfirmDialog";
+export type {
+  ConfirmDialogProps,
+  ConfirmDialogVariant,
+  ConfirmDontAskAgain,
+} from "./ConfirmDialog";
 
 export { Toggle } from "./Toggle";
 export type { ToggleProps } from "./Toggle";

--- a/src/components/ui/ui.css
+++ b/src/components/ui/ui.css
@@ -701,3 +701,25 @@
   color: var(--text-secondary);
   cursor: pointer;
 }
+
+/* Variant-driven title accent icon (see ConfirmDialogVariant). */
+.ui-confirm__title {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.ui-confirm__title-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  /* `default` (caller-supplied glyph) inherits the title text colour. */
+  color: inherit;
+}
+
+.ui-confirm__title-icon--danger {
+  color: var(--color-error);
+}
+
+.ui-confirm__title-icon--warn {
+  color: var(--color-warning);
+}


### PR DESCRIPTION
## Summary

Adds the variant-driven title accent icon the `confirm-dialog-primitive` concept mockups show but the shipped primitive omitted.

- New `variant` prop (`default` / `warn` / `danger`) and optional `icon` prop on the shared `ConfirmDialog` primitive.
  - `danger` → alert triangle tinted `--color-error` (the danger confirm Button's token).
  - `warn` → alert triangle tinted `--color-warning`.
  - `default` → no icon, unless the caller supplies one via `icon` (rendered untinted).
- Wired the three migrated call sites to match the mockups:
  - `ConfirmDeleteDialog` → `variant="danger"`.
  - `PortScannerPanel` large-scan warning → `variant="warn"`.
  - `WolPanel` save modal → `icon={<Save />}` on the default variant.
- Tokens only — the tint uses `--color-error` / `--color-warning` (the app's danger token is `--color-error`; the concept's literal `--color-danger` is not a defined token).

## Testing

- New unit tests in `ConfirmDialog.test.tsx` assert the accent icon per variant: none for `default`, tinted alert triangle for `danger`/`warn`, caller icon on `default`, caller icon overriding a variant default while keeping the tint, and testid derivation.
- `pnpm exec vitest run` (ConfirmDialog + all three call-site suites) green; `pnpm run lint` and `tsc --noEmit` clean.

Closes #1928