### PR TITLE
feat(plugin): add termihub-plugin-api crate with stable backend ABI (Closes #1990)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7691,6 +7691,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "termihub-plugin-api"
+version = "0.1.0"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "termios"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["core", "src-tauri", "agent", "vendor/vnc-rs"]
+members = ["core", "src-tauri", "agent", "plugin-api", "vendor/vnc-rs"]
 # The RDP sidecar (#1747) is a standalone build unit with its OWN Cargo.lock:
 # IronRDP's CredSSP crypto and russh pin incompatible RustCrypto pre-releases,
 # and Cargo allows one version per crate per lockfile (#1725). A workspace

--- a/plugin-api/Cargo.toml
+++ b/plugin-api/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "termihub-plugin-api"
+# Independently versioned from the rest of the workspace: this crate is the
+# ABI contract compiled into BOTH the host and every third-party plugin, so its
+# semver is the plugin-compatibility promise. Bump it (and
+# `CURRENT_PLUGIN_API_VERSION`) deliberately — see the crate docs.
+version = "0.1.0"
+description = "Stable ABI contract for termiHub native (dynamically-loaded) terminal-backend plugins"
+edition = "2021"
+
+[dependencies]
+# Only dependency: ergonomic Rust-side error type. Kept intentionally minimal —
+# this crate is linked into every plugin, so its dependency surface is part of
+# the compatibility contract.
+thiserror = { workspace = true }

--- a/plugin-api/README.md
+++ b/plugin-api/README.md
@@ -1,0 +1,61 @@
+# termihub-plugin-api
+
+The **stable ABI contract** for termiHub native (dynamically-loaded)
+terminal-backend plugins. This crate is compiled into **both** the termiHub host
+and every third-party plugin, so it is the shared boundary between them — and its
+ABI stability is the whole point.
+
+## What this crate is (and is not)
+
+It defines the *contract*: the metadata a plugin reports, the session-config it
+receives, the output channel it writes to, the backend trait it implements, and
+the exported symbols its dynamic library must provide. It does **not** contain
+the host-side loader (that lives in a separate crate/issue), and it links no
+`libloading`.
+
+## Why the boundary is hand-rolled `#[repr(C)]`
+
+Rust has **no stable ABI**: the layout of `String`, `&[u8]`, `dyn Trait` fat
+pointers, and most enums is not guaranteed across compiler versions or builds.
+The plugin-system concept originally sketched returning
+`*mut dyn PluginTerminalBackend` across `extern "C"` — this is **undefined
+behavior**, because a `dyn` fat pointer's vtable layout is not guaranteed to
+match between a host and a separately-compiled plugin.
+
+Instead, everything that crosses the boundary is either a `#[repr(C)]` struct of
+FFI-safe fields, or an **opaque handle** (`*mut c_void`) plus a `#[repr(C)]`
+vtable / callback of `extern "C"` function pointers. No `dyn` pointer, `String`,
+or allocator ever crosses. Every owned resource carries its own destructor
+function pointer, so each side frees only what it allocated.
+
+This is the hand-written opaque-handle C ABI sanctioned by the design correction
+in issue #1990 (the alternative was the `abi_stable` crate). It was chosen to
+keep this every-plugin-links-it crate free of a heavy dependency and its
+version-pinning constraints, and because it maps directly onto the FFI-safety
+acceptance test (`improper_ctypes`).
+
+## Writing a plugin
+
+1. Add `termihub-plugin-api` as a dependency and build a `cdylib`.
+2. Implement `PluginTerminalBackend` for your session type
+   (`write_input` / `resize` / `close` / `is_alive`).
+3. Export the four `extern "C"` entry points (names live in
+   `termihub_plugin_api::symbols`):
+
+   | Symbol | Purpose |
+   | --- | --- |
+   | `termihub_plugin_abi_version` | Return `CURRENT_PLUGIN_API_VERSION` you built against. |
+   | `termihub_plugin_init` | Fill an out `PluginInfo` with your metadata. |
+   | `termihub_plugin_create_backend` | Build a backend from the borrowed config + host output sender; return it via `PluginBackend::from_boxed`. |
+   | `termihub_plugin_shutdown` | Process-wide cleanup before unload. |
+
+The host checks your reported ABI version against its own and refuses
+incompatible plugins.
+
+See the crate-level rustdoc for a complete, compiling round-trip example.
+
+## Versioning
+
+`CURRENT_PLUGIN_API_VERSION` is the machine-readable half of the compatibility
+promise; the crate's semver is the other half. Bump both deliberately whenever
+the ABI changes in a way that breaks previously-built plugins.

--- a/plugin-api/src/backend.rs
+++ b/plugin-api/src/backend.rs
@@ -1,0 +1,244 @@
+//! The terminal-backend contract: a safe Rust trait for plugin authors, and the
+//! stable `#[repr(C)]` vtable that actually crosses the ABI.
+//!
+//! ## Why not `*mut dyn PluginTerminalBackend`
+//!
+//! The originating concept sketched
+//! `extern "C" fn plugin_create_backend(...) -> *mut dyn PluginTerminalBackend`.
+//! A `*mut dyn Trait` is a **fat pointer** carrying a pointer to a Rust vtable
+//! whose layout is not part of any stable ABI. Passing it between a host and a
+//! plugin built with a different compiler/version is undefined behavior. This
+//! module instead exposes:
+//!
+//! * an **opaque state pointer** (`*mut c_void`) the host never dereferences, and
+//! * a `#[repr(C)]` [`PluginBackendVTable`] of `extern "C"` function pointers,
+//!
+//! so only thin, FFI-safe pointers ever cross. The plugin's real
+//! `Box<dyn PluginTerminalBackend>` stays entirely inside the plugin.
+
+use core::ffi::c_void;
+use std::panic::AssertUnwindSafe;
+
+use crate::error::{PluginError, PluginStatus};
+use crate::ffi::FfiByteSlice;
+
+/// The behavior a plugin terminal backend implements. Plugin authors write a
+/// normal Rust type implementing this trait; [`PluginBackend::from_boxed`] wraps
+/// it into the FFI-safe representation.
+///
+/// Mirrors the host's internal process-handle contract (`write_input`, `resize`,
+/// `close`, `is_alive`) so a plugin backend slots into the same session
+/// machinery as the built-in backends.
+///
+/// Implementations must be [`Send`]: backends live off the UI thread and are
+/// driven from session-manager / RPC threads.
+pub trait PluginTerminalBackend: Send {
+    /// Write input bytes (keystrokes / control sequences) to the session.
+    fn write_input(&self, data: &[u8]) -> Result<(), PluginError>;
+
+    /// Resize the session's terminal to `cols` x `rows`.
+    fn resize(&self, cols: u16, rows: u16) -> Result<(), PluginError>;
+
+    /// Gracefully close the session, releasing its resources.
+    fn close(&self) -> Result<(), PluginError>;
+
+    /// Report whether the underlying session is still running.
+    fn is_alive(&self) -> bool;
+}
+
+/// Boxed trait object, double-boxed so a **thin** pointer represents it across
+/// the ABI. `*mut BoxedBackend` is thin (a pointer to the fat `Box`), whereas
+/// `*mut dyn PluginTerminalBackend` would be fat.
+type BoxedBackend = Box<dyn PluginTerminalBackend>;
+
+/// Stable, `#[repr(C)]` table of `extern "C"` function pointers implementing the
+/// backend behavior against an opaque state pointer.
+///
+/// Every function takes the backend's opaque `state` (produced by
+/// [`PluginBackend::from_boxed`]) as its first argument. All are
+/// `unsafe extern "C"`: they dereference `state` and must only be called with a
+/// `state` produced by the same plugin.
+#[repr(C)]
+pub struct PluginBackendVTable {
+    /// See [`PluginTerminalBackend::write_input`].
+    pub write_input: unsafe extern "C" fn(state: *mut c_void, data: FfiByteSlice) -> PluginStatus,
+    /// See [`PluginTerminalBackend::resize`].
+    pub resize: unsafe extern "C" fn(state: *mut c_void, cols: u16, rows: u16) -> PluginStatus,
+    /// See [`PluginTerminalBackend::close`].
+    pub close: unsafe extern "C" fn(state: *mut c_void) -> PluginStatus,
+    /// See [`PluginTerminalBackend::is_alive`].
+    pub is_alive: unsafe extern "C" fn(state: *mut c_void) -> bool,
+    /// Drop the backend and free its `state`. Called exactly once, by the host,
+    /// when it is done with the backend.
+    pub destroy: unsafe extern "C" fn(state: *mut c_void),
+}
+
+/// FFI-safe handle to a plugin-created backend: an opaque `state` pointer plus a
+/// pointer to its (usually `'static`) [`PluginBackendVTable`].
+///
+/// Returned by out-parameter from `plugin_create_backend`. The host wraps it in
+/// a [`LoadedBackend`] for safe use.
+#[repr(C)]
+pub struct PluginBackend {
+    /// Opaque backend state; only the producing plugin may interpret it.
+    pub state: *mut c_void,
+    /// Pointer to the vtable implementing this backend's behavior.
+    pub vtable: *const PluginBackendVTable,
+}
+
+impl PluginBackend {
+    /// Wrap a boxed trait object into the FFI-safe representation.
+    ///
+    /// Call this inside a plugin's `plugin_create_backend` to hand a backend
+    /// back to the host. The returned [`PluginBackend`] owns the box; it is
+    /// released when the host calls the vtable's `destroy`.
+    #[must_use]
+    pub fn from_boxed(backend: BoxedBackend) -> Self {
+        // Double-box: the outer `Box` is a thin pointer to the fat inner box, so
+        // only a thin `*mut c_void` crosses the ABI.
+        let boxed: Box<BoxedBackend> = Box::new(backend);
+        Self {
+            state: Box::into_raw(boxed).cast::<c_void>(),
+            vtable: &VTABLE,
+        }
+    }
+}
+
+/// Run `f` (which borrows the backend from `state`) with a panic guard, mapping
+/// its result to a status. Panics are contained rather than unwinding across
+/// FFI, which would be undefined behavior.
+///
+/// # Safety
+///
+/// `state` must be a live `*mut BoxedBackend` produced by
+/// [`PluginBackend::from_boxed`].
+unsafe fn with_backend<F>(state: *mut c_void, f: F) -> PluginStatus
+where
+    F: FnOnce(&BoxedBackend) -> Result<(), PluginError>,
+{
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        // SAFETY: caller guarantees `state` is a live `*mut BoxedBackend`.
+        let backend = unsafe { &*state.cast::<BoxedBackend>() };
+        f(backend)
+    }));
+    match result {
+        Ok(r) => PluginStatus::from_result(r),
+        Err(_) => PluginStatus::Panic,
+    }
+}
+
+unsafe extern "C" fn vt_write_input(state: *mut c_void, data: FfiByteSlice) -> PluginStatus {
+    // SAFETY: `state` is a live backend; `data` is a valid borrowed slice for the
+    // duration of the call.
+    unsafe { with_backend(state, |b| b.write_input(data.as_slice())) }
+}
+
+unsafe extern "C" fn vt_resize(state: *mut c_void, cols: u16, rows: u16) -> PluginStatus {
+    // SAFETY: `state` is a live backend.
+    unsafe { with_backend(state, |b| b.resize(cols, rows)) }
+}
+
+unsafe extern "C" fn vt_close(state: *mut c_void) -> PluginStatus {
+    // SAFETY: `state` is a live backend.
+    unsafe { with_backend(state, |b| b.close()) }
+}
+
+unsafe extern "C" fn vt_is_alive(state: *mut c_void) -> bool {
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        // SAFETY: `state` is a live `*mut BoxedBackend`.
+        let backend = unsafe { &*state.cast::<BoxedBackend>() };
+        backend.is_alive()
+    }));
+    result.unwrap_or(false)
+}
+
+unsafe extern "C" fn vt_destroy(state: *mut c_void) {
+    if state.is_null() {
+        return;
+    }
+    // SAFETY: reclaims the double-box leaked in `from_boxed`, exactly once.
+    let boxed = unsafe { Box::from_raw(state.cast::<BoxedBackend>()) };
+    // Contain any panic from the backend's `Drop` rather than unwinding across FFI.
+    let _ = std::panic::catch_unwind(AssertUnwindSafe(move || drop(boxed)));
+}
+
+/// The single shared vtable. It is generic-free — every entry operates on
+/// `BoxedBackend` — so one `'static` instance serves all backends.
+static VTABLE: PluginBackendVTable = PluginBackendVTable {
+    write_input: vt_write_input,
+    resize: vt_resize,
+    close: vt_close,
+    is_alive: vt_is_alive,
+    destroy: vt_destroy,
+};
+
+/// Safe host-side wrapper over a [`PluginBackend`].
+///
+/// Provides ergonomic, panic-guarded methods that dispatch through the vtable,
+/// and drops the backend (via the vtable's `destroy`) when it goes out of scope.
+/// The host loader (a separate issue) returns these to the session manager.
+pub struct LoadedBackend {
+    inner: PluginBackend,
+}
+
+// SAFETY: `PluginTerminalBackend: Send`, and the vtable functions only touch the
+// owned backend state, so the wrapper is safe to move between threads.
+unsafe impl Send for LoadedBackend {}
+
+impl LoadedBackend {
+    /// Adopt a raw [`PluginBackend`] returned by a plugin.
+    ///
+    /// # Safety
+    ///
+    /// `backend.state`/`backend.vtable` must be valid and produced by a
+    /// compatible plugin, and ownership of them is transferred to the wrapper
+    /// (which will call `destroy` exactly once, on drop).
+    #[must_use]
+    pub unsafe fn from_raw(backend: PluginBackend) -> Self {
+        Self { inner: backend }
+    }
+
+    fn vtable(&self) -> &PluginBackendVTable {
+        // SAFETY: `vtable` is a valid pointer for the wrapper's lifetime (upheld
+        // by the `from_raw` contract; in-process backends point at `VTABLE`).
+        unsafe { &*self.inner.vtable }
+    }
+
+    /// Write input bytes to the backend. See [`PluginTerminalBackend::write_input`].
+    pub fn write_input(&self, data: &[u8]) -> Result<(), PluginError> {
+        // SAFETY: `state` is owned and valid; `data` outlives the call.
+        let status = unsafe {
+            (self.vtable().write_input)(self.inner.state, FfiByteSlice::from_slice(data))
+        };
+        status.into_result()
+    }
+
+    /// Resize the backend's terminal. See [`PluginTerminalBackend::resize`].
+    pub fn resize(&self, cols: u16, rows: u16) -> Result<(), PluginError> {
+        // SAFETY: `state` is owned and valid.
+        let status = unsafe { (self.vtable().resize)(self.inner.state, cols, rows) };
+        status.into_result()
+    }
+
+    /// Close the backend. See [`PluginTerminalBackend::close`].
+    pub fn close(&self) -> Result<(), PluginError> {
+        // SAFETY: `state` is owned and valid.
+        let status = unsafe { (self.vtable().close)(self.inner.state) };
+        status.into_result()
+    }
+
+    /// Report whether the backend is still alive. See
+    /// [`PluginTerminalBackend::is_alive`].
+    #[must_use]
+    pub fn is_alive(&self) -> bool {
+        // SAFETY: `state` is owned and valid.
+        unsafe { (self.vtable().is_alive)(self.inner.state) }
+    }
+}
+
+impl Drop for LoadedBackend {
+    fn drop(&mut self) {
+        // SAFETY: `state` is owned and valid; `destroy` is called exactly once.
+        unsafe { (self.vtable().destroy)(self.inner.state) };
+    }
+}

