### PR TITLE
feat(terminal): broadcast-input foundation — store state, actions, and onData fan-out

### DIFF
--- a/docs/changes/dev5/feat/1955-broadcast-foundation.md
+++ b/docs/changes/dev5/feat/1955-broadcast-foundation.md
@@ -1,0 +1,10 @@
+### Added
+
+- Broadcast input (foundation): a new **Broadcast Input** toggle (Radio icon) in
+  the terminal-view toolbar mirrors typed input from the active terminal to every
+  other connected terminal in real time. Click once to start (all-terminals
+  scope), click again to stop; closing the source tab also ends broadcast. Only
+  connected terminal sessions receive the input — disconnected, connecting, and
+  non-terminal tabs are skipped silently. This is the base for the scope
+  dropdown, visual indicators, and keyboard shortcut that follow (#1955,
+  epic #1954).

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -312,6 +312,7 @@ export function Terminal({
   const {
     register,
     unregister,
+    getSessionId,
     registerSession,
     unregisterSession,
     copySelectionToClipboard,
@@ -754,7 +755,25 @@ export function Terminal({
         // Send user input to backend
         const onDataDisposable = xterm.onData((data) => {
           lastInputTimeRef.current = Date.now();
-          if (sessionIdRef.current) {
+          const store = useAppStore.getState();
+          // Broadcast fan-out (#1955): when this terminal is the active
+          // broadcast source, mirror typed input to every connected target
+          // session instead of only this one. The source tab is included in the
+          // target set, so the loop is uniform (no separate self-send).
+          // Non-source terminals and the inactive state fall through to the
+          // normal single-session path below. Paste flows through onData too, so
+          // it is broadcast like typed input.
+          if (store.broadcastActive && store.broadcastSourceTabId === tabId) {
+            for (const targetTabId of store.getBroadcastTargetTabIds()) {
+              const targetSessionId = getSessionId(targetTabId);
+              // Fire-and-forget, dispatched in parallel; line-ending
+              // translation happens in the backend send_input choke point.
+              if (targetSessionId) sendInput(targetSessionId, data);
+            }
+            // Tap the input stream for macro recording (#1674) once, for the
+            // source's keystrokes only. No-op unless a recording is active.
+            store.recordMacroInput(data);
+          } else if (sessionIdRef.current) {
             // Line-ending translation (Enter / paste) happens in the backend
             // send_input choke point using the session's configured ending.
             sendInput(sessionIdRef.current, data);
@@ -762,7 +781,7 @@ export function Terminal({
             // single point where user-typed bytes flow to the PTY, so it
             // captures input only (never terminal output). No-op unless a
             // recording is active — the store guards on the recording flag.
-            useAppStore.getState().recordMacroInput(data);
+            store.recordMacroInput(data);
           }
         });
 
@@ -855,7 +874,7 @@ export function Terminal({
     // captured at mount time and must not trigger re-setup when the store writes
     // the session ID back after creation (which would blank the terminal).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [config, tabId, registerSession, unregisterSession]
+    [config, tabId, getSessionId, registerSession, unregisterSession]
   );
 
   // Resolve the effective highlighting state for this terminal and apply it to

--- a/src/components/Terminal/TerminalRegistry.tsx
+++ b/src/components/Terminal/TerminalRegistry.tsx
@@ -70,6 +70,13 @@ interface TerminalRegistryContextType {
   clearTerminalSelection: (tabId: string) => void;
   /** Copy the current text selection to the clipboard (no-op if nothing selected). */
   copySelectionToClipboard: (tabId: string) => Promise<void>;
+  /**
+   * Resolve a tab's live backend session ID, or `undefined` when no session is
+   * registered for the tab. Stable accessor over the internal `tabId → sessionId`
+   * map; used by the broadcast-input fan-out (#1955) to dispatch typed input to
+   * every target session.
+   */
+  getSessionId: (tabId: string) => SessionId | undefined;
   /** Associate a backend session ID with a tab for paste support. */
   registerSession: (tabId: string, sessionId: SessionId) => void;
   /** Remove the session ID association for a tab. */
@@ -305,6 +312,10 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
     [getTerminalSelection]
   );
 
+  const getSessionId = useCallback((tabId: string): SessionId | undefined => {
+    return sessionRegistryRef.current.get(tabId);
+  }, []);
+
   const registerSession = useCallback((tabId: string, sessionId: SessionId) => {
     sessionRegistryRef.current.set(tabId, sessionId);
     useAppStore.getState().setTabSessionId(tabId, sessionId);
@@ -401,6 +412,7 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
       getTerminalSelection,
       clearTerminalSelection,
       copySelectionToClipboard,
+      getSessionId,
       registerSession,
       unregisterSession,
       pasteToTerminal,
@@ -427,6 +439,7 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
       getTerminalSelection,
       clearTerminalSelection,
       copySelectionToClipboard,
+      getSessionId,
       registerSession,
       unregisterSession,
       pasteToTerminal,

--- a/src/components/Terminal/TerminalView.css
+++ b/src/components/Terminal/TerminalView.css
@@ -32,6 +32,13 @@
   color: var(--text-primary);
 }
 
+/* Active-broadcast indicator: the broadcast toggle takes the accent color while
+   typed input is being mirrored to every target terminal (#1955). */
+.ui-btn.terminal-view__toolbar-action--broadcast,
+.ui-btn.terminal-view__toolbar-action--broadcast:hover {
+  color: var(--accent-color);
+}
+
 /* Active-recording indicator: the record button turns the error/red accent and
    gently pulses so the user always knows input is being captured (#1674). */
 .ui-btn.terminal-view__toolbar-action--recording,

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
-import { Plus, Columns2, Rows2, X, PanelLeft, Circle, Square, Play } from "lucide-react";
+import { Plus, Columns2, Rows2, X, PanelLeft, Circle, Square, Play, Radio } from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
-import { useAppStore } from "@/store/appStore";
+import { toast } from "sonner";
+import { useAppStore, getActiveTab } from "@/store/appStore";
 import { TerminalTab } from "@/types/terminal";
 import { getAllLeaves } from "@/utils/panelTree";
 import { countLiveSessions } from "@/utils/tabLiveSession";
@@ -253,6 +254,9 @@ export function TerminalView() {
   const macroRecordingStepCount = useAppStore((s) => s.macroRecordingSteps.length);
   const saveRecordedMacro = useAppStore((s) => s.saveRecordedMacro);
   const discardRecordedMacro = useAppStore((s) => s.discardRecordedMacro);
+  const broadcastActive = useAppStore((s) => s.broadcastActive);
+  const startBroadcast = useAppStore((s) => s.startBroadcast);
+  const stopBroadcast = useAppStore((s) => s.stopBroadcast);
   const macros = useAppStore((s) => s.macros);
   const macroPlayback = useAppStore((s) => s.macroPlayback);
   const playMacro = useAppStore((s) => s.playMacro);
@@ -265,6 +269,29 @@ export function TerminalView() {
 
   const handleNewTerminal = () => {
     addTab("Terminal", "local");
+  };
+
+  // Minimal broadcast toggle (#1955): activates the "all terminals" scope
+  // directly (no scope dropdown yet — that is the #1956 follow-up) and toggles
+  // off on the second click. The source is the active terminal tab; every
+  // terminal tab in the current group is a target (the source included, so the
+  // fan-out loop stays uniform). Connected-only filtering happens at the seam.
+  const handleToggleBroadcast = () => {
+    if (broadcastActive) {
+      stopBroadcast();
+      return;
+    }
+    const state = useAppStore.getState();
+    const source = getActiveTab(state);
+    if (!source || source.contentType !== "terminal") {
+      toast.info("Focus a terminal to start broadcasting input");
+      return;
+    }
+    const terminalTabIds = getAllLeaves(state.rootPanel)
+      .flatMap((leaf) => leaf.tabs)
+      .filter((tab) => tab.contentType === "terminal")
+      .map((tab) => tab.id);
+    startBroadcast("all", source.id, terminalTabIds);
   };
 
   const handleSplitHorizontal = () => {
@@ -305,6 +332,24 @@ export function TerminalView() {
         <div className="terminal-view__toolbar">
           <TabGroupChips />
           <div className="terminal-view__toolbar-actions">
+            <Tooltip
+              content={broadcastActive ? "Stop Broadcast" : "Broadcast Input"}
+              side="bottom"
+            >
+              <Button
+                variant="ghost"
+                size="sm"
+                iconOnly
+                className={
+                  broadcastActive ? "terminal-view__toolbar-action--broadcast" : undefined
+                }
+                icon={<Radio size={16} />}
+                onClick={handleToggleBroadcast}
+                aria-label={broadcastActive ? "Stop Broadcast" : "Broadcast Input"}
+                aria-pressed={broadcastActive}
+                data-testid="terminal-view-broadcast"
+              />
+            </Tooltip>
             <Tooltip content="New Terminal" side="bottom">
               <Button
                 variant="ghost"

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -332,17 +332,12 @@ export function TerminalView() {
         <div className="terminal-view__toolbar">
           <TabGroupChips />
           <div className="terminal-view__toolbar-actions">
-            <Tooltip
-              content={broadcastActive ? "Stop Broadcast" : "Broadcast Input"}
-              side="bottom"
-            >
+            <Tooltip content={broadcastActive ? "Stop Broadcast" : "Broadcast Input"} side="bottom">
               <Button
                 variant="ghost"
                 size="sm"
                 iconOnly
-                className={
-                  broadcastActive ? "terminal-view__toolbar-action--broadcast" : undefined
-                }
+                className={broadcastActive ? "terminal-view__toolbar-action--broadcast" : undefined}
                 icon={<Radio size={16} />}
                 onClick={handleToggleBroadcast}
                 aria-label={broadcastActive ? "Stop Broadcast" : "Broadcast Input"}

--- a/src/store/appStore.broadcast.test.ts
+++ b/src/store/appStore.broadcast.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for the broadcast-input Zustand slice (#1955).
+ *
+ * Pins the store foundation for broadcast input: the start/stop/add/remove/
+ * isTarget actions, the connected-only target resolution the `onData` fan-out
+ * relies on (`getBroadcastTargetTabIds`), the source-inclusion invariant, and
+ * the source-close teardown wired into `closeTab`.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// The store pulls in the full service graph on import; stub the modules with
+// side effects at load time (mirrors the sibling macro-slice suites).
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+import { useAppStore } from "./appStore";
+import type { LeafPanel, TerminalTab, TabContentType } from "@/types/terminal";
+
+interface SeedTab {
+  id: string;
+  contentType?: TabContentType;
+  sessionId?: string | null;
+}
+
+/** Build a terminal-ish tab with sensible defaults for the broadcast tests. */
+function makeTab({ id, contentType = "terminal", sessionId = `sess-${id}` }: SeedTab): TerminalTab {
+  return {
+    id,
+    sessionId,
+    title: id,
+    connectionType: "local",
+    contentType,
+    config: { type: "local", config: {} },
+    panelId: "leaf-1",
+    isActive: id === "src",
+  };
+}
+
+/** Seed a single leaf panel holding the given tabs as the active tab group. */
+function seedTabs(tabs: TerminalTab[], activeTabId = tabs[0]?.id ?? null) {
+  const leaf: LeafPanel = { type: "leaf", id: "leaf-1", tabs, activeTabId };
+  useAppStore.setState({ rootPanel: leaf, activePanelId: "leaf-1" });
+}
+
+describe("appStore — broadcast input slice (#1955)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  it("starts inactive with the default 'all' scope and empty target set", () => {
+    const s = useAppStore.getState();
+    expect(s.broadcastActive).toBe(false);
+    expect(s.broadcastSourceTabId).toBeNull();
+    expect(s.broadcastScope).toBe("all");
+    expect(s.lastBroadcastScope).toBe("all");
+    expect(s.broadcastTargetTabIds.size).toBe(0);
+  });
+
+  it("startBroadcast activates, sets source/scope, and includes the source as a target", () => {
+    useAppStore.getState().startBroadcast("all", "src", ["t2", "t3"]);
+
+    const s = useAppStore.getState();
+    expect(s.broadcastActive).toBe(true);
+    expect(s.broadcastSourceTabId).toBe("src");
+    expect(s.broadcastScope).toBe("all");
+    expect(s.lastBroadcastScope).toBe("all");
+    // Source is just another target — the fan-out loop stays uniform.
+    expect([...s.broadcastTargetTabIds].sort()).toEqual(["src", "t2", "t3"]);
+  });
+
+  it("stopBroadcast clears active/source/targets", () => {
+    useAppStore.getState().startBroadcast("all", "src", ["t2"]);
+    useAppStore.getState().stopBroadcast();
+
+    const s = useAppStore.getState();
+    expect(s.broadcastActive).toBe(false);
+    expect(s.broadcastSourceTabId).toBeNull();
+    expect(s.broadcastTargetTabIds.size).toBe(0);
+  });
+
+  it("remembers the last scope after stopping (for the shortcut toggle)", () => {
+    useAppStore.getState().startBroadcast("panel", "src", []);
+    useAppStore.getState().stopBroadcast();
+    expect(useAppStore.getState().lastBroadcastScope).toBe("panel");
+  });
+
+  it("add/remove/isBroadcastTarget mutate the target set", () => {
+    const store = useAppStore.getState();
+    store.startBroadcast("all", "src", []);
+
+    expect(useAppStore.getState().isBroadcastTarget("t2")).toBe(false);
+    store.addBroadcastTarget("t2");
+    expect(useAppStore.getState().isBroadcastTarget("t2")).toBe(true);
+    expect(useAppStore.getState().broadcastTargetTabIds.has("src")).toBe(true);
+
+    store.removeBroadcastTarget("t2");
+    expect(useAppStore.getState().isBroadcastTarget("t2")).toBe(false);
+  });
+
+  it("addBroadcastTarget is idempotent (no duplicate, no needless replacement)", () => {
+    const store = useAppStore.getState();
+    store.startBroadcast("all", "src", ["t2"]);
+    const before = useAppStore.getState().broadcastTargetTabIds;
+    store.addBroadcastTarget("t2");
+    // No-op returns the same Set reference (guards against needless re-renders).
+    expect(useAppStore.getState().broadcastTargetTabIds).toBe(before);
+    expect(useAppStore.getState().broadcastTargetTabIds.size).toBe(2);
+  });
+
+  describe("getBroadcastTargetTabIds — connected-only filtering", () => {
+    it("returns [] when broadcast is inactive", () => {
+      seedTabs([makeTab({ id: "src" })]);
+      expect(useAppStore.getState().getBroadcastTargetTabIds()).toEqual([]);
+    });
+
+    it("keeps only connected terminal targets, dropping the rest silently", () => {
+      seedTabs([
+        makeTab({ id: "src" }), // connected terminal
+        makeTab({ id: "t2" }), // connected terminal
+        makeTab({ id: "t3" }), // terminal but exited
+        makeTab({ id: "t4" }), // terminal but connecting
+        makeTab({ id: "t5", contentType: "editor" }), // non-terminal tab
+        makeTab({ id: "t6", sessionId: null }), // terminal without a live session
+      ]);
+      useAppStore.setState({
+        terminalExitedTabs: { t3: true },
+        terminalConnecting: { t4: true },
+      });
+      useAppStore
+        .getState()
+        .startBroadcast("all", "src", ["t2", "t3", "t4", "t5", "t6"]);
+
+      const result = useAppStore.getState().getBroadcastTargetTabIds().sort();
+      expect(result).toEqual(["src", "t2"]);
+    });
+
+    it("drops a target whose tab no longer exists", () => {
+      seedTabs([makeTab({ id: "src" }), makeTab({ id: "t2" })]);
+      useAppStore.getState().startBroadcast("all", "src", ["t2", "ghost"]);
+      expect(useAppStore.getState().getBroadcastTargetTabIds().sort()).toEqual(["src", "t2"]);
+    });
+
+    it("skips a target that later fails (spawn error)", () => {
+      seedTabs([makeTab({ id: "src" }), makeTab({ id: "t2" })]);
+      useAppStore.getState().startBroadcast("all", "src", ["t2"]);
+      expect(useAppStore.getState().getBroadcastTargetTabIds().sort()).toEqual(["src", "t2"]);
+
+      useAppStore.setState({ terminalSpawnErrors: { t2: "boom" } });
+      expect(useAppStore.getState().getBroadcastTargetTabIds()).toEqual(["src"]);
+    });
+  });
+
+  describe("onData routing decision (source vs non-source vs inactive)", () => {
+    // The fan-out branch in Terminal.tsx broadcasts iff broadcast is active AND
+    // this terminal is the source; every other case falls through to the normal
+    // single-session send. This mirrors that predicate against store state.
+    const shouldBroadcast = (tabId: string) => {
+      const s = useAppStore.getState();
+      return s.broadcastActive && s.broadcastSourceTabId === tabId;
+    };
+
+    beforeEach(() => {
+      seedTabs([makeTab({ id: "src" }), makeTab({ id: "t2" })]);
+    });
+
+    it("the source broadcasts to all connected targets", () => {
+      useAppStore.getState().startBroadcast("all", "src", ["t2"]);
+      expect(shouldBroadcast("src")).toBe(true);
+      expect(useAppStore.getState().getBroadcastTargetTabIds().sort()).toEqual(["src", "t2"]);
+    });
+
+    it("a non-source terminal falls through to single-session input", () => {
+      useAppStore.getState().startBroadcast("all", "src", ["t2"]);
+      expect(shouldBroadcast("t2")).toBe(false);
+    });
+
+    it("no terminal broadcasts while inactive", () => {
+      expect(shouldBroadcast("src")).toBe(false);
+      expect(shouldBroadcast("t2")).toBe(false);
+    });
+  });
+
+  describe("closeTab teardown", () => {
+    it("closing the source tab ends broadcast entirely", () => {
+      // sessionId null avoids the backend session-release path in closeTab.
+      seedTabs([
+        makeTab({ id: "src", sessionId: null }),
+        makeTab({ id: "t2", sessionId: null }),
+      ]);
+      useAppStore.getState().startBroadcast("all", "src", ["t2"]);
+
+      useAppStore.getState().closeTab("src", "leaf-1");
+
+      const s = useAppStore.getState();
+      expect(s.broadcastActive).toBe(false);
+      expect(s.broadcastSourceTabId).toBeNull();
+      expect(s.broadcastTargetTabIds.size).toBe(0);
+    });
+
+    it("closing a plain target drops it from the set but keeps broadcast active", () => {
+      seedTabs([
+        makeTab({ id: "src", sessionId: null }),
+        makeTab({ id: "t2", sessionId: null }),
+      ]);
+      useAppStore.getState().startBroadcast("all", "src", ["t2"]);
+
+      useAppStore.getState().closeTab("t2", "leaf-1");
+
+      const s = useAppStore.getState();
+      expect(s.broadcastActive).toBe(true);
+      expect(s.broadcastSourceTabId).toBe("src");
+      expect(s.broadcastTargetTabIds.has("t2")).toBe(false);
+      expect(s.broadcastTargetTabIds.has("src")).toBe(true);
+    });
+  });
+});

--- a/src/store/appStore.broadcast.test.ts
+++ b/src/store/appStore.broadcast.test.ts
@@ -150,9 +150,7 @@ describe("appStore — broadcast input slice (#1955)", () => {
         terminalExitedTabs: { t3: true },
         terminalConnecting: { t4: true },
       });
-      useAppStore
-        .getState()
-        .startBroadcast("all", "src", ["t2", "t3", "t4", "t5", "t6"]);
+      useAppStore.getState().startBroadcast("all", "src", ["t2", "t3", "t4", "t5", "t6"]);
 
       const result = useAppStore.getState().getBroadcastTargetTabIds().sort();
       expect(result).toEqual(["src", "t2"]);
@@ -207,10 +205,7 @@ describe("appStore — broadcast input slice (#1955)", () => {
   describe("closeTab teardown", () => {
     it("closing the source tab ends broadcast entirely", () => {
       // sessionId null avoids the backend session-release path in closeTab.
-      seedTabs([
-        makeTab({ id: "src", sessionId: null }),
-        makeTab({ id: "t2", sessionId: null }),
-      ]);
+      seedTabs([makeTab({ id: "src", sessionId: null }), makeTab({ id: "t2", sessionId: null })]);
       useAppStore.getState().startBroadcast("all", "src", ["t2"]);
 
       useAppStore.getState().closeTab("src", "leaf-1");
@@ -222,10 +217,7 @@ describe("appStore — broadcast input slice (#1955)", () => {
     });
 
     it("closing a plain target drops it from the set but keeps broadcast active", () => {
-      seedTabs([
-        makeTab({ id: "src", sessionId: null }),
-        makeTab({ id: "t2", sessionId: null }),
-      ]);
+      seedTabs([makeTab({ id: "src", sessionId: null }), makeTab({ id: "t2", sessionId: null })]);
       useAppStore.getState().startBroadcast("all", "src", ["t2"]);
 
       useAppStore.getState().closeTab("t2", "leaf-1");

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -20,6 +20,7 @@ import {
   TabGroup,
   TerminalExitInfo,
   SessionCloseConfirmRequest,
+  BroadcastScope,
 } from "@/types/terminal";
 import type { HttpMonitorState } from "@/types/network";
 import {
@@ -68,6 +69,7 @@ import {
 } from "@/services/sessionHistoryApi";
 import { SessionHistoryEntry } from "@/types/sessionHistory";
 import { sessionHistoryTitle } from "@/utils/sessionHistoryTitle";
+import { deriveTabStatus, type TabStatusMaps } from "@/utils/tabStatus";
 import {
   sftpOpen,
   sftpClose,
@@ -1442,6 +1444,36 @@ interface AppState {
   playMacro: (macroId: string, opts?: PlayMacroOptions) => Promise<void>;
   /** Cancel the in-flight macro playback, if any. Idempotent. */
   cancelMacroPlayback: () => void;
+
+  // Broadcast input (#1955) — mirror typed input from a source terminal to many.
+  /** Whether broadcast mode is currently active. */
+  broadcastActive: boolean;
+  /** The tab ID of the source terminal (where the user types). */
+  broadcastSourceTabId: string | null;
+  /** The scope used for the current broadcast session. */
+  broadcastScope: BroadcastScope;
+  /** Set of tab IDs that are broadcast targets (includes the source). */
+  broadcastTargetTabIds: Set<string>;
+  /** Last used scope, retained for the keyboard-shortcut toggle (#1958). */
+  lastBroadcastScope: BroadcastScope;
+  /** Enter broadcast mode with the given scope, source tab, and target tabs. */
+  startBroadcast: (scope: BroadcastScope, sourceTabId: string, targetTabIds: string[]) => void;
+  /** Leave broadcast mode and clear the source/target selection. */
+  stopBroadcast: () => void;
+  /** Add a tab to the broadcast target set (no-op when inactive). */
+  addBroadcastTarget: (tabId: string) => void;
+  /** Remove a tab from the broadcast target set. */
+  removeBroadcastTarget: (tabId: string) => void;
+  /** Whether the given tab is currently a broadcast target. */
+  isBroadcastTarget: (tabId: string) => boolean;
+  /**
+   * The subset of {@link broadcastTargetTabIds} that are *connected* terminal
+   * tabs — the tabs the `onData` fan-out should mirror input to. Disconnected,
+   * connecting, and non-terminal tabs are filtered out silently. Returns `[]`
+   * when broadcast is inactive. Resolution of each tab id to a live session id
+   * is done by the terminal registry at the dispatch seam.
+   */
+  getBroadcastTargetTabIds: () => string[];
 
   // Workflows (#1852) — the foundation of the Workflow Automation epic (#1851).
   /** All stored workflows. */
@@ -3920,6 +3952,17 @@ export const useAppStore = create<AppState>((set, get) => {
           ...sftpBrowserReset,
         };
       });
+
+      // Broadcast (#1955): closing the source tab ends broadcast entirely;
+      // closing a plain target silently drops it from the set.
+      const bc = get();
+      if (bc.broadcastActive) {
+        if (bc.broadcastSourceTabId === tabId) {
+          bc.stopBroadcast();
+        } else if (bc.broadcastTargetTabIds.has(tabId)) {
+          bc.removeBroadcastTarget(tabId);
+        }
+      }
     },
 
     setActiveTab: (tabId, panelId) =>
@@ -6873,6 +6916,75 @@ export const useAppStore = create<AppState>((set, get) => {
       if (activeMacroPlayback) {
         activeMacroPlayback.cancel();
       }
+    },
+
+    // Broadcast input (#1955)
+    broadcastActive: false,
+    broadcastSourceTabId: null,
+    broadcastScope: "all",
+    broadcastTargetTabIds: new Set<string>(),
+    lastBroadcastScope: "all",
+
+    startBroadcast: (scope, sourceTabId, targetTabIds) => {
+      set({
+        broadcastActive: true,
+        broadcastScope: scope,
+        lastBroadcastScope: scope,
+        broadcastSourceTabId: sourceTabId,
+        // The source is just another target — keeping the fan-out loop uniform.
+        broadcastTargetTabIds: new Set<string>([sourceTabId, ...targetTabIds]),
+      });
+    },
+
+    stopBroadcast: () => {
+      set({
+        broadcastActive: false,
+        broadcastSourceTabId: null,
+        broadcastTargetTabIds: new Set<string>(),
+      });
+    },
+
+    addBroadcastTarget: (tabId) => {
+      set((state) => {
+        if (state.broadcastTargetTabIds.has(tabId)) return {};
+        const next = new Set(state.broadcastTargetTabIds);
+        next.add(tabId);
+        return { broadcastTargetTabIds: next };
+      });
+    },
+
+    removeBroadcastTarget: (tabId) => {
+      set((state) => {
+        if (!state.broadcastTargetTabIds.has(tabId)) return {};
+        const next = new Set(state.broadcastTargetTabIds);
+        next.delete(tabId);
+        return { broadcastTargetTabIds: next };
+      });
+    },
+
+    isBroadcastTarget: (tabId) => get().broadcastTargetTabIds.has(tabId),
+
+    getBroadcastTargetTabIds: () => {
+      const state = get();
+      if (!state.broadcastActive) return [];
+      const statusMaps: TabStatusMaps = {
+        terminalConnecting: state.terminalConnecting,
+        terminalReconnectingTabs: state.terminalReconnectingTabs,
+        terminalSpawnErrors: state.terminalSpawnErrors,
+        terminalDisconnectErrors: state.terminalDisconnectErrors,
+        terminalExitedTabs: state.terminalExitedTabs,
+      };
+      const tabsById = new Map(collectLiveTabs(state).map((t) => [t.id, t]));
+      const result: string[] = [];
+      for (const tabId of state.broadcastTargetTabIds) {
+        const tab = tabsById.get(tabId);
+        // Only connected terminal sessions receive input. Disconnected/
+        // connecting sessions and non-terminal tabs are skipped silently.
+        if (!tab || tab.contentType !== "terminal" || !tab.sessionId) continue;
+        if (deriveTabStatus(statusMaps, tabId) !== "connected") continue;
+        result.push(tabId);
+      }
+      return result;
     },
 
     // Workflows (#1852)

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -278,6 +278,49 @@ export interface ConnectionConfig {
   config: Record<string, unknown>;
 }
 
+/**
+ * Which terminals a broadcast session targets. Only `"all"` is wired up by the
+ * broadcast foundation (#1955); `"panel"` and `"custom"` are reserved for the
+ * scope-selection follow-up (#1956).
+ */
+export type BroadcastScope = "all" | "panel" | "custom";
+
+/**
+ * Broadcast-input state (#1955). When {@link BroadcastState.broadcastActive} is
+ * set, typed input in the source terminal is mirrored to every connected target
+ * session. The source tab is itself included in `broadcastTargetTabIds`, so the
+ * fan-out loop treats it as just another target.
+ */
+export interface BroadcastState {
+  /** Whether broadcast mode is currently active. */
+  broadcastActive: boolean;
+  /** The tab ID of the terminal where the user types (source of input). */
+  broadcastSourceTabId: string | null;
+  /** The scope used for the current broadcast session. */
+  broadcastScope: BroadcastScope;
+  /** Set of tab IDs that are broadcast targets (includes the source). */
+  broadcastTargetTabIds: Set<string>;
+  /** Last used scope, retained for the keyboard-shortcut toggle (#1958). */
+  lastBroadcastScope: BroadcastScope;
+}
+
+/**
+ * Broadcast-input actions (#1955). Mutate {@link BroadcastState}; the input
+ * fan-out itself lives at the `xterm.onData` seam in `Terminal.tsx`.
+ */
+export interface BroadcastActions {
+  /** Enter broadcast mode with the given scope, source tab, and target tabs. */
+  startBroadcast: (scope: BroadcastScope, sourceTabId: string, targetTabIds: string[]) => void;
+  /** Leave broadcast mode and clear the source/target selection. */
+  stopBroadcast: () => void;
+  /** Add a tab to the broadcast target set (no-op when inactive). */
+  addBroadcastTarget: (tabId: string) => void;
+  /** Remove a tab from the broadcast target set. */
+  removeBroadcastTarget: (tabId: string) => void;
+  /** Whether the given tab is currently a broadcast target. */
+  isBroadcastTarget: (tabId: string) => boolean;
+}
+
 export interface TerminalTab {
   id: string;
   sessionId: SessionId | null;


### PR DESCRIPTION
## Summary

Part 1 of 4 for broadcast input (epic #1954). Establishes the core plumbing so
typed input in a **source** terminal is mirrored to every connected **target**
session, plus a minimal toolbar toggle to enter/exit the mode. No scope
dropdown, visual polish, or shortcut yet — those build on this foundation
(#1956/#1957/#1958).

Concept (source of truth): `docs/concepts/backlog/broadcast-input.html`.

## What changed

- **Store (`appStore.ts`)** — broadcast slice: `broadcastActive`,
  `broadcastSourceTabId`, `broadcastScope`, `broadcastTargetTabIds` (Set),
  `lastBroadcastScope`; actions `startBroadcast` / `stopBroadcast` /
  `addBroadcastTarget` / `removeBroadcastTarget` / `isBroadcastTarget`; and
  `getBroadcastTargetTabIds()`, which resolves the connected-only target set the
  fan-out mirrors to (disconnected/connecting/non-terminal/session-less tabs are
  filtered out silently via `deriveTabStatus`). The source tab is included in the
  target set so the fan-out loop stays uniform.
- **Types (`types/terminal.ts`)** — `BroadcastScope` union plus `BroadcastState`
  / `BroadcastActions` interfaces.
- **Registry (`TerminalRegistry.tsx`)** — a stable `getSessionId(tabId)` accessor
  over the existing `tabId → sessionId` map, used at the dispatch seam to resolve
  each target to a live session.
- **Fan-out (`Terminal.tsx`, ~onData seam)** — when `broadcastActive` and this
  terminal is the source, typed input is dispatched (fire-and-forget) to every
  connected target session; otherwise the existing single-session path (and the
  macro-recording tap) is unchanged. Paste flows through `onData`, so it is
  broadcast like typed input.
- **Toolbar (`TerminalView.tsx`)** — a minimal **Broadcast** toggle (lucide
  `Radio`) left of New/Split. Activates the "all terminals" scope directly and
  toggles off on the second click; guards with a toast when the active tab is not
  a terminal.
- **Source-close ends broadcast** — `closeTab` calls `stopBroadcast()` when the
  source tab closes; closing a plain target silently drops it from the set.

## Tests

- `appStore.broadcast.test.ts` (15 cases): start/stop/add/remove/isTarget, the
  source-inclusion invariant, last-scope memory, connected-only filtering
  (exited/connecting/non-terminal/session-less/missing/spawn-error), the
  `onData` routing decision (source broadcasts; non-source and inactive fall
  through), and the `closeTab` teardown.

Full frontend suite (4327 tests), `pnpm build`, ESLint, and Prettier all green.

## Follow-ups (not in scope)

- #1956 scope dropdown (replaces the minimal toggle), #1957 visual indicators,
  #1958 keyboard shortcut.

Closes #1955