### PR TITLE
feat(workspace): per-tab selection + offline warnings in restore dialog (Closes #1931)

### DIFF
--- a/docs/changes/dev3/feat/1931-restore-per-tab-selection.md
+++ b/docs/changes/dev3/feat/1931-restore-per-tab-selection.md
@@ -1,0 +1,11 @@
+### Added
+
+- Startup "Restore Previous Session?" dialog now supports **per-tab selection**:
+  each stored tab has a checkbox, so you can restore a subset instead of the
+  whole session. The confirm button relabels to "Restore N Selected" when a
+  subset is chosen and is disabled when nothing is selected. Tabs whose
+  connection target is unavailable are flagged with a warning icon and start
+  unchecked — a serial device that is no longer connected shows "device
+  offline", and an unreachable SSH/telnet host shows "host unreachable". The
+  reachability check runs in the background after the dialog opens and never
+  blocks restore (#1931).

--- a/src-tauri/src/commands/network.rs
+++ b/src-tauri/src/commands/network.rs
@@ -109,6 +109,32 @@ pub fn network_port_scan_cancel(
     manager.cancel_task(&task_id)
 }
 
+/// One-shot TCP reachability probe used by the session-restore dialog to flag
+/// unreachable targets (issue #1931).
+///
+/// Attempts a single TCP connect to `host:port` and returns `true` only when the
+/// connection is accepted within `timeout_ms` (default 1500 ms). A refused,
+/// filtered, unresolved, or timed-out target returns `false` — for the dialog's
+/// purposes those all mean "won't connect right now".
+#[tauri::command]
+pub async fn probe_target_reachable(
+    host: String,
+    port: u16,
+    timeout_ms: Option<u64>,
+) -> Result<bool, TerminalError> {
+    let summary = port_scan::scan_ports(
+        &host,
+        &[port],
+        timeout_ms.unwrap_or(1500),
+        1,
+        |_| {},
+        tokio_util::sync::CancellationToken::new(),
+    )
+    .await
+    .map_err(|e| TerminalError::NetworkError(e.to_string()))?;
+    Ok(summary.open > 0)
+}
+
 // ── Ping ─────────────────────────────────────────────────────────────────────
 
 /// Start a ping session. Returns a task ID; results are emitted as events.
@@ -282,6 +308,39 @@ pub fn network_ping_sweep_cancel(
 }
 
 // ── DNS Lookup ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn probe_reports_open_listener_reachable() {
+        // A bound (even non-accepting) listener completes the TCP handshake.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind test listener");
+        let port = listener.local_addr().unwrap().port();
+
+        let reachable = probe_target_reachable("127.0.0.1".to_string(), port, Some(1000))
+            .await
+            .expect("probe should not error");
+
+        assert!(reachable, "an open TCP listener should be reachable");
+    }
+
+    #[tokio::test]
+    async fn probe_reports_closed_port_unreachable() {
+        // Bind then drop to claim a port that nothing is listening on.
+        let port = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind test listener");
+            listener.local_addr().unwrap().port()
+        };
+
+        let reachable = probe_target_reachable("127.0.0.1".to_string(), port, Some(500))
+            .await
+            .expect("probe should not error");
+
+        assert!(!reachable, "a closed port should be reported unreachable");
+    }
+}
 
 /// Perform a DNS lookup and return the records immediately.
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -980,6 +980,7 @@ pub fn run() {
             // Network diagnostics
             commands::network::network_port_scan,
             commands::network::network_port_scan_cancel,
+            commands::network::probe_target_reachable,
             commands::network::network_ping_start,
             commands::network::network_ping_stop,
             commands::network::network_ping_sweep,

--- a/src/components/SessionRestoreDialog.css
+++ b/src/components/SessionRestoreDialog.css
@@ -14,7 +14,6 @@
 .session-restore__tab {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: var(--spacing-sm);
   padding: var(--spacing-xs) var(--spacing-sm);
   border: 1px solid var(--border-secondary);
@@ -23,11 +22,26 @@
 }
 
 .session-restore__tab-title {
+  flex: 1 1 auto;
+  min-width: 0;
   color: var(--text-primary);
   font-size: var(--font-size-sm);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.session-restore__tab-warning {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  flex-shrink: 0;
+  color: var(--color-warning);
+  font-size: var(--font-size-xs);
+}
+
+.session-restore__tab-warning-text {
+  letter-spacing: var(--letter-spacing-ui);
 }
 
 .session-restore__tab-type {

--- a/src/components/SessionRestoreDialog.test.tsx
+++ b/src/components/SessionRestoreDialog.test.tsx
@@ -79,14 +79,14 @@ describe("SessionRestoreDialog", () => {
     expect(byTestId("session-restore-dialog")?.textContent).toContain("You had 1 tab open");
   });
 
-  it("restores (without remember) when Restore is clicked", () => {
+  it("restores all tabs (without remember) when Restore is clicked", () => {
     storeState.restorePrompt = { tabCount: 1, tabs: [{ title: "Shell", typeLabel: "Local" }] };
     render();
 
     act(() => (byTestId("session-restore-confirm") as HTMLElement).click());
 
     expect(confirmRestorePrompt).toHaveBeenCalledTimes(1);
-    expect(confirmRestorePrompt).toHaveBeenCalledWith(false);
+    expect(confirmRestorePrompt).toHaveBeenCalledWith(false, [0]);
     expect(dismissRestorePrompt).not.toHaveBeenCalled();
   });
 
@@ -108,7 +108,73 @@ describe("SessionRestoreDialog", () => {
     act(() => (byTestId("session-restore-remember") as HTMLElement).click());
     act(() => (byTestId("session-restore-confirm") as HTMLElement).click());
 
-    expect(confirmRestorePrompt).toHaveBeenCalledWith(true);
+    expect(confirmRestorePrompt).toHaveBeenCalledWith(true, [0]);
+  });
+
+  it("renders a checkbox per tab", () => {
+    storeState.restorePrompt = {
+      tabCount: 2,
+      tabs: [
+        { title: "one", typeLabel: "SSH" },
+        { title: "two", typeLabel: "Local" },
+      ],
+    };
+    render();
+    expect(byTestId("session-restore-tab-checkbox-0")).not.toBeNull();
+    expect(byTestId("session-restore-tab-checkbox-1")).not.toBeNull();
+  });
+
+  it("restores only the checked tabs", () => {
+    storeState.restorePrompt = {
+      tabCount: 2,
+      tabs: [
+        { title: "one", typeLabel: "SSH" },
+        { title: "two", typeLabel: "Local" },
+      ],
+    };
+    render();
+
+    // Uncheck the first tab, then confirm.
+    act(() => (byTestId("session-restore-tab-checkbox-0") as HTMLElement).click());
+    act(() => (byTestId("session-restore-confirm") as HTMLElement).click());
+
+    expect(confirmRestorePrompt).toHaveBeenCalledWith(false, [1]);
+  });
+
+  it("shows a warning icon and starts unchecked for an unreachable tab", () => {
+    storeState.restorePrompt = {
+      tabCount: 2,
+      tabs: [
+        { title: "reachable", typeLabel: "SSH", reachability: "reachable" },
+        {
+          title: "/dev/ttyUSB0",
+          typeLabel: "Serial",
+          reachability: "unreachable",
+          unreachableReason: "device offline",
+        },
+      ],
+    };
+    render();
+
+    const warning = byTestId("session-restore-tab-warning-1");
+    expect(warning).not.toBeNull();
+    expect(warning?.textContent).toContain("device offline");
+    // No warning on the reachable tab.
+    expect(byTestId("session-restore-tab-warning-0")).toBeNull();
+
+    // The unreachable tab starts unchecked, so restore excludes it by default.
+    act(() => (byTestId("session-restore-confirm") as HTMLElement).click());
+    expect(confirmRestorePrompt).toHaveBeenCalledWith(false, [0]);
+  });
+
+  it("disables the confirm button when every tab is unchecked", () => {
+    storeState.restorePrompt = { tabCount: 1, tabs: [{ title: "Shell", typeLabel: "Local" }] };
+    render();
+
+    act(() => (byTestId("session-restore-tab-checkbox-0") as HTMLElement).click());
+
+    const confirm = byTestId("session-restore-confirm") as HTMLButtonElement;
+    expect(confirm.disabled).toBe(true);
   });
 
   it("passes remember=true to dismiss after ticking 'Remember my choice'", () => {

--- a/src/components/SessionRestoreDialog.tsx
+++ b/src/components/SessionRestoreDialog.tsx
@@ -1,7 +1,21 @@
 import { useState } from "react";
-import { ConfirmDialog } from "@/components/ui";
+import { AlertTriangle } from "lucide-react";
+import { Checkbox, ConfirmDialog } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
+import type { RestoreTabInfo } from "@/utils/restoreMode";
 import "./SessionRestoreDialog.css";
+
+/**
+ * Whether a tab is selected for restore. Defaults follow reachability — an
+ * unreachable target starts unchecked (per the concept mockups) — but an
+ * explicit user toggle in `overrides` always wins. Because reachability arrives
+ * asynchronously, deriving the default this way lets tabs the user has not
+ * touched flip to reflect a late "unreachable" result without an effect.
+ */
+function isTabChecked(tab: RestoreTabInfo, override: boolean | undefined): boolean {
+  if (override !== undefined) return override;
+  return tab.reachability !== "unreachable";
+}
 
 /**
  * Startup "Restore Previous Session?" dialog shown when the restore mode is
@@ -12,6 +26,11 @@ import "./SessionRestoreDialog.css";
  * "Remember my choice" opt-out persists the mode (`always` on Restore, `never`
  * on Start Fresh) so the dialog is not shown again.
  *
+ * Per-tab selection (#1931): each tab has a checkbox so the user restores only a
+ * subset; the chosen indices are passed to `confirmRestorePrompt`. Tabs whose
+ * connection target is unavailable (device offline / host unreachable) show a
+ * warning icon and start unchecked.
+ *
  * Composes the shared {@link ConfirmDialog}: "Restore" is the primary confirm,
  * "Start Fresh" is the cancel, and the opt-out rides the `dontAskAgain` slot.
  */
@@ -20,22 +39,31 @@ export function SessionRestoreDialog(): React.ReactElement | null {
   const confirmRestorePrompt = useAppStore((s) => s.confirmRestorePrompt);
   const dismissRestorePrompt = useAppStore((s) => s.dismissRestorePrompt);
   const [remember, setRemember] = useState(false);
+  const [overrides, setOverrides] = useState<Record<number, boolean>>({});
 
   if (!restorePrompt) return null;
 
   const { tabCount, tabs } = restorePrompt;
   const tabWord = tabCount === 1 ? "tab" : "tabs";
 
+  const selectedIndices = tabs
+    .map((_, i) => i)
+    .filter((i) => isTabChecked(tabs[i], overrides[i]));
+  const selectedCount = selectedIndices.length;
+  const confirmLabel =
+    selectedCount === tabCount ? "Restore" : `Restore ${selectedCount} Selected`;
+
   return (
     <ConfirmDialog
       open
       title="Restore Previous Session?"
-      description="Choose whether to reopen the tabs from your previous session."
+      description="Choose which tabs to reopen from your previous session."
       message={`You had ${tabCount} ${tabWord} open when termiHub last closed:`}
-      confirmLabel="Restore"
+      confirmLabel={confirmLabel}
       cancelLabel="Start Fresh"
       confirmVariant="primary"
       confirmErrorToast={false}
+      confirmDisabled={selectedCount === 0}
       dontAskAgain={{
         checked: remember,
         onChange: setRemember,
@@ -43,17 +71,44 @@ export function SessionRestoreDialog(): React.ReactElement | null {
         "data-testid": "session-restore-remember",
       }}
       testIdBase="session-restore"
-      onConfirm={() => confirmRestorePrompt(remember)}
+      onConfirm={() => confirmRestorePrompt(remember, selectedIndices)}
       onCancel={() => dismissRestorePrompt(remember)}
       data-testid="session-restore-dialog"
     >
       <ul className="session-restore__tabs" data-testid="session-restore-tabs">
-        {tabs.map((tab, index) => (
-          <li key={index} className="session-restore__tab">
-            <span className="session-restore__tab-title">{tab.title}</span>
-            <span className="session-restore__tab-type">{tab.typeLabel}</span>
-          </li>
-        ))}
+        {tabs.map((tab, index) => {
+          const checked = isTabChecked(tab, overrides[index]);
+          const unreachable = tab.reachability === "unreachable";
+          return (
+            <li
+              key={index}
+              className="session-restore__tab"
+              data-testid={`session-restore-tab-${index}`}
+            >
+              <Checkbox
+                checked={checked}
+                onCheckedChange={(next) =>
+                  setOverrides((prev) => ({ ...prev, [index]: next }))
+                }
+                aria-label={`Restore ${tab.title}`}
+                data-testid={`session-restore-tab-checkbox-${index}`}
+              />
+              <span className="session-restore__tab-title">{tab.title}</span>
+              {unreachable && (
+                <span
+                  className="session-restore__tab-warning"
+                  data-testid={`session-restore-tab-warning-${index}`}
+                >
+                  <AlertTriangle size={14} aria-hidden="true" />
+                  <span className="session-restore__tab-warning-text">
+                    {tab.unreachableReason ?? "unavailable"}
+                  </span>
+                </span>
+              )}
+              <span className="session-restore__tab-type">{tab.typeLabel}</span>
+            </li>
+          );
+        })}
       </ul>
     </ConfirmDialog>
   );

--- a/src/components/SessionRestoreDialog.tsx
+++ b/src/components/SessionRestoreDialog.tsx
@@ -46,12 +46,9 @@ export function SessionRestoreDialog(): React.ReactElement | null {
   const { tabCount, tabs } = restorePrompt;
   const tabWord = tabCount === 1 ? "tab" : "tabs";
 
-  const selectedIndices = tabs
-    .map((_, i) => i)
-    .filter((i) => isTabChecked(tabs[i], overrides[i]));
+  const selectedIndices = tabs.map((_, i) => i).filter((i) => isTabChecked(tabs[i], overrides[i]));
   const selectedCount = selectedIndices.length;
-  const confirmLabel =
-    selectedCount === tabCount ? "Restore" : `Restore ${selectedCount} Selected`;
+  const confirmLabel = selectedCount === tabCount ? "Restore" : `Restore ${selectedCount} Selected`;
 
   return (
     <ConfirmDialog
@@ -87,9 +84,7 @@ export function SessionRestoreDialog(): React.ReactElement | null {
             >
               <Checkbox
                 checked={checked}
-                onCheckedChange={(next) =>
-                  setOverrides((prev) => ({ ...prev, [index]: next }))
-                }
+                onCheckedChange={(next) => setOverrides((prev) => ({ ...prev, [index]: next }))}
                 aria-label={`Restore ${tab.title}`}
                 data-testid={`session-restore-tab-checkbox-${index}`}
               />

--- a/src/services/networkApi.ts
+++ b/src/services/networkApi.ts
@@ -52,6 +52,23 @@ export async function networkPortScanCancel(taskId: string): Promise<void> {
   await invoke("network_port_scan_cancel", { taskId });
 }
 
+/**
+ * One-shot TCP reachability probe (issue #1931). Resolves `true` only when a TCP
+ * connection to `host:port` is accepted within `timeoutMs` (default 1500 ms on
+ * the backend). Used by the session-restore dialog to flag unreachable targets.
+ */
+export async function probeTargetReachable(
+  host: string,
+  port: number,
+  timeoutMs?: number
+): Promise<boolean> {
+  return await invoke<boolean>("probe_target_reachable", {
+    host,
+    port,
+    timeoutMs: timeoutMs ?? null,
+  });
+}
+
 // ── Ping ─────────────────────────────────────────────────────────────────────
 
 /**

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -114,6 +114,7 @@ import {
   detachPersistentTab as apiDetachPersistentTab,
   saveShellIntegrationSettings,
   localReadFile,
+  listSerialPorts,
   openWindow,
   sendHandoffToWindow,
   claimSession,
@@ -196,7 +197,14 @@ import {
   captureAllTabGroups,
   getWorkspaceLeaves,
 } from "@/utils/workspaceLayout";
-import { resolveRestoreMode, summarizeLastSession, type RestorePrompt } from "@/utils/restoreMode";
+import {
+  filterSessionBySelection,
+  resolveRestoreMode,
+  summarizeLastSession,
+  type RestorePrompt,
+} from "@/utils/restoreMode";
+import { probeRestoreTargets } from "@/utils/restoreReachability";
+import { probeTargetReachable } from "@/services/networkApi";
 import { Macro, MacroStep } from "@/types/macro";
 import {
   listMacros as apiListMacros,
@@ -1518,8 +1526,13 @@ interface AppState {
   saveLastSession: () => Promise<void>;
   /** Debounced wrapper around {@link saveLastSession} for high-frequency layout changes. */
   scheduleLastSessionSave: () => void;
-  /** Restore the persisted last session into the live layout. Returns true if a session was restored. */
-  restoreLastSession: () => Promise<boolean>;
+  /**
+   * Restore the persisted last session into the live layout. Returns true if a
+   * session was restored. When `selectedIndices` is given, only the tabs at
+   * those flat indices (as produced by `summarizeLastSession`) are restored —
+   * the partial-restore path from the restore dialog (#1931).
+   */
+  restoreLastSession: (selectedIndices?: readonly number[]) => Promise<boolean>;
   /** Clear the persisted last session (e.g. when restore-on-startup is disabled). */
   clearLastSession: () => Promise<void>;
   /**
@@ -1537,9 +1550,13 @@ interface AppState {
   /**
    * Resolve the restore prompt with "Restore": optionally persist
    * `restoreLastSessionMode: "always"` (when `remember`), then restore the
-   * stored session.
+   * stored session. `selectedIndices` restricts the restore to the checked tabs
+   * (#1931); omitting it restores every stored tab.
    */
-  confirmRestorePrompt: (remember: boolean) => Promise<void>;
+  confirmRestorePrompt: (
+    remember: boolean,
+    selectedIndices?: readonly number[]
+  ) => Promise<void>;
   /**
    * Resolve the restore prompt with "Start Fresh": optionally persist
    * `restoreLastSessionMode: "never"` (when `remember`), then clear the stored
@@ -1857,6 +1874,42 @@ function beginRestoreGuard(setState: (partial: Partial<AppState>) => void): void
     setState({ restoreInProgress: false });
     frontendLog("workspace", "restore settle window elapsed; auto-save re-enabled");
   }, RESTORE_SETTLE_MS);
+}
+
+/**
+ * Probe reachability for a pending restore prompt and patch its tabs with the
+ * results (#1931). Runs in the background after the dialog opens so the prompt
+ * shows immediately; when the probe resolves, the prompt is updated in place so
+ * the dialog can flag unreachable targets. Stale results (the prompt changed or
+ * was dismissed meanwhile) are dropped by identity check.
+ */
+async function probeRestorePromptReachability(
+  prompt: RestorePrompt,
+  getState: () => AppState,
+  setState: (partial: Partial<AppState>) => void
+): Promise<void> {
+  const targets = prompt.tabs.map((t) => t.target ?? { kind: "local" as const });
+  try {
+    const results = await probeRestoreTargets(targets, {
+      listSerialPorts,
+      probeHost: (host, port) => probeTargetReachable(host, port),
+    });
+    // Only apply if this exact prompt is still the active one.
+    if (getState().restorePrompt !== prompt) return;
+    setState({
+      restorePrompt: {
+        ...prompt,
+        tabs: prompt.tabs.map((tab, i) => ({
+          ...tab,
+          reachability: results[i]?.reachability ?? "unknown",
+          unreachableReason: results[i]?.reason,
+        })),
+      },
+    });
+  } catch (err) {
+    // A probe failure leaves reachability unknown — never blocks restore.
+    frontendLog("workspace", `restore reachability probe failed: ${String(err)}`);
+  }
 }
 
 /**
@@ -7510,10 +7563,16 @@ export const useAppStore = create<AppState>((set, get) => {
       }, LAST_SESSION_SAVE_DEBOUNCE_MS);
     },
 
-    restoreLastSession: async () => {
+    restoreLastSession: async (selectedIndices) => {
       try {
-        const session = await apiLoadLastSession();
-        if (!session || session.tabGroups.length === 0) return false;
+        const loaded = await apiLoadLastSession();
+        if (!loaded || loaded.tabGroups.length === 0) return false;
+        // Partial restore (#1931): prune the stored session to the tabs the user
+        // checked before building anything. An empty selection restores nothing.
+        const session = selectedIndices
+          ? filterSessionBySelection(loaded, new Set(selectedIndices))
+          : loaded;
+        if (session.tabGroups.length === 0) return false;
         const state = get();
         // Agents are all disconnected at startup, so agentRef tabs resolve to
         // agent-error tabs rather than silently disappearing.
@@ -7609,10 +7668,16 @@ export const useAppStore = create<AppState>((set, get) => {
       try {
         const session = await apiLoadLastSession();
         if (!session || session.tabGroups.length === 0) return;
-        const summary = summarizeLastSession(session);
+        // Pass loaded connections so `connectionRef` tabs resolve a host/serial
+        // target for the reachability probe (connections are loaded before this
+        // runs at startup).
+        const summary = summarizeLastSession(session, get().connections);
         // Nothing launchable → treat as "no session" and stay silent.
         if (summary.tabCount === 0) return;
         set({ restorePrompt: summary });
+        // Probe each target's reachability in the background and patch the
+        // prompt so the dialog can flag unavailable tabs (#1931).
+        void probeRestorePromptReachability(summary, get, set);
       } catch (err) {
         // A corrupt/failed load must not wedge startup — surface it like a
         // failed restore and start fresh.
@@ -7621,7 +7686,7 @@ export const useAppStore = create<AppState>((set, get) => {
       }
     },
 
-    confirmRestorePrompt: async (remember) => {
+    confirmRestorePrompt: async (remember, selectedIndices) => {
       const state = get();
       if (remember) {
         await state.updateSettings({
@@ -7630,7 +7695,7 @@ export const useAppStore = create<AppState>((set, get) => {
         });
       }
       set({ restorePrompt: null });
-      await get().restoreLastSession();
+      await get().restoreLastSession(selectedIndices);
     },
 
     dismissRestorePrompt: async (remember) => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1553,10 +1553,7 @@ interface AppState {
    * stored session. `selectedIndices` restricts the restore to the checked tabs
    * (#1931); omitting it restores every stored tab.
    */
-  confirmRestorePrompt: (
-    remember: boolean,
-    selectedIndices?: readonly number[]
-  ) => Promise<void>;
+  confirmRestorePrompt: (remember: boolean, selectedIndices?: readonly number[]) => Promise<void>;
   /**
    * Resolve the restore prompt with "Start Fresh": optionally persist
    * `restoreLastSessionMode: "never"` (when `remember`), then clear the stored

--- a/src/utils/restoreMode.test.ts
+++ b/src/utils/restoreMode.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { resolveRestoreMode, summarizeLastSession } from "./restoreMode";
-import type { AppSettings } from "@/types/connection";
+import { filterSessionBySelection, resolveRestoreMode, summarizeLastSession } from "./restoreMode";
+import type { AppSettings, SavedConnection } from "@/types/connection";
 import type { LastSession } from "@/types/lastSession";
+import { countWorkspaceTabs, getWorkspaceLeaves } from "@/utils/workspaceLayout";
 
 function settings(partial: Partial<AppSettings>): AppSettings {
   return { version: "1", externalConnectionFiles: [], ...partial } as AppSettings;
@@ -73,10 +74,104 @@ describe("summarizeLastSession", () => {
 
   it("uses the title override and derives type labels", () => {
     const { tabs } = summarizeLastSession(session);
-    expect(tabs[0]).toEqual({ title: "prod-db", typeLabel: "SSH" });
+    expect(tabs[0]).toMatchObject({ title: "prod-db", typeLabel: "SSH" });
     // No title: falls back to the device path, Serial type badge.
-    expect(tabs[1]).toEqual({ title: "/dev/ttyUSB0", typeLabel: "Serial" });
-    expect(tabs[2]).toEqual({ title: "Local", typeLabel: "Local" });
+    expect(tabs[1]).toMatchObject({ title: "/dev/ttyUSB0", typeLabel: "Serial" });
+    expect(tabs[2]).toMatchObject({ title: "Local", typeLabel: "Local" });
+  });
+
+  it("derives a probe target per tab", () => {
+    const { tabs } = summarizeLastSession(session);
+    expect(tabs[0].target).toEqual({ kind: "host", host: "prod-db", port: 22 });
+    expect(tabs[1].target).toEqual({ kind: "serial", device: "/dev/ttyUSB0" });
+    expect(tabs[2].target).toEqual({ kind: "local" });
+  });
+
+  it("uses the telnet default port when unspecified", () => {
+    const telnet: LastSession = {
+      version: "1",
+      activeGroupIndex: 0,
+      tabGroups: [
+        {
+          name: "G",
+          layout: {
+            type: "leaf",
+            tabs: [{ inlineConfig: { type: "telnet", config: { host: "switch" } } }],
+          },
+        },
+      ],
+    };
+    expect(summarizeLastSession(telnet).tabs[0].target).toEqual({
+      kind: "host",
+      host: "switch",
+      port: 23,
+    });
+  });
+
+  it("honours an explicit host port", () => {
+    const ssh: LastSession = {
+      version: "1",
+      activeGroupIndex: 0,
+      tabGroups: [
+        {
+          name: "G",
+          layout: {
+            type: "leaf",
+            tabs: [{ inlineConfig: { type: "ssh", config: { host: "h", port: 2222 } } }],
+          },
+        },
+      ],
+    };
+    expect(summarizeLastSession(ssh).tabs[0].target).toEqual({
+      kind: "host",
+      host: "h",
+      port: 2222,
+    });
+  });
+
+  it("resolves a connectionRef target from the supplied connections", () => {
+    const connections: SavedConnection[] = [
+      {
+        id: "c1",
+        name: "prod",
+        folderId: null,
+        config: { type: "ssh", config: { host: "10.0.0.5", port: 22 } },
+      } as SavedConnection,
+    ];
+    const refSession: LastSession = {
+      version: "1",
+      activeGroupIndex: 0,
+      tabGroups: [
+        { name: "G", layout: { type: "leaf", tabs: [{ connectionRef: "c1", title: "prod" }] } },
+      ],
+    };
+    expect(summarizeLastSession(refSession, connections).tabs[0].target).toEqual({
+      kind: "host",
+      host: "10.0.0.5",
+      port: 22,
+    });
+    // Without the connections it cannot resolve the ref → not network-probed.
+    expect(summarizeLastSession(refSession).tabs[0].target).toEqual({ kind: "local" });
+  });
+
+  it("derives an agent target from an agentRef tab", () => {
+    const agentSession: LastSession = {
+      version: "1",
+      activeGroupIndex: 0,
+      tabGroups: [
+        {
+          name: "G",
+          layout: {
+            type: "leaf",
+            tabs: [{ agentRef: { agentId: "a1", definitionId: "d1" } }],
+          },
+        },
+      ],
+    };
+    expect(summarizeLastSession(agentSession).tabs[0].target).toEqual({
+      kind: "agent",
+      agentId: "a1",
+    });
   });
 
   it("reports zero tabs for an empty session", () => {
@@ -86,5 +181,72 @@ describe("summarizeLastSession", () => {
       tabGroups: [{ name: "Empty", layout: { type: "leaf", tabs: [] } }],
     };
     expect(summarizeLastSession(empty)).toEqual({ tabCount: 0, tabs: [] });
+  });
+});
+
+describe("filterSessionBySelection", () => {
+  // Flat tab order (matching summarizeLastSession): 0 ssh, 1 serial, 2 local.
+  const session: LastSession = {
+    version: "1",
+    activeGroupIndex: 0,
+    tabGroups: [
+      {
+        name: "Group",
+        layout: {
+          type: "split",
+          direction: "horizontal",
+          sizes: [60, 40],
+          children: [
+            {
+              type: "leaf",
+              tabs: [
+                { title: "ssh", inlineConfig: { type: "ssh", config: { host: "h" } } },
+                { title: "serial", inlineConfig: { type: "serial", config: { device: "/dev/x" } } },
+              ],
+            },
+            {
+              type: "leaf",
+              tabs: [{ title: "local", inlineConfig: { type: "local", config: {} } }],
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  it("keeps only the selected tabs", () => {
+    const filtered = filterSessionBySelection(session, new Set([0, 2]));
+    const titles = filtered.tabGroups.flatMap((g) =>
+      getWorkspaceLeaves(g.layout).flatMap((l) => l.tabs.map((t) => t.title))
+    );
+    expect(titles).toEqual(["ssh", "local"]);
+  });
+
+  it("collapses a split whose sibling leaf empties out", () => {
+    // Deselect the local tab (index 2) → the second leaf empties, the split
+    // collapses to the first leaf.
+    const filtered = filterSessionBySelection(session, new Set([0, 1]));
+    const layout = filtered.tabGroups[0].layout;
+    expect(layout.type).toBe("leaf");
+    expect(countWorkspaceTabs(layout)).toBe(2);
+  });
+
+  it("drops a group whose every tab was deselected", () => {
+    const twoGroups: LastSession = {
+      version: "1",
+      activeGroupIndex: 1,
+      tabGroups: [
+        { name: "A", layout: { type: "leaf", tabs: [{ title: "a" }] } },
+        { name: "B", layout: { type: "leaf", tabs: [{ title: "b" }] } },
+      ],
+    };
+    // Keep only tab 0 (group A) → group B is removed, active remaps to A.
+    const filtered = filterSessionBySelection(twoGroups, new Set([0]));
+    expect(filtered.tabGroups.map((g) => g.name)).toEqual(["A"]);
+    expect(filtered.activeGroupIndex).toBe(0);
+  });
+
+  it("yields no groups when nothing is selected", () => {
+    expect(filterSessionBySelection(session, new Set()).tabGroups).toEqual([]);
   });
 });

--- a/src/utils/restoreMode.ts
+++ b/src/utils/restoreMode.ts
@@ -7,13 +7,43 @@
  * - `"always"` — restore the previous session silently.
  */
 
-import type { AppSettings } from "@/types/connection";
+import type { AppSettings, SavedConnection } from "@/types/connection";
 import type { LastSession } from "@/types/lastSession";
-import type { WorkspaceTabDef } from "@/types/workspace";
+import type { WorkspaceLayoutNode, WorkspaceTabDef, WorkspaceTabGroupDef } from "@/types/workspace";
 import { getWorkspaceLeaves } from "@/utils/workspaceLayout";
 
 /** The three restore modes. */
 export type RestoreLastSessionMode = "never" | "ask" | "always";
+
+/**
+ * Reachability of a restorable tab's connection target, resolved by an
+ * asynchronous probe after the restore dialog opens.
+ *
+ * - `"reachable"` — the target answered (host port open / serial device present).
+ * - `"unreachable"` — the target is down (host unreachable / device offline);
+ *   the dialog flags it with a warning icon.
+ * - `"unknown"` — not probed or the probe was inconclusive (the default before
+ *   the probe resolves, and for targets with nothing meaningful to probe).
+ */
+export type RestoreReachability = "reachable" | "unreachable" | "unknown";
+
+/**
+ * The connection target derived from a stored tab, used to drive the
+ * reachability probe. `kind` selects how the probe checks it; `local` and
+ * `agent` targets are not network-probed (they resolve to `"unknown"`).
+ */
+export interface RestoreTabTarget {
+  /** How the tab connects, selecting the reachability check to run. */
+  kind: "host" | "serial" | "local" | "agent";
+  /** Target host for `host` targets (SSH/telnet). */
+  host?: string;
+  /** Target TCP port for `host` targets. */
+  port?: number;
+  /** Serial device path for `serial` targets. */
+  device?: string;
+  /** Remote agent id for `agent` targets. */
+  agentId?: string;
+}
 
 /** A single restorable tab, described for the restore dialog. */
 export interface RestoreTabInfo {
@@ -21,6 +51,22 @@ export interface RestoreTabInfo {
   title: string;
   /** Short connection-type label (e.g. "SSH", "Serial", "Local"). */
   typeLabel: string;
+  /**
+   * The probe target derived from the stored tab. Optional so display-only
+   * callers (and tests) need not construct it; {@link summarizeLastSession}
+   * always populates it so the reachability probe can run.
+   */
+  target?: RestoreTabTarget;
+  /**
+   * Reachability of {@link target}, set asynchronously once the probe resolves.
+   * Absent until then (treated as `"unknown"`).
+   */
+  reachability?: RestoreReachability;
+  /**
+   * Short human-readable reason shown beside the warning icon when the target is
+   * unreachable (e.g. `"device offline"`, `"host unreachable"`).
+   */
+  unreachableReason?: string;
 }
 
 /** Summary of a stored last session for the restore dialog. */
@@ -81,12 +127,74 @@ function tabFallbackTitle(tab: WorkspaceTabDef): string {
   return tabTypeLabel(tab);
 }
 
+/** Default TCP ports for host-based connection types, used when unspecified. */
+const DEFAULT_HOST_PORTS: Record<string, number> = { ssh: 22, telnet: 23 };
+
+/**
+ * Resolve a stored tab's effective connection type and config, following a
+ * `connectionRef` into the supplied saved connections when present. Returns
+ * `undefined` when neither an inline config nor a resolvable reference exists.
+ */
+function resolveTabConfig(
+  tab: WorkspaceTabDef,
+  connections: SavedConnection[]
+): { type: string; config: Record<string, unknown> } | undefined {
+  if (tab.inlineConfig) return tab.inlineConfig;
+  if (tab.connectionRef) {
+    const saved = connections.find((c) => c.id === tab.connectionRef);
+    if (saved) {
+      return { type: saved.config.type, config: saved.config.config as Record<string, unknown> };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Derive the reachability {@link RestoreTabTarget} for a stored tab. Host-based
+ * types (SSH/telnet) yield a `host` target; serial yields a `serial` target;
+ * agent references yield an `agent` target; everything else (local, docker,
+ * WSL, unresolved refs) is `local` and is not network-probed.
+ */
+function deriveTabTarget(tab: WorkspaceTabDef, connections: SavedConnection[]): RestoreTabTarget {
+  if (tab.agentRef) return { kind: "agent", agentId: tab.agentRef.agentId };
+
+  const resolved = resolveTabConfig(tab, connections);
+  const type = resolved?.type;
+  const config = resolved?.config ?? {};
+
+  if (type === "ssh" || type === "telnet") {
+    const host = typeof config.host === "string" ? config.host : undefined;
+    if (host) {
+      const port = typeof config.port === "number" ? config.port : DEFAULT_HOST_PORTS[type];
+      return { kind: "host", host, port };
+    }
+  }
+
+  if (type === "serial") {
+    const device =
+      typeof config.device === "string"
+        ? config.device
+        : typeof config.port === "string"
+          ? config.port
+          : undefined;
+    if (device) return { kind: "serial", device };
+  }
+
+  return { kind: "local" };
+}
+
 /**
  * Flatten a stored {@link LastSession} into a per-tab summary for the restore
- * dialog. Pure over the session — no connection lookup, so it can run before
- * connections are loaded.
+ * dialog. Iterates groups → leaves → tabs in a stable order; that same order is
+ * the tab index space used by {@link filterSessionBySelection}.
+ *
+ * `connections` (optional) lets `connectionRef` tabs resolve their host/serial
+ * target for the reachability probe; pass the loaded connections when available.
  */
-export function summarizeLastSession(session: LastSession): RestorePrompt {
+export function summarizeLastSession(
+  session: LastSession,
+  connections: SavedConnection[] = []
+): RestorePrompt {
   const tabs: RestoreTabInfo[] = [];
   for (const group of session.tabGroups) {
     for (const leaf of getWorkspaceLeaves(group.layout)) {
@@ -94,9 +202,80 @@ export function summarizeLastSession(session: LastSession): RestorePrompt {
         tabs.push({
           title: tab.title?.trim() || tabFallbackTitle(tab),
           typeLabel: tabTypeLabel(tab),
+          target: deriveTabTarget(tab, connections),
         });
       }
     }
   }
   return { tabCount: tabs.length, tabs };
+}
+
+/**
+ * Prune a stored {@link LastSession} down to the tabs the user chose to restore.
+ *
+ * `selected` holds the flat tab indices to keep, in the same order
+ * {@link summarizeLastSession} produced. Leaves left with no tabs are dropped,
+ * splits collapse when only one child survives (redistributing sizes), and tab
+ * groups whose layout empties out are removed. `activeGroupIndex` is remapped to
+ * the surviving group nearest the original active one; `windows` are preserved
+ * untouched (an emptied window still round-trips, per #1902).
+ */
+export function filterSessionBySelection(
+  session: LastSession,
+  selected: ReadonlySet<number>
+): LastSession {
+  let flatIndex = 0;
+
+  const filterNode = (node: WorkspaceLayoutNode): WorkspaceLayoutNode | null => {
+    if (node.type === "leaf") {
+      const tabs = node.tabs.filter(() => selected.has(flatIndex++));
+      return tabs.length > 0 ? { ...node, tabs } : null;
+    }
+
+    const keptChildren: WorkspaceLayoutNode[] = [];
+    const keptOriginalIndices: number[] = [];
+    node.children.forEach((child, i) => {
+      const filtered = filterNode(child);
+      if (filtered) {
+        keptChildren.push(filtered);
+        keptOriginalIndices.push(i);
+      }
+    });
+
+    if (keptChildren.length === 0) return null;
+    if (keptChildren.length === 1) return keptChildren[0];
+
+    let sizes = node.sizes;
+    if (sizes) {
+      const chosen = keptOriginalIndices.map((i) => sizes?.[i] ?? 0);
+      const total = chosen.reduce((a, b) => a + b, 0);
+      sizes = total > 0 ? chosen.map((s) => (s / total) * 100) : undefined;
+    }
+    return { ...node, children: keptChildren, ...(sizes ? { sizes } : {}) };
+  };
+
+  const groups: WorkspaceTabGroupDef[] = [];
+  const keptGroupIndices: number[] = [];
+  session.tabGroups.forEach((group, i) => {
+    const layout = filterNode(group.layout);
+    if (layout) {
+      groups.push({ ...group, layout });
+      keptGroupIndices.push(i);
+    }
+  });
+
+  // Remap the active group to a surviving one: the same group if it survived,
+  // otherwise the nearest surviving group at or after it, else the first.
+  let activeGroupIndex = 0;
+  if (keptGroupIndices.length > 0) {
+    const exact = keptGroupIndices.indexOf(session.activeGroupIndex);
+    if (exact >= 0) {
+      activeGroupIndex = exact;
+    } else {
+      const after = keptGroupIndices.findIndex((i) => i >= session.activeGroupIndex);
+      activeGroupIndex = after >= 0 ? after : keptGroupIndices.length - 1;
+    }
+  }
+
+  return { ...session, tabGroups: groups, activeGroupIndex };
 }

--- a/src/utils/restoreReachability.test.ts
+++ b/src/utils/restoreReachability.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import { probeRestoreTargets, type ReachabilityProbe } from "./restoreReachability";
+import type { RestoreTabTarget } from "./restoreMode";
+
+function probe(overrides: Partial<ReachabilityProbe> = {}): ReachabilityProbe {
+  return {
+    listSerialPorts: vi.fn(() => Promise.resolve<string[]>([])),
+    probeHost: vi.fn(() => Promise.resolve(true)),
+    ...overrides,
+  };
+}
+
+describe("probeRestoreTargets", () => {
+  it("flags a serial device that is not currently present as offline", async () => {
+    const targets: RestoreTabTarget[] = [
+      { kind: "serial", device: "/dev/ttyUSB0" },
+      { kind: "serial", device: "/dev/ttyUSB1" },
+    ];
+    const results = await probeRestoreTargets(
+      targets,
+      probe({ listSerialPorts: () => Promise.resolve(["/dev/ttyUSB1"]) })
+    );
+    expect(results[0]).toEqual({ reachability: "unreachable", reason: "device offline" });
+    expect(results[1]).toEqual({ reachability: "reachable" });
+  });
+
+  it("lists serial ports only once regardless of how many serial targets", async () => {
+    const listSerialPorts = vi.fn(() => Promise.resolve(["/dev/a"]));
+    await probeRestoreTargets(
+      [
+        { kind: "serial", device: "/dev/a" },
+        { kind: "serial", device: "/dev/b" },
+      ],
+      probe({ listSerialPorts })
+    );
+    expect(listSerialPorts).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks a reachable host reachable and an unreachable host unreachable", async () => {
+    const probeHost = vi.fn((host: string) => Promise.resolve(host === "up"));
+    const results = await probeRestoreTargets(
+      [
+        { kind: "host", host: "up", port: 22 },
+        { kind: "host", host: "down", port: 22 },
+      ],
+      probe({ probeHost })
+    );
+    expect(results[0]).toEqual({ reachability: "reachable" });
+    expect(results[1]).toEqual({ reachability: "unreachable", reason: "host unreachable" });
+  });
+
+  it("degrades to unknown when a host probe throws", async () => {
+    const results = await probeRestoreTargets(
+      [{ kind: "host", host: "boom", port: 22 }],
+      probe({ probeHost: () => Promise.reject(new Error("nope")) })
+    );
+    expect(results[0]).toEqual({ reachability: "unknown" });
+  });
+
+  it("degrades serial targets to unknown when listing serial ports fails", async () => {
+    const results = await probeRestoreTargets(
+      [{ kind: "serial", device: "/dev/x" }],
+      probe({ listSerialPorts: () => Promise.reject(new Error("no ports")) })
+    );
+    expect(results[0]).toEqual({ reachability: "unknown" });
+  });
+
+  it("does not network-probe local or agent targets", async () => {
+    const probeHost = vi.fn(() => Promise.resolve(true));
+    const listSerialPorts = vi.fn(() => Promise.resolve([]));
+    const results = await probeRestoreTargets(
+      [{ kind: "local" }, { kind: "agent", agentId: "a1" }],
+      probe({ probeHost, listSerialPorts })
+    );
+    expect(results).toEqual([{ reachability: "unknown" }, { reachability: "unknown" }]);
+    expect(probeHost).not.toHaveBeenCalled();
+    expect(listSerialPorts).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/restoreReachability.ts
+++ b/src/utils/restoreReachability.ts
@@ -1,0 +1,74 @@
+/**
+ * Reachability probing for the startup session-restore dialog.
+ *
+ * Given the per-tab {@link RestoreTabTarget}s derived from a stored session,
+ * this resolves each target to a {@link RestoreReachability} so the dialog can
+ * flag unavailable targets (device disconnected / host unreachable) with a
+ * warning icon. The probe primitives are injected so the orchestration stays
+ * pure and unit-testable — no direct Tauri/API calls here.
+ */
+
+import type { RestoreReachability, RestoreTabTarget } from "@/utils/restoreMode";
+
+/** Injected probe primitives used to determine reachability. */
+export interface ReachabilityProbe {
+  /** List the serial device paths currently present on the machine. */
+  listSerialPorts: () => Promise<string[]>;
+  /** Attempt a TCP connect to `host:port`, resolving `true` when it succeeds. */
+  probeHost: (host: string, port: number) => Promise<boolean>;
+}
+
+/** Resolved reachability for a single tab. */
+export interface TabReachability {
+  reachability: RestoreReachability;
+  /** Short reason shown beside the warning icon when `unreachable`. */
+  reason?: string;
+}
+
+const UNKNOWN: TabReachability = { reachability: "unknown" };
+
+/**
+ * Probe every target and return a reachability verdict per target, index-aligned
+ * with the input. Serial ports are listed once and shared across all serial
+ * targets; host targets are probed concurrently. `local` and `agent` targets are
+ * not network-probed and resolve to `"unknown"`. Any probe failure degrades to
+ * `"unknown"` rather than a false "unreachable".
+ */
+export async function probeRestoreTargets(
+  targets: RestoreTabTarget[],
+  probe: ReachabilityProbe
+): Promise<TabReachability[]> {
+  const needsSerial = targets.some((t) => t.kind === "serial");
+  let serialPorts: string[] | null = null;
+  if (needsSerial) {
+    try {
+      serialPorts = await probe.listSerialPorts();
+    } catch {
+      serialPorts = null;
+    }
+  }
+
+  return Promise.all(
+    targets.map(async (target): Promise<TabReachability> => {
+      if (target.kind === "serial") {
+        if (!serialPorts || !target.device) return UNKNOWN;
+        return serialPorts.includes(target.device)
+          ? { reachability: "reachable" }
+          : { reachability: "unreachable", reason: "device offline" };
+      }
+
+      if (target.kind === "host" && target.host && target.port) {
+        try {
+          const reachable = await probe.probeHost(target.host, target.port);
+          return reachable
+            ? { reachability: "reachable" }
+            : { reachability: "unreachable", reason: "host unreachable" };
+        } catch {
+          return UNKNOWN;
+        }
+      }
+
+      return UNKNOWN;
+    })
+  );
+}


### PR DESCRIPTION
## Summary

Follow-up from the session-auto-save concept (#1931). The startup "Restore Previous Session?" dialog was all-or-nothing with a read-only tab list. This adds:

- **Per-tab checkboxes** so the user restores a subset of tabs. The selected flat-tab indices are plumbed through `confirmRestorePrompt` → `restoreLastSession`, where `filterSessionBySelection` prunes the stored session (dropping empty leaves, collapsing single-child splits and redistributing sizes, removing emptied groups, remapping `activeGroupIndex`) before anything is built.
- **A reachability probe** that flags unavailable targets with a warning icon per the concept mockups:
  - Serial devices are checked against `list_serial_ports` → "device offline".
  - SSH/telnet hosts are checked with a new one-shot `probe_target_reachable` backend command (single TCP connect, short timeout) → "host unreachable".
  - The probe runs in the background after the dialog opens and patches the prompt in place; failures degrade to "unknown" and never block restore. Unreachable tabs start unchecked (user toggles always win).

The confirm button relabels to "Restore N Selected" when a subset is chosen and disables when nothing is selected.

## Scope

Kept deliberately scoped to the restore-dialog per-tab selection + offline warnings (siblings #1932/#1933 are held until this lands to avoid collisions).

## Tests

- `restoreMode.test.ts`: target derivation (ssh/serial/agent/local, connectionRef resolution, default ports) and `filterSessionBySelection` (restores only checked tabs, prunes/collapses layout, empty selection).
- `restoreReachability.test.ts`: serial-offline warning, host reachable/unreachable, probe-failure → unknown, serial ports listed once.
- `SessionRestoreDialog.test.tsx`: renders checkboxes, passes only checked indices, offline warning icon + default-unchecked, disabled confirm when none selected.
- Rust: `probe_target_reachable` reachable/unreachable unit tests.

Closes #1931