### PR TITLE
feat(ui): load plugin-provided json themes into the theme engine (Closes #1996)

### DIFF
--- a/docs/changes/dev1/feature/1996-theme-plugin-loading.md
+++ b/docs/changes/dev1/feature/1996-theme-plugin-loading.md
@@ -1,0 +1,11 @@
+### Added
+
+- Theme plugins: an enabled plugin's bundled color themes (JSON-only, no code
+  execution) now load into the theme engine and appear in the Appearance theme
+  selector under a **Plugins** separator, each puzzle-badged, alongside the
+  built-in and custom themes. Selecting one applies it like any other theme.
+  Themes are validated against the full color-token schema, registered under a
+  namespaced id, and — when a plugin theme's name collides with a built-in — the
+  built-in wins and the plugin theme is shown prefixed with its plugin name.
+  Disabling or uninstalling a theme plugin removes its themes, falling back to
+  the default theme if one of them was active (#1996).

--- a/src/components/Settings/AppearanceSettings.css
+++ b/src/components/Settings/AppearanceSettings.css
@@ -5,3 +5,15 @@
   margin-top: calc(-1 * var(--spacing-xs));
   margin-bottom: var(--spacing-sm);
 }
+
+/* A plugin-provided theme option: its name preceded by a puzzle-piece badge. */
+.appearance-settings__plugin-theme {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.appearance-settings__plugin-badge {
+  flex-shrink: 0;
+  color: var(--text-accent);
+}

--- a/src/components/Settings/AppearanceSettings.tsx
+++ b/src/components/Settings/AppearanceSettings.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
+import * as RadixSelect from "@radix-ui/react-select";
+import { Puzzle } from "lucide-react";
 import { open, save } from "@tauri-apps/plugin-dialog";
 import { readTextFile, writeTextFile } from "@tauri-apps/plugin-fs";
 import { AppSettings } from "@/types/connection";
+import { useAppStore } from "@/store/appStore";
 import {
   Button,
   NumberInput,
@@ -57,6 +60,9 @@ export function AppearanceSettings({ settings, onChange, visibleFields }: Appear
 
   /** The theme currently open in the editor (new or a copy of an existing one). */
   const [editing, setEditing] = useState<ThemeDefinition | null>(null);
+
+  /** Themes contributed by active theme plugins (#1996), shown under a separator. */
+  const pluginThemes = useAppStore((s) => s.pluginThemes);
 
   const customThemes = settings.customThemes ?? [];
   const themeOptions: SelectOption[] = [
@@ -198,6 +204,34 @@ export function AppearanceSettings({ settings, onChange, visibleFields }: Appear
                     <SelectItem value={opt.value}>{opt.label}</SelectItem>
                   </Tooltip>
                 ))}
+                {pluginThemes.length > 0 && (
+                  <RadixSelect.Group data-testid="appearance-theme-plugins-group">
+                    <RadixSelect.Separator className="ui-select__separator" />
+                    <RadixSelect.Label className="ui-select__group-label">
+                      Plugins
+                    </RadixSelect.Label>
+                    {pluginThemes.map((theme) => (
+                      <Tooltip
+                        key={theme.id}
+                        side="right"
+                        content={<ThemePreview theme={theme} />}
+                        data-testid={`appearance-theme-preview-${theme.id}`}
+                      >
+                        <SelectItem value={theme.id}>
+                          <span className="appearance-settings__plugin-theme">
+                            <Puzzle
+                              className="appearance-settings__plugin-badge"
+                              width={13}
+                              height={13}
+                              aria-hidden="true"
+                            />
+                            {theme.name}
+                          </span>
+                        </SelectItem>
+                      </Tooltip>
+                    ))}
+                  </RadixSelect.Group>
+                )}
               </Select>
             </TooltipProvider>
           </SettingsField>

--- a/src/components/ui/ui.css
+++ b/src/components/ui/ui.css
@@ -378,6 +378,22 @@
   margin-left: auto;
 }
 
+/* Group separator + heading, e.g. a "Plugins" divider in a themed select. */
+.ui-select__separator {
+  height: 1px;
+  margin: var(--spacing-xs) calc(-1 * var(--spacing-xs));
+  background: var(--border-secondary);
+}
+
+.ui-select__group-label {
+  padding: var(--spacing-xs) var(--spacing-sm);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
 /* ── Toggle (Radix Switch skin) ─────────────────────────────────────── */
 .ui-toggle {
   width: 34px;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2388,3 +2388,13 @@ export async function enablePlugin(pluginId: string): Promise<void> {
 export async function disablePlugin(pluginId: string): Promise<void> {
   await invoke("disable_plugin", { pluginId });
 }
+
+/**
+ * Read a file from inside an installed plugin's directory (theme JSON, JS entry
+ * point, …). `path` is relative to `plugins/<id>/`; the backend refuses
+ * traversal. Returns the raw bytes; text consumers decode as UTF-8.
+ */
+export async function readPluginFile(pluginId: string, path: string): Promise<Uint8Array> {
+  const bytes = await invoke<number[]>("read_plugin_file", { id: pluginId, path });
+  return new Uint8Array(bytes);
+}

--- a/src/store/appStore.plugins.test.ts
+++ b/src/store/appStore.plugins.test.ts
@@ -51,6 +51,8 @@ vi.mock("@/services/storage", () => ({
 vi.mock("@/themes", () => ({
   applyTheme: vi.fn(),
   onThemeChange: vi.fn(() => vi.fn()),
+  loadPluginThemes: vi.fn(() => Promise.resolve({ themes: [], errors: [] })),
+  setRegisteredPluginThemes: vi.fn(),
 }));
 
 vi.mock("@/services/api", () => ({
@@ -66,6 +68,7 @@ vi.mock("@/services/api", () => ({
   uninstallPlugin: vi.fn(() => Promise.resolve()),
   enablePlugin: vi.fn(() => Promise.resolve()),
   disablePlugin: vi.fn(() => Promise.resolve()),
+  readPluginFile: vi.fn(() => Promise.resolve(new Uint8Array())),
 }));
 
 import { useAppStore } from "./appStore";
@@ -75,7 +78,11 @@ import {
   uninstallPlugin as apiUninstallPlugin,
   enablePlugin as apiEnablePlugin,
   disablePlugin as apiDisablePlugin,
+  readPluginFile,
 } from "@/services/api";
+import { loadPluginThemes, setRegisteredPluginThemes } from "@/themes";
+import { darkTheme } from "@/themes/dark";
+import type { ThemeDefinition } from "@/themes";
 import type { InstalledPlugin, PluginState } from "@/types/plugin";
 
 function makePlugin(
@@ -136,6 +143,32 @@ describe("appStore — plugins (#1993)", () => {
     expect(state.pluginBackendTypes).toEqual([
       { pluginId: "active-be", connectionType: "active-be", displayName: "Backend active-be" },
     ]);
+  });
+
+  it("loadPlugins loads plugin themes and registers them into the theme engine (#1996)", async () => {
+    const themePlugin = makePlugin("themer", "active", { withBackend: false });
+    vi.mocked(apiListPlugins).mockResolvedValueOnce([themePlugin]);
+    const registered: ThemeDefinition = {
+      id: "plugin:themer:t",
+      name: "T",
+      colorScheme: "dark",
+      colors: darkTheme.colors,
+    };
+    vi.mocked(loadPluginThemes).mockResolvedValueOnce({ themes: [registered], errors: [] });
+
+    await useAppStore.getState().loadPlugins();
+
+    // The active theme plugin's declared themes are passed to the loader…
+    expect(loadPluginThemes).toHaveBeenCalledWith(
+      "themer",
+      [{ id: "t", name: "T", file: "t.json" }],
+      readPluginFile,
+      { pluginName: "Plugin themer" }
+    );
+    // …mirrored into store state for the selector…
+    expect(useAppStore.getState().pluginThemes).toEqual([registered]);
+    // …and pushed into the engine registry so `plugin:` settings resolve.
+    expect(setRegisteredPluginThemes).toHaveBeenCalledWith([registered]);
   });
 
   it("loadPlugins swallows errors and leaves state untouched", async () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -268,7 +268,8 @@ import {
   onSessionMonitoringStatus,
   onPersistentSessionStateChanged,
 } from "@/services/events";
-import { applyTheme, onThemeChange } from "@/themes";
+import { applyTheme, loadPluginThemes, onThemeChange, setRegisteredPluginThemes } from "@/themes";
+import type { ThemeDefinition } from "@/themes";
 import { setOverrides as setKeybindingOverrides } from "@/services/keybindings";
 import {
   registerAdditionalLanguagePackages,
@@ -291,6 +292,7 @@ import {
   uninstallPlugin as apiUninstallPlugin,
   enablePlugin as apiEnablePlugin,
   disablePlugin as apiDisablePlugin,
+  readPluginFile,
 } from "@/services/api";
 import {
   createLeafPanel,
@@ -1485,6 +1487,13 @@ interface AppState {
    * {@link loadPlugins}; not set directly.
    */
   pluginBackendTypes: PluginBackendType[];
+  /**
+   * Color themes contributed by active theme plugins (#1996), for the theme
+   * selector's "Plugins" group. Loaded and validated by {@link loadPlugins} and
+   * mirrored into the theme engine's registry so `plugin:` settings resolve; not
+   * set directly.
+   */
+  pluginThemes: ThemeDefinition[];
   /** Load the installed-plugin list from the backend and refresh derived state. */
   loadPlugins: () => Promise<void>;
   /**
@@ -1835,6 +1844,37 @@ function derivePluginBackendTypes(plugins: InstalledPlugin[]): PluginBackendType
     }
   }
   return result;
+}
+
+/**
+ * Read, validate, and collect the color themes contributed by every *active*
+ * theme plugin (#1996). Each plugin's declared `themes/*.json` files are loaded
+ * via {@link readPluginFile} and validated against the theme engine's schema;
+ * an individual bad theme is logged and skipped rather than blocking the rest.
+ * Disabled/error/incompatible plugins contribute nothing. The result is both
+ * mirrored into store state (for the selector) and pushed into the theme
+ * engine's registry so `plugin:` settings resolve.
+ */
+async function loadActivePluginThemes(plugins: InstalledPlugin[]): Promise<ThemeDefinition[]> {
+  const all: ThemeDefinition[] = [];
+  for (const plugin of plugins) {
+    const theme = plugin.manifest.extensions.theme;
+    if (plugin.state !== "active" || !theme || theme.themes.length === 0) continue;
+    const { themes, errors } = await loadPluginThemes(
+      plugin.manifest.id,
+      theme.themes,
+      readPluginFile,
+      { pluginName: plugin.manifest.name }
+    );
+    for (const err of errors) {
+      frontendLog(
+        "app_store",
+        `Skipped plugin theme ${err.pluginId}:${err.themeId} (${err.file}): ${err.message}`
+      );
+    }
+    all.push(...themes);
+  }
+  return all;
 }
 
 /** UI-facing metadata describing an in-flight workflow run (#1852). */
@@ -7470,11 +7510,22 @@ export const useAppStore = create<AppState>((set, get) => {
     // Plugins (#1993)
     plugins: [],
     pluginBackendTypes: [],
+    pluginThemes: [],
 
     loadPlugins: async () => {
       try {
         const plugins = await apiListPlugins();
-        set({ plugins, pluginBackendTypes: derivePluginBackendTypes(plugins) });
+        // Load plugin-provided themes (#1996) and register them into the theme
+        // engine before publishing state, so a `plugin:` theme selection can
+        // resolve as soon as the selector renders it.
+        const pluginThemes = await loadActivePluginThemes(plugins);
+        setRegisteredPluginThemes(pluginThemes);
+        set({ plugins, pluginBackendTypes: derivePluginBackendTypes(plugins), pluginThemes });
+        // Re-apply the active theme: a just-registered plugin theme now takes
+        // effect, and a theme whose plugin was disabled/uninstalled falls back
+        // to the default (concept edge case).
+        const { theme, customThemes } = get().settings;
+        applyTheme(theme, customThemes);
       } catch (err) {
         // Read-only refresh: log rather than toast, matching loadMacros.
         console.error("Failed to load plugins:", err);

--- a/src/themes/engine.ts
+++ b/src/themes/engine.ts
@@ -9,6 +9,7 @@ import {
   isCustomThemeSetting,
   resolveCustomTheme,
 } from "./customThemes";
+import { findRegisteredPluginTheme, isPluginThemeSetting } from "./pluginThemes";
 
 /**
  * Maps camelCase ThemeColors keys to their corresponding CSS custom
@@ -93,9 +94,11 @@ const changeCallbacks = new Set<ThemeChangeCallback>();
 
 /**
  * Resolve a theme setting string (`"dark"`, `"light"`, `"system"`,
- * `"custom:<id>"`, …) to a fully-resolved {@link ThemeDefinition}. Custom themes
- * are run through {@link resolveCustomTheme} so every color falls back to its
- * base; a missing/deleted custom theme and any unknown setting fall back to
+ * `"custom:<id>"`, `"plugin:<pluginId>:<themeId>"`, …) to a fully-resolved
+ * {@link ThemeDefinition}. Custom themes are run through
+ * {@link resolveCustomTheme} so every color falls back to its base; plugin
+ * themes are looked up in the runtime registry (see `pluginThemes.ts`). A
+ * missing/deleted custom or plugin theme and any unknown setting fall back to
  * dark. `"system"` reads `prefers-color-scheme`, treating a missing `matchMedia`
  * (e.g. under jsdom) as light.
  */
@@ -112,6 +115,12 @@ export function resolveTheme(
       typeof window.matchMedia === "function" &&
       window.matchMedia("(prefers-color-scheme: dark)").matches;
     return prefersDark ? darkTheme : lightTheme;
+  }
+  if (isPluginThemeSetting(setting)) {
+    // Plugin themes carry a complete, pre-validated palette, so no base
+    // fallback is needed. A theme whose plugin is disabled/uninstalled is no
+    // longer registered and falls back to dark (concept edge case).
+    return findRegisteredPluginTheme(setting) ?? darkTheme;
   }
   if (isCustomThemeSetting(setting)) {
     const id = customThemeId(setting);

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -30,3 +30,22 @@ export {
 } from "./customThemes";
 export { THEME_FILE_SCHEMA, serializeTheme, parseThemeFile, themeFileName } from "./themeIO";
 export type { ThemeFile, ThemeImportResult } from "./themeIO";
+export {
+  PLUGIN_THEME_PREFIX,
+  CORE_THEME_NAMES,
+  PluginThemeError,
+  pluginThemeId,
+  isPluginThemeSetting,
+  parsePluginTheme,
+  loadPluginThemes,
+  setRegisteredPluginThemes,
+  getRegisteredPluginThemes,
+  findRegisteredPluginTheme,
+  clearRegisteredPluginThemes,
+} from "./pluginThemes";
+export type {
+  PluginFileReader,
+  PluginThemeLoadError,
+  PluginThemeLoadResult,
+  LoadPluginThemesOptions,
+} from "./pluginThemes";

--- a/src/themes/pluginThemes.test.ts
+++ b/src/themes/pluginThemes.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  clearRegisteredPluginThemes,
+  findRegisteredPluginTheme,
+  getRegisteredPluginThemes,
+  isPluginThemeSetting,
+  loadPluginThemes,
+  parsePluginTheme,
+  PluginThemeError,
+  pluginThemeId,
+  setRegisteredPluginThemes,
+  type PluginFileReader,
+} from "./pluginThemes";
+import { resolveTheme } from "./engine";
+import { COLOR_TOKEN_KEYS } from "./colorTokens";
+import { darkTheme } from "./dark";
+import type { ThemeEntry } from "@/types/plugin";
+
+/** Build a complete, valid `colors` object with every required token present. */
+function fullColors(overrides: Record<string, string> = {}): Record<string, string> {
+  const colors: Record<string, string> = {};
+  for (const key of COLOR_TOKEN_KEYS) colors[key] = "#123456";
+  return { ...colors, ...overrides };
+}
+
+/** Serialise a plugin theme file with a full palette, allowing field overrides. */
+function themeJson(fields: Record<string, unknown> = {}): string {
+  return JSON.stringify({ colorScheme: "dark", colors: fullColors(), ...fields });
+}
+
+const entry = (id: string, name: string, file = `${id}.json`): ThemeEntry => ({ id, name, file });
+
+/** A reader backed by an in-memory `path -> contents` map, tracking reads. */
+function fakeReader(files: Record<string, string>): {
+  read: PluginFileReader;
+  paths: string[];
+} {
+  const paths: string[] = [];
+  const read: PluginFileReader = (_pluginId, path) => {
+    paths.push(path);
+    const contents = files[path];
+    if (contents === undefined) return Promise.reject(new Error(`no such file: ${path}`));
+    return Promise.resolve(new TextEncoder().encode(contents));
+  };
+  return { read, paths };
+}
+
+describe("plugin theme id / setting encoding", () => {
+  it("builds a namespaced plugin:<pluginId>:<themeId> id", () => {
+    expect(pluginThemeId("acme", "midnight")).toBe("plugin:acme:midnight");
+  });
+
+  it("recognises plugin theme settings and rejects others", () => {
+    expect(isPluginThemeSetting("plugin:acme:midnight")).toBe(true);
+    expect(isPluginThemeSetting("custom:abc")).toBe(false);
+    expect(isPluginThemeSetting("dark")).toBe(false);
+    expect(isPluginThemeSetting(undefined)).toBe(false);
+  });
+});
+
+describe("parsePluginTheme", () => {
+  it("parses a valid file into a namespaced, fully-populated theme", () => {
+    const theme = parsePluginTheme("acme", entry("midnight", "Midnight"), themeJson());
+    expect(theme.id).toBe("plugin:acme:midnight");
+    expect(theme.name).toBe("Midnight");
+    expect(theme.colorScheme).toBe("dark");
+    for (const key of COLOR_TOKEN_KEYS) {
+      expect(typeof theme.colors[key]).toBe("string");
+      expect(theme.colors[key]).not.toBe("");
+    }
+  });
+
+  it("takes colorScheme from the file, defaulting to dark", () => {
+    expect(
+      parsePluginTheme("p", entry("a", "A"), themeJson({ colorScheme: "light" })).colorScheme
+    ).toBe("light");
+    expect(
+      parsePluginTheme("p", entry("a", "A"), themeJson({ colorScheme: "weird" })).colorScheme
+    ).toBe("dark");
+  });
+
+  it("rejects a file missing a required color token", () => {
+    const colors = fullColors();
+    delete colors.terminalBg;
+    const json = JSON.stringify({ colors });
+    expect(() => parsePluginTheme("p", entry("a", "A"), json)).toThrow(PluginThemeError);
+    expect(() => parsePluginTheme("p", entry("a", "A"), json)).toThrow(/terminalBg/);
+  });
+
+  it("rejects a blank color value as missing", () => {
+    const json = JSON.stringify({ colors: fullColors({ bgPrimary: "   " }) });
+    expect(() => parsePluginTheme("p", entry("a", "A"), json)).toThrow(/bgPrimary/);
+  });
+
+  it("rejects invalid JSON, a non-object body, and an unknown schema", () => {
+    expect(() => parsePluginTheme("p", entry("a", "A"), "{ not json")).toThrow(/valid JSON/);
+    expect(() => parsePluginTheme("p", entry("a", "A"), "[]")).toThrow(/JSON object/);
+    expect(() =>
+      parsePluginTheme("p", entry("a", "A"), themeJson({ $schema: "other-format-v9" }))
+    ).toThrow(/unsupported version/);
+  });
+});
+
+describe("loadPluginThemes", () => {
+  it("reads each declared file under themes/ and registers valid themes", async () => {
+    const { read, paths } = fakeReader({
+      "themes/midnight.json": themeJson(),
+      "themes/aurora.json": themeJson(),
+    });
+    const { themes, errors } = await loadPluginThemes(
+      "acme",
+      [entry("midnight", "Midnight"), entry("aurora", "Aurora")],
+      read
+    );
+    expect(errors).toHaveLength(0);
+    expect(themes.map((t) => t.id)).toEqual(["plugin:acme:midnight", "plugin:acme:aurora"]);
+    expect(paths).toEqual(["themes/midnight.json", "themes/aurora.json"]);
+  });
+
+  it("does not double-prefix a file path already rooted at themes/", async () => {
+    const { read, paths } = fakeReader({ "themes/midnight.json": themeJson() });
+    await loadPluginThemes("acme", [entry("midnight", "Midnight", "themes/midnight.json")], read);
+    expect(paths).toEqual(["themes/midnight.json"]);
+  });
+
+  it("collects a validation failure without dropping the other themes", async () => {
+    const { read } = fakeReader({
+      "themes/good.json": themeJson(),
+      "themes/bad.json": JSON.stringify({ colors: { bgPrimary: "#000" } }),
+    });
+    const { themes, errors } = await loadPluginThemes(
+      "acme",
+      [entry("good", "Good"), entry("bad", "Bad")],
+      read
+    );
+    expect(themes.map((t) => t.id)).toEqual(["plugin:acme:good"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].themeId).toBe("bad");
+  });
+
+  it("prefixes the plugin name when a theme name clashes with a core theme", async () => {
+    const { read } = fakeReader({ "themes/dark.json": themeJson() });
+    const { themes } = await loadPluginThemes("acme", [entry("dark", "Dark")], read, {
+      pluginName: "Acme Themes",
+    });
+    // Core "Dark" wins the plain name; the plugin theme is prefixed.
+    expect(themes[0].name).toBe("Acme Themes: Dark");
+    expect(themes[0].id).toBe("plugin:acme:dark");
+  });
+
+  it("leaves a non-clashing name untouched", async () => {
+    const { read } = fakeReader({ "themes/x.json": themeJson() });
+    const { themes } = await loadPluginThemes("acme", [entry("x", "Totally Unique")], read, {
+      pluginName: "Acme Themes",
+    });
+    expect(themes[0].name).toBe("Totally Unique");
+  });
+});
+
+describe("plugin theme registry + resolveTheme", () => {
+  beforeEach(() => {
+    clearRegisteredPluginThemes();
+  });
+
+  it("resolves a registered plugin theme by its setting id", () => {
+    const theme = parsePluginTheme("acme", entry("midnight", "Midnight"), themeJson());
+    setRegisteredPluginThemes([theme]);
+    expect(findRegisteredPluginTheme("plugin:acme:midnight")).toBe(theme);
+    expect(getRegisteredPluginThemes()).toEqual([theme]);
+    expect(resolveTheme("plugin:acme:midnight")).toBe(theme);
+  });
+
+  it("falls back to the default theme once the plugin theme is removed (disable/uninstall)", () => {
+    const theme = parsePluginTheme("acme", entry("midnight", "Midnight"), themeJson());
+    setRegisteredPluginThemes([theme]);
+    expect(resolveTheme("plugin:acme:midnight")).toBe(theme);
+
+    // Simulate the plugin being disabled/uninstalled: registry is refreshed empty.
+    setRegisteredPluginThemes([]);
+    expect(findRegisteredPluginTheme("plugin:acme:midnight")).toBeUndefined();
+    expect(resolveTheme("plugin:acme:midnight")).toBe(darkTheme);
+  });
+});

--- a/src/themes/pluginThemes.ts
+++ b/src/themes/pluginThemes.ts
@@ -1,0 +1,210 @@
+/**
+ * Loading and registration of plugin-provided color themes (#1996).
+ *
+ * A theme plugin is the simplest extension type — pure JSON, no native code. On
+ * a plugin's activation the app reads each `themes/*.json` file it declares,
+ * validates it against the theme engine's colour-token schema, and registers it
+ * into a runtime registry the {@link resolveTheme} resolver consults for
+ * `plugin:<pluginId>:<themeId>` settings. Registered themes surface in the theme
+ * selector alongside the built-ins under a "Plugins" separator.
+ *
+ * This module is deliberately free of any Tauri/IPC import: file reading is
+ * injected (the store passes `readPluginFile`), which keeps the parse/validate/
+ * register logic pure and unit-testable, mirroring `themeIO.ts`. Concept:
+ * `docs/concepts/future/plugin-system.html` (impl §9; "Second PR — Theme
+ * plugins"; Edge Cases → core themes win on a name clash).
+ */
+
+import type { ThemeColors, ThemeDefinition } from "./types";
+import type { ThemeEntry } from "@/types/plugin";
+import { COLOR_TOKEN_KEYS } from "./colorTokens";
+import { THEME_FILE_SCHEMA } from "./themeIO";
+import { BASE_THEME_ORDER } from "./customThemes";
+
+/** Prefix used in `AppSettings.theme` (and as the theme id) for a plugin theme. */
+export const PLUGIN_THEME_PREFIX = "plugin:";
+
+/**
+ * Display names of the built-in themes. A plugin theme whose name collides with
+ * one of these is prefixed on registration — core themes always win the name
+ * (concept "Edge Cases").
+ */
+export const CORE_THEME_NAMES: ReadonlySet<string> = new Set(BASE_THEME_ORDER.map((t) => t.name));
+
+/**
+ * Build the namespaced id for a plugin theme: `plugin:<pluginId>:<themeId>`.
+ * This same string is stored in `AppSettings.theme` to select the theme, so a
+ * plugin theme's id and its settings value are identical.
+ */
+export function pluginThemeId(pluginId: string, themeId: string): string {
+  return `${PLUGIN_THEME_PREFIX}${pluginId}:${themeId}`;
+}
+
+/** True when a `theme` setting string references a plugin-provided theme. */
+export function isPluginThemeSetting(setting: string | undefined): setting is string {
+  return typeof setting === "string" && setting.startsWith(PLUGIN_THEME_PREFIX);
+}
+
+/** Error raised when a plugin theme file fails validation. */
+export class PluginThemeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PluginThemeError";
+  }
+}
+
+/** Type guard: a JSON value is a non-null, non-array object. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Validate and parse a single plugin theme file into a {@link ThemeDefinition}.
+ *
+ * Unlike a user-imported theme (which tolerantly inherits missing colours from a
+ * base theme, see {@link parseThemeFile}), a plugin ships a complete theme, so
+ * this is **strict**: every colour token in {@link COLOR_TOKEN_KEYS} must be
+ * present as a non-empty string. A missing/blank token, a non-object body, bad
+ * JSON, or an unknown `$schema` all raise {@link PluginThemeError} and cause the
+ * theme to be skipped. Identity (`id`, display `name`) comes from the manifest
+ * `entry`; colours and `colorScheme` come from the file.
+ */
+export function parsePluginTheme(
+  pluginId: string,
+  entry: ThemeEntry,
+  json: string
+): ThemeDefinition {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    throw new PluginThemeError(`theme "${entry.id}" is not valid JSON`);
+  }
+  if (!isRecord(raw)) {
+    throw new PluginThemeError(`theme "${entry.id}" must be a JSON object`);
+  }
+  const schema = raw.$schema;
+  if (typeof schema === "string" && schema !== THEME_FILE_SCHEMA) {
+    throw new PluginThemeError(`theme "${entry.id}" has unsupported version "${schema}"`);
+  }
+
+  const stored = isRecord(raw.colors) ? raw.colors : {};
+  const colors = {} as ThemeColors;
+  const missing: string[] = [];
+  for (const key of COLOR_TOKEN_KEYS) {
+    const value = stored[key];
+    if (typeof value === "string" && value.trim() !== "") {
+      colors[key] = value;
+    } else {
+      missing.push(key);
+    }
+  }
+  if (missing.length > 0) {
+    throw new PluginThemeError(
+      `theme "${entry.id}" is missing color token${missing.length === 1 ? "" : "s"}: ${missing.join(", ")}`
+    );
+  }
+
+  return {
+    id: pluginThemeId(pluginId, entry.id),
+    name: entry.name,
+    colorScheme: raw.colorScheme === "light" ? "light" : "dark",
+    colors,
+  };
+}
+
+/** A single theme that failed to load, for surfacing/logging. */
+export interface PluginThemeLoadError {
+  pluginId: string;
+  themeId: string;
+  file: string;
+  message: string;
+}
+
+/** Result of {@link loadPluginThemes}: the themes that loaded and any failures. */
+export interface PluginThemeLoadResult {
+  themes: ThemeDefinition[];
+  errors: PluginThemeLoadError[];
+}
+
+/** Injected reader of a plugin file (bytes), relative to `plugins/<id>/`. */
+export type PluginFileReader = (pluginId: string, path: string) => Promise<Uint8Array>;
+
+/** Options for {@link loadPluginThemes}. */
+export interface LoadPluginThemesOptions {
+  /** Plugin display name, used to prefix a theme that clashes with a core name. */
+  pluginName?: string;
+  /** Core theme names to guard against (defaults to {@link CORE_THEME_NAMES}). */
+  coreThemeNames?: ReadonlySet<string>;
+}
+
+/**
+ * Load and validate all themes a single plugin declares. Each file is read via
+ * the injected {@link PluginFileReader} (the `read_plugin_file` command in the
+ * app), decoded as UTF-8, and parsed by {@link parsePluginTheme}. A theme whose
+ * name clashes with a built-in has its display name prefixed with the plugin
+ * name — core themes always win (concept "Edge Cases"). Individual failures are
+ * collected rather than thrown, so one bad theme never blocks the rest.
+ */
+export async function loadPluginThemes(
+  pluginId: string,
+  themeFiles: ThemeEntry[],
+  readFile: PluginFileReader,
+  options: LoadPluginThemesOptions = {}
+): Promise<PluginThemeLoadResult> {
+  const pluginName = options.pluginName ?? pluginId;
+  const coreNames = options.coreThemeNames ?? CORE_THEME_NAMES;
+  const themes: ThemeDefinition[] = [];
+  const errors: PluginThemeLoadError[] = [];
+
+  for (const entry of themeFiles) {
+    try {
+      const path = entry.file.startsWith("themes/") ? entry.file : `themes/${entry.file}`;
+      const bytes = await readFile(pluginId, path);
+      const theme = parsePluginTheme(pluginId, entry, new TextDecoder().decode(bytes));
+      if (coreNames.has(theme.name)) {
+        theme.name = `${pluginName}: ${theme.name}`;
+      }
+      themes.push(theme);
+    } catch (err) {
+      errors.push({
+        pluginId,
+        themeId: entry.id,
+        file: entry.file,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { themes, errors };
+}
+
+// ─── Runtime registry ────────────────────────────────────────────────────────
+//
+// The single source of truth the theme engine consults for `plugin:` settings.
+// The app store owns *when* it is refreshed (on plugin load/enable/disable) and
+// mirrors the same list into its state for the selector UI; the engine only
+// reads it, so a disabled/uninstalled plugin's themes disappear and an active
+// selection of a now-gone theme falls back to the default at resolve time.
+
+let registeredThemes: ThemeDefinition[] = [];
+
+/** Replace the set of registered plugin themes (called by the store). */
+export function setRegisteredPluginThemes(themes: ThemeDefinition[]): void {
+  registeredThemes = themes;
+}
+
+/** All currently registered plugin themes. */
+export function getRegisteredPluginThemes(): ThemeDefinition[] {
+  return registeredThemes;
+}
+
+/** Look up a registered plugin theme by its namespaced id, or `undefined`. */
+export function findRegisteredPluginTheme(id: string): ThemeDefinition | undefined {
+  return registeredThemes.find((t) => t.id === id);
+}
+
+/** Drop all registered plugin themes (used on teardown / in tests). */
+export function clearRegisteredPluginThemes(): void {
+  registeredThemes = [];
+}


### PR DESCRIPTION
## Summary

Implements **theme plugins** — the simplest, JSON-only extension type (no native code). When a theme plugin is enabled, the app reads each `themes/*.json` it declares, validates it, and registers it into the existing theme engine so it appears in the Appearance theme selector alongside the built-ins and custom themes.

Closes #1996.

## What it does

- **`readPluginFile` API wrapper** (`src/services/api.ts`) over the `read_plugin_file` command (#1992), returning the raw bytes.
- **`src/themes/pluginThemes.ts`** — a dependency-light module (file reading is injected, so it stays pure and unit-testable, mirroring `themeIO.ts`):
  - `parsePluginTheme` strictly validates a theme file against the engine's full color-token schema (`COLOR_TOKEN_KEYS`) — **every** required token must be present (unlike tolerant user-imports), rejecting bad JSON / unknown `$schema` / missing tokens.
  - `loadPluginThemes` reads each declared `themes/<file>` via the injected reader, collecting per-theme failures instead of aborting the batch.
  - Registered with a **namespaced id** `plugin:<pluginId>:<themeId>` (the id doubles as the `AppSettings.theme` value).
  - **Core-name-clash → core wins**: a plugin theme whose name matches a built-in is prefixed with its plugin name (concept "Edge Cases").
  - A small runtime **registry** the resolver consults.
- **`resolveTheme`** (`engine.ts`) resolves `plugin:` settings from the registry; a theme whose plugin was disabled/uninstalled is no longer registered and falls back to the default (dark).
- **Store wiring** (`appStore.ts`): `loadPlugins` loads every active theme plugin's themes, registers them into the engine, mirrors them into `pluginThemes` state for the selector, and re-applies the active theme so a plugin theme takes effect (or falls back when removed).
- **Selector UI** (`AppearanceSettings.tsx`): plugin themes render under a **Plugins** separator, each with a puzzle badge, using token-based styles only.

## How themes register into the engine

`loadPlugins` → `loadPluginThemes` (read + validate) → `setRegisteredPluginThemes` (engine registry) + `set({ pluginThemes })` (selector) → `applyTheme` re-run. `resolveTheme("plugin:…")` looks the theme up in the registry; disable/uninstall refreshes the registry without the theme, so the resolver falls back to the default.

## Tests

- `src/themes/pluginThemes.test.ts` — id/setting encoding, strict token validation (incl. **token validation failure**), JSON/schema errors, path resolution, per-theme error collection, **core-name-clash prefixing**, and registry + `resolveTheme` including **removal-on-disable** fallback.
- `src/store/appStore.plugins.test.ts` — `loadPlugins` loads plugin themes, registers them into the engine, and mirrors them into store state.

`pnpm lint`, `pnpm exec tsc --noEmit`, `prettier --check`, and `markdownlint` all pass locally.

## Scope notes

JSON-only, no code execution. Does not touch the Rust plugin host (#1995). Built on #1992 / #1993 / #1997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)