### PR TITLE
feat(sftp): scope transfer display to the owning window even without a move (Closes #1964)

### DIFF
--- a/docs/changes/dev2/feat/1964-transfer-window-display.md
+++ b/docs/changes/dev2/feat/1964-transfer-window-display.md
@@ -1,0 +1,11 @@
+### Changed
+
+- Multi-window: a file transfer now appears **only in the window that owns its
+  session**, from the start — no tab move required. Previously every window
+  folded the app-wide `transfer-progress` broadcast, so a window that never owned
+  a session still showed its transfers in the Open Connections "Transfers"
+  section and the Transfer Queue panel. Folds are now scoped to the owning window
+  via the backend `session → window` ownership map (#1900), and SFTP sidebar
+  sessions now register their ownership so their transfers are scoped too.
+  Single-window behavior is unchanged, and background/spawned transfers whose
+  session no window renders still appear as before (#1964).

--- a/src/hooks/useTransferEvents.ts
+++ b/src/hooks/useTransferEvents.ts
@@ -35,21 +35,52 @@ function toastTerminalPhase(progress: TransferProgress): void {
 }
 
 /**
+ * Coalesce ownership-map refreshes (#1964). `transfer-progress` events fire once
+ * per chunk, so a naive refetch-per-event would spam the IPC bridge; this
+ * collapses a burst into at most one refresh per window, keeping
+ * {@link useAppStore}'s `sessionOwners` fresh during active transfers (so the
+ * fold gate scopes each transfer to its owning window) without flooding the
+ * backend. Module-scoped because the timer is a shared imperative resource.
+ */
+let ownersRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+const OWNERS_REFRESH_DEBOUNCE_MS = 150;
+function scheduleOwnersRefresh(refresh: () => void): void {
+  if (ownersRefreshTimer !== null) return;
+  ownersRefreshTimer = setTimeout(() => {
+    ownersRefreshTimer = null;
+    refresh();
+  }, OWNERS_REFRESH_DEBOUNCE_MS);
+}
+
+/**
  * Hook that listens for `transfer-progress` events from the backend (#1245) and
  * folds them into the store's `transfers` map (#1247), driving the Open
  * Connections "Transfers" section, the file-browser footer, and the status-bar
  * aggregate. On a terminal phase it also raises the one success/error toast for
  * the transfer (#1286).
+ *
+ * It also keeps the backend `session → window` ownership map mirrored in the
+ * store fresh (#1964): once on mount, and coalesced while transfers flow. That
+ * lets a window learn which of its sibling windows owns a session so a broadcast
+ * transfer is folded only in the owning window, even without a tab move.
  */
 export function useTransferEvents(): void {
   const applyTransferProgress = useAppStore((s) => s.applyTransferProgress);
   const applyTransferProgressToQueue = useAppStore((s) => s.applyTransferProgressToQueue);
+  const refreshSessionOwners = useAppStore((s) => s.refreshSessionOwners);
 
   useEffect(() => {
     let unlisten: (() => void) | null = null;
 
+    // Seed the ownership map so scoping is correct from the first event, before
+    // any transfer has flowed.
+    void refreshSessionOwners();
+
     const setup = async () => {
       unlisten = await onTransferProgress((progress) => {
+        // Keep the ownership map fresh while transfers flow (coalesced) so a
+        // session claimed by a sibling window is scoped out here (#1964).
+        scheduleOwnersRefresh(() => void refreshSessionOwners());
         // Feed both consumers from the single `transfer-progress` subscription:
         // the transient #1247 `transfers` map (clears terminal rows) and the
         // persistent #1337 Transfer Queue panel (retains terminal rows).
@@ -64,5 +95,5 @@ export function useTransferEvents(): void {
     return () => {
       unlisten?.();
     };
-  }, [applyTransferProgress, applyTransferProgressToQueue]);
+  }, [applyTransferProgress, applyTransferProgressToQueue, refreshSessionOwners]);
 }

--- a/src/store/appStore.transferQueue.test.ts
+++ b/src/store/appStore.transferQueue.test.ts
@@ -28,6 +28,9 @@ vi.mock("@/services/api", () => ({
   sftpListDir: vi.fn(() => Promise.resolve([])),
   sftpRealpath: vi.fn(() => Promise.resolve("/home/alice")),
   sftpCancelTransfer: vi.fn(() => Promise.resolve()),
+  claimSession: vi.fn(() => Promise.resolve(null)),
+  releaseSession: vi.fn(() => Promise.resolve(true)),
+  listSessionOwners: vi.fn(() => Promise.resolve({})),
   localListDir: vi.fn(),
   vscodeAvailable: vi.fn(() => Promise.resolve(false)),
 }));
@@ -169,6 +172,33 @@ describe("appStore — transfer queue slice (#1337)", () => {
       const q = useAppStore.getState().transferQueue;
       expect(Object.keys(q)).toHaveLength(1);
       expect(q["t1"].transferred).toBe(60);
+    });
+  });
+
+  describe("window-scoped queue folding (#1964)", () => {
+    it("adds a queue row for a session with no ownership entry (single-window / background)", () => {
+      useAppStore.getState().applyTransferProgressToQueue(progress({ sessionId: "sess-a" }));
+      expect(useAppStore.getState().transferQueue["t1"]).toBeDefined();
+    });
+
+    it("suppresses a queue row for a session owned by another window", () => {
+      useAppStore.setState({ windowLabel: "main", sessionOwners: { "sess-a": "win-1" } });
+      useAppStore.getState().applyTransferProgressToQueue(progress({ sessionId: "sess-a" }));
+      expect(useAppStore.getState().transferQueue["t1"]).toBeUndefined();
+    });
+
+    it("adds a queue row for a session this window owns", () => {
+      useAppStore.setState({ windowLabel: "main", sessionOwners: { "sess-a": "main" } });
+      useAppStore.getState().applyTransferProgressToQueue(progress({ sessionId: "sess-a" }));
+      expect(useAppStore.getState().transferQueue["t1"]).toBeDefined();
+    });
+
+    it("prunes a foreign queue row once ownership is learned", () => {
+      useAppStore.getState().applyTransferProgressToQueue(progress({ sessionId: "sess-a" }));
+      expect(useAppStore.getState().transferQueue["t1"]).toBeDefined();
+
+      useAppStore.getState().setSessionOwners({ "sess-a": "win-1" });
+      expect(useAppStore.getState().transferQueue["t1"]).toBeUndefined();
     });
   });
 

--- a/src/store/appStore.transfers.test.ts
+++ b/src/store/appStore.transfers.test.ts
@@ -28,12 +28,20 @@ vi.mock("@/services/api", () => ({
   sftpListDir: vi.fn(() => Promise.resolve([])),
   sftpRealpath: vi.fn(() => Promise.resolve("/home/alice")),
   sftpCancelTransfer: vi.fn(() => Promise.resolve()),
+  claimSession: vi.fn(() => Promise.resolve(null)),
+  releaseSession: vi.fn(() => Promise.resolve(true)),
+  listSessionOwners: vi.fn(() => Promise.resolve({})),
   localListDir: vi.fn(),
   vscodeAvailable: vi.fn(() => Promise.resolve(false)),
 }));
 
 import { useAppStore } from "./appStore";
-import { sftpClose, sftpCancelTransfer, type TransferProgress } from "@/services/api";
+import {
+  sftpClose,
+  sftpCancelTransfer,
+  listSessionOwners,
+  type TransferProgress,
+} from "@/services/api";
 
 function progress(overrides: Partial<TransferProgress> = {}): TransferProgress {
   return {
@@ -112,6 +120,96 @@ describe("appStore — SFTP transfer progress (S2/D3)", () => {
       const transfers = useAppStore.getState().transfers;
       expect(transfers["t1"]).toBeUndefined();
       expect(transfers["t2"]).toBeDefined();
+    });
+  });
+
+  describe("window-scoped folding (#1964)", () => {
+    it("folds a transfer for a session with no ownership entry (background / single-window)", () => {
+      // sessionOwners is empty by default → unclaimed session folds everywhere,
+      // preserving single-window behavior and background/spawned transfers.
+      useAppStore.getState().applyTransferProgress(progress({ sessionId: "sess-a" }));
+      expect(useAppStore.getState().transfers["t1"]).toBeDefined();
+    });
+
+    it("suppresses a transfer for a session owned by another window", () => {
+      useAppStore.setState({ windowLabel: "main", sessionOwners: { "sess-a": "win-1" } });
+      useAppStore.getState().applyTransferProgress(progress({ sessionId: "sess-a" }));
+      expect(useAppStore.getState().transfers["t1"]).toBeUndefined();
+    });
+
+    it("folds a transfer for a session this window owns in the map", () => {
+      useAppStore.setState({ windowLabel: "main", sessionOwners: { "sess-a": "main" } });
+      useAppStore.getState().applyTransferProgress(progress({ sessionId: "sess-a" }));
+      expect(useAppStore.getState().transfers["t1"]).toBeDefined();
+    });
+
+    it("folds a transfer this window renders locally even if a stale map says otherwise", () => {
+      // An SFTP sidebar session in this window's own store is authoritative for
+      // this window, regardless of how stale the ownership snapshot is.
+      useAppStore.setState({
+        windowLabel: "main",
+        sessionOwners: { "sess-a": "win-1" },
+        sftpSessions: { "sess-a": { hostLabel: "alice@a:22", owningTabId: "tab-1" } },
+      });
+      useAppStore.getState().applyTransferProgress(progress({ sessionId: "sess-a" }));
+      expect(useAppStore.getState().transfers["t1"]).toBeDefined();
+    });
+  });
+
+  describe("setSessionOwners prunes foreign rows (#1964)", () => {
+    it("drops a folded row once the map shows another window owns its session", () => {
+      const store = useAppStore.getState();
+      store.applyTransferProgress(progress({ transferId: "t1", sessionId: "sess-a" }));
+      expect(useAppStore.getState().transfers["t1"]).toBeDefined();
+
+      useAppStore.getState().setSessionOwners({ "sess-a": "win-1" });
+      expect(useAppStore.getState().transfers["t1"]).toBeUndefined();
+    });
+
+    it("keeps rows for sessions this window owns or renders locally", () => {
+      useAppStore.setState({
+        windowLabel: "main",
+        sftpSessions: { "sess-local": { hostLabel: "alice@a:22", owningTabId: "tab-1" } },
+      });
+      const store = useAppStore.getState();
+      store.applyTransferProgress(progress({ transferId: "t-own", sessionId: "sess-own" }));
+      store.applyTransferProgress(progress({ transferId: "t-local", sessionId: "sess-local" }));
+      store.applyTransferProgress(progress({ transferId: "t-foreign", sessionId: "sess-foreign" }));
+
+      useAppStore.getState().setSessionOwners({
+        "sess-own": "main",
+        "sess-local": "win-1", // stale — but locally rendered, so kept
+        "sess-foreign": "win-1",
+      });
+
+      const transfers = useAppStore.getState().transfers;
+      expect(transfers["t-own"]).toBeDefined();
+      expect(transfers["t-local"]).toBeDefined();
+      expect(transfers["t-foreign"]).toBeUndefined();
+    });
+  });
+
+  describe("refreshSessionOwners", () => {
+    it("mirrors the backend map and prunes foreign rows", async () => {
+      vi.mocked(listSessionOwners).mockResolvedValueOnce({ "sess-a": "win-1" });
+      useAppStore
+        .getState()
+        .applyTransferProgress(progress({ transferId: "t1", sessionId: "sess-a" }));
+      expect(useAppStore.getState().transfers["t1"]).toBeDefined();
+
+      await useAppStore.getState().refreshSessionOwners();
+
+      expect(useAppStore.getState().sessionOwners).toEqual({ "sess-a": "win-1" });
+      expect(useAppStore.getState().transfers["t1"]).toBeUndefined();
+    });
+
+    it("leaves the map unchanged when the backend refetch fails", async () => {
+      useAppStore.setState({ sessionOwners: { "sess-a": "main" } });
+      vi.mocked(listSessionOwners).mockRejectedValueOnce(new Error("ipc down"));
+
+      await useAppStore.getState().refreshSessionOwners();
+
+      expect(useAppStore.getState().sessionOwners).toEqual({ "sess-a": "main" });
     });
   });
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -122,6 +122,7 @@ import {
   sendHandoffToWindow,
   claimSession,
   releaseSession,
+  listSessionOwners,
   takePendingHandoffs,
   reportWindowLayout,
   collectWindowLayouts,
@@ -740,6 +741,37 @@ interface AppState {
    * seeded for it ({@link seedTransferQueue}).
    */
   releasedTransferSessions: string[];
+  /**
+   * This window's runtime label (`main`, `win-1`, …), captured once at store
+   * creation. Used to scope transfer folds to the owning window (#1964): a
+   * broadcast `transfer-progress` event is folded only when this window owns the
+   * transfer's session. Falls back to {@link MAIN_WINDOW_LABEL} outside Tauri.
+   */
+  windowLabel: string;
+  /**
+   * Local mirror of the backend `session_id → owning_window` map (#1900),
+   * refreshed while transfers are active (#1964). Gates the transfer folds
+   * ({@link applyTransferProgress}, {@link applyTransferProgressToQueue}) so a
+   * transfer is shown only in the window that owns its session — even without a
+   * tab move (which #1951 already handled via {@link releasedTransferSessions}).
+   * A session absent from the map is unclaimed (background/spawned, or not yet
+   * claimed) and folds everywhere as a safe fallback.
+   */
+  sessionOwners: Record<string, string>;
+  /**
+   * Replace {@link sessionOwners} with a fresh snapshot and drop any transient
+   * {@link transfers} / persistent {@link transferQueue} rows for sessions now
+   * owned by a *different* window (#1964). Rows for sessions this window renders
+   * locally are always kept, so a stale snapshot can never evict a live row.
+   */
+  setSessionOwners: (owners: Record<string, string>) => void;
+  /**
+   * Refetch the backend ownership map into {@link sessionOwners} (#1964).
+   * Best-effort (a failed refetch keeps the previous map). Callers that fire it
+   * on high-frequency events (e.g. `transfer-progress`) should coalesce — see
+   * {@link useTransferEvents}.
+   */
+  refreshSessionOwners: () => Promise<void>;
   /** Whether a session is mid-move (read by the source Terminal's unmount cleanup). */
   isSessionMoving: (sessionId: string) => boolean;
   /** Clear a session's moving flag once the source has released its view. */
@@ -2552,6 +2584,89 @@ function removeTransferSessionsFromWindow(
   return { transferQueue, transfers, releasedTransferSessions };
 }
 
+/** State slice needed to decide whether this window renders/owns a session. */
+type OwnershipView = {
+  tabGroups: TabGroup[];
+  activeTabGroupId: string;
+  rootPanel: PanelNode;
+  sftpSessions: Record<string, SftpSessionEntry>;
+  sessionOwners: Record<string, string>;
+  windowLabel: string;
+};
+
+/**
+ * Whether this window renders `sessionId` locally (#1964): a live tab in any of
+ * this window's tab groups is bound to it, or it is an SFTP sidebar session in
+ * this window's store. This is authoritative for *this* window regardless of how
+ * fresh {@link AppState.sessionOwners} is, so the owning window never suppresses
+ * (nor prunes) a row for a session it is actually showing.
+ */
+function windowRendersSession(
+  state: {
+    tabGroups: TabGroup[];
+    activeTabGroupId: string;
+    rootPanel: PanelNode;
+    sftpSessions: Record<string, SftpSessionEntry>;
+  },
+  sessionId: string
+): boolean {
+  if (sessionId in state.sftpSessions) return true;
+  return collectLiveTabs(state).some((t) => t.sessionId === sessionId);
+}
+
+/**
+ * Whether this window should fold a `transfer-progress` event for `sessionId`
+ * into its transfer UI (#1964), scoping a transfer to the window that owns its
+ * session even without a tab move:
+ *
+ *  - a session this window renders is owned here (see {@link windowRendersSession});
+ *  - otherwise the backend `session → window` map (#1900) decides — a session
+ *    owned by another window is suppressed here;
+ *  - a session absent from the map is unclaimed (background/spawned, or not yet
+ *    claimed) and folds everywhere as a safe fallback, preserving single-window
+ *    behavior (the main window owns everything) and background transfers whose
+ *    session may not correspond to a visible tab.
+ */
+function windowOwnsTransferSession(state: OwnershipView, sessionId: string): boolean {
+  if (windowRendersSession(state, sessionId)) return true;
+  const owner = state.sessionOwners?.[sessionId];
+  if (owner === undefined) return true;
+  return owner === state.windowLabel;
+}
+
+/**
+ * Drop transient {@link AppState.transfers} and persistent
+ * {@link AppState.transferQueue} rows for sessions a fresh ownership snapshot
+ * shows are owned by a *different* window (#1964) — the belt-and-suspenders that
+ * clears a row this window may have folded before it learned another window owns
+ * the session. Rows this window renders locally are always kept, so a stale
+ * snapshot can never evict a live row.
+ */
+function pruneForeignTransfers(
+  state: OwnershipView & {
+    transfers: Record<string, TransferState>;
+    transferQueue: Record<string, TransferEntry>;
+  },
+  owners: Record<string, string>
+): Partial<Pick<AppState, "transfers" | "transferQueue">> {
+  const view: OwnershipView = { ...state, sessionOwners: owners };
+  const isForeign = (sessionId: string) => !windowOwnsTransferSession(view, sessionId);
+  const transfers = Object.fromEntries(
+    Object.entries(state.transfers).filter(([, t]) => !isForeign(t.sessionId))
+  );
+  const transferQueue = Object.fromEntries(
+    Object.entries(state.transferQueue).filter(([, t]) => !isForeign(t.sessionId))
+  );
+  const result: Partial<Pick<AppState, "transfers" | "transferQueue">> = {};
+  if (Object.keys(transfers).length !== Object.keys(state.transfers).length) {
+    result.transfers = transfers;
+  }
+  if (Object.keys(transferQueue).length !== Object.keys(state.transferQueue).length) {
+    result.transferQueue = transferQueue;
+  }
+  return result;
+}
+
 /**
  * Remove a tab from a leaf panel, choosing a new active tab if needed.
  * Returns the updated leaf (may have empty tabs).
@@ -2978,6 +3093,23 @@ export const useAppStore = create<AppState>((set, get) => {
     // ── Multi-window foundation (#1900) ──
     movingSessionIds: [],
     releasedTransferSessions: [],
+    windowLabel: currentWindowLabel(),
+    sessionOwners: {},
+    setSessionOwners: (owners) =>
+      set((state) => ({ sessionOwners: owners, ...pruneForeignTransfers(state, owners) })),
+    refreshSessionOwners: async () => {
+      try {
+        const owners = await listSessionOwners();
+        // Coerce a missing/non-object result (e.g. an unmocked IPC bridge in
+        // tests returning `undefined`) to an empty map so the fold gate never
+        // reads through `undefined`.
+        get().setSessionOwners(owners ?? {});
+      } catch {
+        // Ownership is advisory (see `bestEffortOwnership`): a failed refetch (IPC
+        // unavailable / unit test stub) must never disrupt the transfer UI. The
+        // stale map simply keeps the previous scoping.
+      }
+    },
     isSessionMoving: (sessionId) => get().movingSessionIds.includes(sessionId),
     clearMovingSession: (sessionId) =>
       set((state) => ({
@@ -4225,6 +4357,9 @@ export const useAppStore = create<AppState>((set, get) => {
         .map(([sessionId]) => sessionId);
       ownedSftp.forEach((sessionId) => {
         sftpClose(sessionId).catch(() => {});
+        // Relinquish each SFTP session's window ownership (#1964), mirroring the
+        // tab-session release above. Best-effort.
+        bestEffortOwnership(() => releaseSession(sessionId));
       });
 
       set((state) => {
@@ -5269,6 +5404,10 @@ export const useAppStore = create<AppState>((set, get) => {
           } catch {
             // Ignore close errors — the entry is dropped regardless.
           }
+          // Relinquish this SFTP session's window ownership (#1964) so its
+          // transfers stop being attributed to this window (mirrors #1939 for
+          // tab sessions). Best-effort.
+          bestEffortOwnership(() => releaseSession(prevId));
           set((state) => ({ sftpSessions: omitKey(state.sftpSessions, prevId) }));
         }
       }
@@ -5306,6 +5445,7 @@ export const useAppStore = create<AppState>((set, get) => {
           : [];
         staleForTab.forEach((sid) => {
           sftpClose(sid).catch(() => {});
+          bestEffortOwnership(() => releaseSession(sid));
         });
         set((state) => {
           let sessions = state.sftpSessions;
@@ -5322,6 +5462,14 @@ export const useAppStore = create<AppState>((set, get) => {
             sftpSessions: sessions,
           };
         });
+        // Claim window ownership of the tracked SFTP session (#1964) so its
+        // broadcast `transfer-progress` events fold only in this window, even
+        // without a tab move. Only sessions bound to an owning tab are tracked in
+        // the map (and thus attributable); an untracked ad-hoc session stays
+        // unclaimed and folds everywhere as before. Best-effort (see #1939).
+        if (owningTabId) {
+          bestEffortOwnership(() => claimSession(sessionId));
+        }
       } catch (err) {
         set({
           sftpStatus: "error",
@@ -5338,6 +5486,8 @@ export const useAppStore = create<AppState>((set, get) => {
         } catch {
           // Ignore close errors
         }
+        // Relinquish this SFTP session's window ownership (#1964). Best-effort.
+        bestEffortOwnership(() => releaseSession(sessionId));
       }
       set((state) => ({
         sftpSessionId: null,
@@ -5384,6 +5534,8 @@ export const useAppStore = create<AppState>((set, get) => {
       } catch {
         // Ignore close errors — the entry is dropped regardless.
       }
+      // Relinquish this SFTP session's window ownership (#1964). Best-effort.
+      bestEffortOwnership(() => releaseSession(sessionId));
       set((state) => {
         const isActive = state.sftpSessionId === sessionId;
         return {
@@ -5410,6 +5562,10 @@ export const useAppStore = create<AppState>((set, get) => {
         // is no longer ours: ignore its broadcast progress so a moved-away row is
         // not re-created here.
         if (state.releasedTransferSessions.includes(progress.sessionId)) return {};
+        // Scope the fold to the owning window even without a move (#1964): a
+        // `transfer-progress` event is broadcast to every window, but only the
+        // window that owns the session should show it.
+        if (!windowOwnsTransferSession(state, progress.sessionId)) return {};
         // A terminal phase clears the row (D1 already removed any partial local
         // file on cancel/error). done/error toasts are the D2 follow-up.
         if (progress.phase !== "transferring") {
@@ -5467,6 +5623,8 @@ export const useAppStore = create<AppState>((set, get) => {
         // Ignore transfers whose session was handed to another window (#1951) so
         // a moved-away queue row is not re-adopted from a broadcast event.
         if (state.releasedTransferSessions.includes(progress.sessionId)) return {};
+        // Scope the fold to the owning window even without a move (#1964).
+        if (!windowOwnsTransferSession(state, progress.sessionId)) return {};
         const prev = state.transferQueue[progress.transferId];
         const entry = transferEntryFromProgress(progress, prev, Date.now());
         return { transferQueue: { ...state.transferQueue, [entry.id]: entry } };
@@ -5552,6 +5710,8 @@ export const useAppStore = create<AppState>((set, get) => {
         const sessionDead = isSftpSessionDeadError(message);
         if (sessionDead) {
           frontendLog("sftp", `navigateSftp: session appears dead — clearing session (${message})`);
+          // Relinquish the dead SFTP session's window ownership (#1964).
+          bestEffortOwnership(() => releaseSession(sessionId));
         }
         set((state) => ({
           sftpStatus: "error",
@@ -5586,6 +5746,8 @@ export const useAppStore = create<AppState>((set, get) => {
         const sessionDead = isSftpSessionDeadError(message);
         if (sessionDead) {
           frontendLog("sftp", `refreshSftp: session appears dead — clearing session (${message})`);
+          // Relinquish the dead SFTP session's window ownership (#1964).
+          bestEffortOwnership(() => releaseSession(sftpSessionId));
         }
         set((state) => ({
           sftpStatus: "error",


### PR DESCRIPTION
## Summary

Follow-up to #1951 (PR #1963). `transfer-progress` events are `app.emit`-broadcast to **every** native window, and each window's per-window store folded them unconditionally into both the transient `transfers` map (Open Connections "Transfers") and the persistent `transferQueue` (Transfer Queue panel). So a window that never owned a session still showed that session's transfers. #1951 only suppressed folds for sessions a window explicitly *released* on a tab move (`releasedTransferSessions`); a window that simply **never owned** a session was not covered.

This scopes the transfer display to the owning window even **without** a move:

- **Gate both folds** (`applyTransferProgress`, `applyTransferProgressToQueue`) on the backend `session → window` ownership map (#1900), mirrored in the store as `sessionOwners`. A transfer is folded only when this window **renders** the session locally (a bound tab in any of its groups, or an SFTP sidebar session in its own store) **or** the map says this window owns it. A session **absent** from the map is unclaimed (background/spawned, or not yet claimed) and folds everywhere as a **safe fallback** — so single-window behavior (the main window owns everything) and background transfers whose session has no visible tab do **not** regress.
- **SFTP sidebar sessions now claim/release window ownership** on connect/close (mirroring #1939 for tab sessions), so their transfers become attributable across windows. Previously only tab sessions were claimed, so SFTP transfers (the common case) could not be scoped.
- The `sessionOwners` mirror is refreshed on `useTransferEvents` mount and **coalesced** while transfers flow (per-chunk `transfer-progress` events would otherwise spam the IPC bridge). A fresh snapshot **prunes** any transient/queue row this window folded before it learned a sibling window owns the session; rows this window renders locally are always kept, so a stale snapshot can never evict a live row.

The local-render check keeps the owning window authoritative regardless of map freshness, and the released-set check (#1951) still runs first, so the move path is unchanged.

## Done when

- In a multi-window session, a transfer appears only in the window that owns its session, with no move required — moving still transfers ownership (as #1951 already does). ✅

## Test plan

- `src/store/appStore.transfers.test.ts` / `appStore.transferQueue.test.ts`: a transfer for a session owned by another window is suppressed; a session this window owns (map) or renders locally still folds; an unclaimed session folds everywhere (single-window / background); `setSessionOwners` prunes foreign rows while keeping locally-rendered/owned ones; `refreshSessionOwners` mirrors the backend map and tolerates a failed refetch.
- Full frontend suite green (4455 tests); existing transfer/handoff tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Follow-up

- #1985 — broadcast session-ownership changes so a non-owning window updates transfer scoping without the transfer-progress poll (avoids the brief flash-then-prune).