--- a/plugin-api/src/error.rs
+++ b/plugin-api/src/error.rs
@@ -1,0 +1,132 @@
+//! Error and status types for the plugin ABI.
+//!
+//! Two representations exist by design:
+//!
+//! * [`PluginError`] — a rich, ergonomic Rust enum used *within* either side of
+//!   the boundary (plugin authors return it from the safe trait; the host gets
+//!   it back from the safe wrapper). It carries strings and is **not** FFI-safe.
+//! * [`PluginStatus`] — a `#[repr(i32)]` C-style code that actually crosses the
+//!   ABI. It is FFI-safe but lossy: it conveys the *kind* of failure, not any
+//!   attached message. The safe wrappers translate between the two.
+
+/// Rich, Rust-side error type for plugin backends and the host wrapper.
+///
+/// This type is **not** passed across the FFI boundary — [`PluginStatus`] is.
+#[derive(Debug, thiserror::Error)]
+pub enum PluginError {
+    /// The host's output channel has been closed; no further output can be
+    /// delivered. Typically means the session was torn down.
+    #[error("plugin output channel is closed")]
+    ChannelClosed,
+
+    /// The backend is no longer alive and cannot service the request.
+    #[error("plugin backend is not alive")]
+    NotAlive,
+
+    /// The `config_json` handed to the backend could not be parsed or was
+    /// semantically invalid.
+    #[error("invalid plugin session configuration: {0}")]
+    InvalidConfig(String),
+
+    /// An I/O error occurred inside the backend.
+    #[error("plugin backend i/o error: {0}")]
+    Io(String),
+
+    /// The plugin was built against an incompatible ABI version.
+    #[error("plugin API version mismatch: host supports {expected}, plugin built against {found}")]
+    VersionMismatch {
+        /// ABI version the host supports ([`crate::CURRENT_PLUGIN_API_VERSION`]).
+        expected: u32,
+        /// ABI version the plugin reported.
+        found: u32,
+    },
+
+    /// The plugin unwound (panicked) across the FFI boundary; the safe wrappers
+    /// catch this rather than letting it become undefined behavior.
+    #[error("plugin panicked across the FFI boundary")]
+    Panicked,
+
+    /// Any other failure the plugin wishes to report.
+    #[error("plugin error: {0}")]
+    Other(String),
+}
+
+/// FFI-safe status code returned by ABI functions.
+///
+/// This is the value that actually crosses the boundary. It is intentionally a
+/// field-less `#[repr(i32)]` enum so it is guaranteed FFI-safe and stable. It
+/// cannot carry a message — map it back to a [`PluginError`] with
+/// [`PluginStatus::into_result`] for a human-readable (if generic) description.
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginStatus {
+    /// Success.
+    Ok = 0,
+    /// Maps to [`PluginError::ChannelClosed`].
+    ChannelClosed = 1,
+    /// Maps to [`PluginError::NotAlive`].
+    NotAlive = 2,
+    /// Maps to [`PluginError::InvalidConfig`].
+    InvalidConfig = 3,
+    /// Maps to [`PluginError::Io`].
+    Io = 4,
+    /// Maps to [`PluginError::VersionMismatch`].
+    VersionMismatch = 5,
+    /// Maps to [`PluginError::Panicked`]; also returned when a plugin function
+    /// unwinds and the wrapper contains the panic.
+    Panic = 6,
+    /// Maps to [`PluginError::Other`].
+    Other = 7,
+}
+
+impl PluginStatus {
+    /// Collapse a `Result<(), PluginError>` into a status code (dropping any
+    /// attached message).
+    #[must_use]
+    pub fn from_result(result: Result<(), PluginError>) -> Self {
+        match result {
+            Ok(()) => Self::Ok,
+            Err(e) => Self::from_error(&e),
+        }
+    }
+
+    /// The status code corresponding to a given [`PluginError`] variant.
+    #[must_use]
+    pub fn from_error(error: &PluginError) -> Self {
+        match error {
+            PluginError::ChannelClosed => Self::ChannelClosed,
+            PluginError::NotAlive => Self::NotAlive,
+            PluginError::InvalidConfig(_) => Self::InvalidConfig,
+            PluginError::Io(_) => Self::Io,
+            PluginError::VersionMismatch { .. } => Self::VersionMismatch,
+            PluginError::Panicked => Self::Panic,
+            PluginError::Other(_) => Self::Other,
+        }
+    }
+
+    /// Whether this status represents success.
+    #[must_use]
+    pub fn is_ok(self) -> bool {
+        matches!(self, Self::Ok)
+    }
+
+    /// Expand a status code back into a `Result<(), PluginError>`.
+    ///
+    /// Because the code carries no payload, the reconstructed error uses a
+    /// generic message for the string-bearing variants.
+    pub fn into_result(self) -> Result<(), PluginError> {
+        match self {
+            Self::Ok => Ok(()),
+            Self::ChannelClosed => Err(PluginError::ChannelClosed),
+            Self::NotAlive => Err(PluginError::NotAlive),
+            Self::InvalidConfig => Err(PluginError::InvalidConfig("reported by plugin".to_owned())),
+            Self::Io => Err(PluginError::Io("reported by plugin".to_owned())),
+            Self::VersionMismatch => Err(PluginError::VersionMismatch {
+                expected: crate::CURRENT_PLUGIN_API_VERSION,
+                found: 0,
+            }),
+            Self::Panic => Err(PluginError::Panicked),
+            Self::Other => Err(PluginError::Other("reported by plugin".to_owned())),
+        }
+    }
+}

