### PR TITLE
test(network): make closed-port probe test deterministic (Closes #2008)

### DIFF
--- a/src-tauri/src/commands/network.rs
+++ b/src-tauri/src/commands/network.rs
@@ -328,17 +328,37 @@ mod tests {
 
     #[tokio::test]
     async fn probe_reports_closed_port_unreachable() {
-        // Bind then drop to claim a port that nothing is listening on.
-        let port = {
-            let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind test listener");
-            listener.local_addr().unwrap().port()
-        };
+        // Claiming a "closed" port by binding on port 0 and dropping the listener is
+        // racy: under the full parallel suite the just-freed ephemeral port can be
+        // reassigned to another concurrent test's live listener before the probe
+        // fires, so the probe correctly reports it *open* and the assertion fails
+        // (#2008). Retry with a fresh port whenever a probe comes back reachable —
+        // that only happens when the port lost the reuse race, so retrying keeps the
+        // assertion meaningful (a genuinely closed port must read unreachable) while
+        // removing the timing dependence. Losing the race on every one of many
+        // independent ports is astronomically unlikely.
+        const ATTEMPTS: usize = 20;
+        for attempt in 1..=ATTEMPTS {
+            let port = {
+                let listener =
+                    std::net::TcpListener::bind("127.0.0.1:0").expect("bind test listener");
+                listener.local_addr().unwrap().port()
+            };
 
-        let reachable = probe_target_reachable("127.0.0.1".to_string(), port, Some(500))
-            .await
-            .expect("probe should not error");
+            let reachable = probe_target_reachable("127.0.0.1".to_string(), port, Some(500))
+                .await
+                .expect("probe should not error");
 
-        assert!(!reachable, "a closed port should be reported unreachable");
+            if !reachable {
+                return; // A closed port was reported unreachable, as expected.
+            }
+
+            assert!(
+                attempt < ATTEMPTS,
+                "closed port {port} still reported reachable after {ATTEMPTS} attempts \
+                 (all lost the ephemeral-port-reuse race)",
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

`commands::network::tests::probe_reports_closed_port_unreachable` is flaky. It claimed a "closed" port by binding a `TcpListener` on port 0, recording the ephemeral port, then dropping the listener, and asserted the probe reported it unreachable. Under the full parallel suite (~1284 tests) the just-freed ephemeral port can be reassigned to another concurrent test's live listener before the probe fires, so the probe correctly sees it **open** and the assertion fails. Ephemeral-port reuse timing differs by OS, which is why it surfaced on the macOS CI leg (PR #2007).

## Fix

Retry with a fresh port whenever the probe comes back reachable. A reachable result only happens when the just-dropped port lost the reuse race to another listener, so retrying keeps the assertion meaningful — a genuinely closed port must read unreachable — while removing the timing dependence. Losing the race on every one of 20 independent ports is astronomically unlikely. `probe_reports_open_listener_reachable` (which holds its listener alive) is unchanged.

## Verification

- Ran `cargo test -p termihub --lib commands::network -- --test-threads=8` 15 times back-to-back: all green.
- Full `cargo test -p termihub --lib`: 1284 passed, 0 failed — the fixed test runs concurrently with the whole ephemeral-port-binding suite, reproducing the real race conditions.
- `cargo fmt --check` and `cargo clippy -p termihub --lib -- -D warnings` clean.

Closes #2008

🤖 Generated with [Claude Code](https://claude.com/claude-code)