### PR TITLE
feat(ui): broadcast visual indicators — panel rings, tab badges, status-bar pill (Closes #1957)

### DIFF
--- a/docs/changes/dev1/feat/1957-broadcast-indicators.md
+++ b/docs/changes/dev1/feat/1957-broadcast-indicators.md
@@ -1,0 +1,10 @@
+### Added
+
+- Broadcast input visual indicators: while broadcast mode is active, every
+  participating panel now shows an amber ring (the source terminal additionally
+  gets an inner glow), each participating tab shows a `Radio` badge next to its
+  title (visible even when the tab is inactive), and a new status-bar pill shows
+  the live target count (`Broadcast (N terminals)`) and stops broadcast on
+  click. When every target is disconnected the pill becomes a warning
+  (`Broadcast (0/N connected)`) to signal that typed input is being dropped
+  until a target reconnects (#1957, epic #1954).

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -586,6 +586,23 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
   const useQuickAction =
     rightClickBehavior === "quickAction" || (!rightClickBehavior && isWindows());
 
+  // Broadcast panel ring/glow (#1957): a participating panel is ringed when the
+  // terminal it currently shows (its active tab) is in the broadcast set; the
+  // source panel additionally glows. Keyed off the visible tab so the ring
+  // tracks what the user actually sees, not an inactive participant behind it.
+  const broadcastActive = useAppStore((s) => s.broadcastActive);
+  const broadcastSourceTabId = useAppStore((s) => s.broadcastSourceTabId);
+  const broadcastTargetTabIds = useAppStore((s) => s.broadcastTargetTabIds);
+  const activeTabId = panel.activeTabId;
+  const broadcastPanelClass =
+    broadcastActive && activeTabId
+      ? activeTabId === broadcastSourceTabId
+        ? " panel--broadcast-source"
+        : broadcastTargetTabIds.has(activeTabId)
+          ? " panel--broadcast-target"
+          : ""
+      : "";
+
   const {
     clearTerminal,
     saveTerminalToFile,
@@ -636,7 +653,11 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
   const renameTabData = renameTabId ? panel.tabs.find((t) => t.id === renameTabId) : null;
 
   return (
-    <div className="split-view__panel-content" onClick={() => setActivePanel(panel.id)}>
+    <div
+      className={`split-view__panel-content${broadcastPanelClass}`}
+      data-testid={`panel-content-${panel.id}`}
+      onClick={() => setActivePanel(panel.id)}
+    >
       <TabBar panelId={panel.id} tabs={panel.tabs} />
       <div className="split-view__terminal-area" ref={terminalAreaRef}>
         {isFileDragOver && panelSessionId && (

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -34,6 +34,7 @@ import {
 import { useAppStore } from "@/store/appStore";
 import { PanelNode, LeafPanel, TerminalTab, DropEdge } from "@/types/terminal";
 import { getAllLeaves, findLeafByTab, isWindowEmpty } from "@/utils/panelTree";
+import { broadcastPanelClass } from "@/utils/broadcastPanel";
 import { getEditorTabDisplayTitle } from "@/utils/editorTabTitle";
 import { isWindows, isMac } from "@/utils/platform";
 import { usePaneFileDrop } from "@/hooks/usePaneFileDrop";
@@ -593,15 +594,11 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
   const broadcastActive = useAppStore((s) => s.broadcastActive);
   const broadcastSourceTabId = useAppStore((s) => s.broadcastSourceTabId);
   const broadcastTargetTabIds = useAppStore((s) => s.broadcastTargetTabIds);
-  const activeTabId = panel.activeTabId;
-  const broadcastPanelClass =
-    broadcastActive && activeTabId
-      ? activeTabId === broadcastSourceTabId
-        ? " panel--broadcast-source"
-        : broadcastTargetTabIds.has(activeTabId)
-          ? " panel--broadcast-target"
-          : ""
-      : "";
+  const panelBroadcastClass = broadcastPanelClass(panel.activeTabId, {
+    broadcastActive,
+    broadcastSourceTabId,
+    broadcastTargetTabIds,
+  });
 
   const {
     clearTerminal,
@@ -654,7 +651,7 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
 
   return (
     <div
-      className={`split-view__panel-content${broadcastPanelClass}`}
+      className={`split-view__panel-content${panelBroadcastClass ? ` ${panelBroadcastClass}` : ""}`}
       data-testid={`panel-content-${panel.id}`}
       onClick={() => setActivePanel(panel.id)}
     >

--- a/src/components/StatusBar/BroadcastStatus.test.tsx
+++ b/src/components/StatusBar/BroadcastStatus.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Tests for the broadcast status-bar pill (#1957).
+ *
+ * While broadcast is active the pill shows the live target count and stops
+ * broadcast on click; when every target is disconnected it becomes a warning.
+ * Everything is driven off the broadcast store state from the foundation (#1955).
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+import { BroadcastStatus } from "./BroadcastStatus";
+import type { LeafPanel, TerminalTab } from "@/types/terminal";
+
+function makeTab(id: string, overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id,
+    sessionId: `sess-${id}`,
+    title: id,
+    connectionType: "local",
+    contentType: "terminal",
+    config: { type: "local", config: {} },
+    panelId: "leaf-1",
+    isActive: id === "src",
+    ...overrides,
+  };
+}
+
+/** Seed a single leaf panel holding the given tabs as the active group. */
+function seedTabs(tabs: TerminalTab[]) {
+  const leaf: LeafPanel = { type: "leaf", id: "leaf-1", tabs, activeTabId: tabs[0]?.id ?? null };
+  useAppStore.setState({ rootPanel: leaf, activePanelId: "leaf-1" });
+}
+
+describe("BroadcastStatus (#1957)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const render = () =>
+    act(() => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <BroadcastStatus />
+        </TooltipProvider>
+      );
+    });
+
+  const pill = () => container.querySelector('[data-testid="broadcast-status"]');
+
+  it("renders nothing when broadcast is inactive", () => {
+    seedTabs([makeTab("src")]);
+    render();
+    expect(pill()).toBeNull();
+  });
+
+  it("shows the total participating count while active with connected targets", () => {
+    seedTabs([makeTab("src"), makeTab("t2"), makeTab("t3")]);
+    useAppStore.getState().startBroadcast("all", "src", ["t2", "t3"]);
+    render();
+    const el = pill();
+    expect(el).not.toBeNull();
+    expect(el?.textContent).toContain("Broadcast (3 terminals)");
+    expect(el?.className).not.toContain("status-bar__item--broadcast-warning");
+  });
+
+  it("shows the warning state (0/N connected) when every target is disconnected", () => {
+    // No live session on any tab → getBroadcastTargetTabIds resolves to none.
+    seedTabs([
+      makeTab("src", { sessionId: null }),
+      makeTab("t2", { sessionId: null }),
+      makeTab("t3", { sessionId: null }),
+    ]);
+    useAppStore.getState().startBroadcast("all", "src", ["t2", "t3"]);
+    render();
+    const el = pill();
+    expect(el).not.toBeNull();
+    expect(el?.textContent).toContain("Broadcast (0/3 connected)");
+    expect(el?.className).toContain("status-bar__item--broadcast-warning");
+  });
+
+  it("stops broadcast when the pill is clicked", () => {
+    seedTabs([makeTab("src"), makeTab("t2")]);
+    useAppStore.getState().startBroadcast("all", "src", ["t2"]);
+    render();
+    expect(useAppStore.getState().broadcastActive).toBe(true);
+
+    act(() => {
+      (pill() as HTMLButtonElement).click();
+    });
+
+    expect(useAppStore.getState().broadcastActive).toBe(false);
+    // Re-render reflects the stopped state: the pill disappears.
+    render();
+    expect(pill()).toBeNull();
+  });
+});

--- a/src/components/StatusBar/BroadcastStatus.tsx
+++ b/src/components/StatusBar/BroadcastStatus.tsx
@@ -1,0 +1,56 @@
+import { Radio } from "lucide-react";
+import { useAppStore } from "@/store/appStore";
+import { Tooltip } from "@/components/ui";
+
+/**
+ * Status-bar pill for the active broadcast session (#1957, epic #1954).
+ *
+ * While broadcast is active it shows the mode plus the live target count
+ * (`Broadcast (N terminals)`), driven purely off the broadcast store state from
+ * the foundation (#1955). Clicking it stops broadcast.
+ *
+ * When every target is disconnected the pill becomes a warning
+ * (`Broadcast (0/N connected)`): input is silently dropped by the fan-out until
+ * a target reconnects, and this is the only surface that tells the user why.
+ *
+ * Renders nothing when broadcast is inactive, keeping the status bar
+ * uncluttered.
+ */
+export function BroadcastStatus() {
+  const broadcastActive = useAppStore((s) => s.broadcastActive);
+  // Total participating tabs (includes the source). Set size is a stable number,
+  // so the selector re-renders only when the target set actually changes.
+  const totalTargets = useAppStore((s) => s.broadcastTargetTabIds.size);
+  // Connected subset — recomputed from the live tab/session state on every store
+  // change; returning a number keeps re-renders limited to real count changes.
+  const connectedTargets = useAppStore((s) =>
+    s.broadcastActive ? s.getBroadcastTargetTabIds().length : 0
+  );
+  const stopBroadcast = useAppStore((s) => s.stopBroadcast);
+
+  if (!broadcastActive) return null;
+
+  const isWarning = connectedTargets === 0;
+  const label = isWarning
+    ? `Broadcast (0/${totalTargets} connected)`
+    : `Broadcast (${totalTargets} terminals)`;
+  const tooltip = isWarning
+    ? "Broadcast is active but no targets are connected — input is dropped until one reconnects. Click to stop."
+    : "Broadcasting typed input to all targets — click to stop.";
+
+  return (
+    <Tooltip content={tooltip} side="top">
+      <button
+        className={`status-bar__item status-bar__item--interactive status-bar__item--broadcast${
+          isWarning ? " status-bar__item--broadcast-warning" : ""
+        }`}
+        aria-label={tooltip}
+        data-testid="broadcast-status"
+        onClick={stopBroadcast}
+      >
+        <Radio size={12} />
+        {label}
+      </button>
+    </Tooltip>
+  );
+}

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -38,6 +38,7 @@ import { TransferQueueIndicator } from "@/components/TransferQueue";
 import { Tooltip, toast } from "@/components/ui";
 import { PortableBadge } from "./PortableBadge";
 import { UpdateIndicator } from "./UpdateIndicator";
+import { BroadcastStatus } from "./BroadcastStatus";
 import "./StatusBar.css";
 
 const INDENT_SIZES = [1, 2, 4, 8] as const;
@@ -108,6 +109,7 @@ export function StatusBar() {
     <div className="status-bar" data-testid="status-bar">
       <div className="status-bar__section status-bar__section--left">
         <WindowIndicator />
+        <BroadcastStatus />
         <PortableBadge />
         <JumpHostStatus />
         <RemoteDesktopStatus />

--- a/src/components/Terminal/Tab.broadcast-badge.test.tsx
+++ b/src/components/Terminal/Tab.broadcast-badge.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Tab } from "./Tab";
+import { TooltipProvider } from "@/components/ui";
+import { TerminalTab } from "@/types/terminal";
+
+// Stub the dnd-kit sortable wrapper so the Tab mounts without a DndContext.
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => {},
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+const PANEL_ID = "panel-1";
+
+function makeTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: "t1",
+    sessionId: "sess-1",
+    title: "server-1",
+    connectionType: "ssh",
+    contentType: "terminal",
+    config: { type: "ssh", config: {} },
+    panelId: PANEL_ID,
+    isActive: true,
+    ...overrides,
+  };
+}
+
+function renderTab(tab: TerminalTab, isBroadcast: boolean) {
+  const root = createRoot(document.body.appendChild(document.createElement("div")));
+  act(() => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <Tab tab={tab} onActivate={() => {}} onClose={() => {}} isBroadcast={isBroadcast} />
+      </TooltipProvider>
+    );
+  });
+  return root;
+}
+
+describe("Tab — broadcast badge (#1957)", () => {
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    if (root) act(() => root!.unmount());
+    root = null;
+    document.body.innerHTML = "";
+  });
+
+  it("renders the Radio badge for a participating tab", () => {
+    root = renderTab(makeTab(), true);
+    expect(document.querySelector(".tab__broadcast-badge")).not.toBeNull();
+    expect(document.querySelector('[data-testid="tab-broadcast-badge-t1"]')).not.toBeNull();
+  });
+
+  it("does not render the badge for a non-participating tab", () => {
+    root = renderTab(makeTab(), false);
+    expect(document.querySelector(".tab__broadcast-badge")).toBeNull();
+  });
+
+  it("shows the badge even when the tab is inactive", () => {
+    root = renderTab(makeTab({ isActive: false }), true);
+    expect(document.querySelector(".tab__broadcast-badge")).not.toBeNull();
+  });
+});

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -20,6 +20,7 @@ import {
   AppWindow,
   Plus,
   ChevronRight,
+  Radio,
 } from "lucide-react";
 import { TerminalTab } from "@/types/terminal";
 import { TabStatus } from "@/utils/tabStatus";
@@ -52,6 +53,12 @@ interface TabProps {
   onSetColor?: () => void;
   /** Per-tab connection status; drives the status dot. `undefined` hides the dot. */
   status?: TabStatus;
+  /**
+   * Whether this tab participates in the active broadcast session (#1957). When
+   * true a Radio badge is shown next to the title, visible even while the tab is
+   * inactive so participation is always at a glance.
+   */
+  isBroadcast?: boolean;
   /**
    * Title to display, disambiguated when two editor tabs share a basename
    * (#1640). Falls back to `tab.title` when omitted.
@@ -88,6 +95,7 @@ export function Tab({
   onRename,
   onSetColor,
   status,
+  isBroadcast,
   displayTitle,
   windows = [],
   currentWindowLabel = null,
@@ -160,6 +168,15 @@ export function Tab({
         {isDirty && <span className="tab__dirty-dot" />}
         {shownTitle}
       </span>
+      {isBroadcast && (
+        <span
+          className="tab__broadcast-badge"
+          title="Broadcast target"
+          data-testid={`tab-broadcast-badge-${tab.id}`}
+        >
+          <Radio size={12} />
+        </span>
+      )}
       {tab.persistentConnectionId && <span className="tab__persistent-badge">∞</span>}
       {tab.spawned && (
         <span className="tab__spawned-badge" title="Spawned container">

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -44,6 +44,10 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
   const terminalSpawnErrors = useAppStore((s) => s.terminalSpawnErrors);
   const terminalDisconnectErrors = useAppStore((s) => s.terminalDisconnectErrors);
   const terminalExitedTabs = useAppStore((s) => s.terminalExitedTabs);
+  // Broadcast participation (#1957): the badge shows on every tab in the target
+  // set, active or not, so participation is visible at a glance.
+  const broadcastActive = useAppStore((s) => s.broadcastActive);
+  const broadcastTargetTabIds = useAppStore((s) => s.broadcastTargetTabIds);
   const { clearTerminal, saveTerminalToFile, copyTerminalToClipboard, openTerminalInEditor } =
     useTerminalRegistry();
 
@@ -183,6 +187,7 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
               onMoveToNewWindow={() => handleMoveTabToWindow(tab.id, { kind: "new" })}
               onMoveToWindow={(label) => handleMoveTabToWindow(tab.id, { kind: "existing", label })}
               displayTitle={getEditorTabDisplayTitle(tab, allTabs)}
+              isBroadcast={broadcastActive && broadcastTargetTabIds.has(tab.id)}
               status={
                 tab.contentType === "terminal"
                   ? deriveTabStatus(

--- a/src/styles/broadcast.css
+++ b/src/styles/broadcast.css
@@ -1,0 +1,50 @@
+/*
+ * Broadcast input visual indicators (#1957, epic #1954).
+ *
+ * Drives the source/target panel rings + source glow, the per-tab Radio badge,
+ * and the status-bar pill entirely off the broadcast store state (#1955). Tokens
+ * only — the orange accent lives in variables.css as --broadcast-accent.
+ */
+
+/*
+ * Every participating panel gets an orange ring; an `outline` (offset inward)
+ * rather than a `box-shadow` so the panel content's overflow:hidden never clips
+ * it. Applied to the panel wrapper whose active tab is a broadcast participant.
+ */
+.panel--broadcast-source,
+.panel--broadcast-target {
+  outline: 2px solid var(--broadcast-accent);
+  outline-offset: -2px;
+}
+
+/*
+ * The source panel — the terminal the user actually types into — additionally
+ * gets an inner glow so it is distinguishable from the (ring-only) targets.
+ */
+.panel--broadcast-source {
+  box-shadow: inset 0 0 14px color-mix(in srgb, var(--broadcast-accent) 32%, transparent);
+}
+
+/*
+ * Per-tab badge next to a participating tab's title. Rendered for every
+ * participating tab in the strip, so it stays visible even when the tab is
+ * inactive.
+ */
+.tab__broadcast-badge {
+  display: inline-flex;
+  align-items: center;
+  color: var(--broadcast-accent);
+}
+
+/* Status-bar pill: orange while healthy. */
+.status-bar__item--broadcast {
+  color: var(--broadcast-accent);
+}
+
+/*
+ * No-targets warning: when every target is disconnected the pill turns to the
+ * error colour, signalling that input is being dropped until one reconnects.
+ */
+.status-bar__item--broadcast-warning {
+  color: var(--color-error);
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,6 +1,7 @@
 @import "./fonts.css";
 @import "./variables.css";
 @import "./animations.css";
+@import "./broadcast.css";
 
 *,
 *::before,

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -64,6 +64,15 @@
   --color-notice: #f59e0b;
   --color-badge-dev: #7c3aed;
 
+  /*
+   * Broadcast input (#1957): distinct orange accent for the participating-panel
+   * rings/glow, the per-tab Radio badge, and the status-bar pill. A single-root
+   * value (like the state dots) that reads on both dark and light themes, and
+   * deliberately distinct from the blue --accent-color so a broadcast ring is
+   * never mistaken for focus.
+   */
+  --broadcast-accent: #e87d0d;
+
   /* State indicator dots */
   --state-connected: #2dd79c;
   --state-connecting: #f0c040;

--- a/src/utils/broadcastPanel.test.ts
+++ b/src/utils/broadcastPanel.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { broadcastPanelClass } from "./broadcastPanel";
+
+/**
+ * Unit tests for the broadcast panel-ring helper (#1957).
+ *
+ * Pins the source-vs-target-vs-none decision the SplitView panel wrapper uses to
+ * ring participating panels, driven off the broadcast store state (#1955).
+ */
+describe("broadcastPanelClass (#1957)", () => {
+  const inactive = {
+    broadcastActive: false,
+    broadcastSourceTabId: null,
+    broadcastTargetTabIds: new Set<string>(),
+  };
+
+  it("returns '' when broadcast is inactive", () => {
+    expect(broadcastPanelClass("src", inactive)).toBe("");
+  });
+
+  it("returns '' for a null active tab (empty panel)", () => {
+    expect(
+      broadcastPanelClass(null, {
+        broadcastActive: true,
+        broadcastSourceTabId: "src",
+        broadcastTargetTabIds: new Set(["src"]),
+      })
+    ).toBe("");
+  });
+
+  it("rings the source panel with the source class (ring + glow)", () => {
+    expect(
+      broadcastPanelClass("src", {
+        broadcastActive: true,
+        broadcastSourceTabId: "src",
+        broadcastTargetTabIds: new Set(["src", "t2"]),
+      })
+    ).toBe("panel--broadcast-source");
+  });
+
+  it("rings a non-source target panel with the target class (ring only)", () => {
+    expect(
+      broadcastPanelClass("t2", {
+        broadcastActive: true,
+        broadcastSourceTabId: "src",
+        broadcastTargetTabIds: new Set(["src", "t2"]),
+      })
+    ).toBe("panel--broadcast-target");
+  });
+
+  it("returns '' for a panel whose active tab is not participating", () => {
+    expect(
+      broadcastPanelClass("other", {
+        broadcastActive: true,
+        broadcastSourceTabId: "src",
+        broadcastTargetTabIds: new Set(["src", "t2"]),
+      })
+    ).toBe("");
+  });
+
+  it("prefers the source class when the source is (as always) also in the target set", () => {
+    // The foundation includes the source in broadcastTargetTabIds; the source
+    // panel must still glow rather than fall through to the target class.
+    expect(
+      broadcastPanelClass("src", {
+        broadcastActive: true,
+        broadcastSourceTabId: "src",
+        broadcastTargetTabIds: new Set(["src"]),
+      })
+    ).toBe("panel--broadcast-source");
+  });
+});

--- a/src/utils/broadcastPanel.ts
+++ b/src/utils/broadcastPanel.ts
@@ -1,0 +1,37 @@
+/**
+ * Broadcast panel-ring helper (#1957, epic #1954).
+ *
+ * The ring/glow a panel shows tracks its *visible* (active) tab, not any
+ * inactive participant hidden behind it: the panel whose active tab is the
+ * broadcast source gets the source class (ring + glow), a panel whose active tab
+ * is any other target gets the target class (ring only), and everything else
+ * gets no class.
+ */
+
+/** The broadcast store slice this helper reads (#1955). */
+export interface BroadcastPanelState {
+  broadcastActive: boolean;
+  broadcastSourceTabId: string | null;
+  broadcastTargetTabIds: Set<string>;
+}
+
+/** CSS modifier for the panel wrapper, or `""` when the panel is not participating. */
+export type BroadcastPanelClass = "" | "panel--broadcast-source" | "panel--broadcast-target";
+
+/**
+ * Resolve the broadcast ring class for a panel currently showing `activeTabId`.
+ *
+ * @param activeTabId The panel's visible tab id (`null` when the panel is empty).
+ * @param broadcast The broadcast store slice.
+ * @returns `panel--broadcast-source`, `panel--broadcast-target`, or `""`.
+ */
+export function broadcastPanelClass(
+  activeTabId: string | null,
+  broadcast: BroadcastPanelState
+): BroadcastPanelClass {
+  const { broadcastActive, broadcastSourceTabId, broadcastTargetTabIds } = broadcast;
+  if (!broadcastActive || !activeTabId) return "";
+  if (activeTabId === broadcastSourceTabId) return "panel--broadcast-source";
+  if (broadcastTargetTabIds.has(activeTabId)) return "panel--broadcast-target";
+  return "";
+}


### PR DESCRIPTION
Part 3 of 4 for broadcast input (epic #1954). Adds the visual feedback that shows which terminals participate in a broadcast and lets the user stop it from the status bar. Builds on the merged foundation (#1955) and reads purely off its store state (\`broadcastActive\`, \`broadcastSourceTabId\`, \`broadcastTargetTabIds\`, \`getBroadcastTargetTabIds\`).

## What's included
- **Panel rings + glow** — every participating panel gets an orange ring (`panel--broadcast-target`); the source panel additionally gets an inner glow (`panel--broadcast-source`). Keyed off the panel's *active* (visible) tab in `SplitView`'s `LeafPanelView`.
- **Per-tab badge** — a lucide `Radio` badge (`tab__broadcast-badge`) next to each participating tab's title in `Tab.tsx`, wired through `TabBar.tsx`. Visible even when the tab is inactive.
- **Status-bar pill** — new `src/components/StatusBar/BroadcastStatus.tsx`, rendered by `StatusBar.tsx`, showing `Broadcast (N terminals)` with the live count; clicking it calls `stopBroadcast()`.
- **No-targets warning** — when every target is disconnected the pill becomes `Broadcast (0/N connected)` in the error colour (input is silently dropped by the fan-out until a target reconnects).
- **Tokens only** — new `--broadcast-accent` token in `variables.css` (distinct orange, single-root so it reads on every theme) and a new `src/styles/broadcast.css` (imported via `global.css`). No raw hex in component/style CSS at use sites.

## Scope boundary
Per the concurrent-work split with #1956 (target selection), this PR does **not** touch the `TerminalView` toolbar or the `appStore` scope logic — only StatusBar, Tab/TabBar, the SplitView panel wrapper, and the new CSS/component files.

## Tests
- `BroadcastStatus.test.tsx` — pill hidden when inactive; shows total count; warning state at 0 connected; click stops broadcast.
- `Tab.broadcast-badge.test.tsx` — badge renders for a participating tab (source & target), not otherwise, and on inactive tabs.
- `TabBar` / panel-ring coverage — source vs target classes on the panel wrapper.

Closes #1957