### PR TITLE
feat(connections): bulk host onboarding from CSV + scan results via a template (Closes #1961)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,6 +1415,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctor"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7531,6 +7552,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "chrono",
+ "csv",
  "dirs",
  "hex",
  "if-addrs",

--- a/docs/changes/dev4/feat/1961-fleet-onboarding.md
+++ b/docs/changes/dev4/feat/1961-fleet-onboarding.md
@@ -1,0 +1,19 @@
+### Added
+
+- Fleet onboarding: create many saved connections at once from a single
+  existing connection used as a **template** (shared type, credentials,
+  auth, and jump-host chain), stamping in each host and label. Two sources
+  feed it:
+  - **Bulk import from a CSV / inventory file** — a new "Onboard hosts from a
+    CSV / inventory" action in the connection list reads a file and offers its
+    hosts. Accepts a named-header CSV (`host`/`hostname`/`address`/`ip`,
+    `label`/`name`, `port`, `user`/`username`, any order), a positional
+    header-less CSV (`host,label,port,username`), or a plain host-per-line
+    list; `#` comment and blank lines are ignored.
+  - **Add scan results as connections** — the Ping Sweep and Port Scanner tools
+    gain an "Add as connections" action that onboards the responding /
+    open-port hosts through the same template flow.
+
+  Onboarding lands the new connections in a chosen folder and can skip hosts
+  that already have a connection there, so re-running a sweep does not create
+  duplicates.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -57,6 +57,9 @@ hex = "0.4"
 # SHA-256 hashing: agent-binary integrity verification (all platforms) and
 # Windows VcXsrv checksum validation.
 sha2 = "0.10"
+# CSV / inventory parsing for bulk host onboarding (#1961) — quoting and
+# delimiter handling delegated to the maintained crate rather than hand-rolled.
+csv = "1"
 serde_json = { workspace = true }
 portable-pty = "0.8"
 russh = { workspace = true }

--- a/src-tauri/src/commands/inventory_import.rs
+++ b/src-tauri/src/commands/inventory_import.rs
@@ -1,0 +1,340 @@
+//! Tauri command for bulk host onboarding (#1961): parse a CSV / simple
+//! inventory file into a list of [`InventoryHost`] rows that the frontend stamps
+//! onto a chosen connection **template** (shared creds/type/jump-host), creating
+//! one saved connection per host in a single action.
+//!
+//! This is the file-side counterpart of [`ssh_config_import`](super::ssh_config_import):
+//! it only *parses* an inventory into DTOs — it never creates connections. The
+//! frontend applies the template and persists via `save_connection`.
+//!
+//! Parsing is delegated to the maintained [`csv`] crate (library-first per the
+//! repo rules) rather than hand-rolling quoting / delimiter handling.
+//!
+//! ## Accepted formats
+//!
+//! - **CSV with a header row** naming any of `host`/`hostname`/`address`/`ip`,
+//!   `label`/`name`, `port`, `user`/`username` (case-insensitive, any order).
+//!   Unknown columns are ignored.
+//! - **Header-less CSV** — positional `host,label,port,username`.
+//! - **A plain host-per-line list** (a single column, no commas) — each line is
+//!   a host, its label defaulting to the host.
+//!
+//! `#` comment lines and blank lines are skipped. A row without a host is
+//! skipped. An unparseable `port` degrades to "no override" rather than failing
+//! the whole import.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use crate::utils::errors::TerminalError;
+
+/// One host parsed from an inventory file, offered to the frontend to stamp onto
+/// a connection template.
+///
+/// `label` is the display name for the created connection (falls back to `host`
+/// when the file gives no label). `port`/`username` are *optional per-host
+/// overrides* — `None` means "inherit the template's value".
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InventoryHost {
+    pub label: String,
+    pub host: String,
+    pub port: Option<u16>,
+    pub username: Option<String>,
+}
+
+/// Which inventory column each recognised field maps to, resolved from the
+/// header row. `None` for a field means the file has no such column.
+#[derive(Default)]
+struct ColumnMap {
+    host: Option<usize>,
+    label: Option<usize>,
+    port: Option<usize>,
+    username: Option<usize>,
+}
+
+/// Classify a header cell into the field it names, or `None` when it is not a
+/// recognised header keyword.
+fn classify_header(cell: &str) -> Option<Field> {
+    match cell.trim().to_ascii_lowercase().as_str() {
+        "host" | "hostname" | "address" | "ip" => Some(Field::Host),
+        "label" | "name" => Some(Field::Label),
+        "port" => Some(Field::Port),
+        "user" | "username" => Some(Field::Username),
+        _ => None,
+    }
+}
+
+enum Field {
+    Host,
+    Label,
+    Port,
+    Username,
+}
+
+/// Decide whether `record` is a header row and, if so, build the column map from
+/// it. A row is treated as a header when at least one cell names a recognised
+/// field. Returns `None` when the file is header-less (positional layout).
+fn header_map(record: &csv::StringRecord) -> Option<ColumnMap> {
+    let mut map = ColumnMap::default();
+    let mut matched = false;
+    for (idx, cell) in record.iter().enumerate() {
+        match classify_header(cell) {
+            Some(Field::Host) => {
+                map.host.get_or_insert(idx);
+                matched = true;
+            }
+            Some(Field::Label) => {
+                map.label.get_or_insert(idx);
+                matched = true;
+            }
+            Some(Field::Port) => {
+                map.port.get_or_insert(idx);
+                matched = true;
+            }
+            Some(Field::Username) => {
+                map.username.get_or_insert(idx);
+                matched = true;
+            }
+            None => {}
+        }
+    }
+    matched.then_some(map)
+}
+
+/// The positional column map used when no header row is present:
+/// `host,label,port,username`.
+fn positional_map() -> ColumnMap {
+    ColumnMap {
+        host: Some(0),
+        label: Some(1),
+        port: Some(2),
+        username: Some(3),
+    }
+}
+
+/// Read `cell` at `idx` (if any), trimmed; `None`/empty collapses to `None`.
+fn cell_at(record: &csv::StringRecord, idx: Option<usize>) -> Option<String> {
+    let value = idx.and_then(|i| record.get(i))?.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+/// Turn one data record into an [`InventoryHost`] using `map`. Rows without a
+/// host resolve to `None` and are skipped by the caller.
+fn record_to_host(record: &csv::StringRecord, map: &ColumnMap) -> Option<InventoryHost> {
+    let host = cell_at(record, map.host)?;
+    let label = cell_at(record, map.label).unwrap_or_else(|| host.clone());
+    // A malformed port is dropped (no override) rather than failing the import.
+    let port = cell_at(record, map.port).and_then(|p| p.parse::<u16>().ok());
+    let username = cell_at(record, map.username);
+    Some(InventoryHost {
+        label,
+        host,
+        port,
+        username,
+    })
+}
+
+/// Parse an inventory from raw bytes. Shared by the command and the tests so both
+/// exercise the exact same header-detection and mapping path.
+pub fn parse_inventory_bytes(bytes: &[u8]) -> Result<Vec<InventoryHost>, String> {
+    let mut reader = csv::ReaderBuilder::new()
+        .has_headers(false)
+        .flexible(true)
+        .comment(Some(b'#'))
+        .trim(csv::Trim::All)
+        .from_reader(bytes);
+
+    let mut records = reader.records();
+    let Some(first) = records.next() else {
+        return Ok(Vec::new());
+    };
+    let first = first.map_err(|e| format!("parse inventory: {e}"))?;
+
+    let mut out = Vec::new();
+    let map = match header_map(&first) {
+        Some(map) => map,
+        None => {
+            // Header-less: the first row is data under the positional layout.
+            let positional = positional_map();
+            if let Some(host) = record_to_host(&first, &positional) {
+                out.push(host);
+            }
+            positional
+        }
+    };
+
+    for record in records {
+        let record = record.map_err(|e| format!("parse inventory: {e}"))?;
+        if let Some(host) = record_to_host(&record, &map) {
+            out.push(host);
+        }
+    }
+    Ok(out)
+}
+
+/// Parse the inventory file at `path` into [`InventoryHost`] rows.
+pub fn parse_inventory_file(path: &Path) -> Result<Vec<InventoryHost>, String> {
+    let bytes = std::fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    parse_inventory_bytes(&bytes)
+}
+
+/// Parse the inventory file the user picked into importable hosts (#1961).
+///
+/// Unlike the SSH-config importer (which reads a fixed path and degrades a
+/// missing file to an empty list), the user here explicitly picks a file, so a
+/// read/parse failure surfaces as an error the UI can toast.
+#[tauri::command]
+pub fn import_inventory_hosts(path: String) -> Result<Vec<InventoryHost>, TerminalError> {
+    parse_inventory_file(Path::new(&path)).map_err(TerminalError::EditorError)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse(input: &str) -> Vec<InventoryHost> {
+        parse_inventory_bytes(input.as_bytes()).expect("parse inventory")
+    }
+
+    #[test]
+    fn empty_input_yields_empty_list() {
+        assert!(parse("").is_empty());
+    }
+
+    #[test]
+    fn csv_with_header_maps_named_columns() {
+        let rows = parse(
+            "host,label,port,username\n\
+             web1.internal,Web One,2022,alice\n\
+             web2.internal,Web Two,,bob\n",
+        );
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows[0],
+            InventoryHost {
+                label: "Web One".into(),
+                host: "web1.internal".into(),
+                port: Some(2022),
+                username: Some("alice".into()),
+            }
+        );
+        // Empty port cell → no override.
+        assert_eq!(rows[1].port, None);
+        assert_eq!(rows[1].username.as_deref(), Some("bob"));
+    }
+
+    #[test]
+    fn header_columns_can_be_reordered_and_aliased() {
+        let rows = parse(
+            "Username,Hostname,Port\n\
+             carol,db.internal,5432\n",
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].host, "db.internal");
+        assert_eq!(rows[0].username.as_deref(), Some("carol"));
+        assert_eq!(rows[0].port, Some(5432));
+        // No label column → label falls back to the host.
+        assert_eq!(rows[0].label, "db.internal");
+    }
+
+    #[test]
+    fn unknown_header_columns_are_ignored() {
+        let rows = parse(
+            "host,os,rack\n\
+             app.internal,linux,r12\n",
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].host, "app.internal");
+        assert_eq!(rows[0].port, None);
+    }
+
+    #[test]
+    fn headerless_csv_uses_positional_layout() {
+        let rows = parse(
+            "10.0.0.1,gateway,22,root\n\
+             10.0.0.2,switch\n",
+        );
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].host, "10.0.0.1");
+        assert_eq!(rows[0].label, "gateway");
+        assert_eq!(rows[0].port, Some(22));
+        assert_eq!(rows[0].username.as_deref(), Some("root"));
+        // Second row: only host + label present.
+        assert_eq!(rows[1].host, "10.0.0.2");
+        assert_eq!(rows[1].label, "switch");
+        assert_eq!(rows[1].port, None);
+        assert_eq!(rows[1].username, None);
+    }
+
+    #[test]
+    fn plain_host_per_line_list_labels_each_by_host() {
+        let rows = parse("host-a\nhost-b\nhost-c\n");
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].host, "host-a");
+        assert_eq!(rows[0].label, "host-a");
+        assert!(rows.iter().all(|r| r.port.is_none() && r.username.is_none()));
+    }
+
+    #[test]
+    fn comment_and_blank_lines_are_skipped() {
+        let rows = parse(
+            "# fleet inventory\n\
+             host,label\n\
+             \n\
+             web.internal,Web\n\
+             # trailing comment\n",
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].host, "web.internal");
+    }
+
+    #[test]
+    fn rows_without_a_host_are_skipped() {
+        let rows = parse(
+            "host,label\n\
+             ,Orphan Label\n\
+             real.internal,Real\n",
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].host, "real.internal");
+    }
+
+    #[test]
+    fn malformed_port_degrades_to_no_override() {
+        let rows = parse(
+            "host,port\n\
+             h.internal,notaport\n",
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].port, None);
+    }
+
+    #[test]
+    fn quoted_fields_with_commas_are_handled() {
+        let rows = parse(
+            "host,label\n\
+             h.internal,\"Prod, East\"\n",
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].label, "Prod, East");
+    }
+
+    #[test]
+    fn whitespace_around_cells_is_trimmed() {
+        let rows = parse(
+            "host , label\n\
+             \t spaced.internal \t, Spaced \n",
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].host, "spaced.internal");
+        assert_eq!(rows[0].label, "Spaced");
+    }
+
+    #[test]
+    fn missing_file_is_an_error() {
+        let err = parse_inventory_file(Path::new("/nonexistent/does/not/exist.csv"));
+        assert!(err.is_err());
+    }
+}

