### PR TITLE
feat(sftp): scope transfer-queue ownership to the owning window on tab move

### DIFF
--- a/docs/changes/dev2/feat/1951-transfer-queue-window-ownership.md
+++ b/docs/changes/dev2/feat/1951-transfer-queue-window-ownership.md
@@ -1,0 +1,8 @@
+### Changed
+
+- Multi-window: an SFTP/FTP tab's file transfers now **follow the tab** when it
+  is moved to another window. The tab's Transfer Queue rows are carried with the
+  hand-off and seeded into the destination window's queue, while the source
+  window drops them and stops adopting the moved session's later transfers — so
+  moving a transfer-bearing tab no longer leaves orphaned or duplicated queue
+  entries in the original window (#1951).

--- a/docs/concepts/implemented/multi-window.html
+++ b/docs/concepts/implemented/multi-window.html
@@ -1984,7 +1984,8 @@ sequenceDiagram
           </li>
           <li>
             <strong>Transfer-queue ownership</strong> when an SFTP/FTP tab with in-flight transfers
-            moves windows.
+            moves windows. <em>Resolved (#1951): transfers follow the tab</em> — carried in the
+            hand-off and seeded in the destination; see the deferred-items list below.
           </li>
           <li>
             <strong
@@ -2145,9 +2146,9 @@ sequenceDiagram
               <tr>
                 <td>6</td>
                 <td>Transfer-queue ownership scoped to the owning window on move</td>
-                <td>Transfer Queue is app-scoped; not yet re-scoped to the moved-to window</td>
-                <td>Deferred</td>
-                <td>Tracked in #1951</td>
+                <td>Transfers follow the tab: carried in the hand-off, seeded in the destination</td>
+                <td>Resolved (#1951)</td>
+                <td>Source releases the moved sessions so broadcast events don't re-adopt them</td>
               </tr>
             </tbody>
           </table>
@@ -2174,10 +2175,18 @@ sequenceDiagram
             the window boundary is not yet built.
           </li>
           <li>
-            <strong>Still deferred — transfer-queue ownership on move.</strong> The shared Transfer
-            Queue is app-scoped; scoping its ownership to the owning window when an SFTP/FTP tab
-            with in-flight transfers moves is tracked in
-            <a href="https://github.com/armaxri/termiHub/issues/1951">#1951</a>.
+            <strong>Resolved — transfer-queue ownership on move (transfers follow the tab).</strong>
+            The Transfer Queue is per-window store state fed by broadcast
+            <code>transfer-progress</code> events, so an SFTP/FTP tab's transfers used to stay
+            orphaned in the source window on move. A moved tab now carries its Transfer Queue rows
+            (rows on the tab's own session, plus any SFTP sidebar session bound to it via
+            <code>sftpSessions[…].owningTabId</code>) in the opaque hand-off envelope
+            (<code>HandoffTab.transfers</code>): the destination seeds them into its own queue while
+            the source drops them and marks the sessions <em>released</em> so ongoing broadcast
+            events do not re-adopt the moved rows
+            (<a href="https://github.com/armaxri/termiHub/issues/1951">#1951</a>). Fully scoping the
+            display to the owning window <em>without</em> a move (a window that never owned a
+            session still folds its broadcast transfers) remains a separate follow-up.
           </li>
         </ul>
       </section>

--- a/src/store/appStore.transferHandoff.test.ts
+++ b/src/store/appStore.transferHandoff.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock service modules before importing the store.
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+const openWindow = vi.fn();
+const sendHandoffToWindow = vi.fn();
+const claimSession = vi.fn();
+const releaseSession = vi.fn();
+const takePendingHandoffs = vi.fn();
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(() => Promise.resolve()),
+  sftpListDir: vi.fn(() => Promise.resolve([])),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  openWindow: (...args: unknown[]) => openWindow(...args),
+  sendHandoffToWindow: (...args: unknown[]) => sendHandoffToWindow(...args),
+  claimSession: (...args: unknown[]) => claimSession(...args),
+  releaseSession: (...args: unknown[]) => releaseSession(...args),
+  takePendingHandoffs: (...args: unknown[]) => takePendingHandoffs(...args),
+}));
+
+import { useAppStore } from "./appStore";
+import { getAllLeaves } from "@/utils/panelTree";
+import type { TabHandoffRecord } from "@/types/window";
+import type { TransferEntry } from "@/types/transfer";
+import type { TransferState } from "@/types/connection";
+
+/** Seed one live terminal tab (with a backend session id) and return its ids. */
+function seedLiveTab(sessionId: string): { tabId: string; panelId: string } {
+  useAppStore.getState().addTab("bash", "local");
+  const leaf = getAllLeaves(useAppStore.getState().rootPanel)[0];
+  const tabId = leaf.tabs[0].id;
+  useAppStore.getState().setTabSessionId(tabId, sessionId);
+  return { tabId, panelId: leaf.id };
+}
+
+function transfer(overrides: Partial<TransferEntry> = {}): TransferEntry {
+  return {
+    id: "t1",
+    sessionId: "sess-1",
+    direction: "download",
+    name: "file.txt",
+    state: "active",
+    transferred: 10,
+    totalBytes: 100,
+    percent: 10,
+    speedBytesPerSec: null,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function liveTransfer(overrides: Partial<TransferState> = {}): TransferState {
+  return {
+    transferId: "t1",
+    sessionId: "sess-1",
+    direction: "download",
+    fileName: "file.txt",
+    transferred: 10,
+    total: 100,
+    phase: "transferring",
+    ...overrides,
+  };
+}
+
+describe("appStore — transfer-queue ownership follows a moved tab (#1951)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    openWindow.mockReset();
+    sendHandoffToWindow.mockReset();
+    claimSession.mockReset();
+    releaseSession.mockReset();
+    takePendingHandoffs.mockReset();
+    openWindow.mockResolvedValue("win-1");
+    sendHandoffToWindow.mockResolvedValue(undefined);
+    claimSession.mockResolvedValue(null);
+    releaseSession.mockResolvedValue(true);
+    takePendingHandoffs.mockResolvedValue([]);
+  });
+
+  describe("source side — moveTabToWindow", () => {
+    it("carries the tab's transfer rows in the hand-off and drops them from the source", async () => {
+      const { tabId, panelId } = seedLiveTab("sess-1");
+      useAppStore.getState().addTransfer(transfer({ id: "t1", sessionId: "sess-1" }));
+      useAppStore.getState().addTransfer(transfer({ id: "t2", sessionId: "sess-1", name: "b.txt" }));
+      // An unrelated transfer on another session must NOT be carried.
+      useAppStore.getState().addTransfer(transfer({ id: "t3", sessionId: "sess-other" }));
+
+      await useAppStore.getState().moveTabToWindow(tabId, panelId, { kind: "new" });
+
+      const record = openWindow.mock.calls[0][0] as TabHandoffRecord;
+      const carriedIds = (record.tab.transfers ?? []).map((t) => t.id).sort();
+      expect(carriedIds).toEqual(["t1", "t2"]);
+
+      // The moved rows left the source queue; the unrelated row stayed.
+      const queue = useAppStore.getState().transferQueue;
+      expect(queue["t1"]).toBeUndefined();
+      expect(queue["t2"]).toBeUndefined();
+      expect(queue["t3"]).toBeDefined();
+    });
+
+    it("marks the moved session released so a later broadcast event does not re-adopt it", async () => {
+      const { tabId, panelId } = seedLiveTab("sess-1");
+      useAppStore.getState().addTransfer(transfer({ id: "t1", sessionId: "sess-1" }));
+
+      await useAppStore.getState().moveTabToWindow(tabId, panelId, { kind: "new" });
+
+      expect(useAppStore.getState().releasedTransferSessions).toContain("sess-1");
+
+      // A progress event that keeps broadcasting after the move must be ignored.
+      useAppStore
+        .getState()
+        .applyTransferProgressToQueue(liveTransfer({ transferId: "t1", sessionId: "sess-1" }));
+      expect(useAppStore.getState().transferQueue["t1"]).toBeUndefined();
+
+      // The transient in-flight map is likewise suppressed for the moved session.
+      useAppStore.getState().applyTransferProgress(liveTransfer({ transferId: "t1", sessionId: "sess-1" }));
+      expect(useAppStore.getState().transfers["t1"]).toBeUndefined();
+    });
+
+    it("removes the moved session's transient in-flight rows from the source", async () => {
+      const { tabId, panelId } = seedLiveTab("sess-1");
+      useAppStore.getState().applyTransferProgress(liveTransfer({ transferId: "t1", sessionId: "sess-1" }));
+      useAppStore
+        .getState()
+        .applyTransferProgress(liveTransfer({ transferId: "keep", sessionId: "sess-other" }));
+      expect(useAppStore.getState().transfers["t1"]).toBeDefined();
+
+      await useAppStore.getState().moveTabToWindow(tabId, panelId, { kind: "new" });
+
+      expect(useAppStore.getState().transfers["t1"]).toBeUndefined();
+      expect(useAppStore.getState().transfers["keep"]).toBeDefined();
+    });
+
+    it("carries transfers on an SFTP sidebar session bound to the tab via owningTabId", async () => {
+      const { tabId, panelId } = seedLiveTab("term-1");
+      // SFTP sidebar runs on a separate session id, bound to the tab.
+      useAppStore.setState({
+        sftpSessions: { "sftp-1": { hostLabel: "alice@host:22", owningTabId: tabId } },
+      });
+      useAppStore.getState().addTransfer(transfer({ id: "t1", sessionId: "sftp-1" }));
+
+      await useAppStore.getState().moveTabToWindow(tabId, panelId, { kind: "new" });
+
+      const record = openWindow.mock.calls[0][0] as TabHandoffRecord;
+      expect((record.tab.transfers ?? []).map((t) => t.id)).toEqual(["t1"]);
+      expect(useAppStore.getState().transferQueue["t1"]).toBeUndefined();
+      expect(useAppStore.getState().releasedTransferSessions).toContain("sftp-1");
+    });
+
+    it("attaches no transfers field when the tab has none, but still releases the session", async () => {
+      const { tabId, panelId } = seedLiveTab("sess-1");
+
+      await useAppStore.getState().moveTabToWindow(tabId, panelId, { kind: "new" });
+
+      const record = openWindow.mock.calls[0][0] as TabHandoffRecord;
+      expect(record.tab.transfers).toBeUndefined();
+      // The session left this window, so a transfer that starts on it later
+      // (in the destination) must not be adopted here from a broadcast event.
+      expect(useAppStore.getState().releasedTransferSessions).toEqual(["sess-1"]);
+    });
+  });
+
+  describe("destination side — hydrateHandoffTab", () => {
+    it("seeds carried transfers into this window's queue and un-releases the session", () => {
+      // Simulate the destination window having previously released this session.
+      useAppStore.setState({ releasedTransferSessions: ["sess-1"] });
+      const record: TabHandoffRecord = {
+        tab: {
+          sessionId: "sess-1",
+          title: "moved",
+          connectionType: "ssh",
+          contentType: "terminal",
+          config: { type: "ssh", config: {} } as never,
+          transfers: [transfer({ id: "t1", sessionId: "sess-1" })],
+        },
+      };
+
+      useAppStore.getState().hydrateHandoffTab(record);
+
+      expect(useAppStore.getState().transferQueue["t1"]).toMatchObject({ id: "t1", state: "active" });
+      expect(useAppStore.getState().releasedTransferSessions).not.toContain("sess-1");
+    });
+
+    it("does not clobber a row a broadcast event already advanced in this window", () => {
+      // Destination already saw a fresher progress event for the same id.
+      useAppStore.getState().addTransfer(transfer({ id: "t1", sessionId: "sess-1", transferred: 90 }));
+      const record: TabHandoffRecord = {
+        tab: {
+          sessionId: "sess-1",
+          title: "moved",
+          connectionType: "ssh",
+          contentType: "terminal",
+          config: { type: "ssh", config: {} } as never,
+          transfers: [transfer({ id: "t1", sessionId: "sess-1", transferred: 10 })],
+        },
+      };
+
+      useAppStore.getState().hydrateHandoffTab(record);
+
+      // The existing (further-along) row wins over the carried snapshot.
+      expect(useAppStore.getState().transferQueue["t1"].transferred).toBe(90);
+    });
+  });
+
+  describe("round trip and re-ownership", () => {
+    it("lets the destination fold live progress after hydrate", () => {
+      const record: TabHandoffRecord = {
+        tab: {
+          sessionId: "sess-1",
+          title: "moved",
+          connectionType: "ssh",
+          contentType: "terminal",
+          config: { type: "ssh", config: {} } as never,
+          transfers: [transfer({ id: "t1", sessionId: "sess-1", transferred: 10 })],
+        },
+      };
+      useAppStore.getState().hydrateHandoffTab(record);
+
+      useAppStore
+        .getState()
+        .applyTransferProgressToQueue(liveTransfer({ transferId: "t1", sessionId: "sess-1", transferred: 55 }));
+
+      expect(useAppStore.getState().transferQueue["t1"].transferred).toBe(55);
+    });
+
+    it("un-releases a session when a new local transfer is seeded for it", () => {
+      useAppStore.setState({ releasedTransferSessions: ["sess-1"] });
+
+      useAppStore.getState().seedTransferQueue({
+        id: "new-1",
+        sessionId: "sess-1",
+        direction: "upload",
+        name: "up.txt",
+      });
+
+      expect(useAppStore.getState().releasedTransferSessions).not.toContain("sess-1");
+      expect(useAppStore.getState().transferQueue["new-1"]).toBeDefined();
+    });
+  });
+
+  describe("whole-window move — moveWindowSessionsToWindow", () => {
+    it("carries each tab's transfers to the destination", async () => {
+      const { tabId } = seedLiveTab("sess-1");
+      // Add a second live tab in a fresh panel/leaf.
+      useAppStore.getState().addTab("bash", "local");
+      const leaves = getAllLeaves(useAppStore.getState().rootPanel);
+      const secondTab = leaves.flatMap((l) => l.tabs).find((t) => t.id !== tabId)!;
+      useAppStore.getState().setTabSessionId(secondTab.id, "sess-2");
+
+      useAppStore.getState().addTransfer(transfer({ id: "t1", sessionId: "sess-1" }));
+      useAppStore.getState().addTransfer(transfer({ id: "t2", sessionId: "sess-2", name: "b.txt" }));
+
+      await useAppStore.getState().moveWindowSessionsToWindow({ kind: "new" });
+
+      // First tab seeds the new window; the rest are queued via sendHandoffToWindow.
+      const firstRecord = openWindow.mock.calls[0][0] as TabHandoffRecord;
+      const restRecords = sendHandoffToWindow.mock.calls.map((c) => c[1] as TabHandoffRecord);
+      const carried = [firstRecord, ...restRecords].flatMap((r) => r.tab.transfers ?? []);
+      expect(carried.map((t) => t.id).sort()).toEqual(["t1", "t2"]);
+    });
+  });
+});

