### PR TITLE
feat(ssh): optional on-reconnect command for agentless resilient reconnect (Closes #1978)

### DIFF
--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -509,6 +509,33 @@ impl ConnectionType for Ssh {
                             supports_tilde_expansion: false,
                             visible_when: None,
                         },
+                        SettingsField {
+                            key: "onReconnectCommand".to_string(),
+                            label: "On-reconnect Command".to_string(),
+                            description: Some(
+                                "Command to run once after an automatic resilient reconnect"
+                                    .to_string(),
+                            ),
+                            help_text: Some(concat!(
+                                "When resilient reconnect re-establishes a dropped SSH connection, ",
+                                "termiHub can run a single command in the fresh remote shell to help ",
+                                "you recover some server-side context — for example `tmux attach`, ",
+                                "`screen -r`, or `cd \"$LAST_DIR\"`.\n\n",
+                                "The command runs only after an *automatic* reconnect (never on the ",
+                                "first manual connect) and only while Resilient Reconnect is enabled. ",
+                                "Leave empty to run nothing.",
+                            ).to_string()),
+                            field_type: FieldType::Text,
+                            required: false,
+                            default: None,
+                            placeholder: Some("tmux attach".to_string()),
+                            supports_env_expansion: false,
+                            supports_tilde_expansion: false,
+                            visible_when: Some(Condition {
+                                field: "resilientReconnect".to_string(),
+                                equals: serde_json::json!(true),
+                            }),
+                        },
                     ],
                 },
             ],
@@ -899,9 +926,28 @@ mod tests {
                 "connectTimeoutSecs",
                 "env",
                 "shellIntegration",
-                "resilientReconnect"
+                "resilientReconnect",
+                "onReconnectCommand"
             ]
         );
+    }
+
+    #[test]
+    fn schema_on_reconnect_command_is_gated_on_resilient_reconnect() {
+        let ssh = Ssh::new();
+        let schema = ssh.settings_schema();
+        let group = &schema.groups[2];
+        let field = group
+            .fields
+            .iter()
+            .find(|f| f.key == "onReconnectCommand")
+            .expect("onReconnectCommand field present");
+        let condition = field
+            .visible_when
+            .as_ref()
+            .expect("onReconnectCommand is conditionally visible");
+        assert_eq!(condition.field, "resilientReconnect");
+        assert_eq!(condition.equals, serde_json::json!(true));
     }
 
     #[test]

--- a/docs/changes/dev1/feat/1978-on-reconnect-command.md
+++ b/docs/changes/dev1/feat/1978-on-reconnect-command.md
@@ -1,0 +1,11 @@
+### Added
+
+- Optional **on-reconnect command** for agentless resilient reconnect (#1978,
+  follow-up to #1962): a new per-connection "On-reconnect Command" SSH setting in
+  a connection's _Advanced_ settings (shown only when Resilient Reconnect is
+  enabled). When a dropped SSH link is re-established by an _automatic_ resilient
+  reconnect, termiHub runs the configured command once in the fresh remote shell
+  — for example `tmux attach`, `screen -r`, or `cd "$LAST_DIR"` — to recover some
+  server-side context an agentless reconnect otherwise loses. It never runs on the
+  first manual connect and only while Resilient Reconnect is on. The reconnect
+  overlay announces "Will run `<cmd>` on reconnect." while retrying. Empty = off.

--- a/src/components/Terminal/TerminalDisconnectOverlay.autoReconnect.test.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.autoReconnect.test.tsx
@@ -67,6 +67,26 @@ describe("TerminalDisconnectOverlay — agentless auto-reconnect variant (#1962)
     expect(container.textContent).toContain("not restored");
   });
 
