### PR TITLE
feat(backend): expose plugin backends as usable connection types (Closes #1999)

### DIFF
--- a/core/src/plugin/connection.rs
+++ b/core/src/plugin/connection.rs
@@ -356,9 +356,11 @@ mod tests {
     #[test]
     fn empty_or_shapeless_schema_yields_no_groups() {
         // No `properties` at all.
-        assert!(config_schema_to_settings_schema(&serde_json::json!({ "type": "object" }))
-            .groups
-            .is_empty());
+        assert!(
+            config_schema_to_settings_schema(&serde_json::json!({ "type": "object" }))
+                .groups
+                .is_empty()
+        );
         // `properties` present but empty.
         assert!(config_schema_to_settings_schema(
             &serde_json::json!({ "type": "object", "properties": {} })
@@ -366,9 +368,11 @@ mod tests {
         .groups
         .is_empty());
         // Not an object at all.
-        assert!(config_schema_to_settings_schema(&serde_json::json!("nonsense"))
-            .groups
-            .is_empty());
+        assert!(
+            config_schema_to_settings_schema(&serde_json::json!("nonsense"))
+                .groups
+                .is_empty()
+        );
     }
 
     #[test]

--- a/core/src/plugin/connection.rs
+++ b/core/src/plugin/connection.rs
@@ -21,18 +21,21 @@
 //!
 //! # Scope
 //!
-//! This is the *load-and-register* adapter (#1995). Deriving a real
-//! [`SettingsSchema`](crate::connection::SettingsSchema) from the plugin's
-//! declared `configSchema`, and wiring the type through the connection editor and
-//! session-creation flow, is connection-type wiring left to #1999; until then the
-//! schema is empty and the raw settings JSON is forwarded to the plugin verbatim.
+//! This is the *load-and-register* adapter (#1995), now wired through to session
+//! creation (#1999): the plugin's declared `configSchema` is translated into the
+//! type's [`SettingsSchema`](crate::connection::SettingsSchema) (see
+//! [`config_schema_to_settings_schema`]) so the existing `DynamicForm` renders the
+//! config form with no bespoke UI, and the raw settings JSON is forwarded to the
+//! plugin verbatim at connect time.
 
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 
 use termihub_plugin_api::{LoadedBackend, PluginError, PluginOutputSender};
 
 use crate::connection::{
-    Capabilities, ConnectionType, OutputReceiver, OutputSender, SettingsSchema,
+    Capabilities, ConnectionType, FieldType, OutputReceiver, OutputSender, SelectOption,
+    SettingsField, SettingsGroup, SettingsSchema,
 };
 use crate::errors::SessionError;
 use crate::files::FileBrowser;
@@ -51,6 +54,9 @@ pub struct PluginConnectionType {
     library: Arc<LoadedLibrary>,
     connection_type: String,
     display_name: String,
+    /// The form schema the frontend renders for this type, derived from the
+    /// plugin's declared `configSchema` at load time.
+    settings_schema: SettingsSchema,
     /// The active session backend, `None` until [`connect`](ConnectionType::connect).
     backend: Option<LoadedBackend>,
     /// Current output sink; swapped by
@@ -61,16 +67,155 @@ pub struct PluginConnectionType {
 
 impl PluginConnectionType {
     /// Build a fresh, unconnected connection of the given plugin type.
+    ///
+    /// `settings_schema` is the form schema derived from the plugin's manifest
+    /// `configSchema` (see [`config_schema_to_settings_schema`]); the host derives
+    /// it once at load time and clones it into every instance the factory makes.
     #[must_use]
-    pub fn new(library: Arc<LoadedLibrary>, connection_type: String, display_name: String) -> Self {
+    pub fn new(
+        library: Arc<LoadedLibrary>,
+        connection_type: String,
+        display_name: String,
+        settings_schema: SettingsSchema,
+    ) -> Self {
         Self {
             library,
             connection_type,
             display_name,
+            settings_schema,
             backend: None,
             output_tx: Arc::new(Mutex::new(None)),
         }
     }
+}
+
+/// Translate a plugin's declared JSON-Schema `configSchema` into the
+/// [`SettingsSchema`] the dynamic connection form renders.
+///
+/// The subset termiHub's form understands is mapped: a top-level object whose
+/// `properties` each become a [`SettingsField`] in a single "Configuration"
+/// group, in the schema's own key order. A property's `type` maps to a
+/// [`FieldType`] (`boolean` → toggle, `number`/`integer` → number with
+/// `minimum`/`maximum` bounds, a string `enum` → select, a `"password"` format
+/// hint → masked input); everything else degrades to a plain text field so no
+/// declared setting is ever unreachable. `title`, `description`, `default`, and
+/// the object's `required` list flow through. A schema with no usable
+/// `properties` yields an empty schema (the raw settings JSON is still forwarded
+/// to the plugin verbatim).
+#[must_use]
+pub fn config_schema_to_settings_schema(schema: &serde_json::Value) -> SettingsSchema {
+    let Some(props) = schema.get("properties").and_then(|p| p.as_object()) else {
+        return SettingsSchema { groups: vec![] };
+    };
+    let required: HashSet<&str> = schema
+        .get("required")
+        .and_then(|r| r.as_array())
+        .map(|arr| arr.iter().filter_map(serde_json::Value::as_str).collect())
+        .unwrap_or_default();
+
+    let fields: Vec<SettingsField> = props
+        .iter()
+        .map(|(key, spec)| SettingsField {
+            key: key.clone(),
+            label: spec
+                .get("title")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+                .unwrap_or_else(|| humanize_key(key)),
+            description: spec
+                .get("description")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned),
+            help_text: None,
+            field_type: field_type_from_spec(spec),
+            required: required.contains(key.as_str()),
+            default: spec.get("default").cloned(),
+            placeholder: None,
+            supports_env_expansion: false,
+            supports_tilde_expansion: false,
+            visible_when: None,
+        })
+        .collect();
+
+    if fields.is_empty() {
+        return SettingsSchema { groups: vec![] };
+    }
+    SettingsSchema {
+        groups: vec![SettingsGroup {
+            key: "config".to_string(),
+            label: "Configuration".to_string(),
+            fields,
+        }],
+    }
+}
+
+/// Map a single JSON-Schema property spec to a [`FieldType`].
+fn field_type_from_spec(spec: &serde_json::Value) -> FieldType {
+    // A string `enum` renders as a dropdown of its values.
+    if let Some(values) = spec.get("enum").and_then(|e| e.as_array()) {
+        let options: Vec<SelectOption> = values
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .map(|s| SelectOption {
+                value: s.to_string(),
+                label: s.to_string(),
+            })
+            .collect();
+        if !options.is_empty() {
+            return FieldType::Select { options };
+        }
+    }
+    match spec.get("type").and_then(serde_json::Value::as_str) {
+        Some("boolean") => FieldType::Boolean,
+        Some("number") | Some("integer") => FieldType::Number {
+            min: spec.get("minimum").and_then(serde_json::Value::as_f64),
+            max: spec.get("maximum").and_then(serde_json::Value::as_f64),
+        },
+        Some("string")
+            if spec.get("format").and_then(serde_json::Value::as_str) == Some("password") =>
+        {
+            FieldType::Password
+        }
+        // `string` and anything unrecognised become a plain text field.
+        _ => FieldType::Text,
+    }
+}
+
+/// Turn a property key (`echoPrefix`, `default_namespace`) into a human label
+/// (`Echo Prefix`, `Default Namespace`) for when the schema declares no `title`.
+fn humanize_key(key: &str) -> String {
+    let mut words: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut prev_lower = false;
+    for ch in key.chars() {
+        if ch == '_' || ch == '-' || ch == ' ' {
+            if !current.is_empty() {
+                words.push(std::mem::take(&mut current));
+            }
+            prev_lower = false;
+            continue;
+        }
+        // A lower→upper boundary starts a new camelCase word.
+        if ch.is_ascii_uppercase() && prev_lower && !current.is_empty() {
+            words.push(std::mem::take(&mut current));
+        }
+        current.push(ch);
+        prev_lower = ch.is_ascii_lowercase() || ch.is_ascii_digit();
+    }
+    if !current.is_empty() {
+        words.push(current);
+    }
+    words
+        .iter()
+        .map(|w| {
+            let mut chars = w.chars();
+            match chars.next() {
+                Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Map a plugin-side error to the session-error the terminal layer understands.
@@ -95,9 +240,9 @@ impl ConnectionType for PluginConnectionType {
     }
 
     fn settings_schema(&self) -> SettingsSchema {
-        // Deriving a form schema from the plugin's declared `configSchema` is
-        // #1999; the raw settings JSON is forwarded to the plugin as-is for now.
-        SettingsSchema { groups: vec![] }
+        // Derived from the plugin's manifest `configSchema` at load time; the raw
+        // settings JSON is still forwarded to the plugin verbatim at connect.
+        self.settings_schema.clone()
     }
 
     fn capabilities(&self) -> Capabilities {
@@ -192,5 +337,97 @@ impl ConnectionType for PluginConnectionType {
 
     fn file_browser(&self) -> Option<&dyn FileBrowser> {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn humanize_key_splits_camel_and_snake() {
+        assert_eq!(humanize_key("echoPrefix"), "Echo Prefix");
+        assert_eq!(humanize_key("default_namespace"), "Default Namespace");
+        assert_eq!(humanize_key("pod-name"), "Pod Name");
+        assert_eq!(humanize_key("host"), "Host");
+        assert_eq!(humanize_key("apiVersion2"), "Api Version2");
+    }
+
+    #[test]
+    fn empty_or_shapeless_schema_yields_no_groups() {
+        // No `properties` at all.
+        assert!(config_schema_to_settings_schema(&serde_json::json!({ "type": "object" }))
+            .groups
+            .is_empty());
+        // `properties` present but empty.
+        assert!(config_schema_to_settings_schema(
+            &serde_json::json!({ "type": "object", "properties": {} })
+        )
+        .groups
+        .is_empty());
+        // Not an object at all.
+        assert!(config_schema_to_settings_schema(&serde_json::json!("nonsense"))
+            .groups
+            .is_empty());
+    }
+
+    #[test]
+    fn maps_property_types_to_field_types() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "host": { "type": "string", "title": "Host", "description": "Server host" },
+                "port": { "type": "integer", "minimum": 1, "maximum": 65535, "default": 22 },
+                "secure": { "type": "boolean", "default": true },
+                "secret": { "type": "string", "format": "password" },
+                "mode": { "type": "string", "enum": ["fast", "safe"] }
+            },
+            "required": ["host", "port"]
+        });
+        let out = config_schema_to_settings_schema(&schema);
+        assert_eq!(out.groups.len(), 1);
+        let group = &out.groups[0];
+        assert_eq!(group.key, "config");
+        // serde_json orders object keys alphabetically: host, mode, port, secret, secure.
+        let by_key = |k: &str| group.fields.iter().find(|f| f.key == k).unwrap();
+
+        let host = by_key("host");
+        assert_eq!(host.label, "Host");
+        assert_eq!(host.description.as_deref(), Some("Server host"));
+        assert!(host.required);
+        assert!(matches!(host.field_type, FieldType::Text));
+
+        let port = by_key("port");
+        assert!(port.required);
+        assert_eq!(port.default, Some(serde_json::json!(22)));
+        match &port.field_type {
+            FieldType::Number { min, max } => {
+                assert_eq!(*min, Some(1.0));
+                assert_eq!(*max, Some(65535.0));
+            }
+            other => panic!("expected Number, got {other:?}"),
+        }
+
+        assert!(matches!(by_key("secure").field_type, FieldType::Boolean));
+        assert!(!by_key("secure").required);
+        assert!(matches!(by_key("secret").field_type, FieldType::Password));
+
+        match &by_key("mode").field_type {
+            FieldType::Select { options } => {
+                let vals: Vec<&str> = options.iter().map(|o| o.value.as_str()).collect();
+                assert_eq!(vals, vec!["fast", "safe"]);
+            }
+            other => panic!("expected Select, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn label_falls_back_to_humanized_key_without_title() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": { "echoPrefix": { "type": "string" } }
+        });
+        let out = config_schema_to_settings_schema(&schema);
+        assert_eq!(out.groups[0].fields[0].label, "Echo Prefix");
     }
 }

--- a/core/src/plugin/host.rs
+++ b/core/src/plugin/host.rs
@@ -418,9 +418,8 @@ impl PluginHost {
         // Translate the plugin's declared `configSchema` into the form schema the
         // dynamic connection editor renders (#1999). Derived once here and cloned
         // into every instance the factory produces.
-        let settings_schema = super::connection::config_schema_to_settings_schema(
-            &backend.config_schema,
-        );
+        let settings_schema =
+            super::connection::config_schema_to_settings_schema(&backend.config_schema);
 
         // Two plugins may declare the same `connectionType`, and a plugin may even
         // collide with a built-in. Disambiguate against whatever is already
@@ -529,9 +528,7 @@ impl super::manager::PluginLifecycleHook for HostLifecycleHook {
 mod tests {
     use super::*;
 
-    use crate::connection::{
-        Capabilities, ConnectionType, OutputReceiver, SettingsSchema,
-    };
+    use crate::connection::{Capabilities, ConnectionType, OutputReceiver, SettingsSchema};
     use crate::errors::SessionError;
     use crate::files::FileBrowser;
     use crate::monitoring::MonitoringProvider;
@@ -589,13 +586,21 @@ mod tests {
     }
 
     fn register_stub(registry: &mut ConnectionTypeRegistry, type_id: &str) {
-        registry.register(type_id, type_id, "puzzle", Box::new(|| Box::new(StubConnection)));
+        registry.register(
+            type_id,
+            type_id,
+            "puzzle",
+            Box::new(|| Box::new(StubConnection)),
+        );
     }
 
     #[test]
     fn disambiguate_leaves_a_free_id_unchanged() {
         let registry = ConnectionTypeRegistry::new();
-        assert_eq!(disambiguate_type_id("echo", "echo-backend", &registry), "echo");
+        assert_eq!(
+            disambiguate_type_id("echo", "echo-backend", &registry),
+            "echo"
+        );
     }
 
     #[test]

--- a/core/src/plugin/host.rs
+++ b/core/src/plugin/host.rs
@@ -311,6 +311,36 @@ fn symbol_name(sym: &[u8]) -> String {
     String::from_utf8_lossy(sym.strip_suffix(b"\0").unwrap_or(sym)).into_owned()
 }
 
+/// Pick a registry key for a plugin's declared connection type that does not
+/// collide with anything already registered.
+///
+/// If `desired` is free it is used unchanged (the first registrant of a name
+/// wins). Otherwise it is suffixed with the plugin `id` — and, in the vanishingly
+/// unlikely event that is *also* taken, with a numeric counter — so a second
+/// plugin declaring the same `connectionType`, or one colliding with a built-in,
+/// still registers under a distinct, stable id (concept "Edge Cases").
+fn disambiguate_type_id(
+    desired: &str,
+    plugin_id: &str,
+    registry: &ConnectionTypeRegistry,
+) -> String {
+    if !registry.has_type(desired) {
+        return desired.to_string();
+    }
+    let suffixed = format!("{desired}-{plugin_id}");
+    if !registry.has_type(&suffixed) {
+        return suffixed;
+    }
+    let mut n = 2;
+    loop {
+        let candidate = format!("{suffixed}-{n}");
+        if !registry.has_type(&candidate) {
+            return candidate;
+        }
+        n += 1;
+    }
+}
+
 /// A record of one loaded plugin: the connection type it registered and the
 /// library backing it.
 struct HostEntry {
@@ -385,11 +415,31 @@ impl PluginHost {
         let lib_path = find_backend_library(&plugin_dir)?;
         let library = load_backend_library(&lib_path)?;
 
-        let connection_type = backend.connection_type.clone();
-        let display_name = backend.display_name.clone();
+        // Translate the plugin's declared `configSchema` into the form schema the
+        // dynamic connection editor renders (#1999). Derived once here and cloned
+        // into every instance the factory produces.
+        let settings_schema = super::connection::config_schema_to_settings_schema(
+            &backend.config_schema,
+        );
+
+        // Two plugins may declare the same `connectionType`, and a plugin may even
+        // collide with a built-in. Disambiguate against whatever is already
+        // registered by suffixing this one with the plugin id (concept "Edge
+        // Cases"); the first registrant keeps the plain id.
+        let connection_type = {
+            let registry = self.registry.lock().unwrap_or_else(|e| e.into_inner());
+            disambiguate_type_id(&backend.connection_type, &id, &registry)
+        };
+        let display_name = if connection_type == backend.connection_type {
+            backend.display_name.clone()
+        } else {
+            format!("{} ({})", backend.display_name, plugin.manifest.name)
+        };
+
         let lib_for_factory = Arc::clone(&library);
         let ct_for_factory = connection_type.clone();
         let dn_for_factory = display_name.clone();
+        let schema_for_factory = settings_schema;
 
         {
             let mut registry = self.registry.lock().unwrap_or_else(|e| e.into_inner());
@@ -402,6 +452,7 @@ impl PluginHost {
                         Arc::clone(&lib_for_factory),
                         ct_for_factory.clone(),
                         dn_for_factory.clone(),
+                        schema_for_factory.clone(),
                     ))
                 }),
             );
@@ -477,6 +528,93 @@ impl super::manager::PluginLifecycleHook for HostLifecycleHook {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::connection::{
+        Capabilities, ConnectionType, OutputReceiver, SettingsSchema,
+    };
+    use crate::errors::SessionError;
+    use crate::files::FileBrowser;
+    use crate::monitoring::MonitoringProvider;
+
+    /// A do-nothing connection type, just enough for the registry to register it
+    /// so [`disambiguate_type_id`] sees an occupied key.
+    struct StubConnection;
+
+    #[async_trait::async_trait]
+    impl ConnectionType for StubConnection {
+        fn type_id(&self) -> &str {
+            "stub"
+        }
+        fn display_name(&self) -> &str {
+            "Stub"
+        }
+        fn settings_schema(&self) -> SettingsSchema {
+            SettingsSchema { groups: vec![] }
+        }
+        fn capabilities(&self) -> Capabilities {
+            Capabilities {
+                monitoring: false,
+                file_browser: false,
+                graphical: false,
+                resize: true,
+                persistent: false,
+                terminal: true,
+            }
+        }
+        async fn connect(&mut self, _settings: serde_json::Value) -> Result<(), SessionError> {
+            Ok(())
+        }
+        async fn disconnect(&mut self) -> Result<(), SessionError> {
+            Ok(())
+        }
+        fn is_connected(&self) -> bool {
+            false
+        }
+        fn write(&self, _data: &[u8]) -> Result<(), SessionError> {
+            Ok(())
+        }
+        fn resize(&self, _cols: u16, _rows: u16) -> Result<(), SessionError> {
+            Ok(())
+        }
+        fn subscribe_output(&self) -> OutputReceiver {
+            let (_tx, rx) = tokio::sync::mpsc::channel(1);
+            rx
+        }
+        fn monitoring(&self) -> Option<&dyn MonitoringProvider> {
+            None
+        }
+        fn file_browser(&self) -> Option<&dyn FileBrowser> {
+            None
+        }
+    }
+
+    fn register_stub(registry: &mut ConnectionTypeRegistry, type_id: &str) {
+        registry.register(type_id, type_id, "puzzle", Box::new(|| Box::new(StubConnection)));
+    }
+
+    #[test]
+    fn disambiguate_leaves_a_free_id_unchanged() {
+        let registry = ConnectionTypeRegistry::new();
+        assert_eq!(disambiguate_type_id("echo", "echo-backend", &registry), "echo");
+    }
+
+    #[test]
+    fn disambiguate_suffixes_a_taken_id_with_the_plugin_id() {
+        let mut registry = ConnectionTypeRegistry::new();
+        register_stub(&mut registry, "echo");
+        assert_eq!(
+            disambiguate_type_id("echo", "second-plugin", &registry),
+            "echo-second-plugin"
+        );
+    }
+
+    #[test]
+    fn disambiguate_appends_a_counter_when_even_the_suffix_is_taken() {
+        let mut registry = ConnectionTypeRegistry::new();
+        register_stub(&mut registry, "echo");
+        register_stub(&mut registry, "echo-p");
+        assert_eq!(disambiguate_type_id("echo", "p", &registry), "echo-p-2");
+    }
 
     #[test]
     fn symbol_name_strips_trailing_nul() {

--- a/core/src/plugin/mod.rs
+++ b/core/src/plugin/mod.rs
@@ -66,7 +66,7 @@ mod manifest;
 mod pack;
 mod package;
 
-pub use connection::PluginConnectionType;
+pub use connection::{config_schema_to_settings_schema, PluginConnectionType};
 pub use host::{
     find_backend_library, load_backend_library, HostError, HostLifecycleHook, LoadedLibrary,
     LoadedPluginInfo, PluginHost,

--- a/core/tests/plugin_connection_wiring.rs
+++ b/core/tests/plugin_connection_wiring.rs
@@ -1,0 +1,233 @@
+//! End-to-end test that a plugin-provided backend becomes a usable connection
+//! type (#1999).
+//!
+//! Where `plugin_host_roundtrip.rs` (#1995) exercises loading a library and
+//! driving a [`PluginConnectionType`] directly, this test drives the remaining
+//! *wiring*: it loads plugins through the real [`PluginHost`] into a shared
+//! [`ConnectionTypeRegistry`] and then, using only the registry (the same path
+//! the desktop `SessionManager` takes), it
+//!
+//! * creates a session by `type_id` and runs full terminal I/O
+//!   (connect → write → output → disconnect),
+//! * confirms the plugin's manifest `configSchema` surfaced as the type's
+//!   `settings_schema` (so the dynamic form renders with no bespoke UI),
+//! * confirms two plugins declaring the same `connectionType` are disambiguated
+//!   (the second suffixed with its plugin id), and
+//! * confirms sessions are independent — closing one leaves the other running.
+//!
+//! Like the round-trip test it builds the real `cdylib` fixture with `cargo` and
+//! genuinely `dlopen`s it, and is gated on the `plugin` feature.
+#![cfg(feature = "plugin")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use termihub_core::connection::{ConnectionType, ConnectionTypeRegistry, FieldType};
+use termihub_core::plugin::{
+    parse_manifest, InstalledPlugin, PluginHost, PluginState,
+};
+
+/// Path to the fixture plugin's `Cargo.toml` (the same echo `cdylib` the
+/// round-trip test uses).
+fn fixture_manifest() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("test-plugin")
+        .join("Cargo.toml")
+}
+
+/// The platform-specific file name cargo produces for the fixture `cdylib`.
+fn artifact_name() -> String {
+    format!(
+        "{}termihub_test_plugin{}",
+        std::env::consts::DLL_PREFIX,
+        std::env::consts::DLL_SUFFIX
+    )
+}
+
+/// Build the fixture into `target_dir`, returning the freshly-built library path.
+fn build_fixture(target_dir: &Path) -> PathBuf {
+    let status = Command::new(env!("CARGO"))
+        .arg("build")
+        .arg("--manifest-path")
+        .arg(fixture_manifest())
+        .arg("--target-dir")
+        .arg(target_dir)
+        .status()
+        .expect("failed to spawn cargo to build the fixture plugin");
+    assert!(status.success(), "building the fixture plugin failed");
+    target_dir.join("debug").join(artifact_name())
+}
+
+/// A manifest declaring a terminal backend of connection type `connection_type`,
+/// with a small `configSchema` carrying one string property.
+fn manifest_json(id: &str, name: &str, connection_type: &str) -> String {
+    format!(
+        r#"{{
+            "id": "{id}",
+            "name": "{name}",
+            "version": "1.0.0",
+            "author": "test",
+            "description": "echo backend fixture",
+            "license": "MIT",
+            "apiVersion": "1.0",
+            "platforms": ["windows", "linux", "macos"],
+            "permissions": ["terminal"],
+            "extensions": {{
+                "terminalBackend": {{
+                    "connectionType": "{connection_type}",
+                    "displayName": "Echo",
+                    "configSchema": {{
+                        "type": "object",
+                        "properties": {{
+                            "echoPrefix": {{
+                                "type": "string",
+                                "description": "Text prepended to every echoed chunk."
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        }}"#
+    )
+}
+
+/// Install a plugin `id` into `root/<id>/` by writing its manifest and copying
+/// the built `lib` into `backend/`, then return the [`InstalledPlugin`] the host
+/// consumes.
+fn install(root: &Path, lib: &Path, id: &str, name: &str, connection_type: &str) -> InstalledPlugin {
+    let dir = root.join(id);
+    let backend = dir.join("backend");
+    std::fs::create_dir_all(&backend).expect("create plugin backend dir");
+    std::fs::copy(lib, backend.join(artifact_name())).expect("copy backend library");
+
+    let manifest = parse_manifest(&manifest_json(id, name, connection_type))
+        .expect("fixture manifest should parse");
+    manifest.validate().expect("fixture manifest should validate");
+    InstalledPlugin {
+        manifest,
+        state: PluginState::Installed,
+        error_message: None,
+        installed_at: 0,
+    }
+}
+
+/// Drive a full terminal round trip through a connection created from the
+/// registry: connect, write, read the echoed output, disconnect.
+async fn round_trip(conn: &mut Box<dyn ConnectionType>, payload: &[u8]) {
+    let mut rx = conn.subscribe_output();
+    conn.connect(serde_json::json!({ "echoPrefix": "" }))
+        .await
+        .expect("connect should succeed");
+    assert!(conn.is_connected());
+
+    conn.write(payload).expect("write should succeed");
+    let out = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("echoed output should arrive within the timeout")
+        .expect("output channel should yield a chunk");
+    assert_eq!(out, payload);
+}
+
+#[tokio::test]
+async fn plugin_type_is_creatable_and_listed_through_the_registry() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let lib = build_fixture(&tmp.path().join("target"));
+    let root = tmp.path().join("plugins");
+    std::fs::create_dir_all(&root).unwrap();
+
+    let registry = Arc::new(Mutex::new(ConnectionTypeRegistry::new()));
+    let host = PluginHost::new(root.clone(), Arc::clone(&registry));
+
+    // Load two plugins that BOTH declare connectionType "echo". The first keeps
+    // the plain id; the second must be disambiguated with its plugin id.
+    let plugin_a = install(&root, &lib, "echo-a", "Echo A", "echo");
+    let plugin_b = install(&root, &lib, "echo-b", "Echo B", "echo");
+    host.load(&plugin_a).expect("first plugin should load");
+    host.load(&plugin_b).expect("second plugin should load");
+
+    // --- 1. Both types are surfaced, the collision disambiguated. ---
+    let types = registry.lock().unwrap().available_types();
+    let ids: Vec<String> = types.iter().map(|t| t.type_id.clone()).collect();
+    assert!(ids.contains(&"echo".to_string()), "got {ids:?}");
+    assert!(ids.contains(&"echo-echo-b".to_string()), "got {ids:?}");
+
+    // The disambiguated type's display name is suffixed with the plugin name.
+    let echo_b = types.iter().find(|t| t.type_id == "echo-echo-b").unwrap();
+    assert_eq!(echo_b.display_name, "Echo (Echo B)");
+
+    // --- 2. The manifest configSchema surfaced as the type's settings schema. ---
+    let echo = types.iter().find(|t| t.type_id == "echo").unwrap();
+    assert_eq!(echo.schema.groups.len(), 1, "configSchema should yield one group");
+    let field = &echo.schema.groups[0].fields[0];
+    assert_eq!(field.key, "echoPrefix");
+    assert_eq!(field.label, "Echo Prefix"); // humanized from the key
+    assert!(matches!(field.field_type, FieldType::Text));
+
+    // --- 3. A session created BY TYPE ID runs full I/O through the plugin. ---
+    let mut conn = registry
+        .lock()
+        .unwrap()
+        .create("echo")
+        .expect("plugin type should be creatable by id");
+    round_trip(&mut conn, b"hello via registry").await;
+    conn.disconnect().await.expect("disconnect should succeed");
+    assert!(!conn.is_connected());
+
+    // The disambiguated second plugin is equally usable.
+    let mut conn_b = registry.lock().unwrap().create("echo-echo-b").unwrap();
+    round_trip(&mut conn_b, b"second plugin").await;
+    conn_b.disconnect().await.unwrap();
+
+    // --- 4. Unloading a plugin unregisters exactly its (effective) type. ---
+    host.unload("echo-b");
+    let after: Vec<String> = registry
+        .lock()
+        .unwrap()
+        .available_types()
+        .into_iter()
+        .map(|t| t.type_id)
+        .collect();
+    assert!(after.contains(&"echo".to_string()));
+    assert!(!after.contains(&"echo-echo-b".to_string()));
+}
+
+#[tokio::test]
+async fn sessions_are_independent_so_closing_one_leaves_the_other_running() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let lib = build_fixture(&tmp.path().join("target"));
+    let root = tmp.path().join("plugins");
+    std::fs::create_dir_all(&root).unwrap();
+
+    let registry = Arc::new(Mutex::new(ConnectionTypeRegistry::new()));
+    let host = PluginHost::new(root.clone(), Arc::clone(&registry));
+    host.load(&install(&root, &lib, "echo-a", "Echo A", "echo"))
+        .expect("plugin should load");
+
+    // Two independent sessions of the same plugin type.
+    let mut first = registry.lock().unwrap().create("echo").unwrap();
+    let mut second = registry.lock().unwrap().create("echo").unwrap();
+
+    let mut second_rx = second.subscribe_output();
+    first.connect(serde_json::json!({})).await.unwrap();
+    second.connect(serde_json::json!({})).await.unwrap();
+    assert!(first.is_connected() && second.is_connected());
+
+    // Closing the first session must not disturb the second.
+    first.disconnect().await.unwrap();
+    assert!(!first.is_connected());
+    assert!(second.is_connected(), "closing one session killed the other");
+
+    // The surviving session still does full I/O.
+    second.write(b"still alive").expect("second session still writable");
+    let out = tokio::time::timeout(Duration::from_secs(5), second_rx.recv())
+        .await
+        .expect("second session should still echo")
+        .expect("output chunk");
+    assert_eq!(out, b"still alive");
+
+    second.disconnect().await.unwrap();
+}

--- a/core/tests/plugin_connection_wiring.rs
+++ b/core/tests/plugin_connection_wiring.rs
@@ -25,9 +25,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use termihub_core::connection::{ConnectionType, ConnectionTypeRegistry, FieldType};
-use termihub_core::plugin::{
-    parse_manifest, InstalledPlugin, PluginHost, PluginState,
-};
+use termihub_core::plugin::{parse_manifest, InstalledPlugin, PluginHost, PluginState};
 
 /// Path to the fixture plugin's `Cargo.toml` (the same echo `cdylib` the
 /// round-trip test uses).
@@ -98,7 +96,13 @@ fn manifest_json(id: &str, name: &str, connection_type: &str) -> String {
 /// Install a plugin `id` into `root/<id>/` by writing its manifest and copying
 /// the built `lib` into `backend/`, then return the [`InstalledPlugin`] the host
 /// consumes.
-fn install(root: &Path, lib: &Path, id: &str, name: &str, connection_type: &str) -> InstalledPlugin {
+fn install(
+    root: &Path,
+    lib: &Path,
+    id: &str,
+    name: &str,
+    connection_type: &str,
+) -> InstalledPlugin {
     let dir = root.join(id);
     let backend = dir.join("backend");
     std::fs::create_dir_all(&backend).expect("create plugin backend dir");
@@ -106,7 +110,9 @@ fn install(root: &Path, lib: &Path, id: &str, name: &str, connection_type: &str)
 
     let manifest = parse_manifest(&manifest_json(id, name, connection_type))
         .expect("fixture manifest should parse");
-    manifest.validate().expect("fixture manifest should validate");
+    manifest
+        .validate()
+        .expect("fixture manifest should validate");
     InstalledPlugin {
         manifest,
         state: PluginState::Installed,
@@ -161,7 +167,11 @@ async fn plugin_type_is_creatable_and_listed_through_the_registry() {
 
     // --- 2. The manifest configSchema surfaced as the type's settings schema. ---
     let echo = types.iter().find(|t| t.type_id == "echo").unwrap();
-    assert_eq!(echo.schema.groups.len(), 1, "configSchema should yield one group");
+    assert_eq!(
+        echo.schema.groups.len(),
+        1,
+        "configSchema should yield one group"
+    );
     let field = &echo.schema.groups[0].fields[0];
     assert_eq!(field.key, "echoPrefix");
     assert_eq!(field.label, "Echo Prefix"); // humanized from the key
@@ -219,10 +229,15 @@ async fn sessions_are_independent_so_closing_one_leaves_the_other_running() {
     // Closing the first session must not disturb the second.
     first.disconnect().await.unwrap();
     assert!(!first.is_connected());
-    assert!(second.is_connected(), "closing one session killed the other");
+    assert!(
+        second.is_connected(),
+        "closing one session killed the other"
+    );
 
     // The surviving session still does full I/O.
-    second.write(b"still alive").expect("second session still writable");
+    second
+        .write(b"still alive")
+        .expect("second session still writable");
     let out = tokio::time::timeout(Duration::from_secs(5), second_rx.recv())
         .await
         .expect("second session should still echo")

--- a/core/tests/plugin_host_roundtrip.rs
+++ b/core/tests/plugin_host_roundtrip.rs
@@ -87,6 +87,7 @@ async fn plugin_host_round_trip() {
         std::sync::Arc::clone(&lib),
         "test-echo".to_string(),
         "Test Echo".to_string(),
+        termihub_core::connection::SettingsSchema { groups: vec![] },
     );
     let mut rx = conn.subscribe_output();
     conn.connect(serde_json::json!({ "foo": "bar" }))

--- a/docs/changes/dev2/feature/1999-plugin-connection-type.md
+++ b/docs/changes/dev2/feature/1999-plugin-connection-type.md
@@ -1,0 +1,10 @@
+### Added
+
+- Plugin-provided terminal backends are now usable end-to-end as connection
+  types. Once a native plugin (`terminalBackend` extension) is enabled, its
+  connection type appears in the connection-type list the app offers, its
+  manifest `configSchema` drives the connection form automatically (via the
+  existing dynamic form — no bespoke UI), and creating a session of that type
+  dispatches through the plugin for full terminal I/O (connect, write, resize,
+  output, disconnect). Two plugins declaring the same connection-type name are
+  disambiguated by suffixing the second with the plugin name (#1999).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -377,17 +377,20 @@ pub fn run() {
             // Plugin management layer (#1992) + native host loader (#1995): owns
             // <app-data>/plugins/, created lazily. The host loads a plugin's
             // backend dynamic library on enable and registers its connection type
-            // into a shared registry; disabling/uninstalling unloads it. Bridging
-            // this registry into the session-creation flow and connection editor
-            // is left to #1999 — for now the load/register path is exercised
-            // end-to-end through the manager's lifecycle seam.
+            // into a shared registry; disabling/uninstalling unloads it.
+            //
+            // That registry is the SAME one the desktop SessionManager creates
+            // sessions from (#1999): it is seeded with the built-in backends here
+            // and shared (by `Arc`) with the host below, so an enabled plugin's
+            // connection type is immediately creatable and appears in the
+            // connection-type list the UI offers — no separate wiring per plugin.
             let plugins_root = config_dir.join("plugins");
-            let plugin_registry = std::sync::Arc::new(std::sync::Mutex::new(
-                termihub_core::connection::ConnectionTypeRegistry::new(),
+            let connection_registry = std::sync::Arc::new(std::sync::Mutex::new(
+                build_desktop_registry(),
             ));
             let plugin_host = std::sync::Arc::new(termihub_core::plugin::PluginHost::new(
                 plugins_root.clone(),
-                plugin_registry,
+                std::sync::Arc::clone(&connection_registry),
             ));
             app.manage(termihub_core::plugin::PluginManager::with_hook(
                 plugins_root,
@@ -496,9 +499,13 @@ pub fn run() {
             let agent_manager: Arc<dyn AgentRpcClient> =
                 Arc::new(AgentConnectionManager::new(app.handle().clone()));
 
-            // Build the desktop ConnectionType registry and create the SessionManager.
-            let registry = build_desktop_registry();
-            let session_manager = SessionManager::new(registry, agent_manager.clone());
+            // Create the SessionManager over the registry shared with the plugin
+            // host (built above, seeded with the built-in backends), so plugin
+            // connection types are creatable and listed here (#1999).
+            let session_manager = SessionManager::with_shared_registry(
+                std::sync::Arc::clone(&connection_registry),
+                agent_manager.clone(),
+            );
             app.manage(session_manager);
             app.manage(agent_manager);
 

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -280,11 +280,13 @@ impl Drop for ConnectingGuard {
 }
 
 impl SessionManager {
-    /// Create a new session manager that owns its registry exclusively.
+    /// Test-only convenience constructor that owns its registry exclusively.
     ///
-    /// Convenience for callers (and tests) that do not share the registry with a
-    /// plugin host; it simply wraps `registry` in a fresh [`Arc<StdMutex<_>>`] and
-    /// delegates to [`with_shared_registry`](Self::with_shared_registry).
+    /// Production wiring shares the registry with the plugin host via
+    /// [`with_shared_registry`](Self::with_shared_registry); tests that do not care
+    /// about plugins use this, which wraps `registry` in a fresh
+    /// [`Arc<StdMutex<_>>`] and delegates.
+    #[cfg(test)]
     pub fn new(registry: ConnectionTypeRegistry, agent_manager: Arc<dyn AgentRpcClient>) -> Self {
         Self::with_shared_registry(Arc::new(StdMutex::new(registry)), agent_manager)
     }

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -225,7 +225,16 @@ pub struct SessionLogStatus {
 #[derive(Clone)]
 pub struct SessionManager {
     sessions: Arc<Mutex<HashMap<String, SessionEntry>>>,
-    registry: Arc<ConnectionTypeRegistry>,
+    /// Shared registry of connection-type factories.
+    ///
+    /// Wrapped in a [`StdMutex`] and held behind an [`Arc`] so the plugin host
+    /// ([`termihub_core::plugin::PluginHost`]) can register and unregister
+    /// plugin-provided connection types into the *same* registry at runtime —
+    /// enabling a plugin makes its type immediately creatable here and visible in
+    /// [`available_types`](Self::available_types) (#1999). The lock is held only
+    /// briefly to look up a factory or snapshot the type list; it is never held
+    /// across an `await`.
+    registry: Arc<StdMutex<ConnectionTypeRegistry>>,
     agent_manager: Arc<dyn AgentRpcClient>,
     /// Abort handles for active session-monitoring push tasks, keyed by session ID.
     monitoring_tasks: Arc<Mutex<HashMap<String, tokio::task::AbortHandle>>>,
@@ -271,11 +280,28 @@ impl Drop for ConnectingGuard {
 }
 
 impl SessionManager {
-    /// Create a new session manager with the given registry and agent manager.
+    /// Create a new session manager that owns its registry exclusively.
+    ///
+    /// Convenience for callers (and tests) that do not share the registry with a
+    /// plugin host; it simply wraps `registry` in a fresh [`Arc<StdMutex<_>>`] and
+    /// delegates to [`with_shared_registry`](Self::with_shared_registry).
     pub fn new(registry: ConnectionTypeRegistry, agent_manager: Arc<dyn AgentRpcClient>) -> Self {
+        Self::with_shared_registry(Arc::new(StdMutex::new(registry)), agent_manager)
+    }
+
+    /// Create a session manager over a registry shared with the plugin host.
+    ///
+    /// Passing the same `Arc<StdMutex<ConnectionTypeRegistry>>` here and into
+    /// [`PluginHost::new`](termihub_core::plugin::PluginHost::new) is what lets an
+    /// enabled plugin's connection type be created and listed by this manager
+    /// (#1999).
+    pub fn with_shared_registry(
+        registry: Arc<StdMutex<ConnectionTypeRegistry>>,
+        agent_manager: Arc<dyn AgentRpcClient>,
+    ) -> Self {
         Self {
             sessions: Arc::new(Mutex::new(HashMap::new())),
-            registry: Arc::new(registry),
+            registry,
             agent_manager,
             monitoring_tasks: Arc::new(Mutex::new(HashMap::new())),
             persistent_sessions: Arc::new(Mutex::new(HashMap::new())),
@@ -529,11 +555,15 @@ impl SessionManager {
                 let remote_sid = proxy.remote_session_id();
                 (Box::new(proxy), remote_sid)
             } else {
-                // Local: instantiate from registry.
-                let mut conn = self
-                    .registry
-                    .create(type_id)
-                    .map_err(|e| TerminalError::SpawnFailed(e.to_string()))?;
+                // Local: instantiate from registry. Lock only long enough to run
+                // the factory (no `await` under the lock); this resolves built-in
+                // *and* plugin-registered types (#1999).
+                let mut conn = {
+                    let registry = self.registry.lock().unwrap_or_else(|e| e.into_inner());
+                    registry
+                        .create(type_id)
+                        .map_err(|e| TerminalError::SpawnFailed(e.to_string()))?
+                };
                 conn.connect_cancellable(settings.clone(), cancel_token.clone())
                     .await
                     .map_err(|e| TerminalError::SpawnFailed(e.to_string()))?;
@@ -889,7 +919,10 @@ impl SessionManager {
 
     /// Get the list of available connection types from the registry.
     pub fn available_types(&self) -> Vec<ConnectionTypeInfo> {
-        self.registry.available_types()
+        self.registry
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .available_types()
     }
 
     /// Return the capabilities of an active session.


### PR DESCRIPTION
## Summary

Wires a plugin-registered `ConnectionType` (produced by the #1995 host loader) through to real session creation — the thin bridge #1999 asks for. A saved connection whose `type_id` is a plugin backend now creates a session through the plugin, and the plugin's manifest `configSchema` drives the connection form.

Closes #1999.

## What changed

- **One shared registry.** The plugin host and the desktop `SessionManager` previously held *two separate* `ConnectionTypeRegistry` instances, so plugin types never reached session creation or the type list. `lib.rs` now seeds a single `Arc<Mutex<ConnectionTypeRegistry>>` with the built-in backends and shares it (by `Arc`) with both the `PluginHost` and the `SessionManager` (new `SessionManager::with_shared_registry`). Enabling a plugin registers its type into that same registry, so it is immediately:
  - **creatable** — `SessionManager::create` locks the shared registry and dispatches to the plugin's `ConnectionType` wrapper (connect / write / resize / subscribe_output / disconnect), and
  - **listed** — `available_types()` (behind the existing `get_connection_types` command) includes it, so it appears in the connection-type picker with no frontend change (plugin types report `graphical: false`, so the experimental gate does not hide them).
- **`configSchema` → form schema.** New `config_schema_to_settings_schema` translates a plugin's declared JSON-Schema `configSchema` into the `SettingsSchema` the existing `DynamicForm` renders (string/number/boolean/enum/password → field types; `title`/`description`/`default`/`required` flow through; keys humanized when no `title`). `PluginConnectionType::settings_schema()` now returns it instead of an empty schema.
- **Name collisions disambiguated.** Two plugins declaring the same `connectionType` (or one colliding with a built-in) are disambiguated by suffixing the later one's `type_id` with the plugin id and its display name with the plugin name (concept "Edge Cases"). The first registrant keeps the plain id.
- **Session independence** is inherent — each `PluginConnectionType` instance owns its own backend handle; closing one leaves others running (covered by test).

## Tests

- Unit: `configSchema` → schema mapping (types, labels, required, empty/shapeless), key humanization, and `disambiguate_type_id` (free / suffixed / counter).
- Integration (`core/tests/plugin_connection_wiring.rs`, `plugin` feature, real `cdylib` via `dlopen`): loads two plugins through the real `PluginHost` into a shared registry and, using only the registry, verifies listing + disambiguation, `configSchema` surfacing, full create→I/O→close by `type_id`, unregister-on-unload, and session independence. Verified locally (Rust integration tests are dark in per-PR CI).

## Notes / follow-ups

- The concept's §5 enum sketch is stale (no `ConnectionConfig` enum exists); to be marked superseded on the next `/sync-concept` (per the issue), not edited here.
- Enabled plugins are **not** auto-loaded at startup (the manager's `Enabled` state rests un-loaded until an explicit enable); filing a follow-up so a persisted plugin connection resolves after a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)