### PR TITLE
feat(ui): theme dropdown hover color preview (Closes #1929)

### DIFF
--- a/docs/changes/dev1/feat/1929-theme-preview-tooltip.md
+++ b/docs/changes/dev1/feat/1929-theme-preview-tooltip.md
@@ -1,0 +1,7 @@
+### Added
+
+- Appearance settings: hovering a theme option in the Theme dropdown now shows a
+  small color preview popover with the theme's terminal background, terminal
+  foreground, accent, and app-background swatches plus their hex values. Values
+  are resolved through the theme engine, so custom themes preview their real
+  colors (with per-color fallback to their base theme) (#1929).

--- a/src/components/Settings/AppearanceSettings.tsx
+++ b/src/components/Settings/AppearanceSettings.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 import { AppSettings } from "@/types/connection";
-import { Button, NumberInput, Select, toast } from "@/components/ui";
+import { Button, NumberInput, Select, SelectItem, Tooltip, TooltipProvider, toast } from "@/components/ui";
 import type { SelectOption } from "@/components/ui";
 import {
   applyTheme,
@@ -13,11 +13,13 @@ import {
   findCustomTheme,
   isCustomThemeSetting,
   parseThemeFile,
+  resolveTheme,
   serializeTheme,
   themeFileName,
 } from "@/themes";
 import type { ThemeDefinition, ThemeImportResult } from "@/themes";
 import { ThemeEditor } from "@/components/ThemeEditor/ThemeEditor";
+import { ThemePreview } from "./ThemePreview";
 import { SettingsField } from "./SettingsField";
 import "./AppearanceSettings.css";
 
@@ -168,12 +170,26 @@ export function AppearanceSettings({ settings, onChange, visibleFields }: Appear
       {show("theme") && (
         <>
           <SettingsField label="Theme" hint="Application color theme.">
-            <Select
-              data-testid="appearance-theme-select"
-              value={settings.theme ?? "dark"}
-              onChange={(value) => onChange({ ...settings, theme: value as AppSettings["theme"] })}
-              options={themeOptions}
-            />
+            {/* Local provider so each option can reveal a hover preview even when
+                this panel renders outside the app-root TooltipProvider. */}
+            <TooltipProvider>
+              <Select
+                data-testid="appearance-theme-select"
+                value={settings.theme ?? "dark"}
+                onChange={(value) => onChange({ ...settings, theme: value as AppSettings["theme"] })}
+              >
+                {themeOptions.map((opt) => (
+                  <Tooltip
+                    key={opt.value}
+                    side="right"
+                    content={<ThemePreview theme={resolveTheme(opt.value, customThemes)} />}
+                    data-testid={`appearance-theme-preview-${opt.value}`}
+                  >
+                    <SelectItem value={opt.value}>{opt.label}</SelectItem>
+                  </Tooltip>
+                ))}
+              </Select>
+            </TooltipProvider>
           </SettingsField>
           <div className="appearance-settings__theme-actions">
             <Button

--- a/src/components/Settings/AppearanceSettings.tsx
+++ b/src/components/Settings/AppearanceSettings.tsx
@@ -2,7 +2,15 @@ import { useState } from "react";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 import { AppSettings } from "@/types/connection";
-import { Button, NumberInput, Select, SelectItem, Tooltip, TooltipProvider, toast } from "@/components/ui";
+import {
+  Button,
+  NumberInput,
+  Select,
+  SelectItem,
+  Tooltip,
+  TooltipProvider,
+  toast,
+} from "@/components/ui";
 import type { SelectOption } from "@/components/ui";
 import {
   applyTheme,
@@ -176,7 +184,9 @@ export function AppearanceSettings({ settings, onChange, visibleFields }: Appear
               <Select
                 data-testid="appearance-theme-select"
                 value={settings.theme ?? "dark"}
-                onChange={(value) => onChange({ ...settings, theme: value as AppSettings["theme"] })}
+                onChange={(value) =>
+                  onChange({ ...settings, theme: value as AppSettings["theme"] })
+                }
               >
                 {themeOptions.map((opt) => (
                   <Tooltip

--- a/src/components/Settings/ThemePreview.css
+++ b/src/components/Settings/ThemePreview.css
@@ -1,0 +1,50 @@
+.theme-preview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  min-width: 12rem;
+}
+
+.theme-preview__name {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.theme-preview__swatches {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.theme-preview__row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.theme-preview__chip {
+  flex: 0 0 auto;
+  width: var(--spacing-lg);
+  height: var(--spacing-lg);
+  border: 1px solid var(--border-secondary);
+  border-radius: var(--radius-sm);
+}
+
+.theme-preview__label {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: var(--font-size-xs);
+  color: var(--text-secondary);
+}
+
+.theme-preview__hex {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  color: var(--text-primary);
+  text-transform: uppercase;
+}

--- a/src/components/Settings/ThemePreview.test.tsx
+++ b/src/components/Settings/ThemePreview.test.tsx
@@ -46,9 +46,7 @@ describe("ThemePreview", () => {
       darkTheme.colors.bgPrimary,
     ]);
     // One color chip per representative color, filled with the theme's own value.
-    const chips = Array.from(
-      container.querySelectorAll<HTMLElement>(".theme-preview__chip")
-    );
+    const chips = Array.from(container.querySelectorAll<HTMLElement>(".theme-preview__chip"));
     expect(chips).toHaveLength(4);
     expect(chips[0].style.backgroundColor).not.toBe("");
   });

--- a/src/components/Settings/ThemePreview.test.tsx
+++ b/src/components/Settings/ThemePreview.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { darkTheme, resolveTheme } from "@/themes";
+import type { ThemeDefinition } from "@/themes/types";
+import { ThemePreview } from "./ThemePreview";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+/** The hex strings shown in the preview, top to bottom. */
+function hexValues(): string[] {
+  return Array.from(container.querySelectorAll(".theme-preview__hex")).map(
+    (el) => el.textContent ?? ""
+  );
+}
+
+describe("ThemePreview", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("previews a built-in theme's four representative colors and its name", () => {
+    render(<ThemePreview theme={resolveTheme("dark")} data-testid="preview" />);
+
+    expect(container.querySelector('[data-testid="preview"]')).toBeTruthy();
+    expect(container.querySelector(".theme-preview__name")?.textContent).toBe(darkTheme.name);
+    // terminalBg / terminalFg / accentColor / bgPrimary, in that order.
+    expect(hexValues()).toEqual([
+      darkTheme.colors.terminalBg,
+      darkTheme.colors.terminalFg,
+      darkTheme.colors.accentColor,
+      darkTheme.colors.bgPrimary,
+    ]);
+    // One color chip per representative color, filled with the theme's own value.
+    const chips = Array.from(
+      container.querySelectorAll<HTMLElement>(".theme-preview__chip")
+    );
+    expect(chips).toHaveLength(4);
+    expect(chips[0].style.backgroundColor).not.toBe("");
+  });
+
+  it("previews a custom theme, falling back to its base for missing colors", () => {
+    // A custom theme that overrides two colors and leaves the other two unset,
+    // so resolution must fill the gaps from the base (dark) theme.
+    const custom: ThemeDefinition = {
+      id: "t1",
+      name: "Ocean",
+      colorScheme: "dark",
+      baseTheme: "dark",
+      colors: {
+        terminalBg: "#001f3f",
+        accentColor: "#39cccc",
+      } as ThemeDefinition["colors"],
+    };
+
+    render(<ThemePreview theme={resolveTheme("custom:t1", [custom])} />);
+
+    expect(container.querySelector(".theme-preview__name")?.textContent).toBe("Ocean");
+    expect(hexValues()).toEqual([
+      "#001f3f", // overridden terminalBg
+      darkTheme.colors.terminalFg, // missing → base fallback
+      "#39cccc", // overridden accentColor
+      darkTheme.colors.bgPrimary, // missing → base fallback
+    ]);
+  });
+});

--- a/src/components/Settings/ThemePreview.tsx
+++ b/src/components/Settings/ThemePreview.tsx
@@ -1,0 +1,54 @@
+import type { ThemeColors, ThemeDefinition } from "@/themes/types";
+import "./ThemePreview.css";
+
+/** The four representative colors shown when previewing a theme, in display order. */
+const PREVIEW_SWATCHES: { key: keyof ThemeColors; label: string }[] = [
+  { key: "terminalBg", label: "Terminal BG" },
+  { key: "terminalFg", label: "Terminal FG" },
+  { key: "accentColor", label: "Accent" },
+  { key: "bgPrimary", label: "Background" },
+];
+
+export interface ThemePreviewProps {
+  /**
+   * A fully-resolved theme definition (built-in, or a custom theme run through
+   * `resolveCustomTheme` so every color falls back to its base). Passing an
+   * unresolved custom theme risks blank swatches for any missing color.
+   */
+  theme: ThemeDefinition;
+  /** Test hook forwarded to the preview root. */
+  "data-testid"?: string;
+}
+
+/**
+ * A small, self-contained swatch card summarizing a theme: its name plus the
+ * four representative colors (terminal background/foreground, accent, and app
+ * background) as color chips with their hex values. Used as the hover-preview
+ * content for theme options in Appearance settings.
+ *
+ * The chip fills use the theme's own color values (data, not design tokens);
+ * all surrounding chrome is driven by tokens from `variables.css`.
+ */
+export function ThemePreview({ theme, ...rest }: ThemePreviewProps) {
+  return (
+    <div className="theme-preview" data-testid={rest["data-testid"]}>
+      <div className="theme-preview__name">{theme.name}</div>
+      <ul className="theme-preview__swatches">
+        {PREVIEW_SWATCHES.map(({ key, label }) => {
+          const value = theme.colors[key];
+          return (
+            <li key={key} className="theme-preview__row">
+              <span
+                className="theme-preview__chip"
+                style={{ backgroundColor: value }}
+                aria-hidden="true"
+              />
+              <span className="theme-preview__label">{label}</span>
+              <span className="theme-preview__hex">{value}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -42,25 +42,34 @@ export interface SelectProps {
   "data-testid"?: string;
 }
 
-/**
- * A token-styled Radix Select item. Exposed so callers using the `children`
- * escape hatch can render options that match the primitive's styling.
- */
-export function SelectItem({
-  value,
-  disabled,
-  children,
-}: {
+/** Props for the exported {@link SelectItem}. */
+export interface SelectItemProps
+  extends Omit<React.ComponentPropsWithoutRef<typeof RadixSelect.Item>, "value"> {
   value: string;
   disabled?: boolean;
   children: React.ReactNode;
-}): React.ReactElement {
+}
+
+/**
+ * A token-styled Radix Select item. Exposed so callers using the `children`
+ * escape hatch can render options that match the primitive's styling.
+ *
+ * Forwards its ref and any extra props to the underlying item so it can be used
+ * as the `asChild` trigger of another primitive — e.g. wrapping it in a
+ * {@link Tooltip} to show a hover preview for the option.
+ */
+export const SelectItem = React.forwardRef<
+  React.ElementRef<typeof RadixSelect.Item>,
+  SelectItemProps
+>(function SelectItem({ value, disabled, children, ...rest }, ref) {
   return (
     <RadixSelect.Item
+      ref={ref}
       className="ui-select__item"
       value={value}
       disabled={disabled}
       data-value={value}
+      {...rest}
     >
       <RadixSelect.ItemText>{children}</RadixSelect.ItemText>
       <RadixSelect.ItemIndicator className="ui-select__item-indicator">
@@ -68,7 +77,7 @@ export function SelectItem({
       </RadixSelect.ItemIndicator>
     </RadixSelect.Item>
   );
-}
+});
 
 /**
  * The single shared select primitive. Compose from this instead of a native

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -43,8 +43,10 @@ export interface SelectProps {
 }
 
 /** Props for the exported {@link SelectItem}. */
-export interface SelectItemProps
-  extends Omit<React.ComponentPropsWithoutRef<typeof RadixSelect.Item>, "value"> {
+export interface SelectItemProps extends Omit<
+  React.ComponentPropsWithoutRef<typeof RadixSelect.Item>,
+  "value"
+> {
   value: string;
   disabled?: boolean;
   children: React.ReactNode;

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -21,7 +21,7 @@ export { Field } from "./Field";
 export type { FieldProps } from "./Field";
 
 export { Select, SelectItem } from "./Select";
-export type { SelectProps, SelectOption } from "./Select";
+export type { SelectProps, SelectOption, SelectItemProps } from "./Select";
 
 export { Modal, useModalPortalContainer } from "./Modal";
 export type { ModalProps } from "./Modal";

--- a/src/themes/engine.ts
+++ b/src/themes/engine.ts
@@ -91,8 +91,15 @@ let mediaQuery: MediaQueryList | null = null;
 let mediaListener: EventListener | null = null;
 const changeCallbacks = new Set<ThemeChangeCallback>();
 
-/** Resolve the theme setting string to an actual ThemeDefinition. */
-function resolveTheme(
+/**
+ * Resolve a theme setting string (`"dark"`, `"light"`, `"system"`,
+ * `"custom:<id>"`, …) to a fully-resolved {@link ThemeDefinition}. Custom themes
+ * are run through {@link resolveCustomTheme} so every color falls back to its
+ * base; a missing/deleted custom theme and any unknown setting fall back to
+ * dark. `"system"` reads `prefers-color-scheme`, treating a missing `matchMedia`
+ * (e.g. under jsdom) as light.
+ */
+export function resolveTheme(
   setting: string | undefined,
   customThemes: ThemeDefinition[] = []
 ): ThemeDefinition {
@@ -101,7 +108,9 @@ function resolveTheme(
   if (setting === "solarized-light") return solarizedLightTheme;
   if (setting === "system") {
     const prefersDark =
-      typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: dark)").matches;
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches;
     return prefersDark ? darkTheme : lightTheme;
   }
   if (isCustomThemeSetting(setting)) {

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -6,6 +6,7 @@ export { solarizedLightTheme } from "./solarized-light";
 export {
   applyTheme,
   previewTheme,
+  resolveTheme,
   getXtermTheme,
   getCurrentTheme,
   onThemeChange,


### PR DESCRIPTION
## Summary

Adds a hover color preview to the Theme dropdown in Appearance settings. Hovering any option in `appearance-theme-select` now reveals a small popover summarizing that theme: its name plus color swatches + hex for `terminalBg`, `terminalFg`, `accentColor`, and `bgPrimary`.

Values are resolved through the theme engine (`resolveTheme` → `resolveCustomTheme`), so custom themes preview their real colors, and any color missing from a partial custom theme falls back to its base.

## Changes

- New `ThemePreview` component (`src/components/Settings/ThemePreview.tsx` + CSS) — a token-driven swatch card. Chip fills use each theme's own color values (data); all chrome uses `variables.css` tokens (no raw hex).
- Wired per-option previews into the Theme `Select` using the shared `Tooltip` primitive, wrapped in a local `TooltipProvider` so the panel is self-contained.
- Exported `resolveTheme` from `src/themes` and hardened its `"system"` branch to tolerate a missing `matchMedia`.
- `SelectItem` now forwards its ref and extra props so it can act as a `Tooltip` `asChild` trigger.

## Tests

- `ThemePreview.test.tsx` covers a built-in theme (dark) and a custom theme, asserting the four swatches/hex render and that missing custom colors fall back to the base.
- Full frontend suite green (`pnpm test`), plus `pnpm build`, ESLint, and Prettier.

Closes #1929