### PR TITLE
feat(ui): make open connections panel lightly window-aware (Closes #1926)

### DIFF
--- a/docs/changes/dev1/feature/1926-openconn-window-aware.md
+++ b/docs/changes/dev1/feature/1926-openconn-window-aware.md
@@ -1,0 +1,7 @@
+### Added
+
+- The Open Connections panel is now lightly window-aware. When more than one
+  window is open, each session row shows an owning-window chip (e.g.
+  "Window 2") and clicking it brings that window to the foreground. With a
+  single window the panel looks exactly as before. Kill actions stay global —
+  the panel still lists and can stop every connection across all windows.

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -114,6 +114,35 @@ pub fn get_session_owner(
     window_manager.owner_of(&session_id)
 }
 
+/// A snapshot of the full `session_id → owning_window_label` map (#1926).
+///
+/// The Open Connections panel reads this once when it opens to stamp each
+/// session row with an owning-window badge (and a "focus owning window"
+/// affordance). Only claimed sessions appear — an unclaimed session has no
+/// entry, so its row shows no window badge.
+#[tauri::command]
+pub fn list_session_owners(
+    window_manager: State<'_, WindowManager>,
+) -> std::collections::HashMap<String, String> {
+    window_manager.all_owners()
+}
+
+/// Bring the window addressed by `label` to the foreground (#1926).
+///
+/// The "focus owning window" affordance in the Open Connections panel calls this
+/// to surface the window that owns a session. Unminimizes first so a minimized
+/// window is restored, then shows and focuses it. A `label` with no live window
+/// (it was closed between the panel opening and the click) is a no-op.
+#[tauri::command]
+pub fn focus_window(app: AppHandle, label: String) -> Result<(), String> {
+    if let Some(window) = app.get_webview_window(&label) {
+        window.unminimize().map_err(|e| e.to_string())?;
+        window.show().map_err(|e| e.to_string())?;
+        window.set_focus().map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
 /// List all currently open windows, each with its last-reported tab count.
 ///
 /// The tab count is whatever the owning window last pushed via

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -948,6 +948,8 @@ pub fn run() {
             commands::window::claim_session,
             commands::window::release_session,
             commands::window::get_session_owner,
+            commands::window::list_session_owners,
+            commands::window::focus_window,
             commands::window::list_windows,
             commands::window::report_window_tab_count,
             commands::window::report_window_layout,

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -213,6 +213,16 @@ impl WindowManager {
         recover(self.ownership.lock()).get(session_id).cloned()
     }
 
+    /// A snapshot of the full `session_id → owning_window_label` map.
+    ///
+    /// The Open Connections panel reads this once when it opens to stamp each
+    /// session row with the window that owns it (#1926). Only sessions that have
+    /// been claimed (e.g. moved between windows) appear; an unclaimed session has
+    /// no entry and the panel renders no window badge for it.
+    pub fn all_owners(&self) -> HashMap<String, String> {
+        recover(self.ownership.lock()).clone()
+    }
+
     /// Whether `window_label` may issue `resize` for `session_id`.
     ///
     /// `true` when the session is **unclaimed** (legacy single-window: any
@@ -425,6 +435,27 @@ mod tests {
         assert_eq!(wm.owner_of("s1"), None);
         assert_eq!(wm.owner_of("s2"), None);
         assert_eq!(wm.owner_of("s3"), Some("main".to_string()));
+    }
+
+    #[test]
+    fn all_owners_snapshots_the_full_ownership_map() {
+        let wm = WindowManager::new();
+        assert!(wm.all_owners().is_empty(), "no claims → empty snapshot");
+        wm.claim("s1", "win-1");
+        wm.claim("s2", "win-1");
+        wm.claim("s3", "main");
+        let owners = wm.all_owners();
+        assert_eq!(owners.len(), 3);
+        assert_eq!(owners.get("s1"), Some(&"win-1".to_string()));
+        assert_eq!(owners.get("s2"), Some(&"win-1".to_string()));
+        assert_eq!(owners.get("s3"), Some(&"main".to_string()));
+        // The snapshot is a copy — mutating the manager does not change it.
+        wm.release("s1", "win-1");
+        assert_eq!(
+            owners.get("s1"),
+            Some(&"win-1".to_string()),
+            "snapshot is detached from later releases"
+        );
     }
 
     #[test]

--- a/src/components/OpenConnections/OpenConnectionsModal.css
+++ b/src/components/OpenConnections/OpenConnectionsModal.css
@@ -105,6 +105,17 @@
   flex-shrink: 0;
 }
 
+/* Owning-window "focus this window" chip (issue 1926): a compact ghost button
+   shown per row only when more than one window is open. */
+.oc-row__window {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+  padding: 1px var(--spacing-xs);
+  height: auto;
+  gap: var(--spacing-xs);
+}
+
 /* Trailing action cluster for rows that expose more than one intent
    (e.g. an agent's Disconnect vs Shutdown). */
 .oc-row__actions {

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -21,6 +21,7 @@ import {
   Unplug,
   Power,
   Package,
+  AppWindow,
 } from "lucide-react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Modal, Button, Tooltip, Progress, ConfirmDialog, toast } from "@/components/ui";
@@ -40,6 +41,8 @@ import {
   pruneDeadAgents,
   xServerStatus,
   xServerStop,
+  listSessionOwners,
+  focusWindow,
   LocalSessionInfo,
   AgentSessionInfo,
 } from "@/services/api";
@@ -52,6 +55,8 @@ import { frontendLog } from "@/utils/frontendLog";
 import { XServerStatusReport } from "@/types/xserver";
 import { resolveAgentUpdateState } from "@/utils/agentVersion";
 import { useDesktopVersion } from "@/hooks/useDesktopVersion";
+import { useWindowInfo } from "@/hooks/useWindowInfo";
+import { windowDisplayName } from "@/utils/windowPicker";
 import { AgentVersionBadge } from "@/components/AgentVersionBadge/AgentVersionBadge";
 import { XServerSetupDialog } from "./XServerSetupDialog";
 import "./OpenConnectionsModal.css";
@@ -76,6 +81,11 @@ interface ProxySessionsState {
 export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModalProps) {
   const remoteAgents = useAppStore((s) => s.remoteAgents);
   const desktopVersion = useDesktopVersion();
+  // How many native windows are open. The owning-window badge/focus affordance
+  // (#1926) is shown only with >1 window, so single-window users see no change —
+  // mirroring the StatusBar window affordance (#1902).
+  const { count: windowCount } = useWindowInfo();
+  const multiWindow = windowCount > 1;
   const disconnectRemoteAgent = useAppStore((s) => s.disconnectRemoteAgent);
   const shutdownRemoteAgent = useAppStore((s) => s.shutdownRemoteAgent);
   const stopTunnel = useAppStore((s) => s.stopTunnel);
@@ -153,6 +163,10 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const [xServer, setXServer] = useState<XServerStatusReport | null>(null);
   const [xServerSetupOpen, setXServerSetupOpen] = useState(false);
   const [loading, setLoading] = useState(false);
+  // Snapshot of the backend `session_id → owning_window` map (#1900), read when
+  // the panel opens. Sparse — only claimed sessions (e.g. moved between windows)
+  // appear — so a session with no entry renders no window badge.
+  const [sessionOwners, setSessionOwners] = useState<Record<string, string>>({});
 
   // Split backend-local sessions: spawned containers get their own section, the
   // rest stay under "Local Sessions" (#1446). A session is spawned when the
@@ -179,14 +193,16 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const loadData = useCallback(async () => {
     setLoading(true);
     try {
-      const [locals, xServerReport, ...agentSessionArrays] = await Promise.all([
+      const [locals, xServerReport, owners, ...agentSessionArrays] = await Promise.all([
         listLocalSessions(),
         xServerStatus().catch(() => null),
+        listSessionOwners().catch(() => ({}) as Record<string, string>),
         ...connectedAgents.map((a) => listAgentSessions(a.id).catch(() => [])),
       ]);
 
       setLocalSessions(locals.filter((s) => !s.agentId));
       setXServer(xServerReport as XServerStatusReport | null);
+      setSessionOwners(owners as Record<string, string>);
 
       const byProxy: ProxySessionsState = {};
       for (const s of locals) {
@@ -303,6 +319,28 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
           : disconnectRemoteAgent(a.id).catch(() => {})
       )
     );
+  };
+
+  // Resolve a session's owning window into a display name (#1926). Returns null
+  // when only one window is open, the session id is missing, or the session is
+  // unclaimed (no ownership entry) — in all three cases the row shows no window
+  // badge, so single-window users see no change.
+  const resolveOwningWindow = (sessionId: string | null | undefined): OwningWindow | null => {
+    if (!multiWindow || !sessionId) return null;
+    const label = sessionOwners[sessionId];
+    if (!label) return null;
+    return { label, name: windowDisplayName(label) };
+  };
+
+  // Bring an owning window to the foreground (#1926). Focusing the current window
+  // is a harmless no-op.
+  const handleFocusWindow = async (label: string) => {
+    try {
+      await focusWindow(label);
+    } catch (err) {
+      frontendLog("open_connections", `Failed to focus window ${label}: ${err}`);
+      toast.error(`Failed to focus window: ${err}`);
+    }
   };
 
   const handleKillLocal = async (id: string) => {
@@ -639,6 +677,8 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
                 icon={<Terminal size={14} />}
                 title={s.title}
                 badge={s.alive ? "alive" : "dead"}
+                owningWindow={resolveOwningWindow(s.id)}
+                onFocusWindow={handleFocusWindow}
                 onKill={() => handleKillLocal(s.id)}
               />
             ))}
@@ -662,6 +702,8 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
                 icon={<Package size={14} />}
                 title={s.title}
                 badge={s.alive ? "spawned" : "dead"}
+                owningWindow={resolveOwningWindow(s.id)}
+                onFocusWindow={handleFocusWindow}
                 onKill={() => handleKillLocal(s.id)}
               />
             ))}
@@ -750,6 +792,8 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
                   icon={s.connectionType === "ssh" ? <Server size={14} /> : <Terminal size={14} />}
                   title={s.title}
                   badge={s.alive ? "alive" : "dead"}
+                  owningWindow={resolveOwningWindow(s.id)}
+                  onFocusWindow={handleFocusWindow}
                   onKill={() => handleKillProxy(a.id, s.id)}
                 />
               ))}
