### PR TITLE
feat(backend): plugin security hardening — permission enforcement, untrusted-source warnings, error recovery (Closes #2001)

### DIFF
--- a/core/src/plugin/connection.rs
+++ b/core/src/plugin/connection.rs
@@ -27,6 +27,7 @@
 //! session-creation flow, is connection-type wiring left to #1999; until then the
 //! schema is empty and the raw settings JSON is forwarded to the plugin verbatim.
 
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use termihub_plugin_api::{LoadedBackend, PluginError, PluginOutputSender};
@@ -39,6 +40,8 @@ use crate::files::FileBrowser;
 use crate::monitoring::MonitoringProvider;
 
 use super::host::LoadedLibrary;
+use super::security::{PermissionError, PermissionSet};
+use super::PluginPermission;
 
 /// Channel capacity for output forwarded from the plugin to the terminal.
 const OUTPUT_CHANNEL_CAPACITY: usize = 64;
@@ -51,6 +54,10 @@ pub struct PluginConnectionType {
     library: Arc<LoadedLibrary>,
     connection_type: String,
     display_name: String,
+    /// The permissions this plugin was granted, carried so host-mediated
+    /// capabilities (filesystem path resolution, network, …) can enforce them
+    /// per session (concept §13).
+    permissions: PermissionSet,
     /// The active session backend, `None` until [`connect`](ConnectionType::connect).
     backend: Option<LoadedBackend>,
     /// Current output sink; swapped by
@@ -60,16 +67,43 @@ pub struct PluginConnectionType {
 }
 
 impl PluginConnectionType {
-    /// Build a fresh, unconnected connection of the given plugin type.
+    /// Build a fresh, unconnected connection of the given plugin type, scoped to
+    /// the plugin's granted `permissions`.
     #[must_use]
-    pub fn new(library: Arc<LoadedLibrary>, connection_type: String, display_name: String) -> Self {
+    pub fn new(
+        library: Arc<LoadedLibrary>,
+        connection_type: String,
+        display_name: String,
+        permissions: PermissionSet,
+    ) -> Self {
         Self {
             library,
             connection_type,
             display_name,
+            permissions,
             backend: None,
             output_tx: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// The permission set this plugin session was granted.
+    #[must_use]
+    pub fn permissions(&self) -> &PermissionSet {
+        &self.permissions
+    }
+
+    /// Require that this plugin holds `permission` before a host-mediated
+    /// capability acts on its behalf. Returns [`PermissionError::Denied`]
+    /// otherwise (e.g. a backend without `network` cannot open connections).
+    pub fn require_permission(&self, permission: PluginPermission) -> Result<(), PermissionError> {
+        self.permissions.require(permission)
+    }
+
+    /// Resolve and authorize a plugin-supplied filesystem path against this
+    /// plugin's declared scope, rejecting paths outside it (concept §13). This is
+    /// the guard a host-mediated filesystem bridge routes plugin paths through.
+    pub fn resolve_scoped_path(&self, requested: &Path) -> Result<PathBuf, PermissionError> {
+        self.permissions.check_path(requested)
     }
 }
 

--- a/core/src/plugin/host.rs
+++ b/core/src/plugin/host.rs
@@ -53,6 +53,7 @@ use crate::connection::ConnectionTypeRegistry;
 
 use super::connection::PluginConnectionType;
 use super::manager::InstalledPlugin;
+use super::security::{PermissionError, PermissionSet, RecoveryAction, RestartTracker};
 
 /// Everything that can go wrong while loading a plugin's backend library.
 #[derive(Debug, thiserror::Error)]
@@ -88,6 +89,18 @@ pub enum HostError {
     /// The plugin's `plugin_init` entry point reported a failure.
     #[error("plugin initialization failed: {0}")]
     Init(String),
+
+    /// The plugin's declared permissions are inconsistent with what it provides
+    /// (e.g. a terminal backend without the `terminal` permission), so it is
+    /// refused rather than loaded with a capability it never requested.
+    #[error("plugin permission check failed: {0}")]
+    Permission(#[from] PermissionError),
+
+    /// A plugin entry point unwound (panicked) across the FFI boundary. The host
+    /// contains the unwind and refuses the plugin rather than letting it abort
+    /// the process.
+    #[error("plugin panicked during `{0}`")]
+    Panicked(&'static str),
 }
 
 impl HostError {
@@ -178,8 +191,15 @@ impl LoadedLibrary {
         };
         // SAFETY: `config` outlives the call; `output` ownership is transferred to
         // the plugin; `&mut backend` is a valid out-parameter. The plugin writes a
-        // valid `PluginBackend` on `Ok`.
-        let status = unsafe { (self.create_backend)(&config, output, &mut backend) };
+        // valid `PluginBackend` on `Ok`. The call is wrapped in `catch_unwind` so a
+        // panic inside the plugin's entry point is contained rather than unwinding
+        // across the FFI boundary (undefined behavior) — a misbehaving plugin must
+        // not crash the host (concept "Error recovery").
+        let create_backend = self.create_backend;
+        let status = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            create_backend(&config, output, &mut backend)
+        }))
+        .map_err(|_| PluginError::Panicked)?;
         status.into_result()?;
         // SAFETY: on `Ok` the plugin has written a live backend produced by the
         // same library, whose ownership now transfers to the wrapper.
@@ -247,9 +267,14 @@ pub fn load_backend_library(library_path: &Path) -> Result<Arc<LoadedLibrary>, H
                 .get(SYMBOL_PLUGIN_ABI_VERSION)
                 .map_err(|_| HostError::MissingSymbol(symbol_name(SYMBOL_PLUGIN_ABI_VERSION)))?
         };
+        // Copy out the plain `extern "C"` fn pointer (`Copy`, `UnwindSafe`) so the
+        // `catch_unwind` closure does not capture the `Symbol` borrow.
+        let abi_version_fn = *abi_version;
         // SAFETY: the plugin's abi-version entry point takes no arguments and
-        // returns a plain `u32`.
-        unsafe { abi_version() }
+        // returns a plain `u32`. Contained in `catch_unwind` so a panicking plugin
+        // cannot unwind across FFI and abort the host.
+        std::panic::catch_unwind(|| unsafe { abi_version_fn() })
+            .map_err(|_| HostError::Panicked("plugin_abi_version"))?
     };
     if found != CURRENT_PLUGIN_API_VERSION {
         return Err(HostError::IncompatibleAbi {
@@ -266,10 +291,15 @@ pub fn load_backend_library(library_path: &Path) -> Result<Arc<LoadedLibrary>, H
                 .get(SYMBOL_PLUGIN_INIT)
                 .map_err(|_| HostError::MissingSymbol(symbol_name(SYMBOL_PLUGIN_INIT)))?
         };
+        let init_fn = *init;
         let mut info = PluginInfo::empty();
         // SAFETY: `&mut info` is a valid out-parameter the plugin fills in; on a
-        // non-`Ok` status it leaves the empty placeholder untouched.
-        let status = unsafe { init(&mut info) };
+        // non-`Ok` status it leaves the empty placeholder untouched. Contained in
+        // `catch_unwind` so a panic in `plugin_init` cannot unwind across FFI.
+        let status = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            init_fn(&mut info)
+        }))
+        .map_err(|_| HostError::Panicked("plugin_init"))?;
         status
             .into_result()
             .map_err(|e| HostError::Init(e.to_string()))?;
@@ -319,6 +349,21 @@ struct HostEntry {
     library: Arc<LoadedLibrary>,
 }
 
+/// The result of driving [`PluginHost::note_failure`]: what the host decided to
+/// do with a plugin after a runtime failure, following the concept's recovery
+/// policy (auto-restart up to [`MAX_RESTART_ATTEMPTS`], then auto-disable).
+///
+/// [`MAX_RESTART_ATTEMPTS`]: super::security::MAX_RESTART_ATTEMPTS
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryOutcome {
+    /// The plugin should be reloaded; the restart budget is not yet exhausted.
+    /// The caller re-enables the plugin (or the host reloads it) to retry.
+    Restart,
+    /// The restart budget is exhausted; the host has unloaded the plugin and it
+    /// should be persisted as disabled and surfaced to the user.
+    Disabled,
+}
+
 /// The runtime plugin host: loads backend libraries and registers the resulting
 /// connection types into a shared [`ConnectionTypeRegistry`].
 ///
@@ -330,6 +375,9 @@ pub struct PluginHost {
     root: PathBuf,
     registry: Arc<Mutex<ConnectionTypeRegistry>>,
     loaded: Mutex<HashMap<String, HostEntry>>,
+    /// Per-plugin error-recovery counters (concept "Error recovery state
+    /// machine"). Keyed by plugin id; created lazily on first failure.
+    recovery: Mutex<HashMap<String, RestartTracker>>,
 }
 
 impl PluginHost {
@@ -343,6 +391,7 @@ impl PluginHost {
             root: plugins_root.into(),
             registry,
             loaded: Mutex::new(HashMap::new()),
+            recovery: Mutex::new(HashMap::new()),
         }
     }
 
@@ -373,6 +422,14 @@ impl PluginHost {
     /// [`HostError::is_incompatible`] failure is a version problem, everything
     /// else is a load error.
     pub fn load(&self, plugin: &InstalledPlugin) -> Result<(), HostError> {
+        // Enforce the permission model before any library is opened: a plugin
+        // whose declared extensions need a capability it did not request (e.g. a
+        // terminal backend without the `terminal` permission, or `filesystem`
+        // without declared paths) is refused. This surfaces as
+        // `PluginState::Error` — graceful degradation, not a crash.
+        let permissions = PermissionSet::from_manifest(&plugin.manifest);
+        permissions.check_consistency(&plugin.manifest.extensions)?;
+
         let Some(backend) = plugin.manifest.extensions.terminal_backend.as_ref() else {
             return Ok(());
         };
@@ -390,6 +447,10 @@ impl PluginHost {
         let lib_for_factory = Arc::clone(&library);
         let ct_for_factory = connection_type.clone();
         let dn_for_factory = display_name.clone();
+        // Each session created for this plugin carries its own permission scope,
+        // so a host-mediated capability (filesystem path resolution, network, …)
+        // can enforce it per session.
+        let perms_for_factory = permissions.clone();
 
         {
             let mut registry = self.registry.lock().unwrap_or_else(|e| e.into_inner());
@@ -402,6 +463,7 @@ impl PluginHost {
                         Arc::clone(&lib_for_factory),
                         ct_for_factory.clone(),
                         dn_for_factory.clone(),
+                        perms_for_factory.clone(),
                     ))
                 }),
             );
@@ -417,6 +479,9 @@ impl PluginHost {
                     library,
                 },
             );
+        // A clean (re)load means the plugin is healthy again: reset any prior
+        // recovery counter so a future, unrelated failure gets a full budget.
+        self.clear_recovery(&plugin.manifest.id);
         Ok(())
     }
 
