### PR TITLE
feat(plugin): define .termihub-plugin package format + manifest schema and validation (Closes #1989)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7687,6 +7687,7 @@ dependencies = [
  "which",
  "windows-sys 0.59.0",
  "winreg 0.55.0",
+ "zip",
  "zune-jpeg 0.4.21",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -84,6 +84,11 @@ rmp-serde = { version = "1", optional = true }
 ringbuf = "0.5.0"
 shellexpand = "3.1"
 vte = "0.13"
+# ZIP reader for the `.termihub-plugin` package format (#1989). Used instead of
+# hand-rolled archive parsing to open a package and read its `manifest.json`.
+# Behind the optional `plugin` feature so it is only compiled when the plugin
+# system is built.
+zip = { version = "2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 # Used to build a per-user DACL for a security-hardened local-IPC listener
@@ -116,6 +121,10 @@ serial_test = "3"
 
 [features]
 default = []
+# Plugin package format + manifest schema/validation (#1989). Pulls the `zip`
+# crate to read `.termihub-plugin` archives. Foundation only — no plugin
+# loading/UI yet.
+plugin = ["dep:zip"]
 serial = ["dep:serial2", "dep:serial2-tokio", "dep:tracing"]
 local-shell = ["dep:portable-pty", "dep:tracing"]
 telnet = ["dep:tracing"]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -21,5 +21,7 @@ pub mod monitoring;
 pub mod net;
 pub mod network;
 pub mod output;
+#[cfg(feature = "plugin")]
+pub mod plugin;
 pub mod protocol;
 pub mod session;

--- a/core/src/plugin/manifest.rs
+++ b/core/src/plugin/manifest.rs
@@ -1,0 +1,575 @@
+//! The `manifest.json` data model and its validation.
+//!
+//! Every `.termihub-plugin` package carries a `manifest.json` at its root. This
+//! module defines the strongly-typed [`PluginManifest`] that mirrors that file
+//! (see the plugin-system concept, impl §2 and §6), together with strict
+//! (de)serialization and semantic validation.
+//!
+//! Two layers of checking apply:
+//!
+//! * **Deserialization** — [`parse_manifest`] rejects unknown top-level fields,
+//!   missing required fields, and unknown `platforms` / `permissions` values
+//!   (they are modelled as closed enums), producing an actionable serde error.
+//! * **Semantic validation** — [`PluginManifest::validate`] enforces rules that
+//!   the type system cannot express: a filesystem-safe plugin `id`, non-empty
+//!   identity fields, a parseable `apiVersion`, and at least one declared
+//!   extension point.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// The plugin API version this build of termiHub implements.
+///
+/// A plugin's declared `apiVersion` is checked against this constant; see
+/// [`PluginManifest::api_compatibility`] and [`check_api_compatibility`].
+pub const CURRENT_PLUGIN_API_VERSION: &str = "1.0";
+
+/// Maximum length of a plugin `id`. Ids become on-disk directory names
+/// (`<app-data>/plugins/<id>/`), so they are kept short and slug-like.
+const MAX_PLUGIN_ID_LEN: usize = 64;
+
+/// A coarse-grained capability a plugin requests in its manifest.
+///
+/// The set is intentionally closed: an unknown permission string fails
+/// deserialization rather than being silently ignored, which is what lets the
+/// install-time permission prompt be exhaustive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PluginPermission {
+    /// Creating and managing terminal sessions.
+    Terminal,
+    /// Making outbound network connections.
+    Network,
+    /// Reading and writing files (scoped to declared paths).
+    Filesystem,
+    /// Rendering UI components in designated slots.
+    Ui,
+    /// Storing and reading plugin-specific configuration.
+    Settings,
+}
+
+/// A desktop platform a plugin declares support for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Platform {
+    /// Microsoft Windows.
+    Windows,
+    /// Linux.
+    Linux,
+    /// Apple macOS.
+    Macos,
+}
+
+/// The `extensions` object: which extension points a plugin provides.
+///
+/// A plugin declares one or more of these. The individual extension bodies are
+/// modelled here for a faithful round-trip, but this crate only validates their
+/// presence — wiring them into the terminal manager, theme engine, etc. is the
+/// job of later plugin-system issues.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PluginExtensions {
+    /// A new connection type with full terminal I/O (Rust dynamic library).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_backend: Option<TerminalBackendExtension>,
+    /// An output filter that transforms or annotates terminal output (JS).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol_parser: Option<ProtocolParserExtension>,
+    /// One or more custom color themes (JSON data).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub theme: Option<ThemeExtension>,
+    /// A widget rendered into the status bar (JS).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_bar_widget: Option<StatusBarWidgetExtension>,
+}
+
+impl PluginExtensions {
+    /// Whether the plugin declares no extension points at all.
+    pub fn is_empty(&self) -> bool {
+        self.terminal_backend.is_none()
+            && self.protocol_parser.is_none()
+            && self.theme.is_none()
+            && self.status_bar_widget.is_none()
+    }
+}
+
+/// A terminal-backend extension point.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct TerminalBackendExtension {
+    /// The connection type this backend registers.
+    pub connection_type: String,
+    /// Human-readable name shown in the connection-type selector.
+    pub display_name: String,
+    /// JSON Schema describing the backend's connection config. Opaque to this
+    /// crate — later issues drive the schema-based config form.
+    pub config_schema: serde_json::Value,
+}
+
+/// A protocol-parser extension point.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ProtocolParserExtension {
+    /// Parser identifier.
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Path to the JS entry point within the package.
+    pub entry_point: String,
+}
+
+/// A theme extension point: one or more theme definitions bundled in the package.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ThemeExtension {
+    /// The themes provided by this plugin.
+    pub themes: Vec<ThemeEntry>,
+}
+
+/// A single theme provided by a [`ThemeExtension`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ThemeEntry {
+    /// Theme identifier (unique within the plugin).
+    pub id: String,
+    /// Display name.
+    pub name: String,
+    /// Path to the theme JSON file within the package's `themes/` directory.
+    pub file: String,
+}
+
+/// Which side of the status bar a widget renders on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WidgetPosition {
+    /// Left-hand side of the status bar.
+    Left,
+    /// Right-hand side of the status bar.
+    Right,
+}
+
+/// A status-bar-widget extension point.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct StatusBarWidgetExtension {
+    /// Path to the JS entry point within the package.
+    pub entry_point: String,
+    /// Where the widget is placed.
+    pub position: WidgetPosition,
+}
+
+/// The primitive type of a plugin setting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SettingType {
+    /// A text value.
+    String,
+    /// A numeric value.
+    Number,
+    /// A boolean value.
+    Boolean,
+}
+
+/// The schema for a single plugin setting (`settings.<key>`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PluginSettingSchema {
+    /// The setting's primitive type.
+    #[serde(rename = "type")]
+    pub setting_type: SettingType,
+    /// Default value applied when the user has not set one.
+    pub default: serde_json::Value,
+    /// Human-readable description shown in the settings UI.
+    pub description: String,
+    /// Optional closed set of allowed string values.
+    #[serde(rename = "enum", default, skip_serializing_if = "Option::is_none")]
+    pub allowed_values: Option<Vec<String>>,
+}
+
+/// The parsed and (once [`validate`](PluginManifest::validate)d) trusted
+/// contents of a plugin's `manifest.json`.
+///
+/// Field names mirror the concept's manifest (impl §2/§6); JSON keys are
+/// `camelCase`. Unknown keys are rejected.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PluginManifest {
+    /// Stable, filesystem-safe identifier (used as the install directory name).
+    pub id: String,
+    /// Human-readable display name.
+    pub name: String,
+    /// Plugin version string (informational; the host does not interpret it).
+    pub version: String,
+    /// Plugin author.
+    pub author: String,
+    /// Short description.
+    pub description: String,
+    /// SPDX-style license identifier.
+    pub license: String,
+    /// Declared plugin-API version, as `"major.minor"`.
+    pub api_version: String,
+    /// Desktop platforms the plugin supports.
+    pub platforms: Vec<Platform>,
+    /// Coarse-grained permissions the plugin requests.
+    pub permissions: Vec<PluginPermission>,
+    /// The extension points the plugin provides.
+    pub extensions: PluginExtensions,
+    /// Optional user-configurable settings, keyed by setting name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub settings: Option<BTreeMap<String, PluginSettingSchema>>,
+}
+
+impl PluginManifest {
+    /// Run semantic validation over an already-deserialized manifest.
+    ///
+    /// Deserialization has already guaranteed the shape (known fields, known
+    /// enum values); this layer enforces the invariants the type system cannot:
+    /// a filesystem-safe `id`, non-empty identity fields, a parseable
+    /// `apiVersion`, and at least one declared extension point.
+    pub fn validate(&self) -> Result<(), ManifestValidationError> {
+        validate_plugin_id(&self.id)?;
+        require_non_empty("name", &self.name)?;
+        require_non_empty("version", &self.version)?;
+        require_non_empty("author", &self.author)?;
+        if parse_api_version(&self.api_version).is_none() {
+            return Err(ManifestValidationError::InvalidApiVersion(
+                self.api_version.clone(),
+            ));
+        }
+        if self.extensions.is_empty() {
+            return Err(ManifestValidationError::NoExtensions);
+        }
+        Ok(())
+    }
+
+    /// Compatibility of this manifest's `apiVersion` with the host
+    /// ([`CURRENT_PLUGIN_API_VERSION`]).
+    pub fn api_compatibility(&self) -> ApiCompatibility {
+        check_api_compatibility(&self.api_version)
+    }
+}
+
+/// The outcome of an API-version compatibility check — a distinct result from
+/// the other, structural validation failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApiCompatibility {
+    /// The plugin targets an API version this host can load.
+    Compatible,
+    /// The plugin targets an incompatible API version and must not be loaded.
+    Incompatible,
+}
+
+/// Whether a declared `apiVersion` string is compatible with the host.
+///
+/// Compatibility rule: the **major** versions must match and the plugin's
+/// **minor** must not exceed the host's. An unparseable version is treated as
+/// incompatible. (Callers that want an actionable "malformed version" error
+/// should run [`PluginManifest::validate`] first, which reports it distinctly.)
+pub fn check_api_compatibility(declared: &str) -> ApiCompatibility {
+    match (
+        parse_api_version(declared),
+        parse_api_version(CURRENT_PLUGIN_API_VERSION),
+    ) {
+        (Some((dmaj, dmin)), Some((hmaj, hmin))) if dmaj == hmaj && dmin <= hmin => {
+            ApiCompatibility::Compatible
+        }
+        _ => ApiCompatibility::Incompatible,
+    }
+}
+
+/// Deserialize and strictly validate a `manifest.json` string.
+///
+/// Rejects unknown/missing fields and unknown enum values with an actionable
+/// serde error. Note this performs *deserialization* only; call
+/// [`PluginManifest::validate`] for the semantic checks.
+pub fn parse_manifest(json: &str) -> Result<PluginManifest, ManifestParseError> {
+    serde_json::from_str(json).map_err(|e| ManifestParseError(e.to_string()))
+}
+
+/// A failure to deserialize `manifest.json` (malformed JSON, unknown or missing
+/// field, unknown permission/platform, …). Wraps the underlying serde message.
+#[derive(Debug, Error)]
+#[error("invalid plugin manifest: {0}")]
+pub struct ManifestParseError(pub String);
+
+/// A semantic validation failure over an already-parsed manifest.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ManifestValidationError {
+    /// A required identity field was present but empty.
+    #[error("plugin manifest field `{0}` must not be empty")]
+    EmptyField(&'static str),
+    /// The `id` is empty, too long, or contains characters that are not
+    /// lowercase alphanumerics or single interior hyphens.
+    #[error(
+        "plugin manifest `id` must be a non-empty slug of lowercase letters, \
+         digits and hyphens (got `{0}`)"
+    )]
+    InvalidId(String),
+    /// The `apiVersion` string is not of the form `major` or `major.minor`.
+    #[error("plugin manifest `apiVersion` is not a valid `major.minor` version (got `{0}`)")]
+    InvalidApiVersion(String),
+    /// The manifest declares no extension points.
+    #[error("plugin manifest declares no extensions; at least one is required")]
+    NoExtensions,
+}
+
+/// Parse a `"major"` or `"major.minor"` version into its numeric components.
+/// Returns `None` for anything else (extra components, empty, non-numeric).
+fn parse_api_version(s: &str) -> Option<(u32, u32)> {
+    let mut parts = s.split('.');
+    let major = parts.next()?;
+    if major.is_empty() {
+        return None;
+    }
+    let major: u32 = major.parse().ok()?;
+    let minor = match parts.next() {
+        Some(m) => m.parse().ok()?,
+        None => 0,
+    };
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor))
+}
+
+fn require_non_empty(field: &'static str, value: &str) -> Result<(), ManifestValidationError> {
+    if value.trim().is_empty() {
+        Err(ManifestValidationError::EmptyField(field))
+    } else {
+        Ok(())
+    }
+}
+
+/// A plugin id must be a filesystem-safe slug: 1..=64 chars of `[a-z0-9-]`, not
+/// starting or ending with a hyphen and with no consecutive hyphens. This keeps
+/// the install directory (`plugins/<id>/`) safe from traversal and collisions.
+fn validate_plugin_id(id: &str) -> Result<(), ManifestValidationError> {
+    if id.is_empty() || id.len() > MAX_PLUGIN_ID_LEN {
+        return Err(ManifestValidationError::InvalidId(id.to_string()));
+    }
+    let bytes = id.as_bytes();
+    if bytes[0] == b'-' || bytes[bytes.len() - 1] == b'-' {
+        return Err(ManifestValidationError::InvalidId(id.to_string()));
+    }
+    let mut prev_hyphen = false;
+    for &b in bytes {
+        let ok = b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-';
+        if !ok {
+            return Err(ManifestValidationError::InvalidId(id.to_string()));
+        }
+        if b == b'-' && prev_hyphen {
+            return Err(ManifestValidationError::InvalidId(id.to_string()));
+        }
+        prev_hyphen = b == b'-';
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal manifest that passes both deserialization and validation.
+    fn valid_manifest_json() -> &'static str {
+        r#"{
+            "id": "k8s-exec",
+            "name": "Kubernetes Exec",
+            "version": "1.2.0",
+            "author": "k8s-contrib",
+            "description": "Terminal backend for Kubernetes pod exec sessions",
+            "license": "MIT",
+            "apiVersion": "1.0",
+            "platforms": ["windows", "linux", "macos"],
+            "permissions": ["terminal", "network", "filesystem"],
+            "extensions": {
+                "terminalBackend": {
+                    "connectionType": "k8s-exec",
+                    "displayName": "Kubernetes Exec",
+                    "configSchema": {
+                        "type": "object",
+                        "properties": { "pod": { "type": "string" } },
+                        "required": ["pod"]
+                    }
+                }
+            },
+            "settings": {
+                "defaultNamespace": {
+                    "type": "string",
+                    "default": "default",
+                    "description": "Default Kubernetes namespace"
+                }
+            }
+        }"#
+    }
+
+    #[test]
+    fn parses_and_validates_a_good_manifest() {
+        let manifest = parse_manifest(valid_manifest_json()).expect("should parse");
+        assert_eq!(manifest.id, "k8s-exec");
+        assert_eq!(manifest.platforms.len(), 3);
+        assert_eq!(
+            manifest.permissions,
+            vec![
+                PluginPermission::Terminal,
+                PluginPermission::Network,
+                PluginPermission::Filesystem
+            ]
+        );
+        assert!(manifest.extensions.terminal_backend.is_some());
+        assert!(manifest.settings.is_some());
+        manifest.validate().expect("should validate");
+        assert_eq!(manifest.api_compatibility(), ApiCompatibility::Compatible);
+    }
+
+    #[test]
+    fn round_trips_through_serde() {
+        let manifest = parse_manifest(valid_manifest_json()).unwrap();
+        let json = serde_json::to_string(&manifest).unwrap();
+        let reparsed = parse_manifest(&json).unwrap();
+        assert_eq!(manifest, reparsed);
+    }
+
+    #[test]
+    fn rejects_malformed_json() {
+        let err = parse_manifest("{ this is not json ").unwrap_err();
+        // Actionable message from serde.
+        assert!(!err.to_string().is_empty());
+    }
+
+    #[test]
+    fn rejects_unknown_top_level_field() {
+        let json = valid_manifest_json().replace(
+            "\"license\": \"MIT\",",
+            "\"license\": \"MIT\", \"surprise\": 1,",
+        );
+        let err = parse_manifest(&json).unwrap_err();
+        assert!(err.to_string().contains("surprise"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_missing_required_field() {
+        // Drop the required `author` field.
+        let json = valid_manifest_json().replace("\"author\": \"k8s-contrib\",", "");
+        let err = parse_manifest(&json).unwrap_err();
+        assert!(err.to_string().contains("author"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_unknown_permission() {
+        let json = valid_manifest_json().replace(
+            "[\"terminal\", \"network\", \"filesystem\"]",
+            "[\"terminal\", \"root\"]",
+        );
+        let err = parse_manifest(&json).unwrap_err();
+        assert!(err.to_string().contains("root"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_unknown_platform() {
+        let json = valid_manifest_json().replace(
+            "[\"windows\", \"linux\", \"macos\"]",
+            "[\"windows\", \"solaris\"]",
+        );
+        let err = parse_manifest(&json).unwrap_err();
+        assert!(err.to_string().contains("solaris"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_bad_plugin_id() {
+        for bad in [
+            "",
+            "-lead",
+            "trail-",
+            "double--hyphen",
+            "Upper",
+            "has space",
+            "sla/sh",
+            "../escape",
+        ] {
+            let json = valid_manifest_json()
+                .replace("\"id\": \"k8s-exec\"", &format!("\"id\": \"{bad}\""));
+            let manifest = parse_manifest(&json).expect("shape is fine");
+            assert!(
+                matches!(
+                    manifest.validate(),
+                    Err(ManifestValidationError::InvalidId(_))
+                ),
+                "id {bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_accepts_good_plugin_ids() {
+        for good in ["k8s-exec", "a", "plugin1", "my-cool-plugin", "0abc"] {
+            let json = valid_manifest_json()
+                .replace("\"id\": \"k8s-exec\"", &format!("\"id\": \"{good}\""));
+            let manifest = parse_manifest(&json).expect("shape is fine");
+            manifest
+                .validate()
+                .unwrap_or_else(|e| panic!("id {good:?} should validate: {e}"));
+        }
+    }
+
+    #[test]
+    fn validate_rejects_no_extensions() {
+        let json = valid_manifest_json().replace(
+            "\"extensions\": {\n                \"terminalBackend\": {\n                    \"connectionType\": \"k8s-exec\",\n                    \"displayName\": \"Kubernetes Exec\",\n                    \"configSchema\": {\n                        \"type\": \"object\",\n                        \"properties\": { \"pod\": { \"type\": \"string\" } },\n                        \"required\": [\"pod\"]\n                    }\n                }\n            }",
+            "\"extensions\": {}",
+        );
+        let manifest = parse_manifest(&json).expect("empty extensions is a valid shape");
+        assert_eq!(
+            manifest.validate(),
+            Err(ManifestValidationError::NoExtensions)
+        );
+    }
+
+    #[test]
+    fn validate_rejects_bad_api_version() {
+        for bad in ["", "x", "1.y", "1.2.3", "1."] {
+            let json = valid_manifest_json().replace(
+                "\"apiVersion\": \"1.0\"",
+                &format!("\"apiVersion\": \"{bad}\""),
+            );
+            let manifest = parse_manifest(&json).expect("shape is fine");
+            assert!(
+                matches!(
+                    manifest.validate(),
+                    Err(ManifestValidationError::InvalidApiVersion(_))
+                ),
+                "apiVersion {bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn api_compatibility_rules() {
+        // Same version is compatible.
+        assert_eq!(check_api_compatibility("1.0"), ApiCompatibility::Compatible);
+        // Bare major matches minor 0.
+        assert_eq!(check_api_compatibility("1"), ApiCompatibility::Compatible);
+        // Lower minor within the same major is compatible.
+        // (host is 1.0, so only minor 0 qualifies here.)
+        // Higher minor is not.
+        assert_eq!(
+            check_api_compatibility("1.1"),
+            ApiCompatibility::Incompatible
+        );
+        // Different major is incompatible in both directions.
+        assert_eq!(
+            check_api_compatibility("2.0"),
+            ApiCompatibility::Incompatible
+        );
+        assert_eq!(
+            check_api_compatibility("0.9"),
+            ApiCompatibility::Incompatible
+        );
+        // Garbage is incompatible.
+        assert_eq!(
+            check_api_compatibility("nope"),
+            ApiCompatibility::Incompatible
+        );
+    }
+}

--- a/core/src/plugin/mod.rs
+++ b/core/src/plugin/mod.rs
@@ -1,0 +1,55 @@
+//! Plugin package format and manifest contract.
+//!
+//! This module is the *foundation* of termiHub's plugin system (see
+//! `docs/concepts/future/plugin-system.html`, impl §1–2): it defines the
+//! on-disk package format, the `manifest.json` data model, and the validator
+//! every other part of the plugin system builds on. It performs **no**
+//! installation, dynamic-library loading, or UI — only the format contract and
+//! its validation.
+//!
+//! # The `.termihub-plugin` package format
+//!
+//! A plugin is distributed as a single `.termihub-plugin` file: a ZIP archive
+//! with a fixed layout.
+//!
+//! ```text
+//! my-plugin.termihub-plugin (ZIP)
+//! ├── manifest.json           # required — plugin metadata and declarations
+//! ├── backend/                # optional — Rust dynamic library
+//! │   ├── my_plugin.dll       #   Windows
+//! │   ├── libmy_plugin.so     #   Linux
+//! │   └── libmy_plugin.dylib  #   macOS
+//! ├── frontend/               # optional — JavaScript/CSS assets
+//! │   ├── index.js            #   frontend entry point
+//! │   └── styles.css          #   styles
+//! ├── themes/                 # optional — ThemeDefinition JSON files
+//! │   └── dracula.json
+//! └── README.md               # optional — plugin documentation
+//! ```
+//!
+//! Only `manifest.json` is required. The whole file must not exceed
+//! [`MAX_PACKAGE_SIZE_BYTES`] (50 MB), which is enforced before the archive is
+//! opened.
+//!
+//! # Validation
+//!
+//! [`validate_package`] is the entry point: it checks the size, opens the ZIP,
+//! reads and parses `manifest.json`, runs semantic validation, and confirms
+//! API-version compatibility — returning a trusted [`PluginManifest`] or a
+//! descriptive [`PluginPackageError`]. API incompatibility is surfaced as its
+//! own distinct outcome so callers can prompt the user to update rather than
+//! treating it as a malformed package.
+
+mod manifest;
+mod package;
+
+pub use manifest::{
+    check_api_compatibility, parse_manifest, ApiCompatibility, ManifestParseError,
+    ManifestValidationError, Platform, PluginExtensions, PluginManifest, PluginPermission,
+    PluginSettingSchema, ProtocolParserExtension, SettingType, StatusBarWidgetExtension,
+    TerminalBackendExtension, ThemeEntry, ThemeExtension, WidgetPosition,
+    CURRENT_PLUGIN_API_VERSION,
+};
+pub use package::{
+    validate_package, PluginPackageError, MANIFEST_FILE_NAME, MAX_PACKAGE_SIZE_BYTES,
+};

--- a/core/src/plugin/package.rs
+++ b/core/src/plugin/package.rs
@@ -1,0 +1,283 @@
+//! `.termihub-plugin` package-structure validation.
+//!
+//! A package is a ZIP archive (see the module-level docs on [`crate::plugin`]
+//! for the layout). [`validate_package`] performs the full format contract
+//! check: enforce the size limit *before* opening, open the archive, read and
+//! parse the required `manifest.json`, run semantic manifest validation, and
+//! finally confirm API-version compatibility as a distinct outcome.
+
+use std::io::Read;
+use std::path::Path;
+
+use thiserror::Error;
+use zip::ZipArchive;
+
+use super::manifest::{
+    parse_manifest, ApiCompatibility, ManifestParseError, ManifestValidationError, PluginManifest,
+    CURRENT_PLUGIN_API_VERSION,
+};
+
+/// The required manifest entry at the root of every package.
+pub const MANIFEST_FILE_NAME: &str = "manifest.json";
+
+/// Maximum accepted `.termihub-plugin` file size: 50 MB (concept "Edge Cases").
+/// Enforced against the on-disk file length *before* the archive is opened, so
+/// an oversize package is rejected without any decompression.
+pub const MAX_PACKAGE_SIZE_BYTES: u64 = 50 * 1024 * 1024;
+
+/// Everything that can go wrong validating a `.termihub-plugin` package.
+///
+/// [`IncompatibleApiVersion`](PluginPackageError::IncompatibleApiVersion) is a
+/// deliberately distinct outcome from the other, structural failures: the
+/// package is well-formed but targets an API this host cannot load.
+#[derive(Debug, Error)]
+pub enum PluginPackageError {
+    /// The package file could not be read from disk.
+    #[error("could not read plugin package: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The file is larger than [`MAX_PACKAGE_SIZE_BYTES`].
+    #[error("plugin package is {actual} bytes, exceeding the {max}-byte limit")]
+    TooLarge {
+        /// Actual on-disk size in bytes.
+        actual: u64,
+        /// The enforced maximum in bytes.
+        max: u64,
+    },
+
+    /// The file is not a readable ZIP archive.
+    #[error("plugin package is not a valid ZIP archive: {0}")]
+    InvalidArchive(String),
+
+    /// The archive has no `manifest.json` at its root.
+    #[error("plugin package is missing the required `{MANIFEST_FILE_NAME}` entry")]
+    MissingManifest,
+
+    /// `manifest.json` could not be deserialized/validated (malformed JSON,
+    /// unknown/missing field, unknown permission, …).
+    #[error(transparent)]
+    ManifestParse(#[from] ManifestParseError),
+
+    /// `manifest.json` deserialized but failed semantic validation.
+    #[error(transparent)]
+    ManifestInvalid(#[from] ManifestValidationError),
+
+    /// The manifest is valid but its `apiVersion` is incompatible with the host.
+    #[error("plugin targets API version `{declared}` but this host supports `{supported}`")]
+    IncompatibleApiVersion {
+        /// The version the plugin declared.
+        declared: String,
+        /// The version this host supports ([`CURRENT_PLUGIN_API_VERSION`]).
+        supported: String,
+    },
+}
+
+/// Open and fully validate a `.termihub-plugin` package at `path`, returning its
+/// trusted [`PluginManifest`] on success.
+///
+/// This does **not** extract the archive; it only reads `manifest.json`. The
+/// order of checks is deliberate — the size limit is enforced before the
+/// archive is even opened.
+pub fn validate_package(path: &Path) -> Result<PluginManifest, PluginPackageError> {
+    validate_package_with_limit(path, MAX_PACKAGE_SIZE_BYTES)
+}
+
+/// [`validate_package`] with an explicit size limit. Factored out so the size
+/// enforcement can be exercised without materializing a 50 MB fixture.
+fn validate_package_with_limit(
+    path: &Path,
+    max_bytes: u64,
+) -> Result<PluginManifest, PluginPackageError> {
+    let metadata = std::fs::metadata(path)?;
+    if metadata.len() > max_bytes {
+        return Err(PluginPackageError::TooLarge {
+            actual: metadata.len(),
+            max: max_bytes,
+        });
+    }
+
+    let file = std::fs::File::open(path)?;
+    let mut archive =
+        ZipArchive::new(file).map_err(|e| PluginPackageError::InvalidArchive(e.to_string()))?;
+
+    let manifest_json = {
+        let mut entry = match archive.by_name(MANIFEST_FILE_NAME) {
+            Ok(entry) => entry,
+            Err(zip::result::ZipError::FileNotFound) => {
+                return Err(PluginPackageError::MissingManifest)
+            }
+            Err(e) => return Err(PluginPackageError::InvalidArchive(e.to_string())),
+        };
+        let mut buf = String::new();
+        entry.read_to_string(&mut buf)?;
+        buf
+    };
+
+    let manifest = parse_manifest(&manifest_json)?;
+    manifest.validate()?;
+
+    match manifest.api_compatibility() {
+        ApiCompatibility::Compatible => Ok(manifest),
+        ApiCompatibility::Incompatible => Err(PluginPackageError::IncompatibleApiVersion {
+            declared: manifest.api_version.clone(),
+            supported: CURRENT_PLUGIN_API_VERSION.to_string(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+
+    fn good_manifest_json() -> String {
+        r#"{
+            "id": "k8s-exec",
+            "name": "Kubernetes Exec",
+            "version": "1.2.0",
+            "author": "k8s-contrib",
+            "description": "Terminal backend for Kubernetes pod exec sessions",
+            "license": "MIT",
+            "apiVersion": "1.0",
+            "platforms": ["linux", "macos"],
+            "permissions": ["terminal", "network"],
+            "extensions": {
+                "terminalBackend": {
+                    "connectionType": "k8s-exec",
+                    "displayName": "Kubernetes Exec",
+                    "configSchema": {}
+                }
+            }
+        }"#
+        .to_string()
+    }
+
+    /// Build a ZIP package on disk. `manifest` is written as `manifest.json`
+    /// when `Some`; extra entries let a test add non-manifest files.
+    fn make_package(manifest: Option<&str>, extra: &[(&str, &[u8])]) -> NamedTempFile {
+        let file = NamedTempFile::new().unwrap();
+        let mut zip = ZipWriter::new(file.reopen().unwrap());
+        let opts = SimpleFileOptions::default();
+        if let Some(m) = manifest {
+            zip.start_file(MANIFEST_FILE_NAME, opts).unwrap();
+            zip.write_all(m.as_bytes()).unwrap();
+        }
+        for (name, bytes) in extra {
+            zip.start_file(*name, opts).unwrap();
+            zip.write_all(bytes).unwrap();
+        }
+        zip.finish().unwrap();
+        file
+    }
+
+    #[test]
+    fn accepts_a_valid_package() {
+        let pkg = make_package(
+            Some(&good_manifest_json()),
+            &[("README.md", b"# hi"), ("themes/dracula.json", b"{}")],
+        );
+        let manifest = validate_package(pkg.path()).expect("valid package");
+        assert_eq!(manifest.id, "k8s-exec");
+    }
+
+    #[test]
+    fn rejects_missing_manifest() {
+        let pkg = make_package(None, &[("README.md", b"# hi")]);
+        let err = validate_package(pkg.path()).unwrap_err();
+        assert!(
+            matches!(err, PluginPackageError::MissingManifest),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_non_zip_file() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(b"this is definitely not a zip archive")
+            .unwrap();
+        file.flush().unwrap();
+        let err = validate_package(file.path()).unwrap_err();
+        assert!(
+            matches!(err, PluginPackageError::InvalidArchive(_)),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_manifest_json() {
+        let pkg = make_package(Some("{ not valid json"), &[]);
+        let err = validate_package(pkg.path()).unwrap_err();
+        assert!(
+            matches!(err, PluginPackageError::ManifestParse(_)),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_permission() {
+        let bad = good_manifest_json()
+            .replace("[\"terminal\", \"network\"]", "[\"terminal\", \"kernel\"]");
+        let pkg = make_package(Some(&bad), &[]);
+        let err = validate_package(pkg.path()).unwrap_err();
+        assert!(
+            matches!(&err, PluginPackageError::ManifestParse(e) if e.to_string().contains("kernel")),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_semantically_invalid_manifest() {
+        let bad = good_manifest_json().replace("\"id\": \"k8s-exec\"", "\"id\": \"../escape\"");
+        let pkg = make_package(Some(&bad), &[]);
+        let err = validate_package(pkg.path()).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                PluginPackageError::ManifestInvalid(ManifestValidationError::InvalidId(_))
+            ),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_incompatible_api_version() {
+        let bad =
+            good_manifest_json().replace("\"apiVersion\": \"1.0\"", "\"apiVersion\": \"2.0\"");
+        let pkg = make_package(Some(&bad), &[]);
+        let err = validate_package(pkg.path()).unwrap_err();
+        match err {
+            PluginPackageError::IncompatibleApiVersion {
+                declared,
+                supported,
+            } => {
+                assert_eq!(declared, "2.0");
+                assert_eq!(supported, CURRENT_PLUGIN_API_VERSION);
+            }
+            other => panic!("expected IncompatibleApiVersion, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn rejects_oversize_package_before_opening() {
+        // A well-formed package, rejected purely on the size limit — proving the
+        // 50 MB check happens before the archive is opened/parsed.
+        let pkg = make_package(Some(&good_manifest_json()), &[]);
+        let actual = std::fs::metadata(pkg.path()).unwrap().len();
+        let err = validate_package_with_limit(pkg.path(), 8).unwrap_err();
+        match err {
+            PluginPackageError::TooLarge { actual: a, max } => {
+                assert_eq!(a, actual);
+                assert_eq!(max, 8);
+            }
+            other => panic!("expected TooLarge, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn size_limit_constant_is_50_mb() {
+        assert_eq!(MAX_PACKAGE_SIZE_BYTES, 50 * 1024 * 1024);
+    }
+}


### PR DESCRIPTION
## Summary

Foundation for the plugin system (`docs/concepts/future/plugin-system.html`, impl §1–2). Defines the on-disk `.termihub-plugin` **package format** and the **manifest** contract every other part of the plugin system builds on — no installation, dynamic-library loading, or UI yet, just the format contract and its validator.

New optional `plugin` feature on `termihub-core` (pulls the `zip` crate). New module `core/src/plugin/`:

- **`PluginManifest`** data model (`id`, `name`, `version`, `author`, `description`, `license`, `apiVersion`, `platforms`, `permissions`, `extensions`, optional `settings`) mirroring the concept's manifest (§2/§6), with strict serde: `deny_unknown_fields`, closed `permission`/`platform` enums, and actionable errors for unknown/missing fields.
- **Semantic validation** (`PluginManifest::validate`): filesystem-safe plugin `id` (slug; blocks path traversal in the install-dir name), non-empty identity fields, parseable `apiVersion`, and at least one declared extension point.
- **`validate_package(path)`**: enforces the **50 MB** size limit *before* opening (concept "Edge Cases"), opens the ZIP via the `zip` crate, reads + parses `manifest.json`, validates it, then checks API-version compatibility against a `CURRENT_PLUGIN_API_VERSION` constant — surfaced as a **distinct `IncompatibleApiVersion` outcome**.
- Package format documented in the module rustdoc (`core/src/plugin/mod.rs`).

## Testing

21 unit tests covering: valid manifest + package, missing manifest, malformed JSON, unknown permission, unknown platform, oversize package (rejected before opening), incompatible API version, plugin-id validation (good/bad incl. `../escape`), no-extensions, bad apiVersion, and serde round-trip.

- `cargo test -p termihub-core --features plugin` — green
- `cargo clippy -p termihub-core --features plugin --all-targets -- -D warnings` — clean
- `cargo fmt --check`, default (no-feature) build, and `cargo test --no-run` (no features) — all pass

Non-user-facing (internal foundation module, no UI), so no changelog fragment.

Closes #1989