--- a/plugin-api/src/ffi.rs
+++ b/plugin-api/src/ffi.rs
@@ -1,0 +1,230 @@
+//! FFI-safe primitive carriers used throughout the plugin ABI.
+//!
+//! These `#[repr(C)]` types replace `&[u8]`, `&str` and `String` at the ABI
+//! boundary, because Rust's own slice/`String` layout is not part of any stable
+//! ABI and must never be passed between separately-compiled dynamic libraries.
+//!
+//! Ownership rule for the whole ABI: **every owned resource carries its own
+//! destructor function pointer.** A buffer allocated inside a plugin is freed by
+//! calling the plugin's own free function (which travels with the data), never
+//! by the host's allocator. That is what makes it sound to move ownership across
+//! the boundary even though the two sides may be built with different compilers.
+
+use std::ptr::NonNull;
+
+/// A non-owning, FFI-safe view over a byte slice — the ABI equivalent of
+/// `&[u8]`.
+///
+/// The pointed-to bytes are borrowed: the value is only valid for as long as the
+/// producer keeps the backing buffer alive, exactly like `&[u8]`. It is `Copy`
+/// because it owns nothing.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct FfiByteSlice {
+    /// Pointer to the first byte. May be dangling (but non-null) when `len == 0`.
+    pub ptr: *const u8,
+    /// Number of bytes.
+    pub len: usize,
+}
+
+impl FfiByteSlice {
+    /// Borrow a Rust slice as an [`FfiByteSlice`].
+    ///
+    /// The returned value borrows `slice`; it must not outlive it.
+    #[must_use]
+    pub fn from_slice(slice: &[u8]) -> Self {
+        Self {
+            ptr: slice.as_ptr(),
+            len: slice.len(),
+        }
+    }
+
+    /// An empty slice (`len == 0`, dangling non-null pointer).
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            ptr: NonNull::dangling().as_ptr(),
+            len: 0,
+        }
+    }
+
+    /// Reconstruct a `&[u8]` from the raw parts.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that `ptr`/`len` describe a valid, initialised
+    /// byte region that stays alive and immutable for the entire chosen
+    /// lifetime `'a`. This is upheld when the value was produced by
+    /// [`FfiByteSlice::from_slice`] and the source slice is still borrowed.
+    #[must_use]
+    pub unsafe fn as_slice<'a>(self) -> &'a [u8] {
+        if self.len == 0 {
+            &[]
+        } else {
+            // SAFETY: guaranteed valid by the caller's contract above.
+            unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+        }
+    }
+}
+
+/// A non-owning, FFI-safe view over a UTF-8 string — the ABI equivalent of
+/// `&str`.
+///
+/// Like [`FfiByteSlice`] the bytes are borrowed, and they are additionally
+/// promised to be valid UTF-8 by the producer.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct FfiStr {
+    /// Pointer to the first byte. May be dangling (but non-null) when `len == 0`.
+    pub ptr: *const u8,
+    /// Length in bytes (not chars).
+    pub len: usize,
+}
+
+impl FfiStr {
+    /// Borrow a `&str` as an [`FfiStr`]. The result borrows `s`.
+    #[must_use]
+    pub fn new(s: &str) -> Self {
+        Self {
+            ptr: s.as_ptr(),
+            len: s.len(),
+        }
+    }
+
+    /// An empty string.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            ptr: NonNull::dangling().as_ptr(),
+            len: 0,
+        }
+    }
+
+    /// Reconstruct a `&str`.
+    ///
+    /// # Safety
+    ///
+    /// In addition to the pointer-validity contract of
+    /// [`FfiByteSlice::as_slice`], the bytes must be valid UTF-8. Both hold when
+    /// the value came from [`FfiStr::new`] and the source is still borrowed.
+    #[must_use]
+    pub unsafe fn as_str<'a>(self) -> &'a str {
+        let bytes = if self.len == 0 {
+            &[][..]
+        } else {
+            // SAFETY: caller upholds pointer validity.
+            unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+        };
+        // SAFETY: caller upholds the UTF-8 invariant.
+        unsafe { std::str::from_utf8_unchecked(bytes) }
+    }
+}
+
+/// The exact signature of a heap-buffer destructor carried inside an
+/// [`FfiString`]. It receives the raw parts of the original `Vec<u8>`.
+pub type FfiStringFree = unsafe extern "C" fn(ptr: *mut u8, len: usize, cap: usize);
+
+/// An **owned**, FFI-safe UTF-8 string that carries its own destructor.
+///
+/// Ownership can cross the ABI boundary safely because [`FfiString`] embeds the
+/// [`FfiStringFree`] function pointer that allocated it: whoever ends up holding
+/// the value drops it by calling *that* pointer, which runs inside the module
+/// that owns the allocation. The host therefore never frees a plugin's buffer
+/// with its own allocator (and vice-versa).
+#[repr(C)]
+pub struct FfiString {
+    ptr: *mut u8,
+    len: usize,
+    cap: usize,
+    /// `None` for the empty/static string, which owns no allocation.
+    free: Option<FfiStringFree>,
+}
+
+// SAFETY: `FfiString` uniquely owns its heap buffer (move-only, no interior
+// mutability), so it is sound to send it and share `&FfiString` across threads.
+unsafe impl Send for FfiString {}
+unsafe impl Sync for FfiString {}
+
+/// Destructor installed by [`FfiString::from_string`]; reconstitutes and drops
+/// the original `Vec<u8>`.
+///
+/// # Safety
+///
+/// Must be called at most once, with the exact `ptr`/`len`/`cap` a matching
+/// [`FfiString::from_string`] stored. [`FfiString::drop`] upholds this.
+unsafe extern "C" fn ffi_string_free(ptr: *mut u8, len: usize, cap: usize) {
+    if !ptr.is_null() && cap != 0 {
+        // SAFETY: raw parts of the `Vec<u8>` forgotten in `from_string`.
+        drop(unsafe { Vec::from_raw_parts(ptr, len, cap) });
+    }
+}
+
+impl FfiString {
+    /// Take ownership of a `String`, producing an FFI-safe owned string.
+    #[must_use]
+    pub fn from_string(s: String) -> Self {
+        if s.is_empty() {
+            return Self::empty();
+        }
+        let mut bytes = s.into_bytes();
+        let (ptr, len, cap) = (bytes.as_mut_ptr(), bytes.len(), bytes.capacity());
+        std::mem::forget(bytes);
+        Self {
+            ptr,
+            len,
+            cap,
+            free: Some(ffi_string_free),
+        }
+    }
+
+    /// An empty owned string that holds no allocation.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            ptr: NonNull::dangling().as_ptr(),
+            len: 0,
+            cap: 0,
+            free: None,
+        }
+    }
+
+    /// Borrow the contents as bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        if self.len == 0 {
+            &[]
+        } else {
+            // SAFETY: `ptr`/`len` describe the live, owned buffer.
+            unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+        }
+    }
+
+    /// Borrow the contents as `&str`.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        // SAFETY: the buffer was built from a `String`, hence valid UTF-8.
+        unsafe { std::str::from_utf8_unchecked(self.as_bytes()) }
+    }
+}
+
+impl Drop for FfiString {
+    fn drop(&mut self) {
+        if let Some(free) = self.free.take() {
+            // SAFETY: called exactly once (guarded by taking `free`), with the
+            // raw parts this value has owned since construction.
+            unsafe { free(self.ptr, self.len, self.cap) };
+        }
+    }
+}
+
+impl From<String> for FfiString {
+    fn from(s: String) -> Self {
+        Self::from_string(s)
+    }
+}
+
+impl From<&str> for FfiString {
+    fn from(s: &str) -> Self {
+        Self::from_string(s.to_owned())
+    }
+}