@@ -437,6 +502,44 @@ impl PluginHost {
             // `entry.library` (Arc) drops here; the OS unloads the library once
             // the last outstanding session Arc also drops.
         }
+    }
+
+    /// Record a runtime failure of a loaded plugin and apply the recovery policy
+    /// (concept "Error recovery state machine").
+    ///
+    /// The plugin's restart counter is advanced. While the restart budget
+    /// ([`MAX_RESTART_ATTEMPTS`]) is not exhausted this returns
+    /// [`RecoveryOutcome::Restart`] — the caller reloads the plugin (e.g. via the
+    /// manager's enable path) to retry. Once the budget is exhausted the host
+    /// **unloads** the plugin and returns [`RecoveryOutcome::Disabled`], so the
+    /// caller persists it as disabled and notifies the user. A failing plugin can
+    /// therefore never spin forever.
+    ///
+    /// [`MAX_RESTART_ATTEMPTS`]: super::security::MAX_RESTART_ATTEMPTS
+    pub fn note_failure(&self, id: &str) -> RecoveryOutcome {
+        let action = {
+            let mut recovery = self.recovery.lock().unwrap_or_else(|e| e.into_inner());
+            recovery.entry(id.to_string()).or_default().record_failure()
+        };
+        match action {
+            RecoveryAction::Restart => RecoveryOutcome::Restart,
+            RecoveryAction::Disable => {
+                // Budget exhausted: stop the plugin. It stays installed but is not
+                // loaded until the user re-enables it (which also clears the
+                // counter via `clear_recovery`).
+                self.unload(id);
+                RecoveryOutcome::Disabled
+            }
+        }
+    }
+
+    /// Clear a plugin's recovery counter — called when it is (re-)enabled or
+    /// loads cleanly, so a later, unrelated failure starts from a full budget.
+    pub fn clear_recovery(&self, id: &str) {
+        self.recovery
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(id);
     }
 }
 
