### PR TITLE
fix(terminal): scope broadcast targets to the source's own tab group

### DIFF
--- a/docs/changes/dev5/fix/1980-broadcast-cross-group.md
+++ b/docs/changes/dev5/fix/1980-broadcast-cross-group.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **Broadcast input** now resolves its target terminals within the **source
+  tab's own tab group**, never the active group. Previously, with broadcast
+  active, opening or switching tab groups could silently retarget input to a
+  terminal in a different, possibly invisible group while the visible terminals
+  received nothing. Membership is also refreshed when a tab is moved across
+  groups. (#1980)

--- a/src/components/Terminal/BroadcastScopeDialog.tsx
+++ b/src/components/Terminal/BroadcastScopeDialog.tsx
@@ -49,8 +49,17 @@ export function BroadcastScopeDialog({
   sourceTabId,
 }: BroadcastScopeDialogProps) {
   const rootPanel = useAppStore((s) => s.rootPanel);
+  const tabGroups = useAppStore((s) => s.tabGroups);
+  const activeTabGroupId = useAppStore((s) => s.activeTabGroupId);
   const lastBroadcastScope = useAppStore((s) => s.lastBroadcastScope);
   const startBroadcast = useAppStore((s) => s.startBroadcast);
+
+  // Resolve broadcast membership against the source's own group tree (#1980),
+  // not just the active `rootPanel`.
+  const resolveState = useMemo(
+    () => ({ tabGroups, activeTabGroupId, rootPanel }),
+    [tabGroups, activeTabGroupId, rootPanel]
+  );
 
   const [scope, setScope] = useState<BroadcastScope>(lastBroadcastScope);
   const [customSelected, setCustomSelected] = useState<Set<string>>(new Set());
@@ -76,14 +85,13 @@ export function BroadcastScopeDialog({
   }, [open, lastBroadcastScope, terminalTabs]);
 
   const allCount = useMemo(
-    () =>
-      sourceTabId ? resolveBroadcastTargetTabIds({ rootPanel }, "all", sourceTabId).length : 0,
-    [rootPanel, sourceTabId]
+    () => (sourceTabId ? resolveBroadcastTargetTabIds(resolveState, "all", sourceTabId).length : 0),
+    [resolveState, sourceTabId]
   );
   const panelCount = useMemo(
     () =>
-      sourceTabId ? resolveBroadcastTargetTabIds({ rootPanel }, "panel", sourceTabId).length : 0,
-    [rootPanel, sourceTabId]
+      sourceTabId ? resolveBroadcastTargetTabIds(resolveState, "panel", sourceTabId).length : 0,
+    [resolveState, sourceTabId]
   );
 
   const scopeOptions = useMemo(
@@ -102,8 +110,8 @@ export function BroadcastScopeDialog({
       const terminalIds = new Set(terminalTabs.map((t) => t.id));
       return [...customSelected].filter((id) => terminalIds.has(id));
     }
-    return resolveBroadcastTargetTabIds({ rootPanel }, scope, sourceTabId);
-  }, [scope, sourceTabId, rootPanel, customSelected, terminalTabs]);
+    return resolveBroadcastTargetTabIds(resolveState, scope, sourceTabId);
+  }, [scope, sourceTabId, resolveState, customSelected, terminalTabs]);
 
   const canStart = sourceTabId !== null && resolvedTargets.length > 0;
 

--- a/src/store/appStore.broadcastScope.test.ts
+++ b/src/store/appStore.broadcastScope.test.ts
@@ -143,6 +143,37 @@ describe("resolveBroadcastTargetTabIds (#1956)", () => {
     seed(leaf("leaf-1", [makeTab({ id: "src" })]));
     expect(resolveBroadcastTargetTabIds(useAppStore.getState(), "panel", "ghost")).toEqual([]);
   });