--- a/plugin-api/src/info.rs
+++ b/plugin-api/src/info.rs
@@ -1,0 +1,78 @@
+//! Plugin metadata and session-configuration carriers.
+
+use crate::ffi::{FfiStr, FfiString};
+
+/// Metadata a plugin reports to the host during initialization.
+///
+/// Returned (by out-parameter) from the plugin's `plugin_init` entry point — see
+/// [`crate::symbols`]. Every string is an **owned** [`FfiString`]: the plugin
+/// allocates them and the host frees them by dropping this struct, which invokes
+/// each field's embedded destructor. That is what lets the strings cross the ABI
+/// boundary soundly.
+#[repr(C)]
+pub struct PluginInfo {
+    /// Stable, unique plugin identifier (e.g. `"k8s-exec"`).
+    pub id: FfiString,
+    /// Human-readable display name.
+    pub name: FfiString,
+    /// Plugin's own semantic version string (independent of the ABI version).
+    pub version: FfiString,
+    /// ABI version the plugin was built against; the host compares this to
+    /// [`crate::CURRENT_PLUGIN_API_VERSION`] and refuses incompatible plugins.
+    pub api_version: u32,
+}
+
+impl PluginInfo {
+    /// Build a [`PluginInfo`], reporting the given ABI `api_version`.
+    ///
+    /// Plugins should pass [`crate::CURRENT_PLUGIN_API_VERSION`].
+    #[must_use]
+    pub fn new(
+        id: impl Into<String>,
+        name: impl Into<String>,
+        version: impl Into<String>,
+        api_version: u32,
+    ) -> Self {
+        Self {
+            id: FfiString::from_string(id.into()),
+            name: FfiString::from_string(name.into()),
+            version: FfiString::from_string(version.into()),
+            api_version,
+        }
+    }
+
+    /// An empty placeholder the host allocates before calling `plugin_init`,
+    /// which the plugin fills in via the out-parameter.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            id: FfiString::empty(),
+            name: FfiString::empty(),
+            version: FfiString::empty(),
+            api_version: 0,
+        }
+    }
+}
+
+/// Configuration handed to a plugin when creating a new terminal session.
+///
+/// `config_json` is a **borrowed** JSON document (owned by the host for the
+/// duration of the `plugin_create_backend` call) whose shape matches the
+/// plugin's declared `configSchema` in its manifest. The plugin parses it and
+/// copies out whatever it needs before the call returns; it must not retain the
+/// borrowed pointer afterwards.
+#[repr(C)]
+pub struct PluginSessionConfig {
+    /// JSON configuration for the session, matching the plugin's `configSchema`.
+    pub config_json: FfiStr,
+}
+
+impl PluginSessionConfig {
+    /// Borrow a JSON string as a session config. The result borrows `config_json`.
+    #[must_use]
+    pub fn new(config_json: &str) -> Self {
+        Self {
+            config_json: FfiStr::new(config_json),
+        }
+    }
+}

