### PR TITLE
feat(ssh): agentless auto-reconnect keeping continuity over flaky links (Closes #1962)

### DIFF
--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -483,6 +483,32 @@ impl ConnectionType for Ssh {
                             supports_tilde_expansion: false,
                             visible_when: None,
                         },
+                        SettingsField {
+                            key: "resilientReconnect".to_string(),
+                            label: "Resilient Reconnect".to_string(),
+                            description: Some(
+                                "Auto-reconnect a dropped link with backoff into the same tab"
+                                    .to_string(),
+                            ),
+                            help_text: Some(concat!(
+                                "For flaky links (cellular, spotty Wi-Fi), termiHub automatically ",
+                                "re-establishes a dropped SSH connection with an exponential backoff ",
+                                "instead of showing the manual reconnect prompt. It reattaches to the ",
+                                "same tab and keeps the local scrollback visible while it retries; a ",
+                                "Cancel control lets you stop and browse the scrollback.\n\n",
+                                "Without a remote agent, server-side shell state (running commands, a ",
+                                "half-typed line, the working directory) is NOT preserved — the ",
+                                "reconnect opens a fresh remote shell. Deploy an agent for full ",
+                                "session continuity.",
+                            ).to_string()),
+                            field_type: FieldType::Boolean,
+                            required: false,
+                            default: Some(serde_json::json!(false)),
+                            placeholder: None,
+                            supports_env_expansion: false,
+                            supports_tilde_expansion: false,
+                            visible_when: None,
+                        },
                     ],
                 },
             ],
@@ -872,7 +898,8 @@ mod tests {
                 "enableX11Forwarding",
                 "connectTimeoutSecs",
                 "env",
-                "shellIntegration"
+                "shellIntegration",
+                "resilientReconnect"
             ]
         );
     }