+
+  it("resolves within the source's OWN group, not the active group (#1980)", () => {
+    // Regression: a source in a non-active tab group must resolve targets in ITS
+    // group's tree — never the active group's — so broadcast input can't silently
+    // reach a terminal in a different, invisible group.
+    const groupA = leaf("leaf-A", [
+      makeTab({ id: "srcA", panelId: "leaf-A" }),
+      makeTab({ id: "a2", panelId: "leaf-A" }),
+    ]);
+    const groupB = leaf("leaf-B", [makeTab({ id: "b1", panelId: "leaf-B" })]);
+    useAppStore.setState({
+      // Active group is B; its live tree is `rootPanel`. Group A is inactive and
+      // keeps its tree in `group.rootPanel`.
+      activeTabGroupId: "gB",
+      rootPanel: groupB,
+      activePanelId: "leaf-B",
+      tabGroups: [
+        { id: "gA", name: "A", rootPanel: groupA, activePanelId: "leaf-A" },
+        { id: "gB", name: "B", rootPanel: groupB, activePanelId: "leaf-B" },
+      ],
+    });
+    // Source lives in the INACTIVE group A → targets are A's terminals only.
+    expect(resolveBroadcastTargetTabIds(useAppStore.getState(), "all", "srcA").sort()).toEqual([
+      "a2",
+      "srcA",
+    ]);
+    // The active group B's terminal is never pulled in for a source in A.
+    expect(resolveBroadcastTargetTabIds(useAppStore.getState(), "all", "srcA")).not.toContain("b1");
+    // And a source in the active group B resolves B's terminals only.
+    expect(resolveBroadcastTargetTabIds(useAppStore.getState(), "all", "b1")).toEqual(["b1"]);
+  });
 });
 
 describe("refreshBroadcastMembership — dynamic add on open (#1956)", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2324,28 +2324,38 @@ function driveAutoReconnect(
  * — non-terminal tabs (editors, SFTP/file browsers, ...) are never broadcast
  * targets, matching the concept's "Non-terminal tabs never appear" rule.
  *
- * - `"all"` — every terminal tab in the active tab group.
+ * - `"all"` — every terminal tab in the source tab's own group.
  * - `"panel"` — every terminal tab in the same split panel as the source.
  * - `"custom"` — `[]`; membership comes from the user's picker, not the scope.
  *
  * Exported for the scope dropdown's live counts and the dynamic-membership tests
- * (#1956). Operates on the active group's `rootPanel`, matching the foundation's
- * (#1955) all-terminals fan-out.
+ * (#1956). Resolves within the **source tab's own group tree** — not the active
+ * group — so broadcast never silently retargets to a terminal in a different,
+ * possibly invisible tab group when the source is not in the active group
+ * (#1980). The active group's live tree is `state.rootPanel`; every other
+ * group keeps its tree in `group.rootPanel`.
  */
 export function resolveBroadcastTargetTabIds(
-  state: { rootPanel: PanelNode },
+  state: { tabGroups: TabGroup[]; activeTabGroupId: string; rootPanel: PanelNode },
   scope: BroadcastScope,
   sourceTabId: string
 ): string[] {
   if (scope === "custom") return [];
   const isTerminal = (t: TerminalTab): boolean => t.contentType === "terminal";
+  // Find the source's own group tree (active group's live tree is `rootPanel`;
+  // inactive groups keep theirs in `group.rootPanel`). Fall back to the active
+  // tree if the source cannot be located (shouldn't happen for a live source).
+  const trees = state.tabGroups.map((g) =>
+    g.id === state.activeTabGroupId ? state.rootPanel : g.rootPanel
+  );
+  const sourceTree = trees.find((tree) => findLeafByTab(tree, sourceTabId)) ?? state.rootPanel;
   if (scope === "panel") {
-    const leaf = findLeafByTab(state.rootPanel, sourceTabId);
+    const leaf = findLeafByTab(sourceTree, sourceTabId);
     if (!leaf) return [];
     return leaf.tabs.filter(isTerminal).map((t) => t.id);
   }
-  // "all"
-  return getAllLeaves(state.rootPanel)
+  // "all" — every terminal tab in the source's group
+  return getAllLeaves(sourceTree)
     .flatMap((leaf) => leaf.tabs)
     .filter(isTerminal)
     .map((t) => t.id);
@@ -2861,7 +2871,7 @@ export const useAppStore = create<AppState>((set, get) => {
         return { tabGroups: groups };
       }),
 
-    moveTabToGroup: (tabId, fromPanelId, targetGroupId) =>
+    moveTabToGroup: (tabId, fromPanelId, targetGroupId) => {
       set((state) => {
         if (targetGroupId === state.activeTabGroupId) return state;
 
@@ -2914,7 +2924,12 @@ export const useAppStore = create<AppState>((set, get) => {
           tabGroups: newTabGroups,
           activePanelId: newActivePanelId,
         };
-      }),
+      });
+      // Moving a tab across groups changes broadcast membership when the source
+      // or a target crosses the group boundary (#1980) — re-resolve so an
+      // "all"/"panel" scope drops/adds it in the source's own group.
+      get().refreshBroadcastMembership();
+    },
 
     addTabGroupWithTab: (tabId, fromPanelId) =>
       set((state) => {


### PR DESCRIPTION
Fixes the release-blocker found in the #1954 broadcast pre-release review.

**Bug:** `resolveBroadcastTargetTabIds` resolved "all"/"panel" membership against the **active** group's `rootPanel`. With broadcast active, opening/switching tab groups could silently retarget input to a terminal in a **different, invisible** group (the fan-out draws from all groups) while the visible terminals received nothing — the 'keystrokes hit the wrong host' class.

**Fix:**
- `resolveBroadcastTargetTabIds` now resolves within the **source tab's own group tree** (active group's live tree is `rootPanel`; inactive groups use `group.rootPanel`), never the active group.
- `refreshBroadcastMembership` is invoked on `moveTabToGroup` so a target/source crossing the group boundary re-resolves.
- `BroadcastScopeDialog` passes the full group state to the resolver.

**Tests:** new regression test — a source in a non-active group resolves ITS group's terminals only, never the active group's; all 39 broadcast tests pass.

Closes #1980