--- a/plugin-api/src/lib.rs
+++ b/plugin-api/src/lib.rs
@@ -1,0 +1,116 @@
+//! # termihub-plugin-api
+//!
+//! The **stable ABI contract** for termiHub native terminal-backend plugins.
+//!
+//! termiHub can be extended with terminal backends distributed as native dynamic
+//! libraries (`.dll` / `.so` / `.dylib`). Such backends need direct system
+//! access (PTYs, sockets, serial ports) that a JavaScript plugin cannot provide.
+//! This crate is the shared dependency compiled into **both** the host and every
+//! plugin, and it defines the boundary between them. Its stability is the whole
+//! point: a plugin built against version *N* of this crate must keep working
+//! against a host built against the same major ABI version.
+//!
+//! ## Why the ABI is hand-rolled and `#[repr(C)]`
+//!
+//! Rust has **no stable ABI**. The layout of `String`, `&[u8]`, `dyn Trait` fat
+//! pointers, and most `enum`s can change between compiler versions and even
+//! builds. The plugin-system concept sketched returning
+//! `*mut dyn PluginTerminalBackend` across `extern "C"`; that is undefined
+//! behavior, because the `dyn` fat pointer's vtable layout is not guaranteed to
+//! match between the host and a separately-compiled plugin. See
+//! [`backend`] for the full rationale.
+//!
+//! Instead, everything that crosses the boundary is either:
+//!
+//! * a `#[repr(C)]` struct of FFI-safe fields ([`ffi`], [`info`]), or
+//! * an **opaque handle** (`*mut c_void`) plus a `#[repr(C)]` vtable / callback
+//!   of `extern "C"` function pointers ([`backend::PluginBackendVTable`],
+//!   [`output::PluginOutputSender`]).
+//!
+//! No `dyn` pointer, `String`, or allocator ever crosses. Owned resources carry
+//! their own destructor function pointer, so each side frees what it allocated.
+//! This is the second approach the originating issue sanctioned (a hand-written
+//! opaque-handle C ABI); it was chosen over the `abi_stable` crate to keep this
+//! foundational, every-plugin-links-it crate free of a heavy dependency and its
+//! version-pinning constraints, and because the acceptance criterion — proving
+//! FFI-safety via `improper_ctypes` — maps directly onto hand-written
+//! `extern "C"` signatures (see [`symbols`]).
+//!
+//! ## Writing a plugin
+//!
+//! Depend on this crate, implement [`PluginTerminalBackend`] for your session
+//! type, and export the four entry points documented in [`symbols`]. A minimal
+//! in-process round trip:
+//!
+//! ```
+//! use std::sync::mpsc;
+//! use termihub_plugin_api::{
+//!     LoadedBackend, PluginBackend, PluginError, PluginOutputSender,
+//!     PluginTerminalBackend,
+//! };
+//!
+//! // A trivial backend that echoes input to the host's output channel.
+//! struct EchoBackend {
+//!     output: PluginOutputSender,
+//!     alive: std::sync::atomic::AtomicBool,
+//! }
+//!
+//! impl PluginTerminalBackend for EchoBackend {
+//!     fn write_input(&self, data: &[u8]) -> Result<(), PluginError> {
+//!         self.output.send(data)
+//!     }
+//!     fn resize(&self, _cols: u16, _rows: u16) -> Result<(), PluginError> {
+//!         Ok(())
+//!     }
+//!     fn close(&self) -> Result<(), PluginError> {
+//!         self.alive.store(false, std::sync::atomic::Ordering::SeqCst);
+//!         Ok(())
+//!     }
+//!     fn is_alive(&self) -> bool {
+//!         self.alive.load(std::sync::atomic::Ordering::SeqCst)
+//!     }
+//! }
+//!
+//! // Host side: wire an output channel and hand the sender to the plugin.
+//! let (tx, rx) = mpsc::channel::<Vec<u8>>();
+//! let output = PluginOutputSender::from_sender(tx);
+//!
+//! // Plugin side: build the backend and expose it via the FFI-safe handle.
+//! let backend = PluginBackend::from_boxed(Box::new(EchoBackend {
+//!     output,
+//!     alive: std::sync::atomic::AtomicBool::new(true),
+//! }));
+//!
+//! // Host side: adopt the handle and drive it through the safe wrapper.
+//! let loaded = unsafe { LoadedBackend::from_raw(backend) };
+//! assert!(loaded.is_alive());
+//! loaded.write_input(b"hello").unwrap();
+//! assert_eq!(rx.recv().unwrap(), b"hello".to_vec());
+//! loaded.close().unwrap();
+//! assert!(!loaded.is_alive());
+//! ```
+
+#![deny(missing_docs)]
+#![deny(unsafe_op_in_unsafe_fn)]
+
+pub mod backend;
+pub mod error;
+pub mod ffi;
+pub mod info;
+pub mod output;
+pub mod symbols;
+
+pub use backend::{LoadedBackend, PluginBackend, PluginBackendVTable, PluginTerminalBackend};
+pub use error::{PluginError, PluginStatus};
+pub use ffi::{FfiByteSlice, FfiStr, FfiString};
+pub use info::{PluginInfo, PluginSessionConfig};
+pub use output::PluginOutputSender;
+
+/// The plugin ABI version this crate defines.
+///
+/// A plugin reports the value it was built against (via its
+/// `termihub_plugin_abi_version` / `plugin_init` entry points); the host refuses
+/// to load a plugin whose value is incompatible with its own. Bump this whenever
+/// the ABI changes in a way that breaks previously-built plugins — it is the
+/// machine-readable half of this crate's compatibility promise.
+pub const CURRENT_PLUGIN_API_VERSION: u32 = 1;

