### PR TITLE
feat(terminal): per-session output logging to file (Closes #1960)

### DIFF
--- a/core/src/output/mod.rs
+++ b/core/src/output/mod.rs
@@ -1,2 +1,3 @@
 pub mod coalescer;
 pub mod screen_clear;
+pub mod session_log;

--- a/core/src/output/session_log.rs
+++ b/core/src/output/session_log.rs
@@ -316,9 +316,11 @@ mod tests {
     fn per_line_timestamps_prefix_each_line() {
         let dir = temp_dir();
         let path = dir.join("ts.log");
-        let mut logger =
-            SessionLogger::open(SessionLogConfig::new(&path, true), fixed_clock("2026-07-25"))
-                .unwrap();
+        let mut logger = SessionLogger::open(
+            SessionLogConfig::new(&path, true),
+            fixed_clock("2026-07-25"),
+        )
+        .unwrap();
         logger.write(b"first\nsecond\n").unwrap();
         logger.flush().unwrap();
 

--- a/core/src/output/session_log.rs
+++ b/core/src/output/session_log.rs
@@ -1,0 +1,456 @@
+//! Per-session output logging to a file (#1960).
+//!
+//! termiHub keeps a 1 MiB scrollback ring per session and a rotating app
+//! diagnostics log, but neither is a durable transcript of a session's output:
+//! when a tab closes the evidence is gone. This module adds the missing piece —
+//! an opt-in per-session sink that mirrors every output byte the core already
+//! sees ([`crate::output::coalescer`] / the session output reader) into a file,
+//! the way PuTTY / Termius / iTerm log sessions.
+//!
+//! # Design notes
+//!
+//! **Timestamps are injected, not computed here.** Producing a wall-clock
+//! timestamp string means pulling in a date library, and the core crate is
+//! deliberately dependency-light. So [`SessionLogger`] takes a [`Clock`]
+//! closure that returns the timestamp string; the desktop wires in a
+//! `chrono`-based clock, and tests inject a fixed one for deterministic output.
+//!
+//! **Synchronous, line-buffered writes.** Output volume for an interactive
+//! session is modest, and a durable transcript must not lose its tail if the
+//! process dies — so writes go straight through a [`BufWriter`] that is flushed
+//! on close (and on [`Drop`]), rather than through a background channel that a
+//! crash would discard.
+//!
+//! **Per-line timestamping is opt-in and line-boundary aware.** Raw PTY output
+//! arrives in arbitrary chunks; a single logical line can straddle two writes.
+//! The logger tracks whether it is at the start of a line so a timestamp is
+//! emitted once per line, never mid-line, regardless of how the bytes were
+//! chunked.
+//!
+//! **Size-based rotation gives a hard ceiling.** When the active file grows past
+//! [`SessionLogConfig::max_bytes`] it is rolled to a single `<name>.1` archive,
+//! bounding on-disk use at roughly `2 × max_bytes` per session without depending
+//! on how long the session runs.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+/// Default size at which the active log file is rolled to an archive (50 MiB).
+pub const DEFAULT_MAX_FILE_BYTES: u64 = 50 * 1024 * 1024;
+
+/// A clock returning the current timestamp string for per-line prefixes.
+///
+/// Injected so the core crate needs no date dependency and tests stay
+/// deterministic. The desktop supplies a `chrono`-formatted clock.
+pub type Clock = Box<dyn Fn() -> String + Send>;
+
+/// Configuration for opening a [`SessionLogger`].
+#[derive(Debug, Clone)]
+pub struct SessionLogConfig {
+    /// Destination file path. Parent directories are created if absent.
+    pub path: PathBuf,
+    /// When `true`, each output line is prefixed with `[<timestamp>] `.
+    pub timestamps: bool,
+    /// When `true`, an existing file is appended to; otherwise it is truncated.
+    pub append: bool,
+    /// Roll the active file to `<name>.1` once it exceeds this many bytes.
+    pub max_bytes: u64,
+}
+
+impl SessionLogConfig {
+    /// Build a config for `path` with sensible defaults (append, 50 MiB cap).
+    pub fn new(path: impl Into<PathBuf>, timestamps: bool) -> Self {
+        Self {
+            path: path.into(),
+            timestamps,
+            append: true,
+            max_bytes: DEFAULT_MAX_FILE_BYTES,
+        }
+    }
+}
+
+/// A per-session output-to-file sink.
+///
+/// Write raw session output with [`write`](Self::write); the logger handles
+/// optional per-line timestamping, size-based rotation, and flushing. Bytes are
+/// flushed to the OS on [`flush`](Self::flush) and on [`Drop`].
+pub struct SessionLogger {
+    writer: BufWriter<File>,
+    path: PathBuf,
+    timestamps: bool,
+    max_bytes: u64,
+    /// Whether the next byte written begins a new line (drives timestamp
+    /// prefixing across chunk boundaries).
+    at_line_start: bool,
+    /// Bytes written to the current active file (reset on rotation).
+    bytes_written: u64,
+    clock: Clock,
+}
+
+impl SessionLogger {
+    /// Open (or create) the log file described by `config`.
+    ///
+    /// `clock` supplies the per-line timestamp string; it is only invoked when
+    /// `config.timestamps` is `true`. Creates any missing parent directories.
+    pub fn open(config: SessionLogConfig, clock: Clock) -> io::Result<Self> {
+        if let Some(parent) = config.path.parent() {
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent)?;
+            }
+        }
+
+        let mut opts = OpenOptions::new();
+        opts.create(true).write(true);
+        if config.append {
+            opts.append(true);
+        } else {
+            opts.truncate(true);
+        }
+        let file = opts.open(&config.path)?;
+        let bytes_written = file.metadata().map(|m| m.len()).unwrap_or(0);
+
+        Ok(Self {
+            writer: BufWriter::new(file),
+            path: config.path,
+            timestamps: config.timestamps,
+            max_bytes: config.max_bytes.max(1),
+            // A freshly appended-to file that does not end in a newline is still
+            // mid-line, but treating the first write as a line start is the safe
+            // and predictable choice for a transcript.
+            at_line_start: true,
+            bytes_written,
+            clock,
+        })
+    }
+
+    /// The path of the active log file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Whether per-line timestamping is enabled for this logger.
+    pub fn timestamps_enabled(&self) -> bool {
+        self.timestamps
+    }
+
+    /// Write raw session output to the log file.
+    ///
+    /// With timestamps disabled the bytes are written verbatim (an exact
+    /// transcript). With timestamps enabled, `[<timestamp>] ` is inserted at the
+    /// start of every line — correctly, even when a line spans multiple calls.
+    pub fn write(&mut self, data: &[u8]) -> io::Result<()> {
+        if data.is_empty() {
+            return Ok(());
+        }
+        if self.timestamps {
+            self.write_timestamped(data)?;
+        } else {
+            self.write_raw(data)?;
+        }
+        if self.bytes_written >= self.max_bytes {
+            self.rotate()?;
+        }
+        Ok(())
+    }
+
+    /// Write `data` verbatim, tracking line position and byte count.
+    fn write_raw(&mut self, data: &[u8]) -> io::Result<()> {
+        self.writer.write_all(data)?;
+        self.bytes_written += data.len() as u64;
+        self.at_line_start = data.last() == Some(&b'\n');
+        Ok(())
+    }
+
+    /// Write `data`, prefixing each line with the clock timestamp.
+    fn write_timestamped(&mut self, data: &[u8]) -> io::Result<()> {
+        for &byte in data {
+            if self.at_line_start {
+                let prefix = format!("[{}] ", (self.clock)());
+                self.writer.write_all(prefix.as_bytes())?;
+                self.bytes_written += prefix.len() as u64;
+                self.at_line_start = false;
+            }
+            self.writer.write_all(&[byte])?;
+            self.bytes_written += 1;
+            if byte == b'\n' {
+                self.at_line_start = true;
+            }
+        }
+        Ok(())
+    }
+
+    /// Flush buffered bytes to the underlying file.
+    pub fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()
+    }
+
+    /// Roll the active file to a single `<name>.1` archive and reopen empty.
+    ///
+    /// Best-effort: the previous archive is replaced. On any filesystem error
+    /// the current writer is left intact so logging continues rather than
+    /// aborting the session.
+    fn rotate(&mut self) -> io::Result<()> {
+        self.writer.flush()?;
+
+        let archive = rotated_path(&self.path);
+        // Replacing the archive and renaming are best-effort; ignore errors so a
+        // rotation hiccup never tears down an active session's logging.
+        let _ = fs::remove_file(&archive);
+        if fs::rename(&self.path, &archive).is_err() {
+            // Could not roll (e.g. cross-device); keep writing to the same file.
+            return Ok(());
+        }
+
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&self.path)?;
+        self.writer = BufWriter::new(file);
+        self.bytes_written = 0;
+        self.at_line_start = true;
+        Ok(())
+    }
+}
+
+impl Drop for SessionLogger {
+    fn drop(&mut self) {
+        // Best-effort final flush so a closed session's tail is not lost.
+        let _ = self.writer.flush();
+    }
+}
+
+/// Compute the archive path for `path` by inserting `.1` before the extension
+/// (`app-2026.log` → `app-2026.1.log`; extension-less paths gain a `.1` suffix).
+fn rotated_path(path: &Path) -> PathBuf {
+    match path.extension() {
+        Some(ext) => path.with_extension(format!("1.{}", ext.to_string_lossy())),
+        None => {
+            let mut s = path.as_os_str().to_os_string();
+            s.push(".1");
+            PathBuf::from(s)
+        }
+    }
+}
+
+/// Sanitize a connection name into a filesystem-safe filename fragment.
+///
+/// Path separators, control characters, and characters illegal on common
+/// filesystems (including Windows) are replaced with `_`; the result is trimmed
+/// and capped so the default filename stays reasonable. Empty or all-invalid
+/// input yields `"session"`.
+pub fn sanitize_connection_name(name: &str) -> String {
+    let mut out: String = name
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            c if c.is_control() => '_',
+            c if c.is_whitespace() => '_',
+            c => c,
+        })
+        .collect();
+    out = out.trim_matches(|c| c == '_' || c == '.').to_string();
+    if out.len() > 64 {
+        out.truncate(64);
+    }
+    if out.is_empty() {
+        "session".to_string()
+    } else {
+        out
+    }
+}
+
+/// Build the default per-session log filename: `<connection>-<timestamp>.log`.
+///
+/// `connection` is sanitized via [`sanitize_connection_name`]; `timestamp` is a
+/// caller-supplied stamp (e.g. `20260725-140302`) so the core stays date-library
+/// free and the result is deterministic in tests.
+pub fn default_log_filename(connection: &str, timestamp: &str) -> String {
+    format!("{}-{}.log", sanitize_connection_name(connection), timestamp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn fixed_clock(stamp: &'static str) -> Clock {
+        Box::new(move || stamp.to_string())
+    }
+
+    fn temp_dir() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "termihub-session-log-test-{}-{}",
+            std::process::id(),
+            uuid_like()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Small unique-ish token without pulling `uuid` into the test.
+    fn uuid_like() -> u128 {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    }
+
+    #[test]
+    fn raw_write_is_byte_exact() {
+        let dir = temp_dir();
+        let path = dir.join("raw.log");
+        let mut logger =
+            SessionLogger::open(SessionLogConfig::new(&path, false), fixed_clock("T")).unwrap();
+        logger.write(b"hello\nwo").unwrap();
+        logger.write(b"rld\n").unwrap();
+        logger.flush().unwrap();
+
+        let contents = fs::read(&path).unwrap();
+        assert_eq!(contents, b"hello\nworld\n");
+    }
+
+    #[test]
+    fn per_line_timestamps_prefix_each_line() {
+        let dir = temp_dir();
+        let path = dir.join("ts.log");
+        let mut logger =
+            SessionLogger::open(SessionLogConfig::new(&path, true), fixed_clock("2026-07-25"))
+                .unwrap();
+        logger.write(b"first\nsecond\n").unwrap();
+        logger.flush().unwrap();
+
+        let contents = String::from_utf8(fs::read(&path).unwrap()).unwrap();
+        assert_eq!(contents, "[2026-07-25] first\n[2026-07-25] second\n");
+    }
+
+    #[test]
+    fn timestamp_not_repeated_when_line_spans_chunks() {
+        let dir = temp_dir();
+        let path = dir.join("split.log");
+        let mut logger =
+            SessionLogger::open(SessionLogConfig::new(&path, true), fixed_clock("TS")).unwrap();
+        // A single logical line delivered across three writes must get exactly
+        // one timestamp, and the next line a fresh one.
+        logger.write(b"hel").unwrap();
+        logger.write(b"lo").unwrap();
+        logger.write(b" world\nnext\n").unwrap();
+        logger.flush().unwrap();
+
+        let contents = String::from_utf8(fs::read(&path).unwrap()).unwrap();
+        assert_eq!(contents, "[TS] hello world\n[TS] next\n");
+    }
+
+    #[test]
+    fn no_trailing_timestamp_emitted_for_unterminated_line() {
+        let dir = temp_dir();
+        let path = dir.join("partial.log");
+        let mut logger =
+            SessionLogger::open(SessionLogConfig::new(&path, true), fixed_clock("TS")).unwrap();
+        logger.write(b"line\n").unwrap();
+        logger.write(b"tail-without-newline").unwrap();
+        logger.flush().unwrap();
+
+        let contents = String::from_utf8(fs::read(&path).unwrap()).unwrap();
+        // No dangling "[TS] " after the final line since no new line started.
+        assert_eq!(contents, "[TS] line\n[TS] tail-without-newline");
+    }
+
+    #[test]
+    fn append_mode_preserves_existing_content() {
+        let dir = temp_dir();
+        let path = dir.join("append.log");
+        fs::write(&path, b"existing\n").unwrap();
+        let mut logger =
+            SessionLogger::open(SessionLogConfig::new(&path, false), fixed_clock("T")).unwrap();
+        logger.write(b"more\n").unwrap();
+        logger.flush().unwrap();
+
+        assert_eq!(fs::read(&path).unwrap(), b"existing\nmore\n");
+    }
+
+    #[test]
+    fn truncate_mode_replaces_existing_content() {
+        let dir = temp_dir();
+        let path = dir.join("truncate.log");
+        fs::write(&path, b"old-content\n").unwrap();
+        let mut config = SessionLogConfig::new(&path, false);
+        config.append = false;
+        let mut logger = SessionLogger::open(config, fixed_clock("T")).unwrap();
+        logger.write(b"fresh\n").unwrap();
+        logger.flush().unwrap();
+
+        assert_eq!(fs::read(&path).unwrap(), b"fresh\n");
+    }
+
+    #[test]
+    fn open_creates_missing_parent_directories() {
+        let dir = temp_dir();
+        let path = dir.join("nested/sub/dir/out.log");
+        let mut logger =
+            SessionLogger::open(SessionLogConfig::new(&path, false), fixed_clock("T")).unwrap();
+        logger.write(b"x").unwrap();
+        logger.flush().unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn drop_flushes_pending_bytes() {
+        let dir = temp_dir();
+        let path = dir.join("drop.log");
+        {
+            let mut logger =
+                SessionLogger::open(SessionLogConfig::new(&path, false), fixed_clock("T")).unwrap();
+            logger.write(b"buffered-but-not-flushed").unwrap();
+            // No explicit flush — Drop must persist it.
+        }
+        assert_eq!(fs::read(&path).unwrap(), b"buffered-but-not-flushed");
+    }
+
+    #[test]
+    fn rotation_rolls_to_archive_and_continues() {
+        let dir = temp_dir();
+        let path = dir.join("rot.log");
+        let mut config = SessionLogConfig::new(&path, false);
+        config.max_bytes = 8;
+        let mut logger = SessionLogger::open(config, fixed_clock("T")).unwrap();
+
+        logger.write(b"12345678").unwrap(); // hits the 8-byte threshold → rotate
+        logger.write(b"9").unwrap(); // lands in the fresh active file
+        logger.flush().unwrap();
+
+        let archive = rotated_path(&path);
+        assert_eq!(fs::read(&archive).unwrap(), b"12345678");
+        assert_eq!(fs::read(&path).unwrap(), b"9");
+    }
+
+    #[test]
+    fn rotated_path_inserts_generation_before_extension() {
+        assert_eq!(
+            rotated_path(Path::new("/tmp/sess-2026.log")),
+            PathBuf::from("/tmp/sess-2026.1.log")
+        );
+        assert_eq!(
+            rotated_path(Path::new("/tmp/sess-no-ext")),
+            PathBuf::from("/tmp/sess-no-ext.1")
+        );
+    }
+
+    #[test]
+    fn sanitize_connection_name_replaces_unsafe_chars() {
+        assert_eq!(sanitize_connection_name("SSH: user@host"), "SSH__user@host");
+        assert_eq!(sanitize_connection_name("a/b\\c:d"), "a_b_c_d");
+        assert_eq!(sanitize_connection_name(""), "session");
+        assert_eq!(sanitize_connection_name("///"), "session");
+    }
+
+    #[test]
+    fn default_log_filename_combines_name_and_timestamp() {
+        assert_eq!(
+            default_log_filename("Serial: /dev/tty", "20260725-140302"),
+            "Serial___dev_tty-20260725-140302.log"
+        );
+    }
+}

--- a/docs/changes/dev2/feat/1960-session-logging.md
+++ b/docs/changes/dev2/feat/1960-session-logging.md
@@ -1,0 +1,10 @@
+### Added
+
+- Per-session output logging to a file (#1960). A terminal-toolbar toggle
+  (`Log Session Output`) starts and stops writing the active session's output to
+  a timestamped transcript on demand, and a per-connection Terminal setting
+  (`Log Session Output`, with an optional `Timestamp Each Line`) auto-starts
+  logging on connect. Transcripts default to
+  `<connection>-<timestamp>.log` under the platform log directory's `sessions`
+  subfolder, capture every session type (local, SSH, serial, telnet, docker, and
+  agent-proxied remote), rotate at a size cap, and are flushed on close.

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -14,7 +14,9 @@ use termihub_core::files::FileEntry;
 
 use crate::connection::manager::ConnectionManager;
 use crate::session::line_ending::LineEnding;
-use crate::session::manager::{PersistentSessionSummary, SessionInfo, SessionManager};
+use crate::session::manager::{
+    PersistentSessionSummary, SessionInfo, SessionLogStatus, SessionManager,
+};
 use crate::utils::errors::TerminalError;
 use crate::utils::shell_detect;
 use crate::window::WindowManager;
@@ -427,6 +429,55 @@ pub async fn session_monitoring_cancel(
 ) -> Result<(), TerminalError> {
     info!(session_id, "Cancelling session monitoring connect");
     manager.cancel_session_monitoring(&session_id).await
+}
+
+// --- Session output logging commands (#1960) ---
+
+/// Start writing a session's output to a file.
+///
+/// `path` is the destination; when omitted a default
+/// `<connection>-<timestamp>.log` under the platform log directory's `sessions`
+/// subfolder is used. `timestamps` prefixes each line with a wall-clock stamp.
+/// Returns the resolved transcript path.
+#[tauri::command]
+pub async fn session_logging_start(
+    session_id: String,
+    path: Option<String>,
+    timestamps: Option<bool>,
+    manager: State<'_, SessionManager>,
+) -> Result<String, TerminalError> {
+    info!(session_id, timestamps = ?timestamps, "Starting session logging");
+    let resolved = manager
+        .start_session_logging(
+            &session_id,
+            path.map(std::path::PathBuf::from),
+            timestamps.unwrap_or(false),
+        )
+        .await?;
+    Ok(resolved.to_string_lossy().into_owned())
+}
+
+/// Stop writing a session's output to a file.
+///
+/// Returns the transcript path if logging was active, else `null`.
+#[tauri::command]
+pub fn session_logging_stop(
+    session_id: String,
+    manager: State<'_, SessionManager>,
+) -> Option<String> {
+    info!(session_id, "Stopping session logging");
+    manager
+        .stop_session_logging(&session_id)
+        .map(|p| p.to_string_lossy().into_owned())
+}
+
+/// Current logging status for a session, or `null` when not logging.
+#[tauri::command]
+pub fn session_logging_status(
+    session_id: String,
+    manager: State<'_, SessionManager>,
+) -> Option<SessionLogStatus> {
+    manager.session_logging_status(&session_id)
 }
 
 // --- Persistent session commands ---

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -846,6 +846,10 @@ pub fn run() {
             commands::session::session_monitoring_set_paused,
             commands::session::session_monitoring_set_interval,
             commands::session::session_monitoring_cancel,
+            // Session output logging (#1960)
+            commands::session::session_logging_start,
+            commands::session::session_logging_stop,
+            commands::session::session_logging_status,
             // Persistent session management
             commands::session::start_persistent_session,
             commands::session::adopt_persistent_session,

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -6,6 +6,7 @@
 //! remote connections use [`RemoteProxy`](super::remote_proxy::RemoteProxy).
 
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
@@ -22,6 +23,7 @@ use termihub_core::files::FileEntry;
 use termihub_core::monitoring::{MonitorStatus, MonitorStatusReceiver, SystemStats};
 use termihub_core::output::coalescer::OutputCoalescer;
 use termihub_core::output::screen_clear::ScreenClearDetector;
+use termihub_core::output::session_log::{SessionLogConfig, SessionLogger};
 use tracing::{error, info, warn};
 
 use crate::terminal::agent_manager::AgentRpcClient;
@@ -29,6 +31,7 @@ use crate::utils::errors::TerminalError;
 
 use super::line_ending::{normalize_line_endings, LineEnding};
 use super::remote_proxy::RemoteProxy;
+use super::session_log::{default_session_log_path, desktop_clock};
 
 /// Maximum number of concurrent sessions.
 const MAX_SESSIONS: usize = 50;
@@ -196,6 +199,24 @@ async fn recv_optional(rx: &mut Option<MonitorStatusReceiver>) -> Option<Monitor
 /// path and read on replay.
 type OutputBuffers = Arc<StdMutex<HashMap<String, Arc<StdMutex<RingBuffer>>>>>;
 
+/// Per-session output-to-file loggers, keyed by `session_id` (#1960).
+///
+/// An entry exists only while a session is actively logging (started via the
+/// toolbar toggle or a per-connection setting). The output reader looks the
+/// logger up on each emitted chunk, so logging can be started and stopped mid
+/// session without disturbing the reader.
+type SessionLoggers = Arc<StdMutex<HashMap<String, Arc<StdMutex<SessionLogger>>>>>;
+
+/// Status of a session's output logging, returned to the frontend.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionLogStatus {
+    /// Absolute path of the active transcript file.
+    pub path: String,
+    /// Whether each line is prefixed with a timestamp.
+    pub timestamps: bool,
+}
+
 /// Manages all active connection sessions.
 ///
 /// Holds a [`ConnectionTypeRegistry`] for creating local connections and
@@ -225,6 +246,12 @@ pub struct SessionManager {
     /// later with replay" primitive. The outer lock is held only briefly at
     /// create/replay/cleanup; the hot output path writes through the inner lock.
     output_buffers: OutputBuffers,
+    /// Per-session output-to-file loggers (#1960), keyed by `session_id`.
+    ///
+    /// Populated only for sessions with logging active. The output reader writes
+    /// each emitted chunk through the matching logger, so a session's transcript
+    /// captures exactly what the frontend receives — for every session type.
+    session_loggers: SessionLoggers,
 }
 
 /// Removes a `connect_id` from the [`SessionManager::connecting`] map when the
@@ -254,6 +281,126 @@ impl SessionManager {
             persistent_sessions: Arc::new(Mutex::new(HashMap::new())),
             connecting: Arc::new(StdMutex::new(HashMap::new())),
             output_buffers: Arc::new(StdMutex::new(HashMap::new())),
+            session_loggers: Arc::new(StdMutex::new(HashMap::new())),
+        }
+    }
+
+    // ── Per-session output logging (#1960) ─────────────────────────────
+
+    /// Start writing the session's output to a file.
+    ///
+    /// `path` chooses the destination; when `None`, a default
+    /// `<connection>-<timestamp>.log` under the platform log directory's
+    /// `sessions` subfolder is used. `timestamps` prefixes each line with a
+    /// wall-clock stamp. Returns the resolved transcript path.
+    ///
+    /// Idempotent: if the session is already logging, the existing transcript
+    /// path is returned unchanged.
+    pub async fn start_session_logging(
+        &self,
+        session_id: &str,
+        path: Option<PathBuf>,
+        timestamps: bool,
+    ) -> Result<PathBuf, TerminalError> {
+        // Validate the session exists and grab its title for default naming.
+        let title = {
+            let sessions = self.sessions.lock().await;
+            sessions
+                .get(session_id)
+                .map(|e| e.info.title.clone())
+                .ok_or_else(|| TerminalError::SessionNotFound(session_id.to_string()))?
+        };
+
+        // Already logging → return the current path without reopening.
+        {
+            let map = self
+                .session_loggers
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(existing) = map.get(session_id) {
+                let path = existing
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .path()
+                    .to_path_buf();
+                return Ok(path);
+            }
+        }
+
+        let path = match path {
+            Some(p) => p,
+            None => default_session_log_path(&title).ok_or_else(|| {
+                TerminalError::SpawnFailed(
+                    "could not resolve the default session-log directory".to_string(),
+                )
+            })?,
+        };
+
+        let logger = SessionLogger::open(SessionLogConfig::new(&path, timestamps), desktop_clock())
+            .map_err(|e| TerminalError::WriteFailed(format!("open session log: {e}")))?;
+        let resolved = logger.path().to_path_buf();
+        self.session_loggers
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(session_id.to_string(), Arc::new(StdMutex::new(logger)));
+
+        info!(session_id, path = %resolved.display(), timestamps, "Started session logging");
+        Ok(resolved)
+    }
+
+    /// Stop logging the session's output, flushing the transcript.
+    ///
+    /// Returns the transcript path if logging was active, else `None`.
+    pub fn stop_session_logging(&self, session_id: &str) -> Option<PathBuf> {
+        let logger = self
+            .session_loggers
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(session_id)?;
+        let mut logger = logger
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let path = logger.path().to_path_buf();
+        let _ = logger.flush();
+        info!(session_id, path = %path.display(), "Stopped session logging");
+        Some(path)
+    }
+
+    /// Current logging status for a session, or `None` when not logging.
+    pub fn session_logging_status(&self, session_id: &str) -> Option<SessionLogStatus> {
+        let map = self
+            .session_loggers
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let logger = map.get(session_id)?;
+        let logger = logger
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        Some(SessionLogStatus {
+            path: logger.path().to_string_lossy().into_owned(),
+            timestamps: logger.timestamps_enabled(),
+        })
+    }
+
+    /// Write emitted output to the session's logger, if one is active (#1960).
+    ///
+    /// Looks the logger up per call so start/stop can happen mid-session. A
+    /// write error is logged and swallowed — a failing transcript must never
+    /// tear down the live session's output stream.
+    fn log_output(session_loggers: &SessionLoggers, session_id: &str, data: &[u8]) {
+        let logger = {
+            let map = session_loggers
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            map.get(session_id).cloned()
+        };
+        if let Some(logger) = logger {
+            let mut logger = logger
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Err(e) = logger.write(data) {
+                warn!(session_id, error = %e, "Session log write failed");
+            }
         }
     }
 
@@ -432,6 +579,7 @@ impl SessionManager {
         let sessions_clone = self.sessions.clone();
         let capture = self.ensure_output_buffer(&session_id);
         let output_buffers = self.output_buffers.clone();
+        let session_loggers = self.session_loggers.clone();
         let sid = session_id.clone();
         tokio::spawn(async move {
             Self::run_output_reader(
@@ -442,6 +590,7 @@ impl SessionManager {
                 has_initial_command,
                 capture,
                 output_buffers,
+                session_loggers,
             )
             .await;
         });
@@ -1160,6 +1309,7 @@ impl SessionManager {
                     let emitter_clone = emitter.clone();
                     let capture = self.ensure_output_buffer(&session_id);
                     let output_buffers = self.output_buffers.clone();
+                    let session_loggers = self.session_loggers.clone();
                     let sid = session_id.clone();
                     tokio::spawn(async move {
                         Self::run_output_reader(
@@ -1170,6 +1320,7 @@ impl SessionManager {
                             false,
                             capture,
                             output_buffers,
+                            session_loggers,
                         )
                         .await;
                     });
@@ -1414,6 +1565,7 @@ impl SessionManager {
         wait_for_clear: bool,
         capture: Arc<StdMutex<RingBuffer>>,
         output_buffers: OutputBuffers,
+        session_loggers: SessionLoggers,
     ) {
         // Phase 1: optionally buffer until the screen-clear sequence.
         if wait_for_clear {
@@ -1438,12 +1590,14 @@ impl SessionManager {
                     Ok(None) => {
                         // Channel closed during startup.
                         Self::capture_bytes(&capture, &buffer);
+                        Self::log_output(&session_loggers, &session_id, &buffer);
                         Self::emit_and_cleanup(
                             &session_id,
                             buffer,
                             &emitter,
                             &sessions,
                             &output_buffers,
+                            &session_loggers,
                         )
                         .await;
                         return;
@@ -1455,6 +1609,7 @@ impl SessionManager {
             // Flush the buffered output as a single event.
             if !buffer.is_empty() {
                 Self::capture_bytes(&capture, &buffer);
+                Self::log_output(&session_loggers, &session_id, &buffer);
                 let event = TerminalOutputEvent {
                     session_id: session_id.clone(),
                     data: buffer,
@@ -1482,6 +1637,7 @@ impl SessionManager {
 
             if let Some(data) = coalescer.flush() {
                 Self::capture_bytes(&capture, &data);
+                Self::log_output(&session_loggers, &session_id, &data);
                 let event = TerminalOutputEvent {
                     session_id: session_id.clone(),
                     data,
@@ -1499,6 +1655,7 @@ impl SessionManager {
             &emitter,
             &sessions,
             &output_buffers,
+            &session_loggers,
         )
         .await;
     }
@@ -1527,6 +1684,7 @@ impl SessionManager {
         emitter: &E,
         sessions: &Arc<Mutex<HashMap<String, SessionEntry>>>,
         output_buffers: &OutputBuffers,
+        session_loggers: &SessionLoggers,
     ) {
         if !data.is_empty() {
             let event = TerminalOutputEvent {
@@ -1553,6 +1711,19 @@ impl SessionManager {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .remove(session_id);
+
+        // Flush and drop the session's output logger (#1960) so the transcript's
+        // tail is persisted and its file handle is released when the session ends.
+        if let Some(logger) = session_loggers
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(session_id)
+        {
+            let _ = logger
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .flush();
+        }
 
         info!("Session ended: {session_id}");
     }
@@ -1646,6 +1817,11 @@ mod tests {
 
     /// A fresh, empty `output_buffers` map for the cleanup path (#1900).
     fn new_output_buffers() -> OutputBuffers {
+        Arc::new(StdMutex::new(HashMap::new()))
+    }
+
+    /// A fresh, empty `session_loggers` map for the logging path (#1960).
+    fn new_session_loggers() -> SessionLoggers {
         Arc::new(StdMutex::new(HashMap::new()))
     }
 
@@ -1921,6 +2097,7 @@ mod tests {
             &emitter,
             &sessions,
             &output_buffers,
+            &new_session_loggers(),
         )
         .await;
 
@@ -1945,6 +2122,7 @@ mod tests {
             &emitter,
             &sessions,
             &output_buffers,
+            &new_session_loggers(),
         )
         .await;
 
@@ -1975,6 +2153,7 @@ mod tests {
             false,
             capture.clone(),
             output_buffers,
+            new_session_loggers(),
         )
         .await;
 
@@ -2008,6 +2187,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_output_reader_writes_to_active_session_logger() {
+        let emitter = MockEventEmitter::new();
+        let sessions = sessions_with_mock("sess-log").await;
+        let session_loggers = new_session_loggers();
+
+        // Point a logger at a temp file and register it as the active logger for
+        // the session, mirroring what `start_session_logging` does.
+        let dir = std::env::temp_dir().join(format!(
+            "termihub-mgr-log-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("out.log");
+        let logger = SessionLogger::open(
+            SessionLogConfig::new(&path, false),
+            Box::new(|| "T".to_string()),
+        )
+        .unwrap();
+        session_loggers
+            .lock()
+            .unwrap()
+            .insert("sess-log".to_string(), Arc::new(StdMutex::new(logger)));
+
+        let (tx, rx) = tokio::sync::mpsc::channel::<Vec<u8>>(10);
+        tx.send(b"logged output\n".to_vec()).await.unwrap();
+        drop(tx); // EOF → reader runs cleanup, flushing + dropping the logger
+
+        SessionManager::run_output_reader(
+            "sess-log".to_string(),
+            rx,
+            emitter,
+            sessions,
+            false,
+            new_capture(),
+            new_output_buffers(),
+            session_loggers.clone(),
+        )
+        .await;
+
+        // The transcript captured the streamed output...
+        let contents = std::fs::read(&path).unwrap();
+        assert!(
+            contents.windows(6).any(|w| w == b"logged"),
+            "expected streamed output in the transcript file"
+        );
+        // ...and cleanup removed the logger from the active map.
+        assert!(
+            !session_loggers.lock().unwrap().contains_key("sess-log"),
+            "logger should be dropped when the session ends"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
     async fn run_output_reader_stops_on_emitter_failure() {
         let emitter = MockEventEmitter::failing();
         let sessions = sessions_with_mock("sess-fail").await;
@@ -2024,6 +2259,7 @@ mod tests {
             false,
             new_capture(),
             new_output_buffers(),
+            new_session_loggers(),
         )
         .await;
 
@@ -2062,6 +2298,7 @@ mod tests {
             &emitter,
             &sessions,
             &new_output_buffers(),
+            &new_session_loggers(),
         )
         .await;
 

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -4,5 +4,6 @@ pub mod manager;
 pub mod rdp_trust_store;
 pub mod registry;
 pub mod remote_proxy;
+pub mod session_log;
 pub mod ssh_host_key_verifier;
 pub mod ssh_trust_store;

--- a/src-tauri/src/session/session_log.rs
+++ b/src-tauri/src/session/session_log.rs
@@ -1,0 +1,35 @@
+//! Desktop helpers for per-session output logging (#1960).
+//!
+//! The core [`SessionLogger`](termihub_core::output::session_log::SessionLogger)
+//! is date-library free and takes an injected clock. This module supplies the
+//! desktop wiring: a `chrono`-based clock for per-line timestamps and the
+//! default transcript location (`<connection>-<timestamp>.log` beside the app
+//! diagnostics log).
+
+use std::path::PathBuf;
+
+use chrono::Local;
+use termihub_core::output::session_log::{default_log_filename, Clock};
+
+use crate::utils::file_log;
+
+/// A clock producing millisecond-precision local timestamps for line prefixes.
+pub fn desktop_clock() -> Clock {
+    Box::new(|| Local::now().format("%Y-%m-%d %H:%M:%S%.3f").to_string())
+}
+
+/// The default directory for per-session transcripts: a `sessions` subfolder
+/// beside the platform app-log directory (`file_log::log_dir()`).
+pub fn default_session_log_dir() -> Option<PathBuf> {
+    file_log::log_dir().map(|d| d.join("sessions"))
+}
+
+/// Build the default transcript path for a session titled `title`.
+///
+/// Yields `<default dir>/<sanitized-title>-<YYYYMMDD-HHMMSS>.log`. `None` when
+/// the platform log directory cannot be resolved.
+pub fn default_session_log_path(title: &str) -> Option<PathBuf> {
+    let dir = default_session_log_dir()?;
+    let stamp = Local::now().format("%Y%m%d-%H%M%S").to_string();
+    Some(dir.join(default_log_filename(title, &stamp)))
+}

--- a/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
+++ b/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
@@ -313,6 +313,42 @@ export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerm
       </label>
 
       <div className="settings-form__field">
+        <span className="settings-form__label">Log Session Output</span>
+        <Toggle
+          checked={options.logToFile ?? false}
+          onCheckedChange={(v) =>
+            onChange({
+              ...options,
+              logToFile: v || undefined,
+              // Drop the timestamp sub-option when logging is turned off so the
+              // connection does not persist a dangling override.
+              logTimestamps: v ? options.logTimestamps : undefined,
+            })
+          }
+          aria-label="Log Session Output"
+          data-testid="connection-log-to-file"
+        />
+        <span className="settings-form__hint">
+          Write this connection&rsquo;s session output to a file on connect (
+          <code>&lt;connection&gt;-&lt;timestamp&gt;.log</code>). The terminal toolbar can also
+          start and stop logging on demand.
+        </span>
+      </div>
+
+      {options.logToFile ? (
+        <div className="settings-form__field">
+          <span className="settings-form__label">Timestamp Each Line</span>
+          <Toggle
+            checked={options.logTimestamps ?? false}
+            onCheckedChange={(v) => onChange({ ...options, logTimestamps: v || undefined })}
+            aria-label="Timestamp Each Line"
+            data-testid="connection-log-timestamps"
+          />
+          <span className="settings-form__hint">Prefix each logged line with a timestamp.</span>
+        </div>
+      ) : null}
+
+      <div className="settings-form__field">
         <span className="settings-form__label">Cursor Blink</span>
         <Toggle
           checked={options.cursorBlink ?? globalCursorBlink}

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -12,6 +12,7 @@ import {
   cancelConnecting,
   sendInput,
   setSessionLineEnding,
+  sessionLoggingStart,
   resizeTerminal,
   closeTerminal,
   detachPersistentTab,
@@ -210,6 +211,24 @@ async function pushLineEnding(tabId: string, sessionId: string): Promise<void> {
     await setSessionLineEnding(sessionId, ending);
   } catch (e) {
     frontendLog("terminal", `failed to set line ending for session ${sessionId}: ${String(e)}`);
+  }
+}
+
+/**
+ * Auto-start per-session output logging when the connection opts in (#1960).
+ *
+ * Reads the per-connection `logToFile` / `logTimestamps` terminal options and,
+ * when enabled, starts logging to the default `<connection>-<timestamp>.log`
+ * location. Best-effort: a failure is logged but never blocks establishment,
+ * and the toolbar toggle remains available regardless.
+ */
+async function pushSessionLogging(tabId: string, sessionId: string): Promise<void> {
+  const options = useAppStore.getState().tabTerminalOptions[tabId];
+  if (!options?.logToFile) return;
+  try {
+    await sessionLoggingStart(sessionId, undefined, options.logTimestamps ?? false);
+  } catch (e) {
+    frontendLog("terminal", `failed to start session logging for ${sessionId}: ${String(e)}`);
   }
 }
 
@@ -643,6 +662,11 @@ export function Terminal({
         // reconnect) passes through; later setting changes are synced by the
         // effect below.
         await pushLineEnding(tabId, sessionId);
+
+        // Auto-start per-session output logging when the connection opts in
+        // (#1960). Idempotent on the backend, so reattach/reconnect paths that
+        // pass through here again do not double-open the transcript.
+        await pushSessionLogging(tabId, sessionId);
 
         // Resize-deduplication: track the last (cols, rows) sent to the PTY
         // to avoid spurious SIGWINCH signals.  Multiple rapid fit() calls

--- a/src/components/Terminal/TerminalView.agent-tabdot.test.tsx
+++ b/src/components/Terminal/TerminalView.agent-tabdot.test.tsx
@@ -75,6 +75,9 @@ vi.mock("@/services/api", () => ({
   sessionGetCapabilities: vi.fn(() => Promise.resolve({ monitoring: false, fileBrowser: false })),
   sessionMonitoringOpen: vi.fn(() => Promise.resolve()),
   sessionMonitoringClose: vi.fn(() => Promise.resolve()),
+  sessionLoggingStart: vi.fn(() => Promise.resolve("/tmp/session.log")),
+  sessionLoggingStop: vi.fn(() => Promise.resolve(null)),
+  sessionLoggingStatus: vi.fn(() => Promise.resolve(null)),
 }));
 vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
 

--- a/src/components/Terminal/TerminalView.logging-button.test.tsx
+++ b/src/components/Terminal/TerminalView.logging-button.test.tsx
@@ -1,12 +1,18 @@
 /**
- * The terminal toolbar exposes a record/stop button wired to the macro
- * recording store slice (#1674): it toggles recording and reflects the active
- * state so the user always sees whether input is being captured.
+ * The terminal toolbar exposes a session-logging toggle (#1960): it starts and
+ * stops writing the active session's output to a file. With no terminal focused
+ * it surfaces guidance rather than silently doing nothing.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
+import { toast } from "sonner";
+import { sessionLoggingStart } from "@/services/api";
+
+vi.mock("sonner", () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+}));
 
 vi.mock("@tauri-apps/api/event", () => ({
   listen: vi.fn(() => Promise.resolve(() => {})),
@@ -63,11 +69,13 @@ import { TerminalView } from "./TerminalView";
 let container: HTMLDivElement;
 let root: Root;
 
-function recordButton(): HTMLButtonElement {
-  return document.querySelector('[data-testid="terminal-view-record-macro"]') as HTMLButtonElement;
+function loggingButton(): HTMLButtonElement {
+  return document.querySelector(
+    '[data-testid="terminal-view-toggle-logging"]'
+  ) as HTMLButtonElement;
 }
 
-describe("TerminalView — macro record button (#1674)", () => {
+describe("TerminalView — session logging button (#1960)", () => {
   beforeEach(() => {
     useAppStore.setState(useAppStore.getInitialState());
     container = document.createElement("div");
@@ -82,29 +90,17 @@ describe("TerminalView — macro record button (#1674)", () => {
     vi.clearAllMocks();
   });
 
-  it("renders the record button in an idle state", () => {
-    const btn = recordButton();
+  it("renders the logging button in an idle (not-logging) state", () => {
+    const btn = loggingButton();
     expect(btn).toBeTruthy();
     expect(btn.getAttribute("aria-pressed")).toBe("false");
-    expect(btn.className).not.toContain("terminal-view__toolbar-action--recording");
+    expect(btn.className).not.toContain("terminal-view__toolbar-action--active");
   });
 
-  it("clicking starts recording and reflects the active state", () => {
-    act(() => recordButton().click());
+  it("guides the user instead of logging when no terminal is focused", () => {
+    act(() => loggingButton().click());
 
-    expect(useAppStore.getState().macroRecording).toBe(true);
-    const btn = recordButton();
-    expect(btn.getAttribute("aria-pressed")).toBe("true");
-    expect(btn.className).toContain("terminal-view__toolbar-action--recording");
-  });
-
-  it("clicking again stops recording (opening the save dialog after capture)", () => {
-    act(() => recordButton().click());
-    // Simulate captured input so stopping routes to the save dialog.
-    act(() => useAppStore.getState().recordMacroInput("ls\r"));
-    act(() => recordButton().click());
-
-    expect(useAppStore.getState().macroRecording).toBe(false);
-    expect(useAppStore.getState().macroSaveDialogOpen).toBe(true);
+    expect(toast.info).toHaveBeenCalledTimes(1);
+    expect(sessionLoggingStart).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -1,5 +1,16 @@
 import { useEffect, useMemo, useState } from "react";
-import { Plus, Columns2, Rows2, X, PanelLeft, Circle, Square, Play, Radio } from "lucide-react";
+import {
+  Plus,
+  Columns2,
+  Rows2,
+  X,
+  PanelLeft,
+  Circle,
+  Square,
+  Play,
+  Radio,
+  ScrollText,
+} from "lucide-react";
 import { listen } from "@tauri-apps/api/event";
 import { toast } from "sonner";
 import { useAppStore, getActiveTab } from "@/store/appStore";
@@ -18,7 +29,12 @@ import { MacroPlaybackDialog } from "./MacroPlaybackDialog";
 import { BroadcastScopeDialog } from "./BroadcastScopeDialog";
 import { SplitView } from "@/components/SplitView";
 import { terminalDispatcher } from "@/services/events";
-import { listAgentSessions } from "@/services/api";
+import {
+  listAgentSessions,
+  sessionLoggingStart,
+  sessionLoggingStop,
+  sessionLoggingStatus,
+} from "@/services/api";
 import { frontendLog } from "@/utils/frontendLog";
 import "./TerminalView.css";
 
@@ -264,13 +280,79 @@ export function TerminalView() {
   const [macroPlaybackDialogOpen, setMacroPlaybackDialogOpen] = useState(false);
   const [broadcastDialogOpen, setBroadcastDialogOpen] = useState(false);
   const [broadcastSourceTabId, setBroadcastSourceTabId] = useState<string | null>(null);
+  // Session output logging (#1960): the set of session IDs currently logging to
+  // a file. The toolbar toggle drives the active terminal's session; the backend
+  // is the source of truth, so the active session's state is synced on change.
+  const [loggingSessions, setLoggingSessions] = useState<Set<string>>(new Set());
+  const activeSessionId = useAppStore((s) => {
+    const tab = getActiveTab(s);
+    return tab && tab.contentType === "terminal" ? (tab.sessionId ?? null) : null;
+  });
   const isMac = navigator.platform.toUpperCase().includes("MAC");
   const sidebarToggleTitle = `Toggle Sidebar (${isMac ? "Cmd" : "Ctrl"}+B)`;
 
   const allLeaves = getAllLeaves(rootPanel);
 
+  // Keep the toggle's pressed state honest when the active terminal changes:
+  // logging may have been started elsewhere (per-connection setting) or stopped
+  // by the session ending, so re-query the backend for the active session.
+  useEffect(() => {
+    if (!activeSessionId) return;
+    let cancelled = false;
+    sessionLoggingStatus(activeSessionId)
+      .then((status) => {
+        if (cancelled) return;
+        setLoggingSessions((prev) => {
+          const isLogging = prev.has(activeSessionId);
+          if (!!status === isLogging) return prev;
+          const next = new Set(prev);
+          if (status) next.add(activeSessionId);
+          else next.delete(activeSessionId);
+          return next;
+        });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSessionId]);
+
+  const isActiveSessionLogging = activeSessionId ? loggingSessions.has(activeSessionId) : false;
+
   const handleNewTerminal = () => {
     addTab("Terminal", "local");
+  };
+
+  // Session output logging toggle (#1960): start/stop writing the active
+  // terminal's output to a timestamped file on demand.
+  const handleToggleLogging = async () => {
+    const tab = getActiveTab(useAppStore.getState());
+    if (!tab || tab.contentType !== "terminal" || !tab.sessionId) {
+      toast.info("Focus a terminal to log its output");
+      return;
+    }
+    const sid = tab.sessionId;
+    if (loggingSessions.has(sid)) {
+      try {
+        await sessionLoggingStop(sid);
+        setLoggingSessions((prev) => {
+          const next = new Set(prev);
+          next.delete(sid);
+          return next;
+        });
+        toast.success("Stopped session logging");
+      } catch (e) {
+        toast.error(`Failed to stop logging: ${String(e)}`);
+      }
+      return;
+    }
+    try {
+      const path = await sessionLoggingStart(sid, undefined, true);
+      setLoggingSessions((prev) => new Set(prev).add(sid));
+      toast.success(`Logging session output to ${path}`);
+    } catch (e) {
+      toast.error(`Failed to start logging: ${String(e)}`);
+    }
   };
 
   // Broadcast toggle (#1956): clicking opens the scope-selection dialog (All /
@@ -339,6 +421,24 @@ export function TerminalView() {
                 aria-label={broadcastActive ? "Stop Broadcast" : "Broadcast Input"}
                 aria-pressed={broadcastActive}
                 data-testid="terminal-view-broadcast"
+              />
+            </Tooltip>
+            <Tooltip
+              content={isActiveSessionLogging ? "Stop Logging Output" : "Log Session Output"}
+              side="bottom"
+            >
+              <Button
+                variant="ghost"
+                size="sm"
+                iconOnly
+                className={
+                  isActiveSessionLogging ? "terminal-view__toolbar-action--active" : undefined
+                }
+                icon={<ScrollText size={16} />}
+                onClick={() => void handleToggleLogging()}
+                aria-label={isActiveSessionLogging ? "Stop Logging Output" : "Log Session Output"}
+                aria-pressed={isActiveSessionLogging}
+                data-testid="terminal-view-toggle-logging"
               />
             </Tooltip>
             <Tooltip content="New Terminal" side="bottom">

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -471,6 +471,43 @@ export async function setSessionLineEnding(
   await invoke("set_session_line_ending", { sessionId, lineEnding });
 }
 
+/** Status of a session's output-to-file logging (#1960). */
+export interface SessionLogStatus {
+  /** Absolute path of the active transcript file. */
+  path: string;
+  /** Whether each line is prefixed with a timestamp. */
+  timestamps: boolean;
+}
+
+/**
+ * Start writing a session's output to a file (#1960).
+ *
+ * When `path` is omitted the backend picks a default
+ * `<connection>-<timestamp>.log` under the platform log directory. When
+ * `timestamps` is true each line is prefixed with a wall-clock stamp. Resolves
+ * to the transcript path actually used.
+ */
+export async function sessionLoggingStart(
+  sessionId: SessionId,
+  path?: string,
+  timestamps?: boolean
+): Promise<string> {
+  return await invoke<string>("session_logging_start", { sessionId, path, timestamps });
+}
+
+/**
+ * Stop writing a session's output to a file (#1960). Resolves to the transcript
+ * path if logging was active, else `null`.
+ */
+export async function sessionLoggingStop(sessionId: SessionId): Promise<string | null> {
+  return await invoke<string | null>("session_logging_stop", { sessionId });
+}
+
+/** Current logging status for a session, or `null` when not logging (#1960). */
+export async function sessionLoggingStatus(sessionId: SessionId): Promise<SessionLogStatus | null> {
+  return await invoke<SessionLogStatus | null>("session_logging_status", { sessionId });
+}
+
 /** Resize a terminal session */
 export async function resizeTerminal(
   sessionId: SessionId,

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -209,6 +209,14 @@ export interface TerminalOptions {
   /** Per-connection line-ending override. Falls back to the global default. */
   lineEnding?: LineEnding;
   /**
+   * When `true`, this connection's session output is logged to a file on
+   * connect (#1960), using the default `<connection>-<timestamp>.log` location.
+   * Absent/false → no automatic logging (the toolbar toggle still works).
+   */
+  logToFile?: boolean;
+  /** When logging to a file, prefix each line with a timestamp (#1960). */
+  logTimestamps?: boolean;
+  /**
    * Per-connection syntax-highlighting override (epic #1696). Absent → the
    * connection follows the global setting (`override: "global"`). See
    * `services/syntaxHighlightingConfig.ts` → `resolveHighlightingConfig`.


### PR DESCRIPTION
## Summary

Adds opt-in per-session output logging to a file, addressing the field-audit gap in #1960: termiHub kept scrollback in a ring buffer and an app diagnostics log, but had no durable per-session transcript — when a tab closed, the evidence was gone (PuTTY/Termius/iTerm all log sessions).

## What's included

- **Core sink** (`core/src/output/session_log.rs`): a `SessionLogger` that mirrors raw session output into a file, with:
  - optional **per-line timestamps** that are line-boundary aware (a line split across output chunks gets exactly one timestamp);
  - size-based **rotation** to a single `<name>.1` archive (bounded on-disk use);
  - **flush on close** (and on `Drop`) so a closed session's tail is never lost.
  - Timestamps are injected via a `Clock` closure to keep the core crate date-library free and tests deterministic.
- **Desktop wiring** (`SessionManager`): a per-session logger map parallel to the scrollback capture, written on the same output-reader hot path — so it captures **all session types** (local, SSH, serial, telnet, docker, and agent-proxied remote sessions).
- **Toolbar toggle** in `TerminalView.tsx` to start/stop logging the active session on demand, with a default path `<connection>-<timestamp>.log`.
- **Per-connection setting**: "Log session output to file" (+ per-line timestamps) in the connection Terminal settings, auto-started on connect.
- Tauri commands + `api.ts` wrappers for start/stop/status.

## Tests

- Core sink + timestamping unit tests (raw byte-exactness, per-line timestamps, timestamp across chunk boundaries, append vs truncate, parent-dir creation, drop-flush, rotation, filename sanitization).

Closes #1960