+  it("announces the on-reconnect command when one is configured (#1978)", () => {
+    setAuto("tab-1", { onReconnectCommand: "tmux attach" });
+    act(() => {
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
+    });
+
+    const note = container.querySelector("[data-testid='terminal-auto-reconnect-command']");
+    expect(note).not.toBeNull();
+    expect(note?.textContent).toContain("Will run");
+    expect(note?.querySelector("code")?.textContent).toBe("tmux attach");
+  });
+
+  it("omits the on-reconnect note when no command is configured (#1978)", () => {
+    setAuto("tab-1", {});
+    act(() => {
+      root.render(withTooltip(<TerminalDisconnectOverlay tabId="tab-1" />));
+    });
+    expect(container.querySelector("[data-testid='terminal-auto-reconnect-command']")).toBeNull();
+  });
+
   it("takes precedence over the exited/disconnected overlay", () => {
     setAuto("tab-1", {});
     act(() => {

--- a/src/components/Terminal/TerminalDisconnectOverlay.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.tsx
@@ -97,6 +97,14 @@ function AutoReconnectingOverlay({ tabId }: { tabId: string }) {
           Local scrollback is preserved. Without an agent, the remote shell state (running commands,
           working directory) is not restored — a fresh shell opens.
         </p>
+        {auto.onReconnectCommand && (
+          <p
+            className="terminal-disconnect-overlay__subheading terminal-disconnect-overlay__note"
+            data-testid="terminal-auto-reconnect-command"
+          >
+            Will run <code>{auto.onReconnectCommand}</code> on reconnect.
+          </p>
+        )}
         <div className="terminal-disconnect-overlay__actions">
           <Button
             variant="secondary"

--- a/src/store/appStore.autoReconnect.test.ts
+++ b/src/store/appStore.autoReconnect.test.ts
@@ -55,6 +55,7 @@ vi.mock("@/services/api", () => ({
 import { useAppStore } from "./appStore";
 import { getAllLeaves } from "@/utils/panelTree";
 import { DEFAULT_BACKOFF } from "@/utils/reconnectBackoff";
+import { registerTerminalInputInjector } from "@/services/macroPlayback";
 
 function findTab(tabId: string) {
   const state = useAppStore.getState();
@@ -65,7 +66,11 @@ function findTab(tabId: string) {
 }
 
 /** Create a plain-SSH terminal tab; `resilient` toggles the per-connection opt-in. */
-function makeSshTab(resilient: boolean, sessionId: string | null = "sess-1"): string {
+function makeSshTab(
+  resilient: boolean,
+  sessionId: string | null = "sess-1",
+  onReconnectCommand?: string
+): string {
   return useAppStore.getState().addTab(
     "web01",
     "ssh",
@@ -75,6 +80,7 @@ function makeSshTab(resilient: boolean, sessionId: string | null = "sess-1"): st
         host: "web01.example.com",
         username: "deploy",
         resilientReconnect: resilient,
+        ...(onReconnectCommand !== undefined ? { onReconnectCommand } : {}),
       },
     },
     { contentType: "terminal", sessionId }
@@ -244,5 +250,94 @@ describe("appStore — agentless auto-reconnect (#1962)", () => {
     // No timer should fire against the gone tab.
     expect(() => vi.advanceTimersByTime(60_000)).not.toThrow();
     expect(findTab(tabId)).toBeUndefined();
+  });
+});
+
+describe("appStore — on-reconnect command (#1978)", () => {
+  let injected: Array<{ tabId: string; data: string }>;
+
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.useFakeTimers();
+    injected = [];
+    registerTerminalInputInjector((tabId, data) => {
+      injected.push({ tabId, data });
+      return Promise.resolve(true);
+    });
+  });
+
+  afterEach(() => {
+    registerTerminalInputInjector(null);
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  /** Drive a tab through drop → attempt → successful reconnect. */
+  function reconnectSuccessfully(tabId: string): void {
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+    vi.advanceTimersByTime(auto(tabId).delayMs);
+    expect(auto(tabId).phase).toBe("connecting");
+    useAppStore.getState().setTabSessionId(tabId, "sess-2");
+    expect(auto(tabId)).toBeUndefined();
+  }
+
+  it("runs the configured command once after a successful auto-reconnect", () => {
+    const tabId = makeSshTab(true, "sess-1", "tmux attach");
+
+    reconnectSuccessfully(tabId);
+
+    expect(injected).toEqual([{ tabId, data: "tmux attach\n" }]);
+  });
+
+  it("trims the command and appends a single newline", () => {
+    const tabId = makeSshTab(true, "sess-1", "  screen -r  ");
+    reconnectSuccessfully(tabId);
+    expect(injected).toEqual([{ tabId, data: "screen -r\n" }]);
+  });
+
+  it("does not run anything when no command is configured", () => {
+    const tabId = makeSshTab(true, "sess-1");
+    reconnectSuccessfully(tabId);
+    expect(injected).toEqual([]);
+  });
+
+  it("treats a whitespace-only command as no command", () => {
+    const tabId = makeSshTab(true, "sess-1", "   ");
+    reconnectSuccessfully(tabId);
+    expect(injected).toEqual([]);
+  });
+
+  it("does not run the command on the initial connect (no active loop)", () => {
+    const tabId = makeSshTab(true, null, "tmux attach");
+    // A first-ever session id landing with no loop in flight must not fire it.
+    useAppStore.getState().setTabSessionId(tabId, "sess-1");
+    expect(injected).toEqual([]);
+  });
+
+  it("does not run the command when the loop is cancelled before success", () => {
+    const tabId = makeSshTab(true, "sess-1", "tmux attach");
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+    expect(auto(tabId).phase).toBe("waiting");
+    useAppStore.getState().cancelAutoReconnect(tabId);
+    expect(injected).toEqual([]);
+  });
+
+  it("runs the command again on each subsequent successful reconnect", () => {
+    const tabId = makeSshTab(true, "sess-1", "tmux attach");
+    reconnectSuccessfully(tabId);
+    // A fresh drop and reconnect fires the command a second time.
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+    vi.advanceTimersByTime(auto(tabId).delayMs);
+    useAppStore.getState().setTabSessionId(tabId, "sess-3");
+    expect(injected).toEqual([
+      { tabId, data: "tmux attach\n" },
+      { tabId, data: "tmux attach\n" },
+    ]);
+  });
+
+  it("exposes the command in the loop display state for the overlay", () => {
+    const tabId = makeSshTab(true, "sess-1", "tmux attach");
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+    expect(auto(tabId).onReconnectCommand).toBe("tmux attach");
   });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2199,6 +2199,63 @@ function isResilientReconnectTab(tab: TerminalTab | undefined): boolean {
 }
 
 /**
+ * The trimmed on-reconnect command configured for a tab's connection (#1978), or
+ * `undefined` when none is set. This is the command run once in the fresh remote
+ * shell after a *successful* automatic reconnect to recover some server-side
+ * context (e.g. `tmux attach`) that an agentless reconnect otherwise loses.
+ * Empty/whitespace-only values are treated as "no command".
+ */
+function onReconnectCommandForTab(tab: TerminalTab | undefined): string | undefined {
+  if (!tab) return undefined;
+  const cfg = tab.config?.config as { onReconnectCommand?: unknown } | undefined;
+  const raw = cfg?.onReconnectCommand;
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Find a terminal tab by id across the active panel tree (#1978 helper). Used by
+ * the auto-reconnect loop to read a tab's live connection config when settling.
+ */
+function findTabById(tabId: string): TerminalTab | undefined {
+  return getAllLeaves(useAppStore.getState().rootPanel)
+    .flatMap((l) => l.tabs)
+    .find((t) => t.id === tabId);
+}
+
+/**
+ * Send the configured on-reconnect command once into a tab after its resilient
+ * reconnect settled (#1978). Routes through the shared terminal-input injector —
+ * the same `send_input` choke point interactive typing and macros use — so the
+ * command is delivered to the fresh remote shell exactly as if typed, with a
+ * trailing newline to execute it. A missing command or absent injector is a
+ * silent no-op; delivery failures are logged, never thrown.
+ */
+function runOnReconnectCommand(tabId: string): void {
+  const command = onReconnectCommandForTab(findTabById(tabId));
+  if (!command) return;
+  const injector = getTerminalInputInjector();
+  if (!injector) {
+    frontendLog(
+      "disconnect",
+      `auto-reconnect tab=${tabId}: on-reconnect command skipped (no injector)`
+    );
+    return;
+  }
+  void Promise.resolve(injector(tabId, command + "\n"))
+    .then((delivered) => {
+      frontendLog(
+        "disconnect",
+        `auto-reconnect tab=${tabId}: on-reconnect command ${delivered ? "sent" : "not delivered"}`
+      );
+    })
+    .catch(() => {
+      frontendLog("disconnect", `auto-reconnect tab=${tabId}: on-reconnect command failed`);
+    });
+}
+
+/**
  * Drive the resilient-reconnect state machine for one tab by feeding it an event
  * (#1962), then reconcile the imperative side effects (backoff timer, redriving
  * the connection, overlay state) with the resulting phase. Centralising this
@@ -2232,6 +2289,10 @@ function driveAutoReconnect(
 
   clearAutoReconnectTimer(tabId);
 
+  // The configured on-reconnect command (#1978), echoed into the display state so
+  // the countdown overlay can announce what will run once the link is back.
+  const onReconnectCommand = onReconnectCommandForTab(findTabById(tabId));
+
   switch (next.phase) {
     case "waiting": {
       const nextAttemptAt = Date.now() + next.delayMs;
@@ -2241,6 +2302,7 @@ function driveAutoReconnect(
         maxAttempts: autoReconnectConfig.maxAttempts,
         delayMs: next.delayMs,
         nextAttemptAt,
+        ...(onReconnectCommand ? { onReconnectCommand } : {}),
       };
       useAppStore.setState((state) => ({
         terminalAutoReconnect: { ...state.terminalAutoReconnect, [tabId]: record },
@@ -2268,6 +2330,7 @@ function driveAutoReconnect(
         maxAttempts: autoReconnectConfig.maxAttempts,
         delayMs: 0,
         nextAttemptAt: 0,
+        ...(onReconnectCommand ? { onReconnectCommand } : {}),
       };
       useAppStore.setState((state) => ({
         terminalAutoReconnect: { ...state.terminalAutoReconnect, [tabId]: record },
@@ -2287,6 +2350,10 @@ function driveAutoReconnect(
         terminalAutoReconnect: omitKey(state.terminalAutoReconnect, tabId),
       }));
       frontendLog("disconnect", `auto-reconnect tab=${tabId}: reconnected`);
+      // Run the optional on-reconnect command once in the fresh remote shell to
+      // recover some server-side context (#1978). Only reached on an *automatic*
+      // reconnect success — the initial manual connect never drives this loop.
+      runOnReconnectCommand(tabId);
       break;
 
     case "gaveup":

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -221,6 +221,14 @@ export interface TerminalAutoReconnectState {
    * used by the overlay to render a live countdown. `0` while `connecting`.
    */
   nextAttemptAt: number;
+  /**
+   * Optional per-connection command run once in the fresh remote shell after a
+   * successful automatic reconnect (#1978) — e.g. `tmux attach` / `screen -r` —
+   * to recover some server-side context an agentless reconnect otherwise loses.
+   * Present here (echoed from the connection config) so the overlay can surface
+   * "will run `<cmd>` on reconnect" while the loop is active. Absent = nothing runs.
+   */
+  onReconnectCommand?: string;
 }
 
 export interface TerminalOptions {


### PR DESCRIPTION
## Summary

Follow-up to #1962 (PR #1976). Lets a user recover *some* server-side context
after an **agentless** resilient reconnect by running a configurable command in
the fresh remote shell.

Closes #1978

## What it does

- **New per-connection SSH setting** — "On-reconnect Command" in a connection's
  *Advanced* settings, schema-driven so it renders automatically. It is
  conditionally visible: it only appears when **Resilient Reconnect** is enabled
  (`visible_when` gated on `resilientReconnect === true`). Empty = off.
- **Runs once after a successful auto-reconnect** — when #1962's backoff loop
  settles to `connected` (the `success` transition wired in PR #1976), the
  command is sent once into the new session with a trailing newline, e.g.
  `tmux attach`, `screen -r`, or `cd "$LAST_DIR"`.
- **Only on automatic reconnect** — it fires from the reconnect loop's settle
  path, so the initial manual connect never triggers it; it is inert unless
  resilient reconnect is enabled.
- **Overlay copy** — the countdown overlay announces "Will run \`<cmd>\` on
  reconnect." while retrying.

## Implementation

- `core/src/backends/ssh/mod.rs` — the `onReconnectCommand` schema field
  (advanced group, gated on `resilientReconnect`).
- `src/store/appStore.ts` — sends the trimmed command through the shared
  terminal-input injector (the same `send_input` choke point macros use) in the
  auto-reconnect `connected` case; echoes it into the loop display state.
- `src/types/terminal.ts` — `onReconnectCommand?` on `TerminalAutoReconnectState`.
- `src/components/Terminal/TerminalDisconnectOverlay.tsx` — the overlay note.

## Tests

- `core/src/backends/ssh/mod.rs` — schema field present + gated on resilient
  reconnect.
- `src/store/appStore.autoReconnect.test.ts` — send-once on success, trim +
  single newline, no command / whitespace-only = no-op, not on initial connect,
  not after cancel, fires again on each subsequent reconnect, exposed in display
  state.
- `src/components/Terminal/TerminalDisconnectOverlay.autoReconnect.test.tsx` —
  overlay announces the command, omits the note when none is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)