--- a/plugin-api/src/output.rs
+++ b/plugin-api/src/output.rs
@@ -1,0 +1,135 @@
+//! Output channel a plugin backend uses to push terminal data to the host.
+
+use core::ffi::c_void;
+
+use crate::error::{PluginError, PluginStatus};
+use crate::ffi::FfiByteSlice;
+
+/// Signature of the host-provided output callback.
+///
+/// Receives the opaque host context and the bytes to deliver, and returns a
+/// status (notably [`PluginStatus::ChannelClosed`] once the session is gone).
+pub type PluginOutputSendFn =
+    unsafe extern "C" fn(ctx: *mut c_void, data: FfiByteSlice) -> PluginStatus;
+
+/// Signature of the destructor for the host-provided output context.
+pub type PluginOutputDestroyFn = unsafe extern "C" fn(ctx: *mut c_void);
+
+/// FFI-safe sink a plugin backend writes terminal output into.
+///
+/// The host constructs it (see [`PluginOutputSender::from_sender`]) and passes
+/// it **by value** to `plugin_create_backend`; the plugin then owns it, stores
+/// it in its backend, and calls [`PluginOutputSender::send`] whenever the child
+/// process produces output. When the backend is dropped, so is the sender, which
+/// runs the host-provided `destroy` callback.
+///
+/// This replaces the concept's `std::sync::mpsc::SyncSender<Vec<u8>>`, which
+/// could not cross the ABI boundary (its layout is not stable), with an
+/// opaque-context + `extern "C"` function pointer that can.
+#[repr(C)]
+pub struct PluginOutputSender {
+    ctx: *mut c_void,
+    send: PluginOutputSendFn,
+    destroy: Option<PluginOutputDestroyFn>,
+}
+
+// SAFETY: the sender uniquely owns `ctx`, and the host guarantees (by
+// constructing it from a `Send` sink) that invoking `send`/`destroy` from the
+// plugin's threads is sound. Backends run off the UI thread, so this must be
+// `Send`.
+unsafe impl Send for PluginOutputSender {}
+
+impl PluginOutputSender {
+    /// Assemble a sender from raw FFI parts.
+    ///
+    /// Mainly for the host loader and for plugins that already hold raw
+    /// callbacks; most host code should prefer [`PluginOutputSender::from_sender`].
+    ///
+    /// # Safety
+    ///
+    /// * `send` (and `destroy`, if any) must be safe to call with `ctx`.
+    /// * `ctx` must remain valid until `destroy` is invoked, and ownership of it
+    ///   is transferred to the returned sender.
+    #[must_use]
+    pub unsafe fn from_raw(
+        ctx: *mut c_void,
+        send: PluginOutputSendFn,
+        destroy: Option<PluginOutputDestroyFn>,
+    ) -> Self {
+        Self { ctx, send, destroy }
+    }
+
+    /// Deliver `data` to the host.
+    ///
+    /// Returns [`PluginError::ChannelClosed`] once the host side has gone away.
+    pub fn send(&self, data: &[u8]) -> Result<(), PluginError> {
+        // SAFETY: `send`/`ctx` were validated at construction and `ctx` is still
+        // owned by `self`.
+        let status = unsafe { (self.send)(self.ctx, FfiByteSlice::from_slice(data)) };
+        status.into_result()
+    }
+}
+
+impl Drop for PluginOutputSender {
+    fn drop(&mut self) {
+        if let Some(destroy) = self.destroy.take() {
+            // SAFETY: called once (guarded by taking `destroy`) with the `ctx`
+            // this sender has owned since construction.
+            unsafe { destroy(self.ctx) };
+        }
+    }
+}
+
+/// Host-side helpers, gated behind nothing — always available so tests and the
+/// loader can wire a real channel to a plugin.
+impl PluginOutputSender {
+    /// Build a sender backed by an `std::sync::mpsc::Sender<Vec<u8>>`.
+    ///
+    /// This is the host-side convenience matching the concept's channel model:
+    /// bytes the plugin sends arrive as `Vec<u8>` on the paired `Receiver`. Each
+    /// [`PluginOutputSender::send`] copies the bytes into an owned `Vec` before
+    /// they cross back, so no borrowed pointer escapes the call.
+    #[must_use]
+    pub fn from_sender(sender: std::sync::mpsc::Sender<Vec<u8>>) -> Self {
+        let boxed = Box::new(sender);
+        let ctx = Box::into_raw(boxed).cast::<c_void>();
+        // SAFETY: `ctx` is a `Box<Sender<Vec<u8>>>` we just leaked; `send`/
+        // `destroy` below only ever interpret it as exactly that, and `destroy`
+        // reclaims it.
+        unsafe { Self::from_raw(ctx, mpsc_send, Some(mpsc_destroy)) }
+    }
+}
+
+/// `send` callback for [`PluginOutputSender::from_sender`].
+///
+/// # Safety
+///
+/// `ctx` must be a live `*mut std::sync::mpsc::Sender<Vec<u8>>`.
+unsafe extern "C" fn mpsc_send(ctx: *mut c_void, data: FfiByteSlice) -> PluginStatus {
+    // SAFETY: `ctx` is the leaked `Box<Sender<Vec<u8>>>`; borrowing it shared is
+    // fine because `Sender::send` takes `&self`. `data` is a valid borrowed
+    // slice for the duration of this call.
+    let result = std::panic::catch_unwind(|| {
+        let sender = unsafe { &*ctx.cast::<std::sync::mpsc::Sender<Vec<u8>>>() };
+        let bytes = unsafe { data.as_slice() }.to_vec();
+        sender.send(bytes)
+    });
+    match result {
+        Ok(Ok(())) => PluginStatus::Ok,
+        Ok(Err(_)) => PluginStatus::ChannelClosed,
+        Err(_) => PluginStatus::Panic,
+    }
+}
+
+/// `destroy` callback for [`PluginOutputSender::from_sender`].
+///
+/// # Safety
+///
+/// `ctx` must be the leaked `Box<std::sync::mpsc::Sender<Vec<u8>>>` and must not
+/// be used afterwards.
+unsafe extern "C" fn mpsc_destroy(ctx: *mut c_void) {
+    if !ctx.is_null() {
+        // SAFETY: reclaims the box leaked in `from_sender`, exactly once.
+        drop(unsafe { Box::from_raw(ctx.cast::<std::sync::mpsc::Sender<Vec<u8>>>()) });
+    }
+}

