### PR TITLE
feat(plugin): plugin manager management layer + tauri command surface (Closes #1992)

### DIFF
--- a/core/src/plugin/manager.rs
+++ b/core/src/plugin/manager.rs
@@ -259,7 +259,8 @@ impl PluginManager {
     /// Look up a single installed plugin by id.
     pub fn get(&self, id: &str) -> Result<InstalledPlugin, PluginManagerError> {
         let dir = self.plugin_dir(id);
-        let manifest = read_manifest(&dir).ok_or_else(|| PluginManagerError::NotFound(id.into()))?;
+        let manifest =
+            read_manifest(&dir).ok_or_else(|| PluginManagerError::NotFound(id.into()))?;
         let state = self.read_state_store()?;
         Ok(self.installed_plugin_from(manifest, &state, &dir))
     }
@@ -359,7 +360,8 @@ impl PluginManager {
         let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
 
         let dir = self.plugin_dir(id);
-        let manifest = read_manifest(&dir).ok_or_else(|| PluginManagerError::NotFound(id.into()))?;
+        let manifest =
+            read_manifest(&dir).ok_or_else(|| PluginManagerError::NotFound(id.into()))?;
 
         let mut state = self.read_state_store()?;
         let record = state
@@ -608,8 +610,8 @@ fn write_json_atomic<T: Serialize>(
     value: &T,
 ) -> Result<(), PluginManagerError> {
     std::fs::create_dir_all(root)?;
-    let json =
-        serde_json::to_string_pretty(value).map_err(|e| PluginManagerError::Store(e.to_string()))?;
+    let json = serde_json::to_string_pretty(value)
+        .map_err(|e| PluginManagerError::Store(e.to_string()))?;
     let tmp = path.with_extension("json.tmp");
     std::fs::write(&tmp, json)?;
     std::fs::rename(&tmp, path)?;
@@ -743,7 +745,11 @@ mod tests {
         assert!(!mgr.root().join("gone").exists());
         assert!(mgr.list().unwrap().is_empty());
         // Settings and state records are dropped.
-        assert!(!mgr.read_settings_store().unwrap().plugins.contains_key("gone"));
+        assert!(!mgr
+            .read_settings_store()
+            .unwrap()
+            .plugins
+            .contains_key("gone"));
         assert!(!mgr.read_state_store().unwrap().plugins.contains_key("gone"));
     }
 

--- a/core/src/plugin/manager.rs
+++ b/core/src/plugin/manager.rs
@@ -1,0 +1,942 @@
+//! The plugin **management layer**: installed-plugin state and the on-disk
+//! layout.
+//!
+//! Where [`super::package`] and [`super::manifest`] define the *format*
+//! contract, [`PluginManager`] owns what is actually installed on this machine:
+//! it scans `<app-data>/plugins/`, installs and uninstalls packages, and
+//! persists each plugin's enabled/disabled state and settings (concept impl
+//! §12, "Migration Path" step 1). It performs **no** code loading — no dynamic
+//! libraries, no theme/JS registration. Enabling or disabling a plugin flips
+//! persisted state and calls a [`PluginLifecycleHook`] seam that a later
+//! plugin-host issue implements; the default hook is a no-op, which is what lets
+//! this layer merge independently.
+//!
+//! # On-disk layout
+//!
+//! ```text
+//! <app-data>/plugins/
+//! ├── plugin-state.json      # per-plugin enabled/disabled + install time
+//! ├── plugin-settings.json   # per-plugin user configuration
+//! ├── <id-a>/                # one directory per installed plugin (extracted)
+//! │   ├── manifest.json
+//! │   └── …
+//! └── <id-b>/
+//!     └── manifest.json
+//! ```
+//!
+//! The two JSON files live alongside the per-plugin directories; scanning only
+//! considers sub*directories*, so they are skipped naturally.
+//!
+//! # Concurrency
+//!
+//! Install and uninstall (and the state/settings mutations behind
+//! enable/disable) are serialized by an internal mutex so two concurrent
+//! operations cannot race on the same directory or clobber each other's
+//! read-modify-write of the state files (concept "Edge Cases").
+
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use thiserror::Error;
+
+use super::manifest::{parse_manifest, ApiCompatibility, PluginManifest};
+use super::package::{validate_package, PluginPackageError, MANIFEST_FILE_NAME};
+
+/// File holding per-plugin enabled/disabled state and install timestamps.
+const STATE_FILE_NAME: &str = "plugin-state.json";
+/// File holding per-plugin user settings.
+const SETTINGS_FILE_NAME: &str = "plugin-settings.json";
+
+/// The lifecycle state of an installed plugin, as surfaced to the frontend.
+///
+/// JSON values are the lowercase names from the plugin-system concept:
+/// `installed` / `active` / `disabled` / `error` / `incompatible`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PluginState {
+    /// Extracted and enabled, but not yet loaded into a running host. This is
+    /// the resting state for an enabled plugin in this foundation layer, which
+    /// does no loading — a later host issue promotes it to [`Active`].
+    ///
+    /// [`Active`]: PluginState::Active
+    Installed,
+    /// Loaded and running. Only a later plugin-host issue can produce this; the
+    /// management layer never assigns it on its own.
+    Active,
+    /// The user has turned the plugin off; it stays extracted but is not loaded.
+    Disabled,
+    /// The plugin is enabled but failed — e.g. its lifecycle hook returned an
+    /// error. [`InstalledPlugin::error_message`] carries the detail.
+    Error,
+    /// The plugin's declared `apiVersion` is not compatible with this host, so
+    /// it must not be loaded even though it is enabled.
+    Incompatible,
+}
+
+/// One installed plugin: its trusted manifest plus the management-layer state
+/// this crate tracks for it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InstalledPlugin {
+    /// The plugin's validated `manifest.json`.
+    pub manifest: PluginManifest,
+    /// The plugin's current lifecycle state.
+    pub state: PluginState,
+    /// Human-readable detail when [`state`](InstalledPlugin::state) is
+    /// [`PluginState::Error`]; `null`/absent otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    /// When the plugin was installed, as milliseconds since the Unix epoch.
+    pub installed_at: u64,
+}
+
+/// The seam through which a later plugin-*host* issue actually loads and unloads
+/// plugin code.
+///
+/// The management layer calls these hooks around the enable/disable/uninstall
+/// bookkeeping; the default [`NoopLifecycleHook`] does nothing, which is what
+/// lets this layer ship and merge before any host exists. A hook error on
+/// enable is surfaced as [`PluginState::Error`] rather than failing the whole
+/// operation — the plugin stays enabled but is reported as errored.
+pub trait PluginLifecycleHook: Send + Sync {
+    /// Called after a plugin is enabled (or on install of an enabled plugin).
+    fn on_enable(&self, _plugin: &InstalledPlugin) -> Result<(), String> {
+        Ok(())
+    }
+    /// Called before a plugin is disabled.
+    fn on_disable(&self, _id: &str) -> Result<(), String> {
+        Ok(())
+    }
+    /// Called before a plugin's directory is removed (the "shutdown hook").
+    fn on_uninstall(&self, _id: &str) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+/// The default no-op [`PluginLifecycleHook`] used until a real host is wired in.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopLifecycleHook;
+
+impl PluginLifecycleHook for NoopLifecycleHook {}
+
+/// Everything that can go wrong in the management layer.
+#[derive(Debug, Error)]
+pub enum PluginManagerError {
+    /// A filesystem operation failed.
+    #[error("plugin storage I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Validating the package to install failed (bad format, incompatible API,
+    /// …). Wraps the format-layer error.
+    #[error(transparent)]
+    Package(#[from] PluginPackageError),
+
+    /// No installed plugin has the given id.
+    #[error("no installed plugin with id `{0}`")]
+    NotFound(String),
+
+    /// The package archive could not be extracted.
+    #[error("failed to extract plugin package: {0}")]
+    Extract(String),
+
+    /// A package entry has an unsafe path (absolute or `..`-escaping) — a
+    /// zip-slip attempt. The install is refused.
+    #[error("plugin package contains an unsafe entry path: `{0}`")]
+    UnsafePath(String),
+
+    /// A requested plugin file path escapes the plugin directory.
+    #[error("path `{0}` escapes the plugin directory")]
+    PathTraversal(String),
+
+    /// A state or settings file could not be (de)serialized.
+    #[error("plugin state store error: {0}")]
+    Store(String),
+}
+
+/// Per-plugin record persisted in `plugin-state.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PluginStateRecord {
+    /// Whether the user has the plugin enabled.
+    enabled: bool,
+    /// Install time in milliseconds since the Unix epoch.
+    installed_at: u64,
+}
+
+/// The whole `plugin-state.json` document.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct StateStore {
+    /// Records keyed by plugin id.
+    #[serde(default)]
+    plugins: BTreeMap<String, PluginStateRecord>,
+}
+
+/// The whole `plugin-settings.json` document: per-plugin free-form settings.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct SettingsStore {
+    /// Settings objects keyed by plugin id.
+    #[serde(default)]
+    plugins: BTreeMap<String, Map<String, Value>>,
+}
+
+/// Owns the installed-plugin directory and its state; the entry point for the
+/// Tauri command layer.
+pub struct PluginManager {
+    /// The `<app-data>/plugins/` root.
+    root: PathBuf,
+    /// Serializes install/uninstall/state mutations against each other.
+    lock: Mutex<()>,
+    /// The loading seam; a no-op until a host issue supplies a real one.
+    hook: Arc<dyn PluginLifecycleHook>,
+}
+
+impl PluginManager {
+    /// Create a manager rooted at `plugins_root` (`<app-data>/plugins/`), using
+    /// the no-op lifecycle hook.
+    ///
+    /// The directory is created lazily on first write; it does not need to exist
+    /// yet.
+    pub fn new(plugins_root: impl Into<PathBuf>) -> Self {
+        Self::with_hook(plugins_root, Arc::new(NoopLifecycleHook))
+    }
+
+    /// Create a manager with an explicit [`PluginLifecycleHook`] — used by the
+    /// later plugin-host issue to wire in real loading.
+    pub fn with_hook(plugins_root: impl Into<PathBuf>, hook: Arc<dyn PluginLifecycleHook>) -> Self {
+        Self {
+            root: plugins_root.into(),
+            lock: Mutex::new(()),
+            hook,
+        }
+    }
+
+    /// The `<app-data>/plugins/` root this manager owns.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Validate a `.termihub-plugin` package without installing it, returning
+    /// its trusted manifest. Thin pass-through to [`validate_package`] so the
+    /// command surface has a single entry point.
+    pub fn validate(&self, package_path: &Path) -> Result<PluginManifest, PluginPackageError> {
+        validate_package(package_path)
+    }
+
+    /// Scan the plugins root and return every installed plugin, sorted by id.
+    ///
+    /// Each sub*directory* with a readable, valid `manifest.json` becomes an
+    /// [`InstalledPlugin`]; its state is derived from API compatibility and the
+    /// persisted enabled/disabled flag. Directories whose manifest is missing or
+    /// invalid are skipped (they were never installed through this manager, or
+    /// were corrupted) rather than aborting the whole scan.
+    pub fn list(&self) -> Result<Vec<InstalledPlugin>, PluginManagerError> {
+        if !self.root.exists() {
+            return Ok(Vec::new());
+        }
+        let state = self.read_state_store()?;
+        let mut out = Vec::new();
+        for entry in std::fs::read_dir(&self.root)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let dir = entry.path();
+            let manifest = match read_manifest(&dir) {
+                Some(m) => m,
+                None => continue,
+            };
+            out.push(self.installed_plugin_from(manifest, &state, &dir));
+        }
+        out.sort_by(|a, b| a.manifest.id.cmp(&b.manifest.id));
+        Ok(out)
+    }
+
+    /// Look up a single installed plugin by id.
+    pub fn get(&self, id: &str) -> Result<InstalledPlugin, PluginManagerError> {
+        let dir = self.plugin_dir(id);
+        let manifest = read_manifest(&dir).ok_or_else(|| PluginManagerError::NotFound(id.into()))?;
+        let state = self.read_state_store()?;
+        Ok(self.installed_plugin_from(manifest, &state, &dir))
+    }
+
+    /// Install a plugin from a `.termihub-plugin` package.
+    ///
+    /// Validates the package (format + API compatibility), extracts it into
+    /// `plugins/<id>/` (replacing any prior install of the same id), records it
+    /// as enabled, and runs the enable hook. Serialized against other
+    /// install/uninstall operations.
+    pub fn install(&self, package_path: &Path) -> Result<InstalledPlugin, PluginManagerError> {
+        let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
+
+        let manifest = validate_package(package_path)?;
+        let id = manifest.id.clone();
+        let dest = self.plugin_dir(&id);
+
+        std::fs::create_dir_all(&self.root)?;
+
+        // Extract into a staging directory on the same filesystem, then swap it
+        // into place, so a failed extraction never leaves a half-written plugin
+        // dir behind.
+        let staging = self.root.join(format!(".staging-{id}"));
+        if staging.exists() {
+            std::fs::remove_dir_all(&staging)?;
+        }
+        let extract_result = extract_package(package_path, &staging);
+        if let Err(e) = extract_result {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(e);
+        }
+        if dest.exists() {
+            std::fs::remove_dir_all(&dest)?;
+        }
+        std::fs::rename(&staging, &dest)?;
+
+        // Record enabled state with the install timestamp.
+        let mut state = self.read_state_store()?;
+        state.plugins.insert(
+            id.clone(),
+            PluginStateRecord {
+                enabled: true,
+                installed_at: now_millis(),
+            },
+        );
+        self.write_state_store(&state)?;
+
+        let mut plugin = self.installed_plugin_from(manifest, &state, &dest);
+        if let Err(msg) = self.hook.on_enable(&plugin) {
+            plugin.state = PluginState::Error;
+            plugin.error_message = Some(msg);
+        }
+        Ok(plugin)
+    }
+
+    /// Uninstall a plugin by id: run its shutdown hook, remove its directory,
+    /// and drop its persisted state and settings. Serialized against other
+    /// install/uninstall operations. Idempotent-ish: a missing directory is a
+    /// [`PluginManagerError::NotFound`].
+    pub fn uninstall(&self, id: &str) -> Result<(), PluginManagerError> {
+        let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
+
+        let dir = self.plugin_dir(id);
+        if !dir.exists() {
+            return Err(PluginManagerError::NotFound(id.into()));
+        }
+
+        // Shutdown hook first (no-op today); a hook failure must not strand the
+        // plugin on disk, so we log-and-continue rather than abort.
+        let _ = self.hook.on_uninstall(id);
+
+        std::fs::remove_dir_all(&dir)?;
+
+        let mut state = self.read_state_store()?;
+        state.plugins.remove(id);
+        self.write_state_store(&state)?;
+
+        let mut settings = self.read_settings_store()?;
+        settings.plugins.remove(id);
+        self.write_settings_store(&settings)?;
+
+        Ok(())
+    }
+
+    /// Enable a plugin, persisting the flag and running the enable hook. Returns
+    /// the refreshed [`InstalledPlugin`].
+    pub fn enable(&self, id: &str) -> Result<InstalledPlugin, PluginManagerError> {
+        self.set_enabled(id, true)
+    }
+
+    /// Disable a plugin, persisting the flag and running the disable hook.
+    pub fn disable(&self, id: &str) -> Result<InstalledPlugin, PluginManagerError> {
+        self.set_enabled(id, false)
+    }
+
+    fn set_enabled(&self, id: &str, enabled: bool) -> Result<InstalledPlugin, PluginManagerError> {
+        let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
+
+        let dir = self.plugin_dir(id);
+        let manifest = read_manifest(&dir).ok_or_else(|| PluginManagerError::NotFound(id.into()))?;
+
+        let mut state = self.read_state_store()?;
+        let record = state
+            .plugins
+            .entry(id.to_string())
+            .or_insert_with(|| PluginStateRecord {
+                enabled,
+                installed_at: now_millis(),
+            });
+        record.enabled = enabled;
+        self.write_state_store(&state)?;
+
+        let mut plugin = self.installed_plugin_from(manifest, &state, &dir);
+
+        // Run the loading seam. Compatibility is decided before the hook: an
+        // incompatible plugin must not be loaded regardless of the flag.
+        if plugin.state != PluginState::Incompatible {
+            let hook_result = if enabled {
+                self.hook.on_enable(&plugin)
+            } else {
+                self.hook.on_disable(id)
+            };
+            if let Err(msg) = hook_result {
+                plugin.state = PluginState::Error;
+                plugin.error_message = Some(msg);
+            }
+        }
+        Ok(plugin)
+    }
+
+    /// Return a plugin's stored settings (the raw persisted object, empty if the
+    /// user has set none). Schema defaults live in the manifest and are applied
+    /// by the caller.
+    pub fn get_settings(&self, id: &str) -> Result<Map<String, Value>, PluginManagerError> {
+        if !self.plugin_dir(id).exists() {
+            return Err(PluginManagerError::NotFound(id.into()));
+        }
+        let settings = self.read_settings_store()?;
+        Ok(settings.plugins.get(id).cloned().unwrap_or_default())
+    }
+
+    /// Replace a plugin's stored settings with `values`.
+    pub fn update_settings(
+        &self,
+        id: &str,
+        values: Map<String, Value>,
+    ) -> Result<(), PluginManagerError> {
+        let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
+
+        if !self.plugin_dir(id).exists() {
+            return Err(PluginManagerError::NotFound(id.into()));
+        }
+        let mut settings = self.read_settings_store()?;
+        settings.plugins.insert(id.to_string(), values);
+        self.write_settings_store(&settings)?;
+        Ok(())
+    }
+
+    /// Read a file from inside an installed plugin's directory. `relative` is a
+    /// path *within* `plugins/<id>/`; absolute or `..`-escaping paths are
+    /// refused. This is the helper the (later) theme/JS loaders use to pull
+    /// asset bytes out of an installed plugin.
+    pub fn read_file(&self, id: &str, relative: &str) -> Result<Vec<u8>, PluginManagerError> {
+        let dir = self.plugin_dir(id);
+        if !dir.exists() {
+            return Err(PluginManagerError::NotFound(id.into()));
+        }
+        let safe = safe_relative(relative)
+            .ok_or_else(|| PluginManagerError::PathTraversal(relative.into()))?;
+        let full = dir.join(safe);
+        Ok(std::fs::read(full)?)
+    }
+
+    // --- internal helpers -------------------------------------------------
+
+    /// Absolute directory for a plugin id. The id is validated at manifest time
+    /// to a filesystem-safe slug, so it cannot contain separators.
+    fn plugin_dir(&self, id: &str) -> PathBuf {
+        self.root.join(id)
+    }
+
+    /// Build an [`InstalledPlugin`], deriving its state from API compatibility
+    /// and the persisted enabled flag.
+    fn installed_plugin_from(
+        &self,
+        manifest: PluginManifest,
+        state: &StateStore,
+        dir: &Path,
+    ) -> InstalledPlugin {
+        let record = state.plugins.get(&manifest.id);
+        let enabled = record.map(|r| r.enabled).unwrap_or(true);
+        let installed_at = record
+            .map(|r| r.installed_at)
+            .unwrap_or_else(|| dir_install_time(dir));
+
+        let plugin_state = if manifest.api_compatibility() == ApiCompatibility::Incompatible {
+            PluginState::Incompatible
+        } else if enabled {
+            // Enabled but not loaded — this layer does no loading, so an enabled
+            // plugin rests at `installed` until a host promotes it to `active`.
+            PluginState::Installed
+        } else {
+            PluginState::Disabled
+        };
+
+        InstalledPlugin {
+            manifest,
+            state: plugin_state,
+            error_message: None,
+            installed_at,
+        }
+    }
+
+    fn state_path(&self) -> PathBuf {
+        self.root.join(STATE_FILE_NAME)
+    }
+
+    fn settings_path(&self) -> PathBuf {
+        self.root.join(SETTINGS_FILE_NAME)
+    }
+
+    fn read_state_store(&self) -> Result<StateStore, PluginManagerError> {
+        read_json_or_default(&self.state_path())
+    }
+
+    fn write_state_store(&self, store: &StateStore) -> Result<(), PluginManagerError> {
+        write_json_atomic(&self.root, &self.state_path(), store)
+    }
+
+    fn read_settings_store(&self) -> Result<SettingsStore, PluginManagerError> {
+        read_json_or_default(&self.settings_path())
+    }
+
+    fn write_settings_store(&self, store: &SettingsStore) -> Result<(), PluginManagerError> {
+        write_json_atomic(&self.root, &self.settings_path(), store)
+    }
+}
+
+/// Current time as milliseconds since the Unix epoch (0 if the clock predates
+/// the epoch, which cannot happen in practice).
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Best-effort install time for a plugin directory that has no state record
+/// (e.g. dropped in by hand): its created time, falling back to modified, then
+/// to now.
+fn dir_install_time(dir: &Path) -> u64 {
+    let meta = match std::fs::metadata(dir) {
+        Ok(m) => m,
+        Err(_) => return now_millis(),
+    };
+    meta.created()
+        .or_else(|_| meta.modified())
+        .ok()
+        .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or_else(now_millis)
+}
+
+/// Read and validate `manifest.json` from a plugin directory, or `None` if it
+/// is missing, unreadable, unparseable, or fails semantic validation.
+fn read_manifest(dir: &Path) -> Option<PluginManifest> {
+    let json = std::fs::read_to_string(dir.join(MANIFEST_FILE_NAME)).ok()?;
+    let manifest = parse_manifest(&json).ok()?;
+    manifest.validate().ok()?;
+    Some(manifest)
+}
+
+/// Sanitize a caller-supplied relative path to one that stays inside a plugin
+/// directory. Returns `None` for absolute paths, roots, or any `..` component.
+fn safe_relative(relative: &str) -> Option<PathBuf> {
+    let path = Path::new(relative);
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => out.push(part),
+            // Reject anything that could escape or re-root the path.
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return None,
+            Component::CurDir => {}
+        }
+    }
+    if out.as_os_str().is_empty() {
+        return None;
+    }
+    Some(out)
+}
+
+/// Extract a validated `.termihub-plugin` (ZIP) into `dest`, creating it.
+///
+/// Every entry path is resolved through `enclosed_name`, which yields `None` for
+/// any path that would escape the destination (zip-slip); such an entry aborts
+/// the extraction with [`PluginManagerError::UnsafePath`].
+fn extract_package(package_path: &Path, dest: &Path) -> Result<(), PluginManagerError> {
+    let file = std::fs::File::open(package_path)?;
+    let mut archive =
+        zip::ZipArchive::new(file).map_err(|e| PluginManagerError::Extract(e.to_string()))?;
+
+    std::fs::create_dir_all(dest)?;
+
+    for i in 0..archive.len() {
+        let mut entry = archive
+            .by_index(i)
+            .map_err(|e| PluginManagerError::Extract(e.to_string()))?;
+        let raw_name = entry.name().to_string();
+        let safe = entry
+            .enclosed_name()
+            .ok_or(PluginManagerError::UnsafePath(raw_name))?;
+        let out_path = dest.join(safe);
+
+        if entry.is_dir() {
+            std::fs::create_dir_all(&out_path)?;
+            continue;
+        }
+        if let Some(parent) = out_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut out = std::fs::File::create(&out_path)?;
+        let mut buf = Vec::new();
+        entry.read_to_end(&mut buf)?;
+        std::io::Write::write_all(&mut out, &buf)?;
+    }
+    Ok(())
+}
+
+/// Read a JSON document, returning `T::default()` when the file does not exist.
+fn read_json_or_default<T>(path: &Path) -> Result<T, PluginManagerError>
+where
+    T: serde::de::DeserializeOwned + Default,
+{
+    match std::fs::read_to_string(path) {
+        Ok(s) => serde_json::from_str(&s).map_err(|e| PluginManagerError::Store(e.to_string())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(T::default()),
+        Err(e) => Err(PluginManagerError::Io(e)),
+    }
+}
+
+/// Serialize `value` to `path` atomically: write a sibling temp file, then
+/// rename it over the target so a crash mid-write cannot corrupt the store.
+fn write_json_atomic<T: Serialize>(
+    root: &Path,
+    path: &Path,
+    value: &T,
+) -> Result<(), PluginManagerError> {
+    std::fs::create_dir_all(root)?;
+    let json =
+        serde_json::to_string_pretty(value).map_err(|e| PluginManagerError::Store(e.to_string()))?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+
+    fn manifest_json(id: &str, api_version: &str) -> String {
+        format!(
+            r#"{{
+                "id": "{id}",
+                "name": "Test Plugin",
+                "version": "1.0.0",
+                "author": "tester",
+                "description": "A plugin for tests",
+                "license": "MIT",
+                "apiVersion": "{api_version}",
+                "platforms": ["linux", "macos", "windows"],
+                "permissions": ["terminal"],
+                "extensions": {{
+                    "theme": {{
+                        "themes": [
+                            {{ "id": "dark", "name": "Dark", "file": "themes/dark.json" }}
+                        ]
+                    }}
+                }}
+            }}"#
+        )
+    }
+
+    /// Build a `.termihub-plugin` package on disk with the given manifest and
+    /// extra files.
+    fn make_package(dir: &Path, manifest: &str, extra: &[(&str, &[u8])]) -> PathBuf {
+        let path = dir.join("plugin.termihub-plugin");
+        let file = std::fs::File::create(&path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let opts = SimpleFileOptions::default();
+        zip.start_file(MANIFEST_FILE_NAME, opts).unwrap();
+        zip.write_all(manifest.as_bytes()).unwrap();
+        for (name, bytes) in extra {
+            zip.start_file(*name, opts).unwrap();
+            zip.write_all(bytes).unwrap();
+        }
+        zip.finish().unwrap();
+        path
+    }
+
+    /// A manager rooted in a fresh temp dir, returned with the temp dir so it
+    /// outlives the manager.
+    fn manager() -> (PluginManager, TempDir) {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("plugins");
+        (PluginManager::new(root), tmp)
+    }
+
+    #[test]
+    fn list_is_empty_when_root_absent() {
+        let (mgr, _t) = manager();
+        assert!(mgr.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn install_then_list_and_get() {
+        let (mgr, tmp) = manager();
+        let pkg = make_package(
+            tmp.path(),
+            &manifest_json("my-theme", "1.0"),
+            &[("themes/dark.json", b"{\"bg\":\"#000\"}")],
+        );
+
+        let installed = mgr.install(&pkg).unwrap();
+        assert_eq!(installed.manifest.id, "my-theme");
+        assert_eq!(installed.state, PluginState::Installed);
+        assert!(installed.installed_at > 0);
+
+        // Extracted to plugins/<id>/ with its files.
+        let plugin_dir = mgr.root().join("my-theme");
+        assert!(plugin_dir.join(MANIFEST_FILE_NAME).exists());
+        assert!(plugin_dir.join("themes/dark.json").exists());
+
+        let list = mgr.list().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].manifest.id, "my-theme");
+
+        let got = mgr.get("my-theme").unwrap();
+        assert_eq!(got.manifest.id, "my-theme");
+    }
+
+    #[test]
+    fn install_replaces_previous_version() {
+        let (mgr, tmp) = manager();
+        let pkg1 = make_package(
+            tmp.path(),
+            &manifest_json("dup", "1.0"),
+            &[("old.txt", b"old")],
+        );
+        mgr.install(&pkg1).unwrap();
+        assert!(mgr.root().join("dup/old.txt").exists());
+
+        // Reinstall with different contents; the old file must be gone.
+        let tmp2 = TempDir::new().unwrap();
+        let pkg2 = make_package(
+            tmp2.path(),
+            &manifest_json("dup", "1.0"),
+            &[("new.txt", b"new")],
+        );
+        mgr.install(&pkg2).unwrap();
+        assert!(mgr.root().join("dup/new.txt").exists());
+        assert!(!mgr.root().join("dup/old.txt").exists());
+        assert_eq!(mgr.list().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn uninstall_removes_dir_state_and_settings() {
+        let (mgr, tmp) = manager();
+        let pkg = make_package(tmp.path(), &manifest_json("gone", "1.0"), &[]);
+        mgr.install(&pkg).unwrap();
+
+        let mut s = Map::new();
+        s.insert("k".into(), Value::from("v"));
+        mgr.update_settings("gone", s).unwrap();
+
+        mgr.uninstall("gone").unwrap();
+        assert!(!mgr.root().join("gone").exists());
+        assert!(mgr.list().unwrap().is_empty());
+        // Settings and state records are dropped.
+        assert!(!mgr.read_settings_store().unwrap().plugins.contains_key("gone"));
+        assert!(!mgr.read_state_store().unwrap().plugins.contains_key("gone"));
+    }
+
+    #[test]
+    fn uninstall_unknown_is_not_found() {
+        let (mgr, _t) = manager();
+        assert!(matches!(
+            mgr.uninstall("nope"),
+            Err(PluginManagerError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn disable_then_enable_persists() {
+        let (mgr, tmp) = manager();
+        let pkg = make_package(tmp.path(), &manifest_json("toggle", "1.0"), &[]);
+        mgr.install(&pkg).unwrap();
+
+        let disabled = mgr.disable("toggle").unwrap();
+        assert_eq!(disabled.state, PluginState::Disabled);
+        // Persisted across a fresh scan.
+        assert_eq!(mgr.get("toggle").unwrap().state, PluginState::Disabled);
+        assert_eq!(mgr.list().unwrap()[0].state, PluginState::Disabled);
+
+        let enabled = mgr.enable("toggle").unwrap();
+        assert_eq!(enabled.state, PluginState::Installed);
+        assert_eq!(mgr.get("toggle").unwrap().state, PluginState::Installed);
+    }
+
+    #[test]
+    fn enable_unknown_is_not_found() {
+        let (mgr, _t) = manager();
+        assert!(matches!(
+            mgr.enable("ghost"),
+            Err(PluginManagerError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn settings_round_trip() {
+        let (mgr, tmp) = manager();
+        let pkg = make_package(tmp.path(), &manifest_json("cfg", "1.0"), &[]);
+        mgr.install(&pkg).unwrap();
+
+        // Empty by default.
+        assert!(mgr.get_settings("cfg").unwrap().is_empty());
+
+        let mut values = Map::new();
+        values.insert("namespace".into(), Value::from("prod"));
+        values.insert("retries".into(), Value::from(3));
+        mgr.update_settings("cfg", values.clone()).unwrap();
+
+        let read_back = mgr.get_settings("cfg").unwrap();
+        assert_eq!(read_back, values);
+
+        // Survives a fresh manager over the same root.
+        let mgr2 = PluginManager::new(mgr.root());
+        assert_eq!(mgr2.get_settings("cfg").unwrap(), values);
+    }
+
+    #[test]
+    fn settings_of_unknown_plugin_is_not_found() {
+        let (mgr, _t) = manager();
+        assert!(matches!(
+            mgr.get_settings("nope"),
+            Err(PluginManagerError::NotFound(_))
+        ));
+        assert!(matches!(
+            mgr.update_settings("nope", Map::new()),
+            Err(PluginManagerError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn incompatible_api_version_surfaces_as_state() {
+        // Install a compatible plugin, then hand-edit its manifest to an
+        // incompatible API version — simulating a host upgrade under a plugin
+        // that was installed while still compatible.
+        let (mgr, tmp) = manager();
+        let pkg = make_package(tmp.path(), &manifest_json("legacy", "1.0"), &[]);
+        mgr.install(&pkg).unwrap();
+
+        let manifest_path = mgr.root().join("legacy").join(MANIFEST_FILE_NAME);
+        let bumped = manifest_json("legacy", "2.0");
+        std::fs::write(&manifest_path, bumped).unwrap();
+
+        assert_eq!(mgr.get("legacy").unwrap().state, PluginState::Incompatible);
+        assert_eq!(mgr.list().unwrap()[0].state, PluginState::Incompatible);
+    }
+
+    #[test]
+    fn install_refuses_incompatible_package() {
+        let (mgr, tmp) = manager();
+        let pkg = make_package(tmp.path(), &manifest_json("future", "2.0"), &[]);
+        assert!(matches!(
+            mgr.install(&pkg),
+            Err(PluginManagerError::Package(
+                PluginPackageError::IncompatibleApiVersion { .. }
+            ))
+        ));
+        // Nothing was extracted.
+        assert!(!mgr.root().join("future").exists());
+    }
+
+    #[test]
+    fn read_file_returns_bytes_and_blocks_traversal() {
+        let (mgr, tmp) = manager();
+        let pkg = make_package(
+            tmp.path(),
+            &manifest_json("assets", "1.0"),
+            &[("themes/dark.json", b"{\"bg\":\"#111\"}")],
+        );
+        mgr.install(&pkg).unwrap();
+
+        let bytes = mgr.read_file("assets", "themes/dark.json").unwrap();
+        assert_eq!(bytes, b"{\"bg\":\"#111\"}");
+
+        for bad in ["../secret", "/etc/passwd", "themes/../../escape", ""] {
+            assert!(
+                matches!(
+                    mgr.read_file("assets", bad),
+                    Err(PluginManagerError::PathTraversal(_))
+                ),
+                "path {bad:?} should be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn extraction_rejects_zip_slip() {
+        // A package whose entry tries to escape via `..`. `enclosed_name`
+        // returns None for it, so install fails with UnsafePath and writes
+        // nothing outside the plugin dir.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("evil.termihub-plugin");
+        let file = std::fs::File::create(&path).unwrap();
+        let mut zip = ZipWriter::new(file);
+        let opts = SimpleFileOptions::default();
+        zip.start_file(MANIFEST_FILE_NAME, opts).unwrap();
+        zip.write_all(manifest_json("evil", "1.0").as_bytes())
+            .unwrap();
+        // Escaping entry.
+        zip.start_file("../escaped.txt", opts).unwrap();
+        zip.write_all(b"pwned").unwrap();
+        zip.finish().unwrap();
+
+        let (mgr, _t) = manager();
+        let result = mgr.install(&path);
+        assert!(
+            matches!(result, Err(PluginManagerError::UnsafePath(_))),
+            "got: {result:?}"
+        );
+        assert!(!mgr.root().join("evil").exists());
+        assert!(!tmp.path().join("escaped.txt").exists());
+    }
+
+    #[test]
+    fn scan_skips_dirs_without_valid_manifest() {
+        let (mgr, tmp) = manager();
+        let pkg = make_package(tmp.path(), &manifest_json("real", "1.0"), &[]);
+        mgr.install(&pkg).unwrap();
+
+        // A stray directory with no manifest, and one with garbage.
+        std::fs::create_dir_all(mgr.root().join("stray")).unwrap();
+        std::fs::create_dir_all(mgr.root().join("broken")).unwrap();
+        std::fs::write(mgr.root().join("broken").join(MANIFEST_FILE_NAME), "{ bad").unwrap();
+
+        let list = mgr.list().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].manifest.id, "real");
+    }
+
+    #[test]
+    fn lifecycle_hook_error_surfaces_as_error_state() {
+        struct FailingHook;
+        impl PluginLifecycleHook for FailingHook {
+            fn on_enable(&self, _plugin: &InstalledPlugin) -> Result<(), String> {
+                Err("boom".into())
+            }
+        }
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("plugins");
+        let mgr = PluginManager::with_hook(root, Arc::new(FailingHook));
+        let pkg = make_package(tmp.path(), &manifest_json("hooked", "1.0"), &[]);
+
+        // Install runs on_enable, which fails: state is Error with the message.
+        let installed = mgr.install(&pkg).unwrap();
+        assert_eq!(installed.state, PluginState::Error);
+        assert_eq!(installed.error_message.as_deref(), Some("boom"));
+
+        // But the plugin is on disk and enabled; a plain scan (no hook) reports
+        // it as installed.
+        assert!(mgr.root().join("hooked").exists());
+    }
+}

--- a/core/src/plugin/mod.rs
+++ b/core/src/plugin/mod.rs
@@ -1,11 +1,12 @@
 //! Plugin package format and manifest contract.
 //!
 //! This module is the *foundation* of termiHub's plugin system (see
-//! `docs/concepts/future/plugin-system.html`, impl §1–2): it defines the
-//! on-disk package format, the `manifest.json` data model, and the validator
-//! every other part of the plugin system builds on. It performs **no**
-//! installation, dynamic-library loading, or UI — only the format contract and
-//! its validation.
+//! `docs/concepts/future/plugin-system.html`): it defines the on-disk package
+//! format, the `manifest.json` data model and validator (§1–2), and the
+//! [`PluginManager`] management layer (§4/§12) that installs, scans, and tracks
+//! installed plugins. It performs **no** dynamic-library loading or JS/theme
+//! registration and has no UI — code loading is delegated to later issues
+//! through the [`PluginLifecycleHook`] seam.
 //!
 //! # The `.termihub-plugin` package format
 //!
@@ -40,9 +41,14 @@
 //! own distinct outcome so callers can prompt the user to update rather than
 //! treating it as a malformed package.
 
+mod manager;
 mod manifest;
 mod package;
 
+pub use manager::{
+    InstalledPlugin, NoopLifecycleHook, PluginLifecycleHook, PluginManager, PluginManagerError,
+    PluginState,
+};
 pub use manifest::{
     check_api_compatibility, parse_manifest, ApiCompatibility, ManifestParseError,
     ManifestValidationError, Platform, PluginExtensions, PluginManifest, PluginPermission,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -73,7 +73,7 @@ shlex = "1"
 base64 = "0.22"
 anyhow = "1"
 thiserror = { workspace = true }
-termihub-core = { path = "../core", features = ["serial", "local-shell", "telnet", "ssh", "docker", "wsl"] }
+termihub-core = { path = "../core", features = ["serial", "local-shell", "telnet", "ssh", "docker", "wsl", "plugin"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "macros", "net", "time", "io-util"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 axum = "0.7"

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod local_process;
 pub mod logs;
 pub mod macros;
 pub mod network;
+pub mod plugin;
 pub mod portable;
 pub mod remote_desktop;
 pub mod session;

--- a/src-tauri/src/commands/plugin.rs
+++ b/src-tauri/src/commands/plugin.rs
@@ -1,0 +1,132 @@
+//! Tauri commands for the plugin **management layer** (#1992).
+//!
+//! Thin wrappers over [`termihub_core::plugin::PluginManager`]: they expose
+//! install / uninstall / enable / disable / scan and the settings + file-read
+//! helpers to the frontend, and emit a [`EVENT_PLUGINS_CHANGED`] event whenever
+//! the installed-plugin set or a plugin's state changes so the UI can refresh.
+//!
+//! This is deliberately the *command surface only* — no code loading. Actual
+//! loading of themes / JS / native backends is delegated to later issues through
+//! the manager's `PluginLifecycleHook` seam. The [`PluginManager`] itself is
+//! created once at startup and shared as managed state.
+
+use tauri::{AppHandle, Emitter, State};
+
+use serde_json::{Map, Value};
+use termihub_core::plugin::{InstalledPlugin, PluginManager, PluginManifest};
+
+/// Event emitted whenever the installed-plugin set or a plugin's state changes.
+/// The frontend re-fetches [`list_plugins`] on receipt.
+pub const EVENT_PLUGINS_CHANGED: &str = "plugin-changed";
+
+/// Emit the plugin-changed event, ignoring transport errors (a missing window
+/// listener must never fail the command).
+fn emit_changed(app: &AppHandle) {
+    let _ = app.emit(EVENT_PLUGINS_CHANGED, ());
+}
+
+/// List every installed plugin with its current state.
+#[tauri::command]
+pub fn list_plugins(manager: State<'_, PluginManager>) -> Result<Vec<InstalledPlugin>, String> {
+    manager.list().map_err(|e| e.to_string())
+}
+
+/// Validate a `.termihub-plugin` package at `path` without installing it,
+/// returning its trusted manifest (which carries the declared permissions the
+/// UI shows in the install prompt). An incompatible or malformed package is an
+/// error.
+#[tauri::command]
+pub fn validate_plugin(
+    path: String,
+    manager: State<'_, PluginManager>,
+) -> Result<PluginManifest, String> {
+    manager
+        .validate(std::path::Path::new(&path))
+        .map_err(|e| e.to_string())
+}
+
+/// Install a plugin from the `.termihub-plugin` package at `path`. Emits
+/// [`EVENT_PLUGINS_CHANGED`] on success.
+#[tauri::command]
+pub fn install_plugin(
+    path: String,
+    app: AppHandle,
+    manager: State<'_, PluginManager>,
+) -> Result<InstalledPlugin, String> {
+    let installed = manager
+        .install(std::path::Path::new(&path))
+        .map_err(|e| e.to_string())?;
+    emit_changed(&app);
+    Ok(installed)
+}
+
+/// Uninstall the plugin with the given id. Emits [`EVENT_PLUGINS_CHANGED`].
+#[tauri::command]
+pub fn uninstall_plugin(
+    id: String,
+    app: AppHandle,
+    manager: State<'_, PluginManager>,
+) -> Result<(), String> {
+    manager.uninstall(&id).map_err(|e| e.to_string())?;
+    emit_changed(&app);
+    Ok(())
+}
+
+/// Enable the plugin with the given id, persisting the flag. Emits
+/// [`EVENT_PLUGINS_CHANGED`].
+#[tauri::command]
+pub fn enable_plugin(
+    id: String,
+    app: AppHandle,
+    manager: State<'_, PluginManager>,
+) -> Result<InstalledPlugin, String> {
+    let plugin = manager.enable(&id).map_err(|e| e.to_string())?;
+    emit_changed(&app);
+    Ok(plugin)
+}
+
+/// Disable the plugin with the given id, persisting the flag. Emits
+/// [`EVENT_PLUGINS_CHANGED`].
+#[tauri::command]
+pub fn disable_plugin(
+    id: String,
+    app: AppHandle,
+    manager: State<'_, PluginManager>,
+) -> Result<InstalledPlugin, String> {
+    let plugin = manager.disable(&id).map_err(|e| e.to_string())?;
+    emit_changed(&app);
+    Ok(plugin)
+}
+
+/// Return a plugin's stored settings as a JSON object (empty when unset).
+#[tauri::command]
+pub fn get_plugin_settings(
+    id: String,
+    manager: State<'_, PluginManager>,
+) -> Result<Map<String, Value>, String> {
+    manager.get_settings(&id).map_err(|e| e.to_string())
+}
+
+/// Replace a plugin's stored settings with `settings`.
+#[tauri::command]
+pub fn update_plugin_settings(
+    id: String,
+    settings: Map<String, Value>,
+    manager: State<'_, PluginManager>,
+) -> Result<(), String> {
+    manager
+        .update_settings(&id, settings)
+        .map_err(|e| e.to_string())
+}
+
+/// Read a file from inside an installed plugin's directory (theme JSON, JS
+/// entry point, …). `path` is relative to `plugins/<id>/`; traversal is
+/// refused. Returns the raw bytes; text consumers decode as UTF-8.
+#[tauri::command]
+pub fn read_plugin_file(
+    id: String,
+    path: String,
+    manager: State<'_, PluginManager>,
+) -> Result<Vec<u8>, String> {
+    manager.read_file(&id, &path).map_err(|e| e.to_string())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -374,6 +374,12 @@ pub fn run() {
                 .expect("Failed to resolve app config directory");
             std::fs::create_dir_all(&config_dir).expect("Failed to create config directory");
 
+            // Plugin management layer (#1992): owns <app-data>/plugins/. Created
+            // lazily — the directory is materialised on first install.
+            app.manage(termihub_core::plugin::PluginManager::new(
+                config_dir.join("plugins"),
+            ));
+
             // Capture path for the connections file watcher before config_dir is moved.
             let connections_file = config_dir.join("connections.json");
 
@@ -806,6 +812,16 @@ pub fn run() {
             commands::ssh_host_key::ssh_host_key_decision,
             commands::ssh_host_key::ssh_trust_list,
             commands::ssh_host_key::ssh_trust_forget,
+            // Plugin management layer (#1992)
+            commands::plugin::list_plugins,
+            commands::plugin::validate_plugin,
+            commands::plugin::install_plugin,
+            commands::plugin::uninstall_plugin,
+            commands::plugin::enable_plugin,
+            commands::plugin::disable_plugin,
+            commands::plugin::get_plugin_settings,
+            commands::plugin::update_plugin_settings,
+            commands::plugin::read_plugin_file,
             // Session commands (replaces old terminal commands)
             commands::session::create_connection,
             commands::session::cancel_connecting,


### PR DESCRIPTION
## Summary

Implements the plugin-system **management layer** (concept impl §4/§7/§12, Migration Path step 1) on top of the #1989 package/manifest foundation. This is bookkeeping + the command surface only — **no code loading** (no dynamic libraries, no theme/JS registration); that is delegated to later issues through a lifecycle-hook seam so this merges independently.

### Core (`core/src/plugin/manager.rs`, behind the `plugin` feature)

`PluginManager` owns `<app-data>/plugins/`:

- **Scan** — reads each `plugins/<id>/manifest.json`, tracking `InstalledPlugin { manifest, state, errorMessage?, installedAt }`. State is derived: `incompatible` (API mismatch), `disabled` (persisted flag off), else `installed` (enabled but not yet loaded — this layer never promotes to `active`). `error` is produced when a lifecycle hook fails.
- **Filesystem layout** — `plugins/<id>/`, plus `plugin-state.json` (enabled/disabled + install time) and `plugin-settings.json` (per-plugin config), both written atomically (temp + rename).
- **Install** — validate (reuses #1989's `validate_package`) → extract to a staging dir → swap into `plugins/<id>/` (replacing any prior install) → record enabled. Extraction is zip-slip-safe via `enclosed_name`. **Uninstall** — shutdown hook (no-op) → remove dir → drop state + settings.
- **Serialization** — install/uninstall/enable/disable/settings mutations are serialized by an internal mutex.
- **`PluginLifecycleHook` seam** — the loading delegation point; default `NoopLifecycleHook`. A later host issue supplies a real one via `PluginManager::with_hook`.
- **`read_file`** — traversal-safe read of a file inside a plugin dir (the helper theme/JS loaders will use).

Unit tests cover scan, install (incl. replace + incompatible refusal + zip-slip), uninstall, enable/disable persistence, settings round-trip, incompatible-state surfacing, traversal rejection, and hook-error surfacing (36 plugin tests pass).

### Command surface (`src-tauri/src/commands/plugin.rs`)

Thin wrappers over a `PluginManager` managed at startup over `<app-data>/plugins/`. Mutating commands emit a `plugin-changed` event.

| Command | Signature |
| --- | --- |
| `list_plugins` | `() -> Vec<InstalledPlugin>` |
| `validate_plugin` | `(path) -> PluginManifest` |
| `install_plugin` | `(path) -> InstalledPlugin` |
| `uninstall_plugin` | `(id) -> ()` |
| `enable_plugin` | `(id) -> InstalledPlugin` |
| `disable_plugin` | `(id) -> InstalledPlugin` |
| `get_plugin_settings` | `(id) -> object` |
| `update_plugin_settings` | `(id, settings) -> ()` |
| `read_plugin_file` | `(id, path) -> bytes` |

The desktop app enables the core `plugin` feature (same pattern as `ssh`/`docker`), so the surface is always compiled and registered.

## Out of scope (per issue)
- Native dynamic-library loading → #1995
- Plugin UI → #1997

## Test plan
- `cargo test -p termihub-core --features plugin` — 36 plugin tests pass
- `cargo clippy` on core (`--features plugin`) and `termihub` — clean with `-D warnings`
- `cargo fmt --all` clean

Closes #1992