--- a/docs/changes/dev4/feat/1962-agentless-reconnect.md
+++ b/docs/changes/dev4/feat/1962-agentless-reconnect.md
@@ -1,0 +1,12 @@
+### Added
+
+- Agentless **resilient reconnect** for plain SSH (#1962): a new per-connection
+  "Resilient Reconnect" toggle in a connection's _Advanced_ settings. When
+  enabled, an unexpected link drop auto-reconnects with exponential backoff
+  (1s → 30s, jittered, bounded) into the **same tab** instead of showing the
+  manual reconnect prompt — reattaching in place and keeping the local
+  scrollback visible. A live countdown overlay shows the next attempt and offers
+  a Cancel affordance. Because there is no remote agent, the overlay is explicit
+  that server-side shell state (running commands, working directory) is not
+  restored — a fresh remote shell opens. Off by default. Found via field audit
+  (debugging from a truck on cellular).

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -905,6 +905,11 @@ function TerminalSlot({ tabId, isVisible }: { tabId: string; isVisible: boolean 
   const isViewMode = useAppStore((s) => s.terminalViewMode[tabId] ?? false);
   const isReconnecting = useAppStore((s) => s.terminalReconnectingTabs[tabId] ?? false);
   const isReconnectPromptVisible = useAppStore((s) => s.terminalReconnectPrompt[tabId] ?? false);
+  // Agentless resilient reconnect (#1962): the backoff countdown overlay must
+  // show even after the first attempt cleared the exited flag mid-loop.
+  const isAutoReconnectWaiting = useAppStore(
+    (s) => s.terminalAutoReconnect[tabId]?.phase === "waiting"
+  );
 
   useEffect(() => {
     const slotEl = slotRef.current;
@@ -955,7 +960,9 @@ function TerminalSlot({ tabId, isVisible }: { tabId: string; isVisible: boolean 
       className={`terminal-container ${isVisible ? "" : "terminal-container--hidden"}`}
       style={tabColor ? { border: `2px solid ${tabColor}` } : undefined}
     >
-      {(isReconnecting || (isExited && !isViewMode)) && <TerminalDisconnectOverlay tabId={tabId} />}
+      {(isReconnecting || isAutoReconnectWaiting || (isExited && !isViewMode)) && (
+        <TerminalDisconnectOverlay tabId={tabId} />
+      )}
       {isExited && isViewMode && (
         <>
           <TerminalViewModeBanner tabId={tabId} />

--- a/src/components/Terminal/TerminalDisconnectOverlay.autoReconnect.test.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.autoReconnect.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { TerminalDisconnectOverlay } from "./TerminalDisconnectOverlay";
+import { withTooltip } from "@/test/tooltip";
+import { useAppStore } from "@/store/appStore";
+import type { TerminalAutoReconnectState } from "@/types/terminal";
+
+// Stub lucide-react icons used in the overlay.
+vi.mock("lucide-react", () => ({
+  WifiOff: () => null,
+  RefreshCw: () => null,
+  X: () => null,
+  AlertTriangle: () => null,
+  Loader2: () => null,
+  CheckCircle2: () => null,
+}));
+
+function setAuto(tabId: string, state: Partial<TerminalAutoReconnectState>) {
+  const full: TerminalAutoReconnectState = {
+    phase: "waiting",
+    attempt: 0,
+    maxAttempts: 10,
+    delayMs: 2_000,
+    nextAttemptAt: Date.now() + 2_000,
+    ...state,
+  };
+  useAppStore.setState({ terminalAutoReconnect: { [tabId]: full } });
+}
+
+describe("TerminalDisconnectOverlay — agentless auto-reconnect variant (#1962)", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState({
+      terminalExitedTabs: { "tab-1": true },
+      terminalDisconnectErrors: {},
+      terminalViewMode: {},
+      terminalReconnectingTabs: {},
+      terminalReconnectTriggerErrors: {},
+      terminalAutoReconnect: {},
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it("shows the countdown, attempt progress, and the honest continuity note while waiting", () => {
+    setAuto("tab-1", { attempt: 1, maxAttempts: 10, nextAttemptAt: Date.now() + 3_400 });
+    act(() => {
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
+    });
+
+    expect(container.querySelector("[data-testid='terminal-disconnect-overlay']")).not.toBeNull();
+    expect(container.textContent).toContain("reconnecting");
+    const countdown = container.querySelector("[data-testid='terminal-auto-reconnect-countdown']");
+    expect(countdown?.textContent).toContain("Attempt 2 of 10");
+    // Honest about agentless continuity.
+    expect(container.textContent).toContain("Local scrollback is preserved");
+    expect(container.textContent).toContain("not restored");
+  });
+
+  it("takes precedence over the exited/disconnected overlay", () => {
+    setAuto("tab-1", {});
+    act(() => {
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
+    });
+    // The manual "Session disconnected" heading must NOT appear while auto-
+    // reconnect is counting down.
+    expect(container.textContent).not.toContain("Session disconnected");
+    expect(container.textContent).toContain("Connection lost");
+  });
+
+  it("cancel button stops the loop via cancelAutoReconnect", () => {
+    const cancelSpy = vi.fn();
+    useAppStore.setState({ cancelAutoReconnect: cancelSpy });
+    setAuto("tab-1", {});
+    act(() => {
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
+    });
+
+    const btn = container.querySelector<HTMLButtonElement>(
+      "[data-testid='terminal-auto-reconnect-cancel-btn']"
+    );
+    expect(btn).not.toBeNull();
+    act(() => {
+      btn!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(cancelSpy).toHaveBeenCalledWith("tab-1");
+  });
+});

--- a/src/components/Terminal/TerminalDisconnectOverlay.css
+++ b/src/components/Terminal/TerminalDisconnectOverlay.css
@@ -86,6 +86,14 @@
   line-height: 1.5;
 }
 
+/* Honesty note for agentless resilient reconnect (#1962): what survives a drop
+   vs. what does not, rendered a step quieter than the subheading. */
+.terminal-disconnect-overlay__note {
+  font-size: var(--font-size-xs);
+  color: var(--text-tertiary, var(--text-secondary));
+  max-width: 42ch;
+}
+
 .terminal-disconnect-overlay__error-box {
   width: 100%;
   max-height: 120px;

--- a/src/components/Terminal/TerminalDisconnectOverlay.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { WifiOff, RefreshCw, X, AlertTriangle, Loader2, CheckCircle2 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { Button, Tooltip } from "@/components/ui";
@@ -58,12 +58,80 @@ function disconnectCopyFor(info: TerminalExitInfo | undefined): DisconnectCopy {
  *
  * The scrollback buffer is always preserved below the overlay.
  */
+/**
+ * Auto-reconnect countdown variant (#1962): shown while the agentless resilient-
+ * reconnect loop is waiting to make its next attempt. Renders a live countdown,
+ * the attempt progress, an honest note that server-side state is not preserved
+ * without an agent, and a Cancel affordance that stops the loop.
+ */
+function AutoReconnectingOverlay({ tabId }: { tabId: string }) {
+  const auto = useAppStore((s) => s.terminalAutoReconnect[tabId]);
+  const cancelAutoReconnect = useAppStore((s) => s.cancelAutoReconnect);
+  // Tick once a second so the countdown stays live.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 500);
+    return () => clearInterval(id);
+  }, []);
+
+  const handleCancel = useCallback(() => {
+    cancelAutoReconnect(tabId);
+  }, [tabId, cancelAutoReconnect]);
+
+  // Guard: the loop may have advanced out of "waiting" between the parent's
+  // render and ours.
+  if (!auto) return null;
+
+  const secondsLeft = Math.max(0, Math.ceil((auto.nextAttemptAt - now) / 1000));
+  const attemptLabel =
+    auto.maxAttempts > 0
+      ? `Attempt ${auto.attempt + 1} of ${auto.maxAttempts}`
+      : `Attempt ${auto.attempt + 1}`;
+
+  return (
+    <div
+      className="terminal-disconnect-overlay terminal-disconnect-overlay--reconnecting"
+      data-testid="terminal-disconnect-overlay"
+    >
+      <div className="terminal-disconnect-overlay__body">
+        <WifiOff size={32} className="terminal-disconnect-overlay__icon" />
+        <p className="terminal-disconnect-overlay__heading">Connection lost — reconnecting…</p>
+        <p
+          className="terminal-disconnect-overlay__subheading"
+          data-testid="terminal-auto-reconnect-countdown"
+        >
+          {secondsLeft > 0
+            ? `Retrying in ${secondsLeft}s · ${attemptLabel}`
+            : `Reconnecting… · ${attemptLabel}`}
+        </p>
+        <p className="terminal-disconnect-overlay__subheading terminal-disconnect-overlay__note">
+          Local scrollback is preserved. Without an agent, the remote shell state
+          (running commands, working directory) is not restored — a fresh shell opens.
+        </p>
+        <div className="terminal-disconnect-overlay__actions">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleCancel}
+            data-testid="terminal-auto-reconnect-cancel-btn"
+          >
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function TerminalDisconnectOverlay({ tabId }: TerminalDisconnectOverlayProps) {
   const reconnectTerminal = useAppStore((s) => s.reconnectTerminal);
   const dismissTerminalDisconnect = useAppStore((s) => s.dismissTerminalDisconnect);
   const setTerminalExited = useAppStore((s) => s.setTerminalExited);
   const disconnectError = useAppStore((s) => s.terminalDisconnectErrors[tabId]);
   const isReconnecting = useAppStore((s) => s.terminalReconnectingTabs[tabId] ?? false);
+  const autoReconnectWaiting = useAppStore(
+    (s) => s.terminalAutoReconnect[tabId]?.phase === "waiting"
+  );
   const reconnectTriggerError = useAppStore((s) => s.terminalReconnectTriggerErrors[tabId]);
   const exitInfo = useAppStore((s) => s.terminalExitInfo[tabId]);
 
@@ -78,6 +146,13 @@ export function TerminalDisconnectOverlay({ tabId }: TerminalDisconnectOverlayPr
   const handleStop = useCallback(() => {
     setTerminalExited(tabId);
   }, [tabId, setTerminalExited]);
+
+  // Agentless resilient reconnect (#1962) takes precedence: while the backoff
+  // loop is counting down, show the countdown/Cancel variant instead of the
+  // manual disconnect prompt.
+  if (autoReconnectWaiting) {
+    return <AutoReconnectingOverlay tabId={tabId} />;
+  }
 
   if (isReconnecting) {
     return (

--- a/src/components/Terminal/TerminalDisconnectOverlay.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.tsx
@@ -48,17 +48,6 @@ function disconnectCopyFor(info: TerminalExitInfo | undefined): DisconnectCopy {
 }
 
 /**
- * Shown as an absolute overlay on top of the terminal content when the session
- * exits unexpectedly or while the agent is auto-reconnecting.
- *
- * Three variants (determined from store state):
- *   - "reconnecting"  — spinner, optional trigger error, Stop button
- *   - "error"         — error box, "Reconnect failed" heading, retry + view-scrollback buttons
- *   - "disconnected"  — standard disconnect, reconnect + view-scrollback buttons
- *
- * The scrollback buffer is always preserved below the overlay.
- */
-/**
  * Auto-reconnect countdown variant (#1962): shown while the agentless resilient-
  * reconnect loop is waiting to make its next attempt. Renders a live countdown,
  * the attempt progress, an honest note that server-side state is not preserved
@@ -105,8 +94,8 @@ function AutoReconnectingOverlay({ tabId }: { tabId: string }) {
             : `Reconnecting… · ${attemptLabel}`}
         </p>
         <p className="terminal-disconnect-overlay__subheading terminal-disconnect-overlay__note">
-          Local scrollback is preserved. Without an agent, the remote shell state
-          (running commands, working directory) is not restored — a fresh shell opens.
+          Local scrollback is preserved. Without an agent, the remote shell state (running commands,
+          working directory) is not restored — a fresh shell opens.
         </p>
         <div className="terminal-disconnect-overlay__actions">
           <Button
@@ -123,6 +112,18 @@ function AutoReconnectingOverlay({ tabId }: { tabId: string }) {
   );
 }
 
+/**
+ * Shown as an absolute overlay on top of the terminal content when the session
+ * exits unexpectedly or while a reconnect is in progress.
+ *
+ * Variants (determined from store state, in priority order):
+ *   - "auto-reconnect" — agentless resilient-reconnect countdown + Cancel (#1962)
+ *   - "reconnecting"   — spinner, optional trigger error, Stop button
+ *   - "error"          — error box, "Reconnect failed" heading, retry + view buttons
+ *   - "disconnected"   — standard disconnect, reconnect + view-scrollback buttons
+ *
+ * The scrollback buffer is always preserved below the overlay.
+ */
 export function TerminalDisconnectOverlay({ tabId }: TerminalDisconnectOverlayProps) {
   const reconnectTerminal = useAppStore((s) => s.reconnectTerminal);
   const dismissTerminalDisconnect = useAppStore((s) => s.dismissTerminalDisconnect);

--- a/src/store/appStore.autoReconnect.test.ts
+++ b/src/store/appStore.autoReconnect.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// The auto-reconnect loop lives entirely in the store and its pure state machine;
+// it never calls the backend directly (it re-drives the existing reconnect path),
+// so the service mocks only need to satisfy module import.
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  persistAgent: vi.fn(() => Promise.resolve()),
+  removeAgent: vi.fn(() => Promise.resolve()),
+  reorderAgents: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  startPersistentSession: vi.fn(() => Promise.resolve("sid")),
+  stopPersistentSession: vi.fn(() => Promise.resolve()),
+  attachPersistentTab: vi.fn(() => Promise.resolve(1)),
+  connectAgent: vi.fn(() => Promise.resolve({ capabilities: {} })),
+  disconnectAgent: vi.fn(),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  listAgentConnections: vi.fn(() => Promise.resolve({ connections: [], folders: [] })),
+  saveAgentDefinition: vi.fn(),
+  updateAgentDefinition: vi.fn(),
+  deleteAgentDefinition: vi.fn(() => Promise.resolve()),
+  createAgentFolder: vi.fn(),
+  updateAgentFolder: vi.fn(() => Promise.resolve({})),
+  deleteAgentFolder: vi.fn(() => Promise.resolve()),
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  removeCredential: vi.fn(() => Promise.resolve()),
+  getConnectionTypes: vi.fn(() => Promise.resolve([])),
+  sessionGetCapabilities: vi.fn(() => Promise.resolve({})),
+}));
+
+import { useAppStore } from "./appStore";
+import { getAllLeaves } from "@/utils/panelTree";
+import { DEFAULT_BACKOFF } from "@/utils/reconnectBackoff";
+
+function findTab(tabId: string) {
+  const state = useAppStore.getState();
+  return [
+    ...getAllLeaves(state.rootPanel).flatMap((l) => l.tabs),
+    ...state.tabGroups.flatMap((g) => getAllLeaves(g.rootPanel).flatMap((l) => l.tabs)),
+  ].find((t) => t.id === tabId);
+}
+
+/** Create a plain-SSH terminal tab; `resilient` toggles the per-connection opt-in. */
+function makeSshTab(resilient: boolean, sessionId: string | null = "sess-1"): string {
+  return useAppStore.getState().addTab(
+    "web01",
+    "ssh",
+    {
+      type: "ssh",
+      config: {
+        host: "web01.example.com",
+        username: "deploy",
+        resilientReconnect: resilient,
+      },
+    },
+    { contentType: "terminal", sessionId }
+  );
+}
+
+const auto = (tabId: string) => useAppStore.getState().terminalAutoReconnect[tabId];
+
+describe("appStore — agentless auto-reconnect (#1962)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("starts a backoff loop when an opted-in SSH tab drops unexpectedly", () => {
+    const tabId = makeSshTab(true);
+
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+
+    const state = auto(tabId);
+    expect(state).toBeDefined();
+    expect(state.phase).toBe("waiting");
+    expect(state.attempt).toBe(0);
+    expect(state.maxAttempts).toBe(DEFAULT_BACKOFF.maxAttempts);
+    // First delay is the base delay ± jitter.
+    expect(state.delayMs).toBeGreaterThan(0);
+    expect(state.delayMs).toBeLessThanOrEqual(
+      Math.round(DEFAULT_BACKOFF.baseDelayMs * (1 + DEFAULT_BACKOFF.jitterRatio)) + 1
+    );
+  });
+
+  it("does NOT auto-reconnect when the connection did not opt in", () => {
+    const tabId = makeSshTab(false);
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+    expect(auto(tabId)).toBeUndefined();
+    // The standard disconnect overlay path still applies.
+    expect(useAppStore.getState().terminalExitedTabs[tabId]).toBe(true);
+  });
+
+  it("does NOT auto-reconnect on a clean exit or a user kill", () => {
+    const cleanTab = makeSshTab(true);
+    useAppStore.getState().setTerminalExited(cleanTab, { code: 0, reason: "clean" });
+    expect(auto(cleanTab)).toBeUndefined();
+
+    const killedTab = makeSshTab(true);
+    useAppStore.getState().setTerminalExited(killedTab, { code: null, reason: "killed" });
+    expect(auto(killedTab)).toBeUndefined();
+  });
+
+  it("fires the connect attempt when the backoff timer elapses", () => {
+    const tabId = makeSshTab(true);
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+    const retryBefore = useAppStore.getState().terminalRetryCounters[tabId] ?? 0;
+
+    vi.advanceTimersByTime(auto(tabId).delayMs);
+
+    const state = auto(tabId);
+    expect(state.phase).toBe("connecting");
+    expect(state.attempt).toBe(1);
+    // reconnectTerminal was invoked → retry counter bumped, connecting overlay armed.
+    expect(useAppStore.getState().terminalRetryCounters[tabId]).toBe(retryBefore + 1);
+    expect(useAppStore.getState().terminalConnecting[tabId]).toBe(true);
+  });
+
+  it("settles the loop when the reconnect attempt succeeds", () => {
+    const tabId = makeSshTab(true);
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+    vi.advanceTimersByTime(auto(tabId).delayMs);
+    expect(auto(tabId).phase).toBe("connecting");
+
+    // A session id landing is the success signal.
+    useAppStore.getState().setTabSessionId(tabId, "sess-2");
+
+    expect(auto(tabId)).toBeUndefined();
+  });
+
+  it("backs off further after a failed attempt, with a longer delay", () => {
+    const tabId = makeSshTab(true);
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+
+    vi.advanceTimersByTime(auto(tabId).delayMs); // attempt 1 (connecting)
+    expect(auto(tabId).phase).toBe("connecting");
+
+    // A direct-SSH failed attempt surfaces via setTerminalSpawnError.
+    useAppStore.getState().setTerminalSpawnError(tabId, "connection refused");
+
+    const state = auto(tabId);
+    expect(state.phase).toBe("waiting");
+    expect(state.attempt).toBe(1);
+    // Delay for attempt #2 is around base*factor, larger than the base window.
+    expect(state.delayMs).toBeGreaterThan(
+      Math.round(DEFAULT_BACKOFF.baseDelayMs * (1 - DEFAULT_BACKOFF.jitterRatio))
+    );
+    // The failed attempt's spawn error is suppressed so it does not compete with
+    // the countdown overlay.
+    expect(useAppStore.getState().terminalSpawnErrors[tabId]).toBeUndefined();
+  });
+
+  it("gives up after exhausting maxAttempts and shows the reconnect-failed overlay", () => {
+    const tabId = makeSshTab(true);
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+
+    // Drive attempt→failure until the loop gives up.
+    for (let i = 0; i < DEFAULT_BACKOFF.maxAttempts; i++) {
+      const state = auto(tabId);
+      if (!state) break;
+      expect(state.phase).toBe("waiting");
+      vi.advanceTimersByTime(state.delayMs);
+      expect(auto(tabId).phase).toBe("connecting");
+      useAppStore.getState().setTerminalSpawnError(tabId, "connection refused");
+    }
+
+    // Loop cleared; the standard "Reconnect failed" overlay takes over.
+    expect(auto(tabId)).toBeUndefined();
+    expect(useAppStore.getState().terminalExitedTabs[tabId]).toBe(true);
+    expect(useAppStore.getState().terminalDisconnectErrors[tabId]).toBe("connection refused");
+  });
+
+  it("cancel stops the loop and leaves the manual disconnect overlay", () => {
+    const tabId = makeSshTab(true);
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+    expect(auto(tabId).phase).toBe("waiting");
+
+    useAppStore.getState().cancelAutoReconnect(tabId);
+
+    expect(auto(tabId)).toBeUndefined();
+    expect(useAppStore.getState().terminalExitedTabs[tabId]).toBe(true);
+    // A cancelled loop must not schedule any further attempt.
+    const retryBefore = useAppStore.getState().terminalRetryCounters[tabId] ?? 0;
+    vi.advanceTimersByTime(60_000);
+    expect(useAppStore.getState().terminalRetryCounters[tabId] ?? 0).toBe(retryBefore);
+  });
+
+  it("cancel is a no-op when no loop is active", () => {
+    const tabId = makeSshTab(true);
+    expect(() => useAppStore.getState().cancelAutoReconnect(tabId)).not.toThrow();
+    expect(auto(tabId)).toBeUndefined();
+  });
+
+  it("a re-drop after a successful reconnect restarts the loop", () => {
+    const tabId = makeSshTab(true);
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+    vi.advanceTimersByTime(auto(tabId).delayMs);
+    useAppStore.getState().setTabSessionId(tabId, "sess-2");
+    expect(auto(tabId)).toBeUndefined();
+
+    // Link drops again → fresh loop from attempt 1.
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+    expect(auto(tabId).phase).toBe("waiting");
+    expect(auto(tabId).attempt).toBe(0);
+  });
+
+  it("clears the pending backoff timer when the tab is closed", () => {
+    const tabId = makeSshTab(true);
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+    expect(auto(tabId).phase).toBe("waiting");
+
+    const panelId = findTab(tabId)!.panelId;
+    useAppStore.getState().closeTab(tabId, panelId);
+
+    expect(auto(tabId)).toBeUndefined();
+    // No timer should fire against the gone tab.
+    expect(() => vi.advanceTimersByTime(60_000)).not.toThrow();
+    expect(findTab(tabId)).toBeUndefined();
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -19,6 +19,7 @@ import {
   NetworkTool,
   TabGroup,
   TerminalExitInfo,
+  TerminalAutoReconnectState,
   SessionCloseConfirmRequest,
   BroadcastScope,
 } from "@/types/terminal";
@@ -272,6 +273,13 @@ import {
   registerCustomGrammars,
 } from "@/utils/monacoCustomLanguages";
 import { frontendLog } from "@/utils/frontendLog";
+import {
+  DEFAULT_BACKOFF,
+  initialReconnectState,
+  reconnectReducer,
+  type BackoffConfig,
+  type ReconnectPhase,
+} from "@/utils/reconnectBackoff";
 import { quotePath } from "@/utils/quotePath";
 import { toast } from "@/components/ui";
 import {
@@ -1121,6 +1129,14 @@ interface AppState {
   /** Error message that triggered the auto-reconnect, shown during the spinner overlay. */
   terminalReconnectTriggerErrors: Record<string, string>;
   /**
+   * Agentless resilient-reconnect loop state per tab (#1962). Present only while
+   * a plain-SSH tab that opted in is auto-reconnecting after a dropped link.
+   * Drives the auto-reconnect overlay's countdown/attempt display and the Cancel
+   * affordance; the actual backoff timer lives at module scope
+   * (`autoReconnectTimers`). Cleared on success, give-up, cancel, or tab close.
+   */
+  terminalAutoReconnect: Record<string, TerminalAutoReconnectState>;
+  /**
    * Mark a tab's session as exited. Pass `info` to record the exit code and
    * cause so the overlay can branch its wording; a `killed` reason additionally
    * drops the tab straight into view mode so no disconnect overlay appears (#1121).
@@ -1194,6 +1210,23 @@ interface AppState {
   reconnectTerminal: (tabId: string) => void;
   showTerminalReconnectPrompt: (tabId: string) => void;
   dismissTerminalReconnectPrompt: (tabId: string) => void;
+
+  /**
+   * Begin the agentless resilient-reconnect loop for a dropped plain-SSH tab
+   * that opted in (#1962). Arms an exponential-backoff timer that re-drives the
+   * tab through {@link reconnectTerminal}; a failed attempt backs off further and
+   * a success settles the loop. Called from {@link setTerminalExited} on a
+   * `dropped` exit — not usually invoked directly. No-op if already looping.
+   */
+  startAutoReconnect: (tabId: string) => void;
+  /**
+   * Stop (give up) the resilient-reconnect loop for a tab (#1962) — the Cancel
+   * affordance and the exhausted-attempts path. Clears the backoff timer and the
+   * loop state and leaves the tab in the standard "disconnected" overlay so the
+   * user can manually reconnect or browse scrollback. `error`, when given, shows
+   * the "Reconnect failed" overlay variant with that message.
+   */
+  cancelAutoReconnect: (tabId: string, error?: string) => void;
 
   // Remote connection states
   remoteStates: Record<string, string>;
@@ -2115,6 +2148,165 @@ function collectLiveTabs(state: {
     g.id === state.activeTabGroupId ? state.rootPanel : g.rootPanel
   );
   return trees.flatMap((tree) => getAllLeaves(tree).flatMap((leaf) => leaf.tabs));
+}
+
+// ── Agentless auto-reconnect (#1962) ────────────────────────────────────────
+//
+// Backoff timers for the resilient-reconnect loop, keyed by tab id. Kept at
+// module scope (not in the store) because a `setTimeout` handle is an imperative
+// resource, not serializable UI state — the store holds only the *display* state
+// (phase/attempt/countdown) in `terminalAutoReconnect`. Every arm clears the
+// prior handle first so a tab never has two live timers.
+const autoReconnectTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+/** Cancel and forget the pending backoff timer for a tab, if any. */
+function clearAutoReconnectTimer(tabId: string): void {
+  const handle = autoReconnectTimers.get(tabId);
+  if (handle !== undefined) {
+    clearTimeout(handle);
+    autoReconnectTimers.delete(tabId);
+  }
+}
+
+/** The backoff schedule for the resilient-reconnect loop. Central so tests and UI agree. */
+const autoReconnectConfig: BackoffConfig = DEFAULT_BACKOFF;
+
+/**
+ * Whether a tab is eligible for agentless resilient reconnect (#1962): a plain
+ * SSH terminal whose saved connection opted in via the "Resilient Reconnect"
+ * setting, and which is NOT agent-backed or a persistent session (those have
+ * their own continuity machinery). Reads the opt-in from the tab's connection
+ * config, where the SSH schema field persists it.
+ */
+function isResilientReconnectTab(tab: TerminalTab | undefined): boolean {
+  if (!tab) return false;
+  if (tab.contentType !== "terminal") return false;
+  if (tab.connectionType !== "ssh") return false;
+  if (tab.persistentConnectionId) return false;
+  const cfg = tab.config?.config as { resilientReconnect?: unknown; agentId?: unknown } | undefined;
+  if (!cfg) return false;
+  if (cfg.agentId) return false;
+  return cfg.resilientReconnect === true;
+}
+
+/**
+ * Drive the resilient-reconnect state machine for one tab by feeding it an event
+ * (#1962), then reconcile the imperative side effects (backoff timer, redriving
+ * the connection, overlay state) with the resulting phase. Centralising this
+ * keeps the timer, the store's display state, and the overlay in lockstep for
+ * every transition — start, retry tick, failure, success, and give-up.
+ *
+ * Called from the store's lifecycle hooks (`setTerminalExited` → `drop`,
+ * `setTabSessionId` → `success`, `setTerminalSpawnError` → `failure`) and from
+ * the Cancel affordance (`cancel`). Reads/writes the live store via
+ * `useAppStore`, so it must only run after module init (always true at call
+ * time). Uses the module-scoped `reconnectReducer` for the pure decision.
+ */
+function driveAutoReconnect(
+  tabId: string,
+  event: "drop" | "attempt" | "success" | "failure" | "cancel",
+  error?: string
+): void {
+  const store = useAppStore.getState();
+  const current = store.terminalAutoReconnect[tabId];
+  // Absent entry ≡ idle. A settled (connected) loop is cleared, so a later drop
+  // re-enters from idle — equivalent to the reducer's connected→waiting edge.
+  const prev = current
+    ? { phase: current.phase as ReconnectPhase, attempt: current.attempt, delayMs: current.delayMs }
+    : initialReconnectState;
+  const next = reconnectReducer(prev, event, autoReconnectConfig);
+
+  // A no-op transition (stray event for the current phase) changes nothing.
+  if (next.phase === prev.phase && next.attempt === prev.attempt && event !== "cancel") {
+    return;
+  }
+
+  clearAutoReconnectTimer(tabId);
+
+  switch (next.phase) {
+    case "waiting": {
+      const nextAttemptAt = Date.now() + next.delayMs;
+      const record: TerminalAutoReconnectState = {
+        phase: "waiting",
+        attempt: next.attempt,
+        maxAttempts: autoReconnectConfig.maxAttempts,
+        delayMs: next.delayMs,
+        nextAttemptAt,
+      };
+      useAppStore.setState((state) => ({
+        terminalAutoReconnect: { ...state.terminalAutoReconnect, [tabId]: record },
+        // Clear any leftover failed-attempt state so no competing overlay shows
+        // beneath the countdown; the auto-reconnect overlay owns the tab now.
+        terminalSpawnErrors: omitKey(state.terminalSpawnErrors, tabId),
+        terminalDisconnectErrors: omitKey(state.terminalDisconnectErrors, tabId),
+      }));
+      const handle = setTimeout(() => {
+        autoReconnectTimers.delete(tabId);
+        driveAutoReconnect(tabId, "attempt");
+      }, next.delayMs);
+      autoReconnectTimers.set(tabId, handle);
+      frontendLog(
+        "disconnect",
+        `auto-reconnect tab=${tabId}: waiting ${next.delayMs}ms before attempt ${next.attempt + 1}`
+      );
+      break;
+    }
+
+    case "connecting": {
+      const record: TerminalAutoReconnectState = {
+        phase: "connecting",
+        attempt: next.attempt,
+        maxAttempts: autoReconnectConfig.maxAttempts,
+        delayMs: 0,
+        nextAttemptAt: 0,
+      };
+      useAppStore.setState((state) => ({
+        terminalAutoReconnect: { ...state.terminalAutoReconnect, [tabId]: record },
+      }));
+      frontendLog("disconnect", `auto-reconnect tab=${tabId}: attempt ${next.attempt} connecting`);
+      // Re-drive the same tab through the normal reconnect path: bumps the retry
+      // counter so Terminal.tsx re-runs setup, replaying local scrollback and
+      // reattaching in place. Success → setTabSessionId → "success"; a direct-SSH
+      // failure → setTerminalSpawnError → "failure".
+      store.reconnectTerminal(tabId);
+      break;
+    }
+
+    case "connected":
+      // Transport recovered — settle and forget the loop.
+      useAppStore.setState((state) => ({
+        terminalAutoReconnect: omitKey(state.terminalAutoReconnect, tabId),
+      }));
+      frontendLog("disconnect", `auto-reconnect tab=${tabId}: reconnected`);
+      break;
+
+    case "gaveup":
+    case "idle":
+    default: {
+      // Cancelled by the user or attempts exhausted. Drop the loop state and
+      // hand off to the manual disconnect overlay (scrollback preserved).
+      useAppStore.setState((state) => ({
+        terminalAutoReconnect: omitKey(state.terminalAutoReconnect, tabId),
+        terminalSpawnErrors: omitKey(state.terminalSpawnErrors, tabId),
+      }));
+      if (error) {
+        // Exhausted: show the "Reconnect failed" overlay with the last error.
+        store.setTerminalDisconnectWithError(tabId, error);
+      } else {
+        // User cancelled mid-loop: ensure the standard disconnect overlay is
+        // visible so Reconnect / View Scrollback remain available.
+        useAppStore.setState((state) => ({
+          terminalExitedTabs: { ...state.terminalExitedTabs, [tabId]: true },
+          terminalReconnectingTabs: omitKey(state.terminalReconnectingTabs, tabId),
+        }));
+      }
+      frontendLog(
+        "disconnect",
+        `auto-reconnect tab=${tabId}: gave up (${error ? "exhausted" : "cancelled"})`
+      );
+      break;
+    }
+  }
 }
 
 /**
@@ -3551,6 +3743,13 @@ export const useAppStore = create<AppState>((set, get) => {
       if (sessionId) {
         get().settleRestoreTab(tabId, "connected");
 
+        // Agentless resilient reconnect (#1962): a session id landing while a
+        // backoff loop is in flight means the transport came back — settle the
+        // loop. (No-op when no loop is active.)
+        if (get().terminalAutoReconnect[tabId]) {
+          driveAutoReconnect(tabId, "success");
+        }
+
         // On-connect workflow triggers (#1855): a terminal session that opened
         // for a saved connection runs any workflow bound to that connection,
         // once per session open (interactive shells only — file-browser and
@@ -4040,6 +4239,7 @@ export const useAppStore = create<AppState>((set, get) => {
         const remainingPrompt = omitKey(state.terminalReconnectPrompt, tabId);
         const remainingAutoRetry = omitKey(state.terminalAutoRetryCount, tabId);
         const remainingWaiting = omitKey(state.terminalWaitingForAgent, tabId);
+        const remainingAutoReconnect = omitKey(state.terminalAutoReconnect, tabId);
 
         // Drop the SFTP sessions owned by this tab (closed above) from the map,
         // and reset the browser when the active session was one of them (#1241).
@@ -4111,6 +4311,7 @@ export const useAppStore = create<AppState>((set, get) => {
             terminalReconnectPrompt: remainingPrompt,
             terminalAutoRetryCount: remainingAutoRetry,
             terminalWaitingForAgent: remainingWaiting,
+            terminalAutoReconnect: remainingAutoReconnect,
             sftpSessions: remainingSftp,
             ...sftpBrowserReset,
           };
@@ -4139,10 +4340,16 @@ export const useAppStore = create<AppState>((set, get) => {
           terminalReconnectPrompt: remainingPrompt,
           terminalAutoRetryCount: remainingAutoRetry,
           terminalWaitingForAgent: remainingWaiting,
+          terminalAutoReconnect: remainingAutoReconnect,
           sftpSessions: remainingSftp,
           ...sftpBrowserReset,
         };
       });
+
+      // Cancel any pending resilient-reconnect backoff timer for the closed tab
+      // (#1962) — the store entry was already dropped above; this frees the
+      // imperative timer so it cannot fire against a gone tab.
+      clearAutoReconnectTimer(tabId);
 
       // Broadcast (#1955): closing the source tab ends broadcast entirely;
       // closing a plain target silently drops it from the set.
@@ -5429,13 +5636,23 @@ export const useAppStore = create<AppState>((set, get) => {
     terminalConnectDeadline: {},
     terminalAutoRetryCount: {},
     terminalWaitingForAgent: {},
-    setTerminalSpawnError: (tabId, error) =>
+    setTerminalSpawnError: (tabId, error) => {
+      // Agentless resilient reconnect (#1962): a spawn error while a backoff loop
+      // is connecting is a failed attempt — feed it to the machine, which backs
+      // off further or gives up (surfacing this error). Do this before writing
+      // the error so the loop can suppress the competing connection overlay while
+      // it retries. When no loop is active this is a plain error write.
+      if (error !== null && get().terminalAutoReconnect[tabId]?.phase === "connecting") {
+        driveAutoReconnect(tabId, "failure", error);
+        return;
+      }
       set((state) => ({
         terminalSpawnErrors:
           error === null
             ? omitKey(state.terminalSpawnErrors, tabId)
             : { ...state.terminalSpawnErrors, [tabId]: error },
-      })),
+      }));
+    },
     retryTerminalSpawn: (tabId) =>
       set((state) => ({
         terminalSpawnErrors: omitKey(state.terminalSpawnErrors, tabId),
@@ -5536,6 +5753,7 @@ export const useAppStore = create<AppState>((set, get) => {
     terminalReattaching: {},
     terminalReconnectPrompt: {},
     terminalReconnectTriggerErrors: {},
+    terminalAutoReconnect: {},
     setTerminalExited: (tabId, info) => {
       set((state) => ({
         terminalExitedTabs: { ...state.terminalExitedTabs, [tabId]: true },
@@ -5559,6 +5777,16 @@ export const useAppStore = create<AppState>((set, get) => {
       const deadKey = monitorKeyForTab(collectLiveTabs(get()).find((t) => t.id === tabId));
       if (deadKey && get().monitors[deadKey]) {
         get().disconnectMonitoring(deadKey);
+      }
+      // Agentless resilient reconnect (#1962): a dropped link on a plain-SSH tab
+      // that opted in kicks off the backoff loop instead of leaving the user at
+      // the manual disconnect prompt. Only an unexpected drop qualifies — a clean
+      // exit or a user kill must not silently reconnect.
+      if (info?.reason === "dropped") {
+        const tab = collectLiveTabs(get()).find((t) => t.id === tabId);
+        if (isResilientReconnectTab(tab)) {
+          get().startAutoReconnect(tabId);
+        }
       }
     },
     markSessionKilled: (sessionId) =>
@@ -5749,6 +5977,18 @@ export const useAppStore = create<AppState>((set, get) => {
       })),
     dismissTerminalReconnectPrompt: (tabId) =>
       set((state) => ({ terminalReconnectPrompt: omitKey(state.terminalReconnectPrompt, tabId) })),
+
+    startAutoReconnect: (tabId) => {
+      // A "drop" only arms the loop from idle (no active entry) or a settled one;
+      // the reducer ignores it while already waiting/connecting, so this is safe
+      // to call on every dropped exit without double-starting.
+      driveAutoReconnect(tabId, "drop");
+    },
+    cancelAutoReconnect: (tabId, error) => {
+      // No active loop → nothing to cancel (avoid spuriously forcing the overlay).
+      if (!get().terminalAutoReconnect[tabId]) return;
+      driveAutoReconnect(tabId, "cancel", error);
+    },
 
     // Remote connection states
     remoteStates: {},

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -197,6 +197,32 @@ export interface TerminalExitInfo {
   reason: TerminalExitReason;
 }
 
+/**
+ * Display state for the agentless resilient-reconnect loop of one tab (#1962).
+ * A serializable snapshot the disconnect overlay reads to render the countdown,
+ * attempt progress, and Cancel affordance. The imperative backoff timer lives at
+ * module scope in `appStore`; this holds only what the UI needs to draw.
+ */
+export interface TerminalAutoReconnectState {
+  /**
+   * Loop phase. `waiting` = counting down to the next attempt; `connecting` =
+   * an attempt is in flight (the standard connection overlay takes over). The
+   * overlay only renders its auto-reconnect variant while `waiting`.
+   */
+  phase: "waiting" | "connecting";
+  /** Attempts started so far in this loop (1-based once the first attempt fires). */
+  attempt: number;
+  /** Maximum attempts before giving up; `0` means unbounded retry. */
+  maxAttempts: number;
+  /** Backoff delay of the current `waiting` window, in ms. */
+  delayMs: number;
+  /**
+   * Wall-clock timestamp (`Date.now()`-based) the next attempt is scheduled for,
+   * used by the overlay to render a live countdown. `0` while `connecting`.
+   */
+  nextAttemptAt: number;
+}
+
 export interface TerminalOptions {
   horizontalScrolling?: boolean;
   color?: string;

--- a/src/utils/reconnectBackoff.test.ts
+++ b/src/utils/reconnectBackoff.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_BACKOFF,
+  backoffDelay,
+  nextReconnectDelay,
+  shouldGiveUp,
+  reconnectReducer,
+  initialReconnectState,
+  isActiveReconnectPhase,
+  type BackoffConfig,
+  type ReconnectState,
+} from "./reconnectBackoff";
+
+/** Deterministic config with jitter disabled, for exact delay assertions. */
+const NO_JITTER: BackoffConfig = {
+  baseDelayMs: 1_000,
+  factor: 2,
+  maxDelayMs: 8_000,
+  maxAttempts: 5,
+  jitterRatio: 0,
+};
+
+describe("reconnectBackoff — backoffDelay", () => {
+  it("returns the base delay for the first attempt", () => {
+    expect(backoffDelay(1, NO_JITTER)).toBe(1_000);
+  });
+
+  it("grows exponentially by the factor per attempt", () => {
+    expect(backoffDelay(2, NO_JITTER)).toBe(2_000);
+    expect(backoffDelay(3, NO_JITTER)).toBe(4_000);
+    expect(backoffDelay(4, NO_JITTER)).toBe(8_000);
+  });
+
+  it("caps at maxDelayMs", () => {
+    // Attempt 5 would be 16_000 but is clamped to the 8_000 ceiling.
+    expect(backoffDelay(5, NO_JITTER)).toBe(8_000);
+    expect(backoffDelay(50, NO_JITTER)).toBe(8_000);
+  });
+
+  it("treats attempt < 1 as the first attempt (never sub-base)", () => {
+    expect(backoffDelay(0, NO_JITTER)).toBe(1_000);
+    expect(backoffDelay(-3, NO_JITTER)).toBe(1_000);
+  });
+});
+
+describe("reconnectBackoff — nextReconnectDelay (jitter)", () => {
+  it("equals the plain backoff when jitter is disabled", () => {
+    expect(nextReconnectDelay(3, NO_JITTER, () => 0.5)).toBe(4_000);
+  });
+
+  it("applies symmetric jitter within ±jitterRatio", () => {
+    const cfg: BackoffConfig = { ...NO_JITTER, jitterRatio: 0.2 };
+    // rand=0 → factor (1 + (-0.2)) = 0.8 → 800 for base 1000
+    expect(nextReconnectDelay(1, cfg, () => 0)).toBe(800);
+    // rand→1 (upper bound) → factor (1 + 0.2) = 1.2 → 1200
+    expect(nextReconnectDelay(1, cfg, () => 0.999999)).toBeCloseTo(1_200, -1);
+    // rand=0.5 → no swing → exactly base
+    expect(nextReconnectDelay(1, cfg, () => 0.5)).toBe(1_000);
+  });
+
+  it("never returns a negative delay", () => {
+    const cfg: BackoffConfig = { ...NO_JITTER, jitterRatio: 2 };
+    expect(nextReconnectDelay(1, cfg, () => 0)).toBeGreaterThanOrEqual(0);
+  });
+
+  it("keeps jittered delays bounded across the full rand range", () => {
+    const cfg: BackoffConfig = { ...DEFAULT_BACKOFF };
+    for (let r = 0; r <= 1; r += 0.05) {
+      const d = nextReconnectDelay(3, cfg, () => r);
+      const base = backoffDelay(3, cfg);
+      expect(d).toBeGreaterThanOrEqual(Math.round(base * (1 - cfg.jitterRatio)) - 1);
+      expect(d).toBeLessThanOrEqual(Math.round(base * (1 + cfg.jitterRatio)) + 1);
+    }
+  });
+});
+
+describe("reconnectBackoff — shouldGiveUp", () => {
+  it("gives up once attempts reach maxAttempts", () => {
+    expect(shouldGiveUp(4, NO_JITTER)).toBe(false);
+    expect(shouldGiveUp(5, NO_JITTER)).toBe(true);
+    expect(shouldGiveUp(6, NO_JITTER)).toBe(true);
+  });
+
+  it("never gives up when maxAttempts is 0 (unbounded)", () => {
+    const cfg: BackoffConfig = { ...NO_JITTER, maxAttempts: 0 };
+    expect(shouldGiveUp(1_000, cfg)).toBe(false);
+  });
+});
+
+describe("reconnectBackoff — reconnectReducer transitions", () => {
+  const rand = () => 0.5; // no swing → deterministic delays
+
+  it("drop from idle arms the first backoff window", () => {
+    const s = reconnectReducer(initialReconnectState, "drop", NO_JITTER, rand);
+    expect(s.phase).toBe("waiting");
+    expect(s.attempt).toBe(0);
+    expect(s.delayMs).toBe(1_000);
+  });
+
+  it("attempt from waiting starts a connection and counts it", () => {
+    const waiting = reconnectReducer(initialReconnectState, "drop", NO_JITTER, rand);
+    const connecting = reconnectReducer(waiting, "attempt", NO_JITTER, rand);
+    expect(connecting.phase).toBe("connecting");
+    expect(connecting.attempt).toBe(1);
+    expect(connecting.delayMs).toBe(0);
+  });
+
+  it("success from connecting settles the loop and resets the counter", () => {
+    let s: ReconnectState = reconnectReducer(initialReconnectState, "drop", NO_JITTER, rand);
+    s = reconnectReducer(s, "attempt", NO_JITTER, rand);
+    s = reconnectReducer(s, "success", NO_JITTER, rand);
+    expect(s.phase).toBe("connected");
+    expect(s.attempt).toBe(0);
+  });
+
+  it("failure from connecting backs off with a longer delay for the next attempt", () => {
+    let s: ReconnectState = reconnectReducer(initialReconnectState, "drop", NO_JITTER, rand);
+    s = reconnectReducer(s, "attempt", NO_JITTER, rand); // attempt 1
+    s = reconnectReducer(s, "failure", NO_JITTER, rand);
+    expect(s.phase).toBe("waiting");
+    expect(s.attempt).toBe(1);
+    // Next attempt is #2 → 2_000ms.
+    expect(s.delayMs).toBe(2_000);
+  });
+
+  it("walks a full escalating backoff schedule until give-up", () => {
+    const delays: number[] = [];
+    let s: ReconnectState = reconnectReducer(initialReconnectState, "drop", NO_JITTER, rand);
+    delays.push(s.delayMs);
+    // 5 attempts allowed; the 5th failure gives up.
+    for (let i = 0; i < 5; i++) {
+      s = reconnectReducer(s, "attempt", NO_JITTER, rand);
+      expect(s.phase).toBe("connecting");
+      s = reconnectReducer(s, "failure", NO_JITTER, rand);
+      if (s.phase === "waiting") delays.push(s.delayMs);
+    }
+    expect(s.phase).toBe("gaveup");
+    expect(s.attempt).toBe(5);
+    // Escalating, capped at 8_000: 1000, 2000, 4000, 8000, 8000.
+    expect(delays).toEqual([1_000, 2_000, 4_000, 8_000, 8_000]);
+  });
+
+  it("cancel from any phase gives up", () => {
+    const waiting = reconnectReducer(initialReconnectState, "drop", NO_JITTER, rand);
+    expect(reconnectReducer(waiting, "cancel", NO_JITTER, rand).phase).toBe("gaveup");
+    const connecting = reconnectReducer(waiting, "attempt", NO_JITTER, rand);
+    expect(reconnectReducer(connecting, "cancel", NO_JITTER, rand).phase).toBe("gaveup");
+  });
+
+  it("a re-drop after a successful reconnect restarts the loop from attempt 1", () => {
+    let s: ReconnectState = reconnectReducer(initialReconnectState, "drop", NO_JITTER, rand);
+    s = reconnectReducer(s, "attempt", NO_JITTER, rand);
+    s = reconnectReducer(s, "success", NO_JITTER, rand);
+    expect(s.phase).toBe("connected");
+    s = reconnectReducer(s, "drop", NO_JITTER, rand);
+    expect(s.phase).toBe("waiting");
+    expect(s.delayMs).toBe(1_000); // fresh attempt-1 delay
+  });
+
+  it("ignores stray events that do not match the current phase", () => {
+    // attempt while idle is a no-op
+    expect(reconnectReducer(initialReconnectState, "attempt", NO_JITTER, rand)).toEqual(
+      initialReconnectState
+    );
+    // success while idle is a no-op
+    expect(reconnectReducer(initialReconnectState, "success", NO_JITTER, rand)).toEqual(
+      initialReconnectState
+    );
+    // duplicate drop while waiting does not re-arm
+    const waiting = reconnectReducer(initialReconnectState, "drop", NO_JITTER, rand);
+    expect(reconnectReducer(waiting, "drop", NO_JITTER, rand)).toEqual(waiting);
+  });
+
+  it("with unbounded retries never reaches gaveup on failure", () => {
+    const cfg: BackoffConfig = { ...NO_JITTER, maxAttempts: 0 };
+    let s: ReconnectState = reconnectReducer(initialReconnectState, "drop", cfg, rand);
+    for (let i = 0; i < 100; i++) {
+      s = reconnectReducer(s, "attempt", cfg, rand);
+      s = reconnectReducer(s, "failure", cfg, rand);
+      expect(s.phase).toBe("waiting");
+    }
+    // Only Cancel stops an unbounded loop.
+    expect(reconnectReducer(s, "cancel", cfg, rand).phase).toBe("gaveup");
+  });
+});
+
+describe("reconnectBackoff — isActiveReconnectPhase", () => {
+  it("is true while waiting or connecting", () => {
+    expect(isActiveReconnectPhase("waiting")).toBe(true);
+    expect(isActiveReconnectPhase("connecting")).toBe(true);
+  });
+
+  it("is false when idle, connected, or gaveup", () => {
+    expect(isActiveReconnectPhase("idle")).toBe(false);
+    expect(isActiveReconnectPhase("connected")).toBe(false);
+    expect(isActiveReconnectPhase("gaveup")).toBe(false);
+  });
+});

--- a/src/utils/reconnectBackoff.ts
+++ b/src/utils/reconnectBackoff.ts
@@ -1,0 +1,213 @@
+/**
+ * Agentless auto-reconnect backoff state machine (#1962).
+ *
+ * A pure, timer-free model of the "resilient reconnect" loop used for plain SSH
+ * connections over flaky links. It answers two questions the store's timer
+ * driver needs:
+ *
+ *   1. How long to wait before the next connection attempt (exponential backoff
+ *      with jitter, capped).
+ *   2. What the next phase is after each event (drop / attempt / success /
+ *      failure / cancel), including when to give up.
+ *
+ * Keeping this logic pure and injectable (`rand`) makes the backoff schedule and
+ * the give-up decision unit-testable without fake timers or a live connection.
+ * The store ({@link "@/store/appStore"}) owns the real `setTimeout` that drives
+ * the machine and the side effects (calling `reconnectTerminal`).
+ *
+ * No agent means the remote shell state cannot be recovered — this machine only
+ * models re-establishing the *transport*, not restoring server-side session
+ * state. The UI is honest about that; see `TerminalDisconnectOverlay`.
+ */
+
+/** Tunables for the exponential backoff schedule. */
+export interface BackoffConfig {
+  /** Delay before the first retry, in ms. */
+  baseDelayMs: number;
+  /** Multiplier applied per attempt (2 → doubles each time). */
+  factor: number;
+  /** Upper bound on any single delay, in ms (before jitter). */
+  maxDelayMs: number;
+  /**
+   * Maximum number of connection attempts before giving up. `0` means retry
+   * forever (the user's Cancel is then the only way to stop).
+   */
+  maxAttempts: number;
+  /**
+   * Fraction of the computed delay applied as symmetric random jitter, in
+   * `[0, 1]`. `0.2` spreads each delay by ±20% so a fleet of dropped tabs does
+   * not stampede the server in lockstep. `0` disables jitter (deterministic).
+   */
+  jitterRatio: number;
+}
+
+/**
+ * Defaults tuned for a truck-on-cellular field scenario (#1962): a quick first
+ * retry so a brief blip recovers almost instantly, doubling up to a 30 s ceiling
+ * so a long outage does not hammer the network, and a bounded attempt count so a
+ * permanently-dead host eventually surfaces the manual "Reconnect failed"
+ * overlay instead of spinning forever.
+ */
+export const DEFAULT_BACKOFF: BackoffConfig = {
+  baseDelayMs: 1_000,
+  factor: 2,
+  maxDelayMs: 30_000,
+  maxAttempts: 10,
+  jitterRatio: 0.2,
+};
+
+/**
+ * Phase of the auto-reconnect loop for one tab.
+ *
+ * - `idle`       — not auto-reconnecting.
+ * - `waiting`    — backoff timer is running before the next attempt.
+ * - `connecting` — an attempt is in flight (the transport is being re-established).
+ * - `connected`  — the transport came back; the loop settled successfully.
+ * - `gaveup`     — attempts exhausted or the user cancelled; hand off to the
+ *                  manual disconnect overlay.
+ */
+export type ReconnectPhase = "idle" | "waiting" | "connecting" | "connected" | "gaveup";
+
+/** Immutable snapshot of the reconnect loop for one tab. */
+export interface ReconnectState {
+  phase: ReconnectPhase;
+  /** Number of connection attempts started so far in this loop. */
+  attempt: number;
+  /** Delay the current `waiting` phase is counting down, in ms (0 otherwise). */
+  delayMs: number;
+}
+
+/**
+ * Events that drive the machine:
+ *
+ * - `drop`    — the connection was lost; begin (or, from `connected`, restart)
+ *               the backoff loop.
+ * - `attempt` — the backoff timer fired; start a connection attempt.
+ * - `success` — the attempt connected.
+ * - `failure` — the attempt failed; back off further or give up.
+ * - `cancel`  — the user asked to stop retrying.
+ */
+export type ReconnectEvent = "drop" | "attempt" | "success" | "failure" | "cancel";
+
+/** The starting state for a tab that is not auto-reconnecting. */
+export const initialReconnectState: ReconnectState = {
+  phase: "idle",
+  attempt: 0,
+  delayMs: 0,
+};
+
+/**
+ * Pure exponential delay for a given attempt (1-based), before jitter and before
+ * the cap-then-jitter in {@link nextReconnectDelay}. Attempt 1 → `baseDelayMs`,
+ * attempt 2 → `baseDelayMs * factor`, and so on, clamped to `maxDelayMs`.
+ *
+ * `attempt < 1` is treated as attempt 1 so a caller never gets a negative or
+ * sub-base delay.
+ */
+export function backoffDelay(attempt: number, config: BackoffConfig): number {
+  const n = Math.max(1, Math.floor(attempt));
+  const raw = config.baseDelayMs * Math.pow(config.factor, n - 1);
+  return Math.min(raw, config.maxDelayMs);
+}
+
+/**
+ * The concrete delay to wait before the given attempt (1-based), applying the
+ * cap and then symmetric jitter of `±jitterRatio`. `rand` is injectable for
+ * deterministic tests; it must return a value in `[0, 1)`.
+ *
+ * The result is clamped to `>= 0` and rounded to whole milliseconds.
+ */
+export function nextReconnectDelay(
+  attempt: number,
+  config: BackoffConfig,
+  rand: () => number = Math.random
+): number {
+  const base = backoffDelay(attempt, config);
+  if (config.jitterRatio <= 0) return Math.round(base);
+  // Map rand() ∈ [0,1) to a symmetric factor in [-1, 1).
+  const swing = (rand() * 2 - 1) * config.jitterRatio;
+  return Math.max(0, Math.round(base * (1 + swing)));
+}
+
+/**
+ * Whether the loop should give up rather than start another attempt. With
+ * `maxAttempts === 0` the loop never gives up on its own (unbounded retry). Once
+ * `attempt` attempts have already been made, a further failure gives up when
+ * `attempt >= maxAttempts`.
+ */
+export function shouldGiveUp(attempt: number, config: BackoffConfig): boolean {
+  if (config.maxAttempts <= 0) return false;
+  return attempt >= config.maxAttempts;
+}
+
+/**
+ * Pure transition for the reconnect state machine. Given the current state, an
+ * event, the config, and an injectable RNG, returns the next state. Unknown
+ * transitions are a no-op (return the same state) so a stray event cannot
+ * corrupt the loop.
+ *
+ * The `delayMs` on a `waiting` result is the concrete jittered delay the timer
+ * driver should arm; `attempt` counts attempts that have been started.
+ */
+export function reconnectReducer(
+  state: ReconnectState,
+  event: ReconnectEvent,
+  config: BackoffConfig,
+  rand: () => number = Math.random
+): ReconnectState {
+  switch (event) {
+    case "cancel":
+      // The user stops the loop from any phase.
+      return { phase: "gaveup", attempt: state.attempt, delayMs: 0 };
+
+    case "drop": {
+      // A fresh drop (from idle or a previously-connected loop) arms the first
+      // backoff window. A drop while already waiting/connecting is ignored — the
+      // loop is already running and `failure` handles a failed attempt.
+      if (state.phase === "idle" || state.phase === "connected") {
+        const nextAttempt = 1;
+        return {
+          phase: "waiting",
+          attempt: state.attempt, // no attempt started yet; incremented on "attempt"
+          delayMs: nextReconnectDelay(nextAttempt, config, rand),
+        };
+      }
+      return state;
+    }
+
+    case "attempt": {
+      // The backoff timer fired: begin a connection attempt.
+      if (state.phase !== "waiting") return state;
+      return { phase: "connecting", attempt: state.attempt + 1, delayMs: 0 };
+    }
+
+    case "success": {
+      if (state.phase !== "connecting") return state;
+      return { phase: "connected", attempt: 0, delayMs: 0 };
+    }
+
+    case "failure": {
+      if (state.phase !== "connecting") return state;
+      // `attempt` already counts this just-failed attempt (incremented on
+      // "attempt"). Give up once we have used our budget; otherwise arm the next
+      // backoff window sized for the *next* attempt number.
+      if (shouldGiveUp(state.attempt, config)) {
+        return { phase: "gaveup", attempt: state.attempt, delayMs: 0 };
+      }
+      const nextAttemptNumber = state.attempt + 1;
+      return {
+        phase: "waiting",
+        attempt: state.attempt,
+        delayMs: nextReconnectDelay(nextAttemptNumber, config, rand),
+      };
+    }
+
+    default:
+      return state;
+  }
+}
+
+/** Whether a phase is one where the loop is actively trying (spinner/countdown). */
+export function isActiveReconnectPhase(phase: ReconnectPhase): boolean {
+  return phase === "waiting" || phase === "connecting";
+}


### PR DESCRIPTION
## Summary

Agentless **resilient reconnect** for plain SSH (#1962): when a link drops on a
flaky connection (truck-on-cellular field scenario), termiHub now auto-reconnects
with exponential backoff into the **same tab** instead of leaving the user at the
manual reconnect prompt — while being honest that, without a remote agent,
server-side shell state cannot be restored.

Closes #1962

## What it does

- **Per-connection opt-in** — a new "Resilient Reconnect" toggle in the SSH
  connection's *Advanced* settings (schema-driven, so it renders automatically).
  Off by default.
- **Auto-reconnect with backoff** — on an unexpected drop of an opted-in plain-SSH
  tab, a pure exponential-backoff state machine schedules retries (1s → 2s → 4s …
  capped at 30s, ±20% jitter, up to 10 attempts) and re-drives the tab through the
  existing `reconnectTerminal` path, so it **reattaches in place and replays the
  local scrollback**. A success settles the loop; a failed attempt backs off
  further; exhaustion falls back to the standard "Reconnect failed" overlay.
- **Cancel / give-up affordance** — the countdown overlay has a Cancel button that
  stops the loop and drops to the manual disconnect overlay (scrollback preserved).
- **Honest UI** — the overlay states that local scrollback is preserved but the
  remote shell state (running commands, working directory) is **not** restored
  without an agent — a fresh shell opens.

## Design note (agentless continuity)

The issue asks for "as much continuity as possible without an agent". Agentless SSH
cannot recover server-side session state, so this PR deliberately scopes continuity
to: same logical tab, replayed local scrollback, and transparent messaging about
what is lost. Full session continuity remains the agent's job. The "optional
lightweight server-side buffer" mentioned in the issue is left out (not reliably
achievable agentless) rather than faked.

## Implementation

- `src/utils/reconnectBackoff.ts` — pure, timer-free backoff + reconnect state
  machine (drop/attempt/success/failure/cancel), fully unit-tested.
- `src/store/appStore.ts` — module-scoped backoff timers + `terminalAutoReconnect`
  display state; hooks into `setTerminalExited` (drop), `setTabSessionId` (success),
  `setTerminalSpawnError` (failure); `startAutoReconnect` / `cancelAutoReconnect`
  actions; timer cleanup on tab close.
- `src/components/Terminal/TerminalDisconnectOverlay.tsx` + `SplitView.tsx` — the
  countdown/Cancel overlay variant.
- `core/src/backends/ssh/mod.rs` — the `resilientReconnect` schema field.

## Tests

- `src/utils/reconnectBackoff.test.ts` — backoff growth, cap, jitter bounds,
  give-up, and every state transition including re-drop-after-success.
- `src/store/appStore.autoReconnect.test.ts` — store loop driven with fake timers:
  opt-in gating, backoff scheduling, success settle, exhaustion, Cancel, tab-close
  cleanup.
- `core/src/backends/ssh/mod.rs` — schema test updated for the new field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)