### PR TITLE
feat(terminal): broadcast target selection — scope dropdown and custom picker (Closes #1956)

### DIFF
--- a/docs/changes/dev5/feat/1956-broadcast-target-selection.md
+++ b/docs/changes/dev5/feat/1956-broadcast-target-selection.md
@@ -1,0 +1,13 @@
+### Added
+
+- Broadcast input (target selection): clicking the terminal-view **Broadcast
+  Input** toggle now opens a scope dialog instead of starting immediately.
+  Choose **All terminals**, **All in current panel**, or **Custom selection**
+  (each showing a live target count); custom selection opens a per-terminal
+  checkbox picker with Select All / Select None that lists only terminal
+  sessions — non-terminal tabs (editors, SFTP) never appear. The chosen scope is
+  remembered for next time. Membership is dynamic: under "All terminals" and
+  "All in current panel", terminals opened during an active broadcast are added
+  automatically (only within the source panel for the panel scope); under
+  "Custom selection" they are never auto-added. Closed terminals are removed
+  silently (#1956, epic #1954).

--- a/src/components/Terminal/BroadcastScopeDialog.css
+++ b/src/components/Terminal/BroadcastScopeDialog.css
@@ -1,0 +1,58 @@
+.broadcast-scope-dialog__custom {
+  margin-top: var(--spacing-md);
+}
+
+.broadcast-scope-dialog__custom-actions {
+  display: flex;
+  gap: var(--spacing-xs);
+  margin-bottom: var(--spacing-sm);
+}
+
+.broadcast-scope-dialog__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 240px;
+  overflow-y: auto;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+}
+
+.broadcast-scope-dialog__row {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs) var(--spacing-sm);
+}
+
+.broadcast-scope-dialog__row + .broadcast-scope-dialog__row {
+  border-top: 1px solid var(--border-primary);
+}
+
+.broadcast-scope-dialog__row-label {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+  cursor: pointer;
+  min-width: 0;
+}
+
+.broadcast-scope-dialog__row-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.broadcast-scope-dialog__row-type {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.broadcast-scope-dialog__empty {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}

--- a/src/components/Terminal/BroadcastScopeDialog.test.tsx
+++ b/src/components/Terminal/BroadcastScopeDialog.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Tests for the broadcast scope-selection dialog (#1956): scope options with
+ * live counts, the custom per-terminal picker (non-terminal exclusion, Select
+ * All / Select None), and that confirming starts broadcast with the resolved
+ * target set and remembered scope.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+import { BroadcastScopeDialog } from "./BroadcastScopeDialog";
+import { useAppStore } from "@/store/appStore";
+import type {
+  LeafPanel,
+  TerminalTab,
+  TabContentType,
+  ConnectionType,
+  BroadcastScope,
+} from "@/types/terminal";
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+function makeTab(
+  id: string,
+  contentType: TabContentType = "terminal",
+  connectionType: ConnectionType = "local"
+): TerminalTab {
+  return {
+    id,
+    sessionId: `sess-${id}`,
+    title: id,
+    connectionType,
+    contentType,
+    config: { type: "local", config: {} },
+    panelId: "leaf-1",
+    isActive: id === "src",
+  };
+}
+
+function seed(tabs: TerminalTab[], scope: BroadcastScope = "all") {
+  const leaf: LeafPanel = { type: "leaf", id: "leaf-1", tabs, activeTabId: "src" };
+  useAppStore.setState({
+    rootPanel: leaf,
+    activePanelId: "leaf-1",
+    lastBroadcastScope: scope,
+  });
+}
+
+const q = (sel: string) => document.querySelector(sel);
+const click = (el: Element | null) => act(() => (el as HTMLElement).click());
+
+describe("BroadcastScopeDialog (#1956)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when closed", () => {
+    seed([makeTab("src")]);
+    render(<BroadcastScopeDialog open={false} onOpenChange={() => {}} sourceTabId="src" />);
+    expect(q('[data-testid="broadcast-scope-select"]')).toBeNull();
+  });
+
+  it("renders the scope select when open", () => {
+    seed([makeTab("src"), makeTab("t2")]);
+    render(<BroadcastScopeDialog open onOpenChange={() => {}} sourceTabId="src" />);
+    expect(q(".ui-modal")).toBeTruthy();
+    expect(q('[data-testid="broadcast-scope-select"]')).toBeTruthy();
+  });
+
+  it("Start with the 'all' scope broadcasts to every terminal plus the source", () => {
+    seed([makeTab("src"), makeTab("t2"), makeTab("editor", "editor")], "all");
+    render(<BroadcastScopeDialog open onOpenChange={() => {}} sourceTabId="src" />);
+
+    click(q('[data-testid="broadcast-scope-confirm"]'));
+
+    const s = useAppStore.getState();
+    expect(s.broadcastActive).toBe(true);
+    expect(s.broadcastScope).toBe("all");
+    expect(s.lastBroadcastScope).toBe("all");
+    // Non-terminal "editor" tab is excluded.
+    expect([...s.broadcastTargetTabIds].sort()).toEqual(["src", "t2"]);
+  });
+
+  it("custom picker lists only terminal tabs, never non-terminal ones", () => {
+    seed([makeTab("src"), makeTab("t2"), makeTab("editor", "editor")], "custom");
+    render(<BroadcastScopeDialog open onOpenChange={() => {}} sourceTabId="src" />);
+
+    expect(q('[data-testid="broadcast-target-src"]')).toBeTruthy();
+    expect(q('[data-testid="broadcast-target-t2"]')).toBeTruthy();
+    expect(q('[data-testid="broadcast-target-editor"]')).toBeNull();
+  });
+
+  it("Select None disables Start; Select All re-enables it", () => {
+    seed([makeTab("src"), makeTab("t2")], "custom");
+    render(<BroadcastScopeDialog open onOpenChange={() => {}} sourceTabId="src" />);
+
+    const confirm = () => q('[data-testid="broadcast-scope-confirm"]') as HTMLButtonElement;
+    // Pre-selected → actionable.
+    expect(confirm().disabled).toBe(false);
+
+    click(q('[data-testid="broadcast-scope-select-none"]'));
+    expect(confirm().disabled).toBe(true);
+
+    click(q('[data-testid="broadcast-scope-select-all"]'));
+    expect(confirm().disabled).toBe(false);
+  });
+
+  it("custom Start broadcasts to exactly the checked terminals", () => {
+    seed([makeTab("src"), makeTab("t2"), makeTab("t3")], "custom");
+    render(<BroadcastScopeDialog open onOpenChange={() => {}} sourceTabId="src" />);
+
+    // Uncheck t3 (starts fully selected).
+    click(q('[data-testid="broadcast-target-t3"]'));
+    click(q('[data-testid="broadcast-scope-confirm"]'));
+
+    const s = useAppStore.getState();
+    expect(s.broadcastActive).toBe(true);
+    expect(s.broadcastScope).toBe("custom");
+    expect([...s.broadcastTargetTabIds].sort()).toEqual(["src", "t2"]);
+  });
+
+  it("Cancel closes without starting broadcast", () => {
+    seed([makeTab("src"), makeTab("t2")]);
+    const onOpenChange = vi.fn();
+    render(<BroadcastScopeDialog open onOpenChange={onOpenChange} sourceTabId="src" />);
+
+    click(q('[data-testid="broadcast-scope-cancel"]'));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(useAppStore.getState().broadcastActive).toBe(false);
+  });
+});