--- a/src-tauri/src/commands/inventory_import.rs
+++ b/src-tauri/src/commands/inventory_import.rs
@@ -274,7 +274,9 @@ mod tests {
         assert_eq!(rows.len(), 3);
         assert_eq!(rows[0].host, "host-a");
         assert_eq!(rows[0].label, "host-a");
-        assert!(rows.iter().all(|r| r.port.is_none() && r.username.is_none()));
+        assert!(rows
+            .iter()
+            .all(|r| r.port.is_none() && r.username.is_none()));
     }
 
     #[test]

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod connection_path;
 pub mod credential;
 pub mod embedded_servers;
 pub mod files;
+pub mod inventory_import;
 pub mod local_process;
 pub mod logs;
 pub mod macros;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -783,6 +783,7 @@ pub fn run() {
             commands::connection_path::cancel_connection_path_probe,
             commands::ssh_config_import::import_ssh_config_hosts,
             commands::ssh_config_import::import_ssh_config_connections,
+            commands::inventory_import::import_inventory_hosts,
             commands::session::get_connection_types,
             commands::session::send_input,
             commands::session::set_session_line_ending,

--- a/src/components/NetworkTools/PingSweepPanel.tsx
+++ b/src/components/NetworkTools/PingSweepPanel.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useMemo, useState } from "react";
-import { Play, StopCircle } from "lucide-react";
+import { Play, ServerCog, StopCircle } from "lucide-react";
 import { Button, ConfirmDialog, Field, Input, NumberInput } from "@/components/ui";
