### PR TITLE
fix(terminal): broadcast keyboard paste to all targets

### DIFF
--- a/docs/changes/dev3/fix/1981-broadcast-paste.md
+++ b/docs/changes/dev3/fix/1981-broadcast-paste.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- **Broadcast input** now includes **keyboard paste**. Pasting with
+  Cmd/Ctrl+Shift+V into a broadcast source previously reached only the source
+  terminal (typed input and context-menu paste already broadcast); it now fans
+  out to every connected broadcast target, each with its own bracketed-paste
+  handling. (#1981)

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -785,8 +785,9 @@ export function Terminal({
           // session instead of only this one. The source tab is included in the
           // target set, so the loop is uniform (no separate self-send).
           // Non-source terminals and the inactive state fall through to the
-          // normal single-session path below. Paste flows through onData too, so
-          // it is broadcast like typed input.
+          // normal single-session path below. Context-menu/native paste flows
+          // through onData and is broadcast here; keyboard-shortcut paste is
+          // preventDefault'd and broadcast in pasteToTerminal instead (#1981).
           if (store.broadcastActive && store.broadcastSourceTabId === tabId) {
             for (const targetTabId of store.getBroadcastTargetTabIds()) {
               const targetSessionId = getSessionId(targetTabId);

--- a/src/components/Terminal/TerminalRegistry.test.tsx
+++ b/src/components/Terminal/TerminalRegistry.test.tsx
@@ -5,6 +5,8 @@ import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { TerminalPortalProvider, useTerminalRegistry } from "./TerminalRegistry";
 import { sendInput } from "@/services/api";
+import { useAppStore } from "@/store/appStore";
+import type { TerminalTab } from "@/types/terminal";
 
 vi.mock("@/themes", () => ({
   applyTheme: vi.fn(),
@@ -373,6 +375,51 @@ describe("pasteToTerminal", () => {
 
     expect(sendInput).toHaveBeenCalledTimes(1);
     expect(sendInput).toHaveBeenCalledWith("session-dup", "hello");
+  });
+
+  it("broadcasts paste to all connected targets when broadcast is active (#1981)", async () => {
+    vi.mocked(sendInput).mockClear();
+    mockReadClipboard.mockResolvedValueOnce("cfg");
+    const mkTab = (id: string): TerminalTab => ({
+      id,
+      sessionId: `session-${id}`,
+      title: id,
+      connectionType: "local",
+      contentType: "terminal",
+      config: { type: "local", config: {} },
+      panelId: "leaf-1",
+      isActive: false,
+    });
+    // Two connected terminals, broadcast active from the source. getBroadcast-
+    // TargetTabIds treats a tab with a sessionId and no error/exit flag as
+    // connected (deriveTabStatus default).
+    useAppStore.setState({
+      ...useAppStore.getInitialState(),
+      rootPanel: {
+        type: "leaf",
+        id: "leaf-1",
+        tabs: [mkTab("src"), mkTab("t2")],
+        activeTabId: "src",
+      },
+      activePanelId: "leaf-1",
+      broadcastActive: true,
+      broadcastSourceTabId: "src",
+      broadcastScope: "all",
+      broadcastTargetTabIds: new Set(["src", "t2"]),
+    });
+    act(() => {
+      registryActions.registerSession("src", "session-src");
+      registryActions.registerSession("t2", "session-t2");
+    });
+
+    await act(async () => {
+      await registryActions.pasteToTerminal("src");
+    });
+
+    // Both target sessions receive the paste (not just the source).
+    expect(sendInput).toHaveBeenCalledWith("session-src", "cfg");
+    expect(sendInput).toHaveBeenCalledWith("session-t2", "cfg");
+    expect(sendInput).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/src/components/Terminal/TerminalRegistry.tsx
+++ b/src/components/Terminal/TerminalRegistry.tsx
@@ -326,32 +326,49 @@ export function TerminalPortalProvider({ children }: { children: ReactNode }) {
     useAppStore.getState().setTabSessionId(tabId, null);
   }, []);
 
-  const pasteToTerminal = useCallback(async (tabId: string) => {
-    const sessionId = sessionRegistryRef.current.get(tabId);
-    if (!sessionId) return;
-    const text = await readClipboard();
-    if (!text) return;
+  const pasteToTerminal = useCallback(
+    async (tabId: string) => {
+      const sessionId = sessionRegistryRef.current.get(tabId);
+      if (!sessionId) return;
+      const text = await readClipboard();
+      if (!text) return;
 
-    const doPaste = async () => {
-      const xterm = xtermRegistryRef.current.get(tabId);
-      // Line endings are normalized in the backend send_input choke point using
-      // the session's configured ending, so paste only handles bracketing here.
-      let payload = text;
+      const doPaste = async () => {
+        // Bracket the payload per-terminal — bracketed-paste mode is a per-terminal
+        // protocol state; line-ending normalization happens in the backend
+        // send_input choke point, so paste only handles bracketing here.
+        const pasteInto = (targetTabId: string, targetSessionId: SessionId) => {
+          const xterm = xtermRegistryRef.current.get(targetTabId);
+          const payload =
+            xterm && xterm.modes.bracketedPasteMode ? `\x1b[200~${text}\x1b[201~` : text;
+          return sendInput(targetSessionId, payload);
+        };
 
-      // Wrap in bracketed paste escape sequences if the terminal supports it
-      if (xterm && xterm.modes.bracketedPasteMode) {
-        payload = `\x1b[200~${text}\x1b[201~`;
+        // Broadcast fan-out (#1981): when this tab is the active broadcast source,
+        // paste into every connected target — matching the onData fan-out and the
+        // context-menu paste path — not just the source session.
+        const store = useAppStore.getState();
+        if (store.broadcastActive && store.broadcastSourceTabId === tabId) {
+          await Promise.all(
+            store.getBroadcastTargetTabIds().flatMap((targetTabId) => {
+              const targetSessionId = getSessionId(targetTabId);
+              return targetSessionId ? [pasteInto(targetTabId, targetSessionId)] : [];
+            })
+          );
+          return;
+        }
+
+        await pasteInto(tabId, sessionId);
+      };
+
+      if (text.length > LARGE_PASTE_THRESHOLD) {
+        useAppStore.getState().showLargePasteDialog(text.length, doPaste);
+      } else {
+        await doPaste();
       }
-
-      await sendInput(sessionId, payload);
-    };
-
-    if (text.length > LARGE_PASTE_THRESHOLD) {
-      useAppStore.getState().showLargePasteDialog(text.length, doPaste);
-    } else {
-      await doPaste();
-    }
-  }, []);
+    },
+    [getSessionId]
+  );
 
   const sendInputToTerminal = useCallback(async (tabId: string, data: string): Promise<boolean> => {
     const sessionId = sessionRegistryRef.current.get(tabId);


### PR DESCRIPTION
Fixes the MEDIUM bug from the #1954 broadcast pre-release review.

Keyboard paste (Cmd/Ctrl+Shift+V) went through `pasteToTerminal`, which `preventDefault`s xterm's native paste and sent to the **single** source session only — so pasting while broadcasting missed every target. Typed input and context-menu paste already fan out via `onData`; keyboard paste did not (its 'paste flows through onData' comment was wrong for this path). The large-paste dialog had the same gap.

**Fix:** when the tab is the active broadcast source, `pasteToTerminal` fans the payload out to every connected target (via `getBroadcastTargetTabIds`), bracketing each target per its own bracketed-paste mode. Corrected the onData comment.

**Tests:** new registry test asserts paste-while-broadcasting reaches all targets.

Closes #1981