--- a/src/components/Terminal/BroadcastScopeDialog.tsx
+++ b/src/components/Terminal/BroadcastScopeDialog.tsx
@@ -1,0 +1,216 @@
+import { useEffect, useMemo, useState } from "react";
+import { Modal, Button, Field, Select, Checkbox } from "@/components/ui";
+import { useAppStore, resolveBroadcastTargetTabIds } from "@/store/appStore";
+import { getAllLeaves } from "@/utils/panelTree";
+import type { BroadcastScope, ConnectionType, TerminalTab } from "@/types/terminal";
+import "./BroadcastScopeDialog.css";
+
+export interface BroadcastScopeDialogProps {
+  /** Whether the dialog is open. */
+  open: boolean;
+  /** Called when the dialog should open/close. */
+  onOpenChange: (open: boolean) => void;
+  /**
+   * The tab that owns broadcast input (the terminal the user types into). The
+   * dialog only opens with a valid terminal source; `null` renders nothing.
+   */
+  sourceTabId: string | null;
+}
+
+/** Short, human-readable label for a terminal's connection type (SSH/local/…). */
+const TYPE_LABELS: Record<string, string> = {
+  ssh: "SSH",
+  local: "local",
+  serial: "serial",
+  telnet: "telnet",
+  docker: "docker",
+  remote: "remote",
+  "remote-session": "remote",
+};
+
+function typeLabel(type: ConnectionType): string {
+  return TYPE_LABELS[type] ?? String(type);
+}
+
+/**
+ * Scope-selection flow shown when the user clicks the broadcast toolbar toggle
+ * (#1956). Presents the three scopes — **All terminals**, **All in current
+ * panel**, **Custom selection** — each with a live target count; picking
+ * "Custom" reveals a per-terminal checkbox picker (Select All / Select None).
+ * Non-terminal tabs (editors, SFTP) never appear. On confirm it resolves the
+ * chosen scope to a concrete target set, starts broadcast, and persists the
+ * scope as `lastBroadcastScope` (via `startBroadcast`).
+ *
+ * Composed from the shared UI primitives (Modal/Select/Checkbox/Button).
+ */
+export function BroadcastScopeDialog({
+  open,
+  onOpenChange,
+  sourceTabId,
+}: BroadcastScopeDialogProps) {
+  const rootPanel = useAppStore((s) => s.rootPanel);
+  const lastBroadcastScope = useAppStore((s) => s.lastBroadcastScope);
+  const startBroadcast = useAppStore((s) => s.startBroadcast);
+
+  const [scope, setScope] = useState<BroadcastScope>(lastBroadcastScope);
+  const [customSelected, setCustomSelected] = useState<Set<string>>(new Set());
+
+  // Terminal tabs in the active group — the only broadcast-eligible tabs and the
+  // rows of the custom picker. Non-terminal tabs are excluded here.
+  const terminalTabs = useMemo<TerminalTab[]>(
+    () =>
+      getAllLeaves(rootPanel)
+        .flatMap((leaf) => leaf.tabs)
+        .filter((tab) => tab.contentType === "terminal"),
+    [rootPanel]
+  );
+
+  // Reset to the remembered scope and pre-select every terminal each time the
+  // dialog opens, so Custom starts as "everything" and Start is immediately
+  // actionable.
+  useEffect(() => {
+    if (open) {
+      setScope(lastBroadcastScope);
+      setCustomSelected(new Set(terminalTabs.map((t) => t.id)));
+    }
+  }, [open, lastBroadcastScope, terminalTabs]);
+
+  const allCount = useMemo(
+    () =>
+      sourceTabId ? resolveBroadcastTargetTabIds({ rootPanel }, "all", sourceTabId).length : 0,
+    [rootPanel, sourceTabId]
+  );
+  const panelCount = useMemo(
+    () =>
+      sourceTabId ? resolveBroadcastTargetTabIds({ rootPanel }, "panel", sourceTabId).length : 0,
+    [rootPanel, sourceTabId]
+  );
+
+  const scopeOptions = useMemo(
+    () => [
+      { value: "all", label: `All terminals (${allCount})` },
+      { value: "panel", label: `All in current panel (${panelCount})` },
+      { value: "custom", label: "Custom selection…" },
+    ],
+    [allCount, panelCount]
+  );
+
+  // The concrete target set the chosen scope resolves to.
+  const resolvedTargets = useMemo<string[]>(() => {
+    if (!sourceTabId) return [];
+    if (scope === "custom") {
+      const terminalIds = new Set(terminalTabs.map((t) => t.id));
+      return [...customSelected].filter((id) => terminalIds.has(id));
+    }
+    return resolveBroadcastTargetTabIds({ rootPanel }, scope, sourceTabId);
+  }, [scope, sourceTabId, rootPanel, customSelected, terminalTabs]);
+
+  const canStart = sourceTabId !== null && resolvedTargets.length > 0;
+
+  const toggleCustom = (tabId: string, checked: boolean) => {
+    setCustomSelected((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(tabId);
+      else next.delete(tabId);
+      return next;
+    });
+  };
+
+  const handleStart = () => {
+    if (!sourceTabId || !canStart) return;
+    startBroadcast(scope, sourceTabId, resolvedTargets);
+    onOpenChange(false);
+  };
+
+  return (
+    <Modal
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Broadcast Input"
+      description="Choose which terminals receive broadcast input"
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && canStart) handleStart();
+      }}
+      data-testid="broadcast-scope-dialog"
+      footer={
+        <>
+          <Button
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            data-testid="broadcast-scope-cancel"
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleStart}
+            disabled={!canStart}
+            data-testid="broadcast-scope-confirm"
+          >
+            Start Broadcast
+          </Button>
+        </>
+      }
+    >
+      <Field label="Broadcast to" htmlFor="broadcast-scope-select">
+        <Select
+          value={scope}
+          onChange={(v) => setScope(v as BroadcastScope)}
+          options={scopeOptions}
+          aria-label="Broadcast scope"
+          data-testid="broadcast-scope-select"
+        />
+      </Field>
+
+      {scope === "custom" && (
+        <div className="broadcast-scope-dialog__custom">
+          <div className="broadcast-scope-dialog__custom-actions">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setCustomSelected(new Set(terminalTabs.map((t) => t.id)))}
+              data-testid="broadcast-scope-select-all"
+            >
+              Select All
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setCustomSelected(new Set())}
+              data-testid="broadcast-scope-select-none"
+            >
+              Select None
+            </Button>
+          </div>
+          {terminalTabs.length === 0 ? (
+            <p className="broadcast-scope-dialog__empty" role="status">
+              No terminal sessions to broadcast to.
+            </p>
+          ) : (
+            <ul className="broadcast-scope-dialog__list">
+              {terminalTabs.map((tab) => {
+                const rowId = `broadcast-target-${tab.id}`;
+                return (
+                  <li key={tab.id} className="broadcast-scope-dialog__row">
+                    <Checkbox
+                      id={rowId}
+                      checked={customSelected.has(tab.id)}
+                      onCheckedChange={(checked) => toggleCustom(tab.id, checked)}
+                      data-testid={`broadcast-target-${tab.id}`}
+                    />
+                    <label htmlFor={rowId} className="broadcast-scope-dialog__row-label">
+                      <span className="broadcast-scope-dialog__row-title">{tab.title}</span>
+                      <span className="broadcast-scope-dialog__row-type">
+                        {typeLabel(tab.connectionType)}
+                      </span>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/Terminal/TerminalView.agent-tabdot.test.tsx
+++ b/src/components/Terminal/TerminalView.agent-tabdot.test.tsx
@@ -67,6 +67,7 @@ vi.mock("@/components/ui", () => ({
 vi.mock("./TabGroupChips", () => ({ TabGroupChips: () => null }));
 vi.mock("./MacroRecordSaveDialog", () => ({ MacroRecordSaveDialog: () => null }));
 vi.mock("./MacroPlaybackDialog", () => ({ MacroPlaybackDialog: () => null }));
+vi.mock("./BroadcastScopeDialog", () => ({ BroadcastScopeDialog: () => null }));
 vi.mock("@/components/SplitView", () => ({ SplitView: () => null }));
 vi.mock("@/services/events", () => ({ terminalDispatcher: { init: vi.fn() } }));
 vi.mock("@/services/api", () => ({

--- a/src/components/Terminal/TerminalView.record-button.test.tsx
+++ b/src/components/Terminal/TerminalView.record-button.test.tsx
@@ -47,6 +47,7 @@ vi.mock("@/components/ui", () => ({
 vi.mock("./TabGroupChips", () => ({ TabGroupChips: () => null }));
 vi.mock("./MacroRecordSaveDialog", () => ({ MacroRecordSaveDialog: () => null }));
 vi.mock("./MacroPlaybackDialog", () => ({ MacroPlaybackDialog: () => null }));
+vi.mock("./BroadcastScopeDialog", () => ({ BroadcastScopeDialog: () => null }));
 vi.mock("@/components/SplitView", () => ({ SplitView: () => null }));
 vi.mock("@/services/events", () => ({ terminalDispatcher: { init: vi.fn() } }));
 vi.mock("@/services/api", () => ({

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -15,6 +15,7 @@ import { applyAgentReconnecting } from "./agentStateHandlers";
 import { TabGroupChips } from "./TabGroupChips";
 import { MacroRecordSaveDialog } from "./MacroRecordSaveDialog";
 import { MacroPlaybackDialog } from "./MacroPlaybackDialog";
+import { BroadcastScopeDialog } from "./BroadcastScopeDialog";
 import { SplitView } from "@/components/SplitView";
 import { terminalDispatcher } from "@/services/events";
 import { listAgentSessions } from "@/services/api";
@@ -255,13 +256,14 @@ export function TerminalView() {
   const saveRecordedMacro = useAppStore((s) => s.saveRecordedMacro);
   const discardRecordedMacro = useAppStore((s) => s.discardRecordedMacro);
   const broadcastActive = useAppStore((s) => s.broadcastActive);
-  const startBroadcast = useAppStore((s) => s.startBroadcast);
   const stopBroadcast = useAppStore((s) => s.stopBroadcast);
   const macros = useAppStore((s) => s.macros);
   const macroPlayback = useAppStore((s) => s.macroPlayback);
   const playMacro = useAppStore((s) => s.playMacro);
   const cancelMacroPlayback = useAppStore((s) => s.cancelMacroPlayback);
   const [macroPlaybackDialogOpen, setMacroPlaybackDialogOpen] = useState(false);
+  const [broadcastDialogOpen, setBroadcastDialogOpen] = useState(false);
+  const [broadcastSourceTabId, setBroadcastSourceTabId] = useState<string | null>(null);
   const isMac = navigator.platform.toUpperCase().includes("MAC");
   const sidebarToggleTitle = `Toggle Sidebar (${isMac ? "Cmd" : "Ctrl"}+B)`;
 
@@ -271,27 +273,21 @@ export function TerminalView() {
     addTab("Terminal", "local");
   };
 
-  // Minimal broadcast toggle (#1955): activates the "all terminals" scope
-  // directly (no scope dropdown yet — that is the #1956 follow-up) and toggles
-  // off on the second click. The source is the active terminal tab; every
-  // terminal tab in the current group is a target (the source included, so the
-  // fan-out loop stays uniform). Connected-only filtering happens at the seam.
+  // Broadcast toggle (#1956): clicking opens the scope-selection dialog (All /
+  // Current panel / Custom) rather than starting broadcast directly; a second
+  // click while active stops it. The source is the active terminal tab.
   const handleToggleBroadcast = () => {
     if (broadcastActive) {
       stopBroadcast();
       return;
     }
-    const state = useAppStore.getState();
-    const source = getActiveTab(state);
+    const source = getActiveTab(useAppStore.getState());
     if (!source || source.contentType !== "terminal") {
       toast.info("Focus a terminal to start broadcasting input");
       return;
     }
-    const terminalTabIds = getAllLeaves(state.rootPanel)
-      .flatMap((leaf) => leaf.tabs)
-      .filter((tab) => tab.contentType === "terminal")
-      .map((tab) => tab.id);
-    startBroadcast("all", source.id, terminalTabIds);
+    setBroadcastSourceTabId(source.id);
+    setBroadcastDialogOpen(true);
   };
 
   const handleSplitHorizontal = () => {
@@ -461,6 +457,11 @@ export function TerminalView() {
         macros={macros}
         onOpenChange={setMacroPlaybackDialogOpen}
         onPlay={(macroId, timingMode) => void playMacro(macroId, { timingMode })}
+      />
+      <BroadcastScopeDialog
+        open={broadcastDialogOpen}
+        onOpenChange={setBroadcastDialogOpen}
+        sourceTabId={broadcastSourceTabId}
       />
     </TerminalPortalProvider>
   );

--- a/src/store/appStore.broadcastScope.test.ts
+++ b/src/store/appStore.broadcastScope.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Tests for broadcast target-selection: scope resolution and dynamic membership
+ * (#1956).
+ *
+ * Covers `resolveBroadcastTargetTabIds` for each scope (all / panel / custom,
+ * including non-terminal exclusion) and the `refreshBroadcastMembership` rule
+ * that auto-adds terminals opened during an active broadcast per scope.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// The store pulls in the full service graph on import; stub the modules with
+// side effects at load time (mirrors the sibling broadcast-slice suite).
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+import { useAppStore, resolveBroadcastTargetTabIds } from "./appStore";
+import type {
+  LeafPanel,
+  PanelNode,
+  SplitContainer,
+  TerminalTab,
+  TabContentType,
+  ConnectionType,
+} from "@/types/terminal";
+
+interface SeedTab {
+  id: string;
+  panelId?: string;
+  contentType?: TabContentType;
+  connectionType?: ConnectionType;
+  sessionId?: string | null;
+}
+
+function makeTab({
+  id,
+  panelId = "leaf-1",
+  contentType = "terminal",
+  connectionType = "local",
+  sessionId = `sess-${id}`,
+}: SeedTab): TerminalTab {
+  return {
+    id,
+    sessionId,
+    title: id,
+    connectionType,
+    contentType,
+    config: { type: "local", config: {} },
+    panelId,
+    isActive: false,
+  };
+}
+
+function leaf(id: string, tabs: TerminalTab[]): LeafPanel {
+  return { type: "leaf", id, tabs, activeTabId: tabs[0]?.id ?? null };
+}
+
+/** Seed the active tab group with a given panel tree. */
+function seed(root: PanelNode) {
+  useAppStore.setState({ rootPanel: root, activePanelId: "leaf-1" });
+}
+
+describe("resolveBroadcastTargetTabIds (#1956)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  it("'all' resolves every terminal tab, excluding non-terminal tabs", () => {
+    seed(
+      leaf("leaf-1", [
+        makeTab({ id: "src" }),
+        makeTab({ id: "t2" }),
+        makeTab({ id: "editor", contentType: "editor" }),
+        makeTab({ id: "sftp", contentType: "file-browser" }),
+      ])
+    );
+    const result = resolveBroadcastTargetTabIds(useAppStore.getState(), "all", "src").sort();
+    expect(result).toEqual(["src", "t2"]);
+  });
+
+  it("'panel' resolves only terminals in the source's panel", () => {
+    const split: SplitContainer = {
+      type: "split",
+      id: "root",
+      direction: "horizontal",
+      children: [
+        leaf("leaf-1", [makeTab({ id: "src" }), makeTab({ id: "t2" })]),
+        leaf("leaf-2", [
+          makeTab({ id: "t3", panelId: "leaf-2" }),
+          makeTab({ id: "t4", panelId: "leaf-2" }),
+        ]),
+      ],
+    };
+    seed(split);
+    // Source lives in leaf-1 → only leaf-1 terminals.
+    expect(resolveBroadcastTargetTabIds(useAppStore.getState(), "panel", "src").sort()).toEqual([
+      "src",
+      "t2",
+    ]);
+    // Source in leaf-2 → only leaf-2 terminals.
+    expect(resolveBroadcastTargetTabIds(useAppStore.getState(), "panel", "t3").sort()).toEqual([
+      "t3",
+      "t4",
+    ]);
+  });
+
+  it("'panel' excludes non-terminal tabs in the same panel", () => {
+    seed(
+      leaf("leaf-1", [makeTab({ id: "src" }), makeTab({ id: "editor", contentType: "editor" })])
+    );
+    expect(resolveBroadcastTargetTabIds(useAppStore.getState(), "panel", "src")).toEqual(["src"]);
+  });
+
+  it("'custom' resolves to [] — membership comes from the picker, not the scope", () => {
+    seed(leaf("leaf-1", [makeTab({ id: "src" }), makeTab({ id: "t2" })]));
+    expect(resolveBroadcastTargetTabIds(useAppStore.getState(), "custom", "src")).toEqual([]);
+  });
+
+  it("'panel' returns [] when the source tab is not found", () => {
+    seed(leaf("leaf-1", [makeTab({ id: "src" })]));
+    expect(resolveBroadcastTargetTabIds(useAppStore.getState(), "panel", "ghost")).toEqual([]);
+  });
+});
+
+describe("refreshBroadcastMembership — dynamic add on open (#1956)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  it("no-op when broadcast is inactive", () => {
+    seed(leaf("leaf-1", [makeTab({ id: "src" })]));
+    useAppStore.getState().refreshBroadcastMembership();
+    expect(useAppStore.getState().broadcastTargetTabIds.size).toBe(0);
+  });
+
+  it("'all' auto-adds a terminal opened during broadcast", () => {
+    seed(leaf("leaf-1", [makeTab({ id: "src" }), makeTab({ id: "t2" })]));
+    useAppStore.getState().startBroadcast("all", "src", ["t2"]);
+
+    // A new terminal appears in the tree, then membership refreshes.
+    seed(leaf("leaf-1", [makeTab({ id: "src" }), makeTab({ id: "t2" }), makeTab({ id: "t3" })]));
+    useAppStore.getState().refreshBroadcastMembership();
+
+    expect([...useAppStore.getState().broadcastTargetTabIds].sort()).toEqual(["src", "t2", "t3"]);
+  });
+
+  it("'all' does not add a non-terminal tab opened during broadcast", () => {
+    seed(leaf("leaf-1", [makeTab({ id: "src" })]));
+    useAppStore.getState().startBroadcast("all", "src", []);
+
+    seed(
+      leaf("leaf-1", [makeTab({ id: "src" }), makeTab({ id: "editor", contentType: "editor" })])
+    );
+    useAppStore.getState().refreshBroadcastMembership();
+
+    expect([...useAppStore.getState().broadcastTargetTabIds]).toEqual(["src"]);
+  });
+
+  it("'panel' auto-adds only terminals opened in the source panel", () => {
+    const split: SplitContainer = {
+      type: "split",
+      id: "root",
+      direction: "horizontal",
+      children: [
+        leaf("leaf-1", [makeTab({ id: "src" })]),
+        leaf("leaf-2", [makeTab({ id: "t3", panelId: "leaf-2" })]),
+      ],
+    };
+    seed(split);
+    useAppStore.getState().startBroadcast("panel", "src", []);
+
+    // Open one terminal in each panel.
+    const split2: SplitContainer = {
+      type: "split",
+      id: "root",
+      direction: "horizontal",
+      children: [
+        leaf("leaf-1", [makeTab({ id: "src" }), makeTab({ id: "t2" })]),
+        leaf("leaf-2", [
+          makeTab({ id: "t3", panelId: "leaf-2" }),
+          makeTab({ id: "t4", panelId: "leaf-2" }),
+        ]),
+      ],
+    };
+    seed(split2);
+    useAppStore.getState().refreshBroadcastMembership();
+
+    // Only the terminal opened in the source panel (leaf-1) is added.
+    expect([...useAppStore.getState().broadcastTargetTabIds].sort()).toEqual(["src", "t2"]);
+  });
+
+  it("'custom' never auto-adds a terminal opened during broadcast", () => {
+    seed(leaf("leaf-1", [makeTab({ id: "src" }), makeTab({ id: "t2" })]));
+    useAppStore.getState().startBroadcast("custom", "src", ["t2"]);
+
+    seed(leaf("leaf-1", [makeTab({ id: "src" }), makeTab({ id: "t2" }), makeTab({ id: "t3" })]));
+    useAppStore.getState().refreshBroadcastMembership();
+
+    expect([...useAppStore.getState().broadcastTargetTabIds].sort()).toEqual(["src", "t2"]);
+  });
+
+  it("addTab wires the auto-add: opening a terminal under 'all' extends the set", () => {
+    seed(leaf("leaf-1", [makeTab({ id: "src" })]));
+    useAppStore.getState().startBroadcast("all", "src", []);
+
+    const newId = useAppStore
+      .getState()
+      .addTab("Terminal", "local", { type: "local", config: {} }, { panelId: "leaf-1" });
+
+    expect(useAppStore.getState().broadcastTargetTabIds.has(newId)).toBe(true);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1484,6 +1484,20 @@ interface AppState {
    * is done by the terminal registry at the dispatch seam.
    */
   getBroadcastTargetTabIds: () => string[];
+  /**
+   * Recompute the broadcast target set for the active {@link broadcastScope} so
+   * membership tracks tabs opening during an active broadcast (#1956). No-op
+   * when inactive.
+   *
+   * - `"all"` / `"panel"` — re-derive members from the scope, so a terminal
+   *   opened in range is auto-added and one no longer in range drops out.
+   * - `"custom"` — never auto-adds; the explicit selection is authoritative
+   *   (closed tabs are pruned at the tab-close seam). No-op here.
+   *
+   * Closing a target is handled at the tab-close seam for every scope, so this
+   * only needs to run on tab open.
+   */
+  refreshBroadcastMembership: () => void;
 
   // Workflows (#1852) — the foundation of the Workflow Automation epic (#1851).
   /** All stored workflows. */
@@ -2101,6 +2115,39 @@ function collectLiveTabs(state: {
     g.id === state.activeTabGroupId ? state.rootPanel : g.rootPanel
   );
   return trees.flatMap((tree) => getAllLeaves(tree).flatMap((leaf) => leaf.tabs));
+}
+
+/**
+ * Resolve the terminal tab ids that belong to a broadcast {@link BroadcastScope}
+ * given the tab that owns input (the source). Only *terminal* tabs are eligible
+ * — non-terminal tabs (editors, SFTP/file browsers, ...) are never broadcast
+ * targets, matching the concept's "Non-terminal tabs never appear" rule.
+ *
+ * - `"all"` — every terminal tab in the active tab group.
+ * - `"panel"` — every terminal tab in the same split panel as the source.
+ * - `"custom"` — `[]`; membership comes from the user's picker, not the scope.
+ *
+ * Exported for the scope dropdown's live counts and the dynamic-membership tests
+ * (#1956). Operates on the active group's `rootPanel`, matching the foundation's
+ * (#1955) all-terminals fan-out.
+ */
+export function resolveBroadcastTargetTabIds(
+  state: { rootPanel: PanelNode },
+  scope: BroadcastScope,
+  sourceTabId: string
+): string[] {
+  if (scope === "custom") return [];
+  const isTerminal = (t: TerminalTab): boolean => t.contentType === "terminal";
+  if (scope === "panel") {
+    const leaf = findLeafByTab(state.rootPanel, sourceTabId);
+    if (!leaf) return [];
+    return leaf.tabs.filter(isTerminal).map((t) => t.id);
+  }
+  // "all"
+  return getAllLeaves(state.rootPanel)
+    .flatMap((leaf) => leaf.tabs)
+    .filter(isTerminal)
+    .map((t) => t.id);
 }
 
 /**
@@ -3596,6 +3643,9 @@ export const useAppStore = create<AppState>((set, get) => {
       if ((contentType ?? "terminal") === "terminal" && config) {
         void get().recordSession(connectionType, config);
       }
+      // Dynamic membership (#1956): a terminal opened during an active broadcast
+      // is auto-added under the "all"/"panel" scopes (never under "custom").
+      get().refreshBroadcastMembership();
       return createdTabId;
     },
 
@@ -7141,6 +7191,22 @@ export const useAppStore = create<AppState>((set, get) => {
         result.push(tabId);
       }
       return result;
+    },
+
+    refreshBroadcastMembership: () => {
+      const state = get();
+      if (!state.broadcastActive) return;
+      const source = state.broadcastSourceTabId;
+      if (!source) return;
+      // Custom selection is frozen at pick time — never auto-add. Removal of
+      // closed targets is handled at the tab-close seam.
+      if (state.broadcastScope === "custom") return;
+      const resolved = resolveBroadcastTargetTabIds(state, state.broadcastScope, source);
+      const next = new Set<string>([source, ...resolved]);
+      const prev = state.broadcastTargetTabIds;
+      // Skip the update (and its re-render) when membership is unchanged.
+      if (next.size === prev.size && [...next].every((id) => prev.has(id))) return;
+      set({ broadcastTargetTabIds: next });
     },
 
     // Workflows (#1852)


### PR DESCRIPTION
## Summary

Part 2 of the broadcast-input epic (#1954), building on the #1955 foundation. Replaces the foundation's minimal all-terminals toggle with a proper **target-selection flow**: clicking the toolbar Broadcast Input toggle now opens a scope dialog instead of starting broadcast immediately.

- **Scope dropdown** — All terminals / All in current panel / Custom selection, each showing a live target count, with Start Broadcast / Cancel.
- **Custom picker** — a per-terminal checkbox list (Select All / Select None) listing only terminal sessions with a type label (SSH/local/serial/…). Non-terminal tabs (editors, SFTP) never appear.
- **Persisted scope** — the chosen scope is remembered as `lastBroadcastScope` (consumed later by the keyboard-shortcut child #1958).
- **Dynamic membership** — under "All terminals" and "All in current panel", terminals opened during an active broadcast are auto-added (only within the source panel for the panel scope); under "Custom" they are never auto-added. Closed targets are removed silently (existing close seam).

## Implementation

- `src/store/appStore.ts` — new exported pure helper `resolveBroadcastTargetTabIds(state, scope, sourceTabId)` (scope → terminal-tab-id set, non-terminal exclusion) and a `refreshBroadcastMembership()` action wired into `addTab` for the open-during-broadcast auto-add.
- `src/components/Terminal/BroadcastScopeDialog.tsx` (+ `.css`) — new dialog composed from the shared `src/components/ui/` primitives (Modal / Select / Checkbox / Button / Field), tokens only.
- `src/components/Terminal/TerminalView.tsx` — toolbar toggle now opens the dialog for the active terminal source.

## Tests

- `appStore.broadcastScope.test.ts` — scope resolution per scope (incl. non-terminal exclusion, panel isolation) and dynamic add-on-open per scope, plus the `addTab` wiring.
- `BroadcastScopeDialog.test.tsx` — scope select rendering, custom picker (terminal-only rows, Select All/None enabling/disabling Start), resolved target set on confirm, Cancel.
- Adjusted two existing `TerminalView` test files to mock the new child dialog (matching the sibling MacroPlaybackDialog pattern).

Frontend `tsc`, `eslint`, `prettier`, and full `vitest` suite are green.

Closes #1956