@@ -477,6 +580,102 @@ impl super::manager::PluginLifecycleHook for HostLifecycleHook {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::plugin::PluginState;
+
+    /// A host wired to a fresh, empty registry over a temp plugins root.
+    fn test_host() -> (PluginHost, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let registry = Arc::new(Mutex::new(ConnectionTypeRegistry::new()));
+        (PluginHost::new(tmp.path().to_path_buf(), registry), tmp)
+    }
+
+    /// Build an [`InstalledPlugin`] from a manifest JSON string (Installed state).
+    fn installed(manifest_json: &str) -> InstalledPlugin {
+        let manifest = super::super::manifest::parse_manifest(manifest_json).expect("parses");
+        InstalledPlugin {
+            manifest,
+            state: PluginState::Installed,
+            error_message: None,
+            installed_at: 0,
+        }
+    }
+
+    fn manifest_json(permissions: &str, fs_paths: &str) -> String {
+        let fs_line = if fs_paths.is_empty() {
+            String::new()
+        } else {
+            format!("\"filesystemPaths\": {fs_paths},")
+        };
+        format!(
+            r#"{{
+                "id": "host-sec",
+                "name": "Host Sec",
+                "version": "1.0.0",
+                "author": "tester",
+                "description": "host security test",
+                "license": "MIT",
+                "apiVersion": "1.0",
+                "platforms": ["linux", "macos", "windows"],
+                "permissions": {permissions},
+                {fs_line}
+                "extensions": {{
+                    "terminalBackend": {{
+                        "connectionType": "host-sec",
+                        "displayName": "Host Sec",
+                        "configSchema": {{}}
+                    }}
+                }}
+            }}"#
+        )
+    }
+
+    #[test]
+    fn load_refuses_terminal_backend_without_terminal_permission() {
+        let (host, _t) = test_host();
+        // Terminal backend but only the `network` permission → refused before any
+        // library is opened. Graceful: the manager maps this to Error state.
+        let plugin = installed(&manifest_json(r#"["network"]"#, ""));
+        let err = host.load(&plugin).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                HostError::Permission(PermissionError::TerminalWithoutPermission)
+            ),
+            "got {err:?}"
+        );
+        assert!(!host.is_loaded("host-sec"));
+    }
+
+    #[test]
+    fn load_refuses_filesystem_permission_without_paths() {
+        let (host, _t) = test_host();
+        let plugin = installed(&manifest_json(r#"["terminal", "filesystem"]"#, ""));
+        let err = host.load(&plugin).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                HostError::Permission(PermissionError::FilesystemWithoutPaths)
+            ),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn note_failure_restarts_up_to_budget_then_disables() {
+        let (host, _t) = test_host();
+        // Nothing is loaded, so `unload` on disable is a harmless no-op; we are
+        // exercising the recovery counter the host keeps per plugin.
+        for _ in 0..super::super::security::MAX_RESTART_ATTEMPTS {
+            assert_eq!(host.note_failure("crashy"), RecoveryOutcome::Restart);
+        }
+        assert_eq!(host.note_failure("crashy"), RecoveryOutcome::Disabled);
+        // Latches disabled.
+        assert_eq!(host.note_failure("crashy"), RecoveryOutcome::Disabled);
+
+        // Clearing (as a re-enable would) restores the full budget.
+        host.clear_recovery("crashy");
+        assert_eq!(host.note_failure("crashy"), RecoveryOutcome::Restart);
+    }
 
     #[test]
     fn symbol_name_strips_trailing_nul() {

--- a/core/src/plugin/manager.rs
+++ b/core/src/plugin/manager.rs
@@ -46,6 +46,7 @@ use thiserror::Error;
 
 use super::manifest::{parse_manifest, ApiCompatibility, PluginManifest};
 use super::package::{validate_package, PluginPackageError, MANIFEST_FILE_NAME};
+use super::security::{assess_trust, TrustAssessment};
 
 /// File holding per-plugin enabled/disabled state and install timestamps.
 const STATE_FILE_NAME: &str = "plugin-state.json";
@@ -156,6 +157,12 @@ pub enum PluginManagerError {
     /// A state or settings file could not be (de)serialized.
     #[error("plugin state store error: {0}")]
     Store(String),
+
+    /// The package is from an unverified (unsigned) source and the caller did not
+    /// explicitly accept the risk, so installation was refused before extraction
+    /// (concept security gate). See [`PluginManager::assess_trust`].
+    #[error("plugin is from an untrusted source and the risk was not accepted")]
+    UntrustedSourceNotAccepted,
 }
 
 /// Per-plugin record persisted in `plugin-state.json`.
@@ -265,13 +272,43 @@ impl PluginManager {
         Ok(self.installed_plugin_from(manifest, &state, &dir))
     }
 
+    /// Assess how much a `.termihub-plugin` package can be trusted before
+    /// installing it.
+    ///
+    /// termiHub has no plugin-signing substrate, so this always reports the
+    /// package as **untrusted** with a user-facing warning; the install gate
+    /// shows the warning and the user must accept the risk (pass
+    /// `accept_untrusted = true` to [`install`](Self::install)) before extraction.
+    /// Cryptographic signature verification is future work, not implemented.
+    #[must_use]
+    pub fn assess_trust(&self, package_path: &Path) -> TrustAssessment {
+        assess_trust(package_path)
+    }
+
     /// Install a plugin from a `.termihub-plugin` package.
     ///
     /// Validates the package (format + API compatibility), extracts it into
     /// `plugins/<id>/` (replacing any prior install of the same id), records it
     /// as enabled, and runs the enable hook. Serialized against other
     /// install/uninstall operations.
-    pub fn install(&self, package_path: &Path) -> Result<InstalledPlugin, PluginManagerError> {
+    ///
+    /// Every package is from an unverified source (see [`assess_trust`](Self::assess_trust)),
+    /// so `accept_untrusted` must be `true` — the caller's record that the user
+    /// saw the untrusted-source warning and accepted the risk. A `false` value
+    /// refuses the install with [`PluginManagerError::UntrustedSourceNotAccepted`]
+    /// **before** anything is extracted.
+    pub fn install(
+        &self,
+        package_path: &Path,
+        accept_untrusted: bool,
+    ) -> Result<InstalledPlugin, PluginManagerError> {
+        // Untrusted-source gate: refuse before touching the package unless the
+        // user accepted the risk (concept security flowchart: "Warn user →
+        // accepts risk? → extract").
+        if self.assess_trust(package_path).requires_acceptance() && !accept_untrusted {
+            return Err(PluginManagerError::UntrustedSourceNotAccepted);
+        }
+
         let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
 
         let manifest = validate_package(package_path)?;
@@ -354,6 +391,50 @@ impl PluginManager {
     /// Disable a plugin, persisting the flag and running the disable hook.
     pub fn disable(&self, id: &str) -> Result<InstalledPlugin, PluginManagerError> {
         self.set_enabled(id, false)
+    }
+
+    /// Auto-disable every installed plugin that has become **incompatible** with
+    /// the current host plugin-API version while it was still enabled, and return
+    /// the ids that were disabled so the caller can notify the user.
+    ///
+    /// This is the concept's "App update changes the plugin API version →
+    /// incompatible plugins are auto-disabled with a notification" behavior: run
+    /// it at startup after a host upgrade. An incompatible plugin is never loaded
+    /// regardless (its derived state is [`PluginState::Incompatible`]); this also
+    /// flips the *persisted* enabled flag off so the plugin does not silently
+    /// re-activate if a later host once again supports its API version. Idempotent:
+    /// a second run finds nothing to disable.
+    pub fn reconcile_compatibility(&self) -> Result<Vec<String>, PluginManagerError> {
+        let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
+
+        if !self.root.exists() {
+            return Ok(Vec::new());
+        }
+        let mut state = self.read_state_store()?;
+        let mut disabled = Vec::new();
+        for entry in std::fs::read_dir(&self.root)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let Some(manifest) = read_manifest(&entry.path()) else {
+                continue;
+            };
+            if manifest.api_compatibility() != ApiCompatibility::Incompatible {
+                continue;
+            }
+            if let Some(record) = state.plugins.get_mut(&manifest.id) {
+                if record.enabled {
+                    record.enabled = false;
+                    disabled.push(manifest.id.clone());
+                }
+            }
+        }
+        if !disabled.is_empty() {
+            self.write_state_store(&state)?;
+        }
+        disabled.sort();
+        Ok(disabled)
     }
 
     fn set_enabled(&self, id: &str, enabled: bool) -> Result<InstalledPlugin, PluginManagerError> {
@@ -689,7 +770,7 @@ mod tests {
             &[("themes/dark.json", b"{\"bg\":\"#000\"}")],
         );
 
-        let installed = mgr.install(&pkg).unwrap();
+        let installed = mgr.install(&pkg, true).unwrap();
         assert_eq!(installed.manifest.id, "my-theme");
         assert_eq!(installed.state, PluginState::Installed);
         assert!(installed.installed_at > 0);
@@ -715,7 +796,7 @@ mod tests {
             &manifest_json("dup", "1.0"),
             &[("old.txt", b"old")],
         );
-        mgr.install(&pkg1).unwrap();
+        mgr.install(&pkg1, true).unwrap();
         assert!(mgr.root().join("dup/old.txt").exists());
 
         // Reinstall with different contents; the old file must be gone.
@@ -725,7 +806,7 @@ mod tests {
             &manifest_json("dup", "1.0"),
             &[("new.txt", b"new")],
         );
-        mgr.install(&pkg2).unwrap();
+        mgr.install(&pkg2, true).unwrap();
         assert!(mgr.root().join("dup/new.txt").exists());
         assert!(!mgr.root().join("dup/old.txt").exists());
         assert_eq!(mgr.list().unwrap().len(), 1);
@@ -735,7 +816,7 @@ mod tests {
     fn uninstall_removes_dir_state_and_settings() {
         let (mgr, tmp) = manager();
         let pkg = make_package(tmp.path(), &manifest_json("gone", "1.0"), &[]);
-        mgr.install(&pkg).unwrap();
+        mgr.install(&pkg, true).unwrap();
 
         let mut s = Map::new();
         s.insert("k".into(), Value::from("v"));
@@ -766,7 +847,7 @@ mod tests {
     fn disable_then_enable_persists() {
         let (mgr, tmp) = manager();
         let pkg = make_package(tmp.path(), &manifest_json("toggle", "1.0"), &[]);
-        mgr.install(&pkg).unwrap();
+        mgr.install(&pkg, true).unwrap();
 
         let disabled = mgr.disable("toggle").unwrap();
         assert_eq!(disabled.state, PluginState::Disabled);
@@ -792,7 +873,7 @@ mod tests {
     fn settings_round_trip() {
         let (mgr, tmp) = manager();
         let pkg = make_package(tmp.path(), &manifest_json("cfg", "1.0"), &[]);
-        mgr.install(&pkg).unwrap();
+        mgr.install(&pkg, true).unwrap();
 
         // Empty by default.
         assert!(mgr.get_settings("cfg").unwrap().is_empty());
@@ -830,7 +911,7 @@ mod tests {
         // that was installed while still compatible.
         let (mgr, tmp) = manager();
         let pkg = make_package(tmp.path(), &manifest_json("legacy", "1.0"), &[]);
-        mgr.install(&pkg).unwrap();
+        mgr.install(&pkg, true).unwrap();
 
         let manifest_path = mgr.root().join("legacy").join(MANIFEST_FILE_NAME);
         let bumped = manifest_json("legacy", "2.0");
@@ -845,7 +926,7 @@ mod tests {
         let (mgr, tmp) = manager();
         let pkg = make_package(tmp.path(), &manifest_json("future", "2.0"), &[]);
         assert!(matches!(
-            mgr.install(&pkg),
+            mgr.install(&pkg, true),
             Err(PluginManagerError::Package(
                 PluginPackageError::IncompatibleApiVersion { .. }
             ))
@@ -862,7 +943,7 @@ mod tests {
             &manifest_json("assets", "1.0"),
             &[("themes/dark.json", b"{\"bg\":\"#111\"}")],
         );
-        mgr.install(&pkg).unwrap();
+        mgr.install(&pkg, true).unwrap();
 
         let bytes = mgr.read_file("assets", "themes/dark.json").unwrap();
         assert_eq!(bytes, b"{\"bg\":\"#111\"}");
@@ -897,7 +978,7 @@ mod tests {
         zip.finish().unwrap();
 
         let (mgr, _t) = manager();
-        let result = mgr.install(&path);
+        let result = mgr.install(&path, true);
         assert!(
             matches!(result, Err(PluginManagerError::UnsafePath(_))),
             "got: {result:?}"
@@ -910,7 +991,7 @@ mod tests {
     fn scan_skips_dirs_without_valid_manifest() {
         let (mgr, tmp) = manager();
         let pkg = make_package(tmp.path(), &manifest_json("real", "1.0"), &[]);
-        mgr.install(&pkg).unwrap();
+        mgr.install(&pkg, true).unwrap();
 
         // A stray directory with no manifest, and one with garbage.
         std::fs::create_dir_all(mgr.root().join("stray")).unwrap();
@@ -937,12 +1018,67 @@ mod tests {
         let pkg = make_package(tmp.path(), &manifest_json("hooked", "1.0"), &[]);
 
         // Install runs on_enable, which fails: state is Error with the message.
-        let installed = mgr.install(&pkg).unwrap();
+        let installed = mgr.install(&pkg, true).unwrap();
         assert_eq!(installed.state, PluginState::Error);
         assert_eq!(installed.error_message.as_deref(), Some("boom"));
 
         // But the plugin is on disk and enabled; a plain scan (no hook) reports
         // it as installed.
         assert!(mgr.root().join("hooked").exists());
+    }
+
+    #[test]
+    fn install_refuses_untrusted_source_without_acceptance() {
+        let (mgr, tmp) = manager();
+        let pkg = make_package(tmp.path(), &manifest_json("untrusted", "1.0"), &[]);
+
+        // Every package is unsigned → untrusted; installing without accepting
+        // the risk is refused before anything is extracted.
+        assert!(matches!(
+            mgr.install(&pkg, false),
+            Err(PluginManagerError::UntrustedSourceNotAccepted)
+        ));
+        assert!(!mgr.root().join("untrusted").exists());
+
+        // The trust assessment surfaces the warning the UI shows.
+        let trust = mgr.assess_trust(&pkg);
+        assert!(trust.requires_acceptance());
+        assert!(!trust.warning.is_empty());
+
+        // Accepting the risk installs it.
+        let installed = mgr.install(&pkg, true).unwrap();
+        assert_eq!(installed.manifest.id, "untrusted");
+        assert!(mgr.root().join("untrusted").exists());
+    }
+
+    #[test]
+    fn reconcile_disables_incompatible_after_api_bump() {
+        let (mgr, tmp) = manager();
+        let pkg = make_package(tmp.path(), &manifest_json("legacy", "1.0"), &[]);
+        mgr.install(&pkg, true).unwrap();
+
+        // Simulate a host upgrade under the plugin: its manifest now targets an
+        // incompatible API version.
+        let manifest_path = mgr.root().join("legacy").join(MANIFEST_FILE_NAME);
+        std::fs::write(&manifest_path, manifest_json("legacy", "2.0")).unwrap();
+
+        // Reconcile auto-disables it and reports it for notification.
+        let disabled = mgr.reconcile_compatibility().unwrap();
+        assert_eq!(disabled, vec!["legacy".to_string()]);
+        // The persisted enabled flag is now off.
+        assert!(!mgr.read_state_store().unwrap().plugins["legacy"].enabled);
+        // Idempotent: a second run finds nothing (already disabled).
+        assert!(mgr.reconcile_compatibility().unwrap().is_empty());
+    }
+
+    #[test]
+    fn reconcile_leaves_compatible_plugins_enabled() {
+        let (mgr, tmp) = manager();
+        let pkg = make_package(tmp.path(), &manifest_json("fine", "1.0"), &[]);
+        mgr.install(&pkg, true).unwrap();
+
+        assert!(mgr.reconcile_compatibility().unwrap().is_empty());
+        assert!(mgr.read_state_store().unwrap().plugins["fine"].enabled);
+        assert_eq!(mgr.get("fine").unwrap().state, PluginState::Installed);
     }
 }

--- a/core/src/plugin/manifest.rs
+++ b/core/src/plugin/manifest.rs
@@ -214,6 +214,13 @@ pub struct PluginManifest {
     pub platforms: Vec<Platform>,
     /// Coarse-grained permissions the plugin requests.
     pub permissions: Vec<PluginPermission>,
+    /// Filesystem paths the plugin is scoped to. Only meaningful together with
+    /// the [`Filesystem`](PluginPermission::Filesystem) permission: the host
+    /// confines the plugin's filesystem access to these roots (concept §13, "must
+    /// declare which paths they need"). Absent/empty for plugins that request no
+    /// filesystem access.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub filesystem_paths: Vec<String>,
     /// The extension points the plugin provides.
     pub extensions: PluginExtensions,
     /// Optional user-configurable settings, keyed by setting name.

--- a/core/src/plugin/mod.rs
+++ b/core/src/plugin/mod.rs
@@ -65,6 +65,7 @@ mod manager;
 mod manifest;
 mod pack;
 mod package;
+mod security;
 
 pub use connection::PluginConnectionType;
 pub use host::{
@@ -85,4 +86,8 @@ pub use manifest::{
 pub use pack::{pack_plugin, PluginPackError};
 pub use package::{
     validate_package, PluginPackageError, MANIFEST_FILE_NAME, MAX_PACKAGE_SIZE_BYTES,
+};
+pub use security::{
+    assess_trust, FilesystemScope, PermissionError, PermissionSet, RecoveryAction, RecoveryState,
+    RestartTracker, TrustAssessment, TrustLevel, MAX_RESTART_ATTEMPTS,
 };

--- a/core/src/plugin/security.rs
+++ b/core/src/plugin/security.rs
@@ -1,0 +1,617 @@
+//! Plugin **security hardening**: permission enforcement, filesystem
+//! path-scoping, untrusted-source assessment, and the error-recovery state
+//! machine (concept impl §13, "Seventh PR — Security and polish").
+//!
+//! This module is the pure, host-agnostic core of the security layer; the
+//! [`super::host::PluginHost`] wires it into the load/execute path. Nothing here
+//! performs I/O, so it is exhaustively unit-testable.
+//!
+//! # What is enforceable today
+//!
+//! A native plugin backend runs as a dynamic library **in the host process**, so
+//! the host cannot intercept a plugin's own syscalls. What it *can* do — and what
+//! this module implements — is:
+//!
+//! * **Permission consistency at load** — a plugin whose declared extensions need
+//!   a permission it did not request is refused ([`PermissionSet::check_consistency`]),
+//!   so the mismatch is caught before the library is registered rather than
+//!   surfacing as a mysterious runtime failure.
+//! * **A path-scope guard** ([`FilesystemScope::check`]) — the primitive any
+//!   host-mediated filesystem access resolves a plugin-supplied path through. It
+//!   requires the `filesystem` permission and rejects paths outside the plugin's
+//!   declared roots (including `..` traversal).
+//! * **A permission query** ([`PermissionSet::require`]) — the gate a host-mediated
+//!   network/settings/etc. capability checks before acting for a plugin.
+//! * **Untrusted-source assessment** ([`assess_trust`]) — every package is
+//!   unsigned today, so this always reports "untrusted"; install requires explicit
+//!   acceptance.
+//! * **An error-recovery counter** ([`RestartTracker`]) — bounded auto-restart of
+//!   a crashing plugin, then auto-disable.
+//!
+//! Cryptographic signature *verification* is **out of scope**: termiHub has no
+//! signing substrate (no keys, format, or verification chain). [`TrustLevel`]
+//! documents this as future work rather than claiming plugins are verified.
+
+use std::collections::BTreeSet;
+use std::path::{Component, Path, PathBuf};
+
+use super::manifest::{PluginExtensions, PluginManifest, PluginPermission};
+
+/// A plugin may auto-restart at most this many times after a crash before it is
+/// auto-disabled (concept "Error recovery": "up to 3 times, then auto-disabled").
+pub const MAX_RESTART_ATTEMPTS: u32 = 3;
+
+/// A permission or path-scope enforcement failure.
+///
+/// Every variant represents *graceful degradation*, not a host crash: the plugin
+/// is refused the operation (and typically marked errored/disabled), while the
+/// host continues normally.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum PermissionError {
+    /// The plugin did not request the permission the operation requires.
+    #[error("plugin does not hold the `{0:?}` permission")]
+    Denied(PluginPermission),
+
+    /// A filesystem path lies outside every root the plugin declared.
+    #[error("path `{path}` is outside the plugin's declared filesystem scope")]
+    PathOutsideScope {
+        /// The offending path (as requested, before normalization).
+        path: PathBuf,
+    },
+
+    /// The plugin requested the `filesystem` permission but declared no paths to
+    /// scope it to — access is confined to declared paths, so a plugin with none
+    /// can access nothing and the declaration is a mistake worth surfacing.
+    #[error("plugin requests the `filesystem` permission but declares no paths")]
+    FilesystemWithoutPaths,
+
+    /// The plugin declared filesystem paths but did not request the `filesystem`
+    /// permission, so those paths would never be honoured.
+    #[error("plugin declares filesystem paths but did not request the `filesystem` permission")]
+    PathsWithoutFilesystem,
+
+    /// The plugin provides a terminal backend but did not request the `terminal`
+    /// permission it needs to create sessions.
+    #[error("plugin provides a terminal backend but did not request the `terminal` permission")]
+    TerminalWithoutPermission,
+}
+
+/// The set of permissions a plugin holds, plus its filesystem scope.
+///
+/// Built once from a validated [`PluginManifest`] and consulted at every gated
+/// call site. Cloneable so a loaded session can carry its own copy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PermissionSet {
+    granted: BTreeSet<PluginPermission>,
+    filesystem: FilesystemScope,
+}
+
+impl PermissionSet {
+    /// Derive the permission set from a plugin's manifest.
+    #[must_use]
+    pub fn from_manifest(manifest: &PluginManifest) -> Self {
+        Self::from_parts(
+            manifest.permissions.iter().copied(),
+            &manifest.filesystem_paths,
+        )
+    }
+
+    /// Build a permission set from explicit granted permissions and declared
+    /// filesystem paths — the manifest-free constructor used by host wiring and
+    /// tests. The filesystem scope is granted iff
+    /// [`Filesystem`](PluginPermission::Filesystem) is among `permissions`.
+    #[must_use]
+    pub fn from_parts(
+        permissions: impl IntoIterator<Item = PluginPermission>,
+        filesystem_paths: &[String],
+    ) -> Self {
+        let granted: BTreeSet<PluginPermission> = permissions.into_iter().collect();
+        let filesystem = FilesystemScope::new(
+            granted.contains(&PluginPermission::Filesystem),
+            filesystem_paths,
+        );
+        Self {
+            granted,
+            filesystem,
+        }
+    }
+
+    /// Whether the plugin holds `permission`.
+    #[must_use]
+    pub fn grants(&self, permission: PluginPermission) -> bool {
+        self.granted.contains(&permission)
+    }
+
+    /// Require that the plugin holds `permission`, or fail with
+    /// [`PermissionError::Denied`]. This is the gate a host-mediated capability
+    /// (network, settings, …) checks before acting on the plugin's behalf.
+    pub fn require(&self, permission: PluginPermission) -> Result<(), PermissionError> {
+        if self.grants(permission) {
+            Ok(())
+        } else {
+            Err(PermissionError::Denied(permission))
+        }
+    }
+
+    /// The plugin's filesystem scope (the roots access is confined to).
+    #[must_use]
+    pub fn filesystem(&self) -> &FilesystemScope {
+        &self.filesystem
+    }
+
+    /// Resolve and authorize a plugin-supplied filesystem path against the
+    /// plugin's declared scope. Convenience for `self.filesystem().check(path)`.
+    pub fn check_path(&self, requested: &Path) -> Result<PathBuf, PermissionError> {
+        self.filesystem.check(requested)
+    }
+
+    /// Validate that the plugin's declared permissions are consistent with the
+    /// extensions it provides, before it is loaded.
+    ///
+    /// A terminal backend needs the `terminal` permission; the `filesystem`
+    /// permission needs at least one declared path (and declared paths need the
+    /// permission). Catching these at load turns a would-be silent runtime denial
+    /// into an actionable [`PluginState::Error`](super::PluginState).
+    pub fn check_consistency(&self, extensions: &PluginExtensions) -> Result<(), PermissionError> {
+        if extensions.terminal_backend.is_some() && !self.grants(PluginPermission::Terminal) {
+            return Err(PermissionError::TerminalWithoutPermission);
+        }
+        let has_fs_perm = self.grants(PluginPermission::Filesystem);
+        let has_paths = !self.filesystem.roots.is_empty();
+        if has_fs_perm && !has_paths {
+            return Err(PermissionError::FilesystemWithoutPaths);
+        }
+        if has_paths && !has_fs_perm {
+            return Err(PermissionError::PathsWithoutFilesystem);
+        }
+        Ok(())
+    }
+}
+
+/// The filesystem paths a plugin is confined to (concept §13: "Plugins
+/// requesting `filesystem` permission must declare which paths they need. The
+/// Plugin Manager enforces path restrictions.").
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilesystemScope {
+    /// Whether the plugin holds the `filesystem` permission at all.
+    granted: bool,
+    /// Normalized, allowed root paths. Access is confined to these subtrees.
+    roots: Vec<PathBuf>,
+}
+
+impl FilesystemScope {
+    /// Build a scope from the `filesystem` permission flag and declared paths.
+    /// Paths are lexically normalized so scope checks do not depend on the
+    /// filesystem's current state.
+    fn new(granted: bool, declared: &[String]) -> Self {
+        let roots = declared
+            .iter()
+            .map(|p| normalize_lexical(Path::new(p)))
+            .collect();
+        Self { granted, roots }
+    }
+
+    /// Whether the plugin holds the `filesystem` permission.
+    #[must_use]
+    pub fn is_granted(&self) -> bool {
+        self.granted
+    }
+
+    /// The normalized roots this scope permits.
+    #[must_use]
+    pub fn roots(&self) -> &[PathBuf] {
+        &self.roots
+    }
+
+    /// Authorize access to `requested`, returning the normalized path on success.
+    ///
+    /// Fails with [`PermissionError::Denied`] if the plugin lacks the
+    /// `filesystem` permission, or [`PermissionError::PathOutsideScope`] if the
+    /// (lexically normalized) path is not contained in any declared root. `..`
+    /// components are collapsed before the containment check, so traversal that
+    /// escapes a root is rejected.
+    pub fn check(&self, requested: &Path) -> Result<PathBuf, PermissionError> {
+        if !self.granted {
+            return Err(PermissionError::Denied(PluginPermission::Filesystem));
+        }
+        let normalized = normalize_lexical(requested);
+        for root in &self.roots {
+            if normalized == *root || normalized.starts_with(root) {
+                return Ok(normalized);
+            }
+        }
+        Err(PermissionError::PathOutsideScope {
+            path: requested.to_path_buf(),
+        })
+    }
+}
+
+/// Lexically normalize a path — collapse `.` and `..` and redundant separators
+/// **without** touching the filesystem (no symlink resolution).
+///
+/// `..` pops the preceding normal component; at the root (or the start of a
+/// relative path) it is dropped rather than escaping upward, so the result can
+/// never rise above its own anchor. This is what makes it sound to compare the
+/// result against a scope root with [`Path::starts_with`].
+fn normalize_lexical(path: &Path) -> PathBuf {
+    let mut out: Vec<Component> = Vec::new();
+    for comp in path.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => match out.last() {
+                Some(Component::Normal(_)) => {
+                    out.pop();
+                }
+                // At a root or an empty relative path, `..` cannot escape upward.
+                Some(Component::RootDir) | Some(Component::Prefix(_)) | None => {}
+                // Preserve a leading run of `..` in a relative path.
+                Some(Component::ParentDir) => out.push(Component::ParentDir),
+                Some(Component::CurDir) => unreachable!("CurDir is never pushed"),
+            },
+            other => out.push(other),
+        }
+    }
+    out.iter().map(|c| c.as_os_str()).collect()
+}
+
+/// How much a plugin package is trusted at install time.
+///
+/// Only one variant exists today: termiHub has **no** plugin-signing substrate,
+/// so every package is [`Untrusted`](TrustLevel::Untrusted). A future
+/// `Signed`/`Verified` variant would carry a cryptographically-checked identity;
+/// this enum names the axis so callers can branch on it without pretending
+/// verification happens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustLevel {
+    /// The package's origin cannot be verified — no signature was checked (and no
+    /// signing infrastructure exists). The user must accept the risk to install.
+    Untrusted,
+}
+
+/// The outcome of assessing a package's trust at install time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustAssessment {
+    /// The assessed trust level (always [`TrustLevel::Untrusted`] today).
+    pub level: TrustLevel,
+    /// A user-facing warning to surface before extraction.
+    pub warning: String,
+}
+
+impl TrustAssessment {
+    /// Whether installing this package requires the user to accept an
+    /// untrusted-source risk.
+    #[must_use]
+    pub fn requires_acceptance(&self) -> bool {
+        matches!(self.level, TrustLevel::Untrusted)
+    }
+}
+
+/// Assess how much a `.termihub-plugin` package can be trusted.
+///
+/// Always reports [`TrustLevel::Untrusted`]: no signature is (or can currently
+/// be) verified. The returned warning is what the install gate shows the user
+/// before extraction. Deliberately does not open the package — trust is a
+/// property of provenance, and no provenance is verifiable today.
+#[must_use]
+pub fn assess_trust(_package_path: &Path) -> TrustAssessment {
+    TrustAssessment {
+        level: TrustLevel::Untrusted,
+        warning: "This plugin comes from an unverified source. termiHub cannot check who \
+                  built it, and a native plugin runs with the same privileges as the app. \
+                  Only install plugins you trust."
+            .to_owned(),
+    }
+}
+
+/// The lifecycle state in the plugin error-recovery machine (concept "Error
+/// recovery state machine").
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryState {
+    /// Running normally.
+    Healthy,
+    /// A crash occurred and `attempts` auto-restarts have been made so far.
+    Recovering {
+        /// Number of restarts attempted since the last healthy state.
+        attempts: u32,
+    },
+    /// The restart budget was exhausted; the plugin is auto-disabled and will not
+    /// be retried until the user re-enables it.
+    Disabled,
+}
+
+/// What the host should do in response to a recorded plugin failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryAction {
+    /// Attempt to reload the plugin (restart budget not yet exhausted).
+    Restart,
+    /// Give up and auto-disable the plugin (budget exhausted).
+    Disable,
+}
+
+/// Bounded restart-then-disable counter for one plugin.
+///
+/// Implements the concept's recovery policy: a crashing plugin is auto-restarted
+/// up to [`MAX_RESTART_ATTEMPTS`] times; the failure that would exceed the budget
+/// auto-disables it instead. A successful run resets the counter.
+#[derive(Debug, Clone)]
+pub struct RestartTracker {
+    state: RecoveryState,
+    max_attempts: u32,
+}
+
+impl Default for RestartTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RestartTracker {
+    /// A fresh tracker in the [`Healthy`](RecoveryState::Healthy) state with the
+    /// default budget of [`MAX_RESTART_ATTEMPTS`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_max(MAX_RESTART_ATTEMPTS)
+    }
+
+    /// A tracker with a custom restart budget (used in tests).
+    #[must_use]
+    pub fn with_max(max_attempts: u32) -> Self {
+        Self {
+            state: RecoveryState::Healthy,
+            max_attempts,
+        }
+    }
+
+    /// The current recovery state.
+    #[must_use]
+    pub fn state(&self) -> RecoveryState {
+        self.state
+    }
+
+    /// Whether the plugin has been auto-disabled.
+    #[must_use]
+    pub fn is_disabled(&self) -> bool {
+        matches!(self.state, RecoveryState::Disabled)
+    }
+
+    /// Record a plugin failure and decide what to do.
+    ///
+    /// Increments the restart count; while it stays within the budget the caller
+    /// should [`Restart`](RecoveryAction::Restart), and the tracker moves to
+    /// [`Recovering`](RecoveryState::Recovering). The failure that would exceed
+    /// the budget returns [`Disable`](RecoveryAction::Disable) and latches the
+    /// tracker in [`Disabled`](RecoveryState::Disabled); every subsequent failure
+    /// also returns `Disable` until [`record_success`](Self::record_success) or a
+    /// reset.
+    pub fn record_failure(&mut self) -> RecoveryAction {
+        let attempts = match self.state {
+            RecoveryState::Disabled => return RecoveryAction::Disable,
+            RecoveryState::Healthy => 0,
+            RecoveryState::Recovering { attempts } => attempts,
+        };
+        let next = attempts + 1;
+        if next > self.max_attempts {
+            self.state = RecoveryState::Disabled;
+            RecoveryAction::Disable
+        } else {
+            self.state = RecoveryState::Recovering { attempts: next };
+            RecoveryAction::Restart
+        }
+    }
+
+    /// Record that the plugin is running healthily again, resetting the counter.
+    pub fn record_success(&mut self) {
+        self.state = RecoveryState::Healthy;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::manifest::parse_manifest;
+
+    fn manifest_with(permissions: &str, filesystem_paths: &str) -> PluginManifest {
+        let fs_line = if filesystem_paths.is_empty() {
+            String::new()
+        } else {
+            format!("\"filesystemPaths\": {filesystem_paths},")
+        };
+        let json = format!(
+            r#"{{
+                "id": "sec-test",
+                "name": "Sec Test",
+                "version": "1.0.0",
+                "author": "tester",
+                "description": "security test plugin",
+                "license": "MIT",
+                "apiVersion": "1.0",
+                "platforms": ["linux", "macos", "windows"],
+                "permissions": {permissions},
+                {fs_line}
+                "extensions": {{
+                    "terminalBackend": {{
+                        "connectionType": "sec",
+                        "displayName": "Sec",
+                        "configSchema": {{}}
+                    }}
+                }}
+            }}"#
+        );
+        parse_manifest(&json).expect("manifest should parse")
+    }
+
+    #[test]
+    fn grants_and_require_reflect_declared_permissions() {
+        let m = manifest_with(r#"["terminal", "network"]"#, "");
+        let perms = PermissionSet::from_manifest(&m);
+        assert!(perms.grants(PluginPermission::Terminal));
+        assert!(perms.grants(PluginPermission::Network));
+        assert!(!perms.grants(PluginPermission::Filesystem));
+
+        assert!(perms.require(PluginPermission::Network).is_ok());
+        // A backend plugin without `network` is denied the network capability.
+        let no_net = PermissionSet::from_manifest(&manifest_with(r#"["terminal"]"#, ""));
+        assert_eq!(
+            no_net.require(PluginPermission::Network),
+            Err(PermissionError::Denied(PluginPermission::Network))
+        );
+    }
+
+    #[test]
+    fn consistency_requires_terminal_permission_for_backend() {
+        // Terminal backend but no `terminal` permission → rejected.
+        let m = manifest_with(r#"["network"]"#, "");
+        let perms = PermissionSet::from_manifest(&m);
+        assert_eq!(
+            perms.check_consistency(&m.extensions),
+            Err(PermissionError::TerminalWithoutPermission)
+        );
+
+        // With the permission it is consistent.
+        let ok = manifest_with(r#"["terminal"]"#, "");
+        assert!(PermissionSet::from_manifest(&ok)
+            .check_consistency(&ok.extensions)
+            .is_ok());
+    }
+
+    #[test]
+    fn consistency_ties_filesystem_permission_and_paths() {
+        // filesystem permission but no declared paths → rejected.
+        let no_paths = manifest_with(r#"["terminal", "filesystem"]"#, "");
+        assert_eq!(
+            PermissionSet::from_manifest(&no_paths).check_consistency(&no_paths.extensions),
+            Err(PermissionError::FilesystemWithoutPaths)
+        );
+
+        // declared paths but no filesystem permission → rejected.
+        let no_perm = manifest_with(r#"["terminal"]"#, r#"["/data"]"#);
+        assert_eq!(
+            PermissionSet::from_manifest(&no_perm).check_consistency(&no_perm.extensions),
+            Err(PermissionError::PathsWithoutFilesystem)
+        );
+
+        // both present → consistent.
+        let ok = manifest_with(r#"["terminal", "filesystem"]"#, r#"["/data"]"#);
+        assert!(PermissionSet::from_manifest(&ok)
+            .check_consistency(&ok.extensions)
+            .is_ok());
+    }
+
+    #[test]
+    fn filesystem_scope_denies_without_permission() {
+        let m = manifest_with(r#"["terminal"]"#, "");
+        let perms = PermissionSet::from_manifest(&m);
+        assert_eq!(
+            perms.check_path(Path::new("/anything")),
+            Err(PermissionError::Denied(PluginPermission::Filesystem))
+        );
+    }
+
+    #[test]
+    fn filesystem_scope_allows_declared_paths_only() {
+        let m = manifest_with(
+            r#"["terminal", "filesystem"]"#,
+            r#"["/data/plugin", "/var/log/app"]"#,
+        );
+        let perms = PermissionSet::from_manifest(&m);
+
+        // Inside a declared root (the root itself and a descendant).
+        assert_eq!(
+            perms.check_path(Path::new("/data/plugin")).unwrap(),
+            PathBuf::from("/data/plugin")
+        );
+        assert_eq!(
+            perms
+                .check_path(Path::new("/data/plugin/sub/file.txt"))
+                .unwrap(),
+            PathBuf::from("/data/plugin/sub/file.txt")
+        );
+        assert!(perms.check_path(Path::new("/var/log/app/x.log")).is_ok());
+
+        // Outside every declared root.
+        assert!(matches!(
+            perms.check_path(Path::new("/etc/passwd")),
+            Err(PermissionError::PathOutsideScope { .. })
+        ));
+        // A sibling that merely shares a prefix string is not contained.
+        assert!(matches!(
+            perms.check_path(Path::new("/data/plugin-evil/secret")),
+            Err(PermissionError::PathOutsideScope { .. })
+        ));
+    }
+
+    #[test]
+    fn filesystem_scope_rejects_traversal_escape() {
+        let m = manifest_with(r#"["terminal", "filesystem"]"#, r#"["/data/plugin"]"#);
+        let perms = PermissionSet::from_manifest(&m);
+
+        // `..` that climbs out of the declared root is rejected.
+        for escape in [
+            "/data/plugin/../../etc/passwd",
+            "/data/plugin/../plugin-evil/x",
+            "/data/../etc/shadow",
+        ] {
+            assert!(
+                matches!(
+                    perms.check_path(Path::new(escape)),
+                    Err(PermissionError::PathOutsideScope { .. })
+                ),
+                "traversal {escape:?} should be rejected"
+            );
+        }
+
+        // `..` that stays inside the root is fine and is normalized away.
+        assert_eq!(
+            perms
+                .check_path(Path::new("/data/plugin/sub/../file.txt"))
+                .unwrap(),
+            PathBuf::from("/data/plugin/file.txt")
+        );
+    }
+
+    #[test]
+    fn normalize_lexical_cannot_escape_root() {
+        // A pile of `..` at the root collapses to the root, never above it.
+        assert_eq!(
+            normalize_lexical(Path::new("/../../../etc")),
+            PathBuf::from("/etc")
+        );
+    }
+
+    #[test]
+    fn assess_trust_is_always_untrusted() {
+        let a = assess_trust(Path::new("/tmp/whatever.termihub-plugin"));
+        assert_eq!(a.level, TrustLevel::Untrusted);
+        assert!(a.requires_acceptance());
+        assert!(!a.warning.is_empty());
+    }
+
+    #[test]
+    fn restart_tracker_restarts_up_to_max_then_disables() {
+        let mut t = RestartTracker::new();
+        assert_eq!(t.state(), RecoveryState::Healthy);
+
+        // Three failures each ask for a restart.
+        for attempt in 1..=MAX_RESTART_ATTEMPTS {
+            assert_eq!(t.record_failure(), RecoveryAction::Restart);
+            assert_eq!(t.state(), RecoveryState::Recovering { attempts: attempt });
+        }
+        // The fourth failure exceeds the budget → auto-disable, and it latches.
+        assert_eq!(t.record_failure(), RecoveryAction::Disable);
+        assert!(t.is_disabled());
+        assert_eq!(t.record_failure(), RecoveryAction::Disable);
+    }
+
+    #[test]
+    fn restart_tracker_success_resets_the_counter() {
+        let mut t = RestartTracker::with_max(2);
+        assert_eq!(t.record_failure(), RecoveryAction::Restart);
+        assert_eq!(t.record_failure(), RecoveryAction::Restart);
+        // A healthy run resets, so the budget is available again.
+        t.record_success();
+        assert_eq!(t.state(), RecoveryState::Healthy);
+        assert_eq!(t.record_failure(), RecoveryAction::Restart);
+        assert_eq!(t.record_failure(), RecoveryAction::Restart);
+        assert_eq!(t.record_failure(), RecoveryAction::Disable);
+    }
+}

--- a/core/tests/plugin_host_roundtrip.rs
+++ b/core/tests/plugin_host_roundtrip.rs
@@ -87,6 +87,10 @@ async fn plugin_host_round_trip() {
         std::sync::Arc::clone(&lib),
         "test-echo".to_string(),
         "Test Echo".to_string(),
+        termihub_core::plugin::PermissionSet::from_parts(
+            [termihub_core::plugin::PluginPermission::Terminal],
+            &[],
+        ),
     );
     let mut rx = conn.subscribe_output();
     conn.connect(serde_json::json!({ "foo": "bar" }))

--- a/docs/changes/dev3/feature/2001-plugin-security.md
+++ b/docs/changes/dev3/feature/2001-plugin-security.md
@@ -1,0 +1,22 @@
+### Added
+
+- Plugin security hardening (concept §13, "Security and polish"): the plugin
+  host now enforces a plugin's declared permissions and recovers from
+  misbehaving plugins.
+  - **Permission enforcement**: a plugin whose extensions need a capability it
+    did not request is refused at load with a clear error rather than loaded —
+    a terminal backend without the `terminal` permission, or the `filesystem`
+    permission without declared paths, is rejected (graceful degradation, not a
+    crash).
+  - **Path-scoped filesystem access**: plugins declare a `filesystemPaths` list
+    in their manifest and the host confines filesystem access to those roots,
+    rejecting paths outside them and any `..` traversal that escapes a root.
+  - **Untrusted-source install gate**: every package is treated as unsigned, so
+    the install dialog shows an "untrusted source" warning the user must accept
+    before extraction. (Cryptographic signature verification remains future
+    work — termiHub has no signing substrate, so no plugin is claimed to be
+    "signed" or "verified".)
+  - **Error recovery**: a crashing plugin is auto-restarted up to 3 times and
+    then auto-disabled; plugin FFI entry points are called under panic guards so
+    a panicking plugin can never abort the host. Plugins made incompatible by an
+    app plugin-API bump are auto-disabled on startup with a notification.

--- a/src-tauri/src/commands/plugin.rs
+++ b/src-tauri/src/commands/plugin.rs
@@ -47,14 +47,20 @@ pub fn validate_plugin(
 
 /// Install a plugin from the `.termihub-plugin` package at `path`. Emits
 /// [`EVENT_PLUGINS_CHANGED`] on success.
+///
+/// Every package is from an unverified source (termiHub has no plugin-signing
+/// substrate), so the install dialog shows an untrusted-source warning and the
+/// user's confirmation is passed as `accept_untrusted`. Without it the manager
+/// refuses the install before extracting anything.
 #[tauri::command]
 pub fn install_plugin(
     path: String,
+    accept_untrusted: bool,
     app: AppHandle,
     manager: State<'_, PluginManager>,
 ) -> Result<InstalledPlugin, String> {
     let installed = manager
-        .install(std::path::Path::new(&path))
+        .install(std::path::Path::new(&path), accept_untrusted)
         .map_err(|e| e.to_string())?;
     emit_changed(&app);
     Ok(installed)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -397,6 +397,21 @@ pub fn run() {
             ));
             app.manage(plugin_host);
 
+            // Security: if a host upgrade made any installed plugin's API version
+            // incompatible, auto-disable it so it never loads, and notify the UI
+            // (concept §13, "App update changes the plugin API version →
+            // incompatible plugins are auto-disabled with a notification").
+            if let Some(plugin_mgr) = app.try_state::<termihub_core::plugin::PluginManager>() {
+                match plugin_mgr.reconcile_compatibility() {
+                    Ok(disabled) if !disabled.is_empty() => {
+                        warn!("auto-disabled now-incompatible plugins: {disabled:?}");
+                        let _ = app.emit(commands::plugin::EVENT_PLUGINS_CHANGED, ());
+                    }
+                    Ok(_) => {}
+                    Err(e) => warn!("plugin compatibility reconciliation failed: {e}"),
+                }
+            }
+
             // Capture path for the connections file watcher before config_dir is moved.
             let connections_file = config_dir.join("connections.json");
 

--- a/src/components/Plugins/PluginInstallDialog.test.tsx
+++ b/src/components/Plugins/PluginInstallDialog.test.tsx
@@ -79,6 +79,13 @@ describe("PluginInstallDialog (#1997)", () => {
     expect(document.querySelector('[data-testid="plugin-install-no-perms"]')).not.toBeNull();
   });
 
+  it("always warns that the source is untrusted", () => {
+    render(manifest());
+    const warning = document.querySelector('[data-testid="plugin-install-untrusted-warning"]');
+    expect(warning).not.toBeNull();
+    expect(warning!.textContent ?? "").toContain("Untrusted source");
+  });
+
   it("installs then enables on confirm, selects the plugin, and closes", async () => {
     const installPlugin = vi.fn(() => Promise.resolve());
     const enablePlugin = vi.fn(() => Promise.resolve());
@@ -96,7 +103,8 @@ describe("PluginInstallDialog (#1997)", () => {
       await Promise.resolve();
     });
 
-    expect(installPlugin).toHaveBeenCalledWith("/tmp/k8s-exec-1.2.0.termihub-plugin");
+    // Confirming implies accepting the untrusted-source risk shown in the dialog.
+    expect(installPlugin).toHaveBeenCalledWith("/tmp/k8s-exec-1.2.0.termihub-plugin", true);
     expect(enablePlugin).toHaveBeenCalledWith("k8s");
     expect(selectPlugin).toHaveBeenCalledWith("k8s");
     expect(onClose).toHaveBeenCalled();

--- a/src/components/Plugins/PluginInstallDialog.tsx
+++ b/src/components/Plugins/PluginInstallDialog.tsx
@@ -78,9 +78,9 @@ export function PluginInstallDialog({ filePath, manifest, onClose }: PluginInsta
       <div className="plugin-install__warning" data-testid="plugin-install-untrusted-warning">
         <ShieldAlert className="plugin-install__warning-icon" aria-hidden="true" />
         <div>
-          <span className="plugin-install__warning-title">Untrusted source.</span>{" "}
-          termiHub cannot verify who built this plugin — it is not signature-checked, and a native
-          plugin runs with the same access as the app. Only install plugins you trust.
+          <span className="plugin-install__warning-title">Untrusted source.</span> termiHub cannot
+          verify who built this plugin — it is not signature-checked, and a native plugin runs with
+          the same access as the app. Only install plugins you trust.
         </div>
       </div>
 

--- a/src/components/Plugins/PluginInstallDialog.tsx
+++ b/src/components/Plugins/PluginInstallDialog.tsx
@@ -41,8 +41,10 @@ export function PluginInstallDialog({ filePath, manifest, onClose }: PluginInsta
   const handleInstall = async () => {
     // installPlugin / enablePlugin own their own pending → success/error toasts
     // and re-throw on failure, so the async Button keeps the dialog open (and
-    // shows the error) when either step fails.
-    await installPlugin(filePath);
+    // shows the error) when either step fails. Clicking "Install & Enable" is the
+    // user accepting the untrusted-source risk shown below, so `acceptUntrusted`
+    // is passed as `true` (no plugin is signature-verified today).
+    await installPlugin(filePath, true);
     await enablePlugin(manifest.id);
     selectPlugin(manifest.id);
     onClose();
@@ -73,6 +75,15 @@ export function PluginInstallDialog({ filePath, manifest, onClose }: PluginInsta
         </>
       }
     >
+      <div className="plugin-install__warning" data-testid="plugin-install-untrusted-warning">
+        <ShieldAlert className="plugin-install__warning-icon" aria-hidden="true" />
+        <div>
+          <span className="plugin-install__warning-title">Untrusted source.</span>{" "}
+          termiHub cannot verify who built this plugin — it is not signature-checked, and a native
+          plugin runs with the same access as the app. Only install plugins you trust.
+        </div>
+      </div>
+
       <div className="plugin-install__meta">
         <div className="plugin-install__row">
           <span className="plugin-install__label">File</span>

--- a/src/components/Plugins/Plugins.css
+++ b/src/components/Plugins/Plugins.css
@@ -310,6 +310,31 @@
 }
 
 /* ── Install dialog ───────────────────────────────────────────────────── */
+.plugin-install__warning {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  margin-bottom: 12px;
+  border: 1px solid var(--color-warning);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--color-warning) 12%, transparent);
+  font-size: 12.5px;
+  line-height: 1.4;
+}
+
+.plugin-install__warning-icon {
+  width: 16px;
+  height: 16px;
+  color: var(--color-warning);
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+
+.plugin-install__warning-title {
+  font-weight: 600;
+}
+
 .plugin-install__meta {
   display: flex;
   flex-direction: column;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2380,7 +2380,7 @@ export async function validatePlugin(filePath: string): Promise<PluginManifest> 
  */
 export async function installPlugin(
   filePath: string,
-  acceptUntrusted: boolean,
+  acceptUntrusted: boolean
 ): Promise<InstalledPlugin> {
   return await invoke<InstalledPlugin>("install_plugin", { filePath, acceptUntrusted });
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2369,9 +2369,20 @@ export async function validatePlugin(filePath: string): Promise<PluginManifest> 
   return await invoke<PluginManifest>("validate_plugin", { filePath });
 }
 
-/** Install a `.termihub-plugin` package from `filePath`, returning the installed record. */
-export async function installPlugin(filePath: string): Promise<InstalledPlugin> {
-  return await invoke<InstalledPlugin>("install_plugin", { filePath });
+/**
+ * Install a `.termihub-plugin` package from `filePath`, returning the installed
+ * record.
+ *
+ * Every package is from an unverified source (termiHub has no plugin-signing
+ * infrastructure), so `acceptUntrusted` records that the user saw the
+ * untrusted-source warning and accepted the risk. The backend refuses the
+ * install if it is not `true`.
+ */
+export async function installPlugin(
+  filePath: string,
+  acceptUntrusted: boolean,
+): Promise<InstalledPlugin> {
+  return await invoke<InstalledPlugin>("install_plugin", { filePath, acceptUntrusted });
 }
 
 /** Uninstall the plugin with the given id. */

--- a/src/store/appStore.plugins.test.ts
+++ b/src/store/appStore.plugins.test.ts
@@ -149,9 +149,9 @@ describe("appStore — plugins (#1993)", () => {
     vi.mocked(apiInstallPlugin).mockResolvedValueOnce(installed);
     vi.mocked(apiListPlugins).mockResolvedValueOnce([installed]);
 
-    await useAppStore.getState().installPlugin("/tmp/new-plugin.termihub-plugin");
+    await useAppStore.getState().installPlugin("/tmp/new-plugin.termihub-plugin", true);
 
-    expect(apiInstallPlugin).toHaveBeenCalledWith("/tmp/new-plugin.termihub-plugin");
+    expect(apiInstallPlugin).toHaveBeenCalledWith("/tmp/new-plugin.termihub-plugin", true);
     expect(toastLoading).toHaveBeenCalledTimes(1);
     expect(toastSuccess).toHaveBeenCalledWith("Installed Plugin new-plugin", { id: "toast-id" });
     expect(useAppStore.getState().plugins).toHaveLength(1);
@@ -160,9 +160,9 @@ describe("appStore — plugins (#1993)", () => {
   it("installPlugin toasts an error and rethrows on failure", async () => {
     vi.mocked(apiInstallPlugin).mockRejectedValueOnce(new Error("bad package"));
 
-    await expect(useAppStore.getState().installPlugin("/tmp/bad.termihub-plugin")).rejects.toThrow(
-      "bad package"
-    );
+    await expect(
+      useAppStore.getState().installPlugin("/tmp/bad.termihub-plugin", true)
+    ).rejects.toThrow("bad package");
 
     expect(toastError).toHaveBeenCalledWith("Failed to install plugin: bad package", {
       id: "toast-id",

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1491,7 +1491,7 @@ interface AppState {
    * Install a `.termihub-plugin` package from `filePath`, then refresh the list.
    * Surfaces a pending → success/error toast; rejects on failure.
    */
-  installPlugin: (filePath: string) => Promise<void>;
+  installPlugin: (filePath: string, acceptUntrusted: boolean) => Promise<void>;
   /** Uninstall a plugin by id, then refresh the list. Toasts feedback; rejects on failure. */
   uninstallPlugin: (pluginId: string) => Promise<void>;
   /** Enable (activate) a plugin by id, then refresh the list. Toasts feedback; rejects on failure. */
@@ -7481,10 +7481,10 @@ export const useAppStore = create<AppState>((set, get) => {
       }
     },
 
-    installPlugin: async (filePath) => {
+    installPlugin: async (filePath, acceptUntrusted) => {
       const toastId = toast.loading("Installing plugin…");
       try {
-        const installed = await apiInstallPlugin(filePath);
+        const installed = await apiInstallPlugin(filePath, acceptUntrusted);
         await get().loadPlugins();
         toast.success(`Installed ${installed.manifest.name}`, { id: toastId });
       } catch (err) {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -143,6 +143,12 @@ export interface PluginManifest {
   platforms: PluginPlatform[];
   /** Coarse-grained permissions the plugin requests. */
   permissions: PluginPermission[];
+  /**
+   * Filesystem paths the plugin is scoped to. Only meaningful with the
+   * `filesystem` permission — the host confines the plugin's filesystem access
+   * to these roots. Absent/empty when the plugin requests no filesystem access.
+   */
+  filesystemPaths?: string[];
   /** The extension points the plugin provides. */
   extensions: PluginExtensions;
   /** Optional user-configurable settings, keyed by setting name. */


### PR DESCRIPTION
## Summary

Hardens the plugin system per concept §13 ("Seventh PR — Security and polish"), building on the merged manifest (#1989), manager (#1992), and native host loader (#1995).

Closes #2001

### What is enforced

- **Permission model (graceful degradation, not a crash)** — a new `PermissionSet` derived from the manifest. `PluginHost::load` refuses a plugin whose declared extensions need a capability it did not request: a terminal backend without the `terminal` permission, or the `filesystem` permission without declared paths. The refusal surfaces as `PluginState::Error`; the host continues. Each loaded session carries its permission scope on `PluginConnectionType` (`require_permission` / `resolve_scoped_path`) as the guard a host-mediated capability enforces.
- **Path-scoped filesystem access** — plugins declare a `filesystemPaths` list in the manifest; `FilesystemScope::check` confines access to those roots, lexically normalizing the path and rejecting anything outside a root, including `..` traversal that escapes it.
- **Untrusted-source install gate** — every package is treated as unsigned. `PluginManager::install` requires an explicit `accept_untrusted` flag and refuses (before extraction) without it. The install dialog shows an "untrusted source" warning; confirming is the acceptance.
- **Error recovery** — `RestartTracker` implements auto-restart up to 3 times then auto-disable (`PluginHost::note_failure`). Plugin FFI entry points (`abi_version` / `init` / `create_backend`) run under `catch_unwind` so a panicking plugin can never unwind across FFI and abort the host. `reconcile_compatibility` auto-disables plugins made incompatible by a plugin-API bump on startup and notifies the UI.

### Explicitly out of scope

**Cryptographic signature verification.** termiHub has no signing substrate (keys, format, verification chain). `TrustLevel` has only an `Untrusted` variant and the code never claims a plugin is "signed"/"verified" — signing is documented as future work (see follow-up).

### Tests

- `core/src/plugin/security.rs`: permission grant/deny, load-time consistency, path-scope allow/deny + traversal-escape rejection, untrusted-source assessment, restart-then-disable counter (+ reset).
- `core/src/plugin/host.rs`: load refused for terminal-without-permission and filesystem-without-paths; `note_failure` restart→disable→latch→clear.
- `core/src/plugin/manager.rs`: install refused without acceptance / succeeds with it; `reconcile_compatibility` disables incompatible + idempotent, leaves compatible enabled.
- Frontend: install dialog always warns untrusted; confirm passes `acceptUntrusted = true`; store/api arg threading.

## Test plan

- [x] `cargo test -p termihub-core --features plugin` (plugin module)
- [x] `cargo clippy` (core + termihub) and `cargo fmt --check`
- [x] `cargo check -p termihub`
- [x] `pnpm exec tsc --noEmit`, `pnpm exec vitest run src/components/Plugins src/store/appStore.plugins.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)