### PR TITLE
fix(ssh): harden headless agent host-key verification (Closes #1969)

### DIFF
--- a/core/src/backends/ssh/handler.rs
+++ b/core/src/backends/ssh/handler.rs
@@ -168,26 +168,24 @@ impl russh::client::Handler for TermiHubHandler {
         &mut self,
         server_public_key: &russh::keys::PublicKey,
     ) -> Result<bool, Self::Error> {
-        // Respect the user's own `~/.ssh/known_hosts`: a host key already
-        // recorded there is trusted silently, exactly as `ssh` would, so
-        // termiHub does not re-prompt for hosts the user already knows. A
-        // missing file or absent host falls through to the verifier; a
-        // *changed* key there is not auto-accepted (it returns `Err`), so it
-        // also falls through and is caught by the trust store / prompt.
-        if !self.host.is_empty()
-            && matches!(
-                russh::keys::check_known_hosts(&self.host, self.port, server_public_key),
-                Ok(true)
-            )
-        {
-            return Ok(true);
-        }
-
+        // Consult the host's own `~/.ssh/known_hosts` once and carry the verdict
+        // into the trust decision (#1969). A recorded key is trusted silently by
+        // every path (exactly as `ssh` would); a *changed* key there is the
+        // possible-MITM case and is never quietly accepted; an unknown host or
+        // unreadable file falls through. The strict headless default (no
+        // verifier registered, e.g. the remote agent) trusts only a recorded key
+        // and refuses the rest, while the desktop verifier can additionally
+        // prompt the user for an unknown key.
         let info = super::host_key::HostKeyInfo {
             host: self.host.clone(),
             port: self.port,
             key_type: super::host_key::key_algorithm(server_public_key),
             fingerprint: super::host_key::fingerprint_sha256(server_public_key),
+            known_hosts: super::host_key::check_system_known_hosts(
+                &self.host,
+                self.port,
+                server_public_key,
+            ),
         };
         Ok(super::host_key::verify_host_key(&info).await)
     }

--- a/core/src/backends/ssh/host_key.rs
+++ b/core/src/backends/ssh/host_key.rs
@@ -18,13 +18,18 @@
 //! in the host crate (`src-tauri`), which owns the config directory and the UI,
 //! exactly like the RDP certificate trust store it mirrors.
 //!
-//! ## Default (no verifier registered)
+//! ## Default (no verifier registered) — strict, known_hosts-only (#1969)
 //!
-//! When no verifier is registered — the agent binary, bare-`core` unit tests —
-//! the key is accepted with a warning, preserving the pre-#1959 behaviour so
-//! server-side and headless paths keep working. The security-critical desktop
-//! client always registers a strict trust-on-first-use verifier, so it never
-//! blind-accepts.
+//! When no verifier is registered — the remote agent, other headless paths,
+//! bare-`core` unit tests — there is no UI to ask, so the key **cannot** be
+//! confirmed interactively. Rather than blind-accept (the pre-#1969 behaviour,
+//! which merely warned), the default policy is strict: trust **only** keys
+//! already recorded in the host's own OpenSSH `~/.ssh/known_hosts`, and refuse
+//! everything else. An unknown host, a changed key, and a key the file cannot
+//! vouch for are all rejected, so a headless agent connecting through a jump
+//! host never silently accepts an arbitrary or changed server key. The
+//! security-critical desktop client registers a trust-on-first-use verifier
+//! that additionally prompts the user, so it can accept new hosts interactively.
 
 use std::sync::{Arc, OnceLock};
 
@@ -43,6 +48,65 @@ pub fn key_algorithm(key: &russh::keys::PublicKey) -> String {
     key.algorithm().as_str().to_string()
 }
 
+/// The verdict of consulting the host's own OpenSSH `~/.ssh/known_hosts` file
+/// for a presented server key (#1969).
+///
+/// This is the trust source honoured everywhere: the desktop accepts a `Match`
+/// silently (exactly as `ssh` would), and the headless default policy trusts a
+/// `Match` and refuses anything else. `Changed` is the possible-MITM case — the
+/// host is recorded but with a *different* key — and must never be quietly
+/// accepted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KnownHostsStatus {
+    /// The presented key matches an entry for this host — already trusted.
+    Match,
+    /// The host is recorded, but with a **different** key (possible MITM).
+    Changed,
+    /// The host is not recorded, no `known_hosts` file exists, or the file
+    /// could not be consulted — the file cannot vouch for this key.
+    Unknown,
+}
+
+/// Consult the host's OpenSSH `~/.ssh/known_hosts` for a presented server key.
+///
+/// A key already recorded there is trusted by every path; a *changed* key is
+/// flagged (never silently accepted); anything else — unknown host, missing
+/// file, or a read/parse error — is [`KnownHostsStatus::Unknown`]. An empty host
+/// (never expected from a real connect) is treated as `Unknown`.
+pub fn check_system_known_hosts(
+    host: &str,
+    port: u16,
+    key: &russh::keys::PublicKey,
+) -> KnownHostsStatus {
+    if host.is_empty() {
+        return KnownHostsStatus::Unknown;
+    }
+    map_known_hosts_result(russh::keys::check_known_hosts(host, port, key), host)
+}
+
+/// Map a `russh` `check_known_hosts*` result to a [`KnownHostsStatus`], logging a
+/// non-`KeyChanged` error so a broken/unreadable file is visible rather than
+/// silently swallowed. Shared by [`check_system_known_hosts`] and its
+/// path-based test helper.
+fn map_known_hosts_result(
+    result: Result<bool, russh::keys::Error>,
+    host: &str,
+) -> KnownHostsStatus {
+    match result {
+        Ok(true) => KnownHostsStatus::Match,
+        Ok(false) => KnownHostsStatus::Unknown,
+        Err(russh::keys::Error::KeyChanged { .. }) => KnownHostsStatus::Changed,
+        Err(e) => {
+            warn!(
+                host = %host,
+                error = %e,
+                "could not read ~/.ssh/known_hosts; treating host as unknown"
+            );
+            KnownHostsStatus::Unknown
+        }
+    }
+}
+
 /// The details of a server host key a [`HostKeyVerifier`] decides whether to
 /// trust.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -55,6 +119,11 @@ pub struct HostKeyInfo {
     pub key_type: String,
     /// The SHA-256 fingerprint in OpenSSH `SHA256:BASE64` form.
     pub fingerprint: String,
