### PR TITLE
feat(ui): claim session ownership for every rendered window (Closes #1939)

### DIFF
--- a/docs/changes/dev2/feat/1939-broaden-ownership-claim.md
+++ b/docs/changes/dev2/feat/1939-broaden-ownership-claim.md
@@ -1,0 +1,8 @@
+### Changed
+
+- Multi-window: the Open Connections panel's owning-window badge now appears for
+  **every** session when more than one window is open — not only for sessions
+  that were moved between windows. Each window now claims ownership of the
+  sessions it renders (on session open, attach, and restore), releasing it when
+  the tab closes or the session ends, so every session row can show which window
+  owns it. Single-window behaviour is unchanged (#1939).

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -118,8 +118,10 @@ pub fn get_session_owner(
 ///
 /// The Open Connections panel reads this once when it opens to stamp each
 /// session row with an owning-window badge (and a "focus owning window"
-/// affordance). Only claimed sessions appear — an unclaimed session has no
-/// entry, so its row shows no window badge.
+/// affordance). Since #1939 every window claims the sessions it renders, so this
+/// normally covers every live session — a session lacks an entry only in the
+/// brief moment before its rendering tab has claimed it, and its row shows no
+/// window badge until then.
 #[tauri::command]
 pub fn list_session_owners(
     window_manager: State<'_, WindowManager>,

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -479,7 +479,11 @@ mod tests {
         // must not change single-window resize gating: the owning window still
         // resizes it.
         let wm = WindowManager::new();
-        assert_eq!(wm.claim("s1", "main"), None, "first render claims the session");
+        assert_eq!(
+            wm.claim("s1", "main"),
+            None,
+            "first render claims the session"
+        );
         assert!(
             wm.may_resize("s1", "main"),
             "the sole window that rendered (and claimed) the session still resizes it"

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -216,9 +216,11 @@ impl WindowManager {
     /// A snapshot of the full `session_id → owning_window_label` map.
     ///
     /// The Open Connections panel reads this once when it opens to stamp each
-    /// session row with the window that owns it (#1926). Only sessions that have
-    /// been claimed (e.g. moved between windows) appear; an unclaimed session has
-    /// no entry and the panel renders no window badge for it.
+    /// session row with the window that owns it (#1926). Since #1939 every window
+    /// claims the sessions it renders (on open/attach/restore, not only on a
+    /// hand-off), so this normally covers every live session; a session still
+    /// carries no entry only in the brief window before its rendering tab has
+    /// claimed it, and the panel renders no window badge for it until then.
     pub fn all_owners(&self) -> HashMap<String, String> {
         recover(self.ownership.lock()).clone()
     }

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -473,6 +473,43 @@ mod tests {
     }
 
     #[test]
+    fn broadened_claim_keeps_single_window_resize_and_single_owner_on_move() {
+        // #1939: every window now claims the sessions it renders, so a session in
+        // a lone window is *claimed* (by "main") rather than left unclaimed. This
+        // must not change single-window resize gating: the owning window still
+        // resizes it.
+        let wm = WindowManager::new();
+        assert_eq!(wm.claim("s1", "main"), None, "first render claims the session");
+        assert!(
+            wm.may_resize("s1", "main"),
+            "the sole window that rendered (and claimed) the session still resizes it"
+        );
+
+        // A move re-parents the session: the destination grants first, so there is
+        // never a moment with two owners, and the source's later release is a
+        // no-op that cannot orphan the moved session.
+        assert_eq!(
+            wm.claim("s1", "win-1"),
+            Some("main".to_string()),
+            "destination supersedes the previous owner atomically"
+        );
+        assert_eq!(wm.owner_of("s1"), Some("win-1".to_string()));
+        assert!(!wm.release("s1", "main"), "stale source release is a no-op");
+        assert_eq!(
+            wm.owner_of("s1"),
+            Some("win-1".to_string()),
+            "single-owner invariant holds across the move"
+        );
+        // Resize gating followed ownership to the destination.
+        assert!(wm.may_resize("s1", "win-1"));
+        assert!(!wm.may_resize("s1", "main"));
+
+        // Closing the tab in the owning window relinquishes ownership.
+        assert!(wm.release("s1", "win-1"), "owner release clears the entry");
+        assert_eq!(wm.owner_of("s1"), None);
+    }
+
+    #[test]
     fn last_window_teardown_policy_is_per_os() {
         // macOS keeps the app alive on last-window-close, so teardown is
         // deferred; every other platform tears down when the last window goes.

--- a/src/components/OpenConnections/OpenConnectionsModal.windowAware.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.windowAware.test.tsx
@@ -131,6 +131,22 @@ describe("OpenConnectionsModal — owning-window affordance (#1926)", () => {
     expect(focusWindow).toHaveBeenCalledWith("win-2");
   });
 
+  it("shows the badge for a normally-opened (non-handoff) session (#1939)", async () => {
+    // #1939 broadened claiming so a window owns every session it renders — not
+    // only ones moved between windows. The panel reads the same ownership map,
+    // so a session owned because its own window claimed it on open renders a
+    // badge exactly like a moved one. Here BOTH sessions are owned (each claimed
+    // by the window that opened it), so both rows show their window badge.
+    listSessionOwners.mockResolvedValue({ "sess-owned": "win-2", "sess-unclaimed": "main" });
+    windowInfo = { label: "main", name: "Main Window", count: 2 };
+    await renderModal();
+
+    expect(windowChip("Owned Shell")?.textContent).toContain("Window 2");
+    // The second, normally-opened session now also carries a badge (its owner is
+    // the main window).
+    expect(windowChip("Unclaimed Shell")).not.toBeNull();
+  });
+
   it("shows no chip for an unclaimed session even with >1 window", async () => {
     windowInfo = { label: "main", name: "Main Window", count: 2 };
     await renderModal();

--- a/src/store/appStore.multiWindow.test.ts
+++ b/src/store/appStore.multiWindow.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/services/storage", () => ({
 const openWindow = vi.fn();
 const sendHandoffToWindow = vi.fn();
 const claimSession = vi.fn();
+const releaseSession = vi.fn();
 const takePendingHandoffs = vi.fn();
 
 vi.mock("@/services/api", () => ({
@@ -39,6 +40,7 @@ vi.mock("@/services/api", () => ({
   openWindow: (...args: unknown[]) => openWindow(...args),
   sendHandoffToWindow: (...args: unknown[]) => sendHandoffToWindow(...args),
   claimSession: (...args: unknown[]) => claimSession(...args),
+  releaseSession: (...args: unknown[]) => releaseSession(...args),
   takePendingHandoffs: (...args: unknown[]) => takePendingHandoffs(...args),
 }));
 
@@ -61,10 +63,12 @@ describe("appStore — multi-window re-parenting seam (#1900)", () => {
     openWindow.mockReset();
     sendHandoffToWindow.mockReset();
     claimSession.mockReset();
+    releaseSession.mockReset();
     takePendingHandoffs.mockReset();
     openWindow.mockResolvedValue("win-1");
     sendHandoffToWindow.mockResolvedValue(undefined);
     claimSession.mockResolvedValue(null);
+    releaseSession.mockResolvedValue(true);
     takePendingHandoffs.mockResolvedValue([]);
   });
 
@@ -169,6 +173,73 @@ describe("appStore — multi-window re-parenting seam (#1900)", () => {
       expect(claimSession).toHaveBeenCalledWith("sess-drain");
       const tabs = getAllLeaves(useAppStore.getState().rootPanel).flatMap((l) => l.tabs);
       expect(tabs.some((t) => t.sessionId === "sess-drain")).toBe(true);
+    });
+  });
+
+  // #1939: every window claims the sessions it renders, so the Open Connections
+  // owning-window badge (#1926) covers every session — not only moved ones.
+  describe("ownership claim lifecycle (#1939)", () => {
+    it("claims ownership when a tab gains a session (normal open, not a hand-off)", () => {
+      seedLiveTab("sess-open");
+      // A normally-opened session is claimed for this window, so its badge shows.
+      expect(claimSession).toHaveBeenCalledWith("sess-open");
+      expect(releaseSession).not.toHaveBeenCalled();
+    });
+
+    it("releases ownership when a tab's session is cleared", () => {
+      const { tabId } = seedLiveTab("sess-clear");
+      claimSession.mockClear();
+
+      useAppStore.getState().setTabSessionId(tabId, null);
+
+      expect(releaseSession).toHaveBeenCalledWith("sess-clear");
+      // Clearing does not claim anything new.
+      expect(claimSession).not.toHaveBeenCalled();
+    });
+
+    it("releases the superseded session and claims the new one on reconnect", () => {
+      const { tabId } = seedLiveTab("sess-old");
+      claimSession.mockClear();
+      releaseSession.mockClear();
+
+      useAppStore.getState().setTabSessionId(tabId, "sess-new");
+
+      expect(releaseSession).toHaveBeenCalledWith("sess-old");
+      expect(claimSession).toHaveBeenCalledWith("sess-new");
+    });
+
+    it("releases ownership when a live tab is closed", () => {
+      const { tabId, panelId } = seedLiveTab("sess-close");
+      releaseSession.mockClear();
+
+      useAppStore.getState().closeTab(tabId, panelId);
+
+      expect(releaseSession).toHaveBeenCalledWith("sess-close");
+    });
+
+    it("does not release a session mid-move (handshake: destination grants first)", async () => {
+      const { tabId, panelId } = seedLiveTab("sess-move");
+      releaseSession.mockClear();
+
+      // A move marks the session as moving, then removes the source tab via the
+      // move path (not closeTab). The destination window has already claimed, so
+      // the source must not release the session out from under it.
+      await useAppStore.getState().moveTabToWindow(tabId, panelId, { kind: "new" });
+
+      expect(useAppStore.getState().isSessionMoving("sess-move")).toBe(true);
+      expect(releaseSession).not.toHaveBeenCalled();
+    });
+
+    it("skips release for a mid-move session even if its tab session is cleared", () => {
+      const { tabId } = seedLiveTab("sess-guard");
+      useAppStore.setState((s) => ({ movingSessionIds: [...s.movingSessionIds, "sess-guard"] }));
+      releaseSession.mockClear();
+
+      // A source Terminal unmount that clears the session id must not release a
+      // session that is being adopted by another window.
+      useAppStore.getState().setTabSessionId(tabId, null);
+
+      expect(releaseSession).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1907,6 +1907,16 @@ function teardownAllSessions(state: {
     } else {
       apiCloseTerminal(tab.sessionId).catch(() => {});
     }
+    // This window stops rendering the session, so relinquish its ownership
+    // (#1939) — the window is not being destroyed here (a restore/launch is
+    // replacing its tabs in place), so the backend's window-destroy
+    // `release_all_for_window` will not fire. Best-effort, like the other
+    // ownership calls.
+    try {
+      void releaseSession(tab.sessionId).catch(() => {});
+    } catch {
+      // api layer unavailable under unit tests — see setTabSessionId.
+    }
   }
   if (closed > 0) {
     frontendLog("workspace", `tore down ${closed} live session(s) before restore/launch`);

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1891,6 +1891,22 @@ function collectWindowTabs(state: {
   return trees.flatMap((tree) => getAllLeaves(tree).flatMap((leaf) => leaf.tabs));
 }
 
+/**
+ * Fire a multi-window ownership call (claim/release, #1939) as a best-effort
+ * signal: a rejected IPC promise is swallowed, and a synchronous throw — which
+ * only happens when a unit test stubs `@/services/api` without the command — is
+ * caught. Ownership is advisory (it feeds the #1926 owning-window badge and
+ * resize gating), so it must never disrupt the session assignment that triggered
+ * it.
+ */
+function bestEffortOwnership(op: () => Promise<unknown>): void {
+  try {
+    void op().catch(() => {});
+  } catch {
+    // api layer unavailable (unit tests stub @/services/api).
+  }
+}
+
 function teardownAllSessions(state: {
   tabGroups: TabGroup[];
   activeTabGroupId: string;
@@ -1900,23 +1916,19 @@ function teardownAllSessions(state: {
   let closed = 0;
   for (const tab of tabs) {
     if (!tab.sessionId) continue;
+    const sessionId = tab.sessionId;
     closed++;
     if (tab.persistentConnectionId) {
       // Persistent session — detach so the background process keeps running.
-      apiDetachPersistentTab(tab.sessionId, tab.id).catch(() => {});
+      apiDetachPersistentTab(sessionId, tab.id).catch(() => {});
     } else {
-      apiCloseTerminal(tab.sessionId).catch(() => {});
+      apiCloseTerminal(sessionId).catch(() => {});
     }
     // This window stops rendering the session, so relinquish its ownership
     // (#1939) — the window is not being destroyed here (a restore/launch is
     // replacing its tabs in place), so the backend's window-destroy
-    // `release_all_for_window` will not fire. Best-effort, like the other
-    // ownership calls.
-    try {
-      void releaseSession(tab.sessionId).catch(() => {});
-    } catch {
-      // api layer unavailable under unit tests — see setTabSessionId.
-    }
+    // `release_all_for_window` will not fire.
+    bestEffortOwnership(() => releaseSession(sessionId));
   }
   if (closed > 0) {
     frontendLog("workspace", `tore down ${closed} live session(s) before restore/launch`);
@@ -3255,23 +3267,13 @@ export const useAppStore = create<AppState>((set, get) => {
       // map from leaking dead entries. A session mid-move is skipped so the
       // claim/release handshake with the destination window is not disturbed: the
       // destination grants first, so the source must never release the moved
-      // session out from under it. Best-effort and wrapped so a stubbed api layer
-      // (unit tests) or a transient IPC error can never break session assignment.
+      // session out from under it. Best-effort (see `bestEffortOwnership`).
       if (existingTab) {
-        try {
-          if (
-            prevSessionId &&
-            prevSessionId !== sessionId &&
-            !get().isSessionMoving(prevSessionId)
-          ) {
-            void releaseSession(prevSessionId).catch(() => {});
-          }
-          if (sessionId) {
-            void claimSession(sessionId).catch(() => {});
-          }
-        } catch {
-          // api layer unavailable (unit tests stub @/services/api) — ownership is
-          // a best-effort signal and must never disrupt session assignment.
+        if (prevSessionId && prevSessionId !== sessionId && !get().isSessionMoving(prevSessionId)) {
+          bestEffortOwnership(() => releaseSession(prevSessionId));
+        }
+        if (sessionId) {
+          bestEffortOwnership(() => claimSession(sessionId));
         }
       }
       // A non-null session id means this tab has connected — settle it in any
@@ -3726,16 +3728,12 @@ export const useAppStore = create<AppState>((set, get) => {
       // `session → window` entry (#1900) must be dropped or it leaks a stale
       // owning-window badge (#1926). Skipped for a session mid-move — that tab is
       // removed via the move path, not closed, and the destination window now
-      // owns it. Best-effort: an ownership call must never block a tab close.
+      // owns it. Best-effort (see `bestEffortOwnership`).
       const closingSessionId = getAllLeaves(useAppStore.getState().rootPanel)
         .flatMap((l) => l.tabs)
         .find((t) => t.id === tabId)?.sessionId;
       if (closingSessionId && !get().isSessionMoving(closingSessionId)) {
-        try {
-          void releaseSession(closingSessionId).catch(() => {});
-        } catch {
-          // api layer unavailable under unit tests — see setTabSessionId.
-        }
+        bestEffortOwnership(() => releaseSession(closingSessionId));
       }
 
       // Close every SFTP session owned by this tab and drop it from the map —

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -117,6 +117,7 @@ import {
   openWindow,
   sendHandoffToWindow,
   claimSession,
+  releaseSession,
   takePendingHandoffs,
   reportWindowLayout,
   collectWindowLayouts,
@@ -3209,17 +3210,20 @@ export const useAppStore = create<AppState>((set, get) => {
       }),
 
     setTabSessionId: (tabId, sessionId) => {
+      // The tab as it stands *before* this update — used both to skip work for an
+      // unknown tab and to capture the session id this tab is superseding, so a
+      // replaced/cleared session releases its ownership as the new one is claimed.
+      const existingTab = getAllLeaves(get().rootPanel)
+        .flatMap((l) => l.tabs)
+        .find((t) => t.id === tabId);
+      const prevSessionId = existingTab?.sessionId ?? null;
+
       // For remote-session tabs gaining a session ID, fetch capabilities so
       // monitoring knows whether this session supports stats collection.
-      if (sessionId) {
-        const tab = getAllLeaves(get().rootPanel)
-          .flatMap((l) => l.tabs)
-          .find((t) => t.id === tabId);
-        if (tab?.connectionType === "remote-session") {
-          sessionGetCapabilities(sessionId)
-            .then((caps) => get().setSessionCapabilities(sessionId, caps))
-            .catch(() => {});
-        }
+      if (sessionId && existingTab?.connectionType === "remote-session") {
+        sessionGetCapabilities(sessionId)
+          .then((caps) => get().setSessionCapabilities(sessionId, caps))
+          .catch(() => {});
       }
       set((state) => {
         const leaf = findLeafByTab(state.rootPanel, tabId);
@@ -3231,6 +3235,35 @@ export const useAppStore = create<AppState>((set, get) => {
           })),
         };
       });
+
+      // Multi-window ownership (#1939): the window that renders a session owns it
+      // in the backend `session → window` map (#1900). Claiming here — the single
+      // choke point every rendered session flows through (terminal, file browser,
+      // remote desktop, restore reconnect) — makes the Open Connections
+      // owning-window badge (#1926) appear for *every* session, not only ones
+      // moved between windows. Releasing a superseded/cleared session keeps the
+      // map from leaking dead entries. A session mid-move is skipped so the
+      // claim/release handshake with the destination window is not disturbed: the
+      // destination grants first, so the source must never release the moved
+      // session out from under it. Best-effort and wrapped so a stubbed api layer
+      // (unit tests) or a transient IPC error can never break session assignment.
+      if (existingTab) {
+        try {
+          if (
+            prevSessionId &&
+            prevSessionId !== sessionId &&
+            !get().isSessionMoving(prevSessionId)
+          ) {
+            void releaseSession(prevSessionId).catch(() => {});
+          }
+          if (sessionId) {
+            void claimSession(sessionId).catch(() => {});
+          }
+        } catch {
+          // api layer unavailable (unit tests stub @/services/api) — ownership is
+          // a best-effort signal and must never disrupt session assignment.
+        }
+      }
       // A non-null session id means this tab has connected — settle it in any
       // in-flight restore/launch cohort so the aggregate summary can fire (#1146).
       if (sessionId) {
@@ -3678,6 +3711,23 @@ export const useAppStore = create<AppState>((set, get) => {
     setPendingAttachedTabCloseConfirm: (req) => set({ pendingAttachedTabCloseConfirm: req }),
 
     closeTab: (tabId, panelId) => {
+      // Relinquish backend ownership of this tab's live session (#1939). A closed
+      // tab's session is torn down here (or already exited), so its
+      // `session → window` entry (#1900) must be dropped or it leaks a stale
+      // owning-window badge (#1926). Skipped for a session mid-move — that tab is
+      // removed via the move path, not closed, and the destination window now
+      // owns it. Best-effort: an ownership call must never block a tab close.
+      const closingSessionId = getAllLeaves(useAppStore.getState().rootPanel)
+        .flatMap((l) => l.tabs)
+        .find((t) => t.id === tabId)?.sessionId;
+      if (closingSessionId && !get().isSessionMoving(closingSessionId)) {
+        try {
+          void releaseSession(closingSessionId).catch(() => {});
+        } catch {
+          // api layer unavailable under unit tests — see setTabSessionId.
+        }
+      }
+
       // Close every SFTP session owned by this tab and drop it from the map —
       // the L1 leak fix (#1241). Fire the async closes here (fire-and-forget)
       // so the state updater below stays pure; the entries are removed regardless.


### PR DESCRIPTION
## Summary

Broadens the #1900 `session_id → owning_window` ownership map beyond the
hand-off-only claim so **every window claims the sessions it renders**. This
makes the Open Connections owning-window badge (#1926) appear for every session
when more than one window is open — not only for sessions that were moved
between windows.

Follow-up to #1926 (PR #1938), part of epic #1899.

## What changed

- `setTabSessionId` (frontend store) — the single choke point every rendered
  session flows through (terminal via `TerminalRegistry.registerSession`, file
  browser, remote desktop, and restore reconnect) — now `claimSession`s the
  session for the calling window and `releaseSession`s the id it supersedes.
- `closeTab` releases a closed tab's live session so the map does not leak a
  stale owning-window entry.
- Both skip a session that is **mid-move** (`isSessionMoving`) so the existing
  claim/release handshake (destination grants first, source never releases the
  moved session out from under it) still holds the single-owner invariant.
- Both are best-effort — an ownership call can never disrupt session assignment.
- Backend doc comments on `all_owners` / `list_session_owners` updated to
  reflect that the map now normally covers every live session.

No backend logic change was needed: the `claim` / `release` / `may_resize`
primitives already exist. `may_resize` is unaffected — a session claimed by its
own single window still resizes from that window (owner match), so single-window
resize behaviour is unchanged.

## Tests

- Frontend: new `appStore.multiWindow.test.ts` cases covering claim-on-open,
  release-on-clear, release-then-claim on reconnect, release-on-close, and the
  mid-move skip that preserves the handshake.
- Rust: new `window::mod` test encoding the #1939 invariant — broadened claiming
  keeps single-window resize gating intact and the single-owner invariant across
  a move.

Closes #1939