### PR TITLE
feat(ui): plugin manager UI — view, detail panel, install dialog (Closes #1997)

### DIFF
--- a/docs/changes/dev1/feature/1997-plugin-manager-ui.md
+++ b/docs/changes/dev1/feature/1997-plugin-manager-ui.md
@@ -1,0 +1,13 @@
+### Added
+
+- Plugin Manager UI: a new **Plugins** entry in the Activity Bar (puzzle icon)
+  opens a sidebar listing installed plugins — each a row with a state dot
+  (green enabled / grey disabled / red error), a type icon, and version — with a
+  search box and an **Install from file…** button. Selecting a plugin opens a
+  detail panel in the main area showing its identity, extension points, requested
+  permissions, and state-appropriate actions (Enable / Disable, Retry on error,
+  Settings…, Uninstall). Installing from a `.termihub-plugin` file validates the
+  package and shows a permission-review dialog before install. Uninstall warns
+  when the plugin has active sessions, and a status-bar segment shows the
+  installed / enabled plugin count. Builds on the plugin command surface (#1992)
+  and frontend store (#1993).

--- a/src/components/ActivityBar/ActivityBar.tsx
+++ b/src/components/ActivityBar/ActivityBar.tsx
@@ -18,6 +18,7 @@ import {
   RefreshCw,
   Info,
   Keyboard,
+  Puzzle,
 } from "lucide-react";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import * as ContextMenu from "@radix-ui/react-context-menu";
@@ -68,6 +69,7 @@ const OPTIONAL_ITEMS: ActivityBarItemDef[] = [
   { view: "services", icon: Server, label: "Services", experimental: true },
   { view: "network-tools", icon: Stethoscope, label: "Network Tools", experimental: true },
   { view: "workflows", icon: Workflow, label: "Workflows", experimental: true },
+  { view: "plugins", icon: Puzzle, label: "Plugins" },
 ];
 
 const EMPTY_HIDDEN_VIEWS: string[] = [];

--- a/src/components/Plugins/PluginDetailPanel.test.tsx
+++ b/src/components/Plugins/PluginDetailPanel.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Tests for the plugin detail panel (#1997): identity/extension-points/permissions
+ * rendering, state-appropriate actions (Enable/Disable/Retry, Settings…), the
+ * error callout, and action dispatch to the store. Uninstall opens a confirm
+ * dialog that warns about active sessions before dispatching.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import React from "react";
+import { useAppStore } from "@/store/appStore";
+import type { InstalledPlugin, PluginManifest, PluginState } from "@/types/plugin";
+import { withTooltip } from "@/test/tooltip";
+import { PluginDetailPanel } from "./PluginDetailPanel";
+
+function manifest(overrides: Partial<PluginManifest> = {}): PluginManifest {
+  return {
+    id: "k8s",
+    name: "Kubernetes Exec",
+    version: "1.2.0",
+    author: "k8s-contrib",
+    description: "Terminal backend for Kubernetes pod exec sessions.",
+    license: "MIT",
+    apiVersion: "1.0",
+    platforms: ["macos"],
+    permissions: ["terminal", "network"],
+    extensions: {
+      terminalBackend: {
+        connectionType: "k8s-exec",
+        displayName: "Kubernetes Exec",
+        configSchema: {},
+      },
+    },
+    ...overrides,
+  };
+}
+
+function plugin(state: PluginState, m: Partial<PluginManifest> = {}): InstalledPlugin {
+  return {
+    manifest: manifest(m),
+    state,
+    errorMessage: state === "error" ? "dependency aws CLI not found in PATH" : undefined,
+    installedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(pluginId = "k8s") {
+  act(() =>
+    root.render(
+      withTooltip(React.createElement(PluginDetailPanel, { meta: { pluginId }, isVisible: true }))
+    )
+  );
+}
+
+describe("PluginDetailPanel (#1997)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders identity, extension points, and permissions", () => {
+    useAppStore.setState({ plugins: [plugin("active")] });
+    render();
+
+    expect(container.querySelector('[data-testid="plugin-detail"]')?.textContent).toContain(
+      "Kubernetes Exec"
+    );
+    expect(container.querySelector('[data-testid="plugin-detail-status"]')?.textContent).toContain(
+      "Enabled"
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("Terminal Backend");
+    expect(text).toContain("k8s-exec");
+    expect(text).toContain("Terminal");
+    expect(text).toContain("create and manage terminal sessions");
+  });
+
+  it("shows Disable for an enabled plugin and dispatches it", () => {
+    const disablePlugin = vi.fn(() => Promise.resolve());
+    useAppStore.setState({ plugins: [plugin("active")], disablePlugin });
+    render();
+
+    const btn = container.querySelector('[data-testid="plugin-action-disable"]');
+    expect(btn).not.toBeNull();
+    expect(container.querySelector('[data-testid="plugin-action-enable"]')).toBeNull();
+    act(() => btn!.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(disablePlugin).toHaveBeenCalledWith("k8s");
+  });
+
+  it("shows Enable for a disabled plugin and dispatches it", () => {
+    const enablePlugin = vi.fn(() => Promise.resolve());
+    useAppStore.setState({ plugins: [plugin("disabled")], enablePlugin });
+    render();
+
+    const btn = container.querySelector('[data-testid="plugin-action-enable"]');
+    expect(btn).not.toBeNull();
+    act(() => btn!.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(enablePlugin).toHaveBeenCalledWith("k8s");
+  });
+
+  it("shows Retry and the error callout for a failed plugin", () => {
+    const enablePlugin = vi.fn(() => Promise.resolve());
+    useAppStore.setState({ plugins: [plugin("error")], enablePlugin });
+    render();
+
+    expect(container.querySelector('[data-testid="plugin-detail-error"]')?.textContent).toContain(
+      "dependency aws CLI not found"
+    );
+    const btn = container.querySelector('[data-testid="plugin-action-retry"]');
+    expect(btn).not.toBeNull();
+    act(() => btn!.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(enablePlugin).toHaveBeenCalledWith("k8s");
+  });
+
+  it("shows the Settings… action only when settings are declared", () => {
+    useAppStore.setState({ plugins: [plugin("active")] });
+    render();
+    expect(container.querySelector('[data-testid="plugin-action-settings"]')).toBeNull();
+
+    act(() => root.unmount());
+    root = createRoot(container);
+    useAppStore.setState({
+      plugins: [
+        plugin("active", { settings: { ns: { type: "string", default: "", description: "" } } }),
+      ],
+    });
+    render();
+    expect(container.querySelector('[data-testid="plugin-action-settings"]')).not.toBeNull();
+  });
+
+  it("renders a placeholder when the plugin is no longer installed", () => {
+    useAppStore.setState({ plugins: [] });
+    render("gone");
+    expect(container.querySelector('[data-testid="plugin-detail-missing"]')).not.toBeNull();
+  });
+
+  it("confirms before uninstalling and dispatches on confirm", async () => {
+    const uninstallPlugin = vi.fn(() => Promise.resolve());
+    useAppStore.setState({ plugins: [plugin("active")], uninstallPlugin });
+    render();
+
+    act(() =>
+      container
+        .querySelector('[data-testid="plugin-action-uninstall"]')!
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }))
+    );
+    const confirm = document.querySelector('[data-testid="plugin-uninstall-confirm"]');
+    expect(confirm).not.toBeNull();
+    expect(uninstallPlugin).not.toHaveBeenCalled();
+
+    await act(async () => {
+      confirm!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(uninstallPlugin).toHaveBeenCalledWith("k8s");
+  });
+});

--- a/src/components/Plugins/PluginDetailPanel.tsx
+++ b/src/components/Plugins/PluginDetailPanel.tsx
@@ -1,0 +1,234 @@
+import { useMemo, useState } from "react";
+import { CircleAlert, Power, Shield, SlidersHorizontal, Trash2 } from "lucide-react";
+import { useAppStore } from "@/store/appStore";
+import { getAllLeaves } from "@/utils/panelTree";
+import type { PluginDetailMeta } from "@/types/terminal";
+import type { InstalledPlugin } from "@/types/plugin";
+import { Button, ConfirmDialog } from "@/components/ui";
+import {
+  PERMISSION_DESCRIPTIONS,
+  PERMISSION_LABELS,
+  extensionPoints,
+  hasSettings,
+  pluginDotState,
+  pluginStatusLabel,
+  pluginTypeIcon,
+  pluginTypeLabel,
+} from "./pluginPresentation";
+import "./Plugins.css";
+
+/** Props for {@link PluginDetailPanel}. */
+export interface PluginDetailPanelProps {
+  /** Identifies which plugin to show; the live record is looked up by id. */
+  meta: PluginDetailMeta;
+  /** Whether this tab is the active, front-most tab (SplitView convention). */
+  isVisible: boolean;
+}
+
+/**
+ * Count open terminal tabs whose connection type is served by this plugin's
+ * terminal-backend extension — i.e. sessions that would be torn down by an
+ * uninstall. Non-backend plugins never own sessions, so this is always 0.
+ */
+function useActiveSessionCount(plugin: InstalledPlugin | undefined): number {
+  const rootPanel = useAppStore((s) => s.rootPanel);
+  return useMemo(() => {
+    const backendType = plugin?.manifest.extensions.terminalBackend?.connectionType;
+    if (!backendType) return 0;
+    let count = 0;
+    for (const leaf of getAllLeaves(rootPanel)) {
+      for (const tab of leaf.tabs) {
+        if (tab.contentType === "terminal" && tab.config.type === backendType) count += 1;
+      }
+    }
+    return count;
+  }, [rootPanel, plugin]);
+}
+
+/**
+ * The plugin detail panel shown in the main area (#1997). Renders a plugin's
+ * identity, extension points, requested permissions, and state-appropriate
+ * actions: Enable/Disable, Retry (on error), Settings… (when the plugin declares
+ * settings — the settings pane lands in a separate issue), and Uninstall.
+ * Uninstall warns first when the plugin has live sessions.
+ *
+ * The plugin is looked up live from the store by {@link PluginDetailMeta.pluginId},
+ * so enabling/disabling/uninstalling it (here or elsewhere) reflects immediately.
+ */
+export function PluginDetailPanel({ meta, isVisible }: PluginDetailPanelProps) {
+  const plugin = useAppStore((s) => s.plugins.find((p) => p.manifest.id === meta.pluginId));
+  const enablePlugin = useAppStore((s) => s.enablePlugin);
+  const disablePlugin = useAppStore((s) => s.disablePlugin);
+  const uninstallPlugin = useAppStore((s) => s.uninstallPlugin);
+  const openSettingsTab = useAppStore((s) => s.openSettingsTab);
+
+  const [confirmUninstall, setConfirmUninstall] = useState(false);
+  const activeSessions = useActiveSessionCount(plugin);
+
+  if (!isVisible) return null;
+
+  if (!plugin) {
+    return (
+      <div className="plugin-detail" data-testid="plugin-detail">
+        <div className="plugin-detail__empty" data-testid="plugin-detail-missing">
+          This plugin is no longer installed.
+        </div>
+      </div>
+    );
+  }
+
+  const { manifest, state, errorMessage } = plugin;
+  const dot = pluginDotState(state);
+  const TypeIcon = pluginTypeIcon(manifest.extensions);
+  const points = extensionPoints(manifest.extensions);
+  const isError = dot === "error";
+  const isEnabled = dot === "enabled";
+  const showSettings = hasSettings(manifest);
+
+  const handleUninstall = () => uninstallPlugin(manifest.id);
+
+  return (
+    <div className="plugin-detail" data-testid="plugin-detail">
+      <div className="plugin-detail__head">
+        <div className={`plugin-detail__icon${isError ? " plugin-detail__icon--error" : ""}`}>
+          <TypeIcon size={22} aria-hidden="true" />
+        </div>
+        <div>
+          <div className="plugin-detail__name">
+            {manifest.name}
+            <span
+              className={`plugin-detail__status plugin-detail__status--${dot}`}
+              data-testid="plugin-detail-status"
+            >
+              <span className={`plugin-state-dot plugin-state-dot--${dot}`} aria-hidden="true" />
+              {pluginStatusLabel(state)}
+            </span>
+          </div>
+          <div className="plugin-detail__meta">
+            v{manifest.version} · by {manifest.author} ·{" "}
+            <code>{pluginTypeLabel(manifest.extensions)}</code>
+          </div>
+        </div>
+      </div>
+
+      {manifest.description && <p className="plugin-detail__desc">{manifest.description}</p>}
+
+      {isError && errorMessage && (
+        <div className="plugin-detail__error" data-testid="plugin-detail-error">
+          <CircleAlert className="plugin-detail__error-icon" aria-hidden="true" />
+          <div>{errorMessage}</div>
+        </div>
+      )}
+
+      <div className="plugin-detail__block">
+        <div className="plugin-detail__section-title">Extension Points</div>
+        <div className="plugin-detail__list">
+          {points.map((point) => {
+            const Icon = point.icon;
+            return (
+              <div className="plugin-detail__item" key={point.key}>
+                <Icon className="plugin-detail__item-icon" aria-hidden="true" />
+                <span>
+                  {point.label}
+                  {point.detail && (
+                    <>
+                      {" — "}
+                      <code>{point.detail}</code>
+                    </>
+                  )}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {manifest.permissions.length > 0 && (
+        <div className="plugin-detail__block">
+          <div className="plugin-detail__section-title">Permissions</div>
+          <div className="plugin-detail__list">
+            {manifest.permissions.map((perm) => (
+              <div className="plugin-detail__item" key={perm}>
+                <Shield
+                  className="plugin-detail__item-icon plugin-detail__item-icon--perm"
+                  aria-hidden="true"
+                />
+                <span className="plugin-detail__item-name">{PERMISSION_LABELS[perm]}</span>
+                <span className="plugin-detail__item-desc">— {PERMISSION_DESCRIPTIONS[perm]}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="plugin-detail__actions">
+        {isError ? (
+          <Button
+            variant="primary"
+            icon={<Power size={14} />}
+            onClick={() => enablePlugin(manifest.id)}
+            data-testid="plugin-action-retry"
+          >
+            Retry
+          </Button>
+        ) : isEnabled ? (
+          <Button
+            variant="secondary"
+            icon={<Power size={14} />}
+            onClick={() => disablePlugin(manifest.id)}
+            data-testid="plugin-action-disable"
+          >
+            Disable
+          </Button>
+        ) : (
+          <Button
+            variant="primary"
+            icon={<Power size={14} />}
+            onClick={() => enablePlugin(manifest.id)}
+            data-testid="plugin-action-enable"
+          >
+            Enable
+          </Button>
+        )}
+
+        {showSettings && (
+          <Button
+            variant="secondary"
+            icon={<SlidersHorizontal size={14} />}
+            onClick={openSettingsTab}
+            data-testid="plugin-action-settings"
+          >
+            Settings…
+          </Button>
+        )}
+
+        <Button
+          variant="danger"
+          icon={<Trash2 size={14} />}
+          onClick={() => setConfirmUninstall(true)}
+          data-testid="plugin-action-uninstall"
+        >
+          Uninstall
+        </Button>
+      </div>
+
+      <ConfirmDialog
+        open={confirmUninstall}
+        title={`Uninstall ${manifest.name}?`}
+        variant="danger"
+        confirmLabel="Uninstall"
+        message={
+          activeSessions > 0
+            ? `This plugin has ${activeSessions} active ${
+                activeSessions === 1 ? "session" : "sessions"
+              } that will be closed. This removes the plugin and its configuration.`
+            : "This removes the plugin and its configuration."
+        }
+        confirmErrorToast={false}
+        onConfirm={handleUninstall}
+        onCancel={() => setConfirmUninstall(false)}
+        testIdBase="plugin-uninstall"
+      />
+    </div>
+  );
+}

--- a/src/components/Plugins/PluginInstallDialog.test.tsx
+++ b/src/components/Plugins/PluginInstallDialog.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Tests for the install-from-file dialog (#1997): rendering the parsed manifest
+ * and the requested-permissions list, and the Install & Enable / Cancel actions
+ * dispatching to the store.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import React from "react";
+import { useAppStore } from "@/store/appStore";
+import type { PluginManifest } from "@/types/plugin";
+import { withTooltip } from "@/test/tooltip";
+import { PluginInstallDialog } from "./PluginInstallDialog";
+
+function manifest(overrides: Partial<PluginManifest> = {}): PluginManifest {
+  return {
+    id: "k8s",
+    name: "Kubernetes Exec",
+    version: "1.2.0",
+    author: "k8s-contrib",
+    description: "desc",
+    license: "MIT",
+    apiVersion: "1.0",
+    platforms: ["macos"],
+    permissions: ["terminal", "network", "filesystem"],
+    extensions: {
+      terminalBackend: {
+        connectionType: "k8s-exec",
+        displayName: "Kubernetes Exec",
+        configSchema: {},
+      },
+    },
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+const onClose = vi.fn();
+
+function render(m: PluginManifest, filePath = "/tmp/k8s-exec-1.2.0.termihub-plugin") {
+  act(() =>
+    root.render(
+      withTooltip(React.createElement(PluginInstallDialog, { filePath, manifest: m, onClose }))
+    )
+  );
+}
+
+describe("PluginInstallDialog (#1997)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    onClose.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders the parsed manifest and requested permissions", () => {
+    render(manifest());
+    const dialog = document.querySelector('[data-testid="plugin-install-dialog"]')!;
+    const text = dialog.textContent ?? "";
+    expect(text).toContain("k8s-exec-1.2.0.termihub-plugin");
+    expect(text).toContain("Kubernetes Exec");
+    expect(text).toContain("1.2.0");
+    expect(text).toContain("k8s-contrib");
+    expect(text).toContain("Terminal Backend");
+    expect(document.querySelector('[data-testid="plugin-install-perm-terminal"]')).not.toBeNull();
+    expect(document.querySelector('[data-testid="plugin-install-perm-filesystem"]')).not.toBeNull();
+    expect(text).toContain("read and write files");
+  });
+
+  it("shows a no-permissions note when none are requested", () => {
+    render(manifest({ permissions: [] }));
+    expect(document.querySelector('[data-testid="plugin-install-no-perms"]')).not.toBeNull();
+  });
+
+  it("installs then enables on confirm, selects the plugin, and closes", async () => {
+    const installPlugin = vi.fn(() => Promise.resolve());
+    const enablePlugin = vi.fn(() => Promise.resolve());
+    const selectPlugin = vi.fn();
+    useAppStore.setState({ installPlugin, enablePlugin, selectPlugin });
+    render(manifest());
+
+    await act(async () => {
+      document
+        .querySelector('[data-testid="plugin-install-confirm"]')!
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(installPlugin).toHaveBeenCalledWith("/tmp/k8s-exec-1.2.0.termihub-plugin");
+    expect(enablePlugin).toHaveBeenCalledWith("k8s");
+    expect(selectPlugin).toHaveBeenCalledWith("k8s");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("closes without installing on Cancel", () => {
+    const installPlugin = vi.fn(() => Promise.resolve());
+    useAppStore.setState({ installPlugin });
+    render(manifest());
+
+    act(() =>
+      document
+        .querySelector('[data-testid="plugin-install-cancel"]')!
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }))
+    );
+    expect(installPlugin).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/Plugins/PluginInstallDialog.tsx
+++ b/src/components/Plugins/PluginInstallDialog.tsx
@@ -1,0 +1,124 @@
+import { Package, ShieldAlert } from "lucide-react";
+import { useAppStore } from "@/store/appStore";
+import type { PluginManifest } from "@/types/plugin";
+import { Button, Modal } from "@/components/ui";
+import { PERMISSION_DESCRIPTIONS, PERMISSION_LABELS, pluginTypeLabel } from "./pluginPresentation";
+import "./Plugins.css";
+
+/** Props for {@link PluginInstallDialog}. */
+export interface PluginInstallDialogProps {
+  /** Absolute path to the validated `.termihub-plugin` package. */
+  filePath: string;
+  /** The manifest parsed from the package by `validate_plugin`. */
+  manifest: PluginManifest;
+  /** Called after a successful install, or on cancel/close. */
+  onClose: () => void;
+}
+
+/** Basename of a path, tolerating both POSIX and Windows separators. */
+function baseName(path: string): string {
+  const parts = path.split(/[\\/]/);
+  return parts[parts.length - 1] || path;
+}
+
+/** Title-case a plugin's primary type for the meta line (e.g. "Terminal Backend"). */
+function typeTitle(manifest: PluginManifest): string {
+  return pluginTypeLabel(manifest.extensions).replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
+ * Install-from-file confirmation dialog (#1997). Renders on the shared Modal
+ * overlay after a package is picked and validated: the parsed manifest (file,
+ * name, version, author, type) and a Requested Permissions list where each
+ * permission shows a shield-alert icon and a plain-language explanation. Cancel
+ * aborts; "Install & Enable" installs the package and activates it.
+ */
+export function PluginInstallDialog({ filePath, manifest, onClose }: PluginInstallDialogProps) {
+  const installPlugin = useAppStore((s) => s.installPlugin);
+  const enablePlugin = useAppStore((s) => s.enablePlugin);
+  const selectPlugin = useAppStore((s) => s.selectPlugin);
+
+  const handleInstall = async () => {
+    // installPlugin / enablePlugin own their own pending → success/error toasts
+    // and re-throw on failure, so the async Button keeps the dialog open (and
+    // shows the error) when either step fails.
+    await installPlugin(filePath);
+    await enablePlugin(manifest.id);
+    selectPlugin(manifest.id);
+    onClose();
+  };
+
+  return (
+    <Modal
+      open
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+      title="Install Plugin"
+      description={`Review ${manifest.name} before installing`}
+      data-testid="plugin-install-dialog"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose} data-testid="plugin-install-cancel">
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleInstall}
+            errorToast={false}
+            data-testid="plugin-install-confirm"
+          >
+            Install &amp; Enable
+          </Button>
+        </>
+      }
+    >
+      <div className="plugin-install__meta">
+        <div className="plugin-install__row">
+          <span className="plugin-install__label">File</span>
+          <span className="plugin-install__file">
+            <Package aria-hidden="true" />
+            {baseName(filePath)}
+          </span>
+        </div>
+        <div className="plugin-install__row">
+          <span className="plugin-install__label">Plugin</span>
+          <span>{manifest.name}</span>
+        </div>
+        <div className="plugin-install__row">
+          <span className="plugin-install__label">Version</span>
+          <span>{manifest.version}</span>
+        </div>
+        <div className="plugin-install__row">
+          <span className="plugin-install__label">Author</span>
+          <span>{manifest.author}</span>
+        </div>
+        <div className="plugin-install__row">
+          <span className="plugin-install__label">Type</span>
+          <span>{typeTitle(manifest)}</span>
+        </div>
+      </div>
+
+      <div className="plugin-install__perm-title">Requested Permissions</div>
+      {manifest.permissions.length === 0 ? (
+        <div className="plugin-install__perm-empty" data-testid="plugin-install-no-perms">
+          This plugin requests no special permissions.
+        </div>
+      ) : (
+        manifest.permissions.map((perm) => (
+          <div
+            className="plugin-install__perm"
+            key={perm}
+            data-testid={`plugin-install-perm-${perm}`}
+          >
+            <ShieldAlert className="plugin-install__perm-icon" aria-hidden="true" />
+            <div>
+              <span className="plugin-install__perm-name">{PERMISSION_LABELS[perm]}</span>{" "}
+              <span className="plugin-install__perm-desc">— {PERMISSION_DESCRIPTIONS[perm]}</span>
+            </div>
+          </div>
+        ))
+      )}
+    </Modal>
+  );
+}

--- a/src/components/Plugins/PluginManagerView.test.tsx
+++ b/src/components/Plugins/PluginManagerView.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Tests for the Plugins sidebar view (#1997): the installed list rendering,
+ * per-plugin state dots, search filtering, row selection dispatch, and the
+ * install-from-file → validate → dialog flow. The store is driven directly
+ * (real slice, overridden actions) and the Tauri file picker + validate command
+ * are mocked.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import React from "react";
+import { useAppStore } from "@/store/appStore";
+import type { InstalledPlugin, PluginState } from "@/types/plugin";
+import { withTooltip } from "@/test/tooltip";
+import { PluginManagerView } from "./PluginManagerView";
+
+const openMock = vi.fn();
+const validateMock = vi.fn();
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({ open: (...a: unknown[]) => openMock(...a) }));
+vi.mock("@/services/api", () => ({ validatePlugin: (...a: unknown[]) => validateMock(...a) }));
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+function plugin(id: string, name: string, version: string, state: PluginState): InstalledPlugin {
+  return {
+    manifest: {
+      id,
+      name,
+      version,
+      author: "author",
+      description: "desc",
+      license: "MIT",
+      apiVersion: "1.0",
+      platforms: ["macos"],
+      permissions: ["terminal", "network"],
+      extensions: {
+        terminalBackend: { connectionType: id, displayName: name, configSchema: {} },
+      },
+    },
+    state,
+    errorMessage: state === "error" ? "boom" : undefined,
+    installedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function render() {
+  act(() => root.render(withTooltip(React.createElement(PluginManagerView))));
+}
+
+describe("PluginManagerView (#1997)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    openMock.mockReset();
+    validateMock.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders each installed plugin with its state dot and version", () => {
+    useAppStore.setState({
+      plugins: [
+        plugin("k8s", "Kubernetes Exec", "1.2.0", "active"),
+        plugin("logcol", "Log Colorizer", "0.3.0", "disabled"),
+        plugin("aws", "AWS CloudShell", "0.9.0", "error"),
+      ],
+    });
+    render();
+
+    expect(container.querySelector('[data-testid="plugin-row-k8s"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="plugin-state-dot-k8s"]')?.className).toContain(
+      "plugin-state-dot--enabled"
+    );
+    expect(container.querySelector('[data-testid="plugin-state-dot-logcol"]')?.className).toContain(
+      "plugin-state-dot--disabled"
+    );
+    expect(container.querySelector('[data-testid="plugin-state-dot-aws"]')?.className).toContain(
+      "plugin-state-dot--error"
+    );
+    expect(container.querySelector('[data-testid="plugin-row-k8s"]')?.textContent).toContain(
+      "v1.2.0"
+    );
+    // Installed count header reflects total.
+    expect(container.querySelector(".plugin-manager__sep")?.textContent).toBe("Installed (3)");
+  });
+
+  it("shows an empty state when nothing is installed", () => {
+    render();
+    expect(container.querySelector('[data-testid="plugin-list-empty"]')?.textContent).toBe(
+      "No plugins installed"
+    );
+  });
+
+  it("filters the list by the search query", async () => {
+    useAppStore.setState({
+      plugins: [
+        plugin("k8s", "Kubernetes Exec", "1.2.0", "active"),
+        plugin("logcol", "Log Colorizer", "0.3.0", "disabled"),
+      ],
+    });
+    render();
+
+    const search = container.querySelector<HTMLInputElement>('[data-testid="plugin-search"]')!;
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value"
+    )!.set!;
+    act(() => {
+      setter.call(search, "color");
+      search.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(container.querySelector('[data-testid="plugin-row-logcol"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="plugin-row-k8s"]')).toBeNull();
+    // Header still shows the full installed count, not the filtered count.
+    expect(container.querySelector(".plugin-manager__sep")?.textContent).toBe("Installed (2)");
+  });
+
+  it("dispatches selectPlugin when a row is clicked", () => {
+    const selectPlugin = vi.fn();
+    useAppStore.setState({
+      plugins: [plugin("k8s", "Kubernetes Exec", "1.2.0", "active")],
+      selectPlugin,
+    });
+    render();
+
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="plugin-row-k8s"]')!
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(selectPlugin).toHaveBeenCalledWith("k8s");
+  });
+
+  it("validates a picked package and opens the install dialog", async () => {
+    openMock.mockResolvedValue("/tmp/k8s-exec-1.2.0.termihub-plugin");
+    validateMock.mockResolvedValue(plugin("k8s", "Kubernetes Exec", "1.2.0", "installed").manifest);
+    render();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="plugin-install-from-file"]')!
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+
+    expect(validateMock).toHaveBeenCalledWith("/tmp/k8s-exec-1.2.0.termihub-plugin");
+    expect(document.querySelector('[data-testid="plugin-install-dialog"]')).not.toBeNull();
+  });
+
+  it("does nothing when the file picker is cancelled", async () => {
+    openMock.mockResolvedValue(null);
+    render();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[data-testid="plugin-install-from-file"]')!
+        .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+
+    expect(validateMock).not.toHaveBeenCalled();
+    expect(document.querySelector('[data-testid="plugin-install-dialog"]')).toBeNull();
+  });
+});

--- a/src/components/Plugins/PluginManagerView.tsx
+++ b/src/components/Plugins/PluginManagerView.tsx
@@ -1,0 +1,145 @@
+import { useCallback, useMemo, useState } from "react";
+import { FileUp } from "lucide-react";
+import { open } from "@tauri-apps/plugin-dialog";
+import { useAppStore } from "@/store/appStore";
+import { validatePlugin } from "@/services/api";
+import type { PluginManifest } from "@/types/plugin";
+import { Button, Input, toast } from "@/components/ui";
+import { frontendLog } from "@/utils/frontendLog";
+import { pluginDotState, pluginTypeIcon } from "./pluginPresentation";
+import { PluginInstallDialog } from "./PluginInstallDialog";
+import "./Plugins.css";
+
+/** A picked-and-validated package awaiting the user's install confirmation. */
+interface PendingInstall {
+  filePath: string;
+  manifest: PluginManifest;
+}
+
+/**
+ * The Plugins sidebar view (#1997): a search box, the installed-plugin list, and
+ * a footer "Install from file…" button. Each plugin is a row with a state dot
+ * (green enabled / grey disabled / red error), a type icon, its name, and
+ * version. Selecting a row opens the plugin's detail panel in the main area.
+ *
+ * The list and all mutations are driven by the plugin store slice (#1993); this
+ * component only projects it and dispatches the native file-picker → validate →
+ * confirm install flow.
+ */
+export function PluginManagerView() {
+  const plugins = useAppStore((s) => s.plugins);
+  const selectedPluginId = useAppStore((s) => s.selectedPluginId);
+  const selectPlugin = useAppStore((s) => s.selectPlugin);
+
+  const [query, setQuery] = useState("");
+  const [pending, setPending] = useState<PendingInstall | null>(null);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return plugins;
+    return plugins.filter((p) => p.manifest.name.toLowerCase().includes(q));
+  }, [plugins, query]);
+
+  const handlePickFile = useCallback(async () => {
+    let filePath: string | null;
+    try {
+      filePath = (await open({
+        multiple: false,
+        directory: false,
+        filters: [{ name: "termiHub plugin", extensions: ["termihub-plugin"] }],
+      })) as string | null;
+    } catch (err) {
+      frontendLog("plugin_manager", `File picker failed: ${err}`);
+      toast.error(
+        `Could not open file picker: ${err instanceof Error ? err.message : String(err)}`
+      );
+      return;
+    }
+    if (!filePath) return;
+
+    const toastId = toast.loading("Validating plugin…");
+    try {
+      const manifest = await validatePlugin(filePath);
+      toast.dismiss(toastId);
+      setPending({ filePath, manifest });
+    } catch (err) {
+      toast.error(`Invalid plugin package: ${err instanceof Error ? err.message : String(err)}`, {
+        id: toastId,
+      });
+    }
+  }, []);
+
+  return (
+    <div className="plugin-manager" data-testid="plugin-manager">
+      <div className="plugin-manager__search">
+        <Input
+          size="sm"
+          type="search"
+          placeholder="Search plugins…"
+          aria-label="Search plugins"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          data-testid="plugin-search"
+        />
+      </div>
+
+      <div className="plugin-manager__list" data-testid="plugin-list">
+        <div className="plugin-manager__sep">Installed ({plugins.length})</div>
+        {filtered.length === 0 ? (
+          <div className="plugin-manager__empty" data-testid="plugin-list-empty">
+            {plugins.length === 0 ? "No plugins installed" : "No plugins match your search"}
+          </div>
+        ) : (
+          filtered.map((plugin) => {
+            const { manifest, state } = plugin;
+            const dot = pluginDotState(state);
+            const TypeIcon = pluginTypeIcon(manifest.extensions);
+            const isSelected = manifest.id === selectedPluginId;
+            return (
+              <button
+                key={manifest.id}
+                type="button"
+                className={`plugin-row${isSelected ? " plugin-row--selected" : ""}${
+                  dot === "disabled" ? " plugin-row--disabled" : ""
+                }`}
+                onClick={() => selectPlugin(manifest.id)}
+                title={`${manifest.name} v${manifest.version}`}
+                data-testid={`plugin-row-${manifest.id}`}
+              >
+                <span
+                  className={`plugin-state-dot plugin-state-dot--${dot}`}
+                  data-testid={`plugin-state-dot-${manifest.id}`}
+                  aria-hidden="true"
+                />
+                <TypeIcon className="plugin-row__icon" aria-hidden="true" />
+                <span className="plugin-row__name">{manifest.name}</span>
+                <span className="plugin-row__ver">v{manifest.version}</span>
+              </button>
+            );
+          })
+        )}
+      </div>
+
+      <div className="plugin-manager__footer">
+        <Button
+          variant="secondary"
+          size="sm"
+          fullWidth
+          icon={<FileUp size={14} />}
+          onClick={handlePickFile}
+          data-testid="plugin-install-from-file"
+        >
+          Install from file…
+        </Button>
+      </div>
+
+      {pending && (
+        <PluginInstallDialog
+          filePath={pending.filePath}
+          manifest={pending.manifest}
+          onClose={() => setPending(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/Plugins/Plugins.css
+++ b/src/components/Plugins/Plugins.css
@@ -1,0 +1,386 @@
+/**
+ * Plugin Manager UI styles (#1997).
+ *
+ * Mirrors the plugin-system concept mockup (docs/concepts/future/
+ * plugin-system.html) — the sidebar installed list, the main-area detail panel,
+ * and the install dialog. Every value references a design token from
+ * variables.css; no raw colours/radii. Classes are namespaced `plugin-*` to stay
+ * clear of the global app stylesheet.
+ */
+
+/* ── Sidebar: search + installed list ─────────────────────────────────── */
+.plugin-manager {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.plugin-manager__search {
+  padding: 8px;
+  border-bottom: 1px solid var(--border-secondary);
+}
+
+.plugin-manager__list {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  min-height: 0;
+  padding: 4px 0;
+}
+
+.plugin-manager__sep {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-disabled);
+}
+
+.plugin-manager__sep::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--border-secondary);
+}
+
+.plugin-manager__empty {
+  padding: 12px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.plugin-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 12px;
+  border: none;
+  background: none;
+  color: var(--text-primary);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.plugin-row:hover {
+  background: var(--bg-hover);
+}
+
+.plugin-row--selected,
+.plugin-row--selected:hover {
+  background: var(--bg-selected, var(--bg-hover));
+}
+
+.plugin-row:focus-visible {
+  outline: 2px solid var(--border-focus, var(--text-accent));
+  outline-offset: -2px;
+}
+
+.plugin-row--disabled {
+  color: var(--text-secondary);
+}
+
+.plugin-row__icon {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+  color: var(--text-secondary);
+}
+
+.plugin-row__name {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.plugin-row__ver {
+  margin-left: auto;
+  color: var(--text-disabled);
+  font-size: 11px;
+  font-family: var(--font-mono);
+  flex: 0 0 auto;
+}
+
+.plugin-manager__footer {
+  padding: 8px;
+  border-top: 1px solid var(--border-secondary);
+}
+
+/* ── State dot ────────────────────────────────────────────────────────── */
+.plugin-state-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: var(--text-disabled);
+}
+
+.plugin-state-dot--enabled {
+  background: var(--state-connected);
+}
+
+.plugin-state-dot--error {
+  background: var(--state-disconnected);
+}
+
+/* ── Detail panel (main area) ─────────────────────────────────────────── */
+.plugin-detail {
+  flex: 1 1 auto;
+  overflow: auto;
+  height: 100%;
+  padding: 18px 20px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.plugin-detail__head {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--border-secondary);
+}
+
+.plugin-detail__icon {
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-md);
+  background: var(--bg-tertiary);
+  color: var(--text-accent);
+  flex: 0 0 auto;
+}
+
+.plugin-detail__icon--error {
+  color: var(--color-error);
+}
+
+.plugin-detail__name {
+  font-size: 15px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.plugin-detail__meta {
+  color: var(--text-secondary);
+  font-size: 12px;
+  margin-top: 2px;
+}
+
+.plugin-detail__meta code {
+  font-family: var(--font-mono);
+}
+
+.plugin-detail__desc {
+  color: var(--text-primary);
+  font-size: 13px;
+  margin: 14px 0 18px;
+  max-width: 560px;
+}
+
+.plugin-detail__section-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+  margin: 0 0 8px;
+}
+
+.plugin-detail__block {
+  margin-bottom: 18px;
+}
+
+.plugin-detail__list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  max-width: 560px;
+}
+
+.plugin-detail__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border: 1px solid var(--border-secondary);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  font-size: 12.5px;
+}
+
+.plugin-detail__item-icon {
+  width: 15px;
+  height: 15px;
+  flex: 0 0 auto;
+  color: var(--text-accent);
+}
+
+.plugin-detail__item-icon--perm {
+  color: var(--color-warning);
+}
+
+.plugin-detail__item code {
+  font-family: var(--font-mono);
+}
+
+.plugin-detail__item-name {
+  font-weight: 600;
+}
+
+.plugin-detail__item-desc {
+  color: var(--text-secondary);
+}
+
+.plugin-detail__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
+.plugin-detail__status--enabled {
+  color: var(--state-connected);
+  background: color-mix(in srgb, var(--state-connected) 16%, transparent);
+}
+
+.plugin-detail__status--disabled {
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+}
+
+.plugin-detail__status--error {
+  color: var(--color-error);
+  background: color-mix(in srgb, var(--color-error) 16%, transparent);
+}
+
+.plugin-detail__error {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  margin: 14px 0 18px;
+  border: 1px solid color-mix(in srgb, var(--color-error) 40%, var(--border-secondary));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-error) 10%, transparent);
+  color: var(--text-primary);
+  font-size: 12.5px;
+  max-width: 560px;
+}
+
+.plugin-detail__error-icon {
+  width: 16px;
+  height: 16px;
+  color: var(--color-error);
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+
+.plugin-detail__actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 6px;
+  flex-wrap: wrap;
+}
+
+.plugin-detail__empty {
+  display: grid;
+  place-items: center;
+  height: 100%;
+  padding: 24px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  text-align: center;
+}
+
+/* ── Install dialog ───────────────────────────────────────────────────── */
+.plugin-install__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding-bottom: 12px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--border-secondary);
+  font-size: 12.5px;
+}
+
+.plugin-install__row {
+  display: flex;
+  gap: 8px;
+}
+
+.plugin-install__label {
+  color: var(--text-secondary);
+  min-width: 64px;
+  flex: 0 0 auto;
+}
+
+.plugin-install__file {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  color: var(--text-accent);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.plugin-install__file svg {
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+}
+
+.plugin-install__perm-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+  margin: 0 0 8px;
+}
+
+.plugin-install__perm-empty {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+}
+
+.plugin-install__perm {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 6px 0;
+  font-size: 12.5px;
+}
+
+.plugin-install__perm-icon {
+  width: 16px;
+  height: 16px;
+  color: var(--color-warning);
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+
+.plugin-install__perm-name {
+  font-weight: 600;
+}
+
+.plugin-install__perm-desc {
+  color: var(--text-secondary);
+}

--- a/src/components/Plugins/index.ts
+++ b/src/components/Plugins/index.ts
@@ -1,0 +1,5 @@
+export { PluginManagerView } from "./PluginManagerView";
+export { PluginDetailPanel } from "./PluginDetailPanel";
+export type { PluginDetailPanelProps } from "./PluginDetailPanel";
+export { PluginInstallDialog } from "./PluginInstallDialog";
+export type { PluginInstallDialogProps } from "./PluginInstallDialog";

--- a/src/components/Plugins/pluginPresentation.test.ts
+++ b/src/components/Plugins/pluginPresentation.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for the plugin presentation helpers (#1997) — the pure mappings
+ * from the plugin data model to dot state, labels, extension points, and
+ * permission text used across the Plugin Manager UI.
+ */
+import { describe, it, expect } from "vitest";
+import type { PluginExtensions, PluginManifest } from "@/types/plugin";
+import {
+  PERMISSION_DESCRIPTIONS,
+  PERMISSION_LABELS,
+  extensionPoints,
+  hasSettings,
+  pluginDotState,
+  pluginStatusLabel,
+  pluginTypeLabel,
+} from "./pluginPresentation";
+
+function manifest(overrides: Partial<PluginManifest> = {}): PluginManifest {
+  return {
+    id: "p",
+    name: "Plugin",
+    version: "1.0.0",
+    author: "me",
+    description: "",
+    license: "MIT",
+    apiVersion: "1.0",
+    platforms: ["macos"],
+    permissions: [],
+    extensions: {},
+    ...overrides,
+  };
+}
+
+describe("pluginDotState", () => {
+  it("maps active to enabled", () => {
+    expect(pluginDotState("active")).toBe("enabled");
+  });
+
+  it("maps installed/disabled to disabled", () => {
+    expect(pluginDotState("installed")).toBe("disabled");
+    expect(pluginDotState("disabled")).toBe("disabled");
+  });
+
+  it("maps error and incompatible to error", () => {
+    expect(pluginDotState("error")).toBe("error");
+    expect(pluginDotState("incompatible")).toBe("error");
+  });
+});
+
+describe("pluginStatusLabel", () => {
+  it("labels each state", () => {
+    expect(pluginStatusLabel("active")).toBe("Enabled");
+    expect(pluginStatusLabel("disabled")).toBe("Disabled");
+    expect(pluginStatusLabel("installed")).toBe("Disabled");
+    expect(pluginStatusLabel("error")).toBe("Error");
+    expect(pluginStatusLabel("incompatible")).toBe("Incompatible");
+  });
+});
+
+describe("pluginTypeLabel", () => {
+  it("picks the primary extension in priority order", () => {
+    const ext: PluginExtensions = {
+      terminalBackend: { connectionType: "k8s", displayName: "K8s", configSchema: {} },
+      theme: { themes: [] },
+    };
+    expect(pluginTypeLabel(ext)).toBe("terminal backend");
+    expect(pluginTypeLabel({ theme: { themes: [] } })).toBe("theme");
+    expect(
+      pluginTypeLabel({ protocolParser: { name: "n", description: "", entryPoint: "e" } })
+    ).toBe("protocol parser");
+    expect(pluginTypeLabel({})).toBe("plugin");
+  });
+});
+
+describe("extensionPoints", () => {
+  it("enumerates each declared extension with its detail", () => {
+    const points = extensionPoints({
+      terminalBackend: { connectionType: "k8s-exec", displayName: "K8s", configSchema: {} },
+      protocolParser: { name: "colorize", description: "", entryPoint: "e" },
+      theme: { themes: [{ id: "a", name: "A", file: "a.json" }] },
+    });
+    expect(points.map((p) => p.key)).toEqual(["terminalBackend", "protocolParser", "theme"]);
+    expect(points[0].detail).toBe("k8s-exec");
+    expect(points[2].detail).toBe("1 theme");
+  });
+
+  it("returns an empty array for no extensions", () => {
+    expect(extensionPoints({})).toEqual([]);
+  });
+});
+
+describe("permission text", () => {
+  it("has a label and description for every permission", () => {
+    for (const perm of ["terminal", "network", "filesystem", "ui", "settings"] as const) {
+      expect(PERMISSION_LABELS[perm]).toBeTruthy();
+      expect(PERMISSION_DESCRIPTIONS[perm]).toBeTruthy();
+    }
+    expect(PERMISSION_LABELS.filesystem).toBe("FileSystem");
+  });
+});
+
+describe("hasSettings", () => {
+  it("is false when no settings are declared", () => {
+    expect(hasSettings(manifest())).toBe(false);
+    expect(hasSettings(manifest({ settings: {} }))).toBe(false);
+  });
+
+  it("is true when at least one setting is declared", () => {
+    expect(
+      hasSettings(manifest({ settings: { ns: { type: "string", default: "", description: "" } } }))
+    ).toBe(true);
+  });
+});

--- a/src/components/Plugins/pluginPresentation.ts
+++ b/src/components/Plugins/pluginPresentation.ts
@@ -1,0 +1,158 @@
+/**
+ * Presentation helpers shared by the Plugin Manager UI (#1997).
+ *
+ * Pure mappings from the plugin data model ({@link InstalledPlugin} and friends)
+ * to icons, labels, and plain-language descriptions used by the sidebar list,
+ * the detail panel, and the install dialog. Keeping these here (rather than
+ * inline in the components) makes them unit-testable and keeps a single source
+ * of truth for how a plugin's type/permissions/state are surfaced.
+ */
+import type { LucideIcon } from "lucide-react";
+import { LayoutDashboard, Network, Palette, Puzzle, SlidersHorizontal } from "lucide-react";
+import type {
+  PluginExtensions,
+  PluginManifest,
+  PluginPermission,
+  PluginState,
+} from "@/types/plugin";
+
+/** Coarse visual state of a plugin's status dot. */
+export type PluginDotState = "enabled" | "disabled" | "error";
+
+/**
+ * Collapse the five install/runtime {@link PluginState}s into the three visual
+ * dot states shown in the list and detail panel: green (enabled), grey
+ * (disabled/installed), red (error/incompatible).
+ */
+export function pluginDotState(state: PluginState): PluginDotState {
+  switch (state) {
+    case "active":
+      return "enabled";
+    case "error":
+    case "incompatible":
+      return "error";
+    default:
+      return "disabled";
+  }
+}
+
+/** Human-readable status word for a plugin state (detail-panel status pill). */
+export function pluginStatusLabel(state: PluginState): string {
+  switch (state) {
+    case "active":
+      return "Enabled";
+    case "disabled":
+    case "installed":
+      return "Disabled";
+    case "error":
+      return "Error";
+    case "incompatible":
+      return "Incompatible";
+  }
+}
+
+/**
+ * Icon for a plugin, chosen from its primary (first-declared) extension point.
+ * Terminal backends read as connections, themes as palettes, and so on; a plugin
+ * with no recognised extension falls back to the generic puzzle piece.
+ */
+export function pluginTypeIcon(extensions: PluginExtensions): LucideIcon {
+  if (extensions.terminalBackend) return Network;
+  if (extensions.theme) return Palette;
+  if (extensions.protocolParser) return SlidersHorizontal;
+  if (extensions.statusBarWidget) return LayoutDashboard;
+  return Puzzle;
+}
+
+/**
+ * Short lower-case type label for the detail-panel meta line
+ * (e.g. `terminal backend`). Picks the primary extension point.
+ */
+export function pluginTypeLabel(extensions: PluginExtensions): string {
+  if (extensions.terminalBackend) return "terminal backend";
+  if (extensions.theme) return "theme";
+  if (extensions.protocolParser) return "protocol parser";
+  if (extensions.statusBarWidget) return "status bar widget";
+  return "plugin";
+}
+
+/** A single extension-point row for the detail panel's "Extension Points" list. */
+export interface ExtensionPointInfo {
+  /** Stable key for React lists. */
+  key: string;
+  icon: LucideIcon;
+  /** The extension-point kind, e.g. "Terminal Backend". */
+  label: string;
+  /** Optional specifics (connection type, parser name, theme count). */
+  detail?: string;
+}
+
+/**
+ * Enumerate every extension point a plugin declares, in a stable order, for the
+ * detail panel. Returns an empty array only for a manifest that declares none
+ * (which the backend rejects at validation).
+ */
+export function extensionPoints(extensions: PluginExtensions): ExtensionPointInfo[] {
+  const points: ExtensionPointInfo[] = [];
+  if (extensions.terminalBackend) {
+    points.push({
+      key: "terminalBackend",
+      icon: Network,
+      label: "Terminal Backend",
+      detail: extensions.terminalBackend.connectionType,
+    });
+  }
+  if (extensions.protocolParser) {
+    points.push({
+      key: "protocolParser",
+      icon: SlidersHorizontal,
+      label: "Protocol Parser",
+      detail: extensions.protocolParser.name,
+    });
+  }
+  if (extensions.theme) {
+    const count = extensions.theme.themes.length;
+    points.push({
+      key: "theme",
+      icon: Palette,
+      label: "Theme",
+      detail: `${count} ${count === 1 ? "theme" : "themes"}`,
+    });
+  }
+  if (extensions.statusBarWidget) {
+    points.push({
+      key: "statusBarWidget",
+      icon: LayoutDashboard,
+      label: "Status Bar Widget",
+      detail: extensions.statusBarWidget.position,
+    });
+  }
+  return points;
+}
+
+/** Title-case display name for a permission (e.g. `filesystem` → "FileSystem"). */
+export const PERMISSION_LABELS: Record<PluginPermission, string> = {
+  terminal: "Terminal",
+  network: "Network",
+  filesystem: "FileSystem",
+  ui: "UI",
+  settings: "Settings",
+};
+
+/**
+ * Plain-language explanation of what each permission grants, shown beside the
+ * permission name in the detail panel and the install prompt (concept
+ * "Plugin Permissions").
+ */
+export const PERMISSION_DESCRIPTIONS: Record<PluginPermission, string> = {
+  terminal: "create and manage terminal sessions",
+  network: "make outbound network connections",
+  filesystem: "read and write files (scoped to declared paths)",
+  ui: "render UI components in designated slots",
+  settings: "store and read plugin configuration",
+};
+
+/** True when the plugin declares at least one user-configurable setting. */
+export function hasSettings(manifest: PluginManifest): boolean {
+  return manifest.settings != null && Object.keys(manifest.settings).length > 0;
+}

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -8,6 +8,7 @@ import { RecentSessionsSidebar } from "@/components/RecentSessionsSidebar";
 import { WorkflowSidebar } from "@/components/WorkflowSidebar";
 import { NetworkToolsSidebar } from "@/components/NetworkTools/NetworkToolsSidebar";
 import { EmbeddedServerSidebar } from "@/components/EmbeddedServerSidebar";
+import { PluginManagerView } from "@/components/Plugins";
 import "./Sidebar.css";
 
 const VIEW_TITLES: Record<string, string> = {
@@ -20,6 +21,7 @@ const VIEW_TITLES: Record<string, string> = {
   workflows: "Workflows",
   "network-tools": "Network Tools",
   "recent-sessions": "Recent Sessions",
+  plugins: "Plugins",
 };
 
 interface SidebarProps {
@@ -47,6 +49,7 @@ export function Sidebar({ width }: SidebarProps) {
         {sidebarView === "recent-sessions" && <RecentSessionsSidebar />}
         {sidebarView === "workflows" && <WorkflowSidebar />}
         {sidebarView === "network-tools" && <NetworkToolsSidebar />}
+        {sidebarView === "plugins" && <PluginManagerView />}
       </div>
     </div>
   );

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -28,6 +28,7 @@ import {
   Check,
   Palette,
   Stethoscope,
+  Puzzle,
   WifiOff,
   X,
 } from "lucide-react";
@@ -51,6 +52,7 @@ import { LogViewer } from "@/components/LogViewer";
 import { TunnelEditor } from "@/components/TunnelEditor";
 import { WorkspaceEditor } from "@/components/WorkspaceEditor";
 import { NetworkDiagnosticPanel } from "@/components/NetworkTools/NetworkDiagnosticPanel";
+import { PluginDetailPanel } from "@/components/Plugins";
 import { TerminalSearchBar } from "@/components/Terminal/TerminalSearchBar";
 import { AgentErrorTab } from "@/components/Terminal/AgentErrorTab";
 import { FileBrowserTab } from "@/components/Terminal/FileBrowserTab";
@@ -306,6 +308,8 @@ export function SplitView() {
                     <LayoutGrid size={14} className="zoom-overlay__icon" />
                   ) : zoomedTab.contentType === "network-diagnostic" ? (
                     <Stethoscope size={14} className="zoom-overlay__icon" />
+                  ) : zoomedTab.contentType === "plugin-detail" ? (
+                    <Puzzle size={14} className="zoom-overlay__icon" />
                   ) : zoomedTab.contentType === "agent-error" ? (
                     <WifiOff size={14} className="zoom-overlay__icon" />
                   ) : (
@@ -460,6 +464,12 @@ export function SplitView() {
                 <NetworkDiagnosticPanel
                   key={`zoom-${zoomedTabId}`}
                   meta={zoomedTab.networkDiagnosticMeta}
+                  isVisible={true}
+                />
+              ) : zoomedTab.contentType === "plugin-detail" && zoomedTab.pluginDetailMeta ? (
+                <PluginDetailPanel
+                  key={`zoom-${zoomedTabId}`}
+                  meta={zoomedTab.pluginDetailMeta}
                   isVisible={true}
                 />
               ) : zoomedTab.contentType === "agent-error" && zoomedTab.agentErrorMeta ? (
@@ -712,6 +722,12 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
             <NetworkDiagnosticPanel
               key={tab.id}
               meta={tab.networkDiagnosticMeta}
+              isVisible={tab.id === panel.activeTabId && zoomedTabId !== tab.id}
+            />
+          ) : tab.contentType === "plugin-detail" && tab.pluginDetailMeta ? (
+            <PluginDetailPanel
+              key={tab.id}
+              meta={tab.pluginDetailMeta}
               isVisible={tab.id === panel.activeTabId && zoomedTabId !== tab.id}
             />
           ) : tab.contentType === "agent-error" && tab.agentErrorMeta ? (

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -17,6 +17,7 @@ import {
   Highlighter,
   AppWindow,
   Infinity as InfinityIcon,
+  Puzzle,
 } from "lucide-react";
 import { useAppStore, getActiveTab, monitorKeyForTab, selectMonitor } from "@/store/appStore";
 import { resolveHighlightingConfig } from "@/services/syntaxHighlightingConfig";
@@ -116,6 +117,7 @@ export function StatusBar() {
         <MonitoringStatus />
         <PersistentSessionsIndicator />
         <ServicesIndicator />
+        <PluginsIndicator />
         <AgentUpdatesIndicator />
         <TransferQueueIndicator />
         <CredentialStoreIndicator />
@@ -383,6 +385,38 @@ function ServicesIndicator() {
       >
         <Server size={12} />
         {runningCount}
+      </button>
+    </Tooltip>
+  );
+}
+
+/**
+ * Installed-plugin count in the status bar (#1997).
+ *
+ * Shows "N plugins · M enabled", reflecting the store's installed-plugin list
+ * (enabled = state `active`). Clicking opens the Plugins sidebar view. Renders
+ * nothing when no plugins are installed, keeping the bar uncluttered.
+ */
+function PluginsIndicator() {
+  const plugins = useAppStore((s) => s.plugins);
+  const setSidebarView = useAppStore((s) => s.setSidebarView);
+
+  const total = plugins.length;
+  if (total === 0) return null;
+
+  const enabled = plugins.filter((p) => p.state === "active").length;
+  const label = `${total} plugin${total !== 1 ? "s" : ""} · ${enabled} enabled — click to open Plugins`;
+
+  return (
+    <Tooltip content={label} side="top">
+      <button
+        className="status-bar__item status-bar__item--interactive"
+        aria-label={label}
+        data-testid="plugins-indicator"
+        onClick={() => setSidebarView("plugins")}
+      >
+        <Puzzle size={12} />
+        {total} · {enabled}
       </button>
     </Tooltip>
   );

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -8,6 +8,7 @@ import {
   SquarePen,
   ScrollText,
   ArrowLeftRight,
+  Puzzle,
   Eraser,
   FileDown,
   ClipboardCopy,
@@ -129,7 +130,9 @@ export function Tab({
             ? SquarePen
             : tab.contentType === "tunnel-editor"
               ? ArrowLeftRight
-              : null;
+              : tab.contentType === "plugin-detail"
+                ? Puzzle
+                : null;
   const isTerminalTab = tab.contentType === "terminal";
 
   const tabElement = (

--- a/src/store/appStore.plugins.test.ts
+++ b/src/store/appStore.plugins.test.ts
@@ -224,4 +224,37 @@ describe("appStore — plugins (#1993)", () => {
     expect(toastLoading).toHaveBeenCalledWith("Enabling unknown-id…");
     expect(toastSuccess).toHaveBeenCalledWith("Enabled unknown-id", { id: "toast-id" });
   });
+
+  describe("selectPlugin (#1997)", () => {
+    it("opens a single plugin-detail tab titled after the plugin and records the selection", () => {
+      useAppStore.setState({ plugins: [makePlugin("k8s", "active")] });
+
+      useAppStore.getState().selectPlugin("k8s");
+
+      const state = useAppStore.getState();
+      expect(state.selectedPluginId).toBe("k8s");
+      const tabs = state.rootPanel && "tabs" in state.rootPanel ? state.rootPanel.tabs : [];
+      const detailTabs = tabs.filter((t) => t.contentType === "plugin-detail");
+      expect(detailTabs).toHaveLength(1);
+      expect(detailTabs[0].pluginDetailMeta).toEqual({ pluginId: "k8s" });
+      expect(detailTabs[0].title).toBe("Plugin k8s");
+      expect(detailTabs[0].isActive).toBe(true);
+    });
+
+    it("reuses the same detail tab when a different plugin is selected", () => {
+      useAppStore.setState({
+        plugins: [makePlugin("a", "active"), makePlugin("b", "disabled")],
+      });
+
+      useAppStore.getState().selectPlugin("a");
+      useAppStore.getState().selectPlugin("b");
+
+      const state = useAppStore.getState();
+      const tabs = state.rootPanel && "tabs" in state.rootPanel ? state.rootPanel.tabs : [];
+      const detailTabs = tabs.filter((t) => t.contentType === "plugin-detail");
+      expect(detailTabs).toHaveLength(1);
+      expect(detailTabs[0].pluginDetailMeta).toEqual({ pluginId: "b" });
+      expect(state.selectedPluginId).toBe("b");
+    });
+  });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -16,6 +16,7 @@ import {
   EditorStatus,
   EditorActions,
   NetworkDiagnosticMeta,
+  PluginDetailMeta,
   NetworkTool,
   TabGroup,
   TerminalExitInfo,
@@ -313,7 +314,8 @@ export type SidebarView =
   | "macros"
   | "workflows"
   | "network-tools"
-  | "recent-sessions";
+  | "recent-sessions"
+  | "plugins";
 
 /** Clipboard state for file browser copy/cut operations. */
 export interface FileClipboard {
@@ -1496,6 +1498,16 @@ interface AppState {
   enablePlugin: (pluginId: string) => Promise<void>;
   /** Disable a plugin by id, then refresh the list. Toasts feedback; rejects on failure. */
   disablePlugin: (pluginId: string) => Promise<void>;
+  /**
+   * The manifest id of the plugin currently selected in the Plugins sidebar
+   * (#1997), or `null` when none is selected. Drives the sidebar row highlight.
+   */
+  selectedPluginId: string | null;
+  /**
+   * Select a plugin in the Plugins sidebar: records {@link selectedPluginId} and
+   * opens (or updates, and focuses) the single plugin-detail tab in the main area.
+   */
+  selectPlugin: (pluginId: string) => void;
 
   // Macro recording (#1674)
   /** Whether terminal input is currently being captured into a macro. */
@@ -5067,6 +5079,8 @@ export const useAppStore = create<AppState>((set, get) => {
       get().loadMacros();
       // Load workflows
       get().loadWorkflows();
+      // Load installed plugins (#1997)
+      get().loadPlugins();
       // Load app mode (portable vs. installed) for status bar and settings display
       await get().loadAppMode();
       // Load credential store status (dialog opens on-demand when credentials are needed)
@@ -7529,6 +7543,49 @@ export const useAppStore = create<AppState>((set, get) => {
         throw err;
       }
     },
+
+    selectedPluginId: null,
+
+    selectPlugin: (pluginId) =>
+      set((state) => {
+        const allLeaves = getAllLeaves(state.rootPanel);
+        const plugin = state.plugins.find((p) => p.manifest.id === pluginId);
+        const title = plugin ? plugin.manifest.name : "Plugin";
+
+        // Reuse the single existing plugin-detail tab: re-point its meta/title at
+        // the newly-selected plugin and activate it, rather than opening one tab
+        // per plugin (matches Settings/Log-Viewer single-tab behaviour).
+        for (const leaf of allLeaves) {
+          const existing = leaf.tabs.find((t) => t.contentType === "plugin-detail");
+          if (existing) {
+            const rootPanel = updateLeaf(state.rootPanel, leaf.id, (l) => ({
+              ...l,
+              tabs: l.tabs.map((t) =>
+                t.id === existing.id
+                  ? { ...t, title, isActive: true, pluginDetailMeta: { pluginId } }
+                  : { ...t, isActive: false }
+              ),
+              activeTabId: existing.id,
+            }));
+            return { rootPanel, activePanelId: leaf.id, selectedPluginId: pluginId };
+          }
+        }
+
+        const targetPanelId = state.activePanelId ?? allLeaves[0]?.id;
+        if (!targetPanelId) return { selectedPluginId: pluginId };
+
+        const dummyConfig: ConnectionConfig = { type: "local", config: {} };
+        const newTab = createTab(title, "local", dummyConfig, targetPanelId, "plugin-detail");
+        (newTab as TerminalTab & { pluginDetailMeta: PluginDetailMeta }).pluginDetailMeta = {
+          pluginId,
+        };
+        const rootPanel = updateLeaf(state.rootPanel, targetPanelId, (leaf) => {
+          const tabs = leaf.tabs.map((t) => ({ ...t, isActive: false }));
+          tabs.push(newTab);
+          return { ...leaf, tabs, activeTabId: newTab.id };
+        });
+        return { rootPanel, activePanelId: targetPanelId, selectedPluginId: pluginId };
+      }),
 
     // Macro recording (#1674)
     macroRecording: false,

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -34,6 +34,12 @@ export type TabContentType =
   | "workspace-editor"
   | "network-diagnostic"
   /**
+   * The plugin detail panel — identity, extension points, permissions, and
+   * state-appropriate actions for a single installed plugin (#1997). Opened from
+   * the Plugins sidebar view; the tab carries a {@link PluginDetailMeta}.
+   */
+  | "plugin-detail"
+  /**
    * A terminal-less connection (e.g. FTP, `Capabilities.terminal === false`).
    * The tab owns a live session so the sidebar file browser can route to it,
    * but renders a non-terminal placeholder body instead of an xterm terminal
@@ -158,6 +164,17 @@ export interface NetworkDiagnosticMeta {
   prefillHost?: string;
   /** Connection ID that triggered this diagnostic (for context). */
   connectionId?: string;
+}
+
+/**
+ * Metadata for a plugin-detail tab (#1997). Carries only the plugin id; the
+ * detail panel looks the live plugin record up from the store by id, so the tab
+ * always reflects the plugin's current state (enabling/disabling/uninstalling it
+ * elsewhere is reflected without stale meta).
+ */
+export interface PluginDetailMeta {
+  /** The manifest id of the plugin whose detail this tab shows. */
+  pluginId: string;
 }
 
 /** Metadata for an agent-error tab shown when a workspace agent connection fails. */
@@ -377,6 +394,7 @@ export interface TerminalTab {
   tunnelEditorMeta?: TunnelEditorMeta;
   workspaceEditorMeta?: WorkspaceEditorMeta;
   networkDiagnosticMeta?: NetworkDiagnosticMeta;
+  pluginDetailMeta?: PluginDetailMeta;
   agentErrorMeta?: AgentErrorMeta;
   /** Set when this tab was launched from a workspace agentRef — enables proper workspace capture. */
   workspaceAgentRef?: { agentId: string; definitionId: string };

--- a/src/utils/activeContext.ts
+++ b/src/utils/activeContext.ts
@@ -21,6 +21,9 @@ const CONTEXT_BY_CONTENT_TYPE: Record<TabContentType, ActiveContext> = {
   "workspace-editor": "form",
   settings: "form",
   "network-diagnostic": "form",
+  // The plugin detail panel is a read-only info surface with action buttons, not
+  // a text-editing surface — editor-delegated shortcuts may still fire over it.
+  "plugin-detail": "other",
   "log-viewer": "other",
   "agent-error": "other",
   "file-browser": "other",


### PR DESCRIPTION
## Summary

Implements the **Plugin Manager UI** per the plugin-system concept mockups (`docs/concepts/future/plugin-system.html`, impl §11 + UI mockups). Builds on the plugin command surface (#1992) and the frontend store/types (#1993).

- **Plugins Activity Bar item** (lucide `Puzzle`) opening a sidebar: a search box + Installed list. Each plugin is a row with a state dot (green enabled / grey disabled / red error), a type icon, and version suffix, plus an **Install from file…** footer button.
- **`PluginDetailPanel`** in the main area (opened by selecting a plugin): identity, Extension Points, Permissions, and state-appropriate actions — Enable/Disable, **Retry** (+ error callout) on error, **Settings…** (shown only when the plugin declares settings; the settings pane itself is #2000), and Uninstall. Uninstall confirms first and warns when the plugin has active sessions.
- **`PluginInstallDialog`** on the shared Modal overlay: native file picker → `validate_plugin` → parsed manifest + Requested Permissions (shield-alert + plain-language text) → Cancel / Install & Enable.
- **Status-bar segment** showing the installed / enabled plugin count; click opens the Plugins view.
- Detail opens as a single reused `plugin-detail` tab (like Settings/Log Viewer). `loadPlugins` now runs at startup.

Composed entirely from the `src/components/ui/` primitives; tokens only (no raw hex/px). New components live under `src/components/Plugins/`, reusable by later leaves (#2000 settings section, #2002 connection-config UI).

## Tests

- Vitest coverage for the presentation helpers, the sidebar list (rows, state dots, count, search filter, row-select dispatch, install flow), the detail panel (per-state actions, error callout, settings gating, uninstall confirm), the install dialog (manifest + permissions rendering, install-then-enable dispatch, cancel), and the `selectPlugin` store action.
- Full frontend suite green (4512 tests); lint, typecheck, prettier, markdownlint, and `pnpm build` all pass.

Closes #1997