+    /// What the host's own `~/.ssh/known_hosts` says about this key (#1969).
+    /// Both the strict headless default and the desktop verifier consult it so a
+    /// key recorded there is trusted and a *changed* key is never quietly
+    /// accepted.
+    pub known_hosts: KnownHostsStatus,
 }
 
 impl HostKeyInfo {
@@ -95,20 +164,47 @@ pub fn host_key_verifier() -> Option<Arc<dyn HostKeyVerifier>> {
 
 /// Decide whether to accept a presented host key.
 ///
-/// Delegates to the registered [`HostKeyVerifier`]; with none registered the key
-/// is accepted with a warning, preserving pre-#1959 behaviour for headless paths
-/// (see the module docs).
+/// Delegates to the registered [`HostKeyVerifier`]; with none registered it
+/// applies the strict headless default ([`default_verify`]) — trust only keys
+/// already in `~/.ssh/known_hosts`, refuse everything else (see the module docs).
 pub(crate) async fn verify_host_key(info: &HostKeyInfo) -> bool {
     match host_key_verifier() {
         Some(verifier) => verifier.verify(info).await,
-        None => {
+        None => default_verify(info),
+    }
+}
+
+/// The strict default policy for headless paths with no interactive verifier
+/// (the remote agent, other server-side paths, tests) — #1969.
+///
+/// Trusts **only** a key already present in the host's `~/.ssh/known_hosts`
+/// ([`KnownHostsStatus::Match`]); an unknown host, a *changed* key, and a key the
+/// file cannot vouch for are all refused. It never blind-accepts, so a headless
+/// agent connecting through a jump host cannot be silently man-in-the-middled.
+/// The refusal is logged so the desktop (which surfaces the agent's stderr) can
+/// see why a connect failed.
+fn default_verify(info: &HostKeyInfo) -> bool {
+    match info.known_hosts {
+        KnownHostsStatus::Match => true,
+        KnownHostsStatus::Changed => {
             warn!(
                 host = %info.host,
                 port = info.port,
                 fingerprint = %info.fingerprint,
-                "no SSH host-key verifier registered; accepting host key unverified"
+                "SSH host key CHANGED from ~/.ssh/known_hosts and no verifier is registered; \
+                 refusing the connection (possible MITM)"
             );
-            true
+            false
+        }
+        KnownHostsStatus::Unknown => {
+            warn!(
+                host = %info.host,
+                port = info.port,
+                fingerprint = %info.fingerprint,
+                "unknown SSH host key and no verifier is registered; refusing the connection \
+                 (add the host to ~/.ssh/known_hosts to trust it)"
+            );
+            false
         }
     }
 }
@@ -137,12 +233,127 @@ mod tests {
             port: 2222,
             key_type: "ssh-ed25519".to_string(),
             fingerprint: "SHA256:AABBCC".to_string(),
+            known_hosts: KnownHostsStatus::Unknown,
         }
     }
 
     #[test]
     fn host_port_keys_like_the_rdp_store() {
         assert_eq!(sample_info().host_port(), "example.com:2222");
+    }
+
+    /// The strict headless default (no verifier registered) trusts a key already
+    /// in `~/.ssh/known_hosts` and refuses an unknown or changed key — it must
+    /// never blind-accept as it did before #1969.
+    #[test]
+    fn default_policy_trusts_only_known_hosts_matches() {
+        let with = |status| HostKeyInfo {
+            known_hosts: status,
+            ..sample_info()
+        };
+        assert!(
+            default_verify(&with(KnownHostsStatus::Match)),
+            "a key recorded in ~/.ssh/known_hosts is trusted"
+        );
+        assert!(
+            !default_verify(&with(KnownHostsStatus::Unknown)),
+            "an unknown host key must be refused headless (no blind accept)"
+        );
+        assert!(
+            !default_verify(&with(KnownHostsStatus::Changed)),
+            "a changed host key must be refused headless (possible MITM)"
+        );
+    }
+
+    /// The `russh` known_hosts result maps to the right verdict: a match trusts,
+    /// a `KeyChanged` error is the MITM case, and everything else is unknown.
+    #[test]
+    fn known_hosts_result_maps_to_status() {
+        assert_eq!(
+            map_known_hosts_result(Ok(true), "h"),
+            KnownHostsStatus::Match
+        );
+        assert_eq!(
+            map_known_hosts_result(Ok(false), "h"),
+            KnownHostsStatus::Unknown
+        );
+        assert_eq!(
+            map_known_hosts_result(Err(russh::keys::Error::KeyChanged { line: 3 }), "h"),
+            KnownHostsStatus::Changed
+        );
+        assert_eq!(
+            map_known_hosts_result(Err(russh::keys::Error::NoHomeDir), "h"),
+            KnownHostsStatus::Unknown,
+            "an unreadable known_hosts is unknown, not trusted"
+        );
+    }
+
+    /// Two distinct, fixed ed25519 public keys — deterministic so the test needs
+    /// no RNG. `RECORDED` is written to the test `known_hosts`; `IMPOSTOR`
+    /// impersonates the same host with a different key.
+    const RECORDED_KEY: &str =
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGvPs1dLFaPzeD8R5jSSrKLm3WqqOHx4W3e7VGFqojXJ recorded";
+    const IMPOSTOR_KEY: &str =
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICiH/XInTaWEkjc02WF1n/O5ypuoc/j8XMLlY9CRkplT impostor";
+
+    fn public_key(openssh: &str) -> russh::keys::PublicKey {
+        let mut key =
+            russh::keys::PublicKey::from_openssh(openssh).expect("parse test public key");
+        // A server key off the wire (and a key parsed out of `known_hosts`) has
+        // no comment; clear it so equality is by key material, as in production.
+        key.set_comment("");
+        key
+    }
+
+    /// An empty host (never expected from a real connect) resolves to `Unknown`
+    /// rather than touching the filesystem, so the strict default refuses it.
+    #[test]
+    fn empty_host_is_unknown() {
+        assert_eq!(
+            check_system_known_hosts("", 22, &public_key(RECORDED_KEY)),
+            KnownHostsStatus::Unknown
+        );
+    }
+
+    /// End-to-end mapping against a real `known_hosts` file: a recorded key is a
+    /// `Match`, a different key for the same host is `Changed`, and an
+    /// unrecorded host is `Unknown`.
+    #[test]
+    fn check_against_known_hosts_file() {
+        use std::io::Write;
+
+        let recorded = public_key(RECORDED_KEY);
+        let impostor = public_key(IMPOSTOR_KEY);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("known_hosts");
+        {
+            let mut f = std::fs::File::create(&path).unwrap();
+            writeln!(f, "[example.com]:2222 {RECORDED_KEY}").unwrap();
+        }
+
+        let map = |host: &str, key: &russh::keys::PublicKey| {
+            map_known_hosts_result(
+                russh::keys::check_known_hosts_path(host, 2222, key, &path),
+                host,
+            )
+        };
+
+        assert_eq!(
+            map("example.com", &recorded),
+            KnownHostsStatus::Match,
+            "the recorded key is trusted"
+        );
+        assert_eq!(
+            map("example.com", &impostor),
+            KnownHostsStatus::Changed,
+            "a different key for a recorded host is a changed key"
+        );
+        assert_eq!(
+            map("unlisted.example", &recorded),
+            KnownHostsStatus::Unknown,
+            "a host not in the file is unknown"
+        );
     }
 
     /// A registered verifier's verdict is what `verify_host_key` returns, and the

--- a/core/src/backends/ssh/host_key.rs
+++ b/core/src/backends/ssh/host_key.rs
@@ -297,8 +297,7 @@ mod tests {
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICiH/XInTaWEkjc02WF1n/O5ypuoc/j8XMLlY9CRkplT impostor";
 
     fn public_key(openssh: &str) -> russh::keys::PublicKey {
-        let mut key =
-            russh::keys::PublicKey::from_openssh(openssh).expect("parse test public key");
+        let mut key = russh::keys::PublicKey::from_openssh(openssh).expect("parse test public key");
         // A server key off the wire (and a key parsed out of `known_hosts`) has
         // no comment; clear it so equality is by key material, as in production.
         key.set_comment("");

--- a/docs/changes/dev3/fix/1969-agent-host-key-hardening.md
+++ b/docs/changes/dev3/fix/1969-agent-host-key-hardening.md
@@ -1,0 +1,12 @@
+### Security
+
+- The remote agent (and other headless SSH paths with no interactive UI) no
+  longer silently accepts an unknown or changed server host key. Where #1959
+  still accepted-with-warning when no host-key prompt was available, the default
+  is now strict: only a key already recorded in the agent host's
+  `~/.ssh/known_hosts` is trusted, and an unknown or changed key is refused with
+  a clear log message rather than blindly accepted. On the desktop, a host key
+  that is *changed* relative to `~/.ssh/known_hosts` (but never seen by
+  termiHub's own trust store) now raises the changed-key man-in-the-middle
+  warning instead of a first-contact prompt, so a changed key is never quietly
+  accepted anywhere (#1969).

--- a/docs/changes/dev3/fix/1969-agent-host-key-hardening.md
+++ b/docs/changes/dev3/fix/1969-agent-host-key-hardening.md
@@ -6,7 +6,7 @@
   is now strict: only a key already recorded in the agent host's
   `~/.ssh/known_hosts` is trusted, and an unknown or changed key is refused with
   a clear log message rather than blindly accepted. On the desktop, a host key
-  that is *changed* relative to `~/.ssh/known_hosts` (but never seen by
+  that is _changed_ relative to `~/.ssh/known_hosts` (but never seen by
   termiHub's own trust store) now raises the changed-key man-in-the-middle
   warning instead of a first-contact prompt, so a changed key is never quietly
   accepted anywhere (#1969).

--- a/src-tauri/src/session/ssh_host_key_verifier.rs
+++ b/src-tauri/src/session/ssh_host_key_verifier.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use serde::Serialize;
-use termihub_core::backends::ssh::host_key::{HostKeyInfo, HostKeyVerifier};
+use termihub_core::backends::ssh::host_key::{HostKeyInfo, HostKeyVerifier, KnownHostsStatus};
 use tokio::sync::oneshot;
 use tracing::warn;
 
@@ -157,11 +157,22 @@ impl SshHostKeyVerifier {
 #[async_trait]
 impl HostKeyVerifier for SshHostKeyVerifier {
     async fn verify(&self, info: &HostKeyInfo) -> bool {
+        // Honour the user's own `~/.ssh/known_hosts` first: a key already
+        // recorded there is trusted silently, exactly as `ssh` would, without a
+        // prompt (#1969 — previously done in the core SSH handler).
+        if info.known_hosts == KnownHostsStatus::Match {
+            return true;
+        }
+
         let host_port = info.host_port();
         let changed = match self.trust_store.lookup(&host_port, &info.fingerprint) {
             // Already trusted → accept without prompting.
             TrustLookup::Trusted => return true,
-            TrustLookup::Unknown => false,
+            // Unknown to termiHub's own store, but if the key is *changed*
+            // relative to the user's `~/.ssh/known_hosts` this is the possible-
+            // MITM case, so warn as a changed key rather than first contact
+            // (#1969 — this previously showed a first-contact prompt).
+            TrustLookup::Unknown => info.known_hosts == KnownHostsStatus::Changed,
             TrustLookup::Changed => true,
         };
 
@@ -197,11 +208,16 @@ mod tests {
     }
 
     fn info(host: &str, port: u16, fp: &str) -> HostKeyInfo {
+        info_kh(host, port, fp, KnownHostsStatus::Unknown)
+    }
+
+    fn info_kh(host: &str, port: u16, fp: &str, known_hosts: KnownHostsStatus) -> HostKeyInfo {
         HostKeyInfo {
             host: host.to_string(),
             port,
             key_type: "ssh-ed25519".to_string(),
             fingerprint: fp.to_string(),
+            known_hosts,
         }
     }
 
@@ -311,6 +327,50 @@ mod tests {
             store.lookup("h:22", "SHA256:CC"),
             TrustLookup::Unknown,
             "accept-once must not remember the key"
+        );
+    }
+
+    /// A key already present in the user's `~/.ssh/known_hosts` is accepted
+    /// silently, with no store lookup and no prompt (#1969).
+    #[tokio::test]
+    async fn system_known_hosts_match_is_trusted_without_prompt() {
+        let store = Arc::new(SshTrustStore::in_memory());
+        let sink = Arc::new(RecordingSink::default());
+        let verifier = Arc::new(SshHostKeyVerifier::new(store, sink.clone()));
+
+        assert!(
+            verifier
+                .verify(&info_kh("h", 22, "SHA256:AA", KnownHostsStatus::Match))
+                .await
+        );
+        assert_eq!(
+            sink.count.load(Ordering::SeqCst),
+            0,
+            "a key in ~/.ssh/known_hosts needs no prompt"
+        );
+    }
+
+    /// A key unknown to termiHub's own store but *changed* in the user's
+    /// `~/.ssh/known_hosts` prompts with the changed-key MITM warning, not a
+    /// first-contact prompt (#1969).
+    #[tokio::test]
+    async fn changed_in_system_known_hosts_warns_as_changed() {
+        let store = Arc::new(SshTrustStore::in_memory());
+        let sink = Arc::new(RecordingSink::default());
+        let verifier = Arc::new(SshHostKeyVerifier::new(store.clone(), sink.clone()));
+
+        let v = verifier.clone();
+        let handle = tokio::spawn(async move {
+            v.verify(&info_kh("h", 22, "SHA256:NEW", KnownHostsStatus::Changed))
+                .await
+        });
+        resolve_when_ready(&verifier, &sink, false, false).await;
+
+        assert!(!handle.await.unwrap(), "rejecting the changed key aborts");
+        let prompt = sink.prompts.lock().unwrap()[0].clone();
+        assert!(
+            prompt.changed,
+            "a key changed in ~/.ssh/known_hosts must flag the MITM warning"
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #1959 (PR #1967). PR #1967 replaced the blind-accept in `core`'s SSH handler with a process-wide `HostKeyVerifier`, but when **no** verifier is registered — the remote agent and other headless paths — the key was still accepted with a warning (a residual blind-ish accept).

This makes the headless default **strict** and tightens the system-`known_hosts` mapping so a changed key is never quietly accepted anywhere.

## Changes

- **Strict headless default (`core`).** With no `HostKeyVerifier` registered, `verify_host_key` now applies a strict policy (`default_verify`): trust **only** a key already recorded in the host's `~/.ssh/known_hosts`; refuse an unknown key, a changed key, or a key the file cannot vouch for — with a clear `warn!` the desktop surfaces via the agent's stderr. No more accept-with-warning.
- **`known_hosts` consulted once, verdict shared.** New `KnownHostsStatus` (`Match` / `Changed` / `Unknown`) computed in the SSH handler and carried on `HostKeyInfo`. The handler no longer early-returns on a match; the trust decision is centralized in the verify layer, so both the headless default and the desktop verifier see the same verdict.
- **Desktop changed-key mapping fixed.** A key that is *changed* in the user's `~/.ssh/known_hosts` but unknown to termiHub's own trust store now raises the changed-key MITM warning instead of a first-contact prompt. A key already in `~/.ssh/known_hosts` is still accepted silently (that logic moved from the core handler into the desktop verifier).

## Tests

- `core`: `default_verify` trusts only `Match` and refuses unknown/changed; `russh` result to `KnownHostsStatus` mapping (incl. `KeyChanged` to `Changed`, unreadable file to `Unknown`); end-to-end check against a real `known_hosts` file (recorded → match, impostor → changed, unlisted → unknown); empty host → unknown.
- desktop: a `known_hosts` match is trusted with no prompt; a key changed in `known_hosts` prompts with the changed-key warning.

Closes #1969