### PR TITLE
fix(network): push session-ownership changes so transfer scoping updates instantly

### DIFF
--- a/docs/changes/dev2/feat/1985-ownership-events.md
+++ b/docs/changes/dev2/feat/1985-ownership-events.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- **Multi-window transfers**: a file transfer for a session owned by another
+  window no longer briefly flashes in a non-owning window before being pruned.
+  The backend now pushes `session → window` ownership changes (on claim,
+  release, and window close) so every window updates its ownership mirror
+  immediately, instead of only once a transfer-progress event happens to flow.
+  (#1985)

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -91,7 +91,14 @@ pub fn claim_session(
     window: WebviewWindow,
     window_manager: State<'_, WindowManager>,
 ) -> Option<String> {
-    window_manager.claim(&session_id, window.label())
+    let previous = window_manager.claim(&session_id, window.label());
+    // Push the ownership change to every window (#1985) so a non-owning window
+    // refreshes its `session → window` mirror immediately, instead of only once
+    // a `transfer-progress` event happens to flow (which caused a brief flash).
+    if let Err(e) = window.app_handle().emit("session-ownership-changed", ()) {
+        tracing::warn!("Failed to emit session-ownership-changed on claim: {e}");
+    }
+    previous
 }
 
 /// Release `session_id` from the **calling** window. No-op unless the calling
@@ -102,7 +109,14 @@ pub fn release_session(
     window: WebviewWindow,
     window_manager: State<'_, WindowManager>,
 ) -> bool {
-    window_manager.release(&session_id, window.label())
+    let removed = window_manager.release(&session_id, window.label());
+    // Only a real removal changed the map; a non-owner no-op release does not.
+    if removed {
+        if let Err(e) = window.app_handle().emit("session-ownership-changed", ()) {
+            tracing::warn!("Failed to emit session-ownership-changed on release: {e}");
+        }
+    }
+    removed
 }
 
 /// The window label currently rendering `session_id`, if any.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1193,6 +1193,13 @@ pub fn run() {
                         if let Err(e) = handle.emit("windows-changed", ()) {
                             tracing::warn!("Failed to emit windows-changed on destroy: {e}");
                         }
+                        // The destroyed window's sessions were just released
+                        // (release_all_for_window above), so push the ownership
+                        // change too (#1985) — a surviving window refreshes its
+                        // mirror without waiting on a transfer-progress event.
+                        if let Err(e) = handle.emit("session-ownership-changed", ()) {
+                            tracing::warn!("Failed to emit session-ownership-changed on destroy: {e}");
+                        }
                     });
                     return;
                 }

--- a/src/hooks/useTransferEvents.test.ts
+++ b/src/hooks/useTransferEvents.test.ts
@@ -3,11 +3,18 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 // A settable callback the mocked `onTransferProgress` hands the event stream to,
 // so tests can drive terminal `transfer-progress` phases directly.
 let emit: ((progress: TransferProgress) => void) | undefined;
+// A settable callback the mocked `onSessionOwnershipChanged` hands the ownership
+// push-event to, so a test can fire it directly (#1985).
+let emitOwnership: (() => void) | undefined;
 const unlisten = vi.fn();
 
 vi.mock("@/services/events", () => ({
   onTransferProgress: vi.fn((cb: (progress: TransferProgress) => void) => {
     emit = cb;
+    return Promise.resolve(unlisten);
+  }),
+  onSessionOwnershipChanged: vi.fn((cb: () => void) => {
+    emitOwnership = cb;
     return Promise.resolve(unlisten);
   }),
 }));
@@ -53,6 +60,7 @@ describe("useTransferEvents — terminal-phase toasts (D2, #1286)", () => {
     root = createRoot(container);
     useAppStore.setState(useAppStore.getInitialState());
     emit = undefined;
+    emitOwnership = undefined;
     vi.clearAllMocks();
   });
 
