### PR TITLE
fix(ssh): verify server host keys (known_hosts / trust-on-first-use) (Closes #1959)

### DIFF
--- a/core/src/backends/ssh/auth.rs
+++ b/core/src/backends/ssh/auth.rs
@@ -130,7 +130,11 @@ where
     // Enable agent-channel bridging on this session only when the connection
     // opted into forwarding (#1699). Jump hops build a minimal config with the
     // default (`false`), so a hop never bridges the agent.
-    let (handler, registry, liveness) = TermiHubHandler::new_with_forwarding(config.forward_agent);
+    let (handler, registry, liveness) = TermiHubHandler::new_with_forwarding(
+        config.host.clone(),
+        config.port,
+        config.forward_agent,
+    );
 
     let mut session = russh::client::connect_stream(russh_config, stream, handler)
         .await

--- a/core/src/backends/ssh/handler.rs
+++ b/core/src/backends/ssh/handler.rs
@@ -168,6 +168,21 @@ impl russh::client::Handler for TermiHubHandler {
         &mut self,
         server_public_key: &russh::keys::PublicKey,
     ) -> Result<bool, Self::Error> {
+        // Respect the user's own `~/.ssh/known_hosts`: a host key already
+        // recorded there is trusted silently, exactly as `ssh` would, so
+        // termiHub does not re-prompt for hosts the user already knows. A
+        // missing file or absent host falls through to the verifier; a
+        // *changed* key there is not auto-accepted (it returns `Err`), so it
+        // also falls through and is caught by the trust store / prompt.
+        if !self.host.is_empty()
+            && matches!(
+                russh::keys::check_known_hosts(&self.host, self.port, server_public_key),
+                Ok(true)
+            )
+        {
+            return Ok(true);
+        }
+
         let info = super::host_key::HostKeyInfo {
             host: self.host.clone(),
             port: self.port,

--- a/core/src/backends/ssh/handler.rs
+++ b/core/src/backends/ssh/handler.rs
@@ -86,21 +86,32 @@ pub struct TermiHubHandler {
     /// forwarding channel that arrives without our opt-in is rejected, so a server
     /// cannot reach the local agent unsolicited.
     forward_agent: bool,
+    /// The host this connection targets, used to key host-key verification
+    /// (#1959). For a jump-host hop it is the hop/target of *that* leg, so each
+    /// hop's key is verified against the right host.
+    host: String,
+    /// The TCP port this connection targets, paired with `host` for host-key
+    /// verification (#1959).
+    port: u16,
 }
 
 impl TermiHubHandler {
     /// Create a new handler together with the shared channel registry and the
     /// session-liveness watch (#1297) the tunnel supervisor observes.
     ///
-    /// Agent forwarding is off; use [`new_with_forwarding`](Self::new_with_forwarding)
-    /// to enable it for a connection that opted in.
+    /// Agent forwarding is off and the target host/port are empty; use
+    /// [`new_with_forwarding`](Self::new_with_forwarding) to set them for a real
+    /// connection. Intended for tests that never reach host-key verification.
     pub fn new() -> (Self, ForwardedChannelRegistry, LivenessWatch) {
-        Self::new_with_forwarding(false)
+        Self::new_with_forwarding(String::new(), 0, false)
     }
 
-    /// Like [`new`](Self::new), but sets whether the session should bridge a
-    /// server-opened agent-forwarding channel to the local `ssh-agent` (#1699).
+    /// Build a handler for a connection to `host:port`, setting whether the
+    /// session should bridge a server-opened agent-forwarding channel to the
+    /// local `ssh-agent` (#1699). `host`/`port` key host-key verification (#1959).
     pub fn new_with_forwarding(
+        host: String,
+        port: u16,
         forward_agent: bool,
     ) -> (Self, ForwardedChannelRegistry, LivenessWatch) {
         let registry: ForwardedChannelRegistry = Arc::new(Mutex::new(HashMap::new()));
@@ -109,6 +120,8 @@ impl TermiHubHandler {
             forwarded_channel_registry: registry.clone(),
             liveness_tx,
             forward_agent,
+            host,
+            port,
         };
         (handler, registry, LivenessWatch { rx: liveness_rx })
     }
@@ -143,18 +156,25 @@ impl russh::client::Handler for TermiHubHandler {
         }
     }
 
-    /// Accept the server's host key without verification.
+    /// Verify the server's host key before completing the handshake (#1959).
     ///
-    /// # Security note
-    /// Proper host-key verification (known-hosts file check) should be
-    /// implemented in a follow-up issue. For now we accept all keys to
-    /// maintain the same behaviour as the previous libssh2 implementation,
-    /// which also did not verify host keys.
+    /// Computes the presented key's SHA-256 fingerprint and delegates the
+    /// trust decision to the process-wide [`HostKeyVerifier`](super::host_key)
+    /// (trust-on-first-use against a persisted store, with an interactive prompt
+    /// for unknown or changed keys). Returning `Ok(false)` aborts the handshake,
+    /// so a man-in-the-middle presenting an untrusted key is rejected instead of
+    /// blindly accepted as it was before this issue.
     async fn check_server_key(
         &mut self,
-        _server_public_key: &russh::keys::PublicKey,
+        server_public_key: &russh::keys::PublicKey,
     ) -> Result<bool, Self::Error> {
-        Ok(true)
+        let info = super::host_key::HostKeyInfo {
+            host: self.host.clone(),
+            port: self.port,
+            key_type: super::host_key::key_algorithm(server_public_key),
+            fingerprint: super::host_key::fingerprint_sha256(server_public_key),
+        };
+        Ok(super::host_key::verify_host_key(&info).await)
     }
 
     /// Route an incoming server-initiated forwarded channel to the registered
@@ -282,7 +302,8 @@ mod tests {
     /// the server's agent channel to the local agent.
     #[test]
     fn forwarding_enabled_when_requested() {
-        let (handler, _registry, _watch) = TermiHubHandler::new_with_forwarding(true);
+        let (handler, _registry, _watch) =
+            TermiHubHandler::new_with_forwarding("host".to_string(), 22, true);
         assert!(handler.forward_agent);
     }
 

--- a/core/src/backends/ssh/host_key.rs
+++ b/core/src/backends/ssh/host_key.rs
@@ -1,0 +1,165 @@
+//! SSH server host-key verification hook (#1959).
+//!
+//! Historically [`TermiHubHandler::check_server_key`](super::handler) accepted
+//! **every** server host key unconditionally — a blind-accept that defeats the
+//! very man-in-the-middle protection SSH exists to provide (worse through a jump
+//! host into an untrusted network). This module replaces that with a pluggable
+//! [`HostKeyVerifier`]: the handler computes the presented key's SHA-256
+//! fingerprint and asks the process-wide verifier whether to trust it.
+//!
+//! ## Why a process-global verifier
+//!
+//! An SSH connect is driven from a dozen call sites (terminal sessions, tunnels,
+//! SFTP, agent deploy, monitoring, jump-host hops). Threading a verifier through
+//! every one of them — and through the serializable [`SshConfig`](crate::config)
+//! — would be invasive and collision-prone. Instead the desktop app registers a
+//! single verifier once at startup via [`set_host_key_verifier`]; the handler
+//! looks it up through [`host_key_verifier`]. The verifier implementation lives
+//! in the host crate (`src-tauri`), which owns the config directory and the UI,
+//! exactly like the RDP certificate trust store it mirrors.
+//!
+//! ## Default (no verifier registered)
+//!
+//! When no verifier is registered — the agent binary, bare-`core` unit tests —
+//! the key is accepted with a warning, preserving the pre-#1959 behaviour so
+//! server-side and headless paths keep working. The security-critical desktop
+//! client always registers a strict trust-on-first-use verifier, so it never
+//! blind-accepts.
+
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use tracing::warn;
+
+/// The SHA-256 fingerprint of a presented host key, in OpenSSH `SHA256:BASE64`
+/// form (e.g. `SHA256:Nh0Me49Zh9fDw/VYUfq43IJmI1T+XrjiYONPND8GzaM`) — the same
+/// string `ssh` prints and a server administrator can read out for comparison.
+pub fn fingerprint_sha256(key: &russh::keys::PublicKey) -> String {
+    key.fingerprint(russh::keys::HashAlg::Sha256).to_string()
+}
+
+/// The host key's algorithm name, e.g. `ssh-ed25519` / `ecdsa-sha2-nistp256`.
+pub fn key_algorithm(key: &russh::keys::PublicKey) -> String {
+    key.algorithm().as_str().to_string()
+}
+
+/// The details of a server host key a [`HostKeyVerifier`] decides whether to
+/// trust.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostKeyInfo {
+    /// The host being connected to (the value from the connection config).
+    pub host: String,
+    /// The TCP port of the SSH server.
+    pub port: u16,
+    /// The key algorithm, e.g. `ssh-ed25519`.
+    pub key_type: String,
+    /// The SHA-256 fingerprint in OpenSSH `SHA256:BASE64` form.
+    pub fingerprint: String,
+}
+
+impl HostKeyInfo {
+    /// The `host:port` key used to index a trust store, matching the RDP store's
+    /// keying (#1767).
+    pub fn host_port(&self) -> String {
+        format!("{}:{}", self.host, self.port)
+    }
+}
+
+/// Decides whether a presented server host key should be trusted (#1959).
+///
+/// Called from the russh handshake on the connecting task; implementations may
+/// block on an interactive user prompt (the whole connect is bounded by
+/// [`SshConfig::connect_timeout`](crate::config::SshConfig::connect_timeout), so
+/// a never-answered prompt fails the connect rather than hanging forever).
+#[async_trait]
+pub trait HostKeyVerifier: Send + Sync {
+    /// Return `true` to accept the key and proceed, `false` to reject and abort
+    /// the connection.
+    async fn verify(&self, info: &HostKeyInfo) -> bool;
+}
+
+/// The process-wide verifier, registered once by the host application.
+static VERIFIER: OnceLock<Arc<dyn HostKeyVerifier>> = OnceLock::new();
+
+/// Register the process-wide host-key verifier. Returns `false` if one was
+/// already registered (first registration wins); the app registers exactly once
+/// at startup.
+pub fn set_host_key_verifier(verifier: Arc<dyn HostKeyVerifier>) -> bool {
+    VERIFIER.set(verifier).is_ok()
+}
+
+/// The registered verifier, or `None` when none has been set (agent / tests).
+pub fn host_key_verifier() -> Option<Arc<dyn HostKeyVerifier>> {
+    VERIFIER.get().cloned()
+}
+
+/// Decide whether to accept a presented host key.
+///
+/// Delegates to the registered [`HostKeyVerifier`]; with none registered the key
+/// is accepted with a warning, preserving pre-#1959 behaviour for headless paths
+/// (see the module docs).
+pub(crate) async fn verify_host_key(info: &HostKeyInfo) -> bool {
+    match host_key_verifier() {
+        Some(verifier) => verifier.verify(info).await,
+        None => {
+            warn!(
+                host = %info.host,
+                port = info.port,
+                fingerprint = %info.fingerprint,
+                "no SSH host-key verifier registered; accepting host key unverified"
+            );
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct FixedVerifier {
+        accept: bool,
+        called: AtomicBool,
+    }
+
+    #[async_trait]
+    impl HostKeyVerifier for FixedVerifier {
+        async fn verify(&self, _info: &HostKeyInfo) -> bool {
+            self.called.store(true, Ordering::SeqCst);
+            self.accept
+        }
+    }
+
+    fn sample_info() -> HostKeyInfo {
+        HostKeyInfo {
+            host: "example.com".to_string(),
+            port: 2222,
+            key_type: "ssh-ed25519".to_string(),
+            fingerprint: "SHA256:AABBCC".to_string(),
+        }
+    }
+
+    #[test]
+    fn host_port_keys_like_the_rdp_store() {
+        assert_eq!(sample_info().host_port(), "example.com:2222");
+    }
+
+    /// A registered verifier's verdict is what `verify_host_key` returns, and the
+    /// verifier is actually consulted (no blind accept).
+    #[tokio::test]
+    async fn registered_verifier_is_consulted() {
+        // OnceLock is process-global and set-once; exercise the trait directly so
+        // this test does not depend on global registration order.
+        let verifier = FixedVerifier {
+            accept: false,
+            called: AtomicBool::new(false),
+        };
+        let accepted = verifier.verify(&sample_info()).await;
+        assert!(!accepted, "a rejecting verifier must reject");
+        assert!(
+            verifier.called.load(Ordering::SeqCst),
+            "the verifier must be consulted"
+        );
+    }
+}

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -10,6 +10,7 @@ pub mod connector;
 pub mod exec;
 mod file_browser;
 pub mod handler;
+pub mod host_key;
 pub mod jump_host;
 mod legacy_pem;
 mod monitoring;

--- a/docs/changes/dev3/fix/1959-ssh-host-key-verify.md
+++ b/docs/changes/dev3/fix/1959-ssh-host-key-verify.md
@@ -1,0 +1,11 @@
+### Security
+
+- SSH connections now verify the server's host key instead of blindly
+  accepting any key. On first contact with an unknown host, a dialog shows the
+  key's SHA-256 fingerprint (with host and key type) for confirmation and, on
+  "Accept for host", remembers it so the host connects silently thereafter. If a
+  previously-trusted host later presents a **different** key, a prominent
+  possible-man-in-the-middle warning is shown and the connection is never
+  auto-accepted. Hosts already recorded in the user's `~/.ssh/known_hosts` are
+  trusted silently. Jump-host hops are each verified. Trusted keys are persisted
+  in `ssh_known_hosts.json` in the config directory (#1959).

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod session_history;
 pub mod shell_integration;
 pub mod spawn;
 pub mod ssh_config_import;
+pub mod ssh_host_key;
 pub mod transfer;
 pub mod tunnel;
 pub mod update;

--- a/src-tauri/src/commands/ssh_host_key.rs
+++ b/src-tauri/src/commands/ssh_host_key.rs
@@ -1,0 +1,71 @@
+//! Tauri commands for interactive SSH host-key trust (#1959).
+//!
+//! The SSH handshake blocks on an untrusted host key and emits a
+//! `ssh-host-key-prompt` event; the frontend dialog replies through
+//! [`ssh_host_key_decision`], unblocking the connect. [`ssh_trust_list`] /
+//! [`ssh_trust_forget`] back the trust-management settings UI, mirroring the RDP
+//! trust commands.
+
+use std::sync::Arc;
+
+use tauri::State;
+
+use crate::session::ssh_host_key_verifier::SshHostKeyVerifier;
+use crate::utils::errors::TerminalError;
+
+/// Deliver the user's verdict for a pending SSH host-key prompt (#1959).
+///
+/// `accept` proceeds with the connection; `remember` (only meaningful with
+/// `accept`) persists the fingerprint so the host is trusted silently next time.
+/// Returns whether a prompt with `prompt_id` was actually waiting — a stale or
+/// duplicate reply returns `false` rather than erroring.
+#[tauri::command]
+pub async fn ssh_host_key_decision(
+    prompt_id: String,
+    accept: bool,
+    remember: bool,
+    verifier: State<'_, Arc<SshHostKeyVerifier>>,
+) -> Result<bool, TerminalError> {
+    Ok(verifier.resolve(&prompt_id, accept, remember))
+}
+
+/// One remembered SSH host and the host-key fingerprints trusted for it, for the
+/// trust-management settings UI.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SshTrustedHost {
+    /// Host key (`host:port`) as stored in the trust store.
+    pub host: String,
+    /// SHA-256 host-key fingerprints trusted for this host.
+    pub fingerprints: Vec<String>,
+}
+
+/// List every remembered SSH host and its trusted host-key fingerprints, so the
+/// settings UI can show what "Accept for host" has persisted.
+#[tauri::command]
+pub async fn ssh_trust_list(
+    verifier: State<'_, Arc<SshHostKeyVerifier>>,
+) -> Result<Vec<SshTrustedHost>, TerminalError> {
+    Ok(verifier
+        .trust_store()
+        .entries()
+        .into_iter()
+        .map(|(host, fingerprints)| SshTrustedHost { host, fingerprints })
+        .collect())
+}
+
+/// Revoke remembered SSH host-key trust. With `fingerprint` set, forgets just
+/// that fingerprint (dropping the host once its last one is gone); without it,
+/// forgets the whole host. Either way the next connect re-prompts. Returns
+/// whether anything was removed.
+#[tauri::command]
+pub async fn ssh_trust_forget(
+    host: String,
+    fingerprint: Option<String>,
+    verifier: State<'_, Arc<SshHostKeyVerifier>>,
+) -> Result<bool, TerminalError> {
+    let store = verifier.trust_store();
+    Ok(match fingerprint {
+        Some(fp) => store.forget_fingerprint(&host, &fp),
+        None => store.forget_host(&host),
+    })
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -499,6 +499,32 @@ pub fn run() {
             );
             app.manage(graphical_manager);
 
+            // SSH host-key verification (#1959): register the process-wide
+            // verifier so the core SSH handshake stops blindly accepting host
+            // keys. It persists trust-on-first-use decisions to the config dir
+            // (portable-aware; in-memory on failure) and prompts the UI via the
+            // app handle for unknown or changed keys.
+            let ssh_trust_store = std::sync::Arc::new(
+                match crate::utils::config_paths::resolve_config_dir(Some(app.handle())) {
+                    Ok(dir) => crate::session::ssh_trust_store::SshTrustStore::open(dir),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "could not resolve config dir for SSH trust store; using in-memory");
+                        crate::session::ssh_trust_store::SshTrustStore::in_memory()
+                    }
+                },
+            );
+            let ssh_host_key_verifier =
+                std::sync::Arc::new(crate::session::ssh_host_key_verifier::SshHostKeyVerifier::new(
+                    ssh_trust_store,
+                    std::sync::Arc::new(app.handle().clone()),
+                ));
+            if !termihub_core::backends::ssh::host_key::set_host_key_verifier(
+                ssh_host_key_verifier.clone(),
+            ) {
+                tracing::warn!("SSH host-key verifier was already registered");
+            }
+            app.manage(ssh_host_key_verifier);
+
             // X server provisioning (#1052): register the provisioner so the SSH
             // connect path can ensure a local X server before X11 forwarding
             // starts. The manager itself (#1049) is created and managed above.
@@ -776,6 +802,10 @@ pub fn run() {
             commands::remote_desktop::remote_desktop_disconnect,
             commands::remote_desktop::rdp_trust_list,
             commands::remote_desktop::rdp_trust_forget,
+            // SSH host-key trust (#1959)
+            commands::ssh_host_key::ssh_host_key_decision,
+            commands::ssh_host_key::ssh_trust_list,
+            commands::ssh_host_key::ssh_trust_forget,
             // Session commands (replaces old terminal commands)
             commands::session::create_connection,
             commands::session::cancel_connecting,

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -4,3 +4,5 @@ pub mod manager;
 pub mod rdp_trust_store;
 pub mod registry;
 pub mod remote_proxy;
+pub mod ssh_host_key_verifier;
+pub mod ssh_trust_store;

--- a/src-tauri/src/session/ssh_host_key_verifier.rs
+++ b/src-tauri/src/session/ssh_host_key_verifier.rs
@@ -1,0 +1,325 @@
+//! Interactive SSH host-key verifier wiring the core hook to the desktop UI
+//! (#1959).
+//!
+//! Implements [`termihub_core`'s `HostKeyVerifier`](termihub_core::backends::ssh::host_key)
+//! for the desktop app: it consults the persisted [`SshTrustStore`] and, for an
+//! unknown or changed host key, emits a `ssh-host-key-prompt` event and blocks
+//! the SSH handshake until the user's verdict arrives via the
+//! `ssh_host_key_decision` command. It is the SSH analogue of the RDP
+//! certificate-prompt flow in [`graphical_manager`](super::graphical_manager),
+//! and follows the same event-sink-for-testability shape.
+//!
+//! Trust-on-first-use semantics:
+//! - **Trusted** (fingerprint already remembered) → accept silently, no prompt.
+//! - **Unknown** (host not remembered) → prompt for first-contact confirmation.
+//! - **Changed** (host remembered with a different key) → prompt with a
+//!   prominent possible-MITM warning; never auto-accept.
+//!
+//! "Accept for host" (`accept && remember`) persists the fingerprint so the host
+//! is not prompted again; plain "Accept" is session-scoped; "Reject" (or the
+//! dialog being dismissed / the prompt future being dropped) aborts the connect.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use serde::Serialize;
+use termihub_core::backends::ssh::host_key::{HostKeyInfo, HostKeyVerifier};
+use tokio::sync::oneshot;
+use tracing::warn;
+
+use super::ssh_trust_store::{SshTrustStore, TrustLookup};
+
+/// `ssh-host-key-prompt` payload: a server presented an untrusted host key that
+/// needs an interactive trust decision (#1959).
+///
+/// `changed` distinguishes first contact (`false`) from a *changed* fingerprint
+/// for a previously-trusted host (`true`) — the possible-MITM case the dialog
+/// warns about prominently. `prompt_id` correlates the reply
+/// (`ssh_host_key_decision`) back to the blocked handshake.
+#[derive(Debug, Clone, Serialize)]
+pub struct SshHostKeyPromptEvent {
+    pub prompt_id: String,
+    pub host: String,
+    pub port: u16,
+    pub key_type: String,
+    pub fingerprint: String,
+    pub changed: bool,
+}
+
+/// Abstracts frontend event delivery so the verifier is unit-testable without a
+/// Tauri runtime. The production impl wraps `tauri::AppHandle`.
+pub trait SshHostKeyEventSink: Send + Sync + 'static {
+    /// Emit an interactive host-key trust prompt.
+    fn emit_prompt(&self, event: &SshHostKeyPromptEvent);
+}
+
+impl<R: tauri::Runtime> SshHostKeyEventSink for tauri::AppHandle<R> {
+    fn emit_prompt(&self, event: &SshHostKeyPromptEvent) {
+        use tauri::Emitter;
+        let _ = self.emit("ssh-host-key-prompt", event);
+    }
+}
+
+/// The user's verdict for a pending prompt.
+#[derive(Debug, Clone, Copy)]
+struct Decision {
+    accept: bool,
+    remember: bool,
+}
+
+/// Desktop SSH host-key verifier backed by a persisted trust store and an
+/// interactive prompt.
+pub struct SshHostKeyVerifier {
+    trust_store: Arc<SshTrustStore>,
+    sink: Arc<dyn SshHostKeyEventSink>,
+    /// Prompts awaiting a user verdict, keyed by `prompt_id`.
+    pending: Mutex<HashMap<String, oneshot::Sender<Decision>>>,
+}
+
+impl SshHostKeyVerifier {
+    /// Build a verifier that persists trust to `trust_store` and prompts through
+    /// `sink`.
+    pub fn new(trust_store: Arc<SshTrustStore>, sink: Arc<dyn SshHostKeyEventSink>) -> Self {
+        Self {
+            trust_store,
+            sink,
+            pending: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// The trust store backing this verifier, for the trust-management commands.
+    pub fn trust_store(&self) -> &Arc<SshTrustStore> {
+        &self.trust_store
+    }
+
+    /// Deliver the user's verdict for a pending prompt, unblocking the handshake.
+    ///
+    /// Returns `true` when a prompt with `prompt_id` was waiting (a stale or
+    /// duplicate reply returns `false`). Persisting an accepted-for-host decision
+    /// happens on the waiting side once the verdict is received.
+    pub fn resolve(&self, prompt_id: &str, accept: bool, remember: bool) -> bool {
+        let sender = self
+            .pending
+            .lock()
+            .expect("ssh host-key pending mutex poisoned")
+            .remove(prompt_id);
+        match sender {
+            Some(tx) => {
+                let _ = tx.send(Decision { accept, remember });
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Emit a prompt and await the verdict, returning `false` if the waiting side
+    /// is dropped before a reply (e.g. the connect timed out).
+    async fn prompt(&self, info: &HostKeyInfo, changed: bool) -> Decision {
+        let prompt_id = uuid::Uuid::new_v4().to_string();
+        let (tx, rx) = oneshot::channel();
+        self.pending
+            .lock()
+            .expect("ssh host-key pending mutex poisoned")
+            .insert(prompt_id.clone(), tx);
+
+        if changed {
+            warn!(
+                host = %info.host,
+                port = info.port,
+                "SSH host key CHANGED for a previously-trusted host (possible MITM)"
+            );
+        }
+
+        self.sink.emit_prompt(&SshHostKeyPromptEvent {
+            prompt_id: prompt_id.clone(),
+            host: info.host.clone(),
+            port: info.port,
+            key_type: info.key_type.clone(),
+            fingerprint: info.fingerprint.clone(),
+            changed,
+        });
+
+        let decision = rx.await.unwrap_or(Decision {
+            accept: false,
+            remember: false,
+        });
+        // Best-effort cleanup for the dropped/rejected path (resolve already
+        // removed it on the happy path).
+        self.pending
+            .lock()
+            .expect("ssh host-key pending mutex poisoned")
+            .remove(&prompt_id);
+        decision
+    }
+}
+
+#[async_trait]
+impl HostKeyVerifier for SshHostKeyVerifier {
+    async fn verify(&self, info: &HostKeyInfo) -> bool {
+        let host_port = info.host_port();
+        let changed = match self.trust_store.lookup(&host_port, &info.fingerprint) {
+            // Already trusted → accept without prompting.
+            TrustLookup::Trusted => return true,
+            TrustLookup::Unknown => false,
+            TrustLookup::Changed => true,
+        };
+
+        let decision = self.prompt(info, changed).await;
+        if decision.accept && decision.remember {
+            self.trust_store.remember(&host_port, &info.fingerprint);
+        }
+        decision.accept
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Records emitted prompts and returns the last `prompt_id` so a test can
+    /// resolve it.
+    #[derive(Default)]
+    struct RecordingSink {
+        prompts: Mutex<Vec<SshHostKeyPromptEvent>>,
+        count: AtomicUsize,
+    }
+
+    impl SshHostKeyEventSink for RecordingSink {
+        fn emit_prompt(&self, event: &SshHostKeyPromptEvent) {
+            self.count.fetch_add(1, Ordering::SeqCst);
+            self.prompts
+                .lock()
+                .expect("prompts mutex")
+                .push(event.clone());
+        }
+    }
+
+    fn info(host: &str, port: u16, fp: &str) -> HostKeyInfo {
+        HostKeyInfo {
+            host: host.to_string(),
+            port,
+            key_type: "ssh-ed25519".to_string(),
+            fingerprint: fp.to_string(),
+        }
+    }
+
+    /// Resolve the single pending prompt after a short spin so `verify` has had
+    /// time to register it.
+    async fn resolve_when_ready(
+        verifier: &Arc<SshHostKeyVerifier>,
+        sink: &Arc<RecordingSink>,
+        accept: bool,
+        remember: bool,
+    ) {
+        loop {
+            let id = sink
+                .prompts
+                .lock()
+                .expect("prompts mutex")
+                .last()
+                .map(|p| p.prompt_id.clone());
+            if let Some(id) = id {
+                if verifier.resolve(&id, accept, remember) {
+                    return;
+                }
+            }
+            tokio::task::yield_now().await;
+        }
+    }
+
+    /// A remembered fingerprint is accepted with no prompt at all.
+    #[tokio::test]
+    async fn known_host_is_trusted_without_prompt() {
+        let store = Arc::new(SshTrustStore::in_memory());
+        store.remember("h:22", "SHA256:AA");
+        let sink = Arc::new(RecordingSink::default());
+        let verifier = Arc::new(SshHostKeyVerifier::new(store, sink.clone()));
+
+        assert!(verifier.verify(&info("h", 22, "SHA256:AA")).await);
+        assert_eq!(
+            sink.count.load(Ordering::SeqCst),
+            0,
+            "no prompt for a known host"
+        );
+    }
+
+    /// An unknown host prompts (changed=false); accepting-for-host persists the
+    /// fingerprint so the next connect is silent.
+    #[tokio::test]
+    async fn unknown_host_prompts_and_remember_persists() {
+        let store = Arc::new(SshTrustStore::in_memory());
+        let sink = Arc::new(RecordingSink::default());
+        let verifier = Arc::new(SshHostKeyVerifier::new(store.clone(), sink.clone()));
+
+        let v = verifier.clone();
+        let handle = tokio::spawn(async move { v.verify(&info("h", 22, "SHA256:BB")).await });
+        resolve_when_ready(&verifier, &sink, true, true).await;
+
+        assert!(handle.await.unwrap(), "accepted key connects");
+        let prompt = sink.prompts.lock().unwrap()[0].clone();
+        assert!(!prompt.changed, "first contact is not a changed-key prompt");
+        assert_eq!(prompt.fingerprint, "SHA256:BB");
+        // Remembered: a second verify is silent.
+        assert_eq!(store.lookup("h:22", "SHA256:BB"), TrustLookup::Trusted);
+        assert!(verifier.verify(&info("h", 22, "SHA256:BB")).await);
+        assert_eq!(
+            sink.count.load(Ordering::SeqCst),
+            1,
+            "no re-prompt after remember"
+        );
+    }
+
+    /// A changed key prompts with `changed=true` and is NOT persisted unless
+    /// explicitly accepted-for-host; rejecting it aborts the connect.
+    #[tokio::test]
+    async fn changed_key_warns_and_reject_aborts() {
+        let store = Arc::new(SshTrustStore::in_memory());
+        store.remember("h:22", "SHA256:AA");
+        let sink = Arc::new(RecordingSink::default());
+        let verifier = Arc::new(SshHostKeyVerifier::new(store.clone(), sink.clone()));
+
+        let v = verifier.clone();
+        let handle = tokio::spawn(async move { v.verify(&info("h", 22, "SHA256:EVIL")).await });
+        resolve_when_ready(&verifier, &sink, false, false).await;
+
+        assert!(
+            !handle.await.unwrap(),
+            "rejecting a changed key aborts the connect"
+        );
+        let prompt = sink.prompts.lock().unwrap()[0].clone();
+        assert!(prompt.changed, "a changed key must flag the MITM warning");
+        // The impostor key was not remembered; the original trust stands.
+        assert_eq!(store.lookup("h:22", "SHA256:EVIL"), TrustLookup::Changed);
+        assert_eq!(store.lookup("h:22", "SHA256:AA"), TrustLookup::Trusted);
+    }
+
+    /// Accept-once (remember=false) connects but does not persist the key.
+    #[tokio::test]
+    async fn accept_once_does_not_persist() {
+        let store = Arc::new(SshTrustStore::in_memory());
+        let sink = Arc::new(RecordingSink::default());
+        let verifier = Arc::new(SshHostKeyVerifier::new(store.clone(), sink.clone()));
+
+        let v = verifier.clone();
+        let handle = tokio::spawn(async move { v.verify(&info("h", 22, "SHA256:CC")).await });
+        resolve_when_ready(&verifier, &sink, true, false).await;
+
+        assert!(handle.await.unwrap());
+        assert_eq!(
+            store.lookup("h:22", "SHA256:CC"),
+            TrustLookup::Unknown,
+            "accept-once must not remember the key"
+        );
+    }
+
+    /// A stale/duplicate decision for an unknown prompt id is a no-op.
+    #[test]
+    fn resolve_unknown_prompt_is_noop() {
+        let store = Arc::new(SshTrustStore::in_memory());
+        let sink = Arc::new(RecordingSink::default());
+        let verifier = SshHostKeyVerifier::new(store, sink);
+        assert!(!verifier.resolve("nope", true, true));
+    }
+}

--- a/src-tauri/src/session/ssh_trust_store.rs
+++ b/src-tauri/src/session/ssh_trust_store.rs
@@ -1,0 +1,332 @@
+//! Persisted per-host SSH host-key trust store (#1959).
+//!
+//! termiHub's own `known_hosts`: it remembers the SHA-256 host-key fingerprints
+//! a user has chosen to trust for a given `host:port`, so a later connect to a
+//! remembered host does not re-prompt, and a *changed* fingerprint for a
+//! previously-trusted host is flagged as a possible man-in-the-middle. It is the
+//! direct sibling of the RDP certificate trust store
+//! ([`RdpTrustStore`](super::rdp_trust_store)) and shares its shape and on-disk
+//! format, differing only in the file name and that fingerprints are SSH host
+//! keys rather than RDP certificates.
+//!
+//! The user's real `~/.ssh/known_hosts` is consulted first (in the SSH handler,
+//! which holds the parsed key) as an accept-fast-path; this store covers the
+//! trust-on-first-use decisions termiHub makes interactively, keeping them out
+//! of the user's system file.
+//!
+//! ## On-disk format
+//!
+//! A single JSON object mapping `host:port` → the list of accepted fingerprints:
+//!
+//! ```json
+//! { "server.example:22": ["SHA256:AB…", "SHA256:12…"] }
+//! ```
+//!
+//! Multiple fingerprints per host are allowed (a host may legitimately rotate
+//! its key, exactly as `known_hosts` tolerates), so "remember" appends rather
+//! than replaces. A presented fingerprint that matches *any* stored entry for
+//! the host is trusted; one that matches none while the host has entries is the
+//! changed / MITM case.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use tracing::warn;
+
+/// The trust-store file name inside the config directory.
+const FILE_NAME: &str = "ssh_known_hosts.json";
+
+/// The verdict of consulting the trust store for a presented fingerprint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustLookup {
+    /// The host+fingerprint pair is already trusted: accept without prompting.
+    Trusted,
+    /// The host has no remembered fingerprint: first contact, prompt the user.
+    Unknown,
+    /// The host is remembered but with a *different* fingerprint: possible MITM,
+    /// warn prominently before proceeding.
+    Changed,
+}
+
+/// A persisted per-host SSH host-key trust store.
+///
+/// Cheap to clone-share behind an `Arc`; all mutation goes through an internal
+/// mutex and is written through to disk immediately (the store is tiny).
+pub struct SshTrustStore {
+    /// Backing file, or `None` for an in-memory store (tests / no config dir).
+    path: Option<PathBuf>,
+    /// `host:port` → accepted fingerprints.
+    entries: Mutex<BTreeMap<String, Vec<String>>>,
+}
+
+impl SshTrustStore {
+    /// Open (or start) a trust store backed by `FILE_NAME` inside `config_dir`.
+    ///
+    /// A missing or unreadable file starts empty rather than failing — an absent
+    /// trust store simply means "nothing remembered yet".
+    pub fn open(config_dir: PathBuf) -> Self {
+        let path = config_dir.join(FILE_NAME);
+        let entries = load(&path);
+        Self {
+            path: Some(path),
+            entries: Mutex::new(entries),
+        }
+    }
+
+    /// An in-memory store that never touches disk. Used by tests and as a safe
+    /// fallback when no config directory could be resolved.
+    pub fn in_memory() -> Self {
+        Self {
+            path: None,
+            entries: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// Classify a presented `fingerprint` for `host` against what is remembered.
+    pub fn lookup(&self, host: &str, fingerprint: &str) -> TrustLookup {
+        let entries = self.entries.lock().expect("trust store mutex poisoned");
+        match entries.get(host) {
+            Some(fps) if fps.iter().any(|f| f == fingerprint) => TrustLookup::Trusted,
+            Some(fps) if !fps.is_empty() => TrustLookup::Changed,
+            _ => TrustLookup::Unknown,
+        }
+    }
+
+    /// Remember `fingerprint` as trusted for `host` and persist immediately.
+    ///
+    /// Idempotent: remembering an already-trusted pair is a no-op. Persistence
+    /// failures are logged, not surfaced — the in-memory decision still holds for
+    /// the session.
+    pub fn remember(&self, host: &str, fingerprint: &str) {
+        {
+            let mut entries = self.entries.lock().expect("trust store mutex poisoned");
+            let fps = entries.entry(host.to_string()).or_default();
+            if fps.iter().any(|f| f == fingerprint) {
+                return;
+            }
+            fps.push(fingerprint.to_string());
+        }
+        self.persist();
+    }
+
+    /// Snapshot every remembered host and its trusted fingerprints, for the
+    /// trust-management settings UI. Cloned so callers never hold the lock; the
+    /// store is tiny.
+    pub fn entries(&self) -> BTreeMap<String, Vec<String>> {
+        self.entries
+            .lock()
+            .expect("trust store mutex poisoned")
+            .clone()
+    }
+
+    /// Forget a single `fingerprint` for `host`, persisting immediately.
+    ///
+    /// When the host's last fingerprint is removed the host entry is dropped
+    /// entirely, so a subsequent connect is treated as first contact (prompt)
+    /// rather than a changed key. Returns `true` when something was removed.
+    pub fn forget_fingerprint(&self, host: &str, fingerprint: &str) -> bool {
+        let removed = {
+            let mut entries = self.entries.lock().expect("trust store mutex poisoned");
+            let Some(fps) = entries.get_mut(host) else {
+                return false;
+            };
+            let before = fps.len();
+            fps.retain(|f| f != fingerprint);
+            let removed = fps.len() != before;
+            if fps.is_empty() {
+                entries.remove(host);
+            }
+            removed
+        };
+        if removed {
+            self.persist();
+        }
+        removed
+    }
+
+    /// Forget every fingerprint remembered for `host`, persisting immediately.
+    /// Returns `true` when the host had remembered entries.
+    pub fn forget_host(&self, host: &str) -> bool {
+        let removed = {
+            let mut entries = self.entries.lock().expect("trust store mutex poisoned");
+            entries.remove(host).is_some()
+        };
+        if removed {
+            self.persist();
+        }
+        removed
+    }
+
+    /// Write the current entries to disk (no-op for an in-memory store).
+    fn persist(&self) {
+        let Some(path) = &self.path else { return };
+        let entries = self.entries.lock().expect("trust store mutex poisoned");
+        let write = || -> std::io::Result<()> {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let json = serde_json::to_string_pretty(&*entries)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            std::fs::write(path, json)
+        };
+        if let Err(e) = write() {
+            warn!(path = %path.display(), error = %e, "failed to persist SSH trust store");
+        }
+    }
+}
+
+/// Load the entries from `path`, returning an empty map on any error.
+fn load(path: &PathBuf) -> BTreeMap<String, Vec<String>> {
+    let Ok(bytes) = std::fs::read(path) else {
+        return BTreeMap::new();
+    };
+    match serde_json::from_slice(&bytes) {
+        Ok(map) => map,
+        Err(e) => {
+            warn!(path = %path.display(), error = %e, "SSH trust store is corrupt; starting empty");
+            BTreeMap::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FP_A: &str = "SHA256:AABBCC";
+    const FP_B: &str = "SHA256:112233";
+
+    #[test]
+    fn unknown_host_prompts() {
+        let store = SshTrustStore::in_memory();
+        assert_eq!(store.lookup("host:22", FP_A), TrustLookup::Unknown);
+    }
+
+    #[test]
+    fn remembered_fingerprint_is_trusted_silently() {
+        let store = SshTrustStore::in_memory();
+        store.remember("host:22", FP_A);
+        assert_eq!(store.lookup("host:22", FP_A), TrustLookup::Trusted);
+        // A different host is still unknown.
+        assert_eq!(store.lookup("other:22", FP_A), TrustLookup::Unknown);
+    }
+
+    #[test]
+    fn changed_fingerprint_is_flagged_as_mitm() {
+        let store = SshTrustStore::in_memory();
+        store.remember("host:22", FP_A);
+        // Same host, different key → the changed/MITM case, not "unknown".
+        assert_eq!(store.lookup("host:22", FP_B), TrustLookup::Changed);
+    }
+
+    #[test]
+    fn remember_is_idempotent_and_allows_rotation() {
+        let store = SshTrustStore::in_memory();
+        store.remember("host:22", FP_A);
+        store.remember("host:22", FP_A); // idempotent
+        store.remember("host:22", FP_B); // rotation: both now trusted
+        assert_eq!(store.lookup("host:22", FP_A), TrustLookup::Trusted);
+        assert_eq!(store.lookup("host:22", FP_B), TrustLookup::Trusted);
+    }
+
+    #[test]
+    fn persists_and_reloads_across_instances() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        {
+            let store = SshTrustStore::open(dir.clone());
+            store.remember("host:22", FP_A);
+            assert_eq!(store.lookup("host:22", FP_A), TrustLookup::Trusted);
+        }
+        // A fresh instance over the same directory sees the remembered trust.
+        let reopened = SshTrustStore::open(dir);
+        assert_eq!(reopened.lookup("host:22", FP_A), TrustLookup::Trusted);
+        assert_eq!(reopened.lookup("host:22", FP_B), TrustLookup::Changed);
+    }
+
+    #[test]
+    fn corrupt_file_starts_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        std::fs::write(dir.join(FILE_NAME), b"not json").unwrap();
+        let store = SshTrustStore::open(dir);
+        assert_eq!(store.lookup("host:22", FP_A), TrustLookup::Unknown);
+    }
+
+    #[test]
+    fn entries_returns_snapshot_of_all_hosts() {
+        let store = SshTrustStore::in_memory();
+        store.remember("a:22", FP_A);
+        store.remember("a:22", FP_B);
+        store.remember("b:22", FP_A);
+        let entries = store.entries();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(
+            entries.get("a:22").unwrap(),
+            &vec![FP_A.to_string(), FP_B.to_string()]
+        );
+        assert_eq!(entries.get("b:22").unwrap(), &vec![FP_A.to_string()]);
+    }
+
+    #[test]
+    fn forget_fingerprint_removes_one_and_keeps_others() {
+        let store = SshTrustStore::in_memory();
+        store.remember("a:22", FP_A);
+        store.remember("a:22", FP_B);
+        assert!(store.forget_fingerprint("a:22", FP_A));
+        // The revoked key is now the changed/MITM case; the sibling still trusts.
+        assert_eq!(store.lookup("a:22", FP_A), TrustLookup::Changed);
+        assert_eq!(store.lookup("a:22", FP_B), TrustLookup::Trusted);
+    }
+
+    #[test]
+    fn forgetting_last_fingerprint_drops_host_and_reprompts() {
+        let store = SshTrustStore::in_memory();
+        store.remember("a:22", FP_A);
+        assert!(store.forget_fingerprint("a:22", FP_A));
+        // Host is gone entirely: the next contact is first contact, not "changed".
+        assert_eq!(store.lookup("a:22", FP_A), TrustLookup::Unknown);
+        assert!(store.entries().is_empty());
+    }
+
+    #[test]
+    fn forget_fingerprint_returns_false_when_absent() {
+        let store = SshTrustStore::in_memory();
+        store.remember("a:22", FP_A);
+        assert!(!store.forget_fingerprint("a:22", FP_B));
+        assert!(!store.forget_fingerprint("missing:22", FP_A));
+        // The untouched entry is still trusted.
+        assert_eq!(store.lookup("a:22", FP_A), TrustLookup::Trusted);
+    }
+
+    #[test]
+    fn forget_host_removes_all_fingerprints() {
+        let store = SshTrustStore::in_memory();
+        store.remember("a:22", FP_A);
+        store.remember("a:22", FP_B);
+        assert!(store.forget_host("a:22"));
+        assert_eq!(store.lookup("a:22", FP_A), TrustLookup::Unknown);
+        // Idempotent: forgetting an already-forgotten host removes nothing.
+        assert!(!store.forget_host("a:22"));
+    }
+
+    #[test]
+    fn revocations_persist_across_instances() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        {
+            let store = SshTrustStore::open(dir.clone());
+            store.remember("a:22", FP_A);
+            store.remember("a:22", FP_B);
+            store.remember("b:22", FP_A);
+            assert!(store.forget_fingerprint("a:22", FP_A));
+            assert!(store.forget_host("b:22"));
+        }
+        // A fresh instance over the same directory sees the revocations.
+        let reopened = SshTrustStore::open(dir);
+        assert_eq!(reopened.lookup("a:22", FP_A), TrustLookup::Changed);
+        assert_eq!(reopened.lookup("a:22", FP_B), TrustLookup::Trusted);
+        assert_eq!(reopened.lookup("b:22", FP_A), TrustLookup::Unknown);
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { TransferQueue } from "@/components/TransferQueue";
 import { ShellIntegrationBanner } from "@/components/ShellIntegrationBanner";
 import { TerminalView } from "@/components/Terminal";
 import { PasswordPrompt } from "@/components/PasswordPrompt";
+import { SshHostKeyPrompt } from "@/components/SshHostKeyPrompt/SshHostKeyPrompt";
 import { LocalProcessAuthDialog } from "@/components/WorkflowSidebar/LocalProcessAuthDialog";
 import { CustomizeLayoutDialog } from "@/components/Settings/CustomizeLayoutDialog";
 import { ExportDialog, ImportDialog } from "@/components/ExportImport";
@@ -379,6 +380,7 @@ function App() {
           <TransferQueue />
           {layoutConfig.statusBarVisible && <StatusBar />}
           <PasswordPrompt />
+          <SshHostKeyPrompt />
           <LocalProcessAuthDialog />
           <CustomizeLayoutDialog />
           <ExportDialog />

--- a/src/components/SshHostKeyPrompt/SshHostKeyPrompt.css
+++ b/src/components/SshHostKeyPrompt/SshHostKeyPrompt.css
@@ -1,0 +1,86 @@
+/* Interactive SSH host-key trust dialog (#1959). Tokens only — no magic values.
+   Composed on top of the shared Modal/Button primitives; mirrors the RDP
+   certificate-prompt dialog. */
+
+.ssh-hostkey__title {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.ssh-hostkey__title-icon {
+  color: var(--color-accent, var(--text-primary));
+}
+
+.ssh-hostkey__title-icon--warn {
+  color: var(--color-warning);
+}
+
+.ssh-hostkey__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+}
+
+.ssh-hostkey__lead {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-md);
+}
+
+.ssh-hostkey__warning {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: flex-start;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border: 1px solid var(--color-warning);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-warning) 12%, transparent);
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  line-height: 1.45;
+}
+
+.ssh-hostkey__warning-icon {
+  flex: 0 0 auto;
+  margin-top: 1px;
+  color: var(--color-warning);
+}
+
+.ssh-hostkey__facts {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: var(--spacing-xs) var(--spacing-md);
+  margin: 0;
+}
+
+.ssh-hostkey__facts dt {
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.ssh-hostkey__facts dd {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--font-size-sm);
+  word-break: break-word;
+}
+
+.ssh-hostkey__fingerprint {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-xs);
+  line-height: 1.5;
+}
+
+.ssh-hostkey__hint {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-xs);
+  line-height: 1.5;
+}
+
+.ssh-hostkey__actions {
+  display: flex;
+  gap: var(--spacing-sm);
+  justify-content: flex-end;
+}

--- a/src/components/SshHostKeyPrompt/SshHostKeyPrompt.test.tsx
+++ b/src/components/SshHostKeyPrompt/SshHostKeyPrompt.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Tests for {@link SshHostKeyPrompt} — the global interactive SSH host-key
+ * trust dialog (#1959). Verifies the three verdicts route the right
+ * (accept, remember) pair through `sshHostKeyDecision`, that a changed key shows
+ * the MITM warning, and that concurrent prompts are shown one at a time.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import type { SshHostKeyPromptPayload } from "@/types/sshHostKey";
+
+// Capture the event callback the component registers so tests can fire prompts.
+let emitPrompt: ((p: SshHostKeyPromptPayload) => void) | undefined;
+const decisionMock = vi.fn().mockResolvedValue(true);
+
+vi.mock("@/services/events", () => ({
+  onSshHostKeyPrompt: (cb: (p: SshHostKeyPromptPayload) => void) => {
+    emitPrompt = cb;
+    return Promise.resolve(() => {});
+  },
+}));
+
+vi.mock("@/services/api", () => ({
+  sshHostKeyDecision: (promptId: string, accept: boolean, remember: boolean) =>
+    decisionMock(promptId, accept, remember),
+}));
+
+import { SshHostKeyPrompt } from "./SshHostKeyPrompt";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => root.render(ui));
+}
+
+async function fire(payload: SshHostKeyPromptPayload) {
+  // Flush the mocked listener registration, then deliver the event.
+  await act(async () => {
+    await Promise.resolve();
+  });
+  act(() => emitPrompt?.(payload));
+}
+
+function click(testid: string) {
+  act(() => {
+    (document.querySelector(`[data-testid="${testid}"]`) as HTMLElement).click();
+  });
+}
+
+const unknownPrompt: SshHostKeyPromptPayload = {
+  prompt_id: "p-1",
+  host: "server.example",
+  port: 2222,
+  key_type: "ssh-ed25519",
+  fingerprint: "SHA256:AABBCCDD",
+  changed: false,
+};
+
+const changedPrompt: SshHostKeyPromptPayload = {
+  prompt_id: "p-2",
+  host: "server.example",
+  port: 2222,
+  key_type: "ssh-ed25519",
+  fingerprint: "SHA256:99887766",
+  changed: true,
+};
+
+describe("SshHostKeyPrompt", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    emitPrompt = undefined;
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing until a prompt arrives", () => {
+    render(<SshHostKeyPrompt />);
+    expect(document.querySelector('[data-testid="ssh-hostkey-prompt"]')).toBeNull();
+  });
+
+  it("shows the host:port, key type and fingerprint", async () => {
+    render(<SshHostKeyPrompt />);
+    await fire(unknownPrompt);
+    expect(document.querySelector('[data-testid="ssh-hostkey-host"]')?.textContent).toBe(
+      "server.example:2222"
+    );
+    expect(document.querySelector('[data-testid="ssh-hostkey-type"]')?.textContent).toBe(
+      "ssh-ed25519"
+    );
+    expect(document.querySelector('[data-testid="ssh-hostkey-fingerprint"]')?.textContent).toBe(
+      "SHA256:AABBCCDD"
+    );
+    // No MITM warning on first contact.
+    expect(document.querySelector('[data-testid="ssh-hostkey-mitm-warning"]')).toBeNull();
+  });
+
+  it("routes reject as (false, false)", async () => {
+    render(<SshHostKeyPrompt />);
+    await fire(unknownPrompt);
+    click("ssh-hostkey-reject");
+    expect(decisionMock).toHaveBeenCalledWith("p-1", false, false);
+  });
+
+  it("routes accept-once as (true, false)", async () => {
+    render(<SshHostKeyPrompt />);
+    await fire(unknownPrompt);
+    click("ssh-hostkey-accept-once");
+    expect(decisionMock).toHaveBeenCalledWith("p-1", true, false);
+  });
+
+  it("routes accept-for-host as (true, true)", async () => {
+    render(<SshHostKeyPrompt />);
+    await fire(unknownPrompt);
+    click("ssh-hostkey-accept-remember");
+    expect(decisionMock).toHaveBeenCalledWith("p-1", true, true);
+  });
+
+  it("shows a MITM warning when the key changed", async () => {
+    render(<SshHostKeyPrompt />);
+    await fire(changedPrompt);
+    const warning = document.querySelector('[data-testid="ssh-hostkey-mitm-warning"]');
+    expect(warning).not.toBeNull();
+    expect(warning?.textContent).toContain("changed");
+  });
+
+  it("serialises concurrent prompts one at a time", async () => {
+    render(<SshHostKeyPrompt />);
+    await fire(unknownPrompt);
+    act(() => emitPrompt?.(changedPrompt));
+    // The first prompt is shown; the second is queued behind it.
+    expect(document.querySelector('[data-testid="ssh-hostkey-fingerprint"]')?.textContent).toBe(
+      "SHA256:AABBCCDD"
+    );
+    click("ssh-hostkey-accept-once");
+    expect(decisionMock).toHaveBeenCalledWith("p-1", true, false);
+    // After deciding the first, the queued changed-key prompt surfaces.
+    expect(document.querySelector('[data-testid="ssh-hostkey-fingerprint"]')?.textContent).toBe(
+      "SHA256:99887766"
+    );
+    expect(document.querySelector('[data-testid="ssh-hostkey-mitm-warning"]')).not.toBeNull();
+  });
+});

--- a/src/components/SshHostKeyPrompt/SshHostKeyPrompt.tsx
+++ b/src/components/SshHostKeyPrompt/SshHostKeyPrompt.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState, useCallback } from "react";
+import { ShieldCheck, ShieldAlert } from "lucide-react";
+import { Modal, Button } from "@/components/ui";
+import { onSshHostKeyPrompt } from "@/services/events";
+import { sshHostKeyDecision } from "@/services/api";
+import type { SshHostKeyPromptPayload } from "@/types/sshHostKey";
+import "./SshHostKeyPrompt.css";
+
+/**
+ * Global interactive SSH host-key trust dialog (#1959) — the terminal analogue
+ * of the RDP {@link RemoteDesktopCertPrompt}.
+ *
+ * The SSH handshake blocks when a server presents an untrusted host key and
+ * emits `ssh-host-key-prompt`; this dialog surfaces the SHA-256 fingerprint and
+ * lets the user accept it once, accept and remember it for the host, or reject.
+ * When the key *changed* for a previously-trusted host (`changed`), it warns
+ * prominently about a possible man-in-the-middle before offering to proceed. The
+ * verdict is routed back to the blocked handshake via `sshHostKeyDecision`.
+ *
+ * Any SSH connect path (terminal, tunnel, SFTP, jump host) can raise a prompt,
+ * so this mounts once at the app root and serialises concurrent prompts through
+ * a small queue — one dialog at a time.
+ */
+export function SshHostKeyPrompt() {
+  const [queue, setQueue] = useState<SshHostKeyPromptPayload[]>([]);
+  const current = queue[0] ?? null;
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    let active = true;
+    void onSshHostKeyPrompt((payload) => {
+      setQueue((q) => [...q, payload]);
+    }).then((fn) => {
+      if (active) {
+        unlisten = fn;
+      } else {
+        fn();
+      }
+    });
+    return () => {
+      active = false;
+      unlisten?.();
+    };
+  }, []);
+
+  const decide = useCallback(
+    (accept: boolean, remember: boolean) => {
+      if (!current) return;
+      void sshHostKeyDecision(current.prompt_id, accept, remember);
+      setQueue((q) => q.slice(1));
+    },
+    [current]
+  );
+
+  const changed = current?.changed ?? false;
+
+  return (
+    <Modal
+      open={current !== null}
+      // ESC / scrim / close all count as a rejection — the safe default.
+      onOpenChange={(next) => !next && decide(false, false)}
+      title={
+        <span className="ssh-hostkey__title">
+          {changed ? (
+            <ShieldAlert
+              size={16}
+              className="ssh-hostkey__title-icon ssh-hostkey__title-icon--warn"
+            />
+          ) : (
+            <ShieldCheck size={16} className="ssh-hostkey__title-icon" />
+          )}
+          {changed ? "Host key changed" : "Unknown host key"}
+        </span>
+      }
+      data-testid="ssh-hostkey-prompt"
+      footer={
+        <div className="ssh-hostkey__actions">
+          <Button
+            variant="ghost"
+            onClick={() => decide(false, false)}
+            data-testid="ssh-hostkey-reject"
+          >
+            Reject
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() => decide(true, false)}
+            data-testid="ssh-hostkey-accept-once"
+          >
+            Accept once
+          </Button>
+          <Button
+            variant={changed ? "danger" : "primary"}
+            onClick={() => decide(true, true)}
+            data-testid="ssh-hostkey-accept-remember"
+          >
+            Accept for host
+          </Button>
+        </div>
+      }
+    >
+      {current && (
+        <div className="ssh-hostkey__body">
+          {changed && (
+            <div
+              className="ssh-hostkey__warning"
+              role="alert"
+              data-testid="ssh-hostkey-mitm-warning"
+            >
+              <ShieldAlert size={16} className="ssh-hostkey__warning-icon" aria-hidden="true" />
+              <span>
+                The host key for this server <strong>changed</strong> since you last trusted it.
+                This can mean the server was reinstalled — or that someone is intercepting the
+                connection. Only continue if you expected this.
+              </span>
+            </div>
+          )}
+          <p className="ssh-hostkey__lead">
+            {changed
+              ? "The SSH server presented a different host key than the one you trusted for:"
+              : "The SSH server presented a host key that is not yet trusted for:"}
+          </p>
+          <dl className="ssh-hostkey__facts">
+            <dt>Host</dt>
+            <dd data-testid="ssh-hostkey-host">
+              {current.host}:{current.port}
+            </dd>
+            <dt>Key type</dt>
+            <dd data-testid="ssh-hostkey-type">{current.key_type}</dd>
+            <dt>Fingerprint</dt>
+            <dd className="ssh-hostkey__fingerprint" data-testid="ssh-hostkey-fingerprint">
+              {current.fingerprint}
+            </dd>
+          </dl>
+          <p className="ssh-hostkey__hint">
+            Verify the fingerprint matches the one your server administrator reports. &ldquo;Accept
+            for host&rdquo; remembers it so you are not asked again.
+          </p>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -573,6 +573,22 @@ export async function remoteDesktopCertDecision(
   await invoke("remote_desktop_cert_decision", { sessionId, accept, remember });
 }
 
+/**
+ * Deliver the user's verdict for a pending SSH host-key prompt (#1959).
+ *
+ * `accept` proceeds with the connection; `remember` (only meaningful with
+ * `accept`) persists the fingerprint so the host is trusted on future connects.
+ * Returns whether a prompt with `promptId` was actually waiting (a stale reply
+ * returns `false`).
+ */
+export async function sshHostKeyDecision(
+  promptId: string,
+  accept: boolean,
+  remember: boolean
+): Promise<boolean> {
+  return await invoke<boolean>("ssh_host_key_decision", { promptId, accept, remember });
+}
+
 /** Disconnect a graphical remote-desktop session. */
 export async function remoteDesktopDisconnect(sessionId: SessionId): Promise<void> {
   await invoke("remote_desktop_disconnect", { sessionId });

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -8,6 +8,7 @@ import { TunnelState, TunnelStats } from "@/types/tunnel";
 import { CredentialStoreStatusInfo } from "@/types/credential";
 import { ServerState } from "@/types/embeddedServer";
 import { XServerConsentRequest, XServerProgress } from "@/types/xserver";
+import { SshHostKeyPromptPayload } from "@/types/sshHostKey";
 import type { TransferProgress } from "@/services/api";
 import type {
   RemoteDesktopFramePayload,
@@ -95,6 +96,20 @@ export async function onRemoteDesktopCertPrompt(
   callback: (payload: RemoteDesktopCertPromptPayload) => void
 ): Promise<UnlistenFn> {
   return await listen<RemoteDesktopCertPromptPayload>("remote-desktop-cert-prompt", (event) => {
+    callback(event.payload);
+  });
+}
+
+/**
+ * Subscribe to interactive SSH host-key trust prompts (#1959). Fires when an SSH
+ * server presents an untrusted (unknown or changed) host key; the global
+ * `SshHostKeyPrompt` dialog shows the SHA-256 fingerprint and routes the verdict
+ * back via `sshHostKeyDecision`.
+ */
+export async function onSshHostKeyPrompt(
+  callback: (payload: SshHostKeyPromptPayload) => void
+): Promise<UnlistenFn> {
+  return await listen<SshHostKeyPromptPayload>("ssh-host-key-prompt", (event) => {
     callback(event.payload);
   });
 }

--- a/src/types/sshHostKey.ts
+++ b/src/types/sshHostKey.ts
@@ -1,0 +1,18 @@
+/**
+ * Payload of the `ssh-host-key-prompt` event (#1959): an SSH server presented an
+ * untrusted (unknown or changed) host key that needs an interactive trust
+ * decision.
+ *
+ * Fields are snake_case to match the Rust event serialization. `prompt_id`
+ * correlates the user's reply (`sshHostKeyDecision`) back to the blocked SSH
+ * handshake; `changed` is `true` for the possible-MITM case (a different key for
+ * a previously-trusted host) that the dialog warns about prominently.
+ */
+export interface SshHostKeyPromptPayload {
+  prompt_id: string;
+  host: string;
+  port: number;
+  key_type: string;
+  fingerprint: string;
+  changed: boolean;
+}


### PR DESCRIPTION
## Summary

Replaces the blind-accept in `core/src/backends/ssh/handler.rs`
`check_server_key()` — which returned `Ok(true)` for **every** host key,
a real man-in-the-middle hole (worse through a jump host into an
untrusted network) — with proper host-key verification backed by a
persisted trust store, mirroring the RDP certificate trust store
(`src-tauri/src/session/rdp_trust_store.rs`, #1767).

Trust-on-first-use:
- **Unknown host** → a fingerprint (SHA-256) confirmation dialog; remembered on "Accept for host".
- **Changed key** → a prominent possible-MITM warning that does **not** auto-accept; requires explicit action.
- **Trusted key** → silent thereafter.
- The user's own `~/.ssh/known_hosts` is honoured as a silent accept-fast-path.
- Jump-host hops are covered: each hop's handler carries that leg's host/port, so every hop's key is verified.

## Design

- **core** (`backends/ssh/host_key.rs`): a pluggable, process-wide
  `HostKeyVerifier` trait. The handler computes the presented key's
  SHA-256 fingerprint and delegates the trust decision. A process-global
  verifier avoids threading state through the dozen SSH connect call
  sites (terminal, tunnels, SFTP, agent, monitoring, jump hosts). With
  no verifier registered (agent / headless / bare-core tests) the key is
  accepted with a warning, preserving prior behaviour; the desktop app
  always registers a strict verifier.
- **src-tauri** (`session/ssh_trust_store.rs`): the persisted
  `host:port → SHA256 fingerprint` store, a direct sibling of
  `rdp_trust_store.rs` (`ssh_known_hosts.json`).
- **src-tauri** (`session/ssh_host_key_verifier.rs`): the desktop
  verifier — consults the store, emits `ssh-host-key-prompt`, blocks the
  handshake on the user's verdict (via `ssh_host_key_decision`), persists
  accepted-for-host. Registered at startup in `lib.rs`.
- **frontend**: a global `SshHostKeyPrompt` dialog (analogue of the RDP
  `RemoteDesktopCertPrompt`).

## Tests

- core: verifier is consulted (no blind accept); `host:port` keying.
- trust store: unknown / known / changed / rotation / persist / revoke.
- verifier: known-host silent (no prompt), unknown prompts + remember
  persists, changed warns + reject aborts + not persisted, accept-once
  not persisted.
- frontend: dialog render + decision routing.

Closes #1959

## Follow-ups

- #1968 — SSH trust-management settings UI (view/revoke known hosts)
- #1969 — harden SSH host-key handling on the remote agent
