### PR TITLE
feat(plugin): native plugin host loader (libloading) + registry integration (Closes #1995)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ tests/system/test-inventory.json
 # RDP sidecar binaries staged for Tauri `externalBin` bundling (#1754). Built by
 # scripts/build-rdp-sidecar.sh --tauri-externalbin; never checked in.
 /src-tauri/binaries/
+
+# Generated when the host-loader round-trip test builds its cdylib fixture (#1995)
+core/tests/fixtures/test-plugin/Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3779,6 +3779,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7653,6 +7663,7 @@ dependencies = [
  "hex",
  "hickory-resolver",
  "ipnet",
+ "libloading",
  "md5",
  "p256",
  "p384",
@@ -7677,6 +7688,7 @@ dependencies = [
  "surge-ping",
  "temp-env",
  "tempfile",
+ "termihub-plugin-api",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -89,6 +89,15 @@ vte = "0.13"
 # Behind the optional `plugin` feature so it is only compiled when the plugin
 # system is built.
 zip = { version = "2", optional = true }
+# Native plugin host loader (#1995): opens a plugin's backend dynamic library
+# (`.dll`/`.so`/`.dylib`) and resolves its stable-ABI entry symbols. The de-facto
+# cross-platform `dlopen`/`LoadLibrary` wrapper — library-first over hand-rolled
+# FFI. Behind the optional `plugin` feature.
+libloading = { version = "0.8", optional = true }
+# The stable ABI contract shared by the host and every plugin (#1990). The host
+# loader resolves the plugin's exported symbols to the type aliases this crate
+# defines and drives the backend through its safe wrappers. Behind `plugin`.
+termihub-plugin-api = { path = "../plugin-api", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 # Used to build a per-user DACL for a security-hardened local-IPC listener
@@ -121,10 +130,11 @@ serial_test = "3"
 
 [features]
 default = []
-# Plugin package format + manifest schema/validation (#1989). Pulls the `zip`
-# crate to read `.termihub-plugin` archives. Foundation only — no plugin
-# loading/UI yet.
-plugin = ["dep:zip"]
+# Plugin package format + manifest schema/validation (#1989), plus the native
+# host loader (#1995). Pulls `zip` to read `.termihub-plugin` archives,
+# `libloading` to open a plugin's backend dynamic library, and
+# `termihub-plugin-api` for the stable ABI contract.
+plugin = ["dep:zip", "dep:libloading", "dep:termihub-plugin-api"]
 serial = ["dep:serial2", "dep:serial2-tokio", "dep:tracing"]
 local-shell = ["dep:portable-pty", "dep:tracing"]
 telnet = ["dep:tracing"]

--- a/core/src/connection/registry.rs
+++ b/core/src/connection/registry.rs
@@ -130,6 +130,20 @@ impl ConnectionTypeRegistry {
     pub fn has_type(&self, type_id: &str) -> bool {
         self.factories.contains_key(type_id)
     }
+
+    /// Remove a previously-registered connection type.
+    ///
+    /// Used by the plugin host to unregister a dynamically-loaded connection type
+    /// when its plugin is disabled or uninstalled. Returns `true` if a type was
+    /// removed, `false` if no type with that id was registered.
+    pub fn unregister(&mut self, type_id: &str) -> bool {
+        if self.factories.remove(type_id).is_some() {
+            self.order.retain(|id| id != type_id);
+            true
+        } else {
+            false
+        }
+    }
 }
 
 impl Default for ConnectionTypeRegistry {

--- a/core/src/connection/registry.rs
+++ b/core/src/connection/registry.rs
@@ -288,6 +288,31 @@ mod tests {
     }
 
     #[test]
+    fn unregister_removes_type_and_order() {
+        let mut registry = ConnectionTypeRegistry::new();
+        registry.register("a", "A", "a", mock_factory("a"));
+        registry.register("b", "B", "b", mock_factory("b"));
+        registry.register("c", "C", "c", mock_factory("c"));
+
+        // Removing a known type reports success and drops it from listing.
+        assert!(registry.unregister("b"));
+        assert!(!registry.has_type("b"));
+        let ids: Vec<String> = registry
+            .available_types()
+            .into_iter()
+            .map(|t| t.type_id)
+            .collect();
+        assert_eq!(ids, vec!["a".to_string(), "c".to_string()]);
+
+        // Removing an unknown type is a no-op that reports false.
+        assert!(!registry.unregister("nope"));
+
+        // A removed type can be registered again.
+        registry.register("b", "B", "b", mock_factory("b"));
+        assert!(registry.has_type("b"));
+    }
+
+    #[test]
     fn has_type_returns_correct_results() {
         let mut registry = ConnectionTypeRegistry::new();
         registry.register("ssh", "SSH", "ssh", mock_factory("ssh"));

--- a/core/src/plugin/connection.rs
+++ b/core/src/plugin/connection.rs
@@ -62,11 +62,7 @@ pub struct PluginConnectionType {
 impl PluginConnectionType {
     /// Build a fresh, unconnected connection of the given plugin type.
     #[must_use]
-    pub fn new(
-        library: Arc<LoadedLibrary>,
-        connection_type: String,
-        display_name: String,
-    ) -> Self {
+    pub fn new(library: Arc<LoadedLibrary>, connection_type: String, display_name: String) -> Self {
         Self {
             library,
             connection_type,

--- a/core/src/plugin/connection.rs
+++ b/core/src/plugin/connection.rs
@@ -134,18 +134,12 @@ impl ConnectionType for PluginConnectionType {
         std::thread::spawn(move || {
             while let Ok(chunk) = std_rx.recv() {
                 let guard = output_tx.lock().unwrap_or_else(|e| e.into_inner());
-                match guard.as_ref() {
-                    Some(sender) => {
-                        if sender.blocking_send(chunk).is_err() {
-                            // Receiver dropped; keep draining so the plugin's
-                            // sender does not block, but stop trying to deliver.
-                        }
-                    }
-                    None => {
-                        // No active subscriber yet; drop the chunk. Terminal
-                        // output before the first `subscribe_output` is not
-                        // retained (matching the other backends).
-                    }
+                // Deliver to the current subscriber if any; a dropped receiver or
+                // no active subscription (output before the first
+                // `subscribe_output`) simply drops the chunk, matching the other
+                // backends. Keep draining so the plugin's sender never blocks.
+                if let Some(sender) = guard.as_ref() {
+                    let _ = sender.blocking_send(chunk);
                 }
             }
         });

--- a/core/src/plugin/connection.rs
+++ b/core/src/plugin/connection.rs
@@ -1,0 +1,206 @@
+//! Adapter that presents a loaded plugin backend as a
+//! [`ConnectionType`](crate::connection::ConnectionType).
+//!
+//! The host loader ([`super::host`]) produces an
+//! [`Arc<LoadedLibrary>`](super::host::LoadedLibrary) that can create backend
+//! sessions over the stable plugin ABI. [`PluginConnectionType`] wraps one such
+//! library so a plugin-provided terminal backend slots into the same
+//! [`ConnectionTypeRegistry`](crate::connection::ConnectionTypeRegistry) and
+//! session machinery as the built-in backends (local shell, SSH, telnet, …).
+//!
+//! # Output bridging
+//!
+//! The plugin ABI delivers terminal output through a
+//! [`PluginOutputSender`](termihub_plugin_api::PluginOutputSender), which the
+//! host builds over a synchronous `std::sync::mpsc` channel. The
+//! [`ConnectionType`](crate::connection::ConnectionType) contract instead exposes
+//! an async `tokio::sync::mpsc` receiver via
+//! [`subscribe_output`](crate::connection::ConnectionType::subscribe_output). A
+//! small forwarding thread bridges the two — the same pattern the telnet and
+//! serial backends use to move a blocking reader onto the async channel.
+//!
+//! # Scope
+//!
+//! This is the *load-and-register* adapter (#1995). Deriving a real
+//! [`SettingsSchema`](crate::connection::SettingsSchema) from the plugin's
+//! declared `configSchema`, and wiring the type through the connection editor and
+//! session-creation flow, is connection-type wiring left to #1999; until then the
+//! schema is empty and the raw settings JSON is forwarded to the plugin verbatim.
+
+use std::sync::{Arc, Mutex};
+
+use termihub_plugin_api::{LoadedBackend, PluginError, PluginOutputSender};
+
+use crate::connection::{
+    Capabilities, ConnectionType, OutputReceiver, OutputSender, SettingsSchema,
+};
+use crate::errors::SessionError;
+use crate::files::FileBrowser;
+use crate::monitoring::MonitoringProvider;
+
+use super::host::LoadedLibrary;
+
+/// Channel capacity for output forwarded from the plugin to the terminal.
+const OUTPUT_CHANNEL_CAPACITY: usize = 64;
+
+/// A [`ConnectionType`] backed by a dynamically-loaded plugin library.
+///
+/// Holds an [`Arc<LoadedLibrary>`] so the plugin's code stays mapped for as long
+/// as this session (and hence any [`LoadedBackend`] it created) is alive.
+pub struct PluginConnectionType {
+    library: Arc<LoadedLibrary>,
+    connection_type: String,
+    display_name: String,
+    /// The active session backend, `None` until [`connect`](ConnectionType::connect).
+    backend: Option<LoadedBackend>,
+    /// Current output sink; swapped by
+    /// [`subscribe_output`](ConnectionType::subscribe_output). The forwarding
+    /// thread reads the latest value each iteration.
+    output_tx: Arc<Mutex<Option<OutputSender>>>,
+}
+
+impl PluginConnectionType {
+    /// Build a fresh, unconnected connection of the given plugin type.
+    #[must_use]
+    pub fn new(
+        library: Arc<LoadedLibrary>,
+        connection_type: String,
+        display_name: String,
+    ) -> Self {
+        Self {
+            library,
+            connection_type,
+            display_name,
+            backend: None,
+            output_tx: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+/// Map a plugin-side error to the session-error the terminal layer understands.
+fn map_plugin_error(err: PluginError) -> SessionError {
+    match err {
+        PluginError::ChannelClosed | PluginError::NotAlive => {
+            SessionError::NotRunning(err.to_string())
+        }
+        PluginError::InvalidConfig(_) => SessionError::InvalidConfig(err.to_string()),
+        other => SessionError::SpawnFailed(other.to_string()),
+    }
+}
+
+#[async_trait::async_trait]
+impl ConnectionType for PluginConnectionType {
+    fn type_id(&self) -> &str {
+        &self.connection_type
+    }
+
+    fn display_name(&self) -> &str {
+        &self.display_name
+    }
+
+    fn settings_schema(&self) -> SettingsSchema {
+        // Deriving a form schema from the plugin's declared `configSchema` is
+        // #1999; the raw settings JSON is forwarded to the plugin as-is for now.
+        SettingsSchema { groups: vec![] }
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            monitoring: false,
+            file_browser: false,
+            graphical: false,
+            resize: true,
+            persistent: false,
+            terminal: true,
+        }
+    }
+
+    async fn connect(&mut self, settings: serde_json::Value) -> Result<(), SessionError> {
+        if self.backend.is_some() {
+            return Err(SessionError::AlreadyExists("Already connected".to_string()));
+        }
+
+        let config_json = serde_json::to_string(&settings)
+            .map_err(|e| SessionError::InvalidConfig(format!("settings not serializable: {e}")))?;
+
+        // Bridge the plugin's synchronous output channel onto the async terminal
+        // channel. The plugin sends `Vec<u8>` on `std_tx`; the forwarding thread
+        // relays each chunk to whichever `OutputSender` is currently subscribed.
+        let (std_tx, std_rx) = std::sync::mpsc::channel::<Vec<u8>>();
+        let output = PluginOutputSender::from_sender(std_tx);
+
+        let backend = self
+            .library
+            .create_backend(&config_json, output)
+            .map_err(map_plugin_error)?;
+
+        let output_tx = Arc::clone(&self.output_tx);
+        std::thread::spawn(move || {
+            while let Ok(chunk) = std_rx.recv() {
+                let guard = output_tx.lock().unwrap_or_else(|e| e.into_inner());
+                match guard.as_ref() {
+                    Some(sender) => {
+                        if sender.blocking_send(chunk).is_err() {
+                            // Receiver dropped; keep draining so the plugin's
+                            // sender does not block, but stop trying to deliver.
+                        }
+                    }
+                    None => {
+                        // No active subscriber yet; drop the chunk. Terminal
+                        // output before the first `subscribe_output` is not
+                        // retained (matching the other backends).
+                    }
+                }
+            }
+        });
+
+        self.backend = Some(backend);
+        Ok(())
+    }
+
+    async fn disconnect(&mut self) -> Result<(), SessionError> {
+        if let Some(backend) = self.backend.take() {
+            // Best-effort graceful close; the backend drops (running its FFI
+            // destructor) at the end of this scope regardless.
+            let _ = backend.close();
+        }
+        // Dropping the sender lets the forwarding thread's `recv` end once the
+        // plugin's own sender is gone.
+        *self.output_tx.lock().unwrap_or_else(|e| e.into_inner()) = None;
+        Ok(())
+    }
+
+    fn is_connected(&self) -> bool {
+        self.backend.as_ref().is_some_and(LoadedBackend::is_alive)
+    }
+
+    fn write(&self, data: &[u8]) -> Result<(), SessionError> {
+        let backend = self
+            .backend
+            .as_ref()
+            .ok_or_else(|| SessionError::NotRunning("Not connected".to_string()))?;
+        backend.write_input(data).map_err(map_plugin_error)
+    }
+
+    fn resize(&self, cols: u16, rows: u16) -> Result<(), SessionError> {
+        let backend = self
+            .backend
+            .as_ref()
+            .ok_or_else(|| SessionError::NotRunning("Not connected".to_string()))?;
+        backend.resize(cols, rows).map_err(map_plugin_error)
+    }
+
+    fn subscribe_output(&self) -> OutputReceiver {
+        let (tx, rx) = tokio::sync::mpsc::channel(OUTPUT_CHANNEL_CAPACITY);
+        *self.output_tx.lock().unwrap_or_else(|e| e.into_inner()) = Some(tx);
+        rx
+    }
+
+    fn monitoring(&self) -> Option<&dyn MonitoringProvider> {
+        None
+    }
+
+    fn file_browser(&self) -> Option<&dyn FileBrowser> {
+        None
+    }
+}

--- a/core/src/plugin/host.rs
+++ b/core/src/plugin/host.rs
@@ -1,0 +1,527 @@
+//! The native plugin **host loader** (#1995).
+//!
+//! Where [`super::manager::PluginManager`] owns what is *installed*, this module
+//! owns what is *loaded*: it opens a plugin's backend dynamic library
+//! (`.dll` / `.so` / `.dylib`) with [`libloading`], resolves the stable-ABI
+//! entry symbols defined by [`termihub_plugin_api`], validates the reported ABI
+//! version, and keeps the loaded library alive for as long as any session it
+//! produced. A loaded backend is exposed to the rest of termiHub as an ordinary
+//! [`ConnectionType`](crate::connection::ConnectionType) (see
+//! [`super::connection::PluginConnectionType`]), registered into the shared
+//! [`ConnectionTypeRegistry`].
+//!
+//! # ABI soundness
+//!
+//! The original plugin-system concept sketched returning
+//! `*mut dyn PluginTerminalBackend` across `extern "C"`. A Rust `dyn Trait` fat
+//! pointer has **no stable ABI** across separately-compiled dynamic libraries, so
+//! that sketch is undefined behavior. This loader instead speaks only the
+//! hand-rolled, `#[repr(C)]` opaque-handle ABI established by
+//! [`termihub_plugin_api`] (#1990): the plugin returns an opaque state pointer
+//! plus a `#[repr(C)]` vtable of `extern "C"` function pointers, which the host
+//! drives through the crate's safe
+//! [`LoadedBackend`](termihub_plugin_api::LoadedBackend) wrapper.
+//!
+//! # Keeping the library alive
+//!
+//! Every backend a plugin creates dispatches through function pointers that live
+//! *inside* the loaded library (the vtable and the backend `state`). Unloading
+//! the library while a session is live would leave those pointers dangling —
+//! undefined behavior. So [`LoadedLibrary`] is reference-counted
+//! ([`Arc`]): each live [`PluginConnectionType`] holds a clone, and the
+//! underlying `libloading::Library` is only dropped (unloaded) once the host's
+//! registration **and** every session created from it are gone.
+//!
+//! [`PluginConnectionType`]: super::connection::PluginConnectionType
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use libloading::{Library, Symbol};
+use termihub_plugin_api::symbols::{
+    PluginAbiVersionFn, PluginCreateBackendFn, PluginInitFn, PluginShutdownFn,
+    SYMBOL_PLUGIN_ABI_VERSION, SYMBOL_PLUGIN_CREATE_BACKEND, SYMBOL_PLUGIN_INIT,
+    SYMBOL_PLUGIN_SHUTDOWN,
+};
+use termihub_plugin_api::{
+    LoadedBackend, PluginBackend, PluginError, PluginInfo, PluginOutputSender, PluginSessionConfig,
+    CURRENT_PLUGIN_API_VERSION,
+};
+
+use crate::connection::ConnectionTypeRegistry;
+
+use super::connection::PluginConnectionType;
+use super::manager::InstalledPlugin;
+
+/// Everything that can go wrong while loading a plugin's backend library.
+#[derive(Debug, thiserror::Error)]
+pub enum HostError {
+    /// No file with the current platform's dynamic-library extension was found
+    /// under the plugin's `backend/` directory.
+    #[error("no backend library found in `{0}`")]
+    LibraryNotFound(PathBuf),
+
+    /// The dynamic library could not be opened (missing dependency, wrong
+    /// architecture, corrupt file, …).
+    #[error("failed to open plugin library `{path}`: {source}")]
+    Open {
+        /// The library path that failed to open.
+        path: PathBuf,
+        /// The underlying `libloading` error.
+        source: libloading::Error,
+    },
+
+    /// A required exported symbol was missing from the library.
+    #[error("plugin library is missing the required symbol `{0}`")]
+    MissingSymbol(String),
+
+    /// The library reported an ABI version this host cannot load.
+    #[error("plugin ABI version mismatch: host supports {expected}, plugin built against {found}")]
+    IncompatibleAbi {
+        /// ABI version this host supports ([`CURRENT_PLUGIN_API_VERSION`]).
+        expected: u32,
+        /// ABI version the plugin reported.
+        found: u32,
+    },
+
+    /// The plugin's `plugin_init` entry point reported a failure.
+    #[error("plugin initialization failed: {0}")]
+    Init(String),
+}
+
+impl HostError {
+    /// Whether this failure is specifically an ABI/version incompatibility, as
+    /// opposed to a load or initialization error. The management layer maps the
+    /// two to different plugin states.
+    #[must_use]
+    pub fn is_incompatible(&self) -> bool {
+        matches!(self, HostError::IncompatibleAbi { .. })
+    }
+}
+
+/// Metadata a loaded plugin reported through `plugin_init`, copied out of the
+/// FFI-owned [`PluginInfo`] into owned Rust strings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadedPluginInfo {
+    /// Stable plugin identifier the library reported.
+    pub id: String,
+    /// Human-readable display name.
+    pub name: String,
+    /// The plugin's own semantic version.
+    pub version: String,
+    /// ABI version the plugin was built against.
+    pub api_version: u32,
+}
+
+impl LoadedPluginInfo {
+    fn from_ffi(info: &PluginInfo) -> Self {
+        Self {
+            id: info.id.as_str().to_owned(),
+            name: info.name.as_str().to_owned(),
+            version: info.version.as_str().to_owned(),
+            api_version: info.api_version,
+        }
+    }
+}
+
+/// A loaded plugin backend library plus its resolved entry points.
+///
+/// Reference-counted via [`Arc`] so it outlives every session it produces (see
+/// the module docs). The `library` field is declared **last** so it is dropped
+/// last: [`Drop`] calls the plugin's `shutdown` entry point while the library is
+/// still mapped, then the library unloads.
+pub struct LoadedLibrary {
+    info: LoadedPluginInfo,
+    /// Resolved `plugin_create_backend`. Valid as long as `library` is loaded.
+    create_backend: PluginCreateBackendFn,
+    /// Resolved `plugin_shutdown`, called once on drop.
+    shutdown: PluginShutdownFn,
+    /// The open library. Never read directly — held solely to keep the mapping
+    /// alive (the resolved function pointers point into it) and to unmap on drop.
+    /// **Must be the last field** so it is dropped last, after [`Drop`] runs.
+    #[allow(dead_code)]
+    library: Library,
+}
+
+// SAFETY: `libloading::Library` is `Send + Sync`; the resolved function pointers
+// are plain `extern "C"` pointers into that library. The plugin ABI requires
+// backends and their entry points to be callable from any thread (see
+// `termihub_plugin_api`), so sharing a `LoadedLibrary` across threads is sound.
+unsafe impl Send for LoadedLibrary {}
+unsafe impl Sync for LoadedLibrary {}
+
+impl LoadedLibrary {
+    /// Metadata this plugin reported at load time.
+    #[must_use]
+    pub fn info(&self) -> &LoadedPluginInfo {
+        &self.info
+    }
+
+    /// Create a new backend session from this plugin.
+    ///
+    /// Calls the plugin's `create_backend` entry point with the borrowed
+    /// `config_json` and the host-owned `output` sink, returning a safe
+    /// [`LoadedBackend`] wrapper on success. The returned backend borrows nothing
+    /// from `config_json` (the plugin copies what it needs before the call
+    /// returns), but it *does* depend on this library staying loaded — callers
+    /// must keep an `Arc<LoadedLibrary>` alive for the backend's lifetime.
+    pub fn create_backend(
+        &self,
+        config_json: &str,
+        output: PluginOutputSender,
+    ) -> Result<LoadedBackend, PluginError> {
+        let config = PluginSessionConfig::new(config_json);
+        let mut backend = PluginBackend {
+            state: std::ptr::null_mut(),
+            vtable: std::ptr::null(),
+        };
+        // SAFETY: `config` outlives the call; `output` ownership is transferred to
+        // the plugin; `&mut backend` is a valid out-parameter. The plugin writes a
+        // valid `PluginBackend` on `Ok`.
+        let status = unsafe { (self.create_backend)(&config, output, &mut backend) };
+        status.into_result()?;
+        // SAFETY: on `Ok` the plugin has written a live backend produced by the
+        // same library, whose ownership now transfers to the wrapper.
+        Ok(unsafe { LoadedBackend::from_raw(backend) })
+    }
+}
+
+impl Drop for LoadedLibrary {
+    fn drop(&mut self) {
+        // Give the plugin a chance to release process-wide resources before the
+        // library unmaps. Contain any panic rather than unwinding across FFI.
+        let shutdown = self.shutdown;
+        // SAFETY: `shutdown` is a valid entry point in the still-loaded library.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe { shutdown() }));
+    }
+}
+
+/// Locate the backend dynamic library inside a plugin directory.
+///
+/// Looks in `<plugin_dir>/backend/` for the first file whose extension matches
+/// the current platform's dynamic-library extension
+/// ([`std::env::consts::DLL_EXTENSION`] — `dll` / `so` / `dylib`). A package may
+/// ship all three; this picks the one this OS can load.
+pub fn find_backend_library(plugin_dir: &Path) -> Result<PathBuf, HostError> {
+    let backend_dir = plugin_dir.join("backend");
+    let ext = std::env::consts::DLL_EXTENSION;
+    let entries = std::fs::read_dir(&backend_dir)
+        .map_err(|_| HostError::LibraryNotFound(backend_dir.clone()))?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) == Some(ext) {
+            return Ok(path);
+        }
+    }
+    Err(HostError::LibraryNotFound(backend_dir))
+}
+
+/// Open a plugin backend library, validate its ABI version, and resolve its
+/// entry points.
+///
+/// The sequence is deliberately ordered so nothing calls into the plugin before
+/// the ABI check passes:
+///
+/// 1. `dlopen` the library.
+/// 2. Resolve and call `termihub_plugin_abi_version`; reject a mismatch.
+/// 3. Resolve and call `termihub_plugin_init` to read [`PluginInfo`].
+/// 4. Resolve `create_backend` and `shutdown` for later use.
+///
+/// On any failure the (partially) opened library is dropped, so a rejected
+/// plugin leaves nothing loaded.
+pub fn load_backend_library(library_path: &Path) -> Result<Arc<LoadedLibrary>, HostError> {
+    // SAFETY: opening an arbitrary library runs its initializers; this is the
+    // irreducible unsafety of a plugin host. Failures are returned, not panicked.
+    let library = unsafe { Library::new(library_path) }.map_err(|source| HostError::Open {
+        path: library_path.to_owned(),
+        source,
+    })?;
+
+    // --- 1. ABI version gate, before anything else is called. ---
+    let found = {
+        // SAFETY: resolving a symbol to its documented type alias; the pointer is
+        // only used while `library` is alive.
+        let abi_version: Symbol<PluginAbiVersionFn> = unsafe {
+            library
+                .get(SYMBOL_PLUGIN_ABI_VERSION)
+                .map_err(|_| HostError::MissingSymbol(symbol_name(SYMBOL_PLUGIN_ABI_VERSION)))?
+        };
+        // SAFETY: the plugin's abi-version entry point takes no arguments and
+        // returns a plain `u32`.
+        unsafe { abi_version() }
+    };
+    if found != CURRENT_PLUGIN_API_VERSION {
+        return Err(HostError::IncompatibleAbi {
+            expected: CURRENT_PLUGIN_API_VERSION,
+            found,
+        });
+    }
+
+    // --- 2. Read plugin metadata. ---
+    let info = {
+        // SAFETY: resolving `plugin_init` to its type alias.
+        let init: Symbol<PluginInitFn> = unsafe {
+            library
+                .get(SYMBOL_PLUGIN_INIT)
+                .map_err(|_| HostError::MissingSymbol(symbol_name(SYMBOL_PLUGIN_INIT)))?
+        };
+        let mut info = PluginInfo::empty();
+        // SAFETY: `&mut info` is a valid out-parameter the plugin fills in; on a
+        // non-`Ok` status it leaves the empty placeholder untouched.
+        let status = unsafe { init(&mut info) };
+        status
+            .into_result()
+            .map_err(|e| HostError::Init(e.to_string()))?;
+        LoadedPluginInfo::from_ffi(&info)
+    };
+
+    // --- 3. Resolve the remaining entry points and detach them from the borrow. ---
+    // We store the raw function pointers alongside the owned `Library` so they
+    // stay valid for the library's whole lifetime.
+    let create_backend: PluginCreateBackendFn = {
+        // SAFETY: resolving `plugin_create_backend` to its type alias.
+        let sym: Symbol<PluginCreateBackendFn> = unsafe {
+            library
+                .get(SYMBOL_PLUGIN_CREATE_BACKEND)
+                .map_err(|_| HostError::MissingSymbol(symbol_name(SYMBOL_PLUGIN_CREATE_BACKEND)))?
+        };
+        *sym
+    };
+    let shutdown: PluginShutdownFn = {
+        // SAFETY: resolving `plugin_shutdown` to its type alias.
+        let sym: Symbol<PluginShutdownFn> = unsafe {
+            library
+                .get(SYMBOL_PLUGIN_SHUTDOWN)
+                .map_err(|_| HostError::MissingSymbol(symbol_name(SYMBOL_PLUGIN_SHUTDOWN)))?
+        };
+        *sym
+    };
+
+    Ok(Arc::new(LoadedLibrary {
+        info,
+        create_backend,
+        shutdown,
+        library,
+    }))
+}
+
+/// Render a NUL-terminated symbol constant as a printable name for errors.
+fn symbol_name(sym: &[u8]) -> String {
+    String::from_utf8_lossy(sym.strip_suffix(b"\0").unwrap_or(sym)).into_owned()
+}
+
+/// A record of one loaded plugin: the connection type it registered and the
+/// library backing it.
+struct HostEntry {
+    connection_type: String,
+    #[allow(dead_code)] // Held to keep the library loaded for the plugin's lifetime.
+    library: Arc<LoadedLibrary>,
+}
+
+/// The runtime plugin host: loads backend libraries and registers the resulting
+/// connection types into a shared [`ConnectionTypeRegistry`].
+///
+/// This is the object a [`super::PluginLifecycleHook`] drives — enabling a
+/// plugin [`load`](PluginHost::load)s it, disabling/uninstalling it
+/// [`unload`](PluginHost::unload)s it. The `<app-data>/plugins/` root is used to
+/// find each plugin's directory by id.
+pub struct PluginHost {
+    root: PathBuf,
+    registry: Arc<Mutex<ConnectionTypeRegistry>>,
+    loaded: Mutex<HashMap<String, HostEntry>>,
+}
+
+impl PluginHost {
+    /// Create a host rooted at `plugins_root` that registers loaded plugin
+    /// connection types into `registry`.
+    pub fn new(plugins_root: impl Into<PathBuf>, registry: Arc<Mutex<ConnectionTypeRegistry>>) -> Self {
+        Self {
+            root: plugins_root.into(),
+            registry,
+            loaded: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// The shared connection-type registry this host feeds.
+    #[must_use]
+    pub fn registry(&self) -> &Arc<Mutex<ConnectionTypeRegistry>> {
+        &self.registry
+    }
+
+    /// Whether a plugin id is currently loaded.
+    #[must_use]
+    pub fn is_loaded(&self, id: &str) -> bool {
+        self.loaded
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains_key(id)
+    }
+
+    /// Load a plugin's backend and register its connection type.
+    ///
+    /// A plugin that declares **no** `terminalBackend` extension has no native
+    /// library to load, so this is a no-op success (its themes/JS are handled by
+    /// other loaders). If a backend *is* declared, the library is opened,
+    /// ABI-checked, and its connection type registered. Re-loading an
+    /// already-loaded id unloads the previous instance first.
+    ///
+    /// The [`HostError`] is returned for the caller to map to a plugin state; an
+    /// [`HostError::is_incompatible`] failure is a version problem, everything
+    /// else is a load error.
+    pub fn load(&self, plugin: &InstalledPlugin) -> Result<(), HostError> {
+        let Some(backend) = plugin.manifest.extensions.terminal_backend.as_ref() else {
+            return Ok(());
+        };
+
+        let id = plugin.manifest.id.clone();
+        // Replace any prior load of the same id.
+        self.unload(&id);
+
+        let plugin_dir = self.root.join(&id);
+        let lib_path = find_backend_library(&plugin_dir)?;
+        let library = load_backend_library(&lib_path)?;
+
+        let connection_type = backend.connection_type.clone();
+        let display_name = backend.display_name.clone();
+        let lib_for_factory = Arc::clone(&library);
+        let ct_for_factory = connection_type.clone();
+        let dn_for_factory = display_name.clone();
+
+        {
+            let mut registry = self.registry.lock().unwrap_or_else(|e| e.into_inner());
+            registry.register(
+                &connection_type,
+                &display_name,
+                "puzzle",
+                Box::new(move || {
+                    Box::new(PluginConnectionType::new(
+                        Arc::clone(&lib_for_factory),
+                        ct_for_factory.clone(),
+                        dn_for_factory.clone(),
+                    ))
+                }),
+            );
+        }
+
+        self.loaded.lock().unwrap_or_else(|e| e.into_inner()).insert(
+            id,
+            HostEntry {
+                connection_type,
+                library,
+            },
+        );
+        Ok(())
+    }
+
+    /// Unload a plugin: unregister its connection type and drop the host's
+    /// reference to the library. The library unmaps once every session created
+    /// from it has also been dropped. A no-op if the id is not loaded.
+    pub fn unload(&self, id: &str) {
+        let entry = self
+            .loaded
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(id);
+        if let Some(entry) = entry {
+            self.registry
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .unregister(&entry.connection_type);
+            // `entry.library` (Arc) drops here; the OS unloads the library once
+            // the last outstanding session Arc also drops.
+        }
+    }
+}
+
+/// A [`super::PluginLifecycleHook`] that drives a [`PluginHost`], so enabling or
+/// disabling a plugin in the [`super::PluginManager`] actually loads or unloads
+/// its native backend.
+///
+/// A load failure is surfaced to the manager as an error message (→
+/// [`PluginState::Error`](super::PluginState)); the plugin stays installed and
+/// enabled but reports the failure, and the host continues normally.
+pub struct HostLifecycleHook {
+    host: Arc<PluginHost>,
+}
+
+impl HostLifecycleHook {
+    /// Wrap a [`PluginHost`] as a lifecycle hook.
+    pub fn new(host: Arc<PluginHost>) -> Self {
+        Self { host }
+    }
+}
+
+impl super::manager::PluginLifecycleHook for HostLifecycleHook {
+    fn on_enable(&self, plugin: &InstalledPlugin) -> Result<(), String> {
+        self.host.load(plugin).map_err(|e| e.to_string())
+    }
+
+    fn on_disable(&self, id: &str) -> Result<(), String> {
+        self.host.unload(id);
+        Ok(())
+    }
+
+    fn on_uninstall(&self, id: &str) -> Result<(), String> {
+        self.host.unload(id);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn symbol_name_strips_trailing_nul() {
+        assert_eq!(symbol_name(SYMBOL_PLUGIN_INIT), "termihub_plugin_init");
+        assert_eq!(symbol_name(b"foo\0"), "foo");
+        assert_eq!(symbol_name(b"bar"), "bar");
+    }
+
+    #[test]
+    fn find_backend_library_missing_dir_is_error() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let err = find_backend_library(tmp.path()).unwrap_err();
+        assert!(matches!(err, HostError::LibraryNotFound(_)));
+    }
+
+    #[test]
+    fn find_backend_library_picks_current_platform_extension() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let backend = tmp.path().join("backend");
+        std::fs::create_dir_all(&backend).unwrap();
+        // Ship all three platform artifacts; the loader must pick this OS's.
+        std::fs::write(backend.join("plugin.dll"), b"").unwrap();
+        std::fs::write(backend.join("libplugin.so"), b"").unwrap();
+        std::fs::write(backend.join("libplugin.dylib"), b"").unwrap();
+        // A non-library file must be ignored.
+        std::fs::write(backend.join("README.md"), b"").unwrap();
+
+        let found = find_backend_library(tmp.path()).unwrap();
+        let ext = found.extension().and_then(|e| e.to_str()).unwrap();
+        assert_eq!(ext, std::env::consts::DLL_EXTENSION);
+    }
+
+    #[test]
+    fn open_nonexistent_library_is_open_error() {
+        let missing = Path::new("/definitely/not/a/real/plugin.so");
+        // `LoadedLibrary` is not `Debug`, so match rather than `unwrap_err`.
+        match load_backend_library(missing) {
+            Err(err @ HostError::Open { .. }) => assert!(!err.is_incompatible()),
+            Err(other) => panic!("expected Open error, got {other:?}"),
+            Ok(_) => panic!("expected loading a nonexistent library to fail"),
+        }
+    }
+
+    #[test]
+    fn incompatible_abi_error_is_flagged() {
+        let err = HostError::IncompatibleAbi {
+            expected: 1,
+            found: 99,
+        };
+        assert!(err.is_incompatible());
+        // A load error is not an incompatibility.
+        assert!(!HostError::MissingSymbol("x".into()).is_incompatible());
+    }
+}

--- a/core/src/plugin/host.rs
+++ b/core/src/plugin/host.rs
@@ -335,7 +335,10 @@ pub struct PluginHost {
 impl PluginHost {
     /// Create a host rooted at `plugins_root` that registers loaded plugin
     /// connection types into `registry`.
-    pub fn new(plugins_root: impl Into<PathBuf>, registry: Arc<Mutex<ConnectionTypeRegistry>>) -> Self {
+    pub fn new(
+        plugins_root: impl Into<PathBuf>,
+        registry: Arc<Mutex<ConnectionTypeRegistry>>,
+    ) -> Self {
         Self {
             root: plugins_root.into(),
             registry,
@@ -404,13 +407,16 @@ impl PluginHost {
             );
         }
 
-        self.loaded.lock().unwrap_or_else(|e| e.into_inner()).insert(
-            id,
-            HostEntry {
-                connection_type,
-                library,
-            },
-        );
+        self.loaded
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(
+                id,
+                HostEntry {
+                    connection_type,
+                    library,
+                },
+            );
         Ok(())
     }
 

--- a/core/src/plugin/mod.rs
+++ b/core/src/plugin/mod.rs
@@ -4,9 +4,18 @@
 //! `docs/concepts/future/plugin-system.html`): it defines the on-disk package
 //! format, the `manifest.json` data model and validator (§1–2), and the
 //! [`PluginManager`] management layer (§4/§12) that installs, scans, and tracks
-//! installed plugins. It performs **no** dynamic-library loading or JS/theme
-//! registration and has no UI — code loading is delegated to later issues
-//! through the [`PluginLifecycleHook`] seam.
+//! installed plugins.
+//!
+//! It also provides the **native host loader** (#1995): [`PluginHost`] opens a
+//! plugin's backend dynamic library over the stable ABI
+//! ([`termihub_plugin_api`]), validates its version, and registers the resulting
+//! [`PluginConnectionType`] into a [`ConnectionTypeRegistry`]. The management
+//! layer stays decoupled from loading through the [`PluginLifecycleHook`] seam:
+//! [`HostLifecycleHook`] wires a [`PluginHost`] into that seam so enabling or
+//! disabling a plugin loads or unloads its backend. JS/theme registration and
+//! connection-editor/session wiring remain later issues.
+//!
+//! [`ConnectionTypeRegistry`]: crate::connection::ConnectionTypeRegistry
 //!
 //! # The `.termihub-plugin` package format
 //!
@@ -41,10 +50,17 @@
 //! own distinct outcome so callers can prompt the user to update rather than
 //! treating it as a malformed package.
 
+mod connection;
+mod host;
 mod manager;
 mod manifest;
 mod package;
 
+pub use connection::PluginConnectionType;
+pub use host::{
+    find_backend_library, load_backend_library, HostError, HostLifecycleHook, LoadedLibrary,
+    LoadedPluginInfo, PluginHost,
+};
 pub use manager::{
     InstalledPlugin, NoopLifecycleHook, PluginLifecycleHook, PluginManager, PluginManagerError,
     PluginState,

--- a/core/tests/fixtures/test-plugin/Cargo.toml
+++ b/core/tests/fixtures/test-plugin/Cargo.toml
@@ -1,0 +1,25 @@
+# Test fixture only — a minimal native plugin `cdylib` used by the host-loader
+# round-trip test (`core/tests/plugin_host_roundtrip.rs`, #1995). It is NOT a
+# workspace member: the empty `[workspace]` table below makes it its own
+# workspace root so the parent workspace ignores it, and the round-trip test
+# builds it on demand with `cargo build`.
+[package]
+name = "termihub-test-plugin"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+termihub-plugin-api = { path = "../../../../plugin-api" }
+
+[features]
+# The default build exports every ABI symbol. Building with
+# `--no-default-features` omits `termihub_plugin_init`, which the test uses to
+# exercise the loader's missing-symbol handling.
+default = ["export-init"]
+export-init = []

--- a/core/tests/fixtures/test-plugin/src/lib.rs
+++ b/core/tests/fixtures/test-plugin/src/lib.rs
@@ -1,0 +1,113 @@
+//! A minimal native plugin `cdylib` fixture for the host-loader round-trip test
+//! (`core/tests/plugin_host_roundtrip.rs`, #1995).
+//!
+//! It implements the sound, `#[repr(C)]` opaque-handle ABI from
+//! `termihub-plugin-api` (#1990): an echo backend that writes any input it
+//! receives straight back to the host's output channel. The four exported
+//! symbols mirror the contract documented in `termihub_plugin_api::symbols`.
+//!
+//! Two knobs let the single fixture drive every test scenario:
+//!
+//! * `termihub_plugin_abi_version` reads the `TERMIHUB_TEST_PLUGIN_ABI`
+//!   environment variable at call time, so the test can force an incompatible
+//!   value without rebuilding.
+//! * `termihub_plugin_init` is gated behind the `export-init` feature (on by
+//!   default), so a `--no-default-features` build omits it and exercises the
+//!   loader's missing-symbol path.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[cfg(feature = "export-init")]
+use termihub_plugin_api::PluginInfo;
+use termihub_plugin_api::{
+    PluginBackend, PluginError, PluginOutputSender, PluginSessionConfig, PluginStatus,
+    PluginTerminalBackend, CURRENT_PLUGIN_API_VERSION,
+};
+
+/// A backend that echoes written input straight back to the host output sink.
+struct EchoBackend {
+    output: PluginOutputSender,
+    alive: AtomicBool,
+}
+
+impl PluginTerminalBackend for EchoBackend {
+    fn write_input(&self, data: &[u8]) -> Result<(), PluginError> {
+        self.output.send(data)
+    }
+
+    fn resize(&self, _cols: u16, _rows: u16) -> Result<(), PluginError> {
+        Ok(())
+    }
+
+    fn close(&self) -> Result<(), PluginError> {
+        self.alive.store(false, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::SeqCst)
+    }
+}
+
+/// Report the ABI version. Honours `TERMIHUB_TEST_PLUGIN_ABI` so the test can
+/// force an incompatible value at load time.
+#[no_mangle]
+pub extern "C" fn termihub_plugin_abi_version() -> u32 {
+    std::env::var("TERMIHUB_TEST_PLUGIN_ABI")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(CURRENT_PLUGIN_API_VERSION)
+}
+
+/// Fill in the plugin metadata. Omitted from `--no-default-features` builds so
+/// the loader's missing-symbol handling can be tested.
+///
+/// # Safety
+///
+/// `out_info` must be a valid, writable `*mut PluginInfo`.
+#[cfg(feature = "export-init")]
+#[no_mangle]
+pub unsafe extern "C" fn termihub_plugin_init(out_info: *mut PluginInfo) -> PluginStatus {
+    if out_info.is_null() {
+        return PluginStatus::Other;
+    }
+    // SAFETY: caller guarantees `out_info` is valid and writable.
+    unsafe {
+        out_info.write(PluginInfo::new(
+            "test-echo",
+            "Test Echo",
+            "0.1.0",
+            CURRENT_PLUGIN_API_VERSION,
+        ));
+    }
+    PluginStatus::Ok
+}
+
+/// Create an [`EchoBackend`] session.
+///
+/// # Safety
+///
+/// `out_backend` must be a valid, writable `*mut PluginBackend`.
+#[no_mangle]
+pub unsafe extern "C" fn termihub_plugin_create_backend(
+    _config: *const PluginSessionConfig,
+    output: PluginOutputSender,
+    out_backend: *mut PluginBackend,
+) -> PluginStatus {
+    if out_backend.is_null() {
+        return PluginStatus::Other;
+    }
+    let backend = PluginBackend::from_boxed(Box::new(EchoBackend {
+        output,
+        alive: AtomicBool::new(true),
+    }));
+    // SAFETY: caller guarantees `out_backend` is valid and writable.
+    unsafe {
+        out_backend.write(backend);
+    }
+    PluginStatus::Ok
+}
+
+/// Process-wide cleanup before unload. Nothing to do for the echo fixture.
+#[no_mangle]
+pub extern "C" fn termihub_plugin_shutdown() {}

--- a/core/tests/plugin_host_roundtrip.rs
+++ b/core/tests/plugin_host_roundtrip.rs
@@ -1,0 +1,128 @@
+//! End-to-end round-trip test for the native plugin host loader (#1995).
+//!
+//! Builds the real `cdylib` fixture at `tests/fixtures/test-plugin`, then drives
+//! it through the public host API: a successful load with metadata, a full
+//! [`ConnectionType`] session that echoes input back through the output channel,
+//! an incompatible-ABI rejection, and missing-symbol handling.
+//!
+//! The fixture is compiled with `cargo build` into a throwaway target directory,
+//! so the test genuinely exercises `dlopen`/`LoadLibrary` on whichever platform
+//! it runs. The whole file is gated on the `plugin` feature (which pulls the host
+//! loader); without it there is nothing to test.
+#![cfg(feature = "plugin")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use termihub_core::connection::ConnectionType;
+use termihub_core::plugin::{load_backend_library, HostError, PluginConnectionType};
+
+/// Path to the fixture plugin's `Cargo.toml`.
+fn fixture_manifest() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("test-plugin")
+        .join("Cargo.toml")
+}
+
+/// The platform-specific file name cargo produces for the fixture `cdylib`.
+fn artifact_name() -> String {
+    format!(
+        "{}termihub_test_plugin{}",
+        std::env::consts::DLL_PREFIX,
+        std::env::consts::DLL_SUFFIX
+    )
+}
+
+/// Build the fixture into `target_dir`. With `default_features == false` the
+/// `termihub_plugin_init` symbol is omitted (for the missing-symbol scenario).
+/// Returns the path to the freshly-built library.
+fn build_fixture(target_dir: &Path, default_features: bool) -> PathBuf {
+    let mut cmd = Command::new(env!("CARGO"));
+    cmd.arg("build")
+        .arg("--manifest-path")
+        .arg(fixture_manifest())
+        .arg("--target-dir")
+        .arg(target_dir);
+    if !default_features {
+        cmd.arg("--no-default-features");
+    }
+    let status = cmd
+        .status()
+        .expect("failed to spawn cargo to build the fixture plugin");
+    assert!(
+        status.success(),
+        "building the fixture plugin failed (features default={default_features})"
+    );
+    target_dir.join("debug").join(artifact_name())
+}
+
+#[tokio::test]
+async fn plugin_host_round_trip() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let target_dir = tmp.path().join("target");
+
+    // Build the full plugin, then the init-less variant into the SAME target dir
+    // (only the fixture crate itself recompiles). Copy each artifact aside since
+    // the two builds share one output filename.
+    let built = build_fixture(&target_dir, true);
+    let good = tmp.path().join(format!("good-{}", artifact_name()));
+    std::fs::copy(&built, &good).expect("copy good artifact");
+
+    let built = build_fixture(&target_dir, false);
+    let noinit = tmp.path().join(format!("noinit-{}", artifact_name()));
+    std::fs::copy(&built, &noinit).expect("copy init-less artifact");
+
+    // --- 1. Successful load + metadata read from plugin_init. ---
+    let lib = load_backend_library(&good).expect("the good plugin should load");
+    assert_eq!(lib.info().id, "test-echo");
+    assert_eq!(lib.info().name, "Test Echo");
+    assert_eq!(lib.info().version, "0.1.0");
+    assert_eq!(lib.info().api_version, 1);
+
+    // --- 2. Full ConnectionType round trip: written input echoes to output. ---
+    let mut conn = PluginConnectionType::new(
+        std::sync::Arc::clone(&lib),
+        "test-echo".to_string(),
+        "Test Echo".to_string(),
+    );
+    let mut rx = conn.subscribe_output();
+    conn.connect(serde_json::json!({ "foo": "bar" }))
+        .await
+        .expect("connect should succeed");
+    assert!(conn.is_connected());
+
+    conn.write(b"hello plugin").expect("write should succeed");
+    let out = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("echoed output should arrive within the timeout")
+        .expect("output channel should yield a chunk");
+    assert_eq!(out, b"hello plugin");
+
+    conn.disconnect().await.expect("disconnect should succeed");
+    assert!(!conn.is_connected());
+
+    // --- 3. Incompatible ABI is rejected without loading, never a crash. ---
+    // SAFETY (env): single-threaded within this test; no other code reads the
+    // variable, and it is removed immediately after the load.
+    std::env::set_var("TERMIHUB_TEST_PLUGIN_ABI", "99");
+    let result = load_backend_library(&good);
+    std::env::remove_var("TERMIHUB_TEST_PLUGIN_ABI");
+    match result {
+        Err(HostError::IncompatibleAbi { expected, found }) => {
+            assert_eq!(expected, 1);
+            assert_eq!(found, 99);
+        }
+        Err(other) => panic!("expected IncompatibleAbi, got {other:?}"),
+        Ok(_) => panic!("expected IncompatibleAbi, got a successful load"),
+    }
+
+    // --- 4. Missing required symbol is a clean error. ---
+    match load_backend_library(&noinit) {
+        Err(HostError::MissingSymbol(name)) => assert_eq!(name, "termihub_plugin_init"),
+        Err(other) => panic!("expected MissingSymbol, got {other:?}"),
+        Ok(_) => panic!("expected MissingSymbol, got a successful load"),
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -374,11 +374,28 @@ pub fn run() {
                 .expect("Failed to resolve app config directory");
             std::fs::create_dir_all(&config_dir).expect("Failed to create config directory");
 
-            // Plugin management layer (#1992): owns <app-data>/plugins/. Created
-            // lazily — the directory is materialised on first install.
-            app.manage(termihub_core::plugin::PluginManager::new(
-                config_dir.join("plugins"),
+            // Plugin management layer (#1992) + native host loader (#1995): owns
+            // <app-data>/plugins/, created lazily. The host loads a plugin's
+            // backend dynamic library on enable and registers its connection type
+            // into a shared registry; disabling/uninstalling unloads it. Bridging
+            // this registry into the session-creation flow and connection editor
+            // is left to #1999 — for now the load/register path is exercised
+            // end-to-end through the manager's lifecycle seam.
+            let plugins_root = config_dir.join("plugins");
+            let plugin_registry = std::sync::Arc::new(std::sync::Mutex::new(
+                termihub_core::connection::ConnectionTypeRegistry::new(),
             ));
+            let plugin_host = std::sync::Arc::new(termihub_core::plugin::PluginHost::new(
+                plugins_root.clone(),
+                plugin_registry,
+            ));
+            app.manage(termihub_core::plugin::PluginManager::with_hook(
+                plugins_root,
+                std::sync::Arc::new(termihub_core::plugin::HostLifecycleHook::new(
+                    std::sync::Arc::clone(&plugin_host),
+                )),
+            ));
+            app.manage(plugin_host);
 
             // Capture path for the connections file watcher before config_dir is moved.
             let connections_file = config_dir.join("connections.json");


### PR DESCRIPTION
## Summary

Implements the **native plugin host loader** (#1995): the "Fourth PR — Backend plugins" loader half. It dynamically loads a plugin's backend dynamic library, validates its ABI, retains the library for the plugin's lifetime, and exposes the loaded backend to termiHub as an ordinary `ConnectionType` registered into a `ConnectionTypeRegistry`.

Builds on the merged foundations: #1989 (`core/src/plugin/` manifest+package), #1990 (`termihub-plugin-api` stable ABI), #1992 (`PluginManager` + lifecycle seam).

## ABI soundness

The concept's `extern "C" fn ... -> *mut dyn PluginTerminalBackend` sketch is **unsound** — a Rust `dyn` fat pointer has no stable ABI across separately-compiled dylibs. This loader speaks **only** the hand-rolled `#[repr(C)]` opaque-handle ABI established by #1990 (opaque `state` pointer + `#[repr(C)]` vtable of `extern "C"` fn pointers), driving backends through the crate's safe `LoadedBackend` wrapper. The unsound sketch is never reconstructed.

## What's here

- **`core/src/plugin/host.rs`** — `libloading` loader: locates `plugins/<id>/backend/<lib>` by the current platform's dylib extension, opens it, **gates on the reported ABI version before calling anything else**, reads `PluginInfo`, and resolves `create_backend`/`shutdown`. `LoadedLibrary` is `Arc`-shared and holds the `Library` as its **last** field so it unmaps only after every session it produced is gone; `Drop` calls the plugin's `shutdown` first.
- **`core/src/plugin/connection.rs`** — `PluginConnectionType`, a `ConnectionType` adapter mapping `write_input`/`resize`/`close`/`is_alive`/output onto the trait, bridging the plugin's synchronous output channel onto the async terminal channel (the telnet/serial pattern).
- **`PluginHost` + `HostLifecycleHook`** — register/unregister a plugin's connection type into a shared registry; wired into `PluginManager::with_hook` in the desktop so **enable/disable now actually load/unload** via the #1992 seam.
- **`ConnectionTypeRegistry::unregister`** — needed to drop a plugin's type on disable/uninstall.

## Error handling

Load failures (missing library, `dlopen` failure, missing symbol, init failure) map to a `HostError` the manager surfaces as `PluginState::Error` — the host continues normally, never crashes. ABI mismatch is distinguished via `HostError::is_incompatible()`.

## Tests

- Unit: platform library-name resolution, ABI-mismatch flagging, open-failure, registry unregister, symbol-name rendering.
- **Round-trip integration test** (`core/tests/plugin_host_roundtrip.rs`): builds a real `cdylib` fixture against `termihub-plugin-api` and drives it through the host — successful load + metadata, a full `ConnectionType` session that **echoes written input back through the output channel**, incompatible-ABI rejection, and missing-symbol handling. This genuinely exercises `dlopen`/`LoadLibrary` on whichever platform CI runs.

## Scope boundary

Stops at load + register. Connection-type wiring (schema derivation, connection editor, session-creation routing) is **#1999**; security hardening is **#2001**; UI is **#1997**. Startup-loading of already-enabled plugins is filed as a follow-up.

Closes #1995