### PR TITLE
feat(ui): full save-as-connection editor with icon, fields, save-password (Closes #1932)

### DIFF
--- a/docs/changes/dev3/feat/1932-saveas-connection-editor.md
+++ b/docs/changes/dev3/feat/1932-saveas-connection-editor.md
@@ -1,0 +1,9 @@
+### Changed
+
+- The Recent Sessions "Save as Connection" dialog is now a full promotion
+  editor. Alongside name and folder it exposes an icon picker and editable
+  connection fields (host/port/username and, for SSH, the auth method)
+  pre-filled from the history entry, plus a "Save password to credential store"
+  checkbox. When ticked and a password is entered, the secret is written to the
+  credential store before the connection is saved; the checkbox is disabled when
+  no credential store is configured (#1932).

--- a/src/components/RecentSessionsSidebar/RecentSessionsSidebar.css
+++ b/src/components/RecentSessionsSidebar/RecentSessionsSidebar.css
@@ -137,29 +137,45 @@
   gap: 8px;
 }
 
-/* --- Save-as-connection dialog details --- */
-.recent-sessions__save-details {
+/* --- Save-as-connection dialog: icon row --- */
+.recent-sessions__save-icon-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* --- Save-as-connection dialog: editable connection details --- */
+.recent-sessions__save-fields {
   margin: 8px 0 0;
-  padding: 8px 12px;
+  padding: 8px 12px 12px;
   border: 1px solid var(--border-color);
   border-radius: var(--radius-md, 6px);
   background: var(--bg-secondary);
 }
 
-.recent-sessions__save-detail {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 2px 0;
+.recent-sessions__save-fields-legend {
+  padding: 0 6px;
+  color: var(--text-secondary);
   font-size: 12px;
 }
 
-.recent-sessions__save-detail dt {
-  color: var(--text-secondary);
+/* --- Save-as-connection dialog: save-password section --- */
+.recent-sessions__save-password {
+  margin-top: 8px;
 }
 
-.recent-sessions__save-detail dd {
-  margin: 0;
+.recent-sessions__save-password-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
   color: var(--text-primary);
-  font-family: var(--font-mono);
+  cursor: pointer;
+}
+
+.recent-sessions__save-password-hint {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-secondary);
+  font-size: 12px;
 }

--- a/src/components/RecentSessionsSidebar/SaveAsConnectionDialog.test.tsx
+++ b/src/components/RecentSessionsSidebar/SaveAsConnectionDialog.test.tsx
@@ -21,8 +21,9 @@ const { credStatus } = vi.hoisted(() => ({
   credStatus: { value: null as CredentialStoreStatusInfo | null },
 }));
 vi.mock("@/store/appStore", () => ({
-  useAppStore: (selector: (s: { credentialStoreStatus: CredentialStoreStatusInfo | null }) => unknown) =>
-    selector({ credentialStoreStatus: credStatus.value }),
+  useAppStore: (
+    selector: (s: { credentialStoreStatus: CredentialStoreStatusInfo | null }) => unknown
+  ) => selector({ credentialStoreStatus: credStatus.value }),
 }));
 
 let container: HTMLDivElement;
@@ -34,10 +35,7 @@ function query(testId: string): HTMLElement | null {
 
 /** Set a controlled input's value the way the DOM would on user typing. */
 function typeInto(el: HTMLInputElement, value: string): void {
-  const setter = Object.getOwnPropertyDescriptor(
-    window.HTMLInputElement.prototype,
-    "value"
-  )!.set!;
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")!.set!;
   act(() => {
     setter.call(el, value);
     el.dispatchEvent(new Event("input", { bubbles: true }));

--- a/src/components/RecentSessionsSidebar/SaveAsConnectionDialog.test.tsx
+++ b/src/components/RecentSessionsSidebar/SaveAsConnectionDialog.test.tsx
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { SaveAsConnectionDialog } from "./SaveAsConnectionDialog";
 import type { SessionHistoryEntry } from "@/types/sessionHistory";
 import type { ConnectionFolder, SavedConnection } from "@/types/connection";
+import type { CredentialStoreStatusInfo } from "@/types/credential";
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
 
@@ -13,11 +14,34 @@ vi.mock("@/components/ui", async (importOriginal) => {
   return { ...actual, toast: { ...actual.toast, error: toastError } };
 });
 
+const { storeCredentialMock } = vi.hoisted(() => ({ storeCredentialMock: vi.fn() }));
+vi.mock("@/services/api", () => ({ storeCredential: storeCredentialMock }));
+
+const { credStatus } = vi.hoisted(() => ({
+  credStatus: { value: null as CredentialStoreStatusInfo | null },
+}));
+vi.mock("@/store/appStore", () => ({
+  useAppStore: (selector: (s: { credentialStoreStatus: CredentialStoreStatusInfo | null }) => unknown) =>
+    selector({ credentialStoreStatus: credStatus.value }),
+}));
+
 let container: HTMLDivElement;
 let root: Root;
 
 function query(testId: string): HTMLElement | null {
   return document.querySelector(`[data-testid="${testId}"]`);
+}
+
+/** Set a controlled input's value the way the DOM would on user typing. */
+function typeInto(el: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value"
+  )!.set!;
+  act(() => {
+    setter.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
 }
 
 const entry: SessionHistoryEntry = {
@@ -34,12 +58,39 @@ const entry: SessionHistoryEntry = {
 
 const folders: ConnectionFolder[] = [{ id: "f1", name: "Work", parentId: null, isExpanded: true }];
 
+function render(props: Partial<React.ComponentProps<typeof SaveAsConnectionDialog>> = {}): {
+  onSave: Mock;
+  onOpenChange: Mock;
+} {
+  const onSave = (props.onSave ?? vi.fn().mockResolvedValue(undefined)) as Mock;
+  const onOpenChange = (props.onOpenChange ?? vi.fn()) as Mock;
+  act(() =>
+    root.render(
+      <SaveAsConnectionDialog
+        entry={props.entry ?? entry}
+        folders={props.folders ?? folders}
+        onOpenChange={onOpenChange}
+        onSave={onSave}
+      />
+    )
+  );
+  return { onSave, onOpenChange };
+}
+
+async function clickSave() {
+  await act(async () => {
+    (query("save-as-connection-submit") as HTMLButtonElement).click();
+    await Promise.resolve();
+  });
+}
+
 describe("SaveAsConnectionDialog", () => {
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
     vi.clearAllMocks();
+    credStatus.value = null;
   });
 
   afterEach(() => {
@@ -47,64 +98,101 @@ describe("SaveAsConnectionDialog", () => {
     container.remove();
   });
 
-  it("pre-fills the name from the entry and creates a connection on save", async () => {
-    const onSave = vi.fn().mockResolvedValue(undefined);
-    const onOpenChange = vi.fn();
-    act(() =>
-      root.render(
-        <SaveAsConnectionDialog
-          entry={entry}
-          folders={folders}
-          onOpenChange={onOpenChange}
-          onSave={onSave}
-        />
-      )
-    );
+  it("pre-fills name and connection fields from the entry", () => {
+    render();
+    expect((query("save-as-connection-name") as HTMLInputElement).value).toBe("admin@prod");
+    expect((query("save-as-connection-host") as HTMLInputElement).value).toBe("prod");
+    expect((query("save-as-connection-port") as HTMLInputElement).value).toBe("22");
+    expect((query("save-as-connection-username") as HTMLInputElement).value).toBe("admin");
+  });
 
-    const name = query("save-as-connection-name") as HTMLInputElement;
-    expect(name.value).toBe("admin@prod");
-
-    await act(async () => {
-      (query("save-as-connection-submit") as HTMLButtonElement).click();
-      await Promise.resolve();
-    });
+  it("creates a connection carrying the (unedited) fields on save", async () => {
+    const { onSave, onOpenChange } = render();
+    await clickSave();
 
     expect(onSave).toHaveBeenCalledTimes(1);
     const [connection, dedupKey] = onSave.mock.calls[0] as [SavedConnection, string];
     expect(connection.name).toBe("admin@prod");
-    expect(connection.config).toEqual(entry.config);
+    expect(connection.config.config).toMatchObject({
+      host: "prod",
+      username: "admin",
+      port: 22,
+      authMethod: "password",
+    });
     expect(dedupKey).toBe("ssh:admin@prod:22");
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it("rejects an empty name", async () => {
-    const onSave = vi.fn().mockResolvedValue(undefined);
-    act(() =>
-      root.render(
-        <SaveAsConnectionDialog
-          entry={entry}
-          folders={folders}
-          onOpenChange={vi.fn()}
-          onSave={onSave}
-        />
-      )
-    );
+  it("writes edited host and username into the saved connection", async () => {
+    const { onSave } = render();
+    typeInto(query("save-as-connection-host") as HTMLInputElement, "prod-db.example.com");
+    typeInto(query("save-as-connection-username") as HTMLInputElement, "root");
+    await clickSave();
 
-    const name = query("save-as-connection-name") as HTMLInputElement;
-    const setter = Object.getOwnPropertyDescriptor(
-      window.HTMLInputElement.prototype,
-      "value"
-    )!.set!;
-    act(() => {
-      setter.call(name, "   ");
-      name.dispatchEvent(new Event("input", { bubbles: true }));
+    const [connection] = onSave.mock.calls[0] as [SavedConnection];
+    expect(connection.config.config).toMatchObject({
+      host: "prod-db.example.com",
+      username: "root",
     });
+  });
+
+  it("rejects an empty name", async () => {
+    const { onSave } = render();
+    typeInto(query("save-as-connection-name") as HTMLInputElement, "   ");
+    await clickSave();
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalled();
+  });
+
+  it("disables the save-password checkbox when no credential store is active", () => {
+    credStatus.value = { mode: "none", status: "unlocked" };
+    render();
+    const box = query("save-as-connection-save-password") as HTMLButtonElement;
+    expect(box.disabled).toBe(true);
+    expect(query("save-as-connection-password")).toBeNull();
+  });
+
+  it("stores the password before writing the connection when save-password is used", async () => {
+    credStatus.value = { mode: "master_password", status: "unlocked" };
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render({ onSave });
 
     await act(async () => {
-      (query("save-as-connection-submit") as HTMLButtonElement).click();
+      (query("save-as-connection-save-password") as HTMLButtonElement).click();
       await Promise.resolve();
     });
+    typeInto(query("save-as-connection-password") as HTMLInputElement, "s3cret");
+    await clickSave();
 
+    expect(storeCredentialMock).toHaveBeenCalledTimes(1);
+    const [connId, credType, value] = storeCredentialMock.mock.calls[0] as [string, string, string];
+    expect(credType).toBe("password");
+    expect(value).toBe("s3cret");
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const [connection] = onSave.mock.calls[0] as [SavedConnection];
+    expect(connection.id).toBe(connId);
+    expect(connection.config.config).toMatchObject({ savePassword: true });
+    // Credential must be stored before the connection is written.
+    expect(storeCredentialMock.mock.invocationCallOrder[0]).toBeLessThan(
+      onSave.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("aborts the save when storing the password fails", async () => {
+    credStatus.value = { mode: "master_password", status: "unlocked" };
+    storeCredentialMock.mockRejectedValueOnce(new Error("locked"));
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render({ onSave });
+
+    await act(async () => {
+      (query("save-as-connection-save-password") as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    typeInto(query("save-as-connection-password") as HTMLInputElement, "s3cret");
+    await clickSave();
+
+    expect(storeCredentialMock).toHaveBeenCalledTimes(1);
     expect(onSave).not.toHaveBeenCalled();
     expect(toastError).toHaveBeenCalled();
   });

--- a/src/components/RecentSessionsSidebar/SaveAsConnectionDialog.tsx
+++ b/src/components/RecentSessionsSidebar/SaveAsConnectionDialog.tsx
@@ -86,10 +86,7 @@ export function SaveAsConnectionDialog({
   const [savePassword, setSavePassword] = useState(false);
   const [password, setPassword] = useState("");
 
-  const inner = useMemo(
-    () => (entry?.config.config ?? {}) as Record<string, unknown>,
-    [entry]
-  );
+  const inner = useMemo(() => (entry?.config.config ?? {}) as Record<string, unknown>, [entry]);
   const connectionType = entry?.connectionType ?? "";
   const hostKey = hostKeyFor(inner);
   const showPort = "port" in inner || connectionType === "ssh" || connectionType === "telnet";
@@ -220,10 +217,7 @@ export function SaveAsConnectionDialog({
         </div>
       </Field>
 
-      <fieldset
-        className="recent-sessions__save-fields"
-        data-testid="save-as-connection-details"
-      >
+      <fieldset className="recent-sessions__save-fields" data-testid="save-as-connection-details">
         <legend className="recent-sessions__save-fields-legend">
           Connection details · {sessionTypeBadge(connectionType)}
         </legend>

--- a/src/components/RecentSessionsSidebar/SaveAsConnectionDialog.tsx
+++ b/src/components/RecentSessionsSidebar/SaveAsConnectionDialog.tsx
@@ -1,11 +1,23 @@
 import { useEffect, useMemo, useState } from "react";
-import { Button, Field, Input, Modal, Select, toast } from "@/components/ui";
+import { Button, Checkbox, Field, Input, Modal, NumberInput, Select, toast } from "@/components/ui";
+import { IconPickerDialog } from "@/components/ConnectionEditor/IconPickerDialog";
+import { IconByName } from "@/utils/connectionIcons";
+import { storeCredential } from "@/services/api";
+import { useAppStore } from "@/store/appStore";
 import type { ConnectionFolder, SavedConnection } from "@/types/connection";
+import type { ConnectionConfig } from "@/types/terminal";
 import type { SessionHistoryEntry } from "@/types/sessionHistory";
 import { sessionTypeBadge } from "@/utils/sessionHistoryTitle";
 
 /** Sentinel for the "No folder" option (Radix Select forbids empty-string item values). */
 const NO_FOLDER = "__no_folder__";
+
+/** SSH auth methods offered by the editable Auth select. */
+const AUTH_OPTIONS = [
+  { value: "password", label: "Password" },
+  { value: "key", label: "Key" },
+  { value: "agent", label: "Agent" },
+];
 
 /** Generate a unique connection id, falling back when `crypto.randomUUID` is absent. */
 function generateConnectionId(): string {
@@ -14,13 +26,26 @@ function generateConnectionId(): string {
   return `conn-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 }
 
-/** Read a config field as a display string, else undefined. */
-function detail(config: Record<string, unknown>, key: string): string | undefined {
+/** Read a config field as a string, else "". */
+function str(config: Record<string, unknown>, key: string): string {
   const value = config[key];
-  if (typeof value === "string" && value.trim() !== "") return value;
+  if (typeof value === "string") return value;
   if (typeof value === "number") return String(value);
-  return undefined;
+  return "";
 }
+
+/** The inner-config key that carries the host/device/container for a given type. */
+function hostKeyFor(config: Record<string, unknown>): "host" | "device" | "container" {
+  if ("device" in config) return "device";
+  if ("container" in config) return "container";
+  return "host";
+}
+
+const HOST_LABEL: Record<string, string> = {
+  host: "Host",
+  device: "Device",
+  container: "Container",
+};
 
 interface SaveAsConnectionDialogProps {
   /** The history entry being promoted, or null when the dialog is closed. */
@@ -33,10 +58,12 @@ interface SaveAsConnectionDialogProps {
 }
 
 /**
- * Promotion dialog: pre-fills a name and folder from a history entry and, on
- * save, creates a normal saved connection (the history entry is retained and
- * flagged as promoted). Connection parameters are shown read-only — full editing
- * happens later via the connection editor.
+ * Promotion dialog: pre-fills name, folder, icon and the connection parameters
+ * (host/port/username/auth) from a history entry, lets the user edit them, and
+ * on save creates a normal saved connection (the history entry is retained and
+ * flagged as promoted). When "Save password to credential store" is ticked and
+ * a password is entered, the secret is written to the credential store before
+ * the connection itself is persisted.
  */
 export function SaveAsConnectionDialog({
   entry,
@@ -44,15 +71,45 @@ export function SaveAsConnectionDialog({
   onOpenChange,
   onSave,
 }: SaveAsConnectionDialogProps) {
+  const credentialStoreStatus = useAppStore((s) => s.credentialStoreStatus);
+  const credentialStoreActive =
+    credentialStoreStatus != null && credentialStoreStatus.mode !== "none";
+
   const [name, setName] = useState("");
   const [folderId, setFolderId] = useState(NO_FOLDER);
+  const [icon, setIcon] = useState<string | undefined>(undefined);
+  const [iconPickerOpen, setIconPickerOpen] = useState(false);
+  const [host, setHost] = useState("");
+  const [port, setPort] = useState<number | "">("");
+  const [username, setUsername] = useState("");
+  const [authMethod, setAuthMethod] = useState("password");
+  const [savePassword, setSavePassword] = useState(false);
+  const [password, setPassword] = useState("");
+
+  const inner = useMemo(
+    () => (entry?.config.config ?? {}) as Record<string, unknown>,
+    [entry]
+  );
+  const connectionType = entry?.connectionType ?? "";
+  const hostKey = hostKeyFor(inner);
+  const showPort = "port" in inner || connectionType === "ssh" || connectionType === "telnet";
+  const showUsername = "username" in inner || connectionType === "ssh";
+  const showAuth = connectionType === "ssh";
 
   useEffect(() => {
-    if (entry) {
-      setName(entry.title);
-      setFolderId(NO_FOLDER);
-    }
-  }, [entry]);
+    if (!entry) return;
+    setName(entry.title);
+    setFolderId(NO_FOLDER);
+    setIcon(undefined);
+    setIconPickerOpen(false);
+    setHost(str(inner, hostKey));
+    const portStr = str(inner, "port");
+    setPort(portStr === "" ? "" : Number(portStr));
+    setUsername(str(inner, "username"));
+    setAuthMethod(str(inner, "authMethod") || "password");
+    setSavePassword(false);
+    setPassword("");
+  }, [entry, inner, hostKey]);
 
   const folderOptions = useMemo(
     () => [
@@ -62,16 +119,6 @@ export function SaveAsConnectionDialog({
     [folders]
   );
 
-  const inner = (entry?.config.config ?? {}) as Record<string, unknown>;
-  const details = entry
-    ? [
-        ["Type", sessionTypeBadge(entry.connectionType)],
-        ["Host", detail(inner, "host") ?? detail(inner, "device") ?? detail(inner, "container")],
-        ["Port", detail(inner, "port")],
-        ["Username", detail(inner, "username")],
-      ].filter(([, v]) => v != null)
-    : [];
-
   const handleSave = async () => {
     if (!entry) return;
     const trimmed = name.trim();
@@ -79,12 +126,36 @@ export function SaveAsConnectionDialog({
       toast.error("Enter a name for the connection");
       return;
     }
+
+    const newInner: Record<string, unknown> = { ...inner };
+    newInner[hostKey] = host.trim();
+    if (showPort && port !== "") newInner.port = port;
+    if (showUsername) newInner.username = username.trim();
+    if (showAuth) newInner.authMethod = authMethod;
+    if (savePassword) newInner.savePassword = true;
+
+    const config: ConnectionConfig = { ...entry.config, config: newInner };
     const connection: SavedConnection = {
       id: generateConnectionId(),
       name: trimmed,
-      config: entry.config,
+      config,
       folderId: folderId === NO_FOLDER ? null : folderId,
+      icon,
     };
+
+    // Persist the entered secret before writing the connection so a store
+    // failure aborts the save rather than orphaning a connection whose
+    // password never made it to the credential store.
+    if (savePassword && password.trim() !== "") {
+      const credentialType = authMethod === "key" ? "key_passphrase" : "password";
+      try {
+        await storeCredential(connection.id, credentialType, password);
+      } catch (err) {
+        toast.error(`Failed to save password: ${err}`);
+        return;
+      }
+    }
+
     await onSave(connection, entry.dedupKey);
     onOpenChange(false);
   };
@@ -124,16 +195,114 @@ export function SaveAsConnectionDialog({
           data-testid="save-as-connection-folder"
         />
       </Field>
-      {details.length > 0 && (
-        <dl className="recent-sessions__save-details" data-testid="save-as-connection-details">
-          {details.map(([label, value]) => (
-            <div key={label} className="recent-sessions__save-detail">
-              <dt>{label}</dt>
-              <dd>{value}</dd>
-            </div>
-          ))}
-        </dl>
-      )}
+      <Field label="Icon" htmlFor="save-as-connection-icon-picker">
+        <div className="recent-sessions__save-icon-row">
+          {icon && <IconByName name={icon} size={18} />}
+          <Button
+            id="save-as-connection-icon-picker"
+            variant="secondary"
+            size="sm"
+            onClick={() => setIconPickerOpen(true)}
+            data-testid="save-as-connection-icon-picker"
+          >
+            {icon ? "Change" : "Set Icon"}
+          </Button>
+          {icon && (
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => setIcon(undefined)}
+              data-testid="save-as-connection-clear-icon"
+            >
+              Clear
+            </Button>
+          )}
+        </div>
+      </Field>
+
+      <fieldset
+        className="recent-sessions__save-fields"
+        data-testid="save-as-connection-details"
+      >
+        <legend className="recent-sessions__save-fields-legend">
+          Connection details · {sessionTypeBadge(connectionType)}
+        </legend>
+        <Field label={HOST_LABEL[hostKey] ?? "Host"} htmlFor="save-as-connection-host">
+          <Input
+            id="save-as-connection-host"
+            value={host}
+            onChange={(e) => setHost(e.target.value)}
+            data-testid="save-as-connection-host"
+          />
+        </Field>
+        {showPort && (
+          <Field label="Port" htmlFor="save-as-connection-port">
+            <NumberInput
+              id="save-as-connection-port"
+              value={port}
+              onValueChange={setPort}
+              data-testid="save-as-connection-port"
+            />
+          </Field>
+        )}
+        {showUsername && (
+          <Field label="Username" htmlFor="save-as-connection-username">
+            <Input
+              id="save-as-connection-username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              data-testid="save-as-connection-username"
+            />
+          </Field>
+        )}
+        {showAuth && (
+          <Field label="Auth" htmlFor="save-as-connection-auth">
+            <Select
+              value={authMethod}
+              onChange={setAuthMethod}
+              options={AUTH_OPTIONS}
+              aria-label="Auth"
+              data-testid="save-as-connection-auth"
+            />
+          </Field>
+        )}
+      </fieldset>
+
+      <div className="recent-sessions__save-password">
+        <label className="recent-sessions__save-password-toggle">
+          <Checkbox
+            checked={savePassword}
+            onCheckedChange={setSavePassword}
+            disabled={!credentialStoreActive}
+            data-testid="save-as-connection-save-password"
+          />
+          <span>Save password to credential store</span>
+        </label>
+        {savePassword && credentialStoreActive && (
+          <Field label="Password" htmlFor="save-as-connection-password">
+            <Input
+              id="save-as-connection-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Password to store"
+              data-testid="save-as-connection-password"
+            />
+          </Field>
+        )}
+        {!credentialStoreActive && (
+          <span className="recent-sessions__save-password-hint">
+            Set up a credential store in Settings to save passwords.
+          </span>
+        )}
+      </div>
+
+      <IconPickerDialog
+        open={iconPickerOpen}
+        onOpenChange={setIconPickerOpen}
+        currentIcon={icon}
+        onIconChange={(i) => setIcon(i ?? undefined)}
+      />
     </Modal>
   );
 }


### PR DESCRIPTION
## Summary

Extends the Recent Sessions **Save as Connection** promotion dialog
(`SaveAsConnectionDialog.tsx`) from a name+folder form with read-only details
into the full editor described in the `session-auto-save` concept mockup:

- **Icon picker** — reuses the shared `IconPickerDialog` + `IconByName`.
- **Editable connection fields** pre-filled from the history entry: host
  (labelled Device/Container for those types), port, username, and — for SSH —
  the auth method. Edits are merged back into the connection config on save.
- **"Save password to credential store" checkbox** wired to the credential
  store. When ticked and a password is entered, the secret is written via
  `storeCredential` *before* the connection is persisted (a store failure aborts
  the save rather than orphaning a passwordless connection). The checkbox is
  disabled with a hint when no credential store is configured.

Composed entirely from `src/components/ui` primitives (Field, Input,
NumberInput, Select, Checkbox, Button, Modal) and `variables.css` tokens.

## Tests

Rewrote `SaveAsConnectionDialog.test.tsx` to cover: field pre-fill, saving
unedited fields, edited host/username flowing into the saved connection, empty
name rejection, the disabled checkbox when no store is active, storing the
password before the connection is written (with call-order assertion), and the
save aborting when credential storage fails.

Closes #1932