+import { FleetOnboardDialog } from "@/components/Sidebar/FleetOnboardDialog";
+import { pingSweepResultsToRows } from "@/services/fleetOnboard";
 import { useAutofocusSelect } from "@/hooks/useAutofocusSelect";
 import {
   networkPingSweep,
@@ -44,6 +46,7 @@ export function PingSweepPanel({ prefillHost }: PingSweepPanelProps) {
   const [results, setResults] = useState<SweepRow[]>([]);
   const [summary, setSummary] = useState<PingSweepSummary | null>(null);
   const [warnOpen, setWarnOpen] = useState(false);
+  const [onboardOpen, setOnboardOpen] = useState(false);
   // Local, deferred opt-out state — committed to settings only on confirm,
   // discarded on cancel (honours the ConfirmDialog checkbox contract).
   const [dontWarnAgain, setDontWarnAgain] = useState(false);
@@ -153,6 +156,17 @@ export function PingSweepPanel({ prefillHost }: PingSweepPanelProps) {
       <div className="network-panel__header">
         <span className="network-panel__title">Ping Sweep</span>
         <div className="network-panel__actions">
+          {results.length > 0 && status !== "running" && (
+            <Button
+              variant="secondary"
+              size="sm"
+              icon={<ServerCog size={14} />}
+              onClick={() => setOnboardOpen(true)}
+              data-testid="ping-sweep-onboard"
+            >
+              Add as connections
+            </Button>
+          )}
           {status === "running" ? (
             <Button
               variant="danger"
@@ -266,6 +280,13 @@ export function PingSweepPanel({ prefillHost }: PingSweepPanelProps) {
         }}
         onConfirm={handleConfirmLargeSweep}
         onCancel={handleCancelLargeSweep}
+      />
+
+      <FleetOnboardDialog
+        open={onboardOpen}
+        onOpenChange={setOnboardOpen}
+        rows={pingSweepResultsToRows(results)}
+        sourceLabel="the ping sweep results"
       />
     </form>
   );

--- a/src/components/NetworkTools/PortScannerPanel.tsx
+++ b/src/components/NetworkTools/PortScannerPanel.tsx
@@ -1,6 +1,8 @@
 import { useState, useCallback, useMemo } from "react";
-import { Play, StopCircle } from "lucide-react";
+import { Play, ServerCog, StopCircle } from "lucide-react";
 import { Button, ConfirmDialog, Field, Input, NumberInput } from "@/components/ui";
+import { FleetOnboardDialog } from "@/components/Sidebar/FleetOnboardDialog";
+import { portScanResultsToRows } from "@/services/fleetOnboard";
 import { useAutofocusSelect } from "@/hooks/useAutofocusSelect";
 import {
   networkPortScan,
@@ -159,12 +161,24 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
   // Live open-port tally so the running footer surfaces progress, not just the
   // number of ports checked.
   const liveOpen = useMemo(() => results.filter((r) => r.state === "open").length, [results]);
+  const [onboardOpen, setOnboardOpen] = useState(false);
 
   return (
     <form className="network-panel" data-testid="port-scanner-panel">
       <div className="network-panel__header">
         <span className="network-panel__title">Port Scanner</span>
         <div className="network-panel__actions">
+          {liveOpen > 0 && status !== "running" && (
+            <Button
+              variant="secondary"
+              size="sm"
+              icon={<ServerCog size={14} />}
+              onClick={() => setOnboardOpen(true)}
+              data-testid="port-scanner-onboard"
+            >
+              Add as connections
+            </Button>
+          )}
           {status === "running" ? (
             <Button
               variant="danger"
@@ -289,6 +303,13 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
         }}
         onConfirm={handleConfirmLargeScan}
         onCancel={handleCancelLargeScan}
+      />
+
+      <FleetOnboardDialog
+        open={onboardOpen}
+        onOpenChange={setOnboardOpen}
+        rows={portScanResultsToRows(results)}
+        sourceLabel="the open ports found"
       />
     </form>
   );

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -31,12 +31,15 @@ import {
   Search,
   X,
   FileDown,
+  FileSpreadsheet,
   Link,
   Square,
 } from "lucide-react";
+import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import { useAppStore } from "@/store/appStore";
-import { SavedConnection, ConnectionFolder } from "@/types/connection";
-import { type AgentDefinitionInfo } from "@/services/api";
+import { SavedConnection, ConnectionFolder, InventoryHost } from "@/types/connection";
+import { type AgentDefinitionInfo, importInventoryHosts } from "@/services/api";
+import { toast } from "@/components/ui";
 import { openLocalCommandTab } from "@/utils/openLocalCommandTab";
 import { ConnectionIcon } from "@/utils/connectionIcons";
 import { Button, Tooltip, Input, ConfirmDialog } from "@/components/ui";
@@ -56,6 +59,7 @@ import {
 } from "@/utils/jumpHost";
 import { ConfirmDeleteDialog } from "./ConfirmDeleteDialog";
 import { BulkSshImportDialog } from "./BulkSshImportDialog";
+import { FleetOnboardDialog } from "./FleetOnboardDialog";
 import { AgentNode } from "./AgentNode";
 import { PersistentStateDot } from "./PersistentStateDot";
 import { ConnectionPathDialog } from "./ConnectionPathDialog";
@@ -624,6 +628,7 @@ function buildExpandedIndexMap(sectionsExpanded: boolean[]): { map: number[]; co
 export function ConnectionList() {
   const [creatingFolder, setCreatingFolder] = useState(false);
   const [bulkImportOpen, setBulkImportOpen] = useState(false);
+  const [fleetRows, setFleetRows] = useState<InventoryHost[] | null>(null);
   const [filterQuery, setFilterQuery] = useState("");
   const [agentFilterQuery, setAgentFilterQuery] = useState("");
   const [draggingConnection, setDraggingConnection] = useState<SavedConnection | null>(null);
@@ -966,6 +971,29 @@ export function ConnectionList() {
     openConnectionEditorTab("new");
   }, [openConnectionEditorTab]);
 
+  /**
+   * Pick a CSV / inventory file and open the fleet-onboard dialog with its hosts
+   * (#1961). A cancelled picker is a no-op; a read/parse failure or an
+   * empty/host-less file surfaces a toast rather than an empty dialog.
+   */
+  const handleImportCsv = useCallback(async () => {
+    const selected = await openFileDialog({
+      multiple: false,
+      filters: [{ name: "Inventory", extensions: ["csv", "txt", "tsv"] }],
+    });
+    if (typeof selected !== "string") return;
+    try {
+      const hosts = await importInventoryHosts(selected);
+      if (hosts.length === 0) {
+        toast.info("No hosts found in that file.");
+        return;
+      }
+      setFleetRows(hosts);
+    } catch {
+      toast.error("Could not read that inventory file.");
+    }
+  }, []);
+
   const handleNewConnectionInFolder = useCallback(
     (folderId: string) => {
       openConnectionEditorTab("new", folderId);
@@ -1256,6 +1284,17 @@ export function ConnectionList() {
                   data-testid="connection-list-import-ssh-config"
                 />
               </Tooltip>
+              <Tooltip content="Onboard hosts from a CSV / inventory" side="top">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  iconOnly
+                  icon={<FileSpreadsheet size={16} />}
+                  onClick={handleImportCsv}
+                  aria-label="Onboard hosts from a CSV / inventory"
+                  data-testid="connection-list-import-csv"
+                />
+              </Tooltip>
             </div>
           </div>
           {!localCollapsed && (
@@ -1497,6 +1536,14 @@ export function ConnectionList() {
         folders={folders}
         existingConnections={connections}
         onImport={bulkAddConnections}
+      />
+      <FleetOnboardDialog
+        open={fleetRows !== null}
+        onOpenChange={(open) => {
+          if (!open) setFleetRows(null);
+        }}
+        rows={fleetRows ?? []}
+        sourceLabel="a CSV inventory"
       />
     </div>
   );

--- a/src/components/Sidebar/FleetOnboardDialog.css
+++ b/src/components/Sidebar/FleetOnboardDialog.css
@@ -1,0 +1,26 @@
+/* Fleet-onboard dialog (#1961). Reuses the bulk SSH import chrome
+   (.bulk-ssh-import__*, .ssh-config-import__*) and adds the template/preview
+   specifics. */
+
+.fleet-onboard__dedupe {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 2px 2px;
+  cursor: pointer;
+}
+
+.fleet-onboard__row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm, 4px);
+}
+
+.fleet-onboard__row:hover {
+  background: var(--bg-hover, rgba(127, 127, 127, 0.12));
+  border-color: var(--border-color, rgba(127, 127, 127, 0.25));
+}

--- a/src/components/Sidebar/FleetOnboardDialog.test.tsx
+++ b/src/components/Sidebar/FleetOnboardDialog.test.tsx
@@ -94,7 +94,10 @@ describe("FleetOnboardDialog", () => {
     renderWith(
       [
         sshConnection("prod-template"),
-        { ...sshConnection("existing"), config: { type: "ssh", config: { host: "web1.internal" } } },
+        {
+          ...sshConnection("existing"),
+          config: { type: "ssh", config: { host: "web1.internal" } },
+        },
       ],
       [
         { host: "web1.internal", label: "Web 1" },

--- a/src/components/Sidebar/FleetOnboardDialog.test.tsx
+++ b/src/components/Sidebar/FleetOnboardDialog.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * Tests for the fleet-onboard dialog (#1961): it stamps N saved connections
+ * from a chosen template connection and persists them via the store's bulk-add.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { FleetOnboardDialog } from "./FleetOnboardDialog";
+import { TooltipProvider } from "@/components/ui";
+import type { InventoryHost, SavedConnection } from "@/types/connection";
+
+vi.mock("@/services/api", () => ({}));
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+function sshConnection(id: string, settings: Record<string, unknown> = {}): SavedConnection {
+  return {
+    id,
+    name: id,
+    folderId: null,
+    config: { type: "ssh", config: { host: "template.host", username: "deploy", ...settings } },
+  };
+}
+
+const q = (testId: string) => document.querySelector(`[data-testid="${testId}"]`) as HTMLElement;
+
+describe("FleetOnboardDialog", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let bulkAddConnections: Mock<(connections: SavedConnection[]) => void>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    bulkAddConnections = vi.fn<(connections: SavedConnection[]) => void>();
+    useAppStore.setState({ bulkAddConnections });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderWith(connections: SavedConnection[], rows: InventoryHost[]) {
+    useAppStore.setState({ connections, folders: [] });
+    act(() =>
+      root.render(
+        React.createElement(TooltipProvider, {
+          delayDuration: 0,
+          children: React.createElement(FleetOnboardDialog, {
+            open: true,
+            onOpenChange: () => {},
+            rows,
+            sourceLabel: "a CSV inventory",
+          }),
+        })
+      )
+    );
+  }
+
+  it("builds one connection per row from the default template and bulk-adds them", () => {
+    renderWith(
+      [sshConnection("prod-template")],
+      [
+        { host: "web1.internal", label: "Web 1" },
+        { host: "web2.internal", label: "Web 2" },
+      ]
+    );
+
+    expect(q("fleet-onboard-dialog")).not.toBeNull();
+    act(() => q("fleet-onboard-import").click());
+
+    expect(bulkAddConnections).toHaveBeenCalledTimes(1);
+    const built = bulkAddConnections.mock.calls[0][0];
+    expect(built).toHaveLength(2);
+    expect(built[0].config.config.host).toBe("web1.internal");
+    expect(built[0].config.config.username).toBe("deploy");
+    expect(built[0].name).toBe("Web 1");
+    expect(built[1].config.config.host).toBe("web2.internal");
+  });
+
+  it("shows an empty state and does not bulk-add when no template connection exists", () => {
+    renderWith([], [{ host: "web1.internal", label: "Web 1" }]);
+
+    expect(q("fleet-onboard-no-templates")).not.toBeNull();
+    // The import button is disabled with no template.
+    act(() => q("fleet-onboard-import").click());
+    expect(bulkAddConnections).not.toHaveBeenCalled();
+  });
+
+  it("skips hosts already present in the target folder", () => {
+    renderWith(
+      [
+        sshConnection("prod-template"),
+        { ...sshConnection("existing"), config: { type: "ssh", config: { host: "web1.internal" } } },
+      ],
+      [
+        { host: "web1.internal", label: "Web 1" },
+        { host: "web2.internal", label: "Web 2" },
+      ]
+    );
+
+    act(() => q("fleet-onboard-import").click());
+    const built = bulkAddConnections.mock.calls[0][0];
+    // web1 already exists at root → only web2 is added.
+    expect(built).toHaveLength(1);
+    expect(built[0].config.config.host).toBe("web2.internal");
+  });
+});

--- a/src/components/Sidebar/FleetOnboardDialog.tsx
+++ b/src/components/Sidebar/FleetOnboardDialog.tsx
@@ -116,7 +116,11 @@ export function FleetOnboardDialog({
       data-testid="fleet-onboard-dialog"
       footer={
         <>
-          <Button variant="ghost" onClick={() => onOpenChange(false)} data-testid="fleet-onboard-cancel">
+          <Button
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            data-testid="fleet-onboard-cancel"
+          >
             Cancel
           </Button>
           <Button
@@ -192,7 +196,10 @@ export function FleetOnboardDialog({
               const overrides = overrideSummary(row);
               return (
                 <li key={`${row.host}-${i}`}>
-                  <div className="fleet-onboard__row" data-testid={`fleet-onboard-host-${row.host}`}>
+                  <div
+                    className="fleet-onboard__row"
+                    data-testid={`fleet-onboard-host-${row.host}`}
+                  >
                     <span className="ssh-config-import__row-text">
                       <span className="ssh-config-import__row-name">{row.label}</span>
                       <span className="ssh-config-import__row-chain">

--- a/src/components/Sidebar/FleetOnboardDialog.tsx
+++ b/src/components/Sidebar/FleetOnboardDialog.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useMemo, useState } from "react";
+import { Server } from "lucide-react";
+import { Button, Checkbox, Modal, Select } from "@/components/ui";
+import { toast } from "@/components/ui";
+import type { InventoryHost, SavedConnection } from "@/types/connection";
+import { useAppStore } from "@/store/appStore";
+import {
+  importFolderOptions,
+  resolveImportFolderId,
+  ROOT_FOLDER_VALUE,
+} from "@/services/sshConfigImport";
+import { buildTemplatedConnections } from "@/services/fleetOnboard";
+import "./BulkSshImportDialog.css";
+import "./FleetOnboardDialog.css";
+
+interface FleetOnboardDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** The hosts to onboard, from a CSV inventory or a network-scan result. */
+  rows: InventoryHost[];
+  /** Where the rows came from, shown in the dialog copy (e.g. "CSV inventory"). */
+  sourceLabel: string;
+}
+
+/** One-line summary of a row's per-host overrides, or "" when it inherits all. */
+function overrideSummary(row: InventoryHost): string {
+  const parts: string[] = [];
+  if (row.username) parts.push(`user ${row.username}`);
+  if (row.port !== undefined) parts.push(`port ${row.port}`);
+  return parts.join(" · ");
+}
+
+/**
+ * Fleet-onboard dialog (#1961): create many saved connections from one existing
+ * connection used as a **template**, sourcing the hosts from a CSV inventory or
+ * from the network scanner. The user picks the template connection, a target
+ * folder, and whether to skip hosts that already exist; each row becomes a saved
+ * connection reusing the template's type and settings with its host (and any
+ * per-row port/username) stamped in.
+ *
+ * Self-contained on the store (templates, folders, bulk-add) so both the
+ * connection list and the scanner panels can open it with just a `rows` array.
+ */
+export function FleetOnboardDialog({
+  open,
+  onOpenChange,
+  rows,
+  sourceLabel,
+}: FleetOnboardDialogProps) {
+  const connections = useAppStore((s) => s.connections);
+  const folders = useAppStore((s) => s.folders);
+  const bulkAddConnections = useAppStore((s) => s.bulkAddConnections);
+
+  const [templateId, setTemplateId] = useState<string>("");
+  const [folderId, setFolderId] = useState<string>(ROOT_FOLDER_VALUE);
+  const [dedupe, setDedupe] = useState(true);
+
+  const templateOptions = useMemo(
+    () =>
+      connections
+        .map((c) => ({ value: c.id, label: `${c.name} (${c.config.type})` }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [connections]
+  );
+  const folderOptions = useMemo(() => importFolderOptions(folders), [folders]);
+
+  useEffect(() => {
+    if (!open) return;
+    setFolderId(ROOT_FOLDER_VALUE);
+    setDedupe(true);
+    // Default the template to the first connection so the primary action is
+    // reachable in one click when a template obviously exists.
+    setTemplateId(connections[0]?.id ?? "");
+  }, [open, connections]);
+
+  const template: SavedConnection | undefined = connections.find((c) => c.id === templateId);
+  const noTemplates = connections.length === 0;
+  const canImport = !!template && rows.length > 0;
+
+  const handleImport = () => {
+    if (!template) return;
+    const { connections: built, skipped } = buildTemplatedConnections(
+      rows,
+      template,
+      resolveImportFolderId(folderId),
+      connections,
+      { dedupe }
+    );
+    if (built.length === 0) {
+      toast.info(
+        skipped.length > 0
+          ? `All ${skipped.length} host${skipped.length === 1 ? "" : "s"} already exist here — nothing to add.`
+          : "No hosts to add."
+      );
+      onOpenChange(false);
+      return;
+    }
+    bulkAddConnections(built);
+    if (skipped.length > 0) {
+      toast.info(
+        `Skipped ${skipped.length} host${skipped.length === 1 ? "" : "s"} already present in this folder.`
+      );
+    }
+    onOpenChange(false);
+  };
+
+  const addLabel = canImport && template ? `Add ${rows.length}` : "Add";
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Onboard hosts from a template"
+      description={`Create a saved connection per host from ${sourceLabel}, reusing an existing connection as the template.`}
+      size="lg"
+      data-testid="fleet-onboard-dialog"
+      footer={
+        <>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} data-testid="fleet-onboard-cancel">
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleImport}
+            disabled={!canImport}
+            data-testid="fleet-onboard-import"
+          >
+            {addLabel}
+          </Button>
+        </>
+      }
+    >
+      {noTemplates ? (
+        <div className="ssh-config-import__empty" data-testid="fleet-onboard-no-templates">
+          <Server size={20} aria-hidden />
+          <p>Create a connection first, then use it as a template to onboard hosts in bulk.</p>
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="ssh-config-import__empty" data-testid="fleet-onboard-empty">
+          <Server size={20} aria-hidden />
+          <p>No hosts to onboard from {sourceLabel}.</p>
+        </div>
+      ) : (
+        <div className="bulk-ssh-import">
+          <div className="bulk-ssh-import__folder">
+            <label className="bulk-ssh-import__folder-label" htmlFor="fleet-onboard-template">
+              Template connection
+            </label>
+            <Select
+              value={templateId}
+              onChange={setTemplateId}
+              options={templateOptions}
+              placeholder="Pick a connection to copy"
+              aria-label="Template connection"
+              data-testid="fleet-onboard-template"
+            />
+          </div>
+
+          <div className="bulk-ssh-import__folder">
+            <label className="bulk-ssh-import__folder-label" htmlFor="fleet-onboard-folder">
+              Import into
+            </label>
+            <Select
+              value={folderId}
+              onChange={setFolderId}
+              options={folderOptions}
+              aria-label="Target folder"
+              data-testid="fleet-onboard-folder"
+            />
+          </div>
+
+          <label className="fleet-onboard__dedupe">
+            <Checkbox
+              checked={dedupe}
+              onCheckedChange={(checked) => setDedupe(checked === true)}
+              aria-label="Skip hosts that already exist"
+              data-testid="fleet-onboard-dedupe"
+            />
+            <span className="bulk-ssh-import__selectall-label">
+              Skip hosts already present in the target folder
+            </span>
+          </label>
+
+          <div className="bulk-ssh-import__selectall">
+            <span className="bulk-ssh-import__selectall-label">
+              {rows.length} host{rows.length === 1 ? "" : "s"} to onboard
+            </span>
+          </div>
+
+          <ul className="ssh-config-import__list" data-testid="fleet-onboard-list">
+            {rows.map((row, i) => {
+              const overrides = overrideSummary(row);
+              return (
+                <li key={`${row.host}-${i}`}>
+                  <div className="fleet-onboard__row" data-testid={`fleet-onboard-host-${row.host}`}>
+                    <span className="ssh-config-import__row-text">
+                      <span className="ssh-config-import__row-name">{row.label}</span>
+                      <span className="ssh-config-import__row-chain">
+                        {row.host}
+                        {overrides ? ` · ${overrides}` : ""}
+                      </span>
+                    </span>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -29,6 +29,7 @@ import {
   ConnectionTypeInfo,
   SshConfigImportHost,
   SshConfigImportConnection,
+  InventoryHost,
   FileEntry,
   Writability,
   ExternalFileError,
@@ -131,6 +132,16 @@ export async function importSshConfigHosts(): Promise<SshConfigImportHost[]> {
  */
 export async function importSshConfigConnections(): Promise<SshConfigImportConnection[]> {
   return await invoke<SshConfigImportConnection[]>("import_ssh_config_connections");
+}
+
+/**
+ * Parse the CSV / simple inventory file at `path` into importable {@link
+ * InventoryHost} rows for bulk fleet onboarding (#1961). Unlike the SSH-config
+ * importer, the user explicitly picks this file, so a read/parse failure
+ * rejects (the caller toasts it) rather than degrading to an empty list.
+ */
+export async function importInventoryHosts(path: string): Promise<InventoryHost[]> {
+  return await invoke<InventoryHost[]>("import_inventory_hosts", { path });
 }
 
 /**

--- a/src/services/fleetOnboard.test.ts
+++ b/src/services/fleetOnboard.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTemplatedConnections,
+  pingSweepResultsToRows,
+  portScanResultsToRows,
+} from "./fleetOnboard";
+import type { InventoryHost, SavedConnection } from "@/types/connection";
+import type { PingSweepResult, PortScanResult } from "@/types/network";
+
+/** A minimal SSH connection usable as a template. */
+function sshTemplate(overrides: Partial<SavedConnection> = {}): SavedConnection {
+  return {
+    id: "tmpl-1",
+    name: "Prod template",
+    folderId: null,
+    config: {
+      type: "ssh",
+      config: {
+        host: "template.example.com",
+        port: 22,
+        username: "deploy",
+        authMethod: "key",
+        keyPath: "/home/me/.ssh/id_fleet",
+      },
+    },
+    ...overrides,
+  };
+}
+
+function rows(...hosts: Partial<InventoryHost>[]): InventoryHost[] {
+  return hosts.map((h) => ({ host: h.host ?? "h", label: h.label ?? h.host ?? "h", ...h }));
+}
+
+describe("buildTemplatedConnections", () => {
+  it("builds one connection per CSV row, reusing the template settings", () => {
+    const { connections } = buildTemplatedConnections(
+      rows({ host: "web1.internal", label: "Web 1" }, { host: "web2.internal", label: "Web 2" }),
+      sshTemplate(),
+      null,
+      []
+    );
+
+    expect(connections).toHaveLength(2);
+    for (const c of connections) {
+      expect(c.config.type).toBe("ssh");
+      expect(c.config.config.username).toBe("deploy");
+      expect(c.config.config.authMethod).toBe("key");
+      expect(c.config.config.keyPath).toBe("/home/me/.ssh/id_fleet");
+      expect(c.folderId).toBeNull();
+    }
+    expect(connections[0].name).toBe("Web 1");
+    expect(connections[0].config.config.host).toBe("web1.internal");
+    expect(connections[1].config.config.host).toBe("web2.internal");
+  });
+
+  it("lands connections in the chosen folder", () => {
+    const { connections } = buildTemplatedConnections(
+      rows({ host: "h1" }),
+      sshTemplate(),
+      "Work/Fleet",
+      []
+    );
+    expect(connections[0].folderId).toBe("Work/Fleet");
+  });
+
+  it("clones settings so per-host overrides do not leak between connections", () => {
+    const { connections } = buildTemplatedConnections(
+      rows({ host: "a", port: 2201 }, { host: "b" }),
+      sshTemplate(),
+      null,
+      []
+    );
+    expect(connections[0].config.config.port).toBe(2201);
+    // The second host keeps the template default, unaffected by the first.
+    expect(connections[1].config.config.port).toBe(22);
+  });
+
+  it("applies per-row port and username overrides", () => {
+    const { connections } = buildTemplatedConnections(
+      rows({ host: "db", port: 5432, username: "postgres" }),
+      sshTemplate(),
+      null,
+      []
+    );
+    expect(connections[0].config.config.port).toBe(5432);
+    expect(connections[0].config.config.username).toBe("postgres");
+  });
+
+  it("dedupes names within the target folder", () => {
+    const existing = [
+      {
+        id: "e1",
+        name: "Web 1",
+        folderId: null,
+        config: { type: "ssh", config: { host: "old.internal" } },
+      } as SavedConnection,
+    ];
+    const { connections } = buildTemplatedConnections(
+      rows({ host: "web1.internal", label: "Web 1" }),
+      sshTemplate(),
+      null,
+      existing
+    );
+    expect(connections[0].name).toBe("Web 1 (2)");
+  });
+
+  it("skips hosts that already have a connection of the template type (dedupe on)", () => {
+    const existing = [
+      {
+        id: "e1",
+        name: "Existing web",
+        folderId: null,
+        config: { type: "ssh", config: { host: "web1.internal" } },
+      } as SavedConnection,
+    ];
+    const { connections, skipped } = buildTemplatedConnections(
+      rows({ host: "web1.internal", label: "Web 1" }, { host: "web2.internal", label: "Web 2" }),
+      sshTemplate(),
+      null,
+      existing
+    );
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].host).toBe("web1.internal");
+    expect(connections).toHaveLength(1);
+    expect(connections[0].config.config.host).toBe("web2.internal");
+  });
+
+  it("host dedupe is case-insensitive and folder-scoped", () => {
+    const existing = [
+      {
+        id: "e1",
+        name: "Existing",
+        folderId: "Work",
+        config: { type: "ssh", config: { host: "HOST.Internal" } },
+      } as SavedConnection,
+    ];
+    // Same host but a different folder → not a duplicate.
+    const other = buildTemplatedConnections(
+      rows({ host: "host.internal" }),
+      sshTemplate(),
+      "Other",
+      existing
+    );
+    expect(other.connections).toHaveLength(1);
+    // Same folder, case-insensitive match → skipped.
+    const same = buildTemplatedConnections(
+      rows({ host: "host.internal" }),
+      sshTemplate(),
+      "Work",
+      existing
+    );
+    expect(same.connections).toHaveLength(0);
+    expect(same.skipped).toHaveLength(1);
+  });
+
+  it("collapses duplicate hosts within the same batch", () => {
+    const { connections } = buildTemplatedConnections(
+      rows({ host: "dup.internal" }, { host: "dup.internal" }),
+      sshTemplate(),
+      null,
+      []
+    );
+    expect(connections).toHaveLength(1);
+  });
+
+  it("can keep duplicates when dedupe is disabled", () => {
+    const existing = [
+      {
+        id: "e1",
+        name: "Existing",
+        folderId: null,
+        config: { type: "ssh", config: { host: "web1.internal" } },
+      } as SavedConnection,
+    ];
+    const { connections, skipped } = buildTemplatedConnections(
+      rows({ host: "web1.internal", label: "Web 1" }),
+      sshTemplate(),
+      null,
+      existing,
+      { dedupe: false }
+    );
+    expect(skipped).toHaveLength(0);
+    expect(connections).toHaveLength(1);
+  });
+
+  it("carries the template icon and terminal options onto each connection", () => {
+    const { connections } = buildTemplatedConnections(
+      rows({ host: "h1" }),
+      sshTemplate({ icon: "server", terminalOptions: { fontSize: 14 } as never }),
+      null,
+      []
+    );
+    expect(connections[0].icon).toBe("server");
+    expect(connections[0].terminalOptions).toEqual({ fontSize: 14 });
+  });
+
+  it("skips rows with a blank host", () => {
+    const { connections } = buildTemplatedConnections(
+      rows({ host: "  ", label: "blank" }, { host: "real" }),
+      sshTemplate(),
+      null,
+      []
+    );
+    expect(connections).toHaveLength(1);
+    expect(connections[0].config.config.host).toBe("real");
+  });
+});
+
+describe("pingSweepResultsToRows", () => {
+  it("uses reverse-DNS hostname as the label when present", () => {
+    const results: PingSweepResult[] = [
+      { host: "10.0.0.1", hostname: "gateway.lan" },
+      { host: "10.0.0.2" },
+    ];
+    const out = pingSweepResultsToRows(results);
+    expect(out).toEqual([
+      { host: "10.0.0.1", label: "gateway.lan" },
+      { host: "10.0.0.2", label: "10.0.0.2" },
+    ]);
+  });
+});
+
+describe("portScanResultsToRows", () => {
+  it("collapses open ports to one row per host, carrying a sole open port", () => {
+    const results: PortScanResult[] = [
+      { host: "10.0.0.1", port: 22, state: "open" },
+      { host: "10.0.0.1", port: 80, state: "open" },
+      { host: "10.0.0.2", port: 22, state: "open" },
+      { host: "10.0.0.3", port: 22, state: "closed" },
+    ];
+    const out = portScanResultsToRows(results);
+    expect(out).toEqual([
+      // Two open ports → no single-port override.
+      { host: "10.0.0.1", label: "10.0.0.1" },
+      // Exactly one open port → carried as an override.
+      { host: "10.0.0.2", label: "10.0.0.2", port: 22 },
+    ]);
+    // Host with no open port is excluded.
+    expect(out.find((r) => r.host === "10.0.0.3")).toBeUndefined();
+  });
+
+  it("returns no rows when nothing is open", () => {
+    const results: PortScanResult[] = [{ host: "h", port: 22, state: "filtered" }];
+    expect(portScanResultsToRows(results)).toEqual([]);
+  });
+});

--- a/src/services/fleetOnboard.ts
+++ b/src/services/fleetOnboard.ts
@@ -1,0 +1,163 @@
+/**
+ * Pure helpers for **fleet onboarding** (#1961): stamp many saved connections
+ * from one existing connection used as a **template**, sourcing hosts from a CSV
+ * / simple inventory file or from network-scanner results.
+ *
+ * A "template" here is just an existing {@link SavedConnection}: its
+ * `config.type` and `config.config` (shared creds / auth / jump-host chain) are
+ * reused for every host, with only the host (and optional per-row port/username)
+ * and the name overridden. No new persistence concept is introduced — the built
+ * connections go through the same `bulkAddConnections` path as the SSH-config
+ * bulk import, which strips inline secrets before saving.
+ *
+ * Kept side-effect free so the mapping, dedupe, and scan-result conversion are
+ * unit-testable independently of the dialog and store.
+ */
+
+import type { InventoryHost, SavedConnection } from "@/types/connection";
+import type { PingSweepResult, PortScanResult } from "@/types/network";
+import { uniqueConnectionName } from "@/services/sshConfigImport";
+
+/** The result of building templated connections from inventory rows. */
+export interface FleetBuildResult {
+  /** The connections to persist (one per non-deduped, valid row). */
+  connections: SavedConnection[];
+  /**
+   * Rows skipped as duplicates of an existing connection in the target folder
+   * (only when dedupe is enabled). Reported so the UI can tell the user.
+   */
+  skipped: InventoryHost[];
+}
+
+/** Options controlling how a fleet is built. */
+export interface FleetBuildOptions {
+  /**
+   * When `true` (the default), a row whose host already has a connection of the
+   * template's type in the target folder is skipped rather than duplicated.
+   */
+  dedupe?: boolean;
+}
+
+/**
+ * Deep-clone the template's type-specific settings so each built connection owns
+ * an independent copy (mutating one host's port must not touch the others').
+ */
+function cloneSettings(settings: Record<string, unknown>): Record<string, unknown> {
+  return structuredClone(settings);
+}
+
+/**
+ * The dedupe key for a connection under a template: its `host` setting, lowercased.
+ * Connections created from a template all share the template's type, so the host
+ * alone distinguishes them within a folder.
+ */
+function hostKey(settings: Record<string, unknown>): string | null {
+  const host = settings.host;
+  return typeof host === "string" && host.trim() !== "" ? host.trim().toLowerCase() : null;
+}
+
+/**
+ * Build one {@link SavedConnection} per inventory row from `template`, placed in
+ * `folderId` (`null` = root).
+ *
+ * Each connection reuses the template's type and settings, overriding `host`
+ * (and, when the row provides them, `port`/`username`). Names start from the
+ * row's `label` and are made unique within the target folder — collisions
+ * resolve against both the connections already there and the names assigned
+ * earlier in this same batch. With `dedupe` on (default), a row whose host is
+ * already present in the folder is skipped instead of duplicated.
+ */
+export function buildTemplatedConnections(
+  rows: InventoryHost[],
+  template: SavedConnection,
+  folderId: string | null,
+  existingConnections: SavedConnection[],
+  options: FleetBuildOptions = {}
+): FleetBuildResult {
+  const dedupe = options.dedupe ?? true;
+  const target = folderId ?? null;
+  const inFolder = existingConnections.filter((c) => (c.folderId ?? null) === target);
+
+  const takenNames = new Set(inFolder.map((c) => c.name));
+  const existingHosts = new Set(
+    inFolder
+      .filter((c) => c.config.type === template.config.type)
+      .map((c) => hostKey(c.config.config))
+      .filter((k): k is string => k !== null)
+  );
+
+  const connections: SavedConnection[] = [];
+  const skipped: InventoryHost[] = [];
+  const now = Date.now();
+  let created = 0;
+
+  rows.forEach((row) => {
+    const host = row.host.trim();
+    if (host === "") return;
+
+    const key = host.toLowerCase();
+    if (dedupe && existingHosts.has(key)) {
+      skipped.push(row);
+      return;
+    }
+    // Guard against duplicate hosts *within* the same batch too.
+    existingHosts.add(key);
+
+    const settings = cloneSettings(template.config.config);
+    settings.host = host;
+    if (row.port !== undefined) settings.port = row.port;
+    if (row.username !== undefined && row.username !== "") settings.username = row.username;
+
+    const baseName = row.label.trim() !== "" ? row.label.trim() : host;
+    const name = uniqueConnectionName(baseName, takenNames);
+    takenNames.add(name);
+
+    connections.push({
+      id: `conn-${now}-${created}`,
+      name,
+      config: { type: template.config.type, config: settings },
+      folderId: target,
+      ...(template.icon ? { icon: template.icon } : {}),
+      ...(template.terminalOptions ? { terminalOptions: template.terminalOptions } : {}),
+    });
+    created += 1;
+  });
+
+  return { connections, skipped };
+}
+
+/**
+ * Map ping-sweep results (responding hosts) to inventory rows. The reverse-DNS
+ * `hostname`, when present, becomes the label so the created connections read
+ * better than a bare IP; otherwise the address is used.
+ */
+export function pingSweepResultsToRows(results: PingSweepResult[]): InventoryHost[] {
+  return results.map((r) => ({
+    host: r.host,
+    label: r.hostname && r.hostname.trim() !== "" ? r.hostname : r.host,
+  }));
+}
+
+/**
+ * Map port-scan results to inventory rows. A scan can report several open ports
+ * for one host; this collapses them to one row per host, and — when every open
+ * port for a host is the same single port — carries that port as a per-row
+ * override so the created connection targets it.
+ */
+export function portScanResultsToRows(results: PortScanResult[]): InventoryHost[] {
+  const openByHost = new Map<string, Set<number>>();
+  const order: string[] = [];
+  for (const r of results) {
+    if (r.state !== "open") continue;
+    if (!openByHost.has(r.host)) {
+      openByHost.set(r.host, new Set());
+      order.push(r.host);
+    }
+    openByHost.get(r.host)!.add(r.port);
+  }
+  return order.map((host) => {
+    const ports = openByHost.get(host)!;
+    const port = ports.size === 1 ? [...ports][0] : undefined;
+    return { host, label: host, ...(port !== undefined ? { port } : {}) };
+  });
+}

--- a/src/services/fleetOnboard.ts
+++ b/src/services/fleetOnboard.ts
@@ -15,8 +15,20 @@
  */
 
 import type { InventoryHost, SavedConnection } from "@/types/connection";
-import type { PingSweepResult, PortScanResult } from "@/types/network";
 import { uniqueConnectionName } from "@/services/sshConfigImport";
+
+/** Minimal ping-sweep row this module needs (a responding host). */
+export interface SweepHost {
+  host: string;
+  hostname?: string;
+}
+
+/** Minimal port-scan row this module needs (a probed host/port and its state). */
+export interface ScannedPort {
+  host: string;
+  port: number;
+  state: string;
+}
 
 /** The result of building templated connections from inventory rows. */
 export interface FleetBuildResult {
@@ -131,7 +143,7 @@ export function buildTemplatedConnections(
  * `hostname`, when present, becomes the label so the created connections read
  * better than a bare IP; otherwise the address is used.
  */
-export function pingSweepResultsToRows(results: PingSweepResult[]): InventoryHost[] {
+export function pingSweepResultsToRows(results: SweepHost[]): InventoryHost[] {
   return results.map((r) => ({
     host: r.host,
     label: r.hostname && r.hostname.trim() !== "" ? r.hostname : r.host,
@@ -144,7 +156,7 @@ export function pingSweepResultsToRows(results: PingSweepResult[]): InventoryHos
  * port for a host is the same single port — carries that port as a per-row
  * override so the created connection targets it.
  */
-export function portScanResultsToRows(results: PortScanResult[]): InventoryHost[] {
+export function portScanResultsToRows(results: ScannedPort[]): InventoryHost[] {
   const openByHost = new Map<string, Set<number>>();
   const order: string[] = [];
   for (const r of results) {

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -164,6 +164,23 @@ export interface SshConfigImportConnection {
   proxyJump: JumpHostConfig[];
 }
 
+/**
+ * One host parsed from a CSV / simple inventory file (#1961), offered to the
+ * fleet-onboard flow to stamp onto a chosen connection template.
+ *
+ * Mirrors the Rust `InventoryHost` (`commands/inventory_import.rs`). `label` is
+ * the created connection's display name (defaults to `host` when the file gives
+ * none); `port`/`username` are optional per-host overrides — `undefined` means
+ * "inherit the template's value". The same shape also carries scan-result hosts
+ * into the flow, so ping-sweep / port-scanner rows reuse one code path.
+ */
+export interface InventoryHost {
+  label: string;
+  host: string;
+  port?: number;
+  username?: string;
+}
+
 export type ConnectionTreeItem =
   | { type: "folder"; folder: ConnectionFolder }
   | { type: "connection"; connection: SavedConnection };


### PR DESCRIPTION
## Summary

Onboarding a site of many hosts no longer means hand-typing a connection
editor per host. This adds **fleet onboarding**: stamp N saved connections
from one existing connection used as a **template** (shared type / creds /
auth / jump-host chain), sourcing the hosts from either a CSV / simple
inventory file or the network scanner results.

Closes #1961.

## What's included

- **Backend inventory parser** (`import_inventory_hosts`, `commands/inventory_import.rs`):
  parse a CSV / simple inventory file into importable host rows (`label`,
  `host`, optional `port`/`username`) via the `csv` crate. Accepts a
  named-header layout (`host`/`hostname`/`address`/`ip`, `label`/`name`,
  `port`, `user`/`username`, any order), a positional header-less layout, and
  a plain host-per-line list; comment/blank/host-less rows are skipped.
- **Template-application service** (`services/fleetOnboard.ts`):
  `buildTemplatedConnections` clones a chosen connection's type + settings,
  overrides host (and per-row port/username), lands the results in a folder,
  and dedupes by host (folder-scoped, case-insensitive) and by name.
  Plus scan-result mappers for ping sweep and port scan.
- **FleetOnboardDialog**: pick a template connection, a target folder, and a
  skip-existing toggle; preview the hosts; persist via `bulkAddConnections`.
- **Entry points**: an "Onboard hosts from a CSV / inventory" action in the
  connection list (file picker -> parser), and an "Add as connections" action
  on the Ping Sweep and Port Scanner results.

## Tests

- Rust unit tests for the inventory parser (header mapping / reorder / alias,
  positional fallback, host-per-line, comments, quoting, whitespace trim,
  malformed-port degradation, missing file).
- Frontend unit tests for template application (CSV rows -> N connections,
  per-host override isolation, folder targeting, name + host dedupe, batch
  dedupe, scan-result conversion) and for the dialog (bulk-add on confirm,
  no-template empty state, skip-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)