@@ -87,6 +95,27 @@ describe("useTransferEvents — terminal-phase toasts (D2, #1286)", () => {
     expect(vi.mocked(toast.success).mock.calls[0][0]).toContain("Downloaded");
     expect(vi.mocked(toast.success).mock.calls[0][0]).toContain("file.txt");
     expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+  });
+
+  it("refreshes the ownership map on a session-ownership-changed event, debounced (#1985)", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    useAppStore.setState({ refreshSessionOwners: refresh });
+    await mountHook();
+    // Drain the on-mount seed call and any debounce pending from earlier tests.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 200));
+    });
+    refresh.mockClear();
+
+    // The backend pushed an ownership change → the hook refreshes (debounced).
+    act(() => {
+      emitOwnership!();
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 200));
+    });
+
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 
   it("labels an uploaded file with 'Uploaded'", async () => {

--- a/src/hooks/useTransferEvents.ts
+++ b/src/hooks/useTransferEvents.ts
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useAppStore } from "@/store/appStore";
-import { onTransferProgress } from "@/services/events";
+import { onTransferProgress, onSessionOwnershipChanged } from "@/services/events";
 import { toast } from "@/components/ui";
 import type { TransferProgress } from "@/services/api";
 
@@ -71,12 +71,21 @@ export function useTransferEvents(): void {
 
   useEffect(() => {
     let unlisten: (() => void) | null = null;
+    let unlistenOwnership: (() => void) | null = null;
 
     // Seed the ownership map so scoping is correct from the first event, before
     // any transfer has flowed.
     void refreshSessionOwners();
 
     const setup = async () => {
+      // Push path (#1985): refresh the ownership mirror the moment the backend
+      // reports a claim/release/window-destroy, so a sibling window's claim is
+      // reflected here immediately — no flash-then-prune waiting on the first
+      // transfer-progress event. Debounced (shared coalescer) to avoid a storm
+      // during multi-session restore.
+      unlistenOwnership = await onSessionOwnershipChanged(() => {
+        scheduleOwnersRefresh(() => void refreshSessionOwners());
+      });
       unlisten = await onTransferProgress((progress) => {
         // Keep the ownership map fresh while transfers flow (coalesced) so a
         // session claimed by a sibling window is scoped out here (#1964).
@@ -94,6 +103,7 @@ export function useTransferEvents(): void {
 
     return () => {
       unlisten?.();
+      unlistenOwnership?.();
     };
   }, [applyTransferProgress, applyTransferProgressToQueue, refreshSessionOwners]);
 }

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -125,6 +125,17 @@ export async function onTerminalExit(
 }
 
 /**
+ * Listen for backend `session → window` ownership changes (#1985): a window
+ * claimed or released a session, or a window was destroyed and its sessions
+ * released. Fires with no payload — the listener refetches the ownership map so
+ * a non-owning window learns of a sibling's claim immediately (push), rather
+ * than only once a `transfer-progress` event happens to flow.
+ */
+export async function onSessionOwnershipChanged(callback: () => void): Promise<UnlistenFn> {
+  return await listen("session-ownership-changed", () => callback());
+}
+
+/**
  * Singleton dispatcher that registers one global Tauri listener for each
  * terminal event type and routes events to per-session callbacks via Map
  * lookup. This replaces the O(N) fan-out pattern where each Terminal


### PR DESCRIPTION
Follow-up to #1964. Fixes the ≤150 ms flash where a transfer for a session a sibling window owns briefly appeared in a non-owning window before the coalesced refresh pruned it.

**Backend:** emit `session-ownership-changed` from `claim_session`, `release_session` (real removals), and the window-destroy `release_all_for_window` path.
**Frontend:** `onSessionOwnershipChanged` listener refreshes `sessionOwners` (debounced via the existing 150ms coalescer) so a non-owning window learns of a claim immediately — no flash-then-prune. The transfer-progress coalesced refresh stays as a backstop.

**Tests:** hook test asserts the ownership event triggers a debounced refresh; Rust fmt/clippy green.

Closes #1985