### PR TITLE
feat(plugin): frontend js plugins — protocol parsers + status-bar widgets (Closes #1998)

### DIFF
--- a/docs/changes/dev1/feature/1998-frontend-js-plugins.md
+++ b/docs/changes/dev1/feature/1998-frontend-js-plugins.md
@@ -1,0 +1,14 @@
+### Added
+
+- Frontend JavaScript plugins: an enabled plugin's JS entry point is now loaded
+  into the app and can register two kinds of frontend extension through a new
+  `window.termihub` API — **protocol parsers** that transform or annotate
+  terminal output (`transform(data, sessionId)`, returning `null` to pass a
+  chunk through unchanged, with optional `onSessionStart`/`onSessionEnd` hooks)
+  and **status-bar widgets** rendered into the left/right status-bar slots
+  (`render()`/`dispose()`). Registered parsers run over every terminal output
+  chunk before it reaches the screen; registered widgets mount into the status
+  bar and are disposed cleanly when the plugin is disabled. Errors thrown by
+  plugin code are caught and isolated so one bad plugin cannot break terminal
+  rendering or the status bar. Frontend plugins share the WebView context (weak
+  isolation, per the plugin-system concept). (#1998)

--- a/src/components/StatusBar/PluginStatusBarWidgets.test.tsx
+++ b/src/components/StatusBar/PluginStatusBarWidgets.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Tests for the plugin status-bar widget host (#1998): a registered widget's
+ * `render()` DOM mounts into the correct side, disabling the plugin unmounts it
+ * and calls `dispose()` exactly once, and a widget whose `render()` throws is
+ * isolated without breaking the status bar.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { PluginStatusBarWidgets } from "./PluginStatusBarWidgets";
+import {
+  ensureTermiHubApi,
+  setLoadingPlugin,
+  unregisterPlugin,
+  clearRegistry,
+  type StatusBarWidget,
+} from "@/plugins/pluginRuntime";
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+function registerWidgetAs(pluginId: string, widget: StatusBarWidget): void {
+  setLoadingPlugin(pluginId);
+  window.termihub.registerStatusBarWidget(widget);
+  setLoadingPlugin(null);
+}
+
+beforeEach(() => {
+  clearRegistry();
+  ensureTermiHubApi();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("PluginStatusBarWidgets", () => {
+  it("mounts a registered widget's DOM into the matching side", () => {
+    const el = document.createElement("span");
+    el.textContent = "42%";
+    el.setAttribute("data-plugin-el", "cpu");
+    registerWidgetAs("p", {
+      id: "cpu",
+      position: "left",
+      render: () => el,
+      dispose: () => {},
+    });
+
+    act(() => root.render(<PluginStatusBarWidgets position="left" />));
+
+    const host = container.querySelector('[data-testid="plugin-widget-cpu"]');
+    expect(host).not.toBeNull();
+    expect(host?.querySelector('[data-plugin-el="cpu"]')?.textContent).toBe("42%");
+  });
+
+  it("does not render a widget registered for the other side", () => {
+    registerWidgetAs("p", {
+      id: "cpu",
+      position: "right",
+      render: () => document.createElement("span"),
+      dispose: () => {},
+    });
+    act(() => root.render(<PluginStatusBarWidgets position="left" />));
+    expect(container.querySelector('[data-testid="plugin-widget-cpu"]')).toBeNull();
+  });
+
+  it("disposes the widget exactly once when its plugin is disabled", () => {
+    const dispose = vi.fn();
+    registerWidgetAs("p", {
+      id: "cpu",
+      position: "left",
+      render: () => document.createElement("span"),
+      dispose,
+    });
+    act(() => root.render(<PluginStatusBarWidgets position="left" />));
+    expect(container.querySelector('[data-testid="plugin-widget-cpu"]')).not.toBeNull();
+
+    // Disabling the plugin drops it from the registry; the host unmounts.
+    act(() => unregisterPlugin("p"));
+
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="plugin-widget-cpu"]')).toBeNull();
+  });
+
+  it("isolates a widget whose render() throws without breaking the bar", () => {
+    registerWidgetAs("bad", {
+      id: "bad",
+      position: "left",
+      render: () => {
+        throw new Error("boom");
+      },
+      dispose: () => {},
+    });
+    const good = document.createElement("span");
+    good.setAttribute("data-plugin-el", "good");
+    registerWidgetAs("good", {
+      id: "good",
+      position: "left",
+      render: () => good,
+      dispose: () => {},
+    });
+
+    expect(() => act(() => root.render(<PluginStatusBarWidgets position="left" />))).not.toThrow();
+
+    // The good widget still mounts alongside the broken one's (empty) host.
+    expect(container.querySelector('[data-plugin-el="good"]')).not.toBeNull();
+  });
+});

--- a/src/components/StatusBar/PluginStatusBarWidgets.tsx
+++ b/src/components/StatusBar/PluginStatusBarWidgets.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useSyncExternalStore } from "react";
+import {
+  getStatusBarWidgets,
+  subscribeStatusBarWidgets,
+  type StatusBarWidget,
+} from "@/plugins/pluginRuntime";
+import type { WidgetPosition } from "@/types/plugin";
+import { frontendLog } from "@/utils/frontendLog";
+
+/**
+ * Renders the status-bar widgets registered by active frontend plugins into one
+ * side of the status bar (#1998, concept §8).
+ *
+ * The widget registry lives in {@link @/plugins/pluginRuntime}; this component
+ * subscribes to it via `useSyncExternalStore` so a plugin enabling/disabling at
+ * runtime mounts or unmounts its widgets without a store round-trip. Each widget
+ * owns its DOM (`render()` → an `HTMLElement`); a plugin being disabled drops it
+ * from the registry, which unmounts its host here and is where `dispose()` runs
+ * — so a widget is disposed exactly once, cleanly.
+ */
+export function PluginStatusBarWidgets({ position }: { position: WidgetPosition }) {
+  const widgets = useSyncExternalStore(subscribeStatusBarWidgets, () =>
+    getStatusBarWidgets(position)
+  );
+
+  return (
+    <>
+      {widgets.map(({ key, widget }) => (
+        <PluginWidgetHost key={key} widget={widget} />
+      ))}
+    </>
+  );
+}
+
+/**
+ * Host for a single plugin status-bar widget: mounts the plugin's `render()`
+ * DOM on mount and calls `dispose()` on unmount. Both calls cross into
+ * plugin-provided code, so both are wrapped — a throwing widget is logged and
+ * isolated, never allowed to break the status bar (concept "Error Handling").
+ */
+function PluginWidgetHost({ widget }: { widget: StatusBarWidget }) {
+  const hostRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    let el: HTMLElement | null = null;
+    try {
+      el = widget.render();
+      if (el) host.appendChild(el);
+    } catch (err) {
+      frontendLog(
+        "plugin_runtime",
+        `Status-bar widget "${widget.id}" render() threw: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    return () => {
+      try {
+        widget.dispose();
+      } catch (err) {
+        frontendLog(
+          "plugin_runtime",
+          `Status-bar widget "${widget.id}" dispose() threw: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+      if (el && el.parentNode === host) host.removeChild(el);
+    };
+  }, [widget]);
+
+  return (
+    <span
+      className="status-bar__item status-bar__plugin-widget"
+      data-testid={`plugin-widget-${widget.id}`}
+      ref={hostRef}
+    />
+  );
+}

--- a/src/components/StatusBar/StatusBar.css
+++ b/src/components/StatusBar/StatusBar.css
@@ -52,6 +52,17 @@
   color: var(--text-primary);
 }
 
+/* Host slot for a frontend-plugin status-bar widget (#1998). Provides layout
+   only; the widget owns its own DOM. Empty (nothing rendered yet) hosts collapse. */
+.status-bar__plugin-widget {
+  display: inline-flex;
+  align-items: center;
+}
+
+.status-bar__plugin-widget:empty {
+  display: none;
+}
+
 /* Update-available count next to the connected-agents indicator (issue 1347). */
 .status-bar__agent-updates {
   display: inline-flex;

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -40,6 +40,7 @@ import { Tooltip, toast } from "@/components/ui";
 import { PortableBadge } from "./PortableBadge";
 import { UpdateIndicator } from "./UpdateIndicator";
 import { BroadcastStatus } from "./BroadcastStatus";
+import { PluginStatusBarWidgets } from "./PluginStatusBarWidgets";
 import "./StatusBar.css";
 
 const INDENT_SIZES = [1, 2, 4, 8] as const;
@@ -121,6 +122,7 @@ export function StatusBar() {
         <AgentUpdatesIndicator />
         <TransferQueueIndicator />
         <CredentialStoreIndicator />
+        <PluginStatusBarWidgets position="left" />
       </div>
       <div className="status-bar__section status-bar__section--center">
         {chordPending && (
@@ -130,6 +132,7 @@ export function StatusBar() {
         )}
       </div>
       <div className="status-bar__section status-bar__section--right">
+        <PluginStatusBarWidgets position="right" />
         <HighlightingIndicator />
         <UpdateIndicator />
         {editorStatus && (

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -30,11 +30,7 @@ import {
   isShellReservedKey,
 } from "@/services/keybindings";
 import { frontendLog } from "@/utils/frontendLog";
-import {
-  transformOutput,
-  notifySessionStart,
-  notifySessionEnd,
-} from "@/plugins/pluginRuntime";
+import { transformOutput, notifySessionStart, notifySessionEnd } from "@/plugins/pluginRuntime";
 import { resolveLineEnding } from "@/utils/lineEndings";
 import { getAllLeaves } from "@/utils/panelTree";
 import { toast } from "@/components/ui";

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -30,6 +30,11 @@ import {
   isShellReservedKey,
 } from "@/services/keybindings";
 import { frontendLog } from "@/utils/frontendLog";
+import {
+  transformOutput,
+  notifySessionStart,
+  notifySessionEnd,
+} from "@/plugins/pluginRuntime";
 import { resolveLineEnding } from "@/utils/lineEndings";
 import { getAllLeaves } from "@/utils/panelTree";
 import { toast } from "@/components/ui";
@@ -745,9 +750,17 @@ export function Terminal({
           terminalDispatcher.clearPendingOutput(sessionId);
         }
 
+        // Notify frontend-plugin protocol parsers that this session started
+        // (#1998), so a parser can reset any per-session state before output
+        // begins flowing.
+        notifySessionStart(sessionId);
+
         // Subscribe to output events via singleton dispatcher (O(1) routing)
         const unsubOutput = terminalDispatcher.subscribeOutput(sessionId, (data) => {
-          outputBuffer.push(data);
+          // Run active frontend-plugin protocol parsers over the chunk (#1998).
+          // A no-op fast path when none are registered, and byte-exact when none
+          // transform, so the common no-plugin case is untouched.
+          outputBuffer.push(transformOutput(data, sessionId));
           if (rafId === null) {
             rafId = requestAnimationFrame(flushOutput);
           }
@@ -771,6 +784,8 @@ export function Terminal({
           const exitLabel =
             exitCode === null ? "[Process exited]" : `[Process exited with code ${exitCode}]`;
           xterm.writeln(`\r\n\x1b[90m${exitLabel}\x1b[0m`);
+          // Notify frontend-plugin protocol parsers the session ended (#1998).
+          notifySessionEnd(sessionId);
           sessionIdRef.current = null;
           unregisterSession(tabId);
           store.setTerminalExited(tabId, { code: exitCode, reason });
@@ -864,6 +879,9 @@ export function Terminal({
           onDataDisposable.dispose();
           onResizeDisposable.dispose();
           if (sessionIdRef.current) {
+            // Session torn down while still live (tab closed/reconnecting) —
+            // the exit handler never fired, so notify parsers here (#1998).
+            notifySessionEnd(sessionId);
             // Defer the close so that React StrictMode's rapid unmount→remount
             // can cancel it before the backend session is destroyed.
             const sid = sessionIdRef.current;

--- a/src/plugins/frontendPlugins.test.ts
+++ b/src/plugins/frontendPlugins.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for the frontend plugin loader (#1998): reading a plugin's JS entry
+ * point, injecting it as a tagged inline `<script>`, unloading (script removal +
+ * unregistration), and reconciling the loaded set against the active plugin
+ * list.
+ *
+ * The injected `<script>` runs in the WebView and registers through
+ * `window.termihub` in the real app. The vitest jsdom environment evaluates
+ * inline scripts in a VM context that does not share `window` with the test
+ * module, so these tests use side-effect-free source and assert on the loader's
+ * DOM effects and bookkeeping; the registration that a script performs is
+ * exercised directly (via `setLoadingPlugin` + `window.termihub`) here and in
+ * `pluginRuntime.test.ts`.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { InstalledPlugin, PluginState } from "@/types/plugin";
+import {
+  loadFrontendPlugin,
+  unloadFrontendPlugin,
+  reconcileFrontendPlugins,
+  frontendEntryPoints,
+  hasFrontendExtension,
+  loadedFrontendPluginIds,
+  resetLoadedFrontendPlugins,
+} from "./frontendPlugins";
+import {
+  clearRegistry,
+  ensureTermiHubApi,
+  setLoadingPlugin,
+  getStatusBarWidgets,
+  type StatusBarWidget,
+} from "./pluginRuntime";
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+/** Build an installed plugin with the given frontend extensions. */
+function plugin(
+  id: string,
+  state: PluginState,
+  extensions: InstalledPlugin["manifest"]["extensions"]
+): InstalledPlugin {
+  return {
+    manifest: {
+      id,
+      name: id,
+      version: "1.0.0",
+      author: "a",
+      description: "d",
+      license: "MIT",
+      apiVersion: "1.0",
+      platforms: ["macos"],
+      permissions: ["ui"],
+      extensions,
+    },
+    state,
+    installedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+const parserPlugin = (id: string, state: PluginState = "active", entry = "frontend/index.js") =>
+  plugin(id, state, {
+    protocolParser: { name: id, description: "d", entryPoint: entry },
+  });
+
+/** Side-effect-free valid JS source (a comment) so jsdom's script eval is a no-op. */
+const SRC = "/* plugin entry point */";
+
+/** A file reader returning {@link SRC} for any path. */
+const reader = () => vi.fn(async () => new TextEncoder().encode(SRC));
+
+/** Register a widget attributed to `pluginId`, as its injected script would. */
+function registerWidgetAs(pluginId: string, widget: StatusBarWidget): void {
+  setLoadingPlugin(pluginId);
+  window.termihub.registerStatusBarWidget(widget);
+  setLoadingPlugin(null);
+}
+
+beforeEach(() => {
+  clearRegistry();
+  ensureTermiHubApi();
+  resetLoadedFrontendPlugins();
+  document.head.querySelectorAll("script[data-termihub-plugin]").forEach((s) => s.remove());
+});
+
+describe("frontendEntryPoints / hasFrontendExtension", () => {
+  it("collects and dedupes entry points across frontend extensions", () => {
+    const p = plugin("p", "active", {
+      protocolParser: { name: "p", description: "d", entryPoint: "frontend/index.js" },
+      statusBarWidget: { entryPoint: "frontend/index.js", position: "left" },
+    });
+    expect(frontendEntryPoints(p)).toEqual(["frontend/index.js"]);
+    expect(hasFrontendExtension(p)).toBe(true);
+  });
+
+  it("keeps distinct entry points when a plugin declares two", () => {
+    const p = plugin("p", "active", {
+      protocolParser: { name: "p", description: "d", entryPoint: "parser.js" },
+      statusBarWidget: { entryPoint: "widget.js", position: "right" },
+    });
+    expect(frontendEntryPoints(p)).toEqual(["parser.js", "widget.js"]);
+  });
+
+  it("reports no frontend extension for a theme-only plugin", () => {
+    const p = plugin("t", "active", { theme: { themes: [] } });
+    expect(hasFrontendExtension(p)).toBe(false);
+    expect(frontendEntryPoints(p)).toEqual([]);
+  });
+});
+
+describe("loadFrontendPlugin", () => {
+  it("reads the entry point and injects a tagged inline script", async () => {
+    const read = reader();
+    const errors = await loadFrontendPlugin(parserPlugin("p"), read);
+
+    expect(errors).toEqual([]);
+    expect(read).toHaveBeenCalledWith("p", "frontend/index.js");
+    const script = document.head.querySelector<HTMLScriptElement>(
+      'script[data-termihub-plugin="p"]'
+    );
+    expect(script).not.toBeNull();
+    expect(script?.textContent).toBe(SRC);
+    expect(loadedFrontendPluginIds()).toEqual(["p"]);
+  });
+
+  it("does not re-inject an already-loaded plugin", async () => {
+    const read = reader();
+    await loadFrontendPlugin(parserPlugin("p"), read);
+    await loadFrontendPlugin(parserPlugin("p"), read);
+    expect(document.head.querySelectorAll('script[data-termihub-plugin="p"]')).toHaveLength(1);
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  it("collects a read failure as an error rather than throwing", async () => {
+    const read = vi.fn(async () => {
+      throw new Error("no such file");
+    });
+    const errors = await loadFrontendPlugin(parserPlugin("p"), read);
+    expect(errors).toEqual([
+      { pluginId: "p", entryPoint: "frontend/index.js", message: "no such file" },
+    ]);
+  });
+
+  it("injects one script per distinct entry point", async () => {
+    const p = plugin("p", "active", {
+      protocolParser: { name: "p", description: "d", entryPoint: "parser.js" },
+      statusBarWidget: { entryPoint: "widget.js", position: "right" },
+    });
+    await loadFrontendPlugin(p, reader());
+    expect(document.head.querySelectorAll('script[data-termihub-plugin="p"]')).toHaveLength(2);
+  });
+});
+
+describe("unloadFrontendPlugin", () => {
+  it("removes injected scripts and unregisters the plugin's widgets", async () => {
+    await loadFrontendPlugin(parserPlugin("p"), reader());
+    // Simulate the widget the plugin's entry point would have registered.
+    registerWidgetAs("p", {
+      id: "w",
+      position: "left",
+      render: () => document.createElement("span"),
+      dispose: () => {},
+    });
+    expect(getStatusBarWidgets("left")).toHaveLength(1);
+
+    unloadFrontendPlugin("p");
+
+    expect(document.head.querySelectorAll('script[data-termihub-plugin="p"]')).toHaveLength(0);
+    expect(getStatusBarWidgets("left")).toHaveLength(0);
+    expect(loadedFrontendPluginIds()).toEqual([]);
+  });
+});
+
+describe("reconcileFrontendPlugins", () => {
+  it("loads active frontend plugins and skips inactive / theme-only ones", async () => {
+    const plugins = [
+      parserPlugin("active-parser", "active"),
+      parserPlugin("disabled-parser", "disabled"),
+      plugin("theme-only", "active", { theme: { themes: [] } }),
+    ];
+    await reconcileFrontendPlugins(plugins, reader());
+    expect(loadedFrontendPluginIds()).toEqual(["active-parser"]);
+  });
+
+  it("unloads a plugin that is no longer active", async () => {
+    await reconcileFrontendPlugins([parserPlugin("p", "active")], reader());
+    expect(loadedFrontendPluginIds()).toEqual(["p"]);
+
+    await reconcileFrontendPlugins([parserPlugin("p", "disabled")], reader());
+    expect(loadedFrontendPluginIds()).toEqual([]);
+    expect(document.head.querySelectorAll('script[data-termihub-plugin="p"]')).toHaveLength(0);
+  });
+
+  it("is idempotent across repeated reconciles of the same set", async () => {
+    const plugins = [parserPlugin("p", "active")];
+    const read = reader();
+    await reconcileFrontendPlugins(plugins, read);
+    await reconcileFrontendPlugins(plugins, read);
+    expect(document.head.querySelectorAll('script[data-termihub-plugin="p"]')).toHaveLength(1);
+    expect(read).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/plugins/frontendPlugins.ts
+++ b/src/plugins/frontendPlugins.ts
@@ -21,11 +21,8 @@
  * enforcement is tracked separately (#2001).
  */
 
-import type { InstalledPlugin } from "@/types/plugin";
+import type { InstalledPlugin, PluginFileReader } from "@/types/plugin";
 import { ensureTermiHubApi, setLoadingPlugin, unregisterPlugin } from "./pluginRuntime";
-
-/** Injected reader of a plugin file (bytes), relative to `plugins/<id>/`. */
-export type PluginFileReader = (pluginId: string, path: string) => Promise<Uint8Array>;
 
 /** Attribute stamped on injected plugin scripts so they can be found and removed. */
 const PLUGIN_SCRIPT_ATTR = "data-termihub-plugin";
@@ -109,18 +106,15 @@ export async function loadFrontendPlugin(
 /**
  * Unload a plugin's frontend extensions: unregister its parsers/widgets (the
  * widget snapshot change disposes their status-bar hosts) and remove its
- * injected `<script>` elements.
+ * injected `<script>` elements. The tracked script list is authoritative — it
+ * holds exactly the elements this loader appended — so detaching each is enough.
  */
-export function unloadFrontendPlugin(pluginId: string, doc: Document = document): void {
+export function unloadFrontendPlugin(pluginId: string): void {
   unregisterPlugin(pluginId);
   const scripts = loadedScripts.get(pluginId);
   if (scripts) {
     for (const script of scripts) script.parentNode?.removeChild(script);
   }
-  // Belt-and-braces: also drop any lingering scripts tagged for this plugin.
-  doc
-    .querySelectorAll(`script[${PLUGIN_SCRIPT_ATTR}="${pluginId.replace(/"/g, '\\"')}"]`)
-    .forEach((el) => el.parentNode?.removeChild(el));
   loadedScripts.delete(pluginId);
 }
 
@@ -142,7 +136,7 @@ export async function reconcileFrontendPlugins(
   );
 
   for (const pluginId of [...loadedScripts.keys()]) {
-    if (!activeIds.has(pluginId)) unloadFrontendPlugin(pluginId, doc);
+    if (!activeIds.has(pluginId)) unloadFrontendPlugin(pluginId);
   }
 
   const errors: FrontendPluginLoadError[] = [];

--- a/src/plugins/frontendPlugins.ts
+++ b/src/plugins/frontendPlugins.ts
@@ -1,0 +1,169 @@
+/**
+ * Loader for frontend JavaScript plugins — protocol parsers and status-bar
+ * widgets (#1998).
+ *
+ * On plugin activation this reads the plugin's declared JS entry point via the
+ * injected file reader (the `read_plugin_file` command in the app), injects it
+ * as an inline `<script>` into the WebView, and lets it register extensions
+ * through the `window.termihub` API in {@link ./pluginRuntime}. Registrations
+ * made while the script runs are attributed to the plugin via
+ * {@link setLoadingPlugin} (inline scripts execute synchronously on append, so
+ * the attribution window is exactly the append). On deactivation the script is
+ * removed and the plugin's registrations are torn down.
+ *
+ * This mirrors the theme loader's "enumerate active plugins → read declared
+ * files → register into a runtime registry" shape (`src/store/appStore.ts` →
+ * `loadActivePluginThemes`, `src/themes/pluginThemes.ts`). It stays free of any
+ * Tauri import: file reading is injected, keeping the module unit-testable.
+ *
+ * Concept: `docs/concepts/future/plugin-system.html` (impl §8). Weak isolation
+ * (shared WebView context) is accepted per the concept; the Rust-side permission
+ * enforcement is tracked separately (#2001).
+ */
+
+import type { InstalledPlugin } from "@/types/plugin";
+import { ensureTermiHubApi, setLoadingPlugin, unregisterPlugin } from "./pluginRuntime";
+
+/** Injected reader of a plugin file (bytes), relative to `plugins/<id>/`. */
+export type PluginFileReader = (pluginId: string, path: string) => Promise<Uint8Array>;
+
+/** Attribute stamped on injected plugin scripts so they can be found and removed. */
+const PLUGIN_SCRIPT_ATTR = "data-termihub-plugin";
+
+/** A frontend entry point that failed to load, for surfacing/logging. */
+export interface FrontendPluginLoadError {
+  pluginId: string;
+  entryPoint: string;
+  message: string;
+}
+
+/** Injected `<script>` elements for a loaded plugin, keyed by plugin id. */
+const loadedScripts = new Map<string, HTMLScriptElement[]>();
+
+/**
+ * The distinct JS entry points a plugin declares across its frontend extensions
+ * (`protocolParser.entryPoint` and `statusBarWidget.entryPoint`). Usually a
+ * single `frontend/index.js`; deduped so one shared entry point loads once even
+ * when a plugin provides both a parser and a widget.
+ */
+export function frontendEntryPoints(plugin: InstalledPlugin): string[] {
+  const ext = plugin.manifest.extensions;
+  const points = new Set<string>();
+  if (ext.protocolParser?.entryPoint) points.add(ext.protocolParser.entryPoint);
+  if (ext.statusBarWidget?.entryPoint) points.add(ext.statusBarWidget.entryPoint);
+  return [...points];
+}
+
+/** True when a plugin declares any frontend (JS) extension point. */
+export function hasFrontendExtension(plugin: InstalledPlugin): boolean {
+  return frontendEntryPoints(plugin).length > 0;
+}
+
+/**
+ * Load a single plugin's frontend entry point(s): read each JS file, inject it
+ * as an inline `<script>` tagged for later removal, and attribute the register
+ * calls it makes to this plugin. A file that fails to read is collected as an
+ * error rather than thrown, so one bad plugin never blocks the rest. No-ops when
+ * the plugin is already loaded.
+ */
+export async function loadFrontendPlugin(
+  plugin: InstalledPlugin,
+  readFile: PluginFileReader,
+  doc: Document = document
+): Promise<FrontendPluginLoadError[]> {
+  const pluginId = plugin.manifest.id;
+  if (loadedScripts.has(pluginId)) return [];
+  ensureTermiHubApi();
+
+  const scripts: HTMLScriptElement[] = [];
+  const errors: FrontendPluginLoadError[] = [];
+  for (const entryPoint of frontendEntryPoints(plugin)) {
+    try {
+      const bytes = await readFile(pluginId, entryPoint);
+      const code = new TextDecoder().decode(bytes);
+      const script = doc.createElement("script");
+      script.type = "text/javascript";
+      script.setAttribute(PLUGIN_SCRIPT_ATTR, pluginId);
+      script.textContent = code;
+      // Inline scripts execute synchronously on append, so bracketing the append
+      // with the loading id attributes the plugin's register calls to it.
+      setLoadingPlugin(pluginId);
+      try {
+        (doc.head ?? doc.documentElement).appendChild(script);
+      } finally {
+        setLoadingPlugin(null);
+      }
+      scripts.push(script);
+    } catch (err) {
+      errors.push({
+        pluginId,
+        entryPoint,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  loadedScripts.set(pluginId, scripts);
+  return errors;
+}
+
+/**
+ * Unload a plugin's frontend extensions: unregister its parsers/widgets (the
+ * widget snapshot change disposes their status-bar hosts) and remove its
+ * injected `<script>` elements.
+ */
+export function unloadFrontendPlugin(pluginId: string, doc: Document = document): void {
+  unregisterPlugin(pluginId);
+  const scripts = loadedScripts.get(pluginId);
+  if (scripts) {
+    for (const script of scripts) script.parentNode?.removeChild(script);
+  }
+  // Belt-and-braces: also drop any lingering scripts tagged for this plugin.
+  doc
+    .querySelectorAll(`script[${PLUGIN_SCRIPT_ATTR}="${pluginId.replace(/"/g, '\\"')}"]`)
+    .forEach((el) => el.parentNode?.removeChild(el));
+  loadedScripts.delete(pluginId);
+}
+
+/**
+ * Reconcile the injected frontend plugins against the current plugin list: load
+ * every *active* plugin that declares a frontend extension and is not yet
+ * loaded, and unload every previously-loaded plugin that is no longer active.
+ * Returns any load errors, for logging by the caller. This is the single entry
+ * point the store calls on every plugin refresh (install/enable/disable).
+ */
+export async function reconcileFrontendPlugins(
+  plugins: InstalledPlugin[],
+  readFile: PluginFileReader,
+  doc: Document = document
+): Promise<FrontendPluginLoadError[]> {
+  ensureTermiHubApi();
+  const activeIds = new Set(
+    plugins.filter((p) => p.state === "active" && hasFrontendExtension(p)).map((p) => p.manifest.id)
+  );
+
+  for (const pluginId of [...loadedScripts.keys()]) {
+    if (!activeIds.has(pluginId)) unloadFrontendPlugin(pluginId, doc);
+  }
+
+  const errors: FrontendPluginLoadError[] = [];
+  for (const plugin of plugins) {
+    if (
+      plugin.state === "active" &&
+      hasFrontendExtension(plugin) &&
+      !loadedScripts.has(plugin.manifest.id)
+    ) {
+      errors.push(...(await loadFrontendPlugin(plugin, readFile, doc)));
+    }
+  }
+  return errors;
+}
+
+/** Ids of the plugins whose frontend entry points are currently loaded (testing/introspection). */
+export function loadedFrontendPluginIds(): string[] {
+  return [...loadedScripts.keys()];
+}
+
+/** Forget all loaded-plugin bookkeeping without touching the DOM (tests only). */
+export function resetLoadedFrontendPlugins(): void {
+  loadedScripts.clear();
+}

--- a/src/plugins/pluginRuntime.test.ts
+++ b/src/plugins/pluginRuntime.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for the frontend plugin runtime (#1998): the `window.termihub`
+ * registration surface, protocol-parser application (transform / pass-through /
+ * ordering), session lifecycle hooks, the status-bar widget registry, and error
+ * isolation so a throwing plugin cannot break the pipeline.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  ensureTermiHubApi,
+  setLoadingPlugin,
+  applyParsers,
+  transformOutput,
+  hasProtocolParsers,
+  notifySessionStart,
+  notifySessionEnd,
+  getStatusBarWidgets,
+  subscribeStatusBarWidgets,
+  unregisterPlugin,
+  clearRegistry,
+  type ProtocolParser,
+  type StatusBarWidget,
+} from "./pluginRuntime";
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+
+/** Register `parser` as though it came from `pluginId`'s entry point. */
+function registerParserAs(pluginId: string, parser: ProtocolParser): void {
+  setLoadingPlugin(pluginId);
+  window.termihub.registerProtocolParser(parser);
+  setLoadingPlugin(null);
+}
+
+/** Register `widget` as though it came from `pluginId`'s entry point. */
+function registerWidgetAs(pluginId: string, widget: StatusBarWidget): void {
+  setLoadingPlugin(pluginId);
+  window.termihub.registerStatusBarWidget(widget);
+  setLoadingPlugin(null);
+}
+
+const decode = (b: Uint8Array) => new TextDecoder().decode(b);
+
+beforeEach(() => {
+  clearRegistry();
+  ensureTermiHubApi();
+});
+
+describe("window.termihub API", () => {
+  it("installs the registration API on window (idempotent)", () => {
+    const first = window.termihub;
+    expect(typeof first.registerProtocolParser).toBe("function");
+    expect(typeof first.registerStatusBarWidget).toBe("function");
+    // Re-installing returns the same object so a plugin's captured ref stays valid.
+    expect(ensureTermiHubApi()).toBe(first);
+  });
+
+  it("rejects an invalid parser without registering it", () => {
+    setLoadingPlugin("p");
+    // Missing transform.
+    window.termihub.registerProtocolParser({ id: "x", name: "x" } as unknown as ProtocolParser);
+    setLoadingPlugin(null);
+    expect(hasProtocolParsers()).toBe(false);
+  });
+});
+
+describe("protocol parser application", () => {
+  it("applies a registered parser's transform to output", () => {
+    registerParserAs("colorizer", {
+      id: "c",
+      name: "c",
+      transform: (data) => data.toUpperCase(),
+    });
+    expect(hasProtocolParsers()).toBe(true);
+    expect(applyParsers("hello", "s1")).toEqual({ text: "HELLO", changed: true });
+  });
+
+  it("passes output through unchanged when transform returns null", () => {
+    registerParserAs("noop", {
+      id: "n",
+      name: "n",
+      transform: () => null,
+    });
+    const result = applyParsers("line", "s1");
+    expect(result).toEqual({ text: "line", changed: false });
+  });
+
+  it("transformOutput returns the exact same bytes on pass-through", () => {
+    registerParserAs("noop", { id: "n", name: "n", transform: () => null });
+    const bytes = new TextEncoder().encode("unchanged");
+    // Same reference => byte-exact pass-through, no re-encode.
+    expect(transformOutput(bytes, "s1")).toBe(bytes);
+  });
+
+  it("transformOutput re-encodes transformed text", () => {
+    registerParserAs("cap", { id: "c", name: "c", transform: (d) => d + "!" });
+    const out = transformOutput(new TextEncoder().encode("hi"), "s1");
+    expect(decode(out)).toBe("hi!");
+  });
+
+  it("is a no-op fast path with no parsers registered", () => {
+    const bytes = new TextEncoder().encode("raw");
+    expect(transformOutput(bytes, "s1")).toBe(bytes);
+  });
+
+  it("chains parsers in registration order, each seeing the prior output", () => {
+    registerParserAs("a", { id: "a", name: "a", transform: (d) => d + "-a" });
+    registerParserAs("b", { id: "b", name: "b", transform: (d) => d + "-b" });
+    expect(applyParsers("x", "s1")).toEqual({ text: "x-a-b", changed: true });
+  });
+
+  it("passes sessionId through to transform", () => {
+    const seen: string[] = [];
+    registerParserAs("p", {
+      id: "p",
+      name: "p",
+      transform: (_d, sid) => {
+        seen.push(sid);
+        return null;
+      },
+    });
+    applyParsers("x", "session-42");
+    expect(seen).toEqual(["session-42"]);
+  });
+});
+
+describe("session lifecycle hooks", () => {
+  it("invokes onSessionStart / onSessionEnd for registered parsers", () => {
+    const start = vi.fn();
+    const end = vi.fn();
+    registerParserAs("p", {
+      id: "p",
+      name: "p",
+      transform: () => null,
+      onSessionStart: start,
+      onSessionEnd: end,
+    });
+    notifySessionStart("s1");
+    notifySessionEnd("s1");
+    expect(start).toHaveBeenCalledWith("s1");
+    expect(end).toHaveBeenCalledWith("s1");
+  });
+
+  it("tolerates parsers without lifecycle hooks", () => {
+    registerParserAs("p", { id: "p", name: "p", transform: () => null });
+    expect(() => {
+      notifySessionStart("s1");
+      notifySessionEnd("s1");
+    }).not.toThrow();
+  });
+});
+
+describe("error isolation", () => {
+  it("a throwing transform is skipped and the next parser still runs", () => {
+    registerParserAs("bad", {
+      id: "bad",
+      name: "bad",
+      transform: () => {
+        throw new Error("boom");
+      },
+    });
+    registerParserAs("good", { id: "good", name: "good", transform: (d) => d + "!" });
+    // Bad parser is skipped; good parser still applies.
+    expect(applyParsers("x", "s1")).toEqual({ text: "x!", changed: true });
+  });
+
+  it("a throwing onSessionStart does not break other parsers", () => {
+    const good = vi.fn();
+    registerParserAs("bad", {
+      id: "bad",
+      name: "bad",
+      transform: () => null,
+      onSessionStart: () => {
+        throw new Error("boom");
+      },
+    });
+    registerParserAs("good", {
+      id: "good",
+      name: "good",
+      transform: () => null,
+      onSessionStart: good,
+    });
+    expect(() => notifySessionStart("s1")).not.toThrow();
+    expect(good).toHaveBeenCalledWith("s1");
+  });
+});
+
+describe("status-bar widget registry", () => {
+  const widget = (id: string, position: "left" | "right"): StatusBarWidget => ({
+    id,
+    position,
+    render: () => document.createElement("span"),
+    dispose: () => {},
+  });
+
+  it("projects widgets to their side with collision-proof keys", () => {
+    registerWidgetAs("p1", widget("clock", "left"));
+    registerWidgetAs("p2", widget("clock", "right"));
+    const left = getStatusBarWidgets("left");
+    const right = getStatusBarWidgets("right");
+    expect(left.map((e) => e.key)).toEqual(["p1:clock"]);
+    expect(right.map((e) => e.key)).toEqual(["p2:clock"]);
+  });
+
+  it("returns a stable reference until the registry changes", () => {
+    const before = getStatusBarWidgets("left");
+    expect(getStatusBarWidgets("left")).toBe(before);
+    registerWidgetAs("p1", widget("clock", "left"));
+    expect(getStatusBarWidgets("left")).not.toBe(before);
+  });
+
+  it("notifies subscribers on registration and unregistration", () => {
+    const listener = vi.fn();
+    const unsub = subscribeStatusBarWidgets(listener);
+    registerWidgetAs("p1", widget("clock", "left"));
+    expect(listener).toHaveBeenCalledTimes(1);
+    unregisterPlugin("p1");
+    expect(listener).toHaveBeenCalledTimes(2);
+    unsub();
+    registerWidgetAs("p2", widget("cpu", "left"));
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects an invalid widget (bad position)", () => {
+    setLoadingPlugin("p");
+    window.termihub.registerStatusBarWidget({
+      id: "x",
+      position: "middle",
+      render: () => document.createElement("span"),
+      dispose: () => {},
+    } as unknown as StatusBarWidget);
+    setLoadingPlugin(null);
+    expect(getStatusBarWidgets("left")).toHaveLength(0);
+    expect(getStatusBarWidgets("right")).toHaveLength(0);
+  });
+});
+
+describe("unregisterPlugin", () => {
+  it("removes only the given plugin's parsers and widgets", () => {
+    registerParserAs("keep", { id: "k", name: "k", transform: (d) => d + "k" });
+    registerParserAs("drop", { id: "d", name: "d", transform: (d) => d + "d" });
+    registerWidgetAs("drop", {
+      id: "w",
+      position: "left",
+      render: () => document.createElement("span"),
+      dispose: () => {},
+    });
+
+    unregisterPlugin("drop");
+
+    expect(applyParsers("x", "s1")).toEqual({ text: "xk", changed: true });
+    expect(getStatusBarWidgets("left")).toHaveLength(0);
+  });
+});

--- a/src/plugins/pluginRuntime.ts
+++ b/src/plugins/pluginRuntime.ts
@@ -112,7 +112,10 @@ let widgets: RegisteredWidget[] = [];
  * The plugin id currently being loaded, set by the loader around the synchronous
  * `<script>` injection so register calls made while a plugin's entry point runs
  * are attributed to it. `null` outside a load (a stray register call then lands
- * under `"unknown"`).
+ * under `"unknown"`). This attributes the synchronous, top-level registration
+ * the concept documents; a plugin that registers asynchronously (from a timer or
+ * promise) lands under `"unknown"` and is not cleanly unregisterable — hardening
+ * that is a follow-up (per-plugin API instance).
  */
 let loadingPluginId: string | null = null;
 
@@ -238,28 +241,27 @@ export function transformOutput(data: Uint8Array, sessionId: string): Uint8Array
   return changed ? encoder.encode(text) : data;
 }
 
-/** Notify every parser's optional `onSessionStart` hook (errors isolated). */
-export function notifySessionStart(sessionId: string): void {
+/** Fire one optional session-lifecycle hook across every parser (errors isolated). */
+function notifySession(phase: "onSessionStart" | "onSessionEnd", sessionId: string): void {
   for (const { pluginId, parser } of parsers) {
-    if (!parser.onSessionStart) continue;
+    const hook = parser[phase];
+    if (!hook) continue;
     try {
-      parser.onSessionStart(sessionId);
+      hook.call(parser, sessionId);
     } catch (err) {
-      logPluginError(pluginId, parser.id, "onSessionStart", err);
+      logPluginError(pluginId, parser.id, phase, err);
     }
   }
 }
 
+/** Notify every parser's optional `onSessionStart` hook (errors isolated). */
+export function notifySessionStart(sessionId: string): void {
+  notifySession("onSessionStart", sessionId);
+}
+
 /** Notify every parser's optional `onSessionEnd` hook (errors isolated). */
 export function notifySessionEnd(sessionId: string): void {
-  for (const { pluginId, parser } of parsers) {
-    if (!parser.onSessionEnd) continue;
-    try {
-      parser.onSessionEnd(sessionId);
-    } catch (err) {
-      logPluginError(pluginId, parser.id, "onSessionEnd", err);
-    }
-  }
+  notifySession("onSessionEnd", sessionId);
 }
 
 // ─── Status-bar widget registry ──────────────────────────────────────────────

--- a/src/plugins/pluginRuntime.ts
+++ b/src/plugins/pluginRuntime.ts
@@ -1,0 +1,317 @@
+/**
+ * Frontend JavaScript plugin runtime — the `window.termihub` registration
+ * surface and the registries it feeds (#1998).
+ *
+ * A frontend plugin is a plain JavaScript file the plugin author ships at
+ * `frontend/index.js` (the `entryPoint` its `protocolParser` / `statusBarWidget`
+ * extension declares). On activation the loader in {@link ./frontendPlugins}
+ * injects that script into the WebView; the script calls the API exposed here on
+ * `window.termihub` to register two kinds of extension:
+ *
+ * - **Protocol parsers** — `transform(data, sessionId)` runs over each chunk of
+ *   terminal output before it reaches xterm; returning `null` passes the chunk
+ *   through unchanged (concept §8).
+ * - **Status-bar widgets** — a `render()`/`dispose()` pair mounted into the
+ *   left/right status-bar slots by {@link ../components/StatusBar/PluginStatusBarWidgets}.
+ *
+ * This module is deliberately free of any Tauri/IPC or React import so the
+ * register/transform/dispose logic stays pure and unit-testable, mirroring
+ * `src/themes/pluginThemes.ts`. Every call *into* plugin code — `transform`,
+ * `onSessionStart`/`onSessionEnd`, `render`, `dispose` — is wrapped so a throw
+ * from one bad plugin can never break rendering or the status bar (concept
+ * "Error Handling").
+ *
+ * Isolation note: per the concept, frontend plugins share the WebView context
+ * (weak isolation). Stronger isolation (Workers/iframes) is an explicit future
+ * improvement and out of scope here (#1998).
+ *
+ * Concept: `docs/concepts/future/plugin-system.html` (impl §8; "Fifth PR —
+ * Frontend plugins").
+ */
+
+import { frontendLog } from "@/utils/frontendLog";
+import type { WidgetPosition } from "@/types/plugin";
+
+/**
+ * A protocol parser a frontend plugin registers via
+ * {@link TermiHubPluginAPI.registerProtocolParser} (concept §8).
+ */
+export interface ProtocolParser {
+  /** Parser identifier (unique within the plugin). */
+  id: string;
+  /** Human-readable name. */
+  name: string;
+  /**
+   * Called for each chunk of terminal output. Returns the transformed text, or
+   * `null` to pass the chunk through unchanged.
+   */
+  transform(data: string, sessionId: string): string | null;
+  /** Optional: called when a terminal session starts. */
+  onSessionStart?(sessionId: string): void;
+  /** Optional: called when a terminal session ends. */
+  onSessionEnd?(sessionId: string): void;
+}
+
+/**
+ * A status-bar widget a frontend plugin registers via
+ * {@link TermiHubPluginAPI.registerStatusBarWidget} (concept §8).
+ */
+export interface StatusBarWidget {
+  /** Widget identifier (unique within the plugin). */
+  id: string;
+  /** Which side of the status bar the widget renders on. */
+  position: WidgetPosition;
+  /** Build the widget's DOM. Called once when the widget mounts. */
+  render(): HTMLElement;
+  /** Tear the widget down. Called when the plugin is disabled/uninstalled. */
+  dispose(): void;
+}
+
+/** The API surface exposed to frontend plugins on `window.termihub`. */
+export interface TermiHubPluginAPI {
+  /** Register a protocol parser (concept §8). */
+  registerProtocolParser(parser: ProtocolParser): void;
+  /** Register a status-bar widget (concept §8). */
+  registerStatusBarWidget(widget: StatusBarWidget): void;
+}
+
+declare global {
+  interface Window {
+    /** The frontend-plugin registration API (#1998). Present once a plugin has loaded. */
+    termihub: TermiHubPluginAPI;
+  }
+}
+
+/** A protocol parser plus the id of the plugin that registered it. */
+interface RegisteredParser {
+  pluginId: string;
+  parser: ProtocolParser;
+}
+
+/** A status-bar widget plus the id of the plugin that registered it. */
+interface RegisteredWidget {
+  pluginId: string;
+  widget: StatusBarWidget;
+}
+
+/**
+ * A status-bar widget projected for rendering, with a stable, collision-proof
+ * key (`<pluginId>:<widgetId>`) so two plugins may reuse a widget id.
+ */
+export interface StatusBarWidgetEntry {
+  key: string;
+  widget: StatusBarWidget;
+}
+
+// ─── Registries ──────────────────────────────────────────────────────────────
+
+let parsers: RegisteredParser[] = [];
+let widgets: RegisteredWidget[] = [];
+
+/**
+ * The plugin id currently being loaded, set by the loader around the synchronous
+ * `<script>` injection so register calls made while a plugin's entry point runs
+ * are attributed to it. `null` outside a load (a stray register call then lands
+ * under `"unknown"`).
+ */
+let loadingPluginId: string | null = null;
+
+/** Cached per-position widget snapshots for {@link getStatusBarWidgets} (stable refs for `useSyncExternalStore`). */
+let widgetSnapshot: Record<WidgetPosition, StatusBarWidgetEntry[]> = { left: [], right: [] };
+
+/** Listeners notified when the widget registry changes (drives the status bar). */
+const widgetListeners = new Set<() => void>();
+
+/** Log a caught error from plugin code without letting it escape. */
+function logPluginError(pluginId: string, extId: string, phase: string, err: unknown): void {
+  frontendLog(
+    "plugin_runtime",
+    `Plugin "${pluginId}" ${phase} for "${extId}" threw: ${err instanceof Error ? err.message : String(err)}`
+  );
+}
+
+/**
+ * Set (or clear) the plugin id that subsequent register calls are attributed to.
+ * Called by the loader immediately around the synchronous script injection.
+ */
+export function setLoadingPlugin(pluginId: string | null): void {
+  loadingPluginId = pluginId;
+}
+
+function registerProtocolParser(parser: ProtocolParser): void {
+  const pluginId = loadingPluginId ?? "unknown";
+  if (
+    !parser ||
+    typeof parser.id !== "string" ||
+    parser.id === "" ||
+    typeof parser.transform !== "function"
+  ) {
+    frontendLog("plugin_runtime", `Plugin "${pluginId}" registered an invalid protocol parser`);
+    return;
+  }
+  // Re-registration of the same (plugin, id) replaces the prior entry.
+  parsers = parsers.filter((p) => !(p.pluginId === pluginId && p.parser.id === parser.id));
+  parsers.push({ pluginId, parser });
+}
+
+function registerStatusBarWidget(widget: StatusBarWidget): void {
+  const pluginId = loadingPluginId ?? "unknown";
+  if (
+    !widget ||
+    typeof widget.id !== "string" ||
+    widget.id === "" ||
+    typeof widget.render !== "function" ||
+    typeof widget.dispose !== "function" ||
+    (widget.position !== "left" && widget.position !== "right")
+  ) {
+    frontendLog("plugin_runtime", `Plugin "${pluginId}" registered an invalid status-bar widget`);
+    return;
+  }
+  widgets = widgets.filter((w) => !(w.pluginId === pluginId && w.widget.id === widget.id));
+  widgets.push({ pluginId, widget });
+  refreshWidgetSnapshot();
+}
+
+/**
+ * Install the `window.termihub` API on the given target (defaults to the global
+ * `window`). Idempotent: the same API object is reused across calls so a
+ * previously-loaded plugin's captured reference stays valid.
+ */
+export function ensureTermiHubApi(
+  target: { termihub?: TermiHubPluginAPI } = window as unknown as {
+    termihub?: TermiHubPluginAPI;
+  }
+): TermiHubPluginAPI {
+  if (!target.termihub) {
+    target.termihub = {
+      registerProtocolParser,
+      registerStatusBarWidget,
+    };
+  }
+  return target.termihub;
+}
+
+// ─── Protocol parser application ─────────────────────────────────────────────
+
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+/** True when at least one protocol parser is registered (pipeline fast-path guard). */
+export function hasProtocolParsers(): boolean {
+  return parsers.length > 0;
+}
+
+/**
+ * Run every registered parser over `data` in registration order. Each parser
+ * sees the previous parser's output; a parser returning `null` (or a non-string)
+ * leaves the running text unchanged. A parser that throws is caught, logged, and
+ * skipped. Returns the final text and whether any parser changed it.
+ */
+export function applyParsers(
+  data: string,
+  sessionId: string
+): { text: string; changed: boolean } {
+  let text = data;
+  let changed = false;
+  for (const { pluginId, parser } of parsers) {
+    let out: string | null;
+    try {
+      out = parser.transform(text, sessionId);
+    } catch (err) {
+      logPluginError(pluginId, parser.id, "transform", err);
+      continue;
+    }
+    if (typeof out === "string") {
+      text = out;
+      changed = true;
+    }
+  }
+  return { text, changed };
+}
+
+/**
+ * Apply registered protocol parsers to a raw output chunk in the terminal
+ * pipeline. Returns the original bytes untouched when no parser is registered or
+ * none transform the chunk (byte-exact pass-through, so unparsed output is never
+ * re-encoded), otherwise the UTF-8 encoding of the transformed text.
+ */
+export function transformOutput(data: Uint8Array, sessionId: string): Uint8Array {
+  if (parsers.length === 0) return data;
+  const { text, changed } = applyParsers(decoder.decode(data), sessionId);
+  return changed ? encoder.encode(text) : data;
+}
+
+/** Notify every parser's optional `onSessionStart` hook (errors isolated). */
+export function notifySessionStart(sessionId: string): void {
+  for (const { pluginId, parser } of parsers) {
+    if (!parser.onSessionStart) continue;
+    try {
+      parser.onSessionStart(sessionId);
+    } catch (err) {
+      logPluginError(pluginId, parser.id, "onSessionStart", err);
+    }
+  }
+}
+
+/** Notify every parser's optional `onSessionEnd` hook (errors isolated). */
+export function notifySessionEnd(sessionId: string): void {
+  for (const { pluginId, parser } of parsers) {
+    if (!parser.onSessionEnd) continue;
+    try {
+      parser.onSessionEnd(sessionId);
+    } catch (err) {
+      logPluginError(pluginId, parser.id, "onSessionEnd", err);
+    }
+  }
+}
+
+// ─── Status-bar widget registry ──────────────────────────────────────────────
+
+function refreshWidgetSnapshot(): void {
+  const next: Record<WidgetPosition, StatusBarWidgetEntry[]> = { left: [], right: [] };
+  for (const { pluginId, widget } of widgets) {
+    next[widget.position].push({ key: `${pluginId}:${widget.id}`, widget });
+  }
+  widgetSnapshot = next;
+  for (const listener of widgetListeners) listener();
+}
+
+/**
+ * Current status-bar widgets for a side, as a stable-reference array suitable
+ * for `useSyncExternalStore`. The reference only changes when the registry does.
+ */
+export function getStatusBarWidgets(position: WidgetPosition): StatusBarWidgetEntry[] {
+  return widgetSnapshot[position];
+}
+
+/** Subscribe to widget-registry changes; returns an unsubscribe. */
+export function subscribeStatusBarWidgets(listener: () => void): () => void {
+  widgetListeners.add(listener);
+  return () => {
+    widgetListeners.delete(listener);
+  };
+}
+
+// ─── Teardown ────────────────────────────────────────────────────────────────
+
+/**
+ * Remove every extension a plugin registered. Called when a plugin is disabled
+ * or uninstalled. Parsers are dropped immediately; widgets are dropped from the
+ * registry and the resulting snapshot change unmounts their status-bar hosts,
+ * which is where `dispose()` runs — so a widget is disposed exactly once, by its
+ * React owner.
+ */
+export function unregisterPlugin(pluginId: string): void {
+  parsers = parsers.filter((p) => p.pluginId !== pluginId);
+  const before = widgets.length;
+  widgets = widgets.filter((w) => w.pluginId !== pluginId);
+  if (widgets.length !== before) refreshWidgetSnapshot();
+}
+
+/** Drop all registered parsers and widgets (used on teardown / in tests). */
+export function clearRegistry(): void {
+  parsers = [];
+  widgets = [];
+  loadingPluginId = null;
+  refreshWidgetSnapshot();
+}

--- a/src/plugins/pluginRuntime.ts
+++ b/src/plugins/pluginRuntime.ts
@@ -207,10 +207,7 @@ export function hasProtocolParsers(): boolean {
  * leaves the running text unchanged. A parser that throws is caught, logged, and
  * skipped. Returns the final text and whether any parser changed it.
  */
-export function applyParsers(
-  data: string,
-  sessionId: string
-): { text: string; changed: boolean } {
+export function applyParsers(data: string, sessionId: string): { text: string; changed: boolean } {
   let text = data;
   let changed = false;
   for (const { pluginId, parser } of parsers) {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -294,6 +294,7 @@ import {
   disablePlugin as apiDisablePlugin,
   readPluginFile,
 } from "@/services/api";
+import { reconcileFrontendPlugins } from "@/plugins/frontendPlugins";
 import {
   createLeafPanel,
   findLeaf,
@@ -7521,6 +7522,16 @@ export const useAppStore = create<AppState>((set, get) => {
         const pluginThemes = await loadActivePluginThemes(plugins);
         setRegisteredPluginThemes(pluginThemes);
         set({ plugins, pluginBackendTypes: derivePluginBackendTypes(plugins), pluginThemes });
+        // Load/unload frontend JS plugins — protocol parsers + status-bar
+        // widgets (#1998). Reconciles the injected scripts against the active
+        // set; individual load failures are logged and skipped.
+        const frontendErrors = await reconcileFrontendPlugins(plugins, readPluginFile);
+        for (const err of frontendErrors) {
+          frontendLog(
+            "app_store",
+            `Skipped frontend plugin ${err.pluginId} (${err.entryPoint}): ${err.message}`
+          );
+        }
         // Re-apply the active theme: a just-registered plugin theme now takes
         // effect, and a theme whose plugin was disabled/uninstalled falls back
         // to the default (concept edge case).

--- a/src/themes/pluginThemes.ts
+++ b/src/themes/pluginThemes.ts
@@ -16,7 +16,7 @@
  */
 
 import type { ThemeColors, ThemeDefinition } from "./types";
-import type { ThemeEntry } from "@/types/plugin";
+import type { ThemeEntry, PluginFileReader } from "@/types/plugin";
 import { COLOR_TOKEN_KEYS } from "./colorTokens";
 import { THEME_FILE_SCHEMA } from "./themeIO";
 import { BASE_THEME_ORDER } from "./customThemes";
@@ -127,8 +127,7 @@ export interface PluginThemeLoadResult {
   errors: PluginThemeLoadError[];
 }
 
-/** Injected reader of a plugin file (bytes), relative to `plugins/<id>/`. */
-export type PluginFileReader = (pluginId: string, path: string) => Promise<Uint8Array>;
+export type { PluginFileReader } from "@/types/plugin";
 
 /** Options for {@link loadPluginThemes}. */
 export interface LoadPluginThemesOptions {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -185,3 +185,12 @@ export interface PluginBackendType {
   /** Human-readable name shown in the selector. */
   displayName: string;
 }
+
+/**
+ * Injected reader of a file inside an installed plugin's directory (`path`
+ * relative to `plugins/<id>/`), returning the raw bytes. This is the shape of
+ * the `readPluginFile` service wrapper; the theme and frontend-plugin loaders
+ * take it as a dependency so their parse/register logic stays free of any
+ * Tauri/IPC import and unit-testable.
+ */
+export type PluginFileReader = (pluginId: string, path: string) => Promise<Uint8Array>;


### PR DESCRIPTION
## Summary

Implements the concept's "Fifth PR — Frontend plugins" (#1998): loads an enabled plugin's JavaScript entry point into the WebView and lets it register two kinds of frontend extension through a new `window.termihub` API.

- **`window.termihub` API** (`src/plugins/pluginRuntime.ts`): `registerProtocolParser({ id, name, transform(data, sessionId), onSessionStart?, onSessionEnd? })` and `registerStatusBarWidget({ id, position, render(), dispose() })`, typed on `Window`.
- **Loader** (`src/plugins/frontendPlugins.ts`): reads a plugin's declared JS entry point(s) via `read_plugin_file`, injects them as tagged inline `<script>` elements, and attributes the registrations they make to the plugin. Unload removes the scripts and tears down the registrations. Mirrors the theme-plugin loader shape (`src/themes/pluginThemes.ts` + `loadActivePluginThemes`).
- **Terminal pipeline** (`src/components/Terminal/Terminal.tsx`): registered protocol parsers run over every output chunk before it reaches xterm. Fast path when no parser is registered; byte-exact pass-through when a parser returns `null`. `onSessionStart`/`onSessionEnd` fire on session start/end.
- **Status bar** (`src/components/StatusBar/PluginStatusBarWidgets.tsx`): registered widgets mount into the left/right status-bar slots via `useSyncExternalStore` over the runtime registry; each widget's `render()` DOM is mounted and `dispose()` runs exactly once when its plugin is disabled.
- **Store** (`src/store/appStore.ts`): `loadPlugins` reconciles the injected frontend plugins on every refresh (install/enable/disable), mirroring the theme reconcile.

### Isolation / security
Per the concept, frontend plugins share the WebView context (weak isolation) — this is explicitly accepted for this PR; stronger isolation (Workers/iframes) is a documented future improvement. Every call into plugin code (`transform`, `onSessionStart`/`onSessionEnd`, `render`, `dispose`) is wrapped so one bad plugin cannot break terminal rendering or the status bar (concept "Error Handling"). Rust-side permission enforcement is tracked separately (#2001).

## Tests
Vitest coverage (33 tests): registration + validation, transform application, pass-through (byte-exact), parser chaining, session hooks, error isolation; loader inject/unload/reconcile; status-bar widget mount/dispose + render-error isolation.

## Test plan
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec vitest run src/plugins src/components/StatusBar src/store/appStore.plugins.test.ts` (87 passed)
- [x] `pnpm exec eslint` + `prettier --check` on changed files

Closes #1998