### PR TITLE
feat(ui): add an xs (24px) Button size and migrate sub-24px affordances (Closes #1907)

### DIFF
--- a/docs/changes/dev1/feat/1907-xs-button-size.md
+++ b/docs/changes/dev1/feat/1907-xs-button-size.md
@@ -1,0 +1,8 @@
+### Changed
+
+- UI: the shared `Button` primitive gained a compact `xs` (24px) size. The dense
+  sidebar action affordances (Start/Attach/Stop on connection and agent rows,
+  the hover Connect button, the inline folder confirm/cancel) and the workspace
+  LayoutDesigner schematic buttons now compose the primitive at this size instead
+  of hand-rolled CSS, so they pick up the shared focus ring, hover, and
+  accessibility handling consistently (#1907).

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -264,48 +264,48 @@ function AgentConnectionItem({
             <span className="connection-tree__persistent-actions">
               {!runState || runState === "stopped" || runState === "error" ? (
                 <Tooltip content="Start session" side="top">
-                  <button
-                    type="button"
-                    className="connection-tree__action"
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    iconOnly
+                    icon={<Play size={12} />}
                     aria-label="Start session"
                     data-testid={`persistent-start-${definition.id}`}
                     onClick={(e) => {
                       e.stopPropagation();
                       onStartPersistent(agentId, definition);
                     }}
-                  >
-                    <Play size={12} />
-                  </button>
+                  />
                 </Tooltip>
               ) : isRunning ? (
                 <>
                   <Tooltip content="Attach new tab" side="top">
-                    <button
-                      type="button"
-                      className="connection-tree__action"
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      iconOnly
+                      icon={<Link size={12} />}
                       aria-label="Attach new tab"
                       data-testid={`persistent-attach-${definition.id}`}
                       onClick={(e) => {
                         e.stopPropagation();
                         onAttachPersistent(agentId, definition);
                       }}
-                    >
-                      <Link size={12} />
-                    </button>
+                    />
                   </Tooltip>
                   <Tooltip content="Stop session" side="top">
-                    <button
-                      type="button"
-                      className="connection-tree__action connection-tree__action--danger"
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      iconOnly
+                      icon={<Square size={12} />}
                       aria-label="Stop session"
                       data-testid={`persistent-stop-${definition.id}`}
                       onClick={(e) => {
                         e.stopPropagation();
                         onStopPersistent(agentId, definition);
                       }}
-                    >
-                      <Square size={12} />
-                    </button>
+                    />
                   </Tooltip>
                 </>
               ) : null}

--- a/src/components/Sidebar/ConnectionList.css
+++ b/src/components/Sidebar/ConnectionList.css
@@ -267,22 +267,6 @@
   outline: none;
 }
 
-.connection-tree__inline {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 18px;
-  height: 18px;
-  border-radius: var(--radius-xs);
-  color: var(--text-secondary);
-}
-
-.connection-tree__inline:hover {
-  color: var(--text-primary);
-  background-color: var(--bg-hover);
-}
-
 /* Drag-and-drop feedback */
 .connection-tree__item--dragging {
   opacity: 0.4;
@@ -375,33 +359,23 @@
   width: 100%;
 }
 
+/*
+ * Hover-reveal positioning for the Connect affordance. Geometry and skin come
+ * from the Button primitive (ghost / xs / iconOnly); only the absolute
+ * placement and the opacity reveal live here.
+ */
 .connection-tree__connect {
   position: absolute;
   right: var(--spacing-sm);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  border-radius: var(--radius-sm);
-  color: var(--text-secondary);
   opacity: 0;
   pointer-events: none;
-  transition:
-    color var(--transition-fast),
-    background-color var(--transition-fast),
-    opacity var(--transition-fast);
+  transition: opacity var(--transition-fast);
 }
 
 .connection-tree__item-row:hover .connection-tree__connect,
 .connection-tree__item-row:focus-within .connection-tree__connect {
   opacity: 1;
   pointer-events: auto;
-}
-
-.connection-tree__connect:hover {
-  color: var(--accent-color);
-  background-color: var(--bg-hover);
 }
 
 /* The Connect affordance replaces the type tag on hover/focus to avoid overlap */
@@ -563,31 +537,4 @@
 
 .connection-tree__item--persistent:hover .connection-tree__persistent-actions {
   display: flex;
-}
-
-.connection-tree__action {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  padding: 0;
-  border: none;
-  background: none;
-  border-radius: var(--radius-sm);
-  color: var(--text-secondary);
-  cursor: pointer;
-  transition:
-    background-color var(--transition-fast),
-    color var(--transition-fast);
-}
-
-.connection-tree__action:hover {
-  background-color: var(--bg-hover);
-  color: var(--text-primary);
-}
-
-.connection-tree__action--danger:hover {
-  background-color: color-mix(in srgb, var(--color-error) 15%, transparent);
-  color: var(--color-error);
 }

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -444,48 +444,48 @@ function ConnectionItem({
                 <span className="connection-tree__persistent-actions">
                   {isPersistentStopped ? (
                     <Tooltip content="Start session" side="top">
-                      <button
-                        type="button"
-                        className="connection-tree__action"
+                      <Button
+                        variant="ghost"
+                        size="xs"
+                        iconOnly
+                        icon={<Play size={12} />}
                         aria-label="Start session"
                         data-testid={`persistent-start-${connection.id}`}
                         onClick={(e) => {
                           e.stopPropagation();
                           handleStartPersistent();
                         }}
-                      >
-                        <Play size={12} />
-                      </button>
+                      />
                     </Tooltip>
                   ) : (
                     <>
                       <Tooltip content="Attach new tab" side="top">
-                        <button
-                          type="button"
-                          className="connection-tree__action"
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          iconOnly
+                          icon={<Link size={12} />}
                           aria-label="Attach new tab"
                           data-testid={`persistent-attach-${connection.id}`}
                           onClick={(e) => {
                             e.stopPropagation();
                             handleAttachPersistent();
                           }}
-                        >
-                          <Link size={12} />
-                        </button>
+                        />
                       </Tooltip>
                       <Tooltip content="Stop session" side="top">
-                        <button
-                          type="button"
-                          className="connection-tree__action connection-tree__action--danger"
+                        <Button
+                          variant="ghost"
+                          size="xs"
+                          iconOnly
+                          icon={<Square size={12} />}
                           aria-label="Stop session"
                           data-testid={`persistent-stop-${connection.id}`}
                           onClick={(e) => {
                             e.stopPropagation();
                             handleStopPersistent();
                           }}
-                        >
-                          <Square size={12} />
-                        </button>
+                        />
                       </Tooltip>
                     </>
                   )}
@@ -494,9 +494,12 @@ function ConnectionItem({
             </button>
             {!persistentCapable && (
               <Tooltip content="Connect" side="right">
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  iconOnly
                   className="connection-tree__connect"
+                  icon={<Play size={14} />}
                   aria-label={`Connect to ${connection.name}`}
                   tabIndex={-1}
                   onClick={(e) => {
@@ -504,9 +507,7 @@ function ConnectionItem({
                     onConnect(connection);
                   }}
                   data-testid={`connection-connect-${connection.id}`}
-                >
-                  <Play size={14} />
-                </button>
+                />
               </Tooltip>
             )}
           </div>

--- a/src/components/Sidebar/InlineFolderInput.tsx
+++ b/src/components/Sidebar/InlineFolderInput.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Folder, Check, X } from "lucide-react";
-import { Input, Tooltip } from "@/components/ui";
+import { Button, Input, Tooltip } from "@/components/ui";
 
 interface InlineFolderInputProps {
   depth: number;
@@ -37,30 +37,32 @@ export function InlineFolderInput({ depth, onConfirm, onCancel }: InlineFolderIn
         data-testid="inline-folder-name-input"
       />
       <Tooltip content="Confirm" side="top">
-        <button
-          className="connection-tree__inline"
+        <Button
+          variant="ghost"
+          size="xs"
+          iconOnly
+          icon={<Check size={14} />}
           onMouseDown={(e) => {
             e.preventDefault();
             if (name.trim()) onConfirm(name.trim());
           }}
           aria-label="Confirm"
           data-testid="inline-folder-confirm"
-        >
-          <Check size={14} />
-        </button>
+        />
       </Tooltip>
       <Tooltip content="Cancel" side="top">
-        <button
-          className="connection-tree__inline"
+        <Button
+          variant="ghost"
+          size="xs"
+          iconOnly
+          icon={<X size={14} />}
           onMouseDown={(e) => {
             e.preventDefault();
             onCancel();
           }}
           aria-label="Cancel"
           data-testid="inline-folder-cancel"
-        >
-          <X size={14} />
-        </button>
+        />
       </Tooltip>
     </div>
   );

--- a/src/components/WorkspaceEditor/LayoutDesigner.tsx
+++ b/src/components/WorkspaceEditor/LayoutDesigner.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { SplitSquareHorizontal, SplitSquareVertical, Plus, X, RotateCcw } from "lucide-react";
-import { NumberInput, Tooltip } from "@/components/ui";
+import { Button, NumberInput, Tooltip } from "@/components/ui";
 import { WorkspaceLayoutNode, WorkspaceSplitNode, WorkspaceTabDef } from "@/types/workspace";
 import {
   getWorkspaceLeaves,
@@ -186,33 +186,36 @@ function LayoutNodePreview({
         <div className="layout-split-container__actions">
           {hasSizes && (
             <Tooltip content="Reset to Equal" side="top">
-              <button
-                className="layout-split-container__action"
+              <Button
+                variant="secondary"
+                size="xs"
+                iconOnly
+                icon={<RotateCcw size={10} />}
                 onClick={() => onUpdateSizes(node, null)}
                 aria-label="Reset to Equal"
                 data-testid="layout-size-reset"
-              >
-                <RotateCcw size={10} />
-              </button>
+              />
             </Tooltip>
           )}
           <Tooltip content="Split Horizontal" side="top">
-            <button
-              className="layout-split-container__action"
+            <Button
+              variant="secondary"
+              size="xs"
+              iconOnly
+              icon={<SplitSquareHorizontal size={10} />}
               onClick={() => onSplitContainer(node, "horizontal")}
               aria-label="Split Horizontal"
-            >
-              <SplitSquareHorizontal size={10} />
-            </button>
+            />
           </Tooltip>
           <Tooltip content="Split Vertical" side="top">
-            <button
-              className="layout-split-container__action"
+            <Button
+              variant="secondary"
+              size="xs"
+              iconOnly
+              icon={<SplitSquareVertical size={10} />}
               onClick={() => onSplitContainer(node, "vertical")}
               aria-label="Split Vertical"
-            >
-              <SplitSquareVertical size={10} />
-            </button>
+            />
           </Tooltip>
         </div>
       </div>
@@ -364,43 +367,46 @@ function LeafPanel({
       <div className="layout-leaf__header">
         <div className="layout-leaf__actions">
           <Tooltip content="Split Horizontal" side="top">
-            <button
-              className="layout-leaf__action"
+            <Button
+              variant="secondary"
+              size="xs"
+              iconOnly
+              icon={<SplitSquareHorizontal size={10} />}
               onClick={(e) => {
                 e.stopPropagation();
                 onSplitH();
               }}
               aria-label="Split Horizontal"
               data-testid={`layout-leaf-split-h-${idx}`}
-            >
-              <SplitSquareHorizontal size={10} />
-            </button>
+            />
           </Tooltip>
           <Tooltip content="Split Vertical" side="top">
-            <button
-              className="layout-leaf__action"
+            <Button
+              variant="secondary"
+              size="xs"
+              iconOnly
+              icon={<SplitSquareVertical size={10} />}
               onClick={(e) => {
                 e.stopPropagation();
                 onSplitV();
               }}
               aria-label="Split Vertical"
               data-testid={`layout-leaf-split-v-${idx}`}
-            >
-              <SplitSquareVertical size={10} />
-            </button>
+            />
           </Tooltip>
           <Tooltip content="Add Connection" side="top">
-            <button
-              className="layout-leaf__action"
+            <Button
+              variant="secondary"
+              size="xs"
+              iconOnly
+              icon={<Plus size={10} />}
               onClick={(e) => {
                 e.stopPropagation();
                 onAddTab();
               }}
               aria-label="Add Connection"
               data-testid={`layout-leaf-add-tab-${idx}`}
-            >
-              <Plus size={10} />
-            </button>
+            />
           </Tooltip>
         </div>
         {leafCount > 1 && (

--- a/src/components/WorkspaceEditor/WorkspaceEditor.css
+++ b/src/components/WorkspaceEditor/WorkspaceEditor.css
@@ -233,25 +233,6 @@
   gap: 2px;
 }
 
-.layout-split-container__action {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  border: 1px solid var(--border-primary);
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
-  cursor: pointer;
-  border-radius: var(--radius-xs);
-  padding: 0;
-}
-
-.layout-split-container__action:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-
 .layout-split-container__content {
   flex: 1;
   display: flex;
@@ -335,25 +316,6 @@
 .layout-leaf__actions {
   display: flex;
   gap: 2px;
-}
-
-.layout-leaf__action {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  border: 1px solid var(--border-primary);
-  background: var(--bg-secondary);
-  color: var(--text-secondary);
-  cursor: pointer;
-  border-radius: var(--radius-xs);
-  padding: 0;
-}
-
-.layout-leaf__action:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
 }
 
 .layout-leaf__empty {

--- a/src/components/ui/Button.test.tsx
+++ b/src/components/ui/Button.test.tsx
@@ -73,6 +73,36 @@ describe("Button", () => {
     );
   });
 
+  it("applies the xs size modifier and omits the other size modifiers", () => {
+    render(
+      <Button data-testid="xs" size="xs">
+        X
+      </Button>
+    );
+    const xs = document.querySelector('[data-testid="xs"]')!;
+    expect(xs.classList.contains("ui-btn--xs")).toBe(true);
+    expect(xs.classList.contains("ui-btn--sm")).toBe(false);
+
+    // sm and md must never pick up the xs modifier.
+    render(
+      <Button data-testid="sm2" size="sm">
+        S
+      </Button>
+    );
+    expect(document.querySelector('[data-testid="sm2"]')!.classList.contains("ui-btn--xs")).toBe(
+      false
+    );
+
+    render(
+      <Button data-testid="md2" size="md">
+        M
+      </Button>
+    );
+    expect(document.querySelector('[data-testid="md2"]')!.classList.contains("ui-btn--xs")).toBe(
+      false
+    );
+  });
+
   it("applies the full-width modifier when fullWidth is set", () => {
     render(
       <Button data-testid="btn" fullWidth>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -6,8 +6,8 @@ import "./ui.css";
 /** Visual variant of the button. */
 export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
 
-/** Control size. `md` (default) is 32px tall; `sm` is 28px. */
-export type ButtonSize = "sm" | "md";
+/** Control size. `md` (default) is 32px tall; `sm` is 28px; `xs` is 24px. */
+export type ButtonSize = "xs" | "sm" | "md";
 
 /** Internal lifecycle state for an async click. */
 type AsyncState = "idle" | "pending" | "success";
@@ -20,6 +20,13 @@ const VARIANT_CLASS: Record<ButtonVariant, string> = {
   secondary: "ui-btn--secondary",
   ghost: "ui-btn--ghost",
   danger: "ui-btn--danger",
+};
+
+/** Size → modifier class. `md` is the base geometry, so it carries no modifier. */
+const SIZE_CLASS: Record<ButtonSize, string> = {
+  xs: "ui-btn--xs",
+  sm: "ui-btn--sm",
+  md: "",
 };
 
 /**
@@ -225,7 +232,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   const classes = [
     "ui-btn",
     VARIANT_CLASS[variant],
-    size === "sm" ? "ui-btn--sm" : "",
+    SIZE_CLASS[size],
     iconOnly ? "ui-btn--icon-only" : "",
     fullWidth ? "ui-btn--full" : "",
     pending ? "ui-btn--pending" : "",

--- a/src/components/ui/ui.css
+++ b/src/components/ui/ui.css
@@ -49,6 +49,19 @@
   font-size: var(--font-size-sm);
 }
 
+/*
+ * `xs` (24px = --control-height-sm): the compact floor for dense affordances
+ * that used to hand-roll their own sub-`sm` geometry — sidebar action rows,
+ * inline confirm/cancel, the LayoutDesigner schematic. Pair with `iconOnly` for
+ * a 24px square icon button; the tighter radius keeps it visually compact.
+ */
+.ui-btn--xs {
+  height: var(--control-height-sm);
+  padding: 0 var(--spacing-xs);
+  font-size: var(--font-size-sm);
+  border-radius: var(--radius-sm);
+}
+
 .ui-btn--full {
   width: 100%;
 }
@@ -58,7 +71,7 @@
  * drops the label padding, for dense action rows (tunnel rows, network-monitor
  * rows). Geometry only — color, hover, radius, focus ring, and the async
  * pending/success affordances all come from the variant + base classes.
- * `aspect-ratio: 1` keeps it square at either size (32px for md, 28px for sm).
+ * `aspect-ratio: 1` keeps it square at any size (32px md, 28px sm, 24px xs).
  * Icon-only buttons require an accessible name (aria-label/tooltip); the
  * primitive warns in the LogViewer when one is missing (issue 1284).
  */


### PR DESCRIPTION
Follow-up to #1885 (PR #1906).

Adds an `xs` (24px = `--control-height-sm`) size to the shared `Button`
primitive so sub-`sm` affordances can compose the primitive instead of
hand-rolling their own geometry, and migrates the affordances called out in the
issue onto it — removing their now-dead bespoke geometry CSS.

## Changes

- **`ui/Button`**: new `xs` size (`ButtonSize = "xs" | "sm" | "md"`), a
  `ui-btn--xs` rule (`--control-height-sm`, `--spacing-xs` padding,
  `--font-size-sm`, tighter `--radius-sm`), and mirrored size tests. `iconOnly`
  squares it to 24px via the existing `aspect-ratio: 1`.
- **Connection tree** (`ConnectionList`, `AgentNode`, `InlineFolderInput`):
  the `connection-tree__action` / `connect` / `inline` buttons now compose
  `<Button variant="ghost" size="xs" iconOnly>`. Their bespoke geometry/skin CSS
  is deleted; `connection-tree__connect` keeps only its hover-reveal positioning.
- **LayoutDesigner** (`layout-split-container__action`, `layout-leaf__action`):
  compose `<Button variant="secondary" size="xs" iconOnly>`; bespoke geometry CSS
  deleted.

## Out of scope (untouched, per the issue)

- `LogViewer` level-filter colour chips and `TunnelEditor` type radio-cards —
  they want dedicated Chip / SegmentedControl primitives.

## Notes for review

- Following the app-wide precedent (e.g. `TunnelListItem`'s destructive Delete is
  a plain `ghost` icon button), the connection-tree "Stop" action now uses the
  `ghost` variant; its former red-on-hover `--danger` tint is dropped rather than
  reintroduced as bespoke CSS.
- The migrated affordances grow from 16–20px to the 24px `xs` floor — this is the
  intended trade for composing the primitive (per the issue).

## Test plan

- `pnpm test` (Button primitive size tests + existing suites)
- `./scripts/check.sh`

Closes #1907