@@ -1156,6 +1200,17 @@ function TransferRow({ transfer, onCancel }: TransferRowProps) {
   );
 }
 
+/**
+ * The window that owns a session, resolved from the backend ownership map for
+ * the owning-window badge / focus affordance (#1926).
+ */
+interface OwningWindow {
+  /** The owning window's runtime label (`main`, `win-1`, …). */
+  label: string;
+  /** Human-readable name, e.g. "Window 2". */
+  name: string;
+}
+
 interface ConnectionRowProps {
   icon: React.ReactNode;
   title: string;
@@ -1164,6 +1219,14 @@ interface ConnectionRowProps {
   badge: BadgeVariant;
   /** Extra info rendered between the title and the status badge (e.g. agent version). */
   meta?: React.ReactNode;
+  /**
+   * The window owning this row's session (#1926). When set, the row renders a
+   * clickable "Window N" chip that focuses that window. Null/undefined for
+   * single-window mode or an unclaimed session — the row then shows no chip.
+   */
+  owningWindow?: OwningWindow | null;
+  /** Bring the owning window to the foreground (#1926). */
+  onFocusWindow?: (label: string) => void | Promise<void>;
   /** When omitted, no per-row kill button is rendered. */
   onKill?: () => void | Promise<void>;
   /** Label for the kill button (defaults to "Kill"). */
@@ -1185,6 +1248,8 @@ function ConnectionRow({
   detail,
   badge,
   meta,
+  owningWindow,
+  onFocusWindow,
   onKill,
   killLabel = "Kill",
   "data-testid": testId,
@@ -1199,6 +1264,21 @@ function ConnectionRow({
         {detail && <span className="oc-row__detail">{detail}</span>}
       </span>
       {meta}
+      {owningWindow && (
+        <Tooltip content={`Focus ${owningWindow.name}`} side="top">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="oc-row__window"
+            icon={<AppWindow size={12} />}
+            onClick={() => onFocusWindow?.(owningWindow.label)}
+            aria-label={`Focus ${owningWindow.name}`}
+            data-testid="oc-row-window"
+          >
+            {owningWindow.name}
+          </Button>
+        </Tooltip>
+      )}
       <span className={`oc-row__badge oc-row__badge--${badge}`}>{badge}</span>
       {actions ??
         (onKill && (

--- a/src/components/OpenConnections/OpenConnectionsModal.windowAware.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.windowAware.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Tests for the light window-awareness of the Open Connections panel (#1926,
+ * epic #1899).
+ *
+ * When more than one native window is open, each session row shows an
+ * owning-window chip (e.g. "Window 2") sourced from #1900's
+ * `session_id → owning_window` map; clicking the chip focuses that window. With
+ * a single window — or for an unclaimed session with no ownership entry — no
+ * chip is shown, so single-window users see no change. Kill actions stay global.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+import type { LocalSessionInfo } from "@/services/api";
+import type { WindowInfoState } from "@/hooks/useWindowInfo";
+
+const listLocalSessions = vi.fn<() => Promise<LocalSessionInfo[]>>();
+const listSessionOwners = vi.fn<() => Promise<Record<string, string>>>();
+const focusWindow = vi.fn((_label: string) => Promise.resolve());
+
+vi.mock("@/services/api", () => ({
+  listLocalSessions: () => listLocalSessions(),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  listSessionOwners: () => listSessionOwners(),
+  focusWindow: (label: string) => focusWindow(label),
+  closeTerminal: vi.fn(() => Promise.resolve()),
+  closeAgentSession: vi.fn(() => Promise.resolve()),
+  cancelConnecting: vi.fn(() => Promise.resolve(true)),
+  cancelConnectAgent: vi.fn(() => Promise.resolve()),
+  pruneDeadAgents: vi.fn(() => Promise.resolve([])),
+  xServerStatus: vi.fn(() =>
+    Promise.resolve({ state: "absent", platform: "linux", managed: false, sessionCount: 0 })
+  ),
+  xServerStop: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/services/networkApi", () => ({
+  networkHttpMonitorStop: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorStopAll: vi.fn(() => Promise.resolve()),
+  networkHttpMonitorList: vi.fn(() => Promise.resolve([])),
+}));
+
+// The window count drives whether the affordance is shown at all — mock the hook
+// directly (as the StatusBar window test does) so the count is deterministic.
+let windowInfo: WindowInfoState = { label: "main", name: "Main Window", count: 1 };
+vi.mock("@/hooks/useWindowInfo", () => ({
+  useWindowInfo: () => windowInfo,
+}));
+
+import { OpenConnectionsModal } from "./OpenConnectionsModal";
+
+const OWNED_SESSION: LocalSessionInfo = {
+  id: "sess-owned",
+  title: "Owned Shell",
+  connectionType: "local",
+  alive: true,
+};
+
+const UNCLAIMED_SESSION: LocalSessionInfo = {
+  id: "sess-unclaimed",
+  title: "Unclaimed Shell",
+  connectionType: "local",
+  alive: true,
+};
+
+function rowMatching(text: string): Element | undefined {
+  return Array.from(document.querySelectorAll(".oc-row")).find((r) =>
+    r.querySelector(".oc-row__title")?.textContent?.includes(text)
+  );
+}
+
+function windowChip(rowText: string): HTMLButtonElement | null {
+  const row = rowMatching(rowText);
+  return (row?.querySelector("[data-testid='oc-row-window']") as HTMLButtonElement) ?? null;
+}
+
+describe("OpenConnectionsModal — owning-window affordance (#1926)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    listLocalSessions.mockReset();
+    listSessionOwners.mockReset();
+    focusWindow.mockClear();
+    listLocalSessions.mockResolvedValue([OWNED_SESSION, UNCLAIMED_SESSION]);
+    listSessionOwners.mockResolvedValue({ "sess-owned": "win-2" });
+    windowInfo = { label: "main", name: "Main Window", count: 1 };
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function renderModal() {
+    await act(async () => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <OpenConnectionsModal open={true} onOpenChange={() => {}} />
+        </TooltipProvider>
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it("shows the owning-window chip for a claimed session when >1 window is open", async () => {
+    windowInfo = { label: "main", name: "Main Window", count: 2 };
+    await renderModal();
+
+    const chip = windowChip("Owned Shell");
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toContain("Window 2");
+  });
+
+  it("focuses the owning window when the chip is clicked", async () => {
+    windowInfo = { label: "main", name: "Main Window", count: 2 };
+    await renderModal();
+
+    const chip = windowChip("Owned Shell");
+    await act(async () => {
+      chip?.click();
+      await Promise.resolve();
+    });
+    expect(focusWindow).toHaveBeenCalledWith("win-2");
+  });
+
+  it("shows no chip for an unclaimed session even with >1 window", async () => {
+    windowInfo = { label: "main", name: "Main Window", count: 2 };
+    await renderModal();
+
+    // The owned session gets a chip; the unclaimed one (no ownership entry) does not.
+    expect(windowChip("Owned Shell")).not.toBeNull();
+    expect(windowChip("Unclaimed Shell")).toBeNull();
+  });
+
+  it("shows no chip at all with a single window (single-window users see no change)", async () => {
+    // count stays 1 (default) — even though the ownership map has an entry.
+    await renderModal();
+
+    expect(windowChip("Owned Shell")).toBeNull();
+    expect(windowChip("Unclaimed Shell")).toBeNull();
+    expect(document.querySelectorAll("[data-testid='oc-row-window']")).toHaveLength(0);
+  });
+});

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -321,6 +321,26 @@ export async function getSessionOwner(sessionId: string): Promise<string | null>
   return await invoke<string | null>("get_session_owner", { sessionId });
 }
 
+/**
+ * A snapshot of the full `session_id → owning_window_label` map (#1926).
+ *
+ * The Open Connections panel reads this when it opens to stamp each session row
+ * with an owning-window badge. Only claimed sessions (e.g. moved between windows)
+ * appear; an unclaimed session has no entry.
+ */
+export async function listSessionOwners(): Promise<Record<string, string>> {
+  return await invoke<Record<string, string>>("list_session_owners");
+}
+
+/**
+ * Bring the window addressed by `label` to the foreground (#1926) — the "focus
+ * owning window" affordance in the Open Connections panel. A label whose window
+ * has since closed is a no-op.
+ */
+export async function focusWindow(label: string): Promise<void> {
+  await invoke("focus_window", { label });
+}
+
 /** List all currently open windows, each with its last-reported tab count. */
 export async function listWindows(): Promise<WindowInfo[]> {
   return await invoke<WindowInfo[]>("list_windows");


### PR DESCRIPTION
Implements the maintainer-decided **light** window-awareness for the Open Connections panel (epic #1899, follow-up to #1905).

## What changed
- **Owning-window badge/column** per session row (e.g. "Window 2"), sourced from #1900's `session_id → owning_window` ownership map.
- **"Focus owning window" affordance** — the badge is a clickable chip that brings the owning window to the foreground.
- Window info is shown **only when >1 window is open** (mirrors the StatusBar affordance from #1902 via `useWindowInfo`), so single-window users see no change.
- Kill actions stay **global** — no per-window scoped kill / grouping (explicitly out of scope).

## Surface
- Backend: `WindowManager::all_owners()` snapshot; new commands `list_session_owners` and `focus_window` (registered in `lib.rs`).
- Frontend: `listSessionOwners()` / `focusWindow()` in `api.ts`; `OpenConnectionsModal` reads the map on open, resolves each session row's owner, and renders the chip on the Local Sessions, Spawned Containers, and proxy-session rows.

## Notes / scope
The ownership map is currently **sparse** — sessions are only claimed on tab hand-off (#1900) / not on normal open, so the badge appears for sessions that have an owner entry. Broadening the claim lifecycle so every window claims the sessions it renders is a larger change to #1900's ownership semantics and is filed as a follow-up.

## Tests
- Rust: `all_owners` snapshot test.
- Frontend: badge + focus behavior, and single-window suppression.

Closes #1926


Follow-up filed: #1939 (broaden the ownership claim lifecycle so the badge covers every session, not only moved ones).