--- a/plugin-api/src/symbols.rs
+++ b/plugin-api/src/symbols.rs
@@ -1,0 +1,129 @@
+//! The exported-symbol contract every plugin dynamic library must satisfy, plus
+//! a compile-time proof that the boundary is FFI-safe.
+//!
+//! A plugin `cdylib` must export exactly these four `unsafe extern "C"` symbols.
+//! The host loader resolves them by the [`SYMBOL_*`](self) names and calls them
+//! through the matching function-pointer type aliases.
+//!
+//! ```ignore
+//! use termihub_plugin_api::*;
+//!
+//! #[no_mangle]
+//! pub extern "C" fn termihub_plugin_abi_version() -> u32 {
+//!     CURRENT_PLUGIN_API_VERSION
+//! }
+//!
+//! #[no_mangle]
+//! pub unsafe extern "C" fn termihub_plugin_init(out_info: *mut PluginInfo) -> PluginStatus {
+//!     if out_info.is_null() {
+//!         return PluginStatus::Other;
+//!     }
+//!     unsafe {
+//!         out_info.write(PluginInfo::new(
+//!             "k8s-exec", "Kubernetes Exec", "1.2.0", CURRENT_PLUGIN_API_VERSION,
+//!         ));
+//!     }
+//!     PluginStatus::Ok
+//! }
+//!
+//! #[no_mangle]
+//! pub unsafe extern "C" fn termihub_plugin_create_backend(
+//!     config: *const PluginSessionConfig,
+//!     output: PluginOutputSender,
+//!     out_backend: *mut PluginBackend,
+//! ) -> PluginStatus {
+//!     // parse `(*config).config_json`, spawn the session, then:
+//!     let backend = PluginBackend::from_boxed(Box::new(my_backend));
+//!     unsafe { out_backend.write(backend); }
+//!     PluginStatus::Ok
+//! }
+//!
+//! #[no_mangle]
+//! pub extern "C" fn termihub_plugin_shutdown() {}
+//! ```
+
+use crate::backend::PluginBackend;
+use crate::error::PluginStatus;
+use crate::info::{PluginInfo, PluginSessionConfig};
+use crate::output::PluginOutputSender;
+
+/// Symbol name (NUL-terminated for `libloading::Library::get`) of the ABI-version
+/// entry point.
+pub const SYMBOL_PLUGIN_ABI_VERSION: &[u8] = b"termihub_plugin_abi_version\0";
+/// Symbol name of the initialization / metadata entry point.
+pub const SYMBOL_PLUGIN_INIT: &[u8] = b"termihub_plugin_init\0";
+/// Symbol name of the backend-factory entry point.
+pub const SYMBOL_PLUGIN_CREATE_BACKEND: &[u8] = b"termihub_plugin_create_backend\0";
+/// Symbol name of the shutdown entry point.
+pub const SYMBOL_PLUGIN_SHUTDOWN: &[u8] = b"termihub_plugin_shutdown\0";
+
+/// Type of [`SYMBOL_PLUGIN_ABI_VERSION`]: returns the ABI version the plugin was
+/// built against. The host compares it to [`crate::CURRENT_PLUGIN_API_VERSION`]
+/// before calling anything else.
+pub type PluginAbiVersionFn = unsafe extern "C" fn() -> u32;
+
+/// Type of [`SYMBOL_PLUGIN_INIT`]: fills `out_info` with the plugin's metadata.
+/// Ownership of the strings in `*out_info` transfers to the host.
+pub type PluginInitFn = unsafe extern "C" fn(out_info: *mut PluginInfo) -> PluginStatus;
+
+/// Type of [`SYMBOL_PLUGIN_CREATE_BACKEND`]: creates a session backend from the
+/// borrowed `config`, taking ownership of `output`, and writes the resulting
+/// [`PluginBackend`] into `out_backend`.
+pub type PluginCreateBackendFn = unsafe extern "C" fn(
+    config: *const PluginSessionConfig,
+    output: PluginOutputSender,
+    out_backend: *mut PluginBackend,
+) -> PluginStatus;
+
+/// Type of [`SYMBOL_PLUGIN_SHUTDOWN`]: called once before the library is
+/// unloaded, for process-wide cleanup.
+pub type PluginShutdownFn = unsafe extern "C" fn();
+
+/// Compile-time proof that the exported ABI surface is FFI-safe.
+///
+/// The `#[deny(...)]` below turns any `improper_ctypes*` finding into a hard
+/// build error, so this module fails to compile if a type in one of the exported
+/// signatures ever stops being FFI-safe. The functions are never called; they
+/// exist purely so the lint runs over their signatures.
+#[deny(improper_ctypes, improper_ctypes_definitions)]
+#[allow(dead_code)]
+mod ffi_safety_check {
+    use super::*;
+    use crate::ffi::FfiByteSlice;
+
+    // Exported entry points, exactly matching the type aliases above.
+    unsafe extern "C" fn _abi_version() -> u32 {
+        crate::CURRENT_PLUGIN_API_VERSION
+    }
+    unsafe extern "C" fn _init(_out: *mut PluginInfo) -> PluginStatus {
+        PluginStatus::Ok
+    }
+    unsafe extern "C" fn _create(
+        _config: *const PluginSessionConfig,
+        _output: PluginOutputSender,
+        _out: *mut PluginBackend,
+    ) -> PluginStatus {
+        PluginStatus::Ok
+    }
+    unsafe extern "C" fn _shutdown() {}
+
+    // Vtable callback shapes.
+    unsafe extern "C" fn _write_input(
+        _s: *mut core::ffi::c_void,
+        _d: FfiByteSlice,
+    ) -> PluginStatus {
+        PluginStatus::Ok
+    }
+    unsafe extern "C" fn _is_alive(_s: *mut core::ffi::c_void) -> bool {
+        true
+    }
+
+    // Assert the aliases accept the definitions (another layer of the same check).
+    const _: PluginAbiVersionFn = _abi_version;
+    const _: PluginInitFn = _init;
+    const _: PluginCreateBackendFn = _create;
+    const _: PluginShutdownFn = _shutdown;
+    const _: unsafe extern "C" fn(*mut core::ffi::c_void, FfiByteSlice) -> PluginStatus =
+        _write_input;
+    const _: unsafe extern "C" fn(*mut core::ffi::c_void) -> bool = _is_alive;
+}

