### PR TITLE
feat(ssh): SSH host-key trust-management settings UI (Closes #1968)

### DIFF
--- a/docs/changes/dev3/feat/1968-ssh-trust-settings.md
+++ b/docs/changes/dev3/feat/1968-ssh-trust-settings.md
@@ -1,0 +1,8 @@
+### Added
+
+- SSH host-key trust management: a new **Security → Remembered SSH Host Keys**
+  settings section lists the hosts whose SSH host key you accepted "for host"
+  (#1959) and lets you revoke a single fingerprint or forget a whole host, so the
+  next connect prompts again. The SSH analogue of the RDP certificate trust UI
+  (#1784), backed by the existing `ssh_trust_list` / `ssh_trust_forget` commands
+  over the per-host SSH trust store (#1968).

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -27,6 +27,7 @@ import { ExternalFilesSettings } from "./ExternalFilesSettings";
 import { KeyboardSettings } from "./KeyboardSettings";
 import { SecuritySettings } from "./SecuritySettings";
 import { RdpTrustSettings } from "./RdpTrustSettings";
+import { SshTrustSettings } from "./SshTrustSettings";
 import { FileTypeSettings } from "./FileTypeSettings";
 import { LanguagePackagesSettings } from "./LanguagePackagesSettings";
 import { CustomGrammarsSettings } from "./CustomGrammarsSettings";
@@ -255,6 +256,7 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
       if (highlightedCategories?.has("security")) {
         sections.push(<SecuritySettings key="security" visibleFields={visibleFields} />);
         sections.push(<RdpTrustSettings key="rdp-trust" visibleFields={visibleFields} />);
+        sections.push(<SshTrustSettings key="ssh-trust" visibleFields={visibleFields} />);
       }
       if (highlightedCategories?.has("editor")) {
         sections.push(<FileTypeSettings key="editor" visibleFields={visibleFields} />);
@@ -295,6 +297,7 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
           <>
             <SecuritySettings />
             <RdpTrustSettings />
+            <SshTrustSettings />
           </>
         );
       case "external-files":

--- a/src/components/Settings/SshTrustSettings.test.tsx
+++ b/src/components/Settings/SshTrustSettings.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { invoke } from "@tauri-apps/api/core";
+import { TooltipProvider } from "@/components/ui";
+import { SshTrustSettings } from "./SshTrustSettings";
+
+vi.mock("@/utils/frontendLog", () => ({
+  frontendLog: vi.fn(),
+}));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: { success: vi.fn(), error: vi.fn() },
+  };
+});
+
+const mockedInvoke = vi.mocked(invoke);
+
+type TrustList = { host: string; fingerprints: string[] }[];
+
+/** Route the two SSH trust commands; default to an empty list. */
+function setup(list: TrustList = []) {
+  mockedInvoke.mockImplementation(async (cmd: string) => {
+    if (cmd === "ssh_trust_list") return list;
+    if (cmd === "ssh_trust_forget") return true;
+    return undefined;
+  });
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+/** Render and flush the mount-time load effect. */
+async function render(props: { visibleFields?: Set<string> } = {}) {
+  await act(async () => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <SshTrustSettings {...props} />
+      </TooltipProvider>
+    );
+  });
+}
+
+function query(testId: string): Element | null {
+  return container.querySelector(`[data-testid="${testId}"]`);
+}
+
+function buttonByLabel(label: string): HTMLButtonElement | null {
+  return container.querySelector(`button[aria-label="${label}"]`);
+}
+
+async function click(el: Element | null) {
+  await act(async () => {
+    el?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("SshTrustSettings", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("shows the empty state when nothing is remembered", async () => {
+    setup([]);
+    await render();
+    expect(query("ssh-trust-empty")).not.toBeNull();
+    expect(mockedInvoke).toHaveBeenCalledWith("ssh_trust_list");
+  });
+
+  it("lists remembered hosts and their fingerprints", async () => {
+    setup([
+      { host: "server.example:22", fingerprints: ["SHA256:AA/BB", "SHA256:CC/DD"] },
+      { host: "other:2222", fingerprints: ["SHA256:11/22"] },
+    ]);
+    await render();
+    const hosts = container.querySelectorAll('[data-testid="ssh-trust-host"]');
+    expect(hosts).toHaveLength(2);
+    expect(container.textContent).toContain("server.example:22");
+    expect(container.textContent).toContain("SHA256:AA/BB");
+    expect(container.textContent).toContain("SHA256:CC/DD");
+    expect(container.textContent).toContain("other:2222");
+  });
+
+  it("revokes a single fingerprint and removes it from the list", async () => {
+    setup([{ host: "server.example:22", fingerprints: ["SHA256:AA/BB", "SHA256:CC/DD"] }]);
+    await render();
+
+    await click(buttonByLabel("Revoke host key SHA256:AA/BB for server.example:22"));
+
+    expect(mockedInvoke).toHaveBeenCalledWith("ssh_trust_forget", {
+      host: "server.example:22",
+      fingerprint: "SHA256:AA/BB",
+    });
+    expect(container.textContent).not.toContain("SHA256:AA/BB");
+    expect(container.textContent).toContain("SHA256:CC/DD");
+  });
+
+  it("dropping a host's last fingerprint removes the host", async () => {
+    setup([{ host: "server.example:22", fingerprints: ["SHA256:AA/BB"] }]);
+    await render();
+
+    await click(buttonByLabel("Revoke host key SHA256:AA/BB for server.example:22"));
+
+    expect(container.querySelectorAll('[data-testid="ssh-trust-host"]')).toHaveLength(0);
+    expect(query("ssh-trust-empty")).not.toBeNull();
+  });
+
+  it("forgets a whole host without a fingerprint argument", async () => {
+    setup([{ host: "server.example:22", fingerprints: ["SHA256:AA/BB", "SHA256:CC/DD"] }]);
+    await render();
+
+    await click(buttonByLabel("Forget all remembered host keys for server.example:22"));
+
+    expect(mockedInvoke).toHaveBeenCalledWith("ssh_trust_forget", {
+      host: "server.example:22",
+      fingerprint: null,
+    });
+    expect(container.querySelectorAll('[data-testid="ssh-trust-host"]')).toHaveLength(0);
+  });
+
+  it("hides itself when visibleFields excludes the SSH trust field", async () => {
+    setup([{ host: "server.example:22", fingerprints: ["SHA256:AA/BB"] }]);
+    await render({ visibleFields: new Set(["somethingElse"]) });
+    expect(query("settings-ssh-trust")).toBeNull();
+  });
+});

--- a/src/components/Settings/SshTrustSettings.tsx
+++ b/src/components/Settings/SshTrustSettings.tsx
@@ -1,0 +1,127 @@
+import { useState, useEffect, useCallback } from "react";
+import { Trash2 } from "lucide-react";
+import { sshTrustList, sshTrustForget, type SshTrustedHost } from "@/services/api";
+import { Button, Tooltip, toast } from "@/components/ui";
+import { frontendLog } from "@/utils/frontendLog";
+
+interface SshTrustSettingsProps {
+  visibleFields?: Set<string>;
+}
+
+/**
+ * Settings section to review and revoke remembered SSH host-key trust (#1968).
+ * Lists each host trusted via the interactive host-key trust prompt (#1959) and
+ * lets the user forget a single fingerprint or a whole host, so the next connect
+ * to that host prompts again. The SSH analogue of {@link RdpTrustSettings}.
+ */
+export function SshTrustSettings({ visibleFields }: SshTrustSettingsProps) {
+  const [hosts, setHosts] = useState<SshTrustedHost[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    try {
+      setHosts(await sshTrustList());
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      frontendLog("ssh_trust_settings", `failed to load trust store: ${message}`);
+      toast.error(`Failed to load remembered SSH host keys: ${message}`);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleForgetFingerprint = useCallback(async (host: string, fingerprint: string) => {
+    try {
+      await sshTrustForget(host, fingerprint);
+      // Drop the fingerprint locally, and the host once its last one is gone —
+      // matching the backend, which removes an emptied host so it re-prompts.
+      setHosts((prev) =>
+        prev
+          .map((h) =>
+            h.host === host
+              ? { ...h, fingerprints: h.fingerprints.filter((f) => f !== fingerprint) }
+              : h
+          )
+          .filter((h) => h.fingerprints.length > 0)
+      );
+      toast.success(`Revoked host key for ${host}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error(`Failed to revoke host key: ${message}`);
+      throw err; // keep the async Button in its error path (no success flash)
+    }
+  }, []);
+
+  const handleForgetHost = useCallback(async (host: string) => {
+    try {
+      await sshTrustForget(host);
+      setHosts((prev) => prev.filter((h) => h.host !== host));
+      toast.success(`Forgot all remembered host keys for ${host}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error(`Failed to forget host: ${message}`);
+      throw err; // keep the async Button in its error path (no success flash)
+    }
+  }, []);
+
+  if (visibleFields && !visibleFields.has("sshTrustedHostKeys")) return null;
+
+  return (
+    <div className="settings-panel__category">
+      <div className="settings-panel__section" data-testid="settings-ssh-trust">
+        <h3 className="settings-panel__section-title">Remembered SSH Host Keys</h3>
+        <p className="settings-panel__description">
+          Hosts whose SSH host key you chose to trust ("Accept for host") are remembered here.
+          Revoke a single fingerprint or forget a host to be prompted again on the next connect.
+        </p>
+
+        {loading ? (
+          <p className="settings-panel__empty">Loading…</p>
+        ) : hosts.length === 0 ? (
+          <p className="settings-panel__empty" data-testid="ssh-trust-empty">
+            No remembered SSH host keys.
+          </p>
+        ) : (
+          hosts.map((h) => (
+            <div key={h.host} className="settings-panel__field" data-testid="ssh-trust-host">
+              <div className="settings-panel__section-header">
+                <h4 className="settings-panel__subsection-title">{h.host}</h4>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => handleForgetHost(h.host)}
+                  errorToast={false}
+                  aria-label={`Forget all remembered host keys for ${h.host}`}
+                >
+                  Forget host
+                </Button>
+              </div>
+              <ul className="settings-panel__file-list">
+                {h.fingerprints.map((fp) => (
+                  <li key={fp} className="settings-panel__file-item">
+                    <code className="settings-panel__file-path">{fp}</code>
+                    <Tooltip content="Revoke this host key">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        iconOnly
+                        icon={<Trash2 size={14} />}
+                        onClick={() => handleForgetFingerprint(h.host, fp)}
+                        errorToast={false}
+                        aria-label={`Revoke host key ${fp} for ${h.host}`}
+                      />
+                    </Tooltip>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Settings/settingsRegistry.ts
+++ b/src/components/Settings/settingsRegistry.ts
@@ -239,6 +239,25 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     ],
   },
   {
+    id: "sshTrustedHostKeys",
+    label: "Remembered SSH Host Keys",
+    description: "Review and revoke SSH host keys you chose to trust",
+    category: "security",
+    keywords: [
+      "ssh",
+      "host key",
+      "hostkey",
+      "trust",
+      "fingerprint",
+      "sha256",
+      "revoke",
+      "forget",
+      "known hosts",
+      "known_hosts",
+      "mitm",
+    ],
+  },
+  {
     id: "workflowLocalProcess",
     label: "Workflow Local Process Execution",
     description:

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -620,6 +620,32 @@ export async function rdpTrustForget(host: string, fingerprint?: string): Promis
   return await invoke<boolean>("rdp_trust_forget", { host, fingerprint: fingerprint ?? null });
 }
 
+/** One remembered SSH host and the host-key fingerprints trusted for it (#1968). */
+export interface SshTrustedHost {
+  host: string;
+  fingerprints: string[];
+}
+
+/**
+ * List remembered SSH hosts and their trusted host-key fingerprints (#1968).
+ *
+ * These are the hosts a user chose "Accept for host" for in the interactive
+ * host-key trust prompt (#1959); the trust-management settings UI reviews them.
+ */
+export async function sshTrustList(): Promise<SshTrustedHost[]> {
+  return await invoke<SshTrustedHost[]>("ssh_trust_list");
+}
+
+/**
+ * Revoke a remembered SSH host key (#1968). Pass a `fingerprint` to forget just
+ * that one (the host is dropped once its last fingerprint is gone); omit it to
+ * forget the whole host. Either way the next connect to that host re-prompts.
+ * Returns whether anything was removed.
+ */
+export async function sshTrustForget(host: string, fingerprint?: string): Promise<boolean> {
+  return await invoke<boolean>("ssh_trust_forget", { host, fingerprint: fingerprint ?? null });
+}
+
 // --- Persistent session commands ---
 
 /** Summary of a persistent session returned by the backend. */


### PR DESCRIPTION
## Summary

Adds the SSH analogue of the RDP certificate trust-management UI (#1784): a new **Security → Remembered SSH Host Keys** settings section.

Builds on #1959's SSH trust store and its `ssh_trust_list` / `ssh_trust_forget` commands (no backend changes were needed — the commands already existed and were registered).

- Lists every host termiHub has trusted (`host:port`) and its trusted SHA-256 host-key fingerprints.
- Per-fingerprint **revoke** (Trash icon) and per-host **Forget host** actions, backed by `ssh_trust_forget`. Dropping a host's last fingerprint removes the host, so the next connect re-prompts.
- Registered in the settings search registry (`sshTrustedHostKeys`) so it is findable/filterable, and rendered in both the search-highlight and the direct Security-category paths.
- Mirrors `RdpTrustSettings` in shape, copy, and structure for consistency (shared `settings-panel__*` classes, `ui` primitives, tokens).

## Test plan

- New `SshTrustSettings.test.tsx` covering empty state, listing, single-fingerprint revoke, last-fingerprint-drops-host, whole-host forget, and `visibleFields` gating.
- `pnpm test` green (all frontend suites).

Closes #1968