### PR TITLE
test(ui): fix open connections api mocks broken by #1938 merge

### DIFF
--- a/src/components/OpenConnections/OpenConnectionsModal.agentShutdown.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.agentShutdown.test.tsx
@@ -16,6 +16,8 @@ const toastSuccess = vi.fn();
 const toastError = vi.fn();
 
 vi.mock("@/services/api", () => ({
+  listSessionOwners: vi.fn(() => Promise.resolve({})),
+  focusWindow: vi.fn(() => Promise.resolve()),
   listLocalSessions: vi.fn(() => Promise.resolve([])),
   listAgentSessions: vi.fn(() => Promise.resolve([])),
   closeTerminal: vi.fn(() => Promise.resolve()),

--- a/src/components/OpenConnections/OpenConnectionsModal.connecting.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.connecting.test.tsx
@@ -12,6 +12,8 @@ import type { TerminalTab } from "@/types/terminal";
 
 const cancelConnecting = vi.fn((_id: string) => Promise.resolve(true));
 vi.mock("@/services/api", () => ({
+  listSessionOwners: vi.fn(() => Promise.resolve({})),
+  focusWindow: vi.fn(() => Promise.resolve()),
   listLocalSessions: vi.fn(() => Promise.resolve([])),
   listAgentSessions: vi.fn(() => Promise.resolve([])),
   closeTerminal: vi.fn(() => Promise.resolve()),

--- a/src/components/OpenConnections/OpenConnectionsModal.establishing.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.establishing.test.tsx
@@ -15,6 +15,8 @@ const cancelConnectAgent = vi.fn((_id: string) => Promise.resolve(true));
 const disconnectAgent = vi.fn((_id: string) => Promise.resolve());
 
 vi.mock("@/services/api", () => ({
+  listSessionOwners: vi.fn(() => Promise.resolve({})),
+  focusWindow: vi.fn(() => Promise.resolve()),
   listLocalSessions: vi.fn(() => Promise.resolve([])),
   listAgentSessions: vi.fn(() => Promise.resolve([])),
   closeTerminal: vi.fn(() => Promise.resolve()),

--- a/src/components/OpenConnections/OpenConnectionsModal.httpMonitors.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.httpMonitors.test.tsx
@@ -31,6 +31,8 @@ if (!Element.prototype.hasPointerCapture) {
 }
 
 vi.mock("@/services/api", () => ({
+  listSessionOwners: vi.fn(() => Promise.resolve({})),
+  focusWindow: vi.fn(() => Promise.resolve()),
   listLocalSessions: vi.fn(() => Promise.resolve([])),
   listAgentSessions: vi.fn(() => Promise.resolve([])),
   closeTerminal: vi.fn(() => Promise.resolve()),

--- a/src/components/OpenConnections/OpenConnectionsModal.monitoringControls.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.monitoringControls.test.tsx
@@ -29,6 +29,8 @@ if (!Element.prototype.hasPointerCapture) {
 }
 
 vi.mock("@/services/api", () => ({
+  listSessionOwners: vi.fn(() => Promise.resolve({})),
+  focusWindow: vi.fn(() => Promise.resolve()),
   listLocalSessions: vi.fn(() => Promise.resolve([])),
   listAgentSessions: vi.fn(() => Promise.resolve([])),
   closeTerminal: vi.fn(() => Promise.resolve()),

--- a/src/components/OpenConnections/OpenConnectionsModal.prune.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.prune.test.tsx
@@ -15,6 +15,8 @@ const toastSuccess = vi.fn();
 const toastError = vi.fn();
 
 vi.mock("@/services/api", () => ({
+  listSessionOwners: vi.fn(() => Promise.resolve({})),
+  focusWindow: vi.fn(() => Promise.resolve()),
   listLocalSessions: vi.fn(() => Promise.resolve([])),
   listAgentSessions: vi.fn(() => Promise.resolve([])),
   closeTerminal: vi.fn(() => Promise.resolve()),

--- a/src/components/OpenConnections/OpenConnectionsModal.spawned.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.spawned.test.tsx
@@ -22,6 +22,8 @@ const closeTerminal = vi.fn((_id: string) => Promise.resolve());
 const listLocalSessions = vi.fn<() => Promise<LocalSessionInfo[]>>();
 
 vi.mock("@/services/api", () => ({
+  listSessionOwners: vi.fn(() => Promise.resolve({})),
+  focusWindow: vi.fn(() => Promise.resolve()),
   listLocalSessions: () => listLocalSessions(),
   listAgentSessions: vi.fn(() => Promise.resolve([])),
   closeTerminal: (id: string) => closeTerminal(id),

--- a/src/components/OpenConnections/OpenConnectionsModal.tooltip.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tooltip.test.tsx
@@ -17,6 +17,8 @@ import { TooltipProvider } from "@/components/ui";
 import type { TerminalTab } from "@/types/terminal";
 
 vi.mock("@/services/api", () => ({
+  listSessionOwners: vi.fn(() => Promise.resolve({})),
+  focusWindow: vi.fn(() => Promise.resolve()),
   listLocalSessions: vi.fn(() => Promise.resolve([])),
   listAgentSessions: vi.fn(() => Promise.resolve([])),
   closeTerminal: vi.fn(() => Promise.resolve()),

--- a/src/components/OpenConnections/OpenConnectionsModal.tunnelError.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tunnelError.test.tsx
@@ -31,6 +31,8 @@ if (!Element.prototype.hasPointerCapture) {
 }
 
 vi.mock("@/services/api", () => ({
+  listSessionOwners: vi.fn(() => Promise.resolve({})),
+  focusWindow: vi.fn(() => Promise.resolve()),
   listLocalSessions: vi.fn(() => Promise.resolve([])),
   listAgentSessions: vi.fn(() => Promise.resolve([])),
   closeTerminal: vi.fn(() => Promise.resolve()),

--- a/src/components/OpenConnections/OpenConnectionsModal.tunnels.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tunnels.test.tsx
@@ -30,6 +30,8 @@ if (!Element.prototype.hasPointerCapture) {
 }
 
 vi.mock("@/services/api", () => ({
+  listSessionOwners: vi.fn(() => Promise.resolve({})),
+  focusWindow: vi.fn(() => Promise.resolve()),
   listLocalSessions: vi.fn(() => Promise.resolve([])),
   listAgentSessions: vi.fn(() => Promise.resolve([])),
   closeTerminal: vi.fn(() => Promise.resolve()),

--- a/src/components/OpenConnections/OpenConnectionsModal.xservers.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.xservers.test.tsx
@@ -14,6 +14,8 @@ import type { XServerStatusReport } from "@/types/xserver";
 const xServerStatus = vi.fn<() => Promise<XServerStatusReport>>();
 const xServerStop = vi.fn(() => Promise.resolve());
 vi.mock("@/services/api", () => ({
+  listSessionOwners: vi.fn(() => Promise.resolve({})),
+  focusWindow: vi.fn(() => Promise.resolve()),
   listLocalSessions: vi.fn(() => Promise.resolve([])),
   listAgentSessions: vi.fn(() => Promise.resolve([])),
   closeTerminal: vi.fn(() => Promise.resolve()),


### PR DESCRIPTION
Follow-up hotfix to the #1938 merge (issue #1926).

PR #1938 made `OpenConnectionsModal` read the new `session_id → owning_window`
map via `listSessionOwners()` in `loadData`, but the sibling test files mock
`@/services/api` with fixed objects that did not include `listSessionOwners`
(nor `focusWindow`). #1938 was merged while those per-PR `Run Tests` checks were
red, so `develop` now fails its frontend test lane: the unmocked call throws in
`loadData`, cascading into the `spawned` and `xservers` suites.

This adds `listSessionOwners` / `focusWindow` to every `OpenConnectionsModal.*`
test's api mock. Full frontend suite is green locally (4246 passed).

Refs #1926.