--- a/plugin-api/tests/roundtrip.rs
+++ b/plugin-api/tests/roundtrip.rs
@@ -1,0 +1,162 @@
+//! End-to-end round-trip tests exercising the ABI types the way the host and a
+//! plugin would across the boundary — but within one process, so no real dylib
+//! is needed. The host loader lives in a separate crate/issue; these tests cover
+//! only the contract this crate defines.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc;
+
+use termihub_plugin_api::{
+    FfiString, LoadedBackend, PluginBackend, PluginError, PluginInfo, PluginOutputSender,
+    PluginSessionConfig, PluginStatus, PluginTerminalBackend, CURRENT_PLUGIN_API_VERSION,
+};
+
+/// A backend whose behavior each test can steer.
+struct TestBackend {
+    output: PluginOutputSender,
+    alive: AtomicBool,
+    panic_on_input: bool,
+}
+
+impl PluginTerminalBackend for TestBackend {
+    fn write_input(&self, data: &[u8]) -> Result<(), PluginError> {
+        assert!(!self.panic_on_input, "boom");
+        self.output.send(data)
+    }
+    fn resize(&self, _cols: u16, _rows: u16) -> Result<(), PluginError> {
+        Ok(())
+    }
+    fn close(&self) -> Result<(), PluginError> {
+        self.alive.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+    fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::SeqCst)
+    }
+}
+
+fn make_backend(panic_on_input: bool) -> (LoadedBackend, mpsc::Receiver<Vec<u8>>) {
+    let (tx, rx) = mpsc::channel::<Vec<u8>>();
+    let backend = PluginBackend::from_boxed(Box::new(TestBackend {
+        output: PluginOutputSender::from_sender(tx),
+        alive: AtomicBool::new(true),
+        panic_on_input,
+    }));
+    // SAFETY: `backend` was just produced by `from_boxed`, so it is valid.
+    let loaded = unsafe { LoadedBackend::from_raw(backend) };
+    (loaded, rx)
+}
+
+#[test]
+fn input_flows_to_output_channel() {
+    let (backend, rx) = make_backend(false);
+    assert!(backend.is_alive());
+    backend.write_input(b"echo me").unwrap();
+    assert_eq!(rx.recv().unwrap(), b"echo me".to_vec());
+    backend.resize(120, 40).unwrap();
+    backend.close().unwrap();
+    assert!(!backend.is_alive());
+}
+
+#[test]
+fn dropped_receiver_reports_channel_closed() {
+    let (backend, rx) = make_backend(false);
+    drop(rx);
+    let err = backend.write_input(b"nowhere").unwrap_err();
+    assert!(matches!(err, PluginError::ChannelClosed));
+}
+
+#[test]
+fn plugin_panic_is_contained_as_status() {
+    // A panic inside the backend must not unwind across the (simulated) FFI
+    // boundary; the wrapper reports it as an error instead of aborting.
+    let (backend, _rx) = make_backend(true);
+    let err = backend.write_input(b"trigger").unwrap_err();
+    assert!(matches!(err, PluginError::Panicked));
+}
+
+#[test]
+fn backend_destroyed_on_drop_without_leak() {
+    // Track construction/destruction via a shared flag in the closure-owned box.
+    static DROPPED: AtomicBool = AtomicBool::new(false);
+    struct DropSpy;
+    impl PluginTerminalBackend for DropSpy {
+        fn write_input(&self, _: &[u8]) -> Result<(), PluginError> {
+            Ok(())
+        }
+        fn resize(&self, _: u16, _: u16) -> Result<(), PluginError> {
+            Ok(())
+        }
+        fn close(&self) -> Result<(), PluginError> {
+            Ok(())
+        }
+        fn is_alive(&self) -> bool {
+            true
+        }
+    }
+    impl Drop for DropSpy {
+        fn drop(&mut self) {
+            DROPPED.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let raw = PluginBackend::from_boxed(Box::new(DropSpy));
+    // SAFETY: freshly produced by `from_boxed`.
+    let backend = unsafe { LoadedBackend::from_raw(raw) };
+    assert!(!DROPPED.load(Ordering::SeqCst));
+    drop(backend);
+    assert!(
+        DROPPED.load(Ordering::SeqCst),
+        "backend must be freed on drop"
+    );
+}
+
+#[test]
+fn plugin_info_owns_and_frees_its_strings() {
+    // Host allocates an empty slot; "plugin" fills it; host reads then drops.
+    let mut info = PluginInfo::empty();
+    assert_eq!(info.id.as_str(), "");
+    info = PluginInfo::new(
+        "k8s-exec",
+        "Kubernetes Exec",
+        "1.2.0",
+        CURRENT_PLUGIN_API_VERSION,
+    );
+    assert_eq!(info.id.as_str(), "k8s-exec");
+    assert_eq!(info.name.as_str(), "Kubernetes Exec");
+    assert_eq!(info.version.as_str(), "1.2.0");
+    assert_eq!(info.api_version, CURRENT_PLUGIN_API_VERSION);
+    drop(info); // must not leak or double-free the embedded FfiStrings
+}
+
+#[test]
+fn session_config_borrows_json() {
+    let json = r#"{"pod":"nginx","namespace":"default"}"#.to_owned();
+    let config = PluginSessionConfig::new(&json);
+    // SAFETY: `json` outlives this borrow.
+    let seen = unsafe { config.config_json.as_str() };
+    assert_eq!(seen, json);
+}
+
+#[test]
+fn ffi_string_round_trips() {
+    let s = FfiString::from_string("héllo".to_owned());
+    assert_eq!(s.as_str(), "héllo");
+    assert_eq!(s.as_bytes(), "héllo".as_bytes());
+    let empty = FfiString::empty();
+    assert_eq!(empty.as_str(), "");
+}
+
+#[test]
+fn status_error_mapping_is_consistent() {
+    assert!(PluginStatus::from_result(Ok(())).is_ok());
+    assert_eq!(
+        PluginStatus::from_error(&PluginError::ChannelClosed),
+        PluginStatus::ChannelClosed,
+    );
+    assert!(matches!(
+        PluginStatus::ChannelClosed.into_result(),
+        Err(PluginError::ChannelClosed),
+    ));
+    assert!(PluginStatus::Ok.into_result().is_ok());
+}


### PR DESCRIPTION
## Summary

Adds the foundation crate **`termihub-plugin-api`** — the stable ABI contract that native (dynamically-loaded) terminal-backend plugins implement, compiled into **both** the host and every plugin. This is the substrate the host loader (#1995) and packaging (#1994) build on; their scope is deliberately excluded.

## Design decision: hand-written opaque-handle C ABI (not `*mut dyn Trait`)

The originating concept (§3) sketched `extern "C" fn plugin_create_backend(...) -> *mut dyn PluginTerminalBackend`. That is **undefined behavior**: a `*mut dyn Trait` is a fat pointer whose Rust vtable layout is not part of any stable ABI, so it cannot be passed between a host and a separately-compiled plugin. Per the issue's design correction, this PR does **not** implement that sketch.

Both sanctioned approaches were on the table (`abi_stable` vs. a hand-written opaque-handle C ABI). I chose the **hand-written opaque-handle C ABI**:

- Everything crossing the boundary is a `#[repr(C)]` struct of FFI-safe fields, or an **opaque handle** (`*mut c_void`) plus a `#[repr(C)]` vtable / callback of `extern "C"` function pointers. No `dyn` pointer, `String`, or allocator ever crosses.
- **Every owned resource carries its own destructor function pointer** (`FfiString`, `PluginOutputSender`, the backend vtable's `destroy`), so each side frees only what it allocated — the key to soundly moving ownership across the boundary.
- Panics are contained with `catch_unwind` at every `extern "C"` entry so a plugin panic never unwinds across FFI (which would be UB).
- Kept this every-plugin-links-it crate free of a heavy dependency and its version-pinning constraints (relevant given the repo's RustCrypto pin conflicts), and maps directly onto the `improper_ctypes` FFI-safety acceptance test.

## What's in the crate

- `CURRENT_PLUGIN_API_VERSION` constant + independently-versioned crate semver.
- `PluginTerminalBackend` safe trait (`write_input` / `resize` / `close` / `is_alive`) + the `#[repr(C)]` `PluginBackendVTable` and `PluginBackend` handle it lowers to; `PluginBackend::from_boxed` (plugin side) and `LoadedBackend` safe wrapper (host side).
- `PluginInfo` metadata carrier, `PluginSessionConfig` (borrowed JSON), `PluginOutputSender` (opaque-ctx + fn-pointer output sink, with an mpsc host helper).
- `PluginError` (rich Rust enum) ↔ `PluginStatus` (`#[repr(i32)]` FFI code).
- Documented exported symbol contract (`termihub_plugin_{abi_version,init,create_backend,shutdown}`) as name consts + fn-pointer type aliases.
- A `#[deny(improper_ctypes, improper_ctypes_definitions)]` module that fails the build if any exported signature stops being FFI-safe.
- Doc comments on all public items (`#![deny(missing_docs)]`), a crate-level compiling round-trip example, a `README.md`, and an 8-case integration test suite (`tests/roundtrip.rs`) covering input→output flow, channel-closed, contained panic, drop/free, info ownership, and status mapping.

## Testing

- `cargo test -p termihub-plugin-api --all-features` — 8 integration tests + 1 doctest pass.
- `cargo clippy -p termihub-plugin-api --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt` — clean.

Closes #1990