### PR TITLE
feat(ui): plugin system frontend foundation — types + store (Closes #1993)

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -23,6 +23,7 @@ import type {
   WindowRestorePayload,
 } from "@/types/window";
 import type { WorkspaceTabGroupDef } from "@/types/workspace";
+import type { InstalledPlugin, PluginManifest } from "@/types/plugin";
 import {
   SavedConnection,
   ConnectionFolder,
@@ -2346,4 +2347,44 @@ export async function setUpdateAutoCheck(enabled: boolean): Promise<void> {
 /** Return current update settings (auto-check flag, last check time, skipped version). */
 export async function getUpdateSettings(): Promise<UpdateSettings> {
   return await invoke<UpdateSettings>("get_update_settings");
+}
+
+// ─── Plugin manager ────────────────────────────────────────────────────────
+//
+// Typed wrappers over the `PluginManager` Tauri commands (plugin-system
+// concept §7). The command surface is defined by the backend plugin manager;
+// these wrappers give the store a typed entry point independent of when that
+// backend lands.
+
+/** List all installed plugins with their current install/runtime state. */
+export async function listPlugins(): Promise<InstalledPlugin[]> {
+  return await invoke<InstalledPlugin[]>("list_plugins");
+}
+
+/**
+ * Validate a `.termihub-plugin` package at `filePath` without installing it,
+ * returning its parsed manifest (e.g. to drive the install permission prompt).
+ */
+export async function validatePlugin(filePath: string): Promise<PluginManifest> {
+  return await invoke<PluginManifest>("validate_plugin", { filePath });
+}
+
+/** Install a `.termihub-plugin` package from `filePath`, returning the installed record. */
+export async function installPlugin(filePath: string): Promise<InstalledPlugin> {
+  return await invoke<InstalledPlugin>("install_plugin", { filePath });
+}
+
+/** Uninstall the plugin with the given id. */
+export async function uninstallPlugin(pluginId: string): Promise<void> {
+  await invoke("uninstall_plugin", { pluginId });
+}
+
+/** Enable (activate) the plugin with the given id. */
+export async function enablePlugin(pluginId: string): Promise<void> {
+  await invoke("enable_plugin", { pluginId });
+}
+
+/** Disable the plugin with the given id. */
+export async function disablePlugin(pluginId: string): Promise<void> {
+  await invoke("disable_plugin", { pluginId });
 }

--- a/src/store/appStore.plugins.test.ts
+++ b/src/store/appStore.plugins.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for the plugin Zustand slice (#1993).
+ *
+ * Pins that the store's plugin actions round-trip through the plugin Tauri
+ * command wrappers in `@/services/api`: loadPlugins populates state and derives
+ * the backend-type projection, the mutating actions refresh via loadPlugins and
+ * surface pending → success/error toasts, and a failing command rethrows without
+ * silently desyncing state.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Toast hub — assert feedback without real DOM toasts. Declared via vi.hoisted
+// so the (hoisted) vi.mock factory can reference them at init time.
+const { toastSuccess, toastError, toastLoading } = vi.hoisted(() => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  toastLoading: vi.fn(() => "toast-id"),
+}));
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: toastSuccess,
+    error: toastError,
+    loading: toastLoading,
+    info: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/api", () => ({
+  // Baseline stubs the store binds at import.
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(() => Promise.resolve()),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  // Plugin command wrappers under test.
+  listPlugins: vi.fn(() => Promise.resolve([])),
+  installPlugin: vi.fn(),
+  uninstallPlugin: vi.fn(() => Promise.resolve()),
+  enablePlugin: vi.fn(() => Promise.resolve()),
+  disablePlugin: vi.fn(() => Promise.resolve()),
+}));
+
+import { useAppStore } from "./appStore";
+import {
+  listPlugins as apiListPlugins,
+  installPlugin as apiInstallPlugin,
+  uninstallPlugin as apiUninstallPlugin,
+  enablePlugin as apiEnablePlugin,
+  disablePlugin as apiDisablePlugin,
+} from "@/services/api";
+import type { InstalledPlugin, PluginState } from "@/types/plugin";
+
+function makePlugin(
+  id: string,
+  state: PluginState,
+  overrides: { connectionType?: string; withBackend?: boolean } = {}
+): InstalledPlugin {
+  const withBackend = overrides.withBackend ?? true;
+  return {
+    manifest: {
+      id,
+      name: `Plugin ${id}`,
+      version: "1.0.0",
+      author: "tester",
+      description: "a test plugin",
+      license: "MIT",
+      apiVersion: "1.0",
+      platforms: ["linux"],
+      permissions: ["terminal"],
+      extensions: withBackend
+        ? {
+            terminalBackend: {
+              connectionType: overrides.connectionType ?? id,
+              displayName: `Backend ${id}`,
+              configSchema: {},
+            },
+          }
+        : { theme: { themes: [{ id: "t", name: "T", file: "t.json" }] } },
+    },
+    state,
+    installedAt: "2026-07-26T00:00:00Z",
+  };
+}
+
+describe("appStore — plugins (#1993)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+  });
+
+  it("starts with empty plugin state", () => {
+    expect(useAppStore.getState().plugins).toEqual([]);
+    expect(useAppStore.getState().pluginBackendTypes).toEqual([]);
+  });
+
+  it("loadPlugins populates the list and derives backend types from active plugins only", async () => {
+    vi.mocked(apiListPlugins).mockResolvedValueOnce([
+      makePlugin("active-be", "active"),
+      makePlugin("disabled-be", "disabled"),
+      makePlugin("theme-only", "active", { withBackend: false }),
+    ]);
+
+    await useAppStore.getState().loadPlugins();
+
+    const state = useAppStore.getState();
+    expect(state.plugins).toHaveLength(3);
+    // Only the active plugin that declares a terminalBackend is projected.
+    expect(state.pluginBackendTypes).toEqual([
+      { pluginId: "active-be", connectionType: "active-be", displayName: "Backend active-be" },
+    ]);
+  });
+
+  it("loadPlugins swallows errors and leaves state untouched", async () => {
+    vi.mocked(apiListPlugins).mockRejectedValueOnce(new Error("backend down"));
+    await expect(useAppStore.getState().loadPlugins()).resolves.toBeUndefined();
+    expect(useAppStore.getState().plugins).toEqual([]);
+  });
+
+  it("installPlugin installs, refreshes, and toasts success", async () => {
+    const installed = makePlugin("new-plugin", "active");
+    vi.mocked(apiInstallPlugin).mockResolvedValueOnce(installed);
+    vi.mocked(apiListPlugins).mockResolvedValueOnce([installed]);
+
+    await useAppStore.getState().installPlugin("/tmp/new-plugin.termihub-plugin");
+
+    expect(apiInstallPlugin).toHaveBeenCalledWith("/tmp/new-plugin.termihub-plugin");
+    expect(toastLoading).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).toHaveBeenCalledWith("Installed Plugin new-plugin", { id: "toast-id" });
+    expect(useAppStore.getState().plugins).toHaveLength(1);
+  });
+
+  it("installPlugin toasts an error and rethrows on failure", async () => {
+    vi.mocked(apiInstallPlugin).mockRejectedValueOnce(new Error("bad package"));
+
+    await expect(useAppStore.getState().installPlugin("/tmp/bad.termihub-plugin")).rejects.toThrow(
+      "bad package"
+    );
+
+    expect(toastError).toHaveBeenCalledWith("Failed to install plugin: bad package", {
+      id: "toast-id",
+    });
+    expect(apiListPlugins).not.toHaveBeenCalled();
+  });
+
+  it("uninstallPlugin removes, refreshes, and toasts success", async () => {
+    useAppStore.setState({ plugins: [makePlugin("gone", "active")] });
+    vi.mocked(apiListPlugins).mockResolvedValueOnce([]);
+
+    await useAppStore.getState().uninstallPlugin("gone");
+
+    expect(apiUninstallPlugin).toHaveBeenCalledWith("gone");
+    expect(toastSuccess).toHaveBeenCalledWith("Uninstalled Plugin gone", { id: "toast-id" });
+    expect(useAppStore.getState().plugins).toEqual([]);
+    expect(useAppStore.getState().pluginBackendTypes).toEqual([]);
+  });
+
+  it("enablePlugin enables, refreshes, and toasts success with the plugin name", async () => {
+    useAppStore.setState({ plugins: [makePlugin("toggle", "disabled")] });
+    vi.mocked(apiListPlugins).mockResolvedValueOnce([makePlugin("toggle", "active")]);
+
+    await useAppStore.getState().enablePlugin("toggle");
+
+    expect(apiEnablePlugin).toHaveBeenCalledWith("toggle");
+    expect(toastSuccess).toHaveBeenCalledWith("Enabled Plugin toggle", { id: "toast-id" });
+    // The now-active backend appears in the projection.
+    expect(useAppStore.getState().pluginBackendTypes).toEqual([
+      { pluginId: "toggle", connectionType: "toggle", displayName: "Backend toggle" },
+    ]);
+  });
+
+  it("disablePlugin disables, refreshes, and toasts success", async () => {
+    useAppStore.setState({ plugins: [makePlugin("toggle", "active")] });
+    vi.mocked(apiListPlugins).mockResolvedValueOnce([makePlugin("toggle", "disabled")]);
+
+    await useAppStore.getState().disablePlugin("toggle");
+
+    expect(apiDisablePlugin).toHaveBeenCalledWith("toggle");
+    expect(toastSuccess).toHaveBeenCalledWith("Disabled Plugin toggle", { id: "toast-id" });
+    expect(useAppStore.getState().pluginBackendTypes).toEqual([]);
+  });
+
+  it("disablePlugin toasts an error and rethrows on failure", async () => {
+    useAppStore.setState({ plugins: [makePlugin("toggle", "active")] });
+    vi.mocked(apiDisablePlugin).mockRejectedValueOnce(new Error("cannot disable"));
+
+    await expect(useAppStore.getState().disablePlugin("toggle")).rejects.toThrow("cannot disable");
+
+    expect(toastError).toHaveBeenCalledWith("Failed to disable Plugin toggle: cannot disable", {
+      id: "toast-id",
+    });
+  });
+
+  it("falls back to the plugin id in feedback when it is not in state", async () => {
+    vi.mocked(apiListPlugins).mockResolvedValueOnce([]);
+    await useAppStore.getState().enablePlugin("unknown-id");
+    expect(toastLoading).toHaveBeenCalledWith("Enabling unknown-id…");
+    expect(toastSuccess).toHaveBeenCalledWith("Enabled unknown-id", { id: "toast-id" });
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -283,6 +283,14 @@ import {
 } from "@/utils/reconnectBackoff";
 import { quotePath } from "@/utils/quotePath";
 import { toast } from "@/components/ui";
+import type { InstalledPlugin, PluginBackendType } from "@/types/plugin";
+import {
+  listPlugins as apiListPlugins,
+  installPlugin as apiInstallPlugin,
+  uninstallPlugin as apiUninstallPlugin,
+  enablePlugin as apiEnablePlugin,
+  disablePlugin as apiDisablePlugin,
+} from "@/services/api";
 import {
   createLeafPanel,
   findLeaf,
@@ -1466,6 +1474,29 @@ interface AppState {
    */
   importMacros: (json: string) => Promise<number>;
 
+  // Plugins (#1993 — frontend foundation for the plugin system)
+  /** Installed plugins with their current install/runtime state. */
+  plugins: InstalledPlugin[];
+  /**
+   * Terminal-backend connection types contributed by active plugins, projected
+   * from {@link plugins} for the connection-type selector. Derived by
+   * {@link loadPlugins}; not set directly.
+   */
+  pluginBackendTypes: PluginBackendType[];
+  /** Load the installed-plugin list from the backend and refresh derived state. */
+  loadPlugins: () => Promise<void>;
+  /**
+   * Install a `.termihub-plugin` package from `filePath`, then refresh the list.
+   * Surfaces a pending → success/error toast; rejects on failure.
+   */
+  installPlugin: (filePath: string) => Promise<void>;
+  /** Uninstall a plugin by id, then refresh the list. Toasts feedback; rejects on failure. */
+  uninstallPlugin: (pluginId: string) => Promise<void>;
+  /** Enable (activate) a plugin by id, then refresh the list. Toasts feedback; rejects on failure. */
+  enablePlugin: (pluginId: string) => Promise<void>;
+  /** Disable a plugin by id, then refresh the list. Toasts feedback; rejects on failure. */
+  disablePlugin: (pluginId: string) => Promise<void>;
+
   // Macro recording (#1674)
   /** Whether terminal input is currently being captured into a macro. */
   macroRecording: boolean;
@@ -1771,6 +1802,27 @@ function generateMacroId(): string {
     return `macro-${c.randomUUID()}`;
   }
   return `macro-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Project the connection-type selector's plugin-backend entries from the
+ * installed-plugin list (#1993): every *active* plugin that declares a
+ * `terminalBackend` extension contributes one entry. Disabled/error/incompatible
+ * plugins register no backend.
+ */
+function derivePluginBackendTypes(plugins: InstalledPlugin[]): PluginBackendType[] {
+  const result: PluginBackendType[] = [];
+  for (const plugin of plugins) {
+    const backend = plugin.manifest.extensions.terminalBackend;
+    if (plugin.state === "active" && backend) {
+      result.push({
+        pluginId: plugin.manifest.id,
+        connectionType: backend.connectionType,
+        displayName: backend.displayName,
+      });
+    }
+  }
+  return result;
 }
 
 /** UI-facing metadata describing an in-flight workflow run (#1852). */
@@ -7399,6 +7451,83 @@ export const useAppStore = create<AppState>((set, get) => {
       // Refresh once, after all saves, rather than per-macro.
       await get().loadMacros();
       return prepared.length;
+    },
+
+    // Plugins (#1993)
+    plugins: [],
+    pluginBackendTypes: [],
+
+    loadPlugins: async () => {
+      try {
+        const plugins = await apiListPlugins();
+        set({ plugins, pluginBackendTypes: derivePluginBackendTypes(plugins) });
+      } catch (err) {
+        // Read-only refresh: log rather than toast, matching loadMacros.
+        console.error("Failed to load plugins:", err);
+      }
+    },
+
+    installPlugin: async (filePath) => {
+      const toastId = toast.loading("Installing plugin…");
+      try {
+        const installed = await apiInstallPlugin(filePath);
+        await get().loadPlugins();
+        toast.success(`Installed ${installed.manifest.name}`, { id: toastId });
+      } catch (err) {
+        toast.error(
+          `Failed to install plugin: ${err instanceof Error ? err.message : String(err)}`,
+          { id: toastId }
+        );
+        throw err;
+      }
+    },
+
+    uninstallPlugin: async (pluginId) => {
+      const name = get().plugins.find((p) => p.manifest.id === pluginId)?.manifest.name ?? pluginId;
+      const toastId = toast.loading(`Uninstalling ${name}…`);
+      try {
+        await apiUninstallPlugin(pluginId);
+        await get().loadPlugins();
+        toast.success(`Uninstalled ${name}`, { id: toastId });
+      } catch (err) {
+        toast.error(
+          `Failed to uninstall ${name}: ${err instanceof Error ? err.message : String(err)}`,
+          { id: toastId }
+        );
+        throw err;
+      }
+    },
+
+    enablePlugin: async (pluginId) => {
+      const name = get().plugins.find((p) => p.manifest.id === pluginId)?.manifest.name ?? pluginId;
+      const toastId = toast.loading(`Enabling ${name}…`);
+      try {
+        await apiEnablePlugin(pluginId);
+        await get().loadPlugins();
+        toast.success(`Enabled ${name}`, { id: toastId });
+      } catch (err) {
+        toast.error(
+          `Failed to enable ${name}: ${err instanceof Error ? err.message : String(err)}`,
+          { id: toastId }
+        );
+        throw err;
+      }
+    },
+
+    disablePlugin: async (pluginId) => {
+      const name = get().plugins.find((p) => p.manifest.id === pluginId)?.manifest.name ?? pluginId;
+      const toastId = toast.loading(`Disabling ${name}…`);
+      try {
+        await apiDisablePlugin(pluginId);
+        await get().loadPlugins();
+        toast.success(`Disabled ${name}`, { id: toastId });
+      } catch (err) {
+        toast.error(
+          `Failed to disable ${name}: ${err instanceof Error ? err.message : String(err)}`,
+          { id: toastId }
+        );
+        throw err;
+      }
     },
 
     // Macro recording (#1674)

--- a/src/types/plugin.test.ts
+++ b/src/types/plugin.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Type-level checks for the plugin frontend types (#1993).
+ *
+ * These construct fully-typed sample values that mirror the Rust manifest model
+ * (`core/src/plugin/manifest.rs`) and the concept's §6 shapes. Because the
+ * values are annotated with the exported interfaces, any drift in the type
+ * definitions (a renamed/removed field, a widened union) fails `tsc` during the
+ * build — the runtime assertions are secondary, the compile-time shape is the point.
+ */
+import { describe, it, expect, expectTypeOf } from "vitest";
+import type {
+  PluginManifest,
+  PluginPermission,
+  PluginPlatform,
+  PluginExtensions,
+  TerminalBackendExtension,
+  ProtocolParserExtension,
+  ThemeExtension,
+  ThemeEntry,
+  StatusBarWidgetExtension,
+  WidgetPosition,
+  PluginState,
+  InstalledPlugin,
+  PluginSettingSchema,
+  PluginSettingType,
+  PluginBackendType,
+} from "./plugin";
+
+/** A manifest exercising every extension point and a settings block. */
+function sampleManifest(): PluginManifest {
+  const terminalBackend: TerminalBackendExtension = {
+    connectionType: "k8s-exec",
+    displayName: "Kubernetes Exec",
+    configSchema: {
+      type: "object",
+      properties: { pod: { type: "string" } },
+      required: ["pod"],
+    },
+  };
+  const protocolParser: ProtocolParserExtension = {
+    name: "ansi-annotate",
+    description: "Annotates output",
+    entryPoint: "frontend/index.js",
+  };
+  const themeEntry: ThemeEntry = { id: "dracula", name: "Dracula", file: "dracula.json" };
+  const theme: ThemeExtension = { themes: [themeEntry] };
+  const statusBarWidget: StatusBarWidgetExtension = {
+    entryPoint: "frontend/widget.js",
+    position: "right",
+  };
+  const extensions: PluginExtensions = {
+    terminalBackend,
+    protocolParser,
+    theme,
+    statusBarWidget,
+  };
+  const setting: PluginSettingSchema = {
+    type: "string",
+    default: "default",
+    description: "Default Kubernetes namespace",
+    enum: ["default", "kube-system"],
+  };
+  return {
+    id: "k8s-exec",
+    name: "Kubernetes Exec",
+    version: "1.2.0",
+    author: "k8s-contrib",
+    description: "Terminal backend for Kubernetes pod exec sessions",
+    license: "MIT",
+    apiVersion: "1.0",
+    platforms: ["windows", "linux", "macos"],
+    permissions: ["terminal", "network", "filesystem"],
+    extensions,
+    settings: { defaultNamespace: setting },
+  };
+}
+
+describe("plugin types (#1993)", () => {
+  it("constructs a full manifest mirroring the Rust model", () => {
+    const manifest = sampleManifest();
+    expect(manifest.id).toBe("k8s-exec");
+    expect(manifest.platforms).toHaveLength(3);
+    expect(manifest.permissions).toContain("terminal");
+    expect(manifest.extensions.terminalBackend?.connectionType).toBe("k8s-exec");
+    expect(manifest.extensions.theme?.themes[0].file).toBe("dracula.json");
+    expect(manifest.settings?.defaultNamespace.type).toBe("string");
+  });
+
+  it("allows a minimal manifest with a single extension and no settings", () => {
+    const manifest: PluginManifest = {
+      id: "just-theme",
+      name: "Just a Theme",
+      version: "0.1.0",
+      author: "someone",
+      description: "A theme-only plugin",
+      license: "MIT",
+      apiVersion: "1.0",
+      platforms: ["linux"],
+      permissions: [],
+      extensions: { theme: { themes: [{ id: "t", name: "T", file: "t.json" }] } },
+    };
+    expect(manifest.settings).toBeUndefined();
+    expect(manifest.extensions.terminalBackend).toBeUndefined();
+  });
+
+  it("models an installed plugin's state and error detail", () => {
+    const installed: InstalledPlugin = {
+      manifest: sampleManifest(),
+      state: "active",
+      installedAt: "2026-07-26T00:00:00Z",
+    };
+    const errored: InstalledPlugin = {
+      manifest: sampleManifest(),
+      state: "error",
+      errorMessage: "failed to load library",
+      installedAt: "2026-07-26T00:00:00Z",
+    };
+    expect(installed.state).toBe("active");
+    expect(errored.errorMessage).toBe("failed to load library");
+  });
+
+  it("pins the closed unions to their manifest-mirroring members", () => {
+    expectTypeOf<PluginPermission>().toEqualTypeOf<
+      "terminal" | "network" | "filesystem" | "ui" | "settings"
+    >();
+    expectTypeOf<PluginPlatform>().toEqualTypeOf<"windows" | "linux" | "macos">();
+    expectTypeOf<WidgetPosition>().toEqualTypeOf<"left" | "right">();
+    expectTypeOf<PluginSettingType>().toEqualTypeOf<"string" | "number" | "boolean">();
+    expectTypeOf<PluginState>().toEqualTypeOf<
+      "installed" | "active" | "disabled" | "error" | "incompatible"
+    >();
+  });
+
+  it("shapes a derived plugin backend type", () => {
+    const backendType: PluginBackendType = {
+      pluginId: "k8s-exec",
+      connectionType: "k8s-exec",
+      displayName: "Kubernetes Exec",
+    };
+    expect(backendType.pluginId).toBe("k8s-exec");
+    expectTypeOf(backendType).toMatchTypeOf<{
+      pluginId: string;
+      connectionType: string;
+      displayName: string;
+    }>();
+  });
+});

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,0 +1,187 @@
+/**
+ * TypeScript types for the plugin system's frontend foundation.
+ *
+ * These mirror the Rust manifest model in `core/src/plugin/manifest.rs`
+ * (serialized as camelCase JSON) and the plugin-system concept
+ * (`docs/concepts/future/plugin-system.html`, impl §6). The `InstalledPlugin`
+ * and `PluginState` types describe a plugin's install-time/runtime status as
+ * surfaced by the `PluginManager` Tauri commands (concept §7); they have no
+ * direct manifest analog.
+ *
+ * Keep these in lockstep with the Rust model — no `any`, per the repo TS rules.
+ */
+
+/**
+ * A JSON value, mirroring `serde_json::Value`. Used for opaque manifest fields
+ * (a plugin's `configSchema` and a setting's `default`) that the host stores
+ * and forwards without interpreting.
+ */
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/**
+ * A JSON Schema object describing a plugin-provided backend's connection config.
+ * Opaque to the host; the schema-driven config form consumes it in later work.
+ */
+export type JsonSchema = { [key: string]: JsonValue };
+
+/**
+ * A coarse-grained capability a plugin requests in its manifest.
+ * Closed set — mirrors Rust `PluginPermission` (lowercase).
+ */
+export type PluginPermission = "terminal" | "network" | "filesystem" | "ui" | "settings";
+
+/** A desktop platform a plugin declares support for. Mirrors Rust `Platform`. */
+export type PluginPlatform = "windows" | "linux" | "macos";
+
+/** A terminal-backend extension point. Mirrors Rust `TerminalBackendExtension`. */
+export interface TerminalBackendExtension {
+  /** The connection type this backend registers. */
+  connectionType: string;
+  /** Human-readable name shown in the connection-type selector. */
+  displayName: string;
+  /** JSON Schema describing the backend's connection config. */
+  configSchema: JsonSchema;
+}
+
+/** A protocol-parser extension point. Mirrors Rust `ProtocolParserExtension`. */
+export interface ProtocolParserExtension {
+  /** Parser identifier. */
+  name: string;
+  /** Human-readable description. */
+  description: string;
+  /** Path to the JS entry point within the package. */
+  entryPoint: string;
+}
+
+/** A single theme provided by a {@link ThemeExtension}. Mirrors Rust `ThemeEntry`. */
+export interface ThemeEntry {
+  /** Theme identifier (unique within the plugin). */
+  id: string;
+  /** Display name. */
+  name: string;
+  /** Path to the theme JSON file within the package's `themes/` directory. */
+  file: string;
+}
+
+/** A theme extension point. Mirrors Rust `ThemeExtension`. */
+export interface ThemeExtension {
+  /** The themes provided by this plugin. */
+  themes: ThemeEntry[];
+}
+
+/** Which side of the status bar a widget renders on. Mirrors Rust `WidgetPosition`. */
+export type WidgetPosition = "left" | "right";
+
+/** A status-bar-widget extension point. Mirrors Rust `StatusBarWidgetExtension`. */
+export interface StatusBarWidgetExtension {
+  /** Path to the JS entry point within the package. */
+  entryPoint: string;
+  /** Where the widget is placed. */
+  position: WidgetPosition;
+}
+
+/**
+ * The `extensions` object: which extension points a plugin provides.
+ * Mirrors Rust `PluginExtensions`; each field is optional and a valid plugin
+ * declares at least one.
+ */
+export interface PluginExtensions {
+  /** A new connection type with full terminal I/O (Rust dynamic library). */
+  terminalBackend?: TerminalBackendExtension;
+  /** An output filter that transforms or annotates terminal output (JS). */
+  protocolParser?: ProtocolParserExtension;
+  /** One or more custom color themes (JSON data). */
+  theme?: ThemeExtension;
+  /** A widget rendered into the status bar (JS). */
+  statusBarWidget?: StatusBarWidgetExtension;
+}
+
+/** The primitive type of a plugin setting. Mirrors Rust `SettingType`. */
+export type PluginSettingType = "string" | "number" | "boolean";
+
+/**
+ * The schema for a single plugin setting (`settings.<key>`).
+ * Mirrors Rust `PluginSettingSchema`.
+ */
+export interface PluginSettingSchema {
+  /** The setting's primitive type. */
+  type: PluginSettingType;
+  /** Default value applied when the user has not set one. */
+  default: JsonValue;
+  /** Human-readable description shown in the settings UI. */
+  description: string;
+  /** Optional closed set of allowed string values. */
+  enum?: string[];
+}
+
+/**
+ * The parsed contents of a plugin's `manifest.json`.
+ * Mirrors Rust `PluginManifest` exactly (camelCase JSON keys).
+ */
+export interface PluginManifest {
+  /** Stable, filesystem-safe identifier (used as the install directory name). */
+  id: string;
+  /** Human-readable display name. */
+  name: string;
+  /** Plugin version string (informational; the host does not interpret it). */
+  version: string;
+  /** Plugin author. */
+  author: string;
+  /** Short description. */
+  description: string;
+  /** SPDX-style license identifier. */
+  license: string;
+  /** Declared plugin-API version, as `"major.minor"`. */
+  apiVersion: string;
+  /** Desktop platforms the plugin supports. */
+  platforms: PluginPlatform[];
+  /** Coarse-grained permissions the plugin requests. */
+  permissions: PluginPermission[];
+  /** The extension points the plugin provides. */
+  extensions: PluginExtensions;
+  /** Optional user-configurable settings, keyed by setting name. */
+  settings?: Record<string, PluginSettingSchema>;
+}
+
+/**
+ * An installed plugin's install-time/runtime status.
+ *
+ * - `installed` — present but not yet activated.
+ * - `active` — loaded and its extension points are registered.
+ * - `disabled` — installed but deactivated by the user.
+ * - `error` — activation failed; see {@link InstalledPlugin.errorMessage}.
+ * - `incompatible` — targets an unsupported plugin-API version.
+ */
+export type PluginState = "installed" | "active" | "disabled" | "error" | "incompatible";
+
+/** An installed plugin as reported by the `PluginManager` (concept §6/§7). */
+export interface InstalledPlugin {
+  /** The plugin's validated manifest. */
+  manifest: PluginManifest;
+  /** Current install/runtime state. */
+  state: PluginState;
+  /** Failure detail when {@link InstalledPlugin.state} is `error`. */
+  errorMessage?: string;
+  /** ISO-8601 timestamp of when the plugin was installed. */
+  installedAt: string;
+}
+
+/**
+ * A terminal-backend connection type contributed by an active plugin, projected
+ * from installed plugins' `terminalBackend` extensions for the connection-type
+ * selector. Mirrors the store shape in concept §10.
+ */
+export interface PluginBackendType {
+  /** ID of the plugin providing this backend. */
+  pluginId: string;
+  /** The connection type it registers. */
+  connectionType: string;
+  /** Human-readable name shown in the selector. */
+  displayName: string;
+}


### PR DESCRIPTION
## Summary

Frontend foundation for the plugin system (concept `docs/concepts/future/plugin-system.html`, impl §6 + §10). This is the typed data layer plus store wiring the later plugin UI leaves build on — no UI components, no Rust.

Builds on the Rust manifest model from #1989.

## What's included

- **`src/types/plugin.ts`** — TypeScript types mirroring the Rust manifest model (`core/src/plugin/manifest.rs`) exactly, no `any`:
  - `PluginManifest`, `PluginPermission`, `PluginPlatform`
  - `PluginExtensions` + `TerminalBackendExtension`, `ProtocolParserExtension`, `ThemeExtension` (+ `ThemeEntry`), `StatusBarWidgetExtension` (+ `WidgetPosition`)
  - `PluginSettingSchema` (+ `PluginSettingType`)
  - `PluginState`, `InstalledPlugin` (concept §6 runtime shapes)
  - `JsonValue` / `JsonSchema` (faithful mirror of the opaque `serde_json::Value` fields), and a derived `PluginBackendType`
- **`src/services/api.ts`** — typed `invoke` wrappers for the PluginManager commands (concept §7): `listPlugins`, `validatePlugin`, `installPlugin`, `uninstallPlugin`, `enablePlugin`, `disablePlugin`.
- **`src/store/appStore.ts`** — plugin store section (concept §10): `plugins`, a derived `pluginBackendTypes` projection, and the `loadPlugins` / `installPlugin` / `uninstallPlugin` / `enablePlugin` / `disablePlugin` actions. Mutating actions surface a pending → `toast.success` / recoverable-error toast and rethrow on failure; `loadPlugins` logs and no-ops on error (mirrors `loadMacros`). `pluginBackendTypes` is projected only from **active** plugins that declare a `terminalBackend`.

The command wrappers assume the PluginManager commands exist (backend landing in parallel via #1992); the typed API isolates the store from that timing.

## Tests

- `src/types/plugin.test.ts` — constructs fully-typed sample values (compile-time mirror check) + `expectTypeOf` union pins.
- `src/store/appStore.plugins.test.ts` — store actions with mocked `invoke` wrappers: state population, backend-type derivation, and pending/success/error toast feedback incl. rethrow-on-failure.

All frontend checks pass locally: `tsc --noEmit`, `eslint src/`, `prettier --check`, and the full vitest suite.

## Scope / not included

No Plugin Manager UI (#1997), settings UI (#2000), theme (#1996), JS plugins (#1998), or connection-config UI (#2002) — this only lands the shared types + store those depend on. No Rust changes (#1992 owns the backend command surface).

Closes #1993
