### PR TITLE
feat(ui): add 'Connect in New Panel' to Recent Sessions menu (Closes #1933)

### DIFF
--- a/docs/changes/dev3/feat/1933-connect-in-new-panel.md
+++ b/docs/changes/dev3/feat/1933-connect-in-new-panel.md
@@ -1,0 +1,5 @@
+### Added
+
+- Recent Sessions: the row context menu now offers **Connect in New Panel**,
+  which opens the recorded session in a new split panel alongside the current
+  one instead of reusing the active panel (#1933).

--- a/src/components/RecentSessionsSidebar/RecentSessionItem.tsx
+++ b/src/components/RecentSessionsSidebar/RecentSessionItem.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import * as ContextMenu from "@radix-ui/react-context-menu";
-import { Pin, PinOff, Plug, Save, Copy, Trash2, Star } from "lucide-react";
+import { Pin, PinOff, Plug, Save, Copy, Trash2, Star, SplitSquareHorizontal } from "lucide-react";
 import { Button, Tooltip } from "@/components/ui";
 import { SidebarListItem } from "@/components/SidebarListItem";
 import { ConnectionIcon } from "@/utils/connectionIcons";
@@ -11,6 +11,7 @@ import type { SessionHistoryEntry } from "@/types/sessionHistory";
 interface RecentSessionItemProps {
   entry: SessionHistoryEntry;
   onConnect: (entry: SessionHistoryEntry) => void;
+  onConnectInNewPanel: (entry: SessionHistoryEntry) => void;
   onTogglePin: (entry: SessionHistoryEntry) => void;
   onSaveAsConnection: (entry: SessionHistoryEntry) => void;
   onCopyString: (entry: SessionHistoryEntry) => void;
@@ -24,11 +25,13 @@ interface RecentSessionItemProps {
 /**
  * A single recorded-session row: connection-type icon, `user@host` title, a
  * type badge, and relative last-used time. Single/double click reconnects; a
- * right-click context menu offers pin, save-as-connection, copy, and remove.
+ * right-click context menu offers connect-in-new-panel, pin,
+ * save-as-connection, copy, and remove.
  */
 export function RecentSessionItem({
   entry,
   onConnect,
+  onConnectInNewPanel,
   onTogglePin,
   onSaveAsConnection,
   onCopyString,
@@ -125,6 +128,13 @@ export function RecentSessionItem({
             data-testid={`recent-session-menu-connect-${key}`}
           >
             <Plug size={14} /> Connect
+          </ContextMenu.Item>
+          <ContextMenu.Item
+            className="context-menu__item"
+            onSelect={() => onConnectInNewPanel(entry)}
+            data-testid={`recent-session-menu-connect-new-panel-${key}`}
+          >
+            <SplitSquareHorizontal size={14} /> Connect in New Panel
           </ContextMenu.Item>
           <ContextMenu.Separator className="context-menu__separator" />
           <ContextMenu.Item

--- a/src/components/RecentSessionsSidebar/RecentSessionsSidebar.test.tsx
+++ b/src/components/RecentSessionsSidebar/RecentSessionsSidebar.test.tsx
@@ -72,6 +72,7 @@ const entries: SessionHistoryEntry[] = [
 ];
 
 const addTab = vi.fn();
+const splitPanel = vi.fn();
 const pinHistoryEntry = vi.fn().mockResolvedValue(undefined);
 const removeHistoryEntry = vi.fn().mockResolvedValue(undefined);
 const clearSessionHistory = vi.fn().mockResolvedValue(undefined);
@@ -88,6 +89,7 @@ describe("RecentSessionsSidebar", () => {
       connectionTypes: [],
       settings: { defaultUser: "root" } as AppSettings,
       addTab,
+      splitPanel,
       requestPassword: vi.fn(),
       pinHistoryEntry,
       removeHistoryEntry,
@@ -163,6 +165,35 @@ describe("RecentSessionsSidebar", () => {
     act(() => (query("recent-session-connect-ssh:admin@prod:22") as HTMLButtonElement).click());
     expect(addTab).toHaveBeenCalledTimes(1);
     expect(addTab.mock.calls[0][1]).toBe("ssh");
+  });
+
+  it("opens the session in a new panel from the context menu", async () => {
+    useAppStore.setState({ sessionHistory: entries });
+    render();
+
+    // Open the row's context menu, then invoke "Connect in New Panel".
+    const row = query("recent-session-serial:/dev/ttyUSB0:115200")!;
+    act(() => {
+      row.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const item = query("recent-session-menu-connect-new-panel-serial:/dev/ttyUSB0:115200");
+    expect(item).not.toBeNull();
+
+    act(() => {
+      item!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Splits into a new panel first, then opens the session there.
+    expect(splitPanel).toHaveBeenCalledTimes(1);
+    expect(addTab).toHaveBeenCalledTimes(1);
+    expect(addTab.mock.calls[0][1]).toBe("serial");
   });
 
   it("toggles pin via the row action", () => {

--- a/src/components/RecentSessionsSidebar/RecentSessionsSidebar.tsx
+++ b/src/components/RecentSessionsSidebar/RecentSessionsSidebar.tsx
@@ -40,6 +40,7 @@ export function RecentSessionsSidebar() {
   const removeHistoryEntry = useAppStore((s) => s.removeHistoryEntry);
   const clearSessionHistory = useAppStore((s) => s.clearSessionHistory);
   const markHistoryPromoted = useAppStore((s) => s.markHistoryPromoted);
+  const splitPanel = useAppStore((s) => s.splitPanel);
   const { connect } = useConnectSavedConnection();
 
   const [query, setQuery] = useState("");
@@ -69,6 +70,17 @@ export function RecentSessionsSidebar() {
   const handleConnect = useCallback(
     (entry: SessionHistoryEntry) => void openConnection(entry.config, entry.title),
     [openConnection]
+  );
+
+  // Split the active panel first, then connect: the freshly created panel
+  // becomes active, so the shared connect flow opens its tab there instead of
+  // the current panel.
+  const handleConnectInNewPanel = useCallback(
+    (entry: SessionHistoryEntry) => {
+      splitPanel();
+      void openConnection(entry.config, entry.title);
+    },
+    [splitPanel, openConnection]
   );
 
   const handleTogglePin = useCallback(
@@ -179,6 +191,7 @@ export function RecentSessionsSidebar() {
                 key={entry.dedupKey}
                 entry={entry}
                 onConnect={handleConnect}
+                onConnectInNewPanel={handleConnectInNewPanel}
                 onTogglePin={handleTogglePin}
                 onSaveAsConnection={setSaveEntry}
                 onCopyString={handleCopyString}


### PR DESCRIPTION
## Summary

Adds a **Connect in New Panel** item to the Recent Sessions row context menu (`RecentSessionItem.tsx`), alongside the existing Connect, Pin, Save as Connection, Copy, and Remove items.

Where the default **Connect** opens the recorded session in the active panel, **Connect in New Panel** splits the active panel first (via the existing `splitPanel` store action) so the freshly created panel becomes active, then runs the shared credential-aware connect flow — which opens the session's tab in that new panel.

## Changes

- `RecentSessionItem.tsx`: new `onConnectInNewPanel` prop + menu item (`SplitSquareHorizontal` icon, testid `recent-session-menu-connect-new-panel-<key>`).
- `RecentSessionsSidebar.tsx`: `handleConnectInNewPanel` wires `splitPanel()` + the existing `openConnection` flow.
- Unit test: opens the context menu, invokes the item, and asserts it splits into a new panel and opens the session there.

## Test plan

- `pnpm test src/components/RecentSessionsSidebar/RecentSessionsSidebar.test.tsx` (10 passed)
- Full frontend suite, `pnpm run lint`, and `pnpm build` all green.

Closes #1933