--- a/src/store/appStore.transferHandoff.test.ts
+++ b/src/store/appStore.transferHandoff.test.ts
@@ -105,7 +105,9 @@ describe("appStore — transfer-queue ownership follows a moved tab (#1951)", ()
     it("carries the tab's transfer rows in the hand-off and drops them from the source", async () => {
       const { tabId, panelId } = seedLiveTab("sess-1");
       useAppStore.getState().addTransfer(transfer({ id: "t1", sessionId: "sess-1" }));
-      useAppStore.getState().addTransfer(transfer({ id: "t2", sessionId: "sess-1", name: "b.txt" }));
+      useAppStore
+        .getState()
+        .addTransfer(transfer({ id: "t2", sessionId: "sess-1", name: "b.txt" }));
       // An unrelated transfer on another session must NOT be carried.
       useAppStore.getState().addTransfer(transfer({ id: "t3", sessionId: "sess-other" }));
 
@@ -137,13 +139,17 @@ describe("appStore — transfer-queue ownership follows a moved tab (#1951)", ()
       expect(useAppStore.getState().transferQueue["t1"]).toBeUndefined();
 
       // The transient in-flight map is likewise suppressed for the moved session.
-      useAppStore.getState().applyTransferProgress(liveTransfer({ transferId: "t1", sessionId: "sess-1" }));
+      useAppStore
+        .getState()
+        .applyTransferProgress(liveTransfer({ transferId: "t1", sessionId: "sess-1" }));
       expect(useAppStore.getState().transfers["t1"]).toBeUndefined();
     });
 
     it("removes the moved session's transient in-flight rows from the source", async () => {
       const { tabId, panelId } = seedLiveTab("sess-1");
-      useAppStore.getState().applyTransferProgress(liveTransfer({ transferId: "t1", sessionId: "sess-1" }));
+      useAppStore
+        .getState()
+        .applyTransferProgress(liveTransfer({ transferId: "t1", sessionId: "sess-1" }));
       useAppStore
         .getState()
         .applyTransferProgress(liveTransfer({ transferId: "keep", sessionId: "sess-other" }));
@@ -201,13 +207,18 @@ describe("appStore — transfer-queue ownership follows a moved tab (#1951)", ()
 
       useAppStore.getState().hydrateHandoffTab(record);
 
-      expect(useAppStore.getState().transferQueue["t1"]).toMatchObject({ id: "t1", state: "active" });
+      expect(useAppStore.getState().transferQueue["t1"]).toMatchObject({
+        id: "t1",
+        state: "active",
+      });
       expect(useAppStore.getState().releasedTransferSessions).not.toContain("sess-1");
     });
 
     it("does not clobber a row a broadcast event already advanced in this window", () => {
       // Destination already saw a fresher progress event for the same id.
-      useAppStore.getState().addTransfer(transfer({ id: "t1", sessionId: "sess-1", transferred: 90 }));
+      useAppStore
+        .getState()
+        .addTransfer(transfer({ id: "t1", sessionId: "sess-1", transferred: 90 }));
       const record: TabHandoffRecord = {
         tab: {
           sessionId: "sess-1",
@@ -242,7 +253,9 @@ describe("appStore — transfer-queue ownership follows a moved tab (#1951)", ()
 
       useAppStore
         .getState()
-        .applyTransferProgressToQueue(liveTransfer({ transferId: "t1", sessionId: "sess-1", transferred: 55 }));
+        .applyTransferProgressToQueue(
+          liveTransfer({ transferId: "t1", sessionId: "sess-1", transferred: 55 })
+        );
 
       expect(useAppStore.getState().transferQueue["t1"].transferred).toBe(55);
     });
@@ -272,7 +285,9 @@ describe("appStore — transfer-queue ownership follows a moved tab (#1951)", ()
       useAppStore.getState().setTabSessionId(secondTab.id, "sess-2");
 
       useAppStore.getState().addTransfer(transfer({ id: "t1", sessionId: "sess-1" }));
-      useAppStore.getState().addTransfer(transfer({ id: "t2", sessionId: "sess-2", name: "b.txt" }));
+      useAppStore
+        .getState()
+        .addTransfer(transfer({ id: "t2", sessionId: "sess-2", name: "b.txt" }));
 
       await useAppStore.getState().moveWindowSessionsToWindow({ kind: "new" });
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2218,7 +2218,10 @@ function tabTransferSessionIds(
  * can drop the moved rows from the source queue and mark the sessions released.
  */
 function buildTransferAwareHandoff(
-  state: { sftpSessions: Record<string, SftpSessionEntry>; transferQueue: Record<string, TransferEntry> },
+  state: {
+    sftpSessions: Record<string, SftpSessionEntry>;
+    transferQueue: Record<string, TransferEntry>;
+  },
   tab: TerminalTab
 ): { record: TabHandoffRecord; transferSessionIds: string[]; movedTransferIds: string[] } {
   const transferSessionIds = tabTransferSessionIds(state, tab);

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -720,6 +720,16 @@ interface AppState {
    * is consumed once by the source's deferred close.
    */
   movingSessionIds: string[];
+  /**
+   * Session ids whose Transfer Queue rows this window handed off to another
+   * window (#1951). While a session id is in this set, this window's transfer
+   * folds ({@link applyTransferProgress}, {@link applyTransferProgressToQueue})
+   * ignore its broadcast `transfer-progress` events, so a moved-away transfer is
+   * not re-adopted into the source window's queue. Cleared for a session when it
+   * is hydrated back in ({@link hydrateHandoffTab}) or a new local transfer is
+   * seeded for it ({@link seedTransferQueue}).
+   */
+  releasedTransferSessions: string[];
   /** Whether a session is mid-move (read by the source Terminal's unmount cleanup). */
   isSessionMoving: (sessionId: string) => boolean;
   /** Clear a session's moving flag once the source has released its view. */
@@ -2182,6 +2192,84 @@ function serializeHandoffTab(tab: TerminalTab): HandoffTab {
 }
 
 /**
+ * The backend session ids whose transfers belong to `tab` (#1951): the tab's own
+ * `sessionId` (FTP `file-browser` tabs transfer on the tab session directly) plus
+ * every SFTP sidebar session bound to the tab via `sftpSessions[…].owningTabId`
+ * (an SSH tab's SFTP browser runs on a separate session). A Transfer Queue row is
+ * attributed to `tab` when its `sessionId` is in this set, so the rows can follow
+ * the tab across a window move.
+ */
+function tabTransferSessionIds(
+  state: { sftpSessions: Record<string, SftpSessionEntry> },
+  tab: TerminalTab
+): string[] {
+  const ids = new Set<string>();
+  if (tab.sessionId) ids.add(tab.sessionId);
+  for (const [sid, entry] of Object.entries(state.sftpSessions)) {
+    if (entry.owningTabId === tab.id) ids.add(sid);
+  }
+  return [...ids];
+}
+
+/**
+ * Build the hand-off record for `tab`, attaching the Transfer Queue rows that
+ * belong to its session(s) so they follow the tab to the destination window
+ * (#1951). Returns both the record and the transfer session ids, so the caller
+ * can drop the moved rows from the source queue and mark the sessions released.
+ */
+function buildTransferAwareHandoff(
+  state: { sftpSessions: Record<string, SftpSessionEntry>; transferQueue: Record<string, TransferEntry> },
+  tab: TerminalTab
+): { record: TabHandoffRecord; transferSessionIds: string[]; movedTransferIds: string[] } {
+  const transferSessionIds = tabTransferSessionIds(state, tab);
+  const carried = Object.values(state.transferQueue).filter((t) =>
+    transferSessionIds.includes(t.sessionId)
+  );
+  const record: TabHandoffRecord = {
+    tab: {
+      ...serializeHandoffTab(tab),
+      ...(carried.length ? { transfers: carried } : {}),
+    },
+  };
+  return { record, transferSessionIds, movedTransferIds: carried.map((t) => t.id) };
+}
+
+/**
+ * Source-side state changes when a tab's transfers are handed to another window
+ * (#1951): drop the moved rows from the persistent {@link AppState.transferQueue}
+ * and the transient {@link AppState.transfers} map, and add their session ids to
+ * {@link AppState.releasedTransferSessions} so broadcast progress events can no
+ * longer re-create the rows in this window. Returns a partial state slice.
+ */
+function removeTransferSessionsFromWindow(
+  state: {
+    transferQueue: Record<string, TransferEntry>;
+    transfers: Record<string, TransferState>;
+    releasedTransferSessions: string[];
+  },
+  transferSessionIds: string[],
+  movedTransferIds: string[]
+): Partial<{
+  transferQueue: Record<string, TransferEntry>;
+  transfers: Record<string, TransferState>;
+  releasedTransferSessions: string[];
+}> {
+  if (transferSessionIds.length === 0) return {};
+  const releaseSet = new Set(transferSessionIds);
+  const transferQueue = movedTransferIds.reduce(
+    (acc, id) => (id in acc ? omitKey(acc, id) : acc),
+    state.transferQueue
+  );
+  const transfers = Object.fromEntries(
+    Object.entries(state.transfers).filter(([, t]) => !releaseSet.has(t.sessionId))
+  );
+  const releasedTransferSessions = Array.from(
+    new Set([...state.releasedTransferSessions, ...transferSessionIds])
+  );
+  return { transferQueue, transfers, releasedTransferSessions };
+}
+
+/**
  * Remove a tab from a leaf panel, choosing a new active tab if needed.
  * Returns the updated leaf (may have empty tabs).
  */
@@ -2606,6 +2694,7 @@ export const useAppStore = create<AppState>((set, get) => {
 
     // ── Multi-window foundation (#1900) ──
     movingSessionIds: [],
+    releasedTransferSessions: [],
     isSessionMoving: (sessionId) => get().movingSessionIds.includes(sessionId),
     clearMovingSession: (sessionId) =>
       set((state) => ({
@@ -2618,7 +2707,12 @@ export const useAppStore = create<AppState>((set, get) => {
       const tab = sourceLeaf?.tabs.find((t) => t.id === tabId);
       if (!tab) return;
 
-      const record: TabHandoffRecord = { tab: serializeHandoffTab(tab) };
+      // Carry this tab's Transfer Queue rows so its transfers follow the tab to
+      // the destination window rather than staying orphaned here (#1951).
+      const { record, transferSessionIds, movedTransferIds } = buildTransferAwareHandoff(
+        get(),
+        tab
+      );
       const sessionId = tab.sessionId;
 
       // Mark the live session as moving so the source window's Terminal does NOT
@@ -2669,7 +2763,20 @@ export const useAppStore = create<AppState>((set, get) => {
             ? { ...g, rootPanel: newRootPanel, activePanelId: newActivePanelId }
             : g
         );
-        return { rootPanel: newRootPanel, tabGroups, activePanelId: newActivePanelId };
+        // Drop the moved tab's transfer rows and mark its sessions released so
+        // ongoing broadcast `transfer-progress` events do not re-adopt them here
+        // (#1951). The destination window seeds the carried rows on hydrate.
+        const transferMoved = removeTransferSessionsFromWindow(
+          state,
+          transferSessionIds,
+          movedTransferIds
+        );
+        return {
+          rootPanel: newRootPanel,
+          tabGroups,
+          activePanelId: newActivePanelId,
+          ...transferMoved,
+        };
       });
     },
 
@@ -2706,7 +2813,31 @@ export const useAppStore = create<AppState>((set, get) => {
         const tabGroups = state.tabGroups.map((g) =>
           g.id === state.activeTabGroupId ? { ...g, rootPanel: newRootPanel } : g
         );
-        return { rootPanel: newRootPanel, tabGroups, activePanelId: targetLeaf.id };
+
+        // Seed the transfers carried with the tab so they follow it into this
+        // window's queue (#1951). Existing rows win over carried ones — a
+        // broadcast event that already advanced a row here must not be clobbered
+        // by the (possibly staler) carried snapshot. The carried sessions are
+        // un-released so this window resumes folding their live progress events.
+        const carried = h.transfers ?? [];
+        const transferQueue = carried.length
+          ? { ...Object.fromEntries(carried.map((t) => [t.id, t])), ...state.transferQueue }
+          : state.transferQueue;
+        const unrelease = new Set(
+          [h.sessionId, ...carried.map((t) => t.sessionId)].filter((id): id is string => !!id)
+        );
+        const releasedTransferSessions =
+          unrelease.size > 0
+            ? state.releasedTransferSessions.filter((id) => !unrelease.has(id))
+            : state.releasedTransferSessions;
+
+        return {
+          rootPanel: newRootPanel,
+          tabGroups,
+          activePanelId: targetLeaf.id,
+          transferQueue,
+          releasedTransferSessions,
+        };
       }),
 
     receivePendingHandoffs: async () => {
@@ -2875,7 +3006,14 @@ export const useAppStore = create<AppState>((set, get) => {
         movingSessionIds: Array.from(new Set([...state.movingSessionIds, ...sessionIds])),
       }));
 
-      const records: TabHandoffRecord[] = tabs.map((tab) => ({ tab: serializeHandoffTab(tab) }));
+      // Carry each tab's Transfer Queue rows so its transfers follow it to the
+      // destination window rather than being lost when this window closes
+      // (#1951). This window is being emptied/torn down, so no source-side
+      // removal is needed — only the destination must receive them.
+      const state = get();
+      const records: TabHandoffRecord[] = tabs.map(
+        (tab) => buildTransferAwareHandoff(state, tab).record
+      );
       try {
         if (target.kind === "new") {
           // Create the destination window seeded with the first tab, then queue
@@ -4956,6 +5094,10 @@ export const useAppStore = create<AppState>((set, get) => {
 
     applyTransferProgress: (progress: TransferState) =>
       set((state) => {
+        // A transfer whose session this window handed to another window (#1951)
+        // is no longer ours: ignore its broadcast progress so a moved-away row is
+        // not re-created here.
+        if (state.releasedTransferSessions.includes(progress.sessionId)) return {};
         // A terminal phase clears the row (D1 already removed any partial local
         // file on cancel/error). done/error toasts are the D2 follow-up.
         if (progress.phase !== "transferring") {
@@ -5010,6 +5152,9 @@ export const useAppStore = create<AppState>((set, get) => {
 
     applyTransferProgressToQueue: (progress: TransferProgress) =>
       set((state) => {
+        // Ignore transfers whose session was handed to another window (#1951) so
+        // a moved-away queue row is not re-adopted from a broadcast event.
+        if (state.releasedTransferSessions.includes(progress.sessionId)) return {};
         const prev = state.transferQueue[progress.transferId];
         const entry = transferEntryFromProgress(progress, prev, Date.now());
         return { transferQueue: { ...state.transferQueue, [entry.id]: entry } };
@@ -5020,7 +5165,15 @@ export const useAppStore = create<AppState>((set, get) => {
         // Idempotent: never overwrite a row an event already advanced (#1632).
         if (seed.id in state.transferQueue) return {};
         const entry = transferEntryFromSeed(seed, Date.now());
-        return { transferQueue: { ...state.transferQueue, [entry.id]: entry } };
+        // Starting a transfer for a session here means this window owns it again,
+        // so clear any stale "released" mark from a prior hand-off (#1951).
+        const releasedTransferSessions = state.releasedTransferSessions.includes(seed.sessionId)
+          ? state.releasedTransferSessions.filter((id) => id !== seed.sessionId)
+          : state.releasedTransferSessions;
+        return {
+          transferQueue: { ...state.transferQueue, [entry.id]: entry },
+          releasedTransferSessions,
+        };
       }),
 
     reconcileTransferQueue: (snapshots: TransferSnapshot[]) =>

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -9,6 +9,7 @@
 
 import type { ConnectionConfig, TabContentType } from "@/types/terminal";
 import type { WorkspaceTabGroupDef } from "@/types/workspace";
+import type { TransferEntry } from "@/types/transfer";
 
 /** Runtime label of the primary application window. */
 export const MAIN_WINDOW_LABEL = "main";
@@ -44,6 +45,19 @@ export interface HandoffTab {
   persistentConnectionId?: string;
   connectionId?: string;
   spawned?: boolean;
+  /**
+   * Transfer Queue rows (SFTP/FTP) that belong to the moved tab's session(s),
+   * carried so in-flight and history transfers **follow the tab** across the
+   * window boundary rather than being orphaned in the source window (#1951).
+   *
+   * Not part of the `TerminalTab` view-model — it rides in this opaque
+   * frontend-owned hand-off envelope (the backend only ferries `tab`), which is
+   * the concept's designated extension seam. The destination seeds these into
+   * its own per-window `transferQueue` on hydrate; the source removes them and
+   * marks the session ids "released" so ongoing broadcast progress events don't
+   * re-adopt the moved rows.
+   */
+  transfers?: TransferEntry[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Deferred item from the multi-window epic (#1899): the SFTP/FTP Transfer Queue was app-scoped, with no window-ownership handling. Because each native window is a separate JS context with its own Zustand store and `transfer-progress` events are `app.emit`-broadcast to every window, a transfer-bearing tab's queued/active transfers stayed orphaned in the source window when the tab moved to another window.

This makes **transfers follow the tab**:

- On `moveTabToWindow` / `moveWindowSessionsToWindow`, the tab's Transfer Queue rows (rows whose `sessionId` is the tab's own session — FTP `file-browser` tabs — or an SFTP sidebar session bound to the tab via `sftpSessions[…].owningTabId`) are carried in the opaque frontend-owned hand-off envelope (`HandoffTab.transfers`). The backend just ferries `tab`, so no Rust change.
- The **destination** window seeds the carried rows into its own `transferQueue` on hydrate (existing rows win, so a broadcast event that already advanced a row is not clobbered) and un-releases those sessions so it resumes folding their live progress.
- The **source** window drops the moved rows from both the persistent `transferQueue` and the transient `transfers` map, and marks the moved session ids `releasedTransferSessions` so ongoing broadcast `transfer-progress` events do not re-adopt the moved rows (no orphaned/duplicated entries).

The released-set is empty by default, so single-window behavior and all existing tests are unchanged.

## Scope note / follow-up

This scopes ownership **on move** (the issue's "Done when"). It does not change the pre-existing app-wide broadcast behavior whereby a window that never participated in a move still folds every broadcast transfer; fully scoping the display to the owning window even without a move needs the backend `session → window` map surfaced to the fold and is filed as a follow-up.

## Test plan

- New `src/store/appStore.transferHandoff.test.ts`: moving a transfer-bearing tab carries its rows to the destination, removes them from the source, releases the session so a later broadcast event does not re-create the row, and un-releases on hydrate/seed. Whole-window move carries per-tab transfers.
- Existing transfer/multi-window/sftp store tests still green.

Concept updated (`docs/concepts/implemented/multi-window.html`) to mark decision 6 resolved.

Closes #1951