### PR TITLE
feat(backend): load already-enabled plugins at startup (Closes #2010)

### DIFF
--- a/core/src/plugin/manager.rs
+++ b/core/src/plugin/manager.rs
@@ -437,6 +437,51 @@ impl PluginManager {
         Ok(disabled)
     }
 
+    /// Load every installed plugin whose persisted state is **enabled and
+    /// compatible**, through the same lifecycle-hook `on_enable` path a fresh
+    /// enable uses. Call this once at startup, after the host is wired in.
+    ///
+    /// The management layer restores each plugin's persisted enabled flag during
+    /// its scan but does **no** loading, so without this an already-enabled
+    /// plugin sits un-loaded until the user toggles it off/on — its
+    /// connection type never gets registered, and a persisted connection of that
+    /// type cannot resolve after a restart. This drives the host's load path for
+    /// each enabled plugin so its `ConnectionType` is registered automatically.
+    ///
+    /// Only plugins the scan resolves to [`PluginState::Installed`] (enabled *and*
+    /// compatible) are loaded: disabled plugins are skipped, and an incompatible
+    /// plugin is never loaded regardless of its flag (run
+    /// [`reconcile_compatibility`](Self::reconcile_compatibility) first to
+    /// auto-disable ones that became incompatible). A plugin whose load **fails**
+    /// surfaces as [`PluginState::Error`] in the returned vector rather than
+    /// aborting startup — it stays installed and enabled, and is retried on the
+    /// next launch or an explicit re-enable.
+    ///
+    /// Returns every plugin it attempted to load, each with its state reflecting
+    /// the outcome ([`PluginState::Installed`] on success,
+    /// [`PluginState::Error`] on failure), so the caller can notify the user of
+    /// any that failed.
+    pub fn load_enabled_plugins(&self) -> Result<Vec<InstalledPlugin>, PluginManagerError> {
+        let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
+
+        let mut attempted = Vec::new();
+        for mut plugin in self.list()? {
+            // `list()` resolves an enabled+compatible plugin to `Installed`, a
+            // disabled one to `Disabled`, and an incompatible one to
+            // `Incompatible`. Only the first should be loaded — this naturally
+            // honors both the persisted flag and API compatibility.
+            if plugin.state != PluginState::Installed {
+                continue;
+            }
+            if let Err(msg) = self.hook.on_enable(&plugin) {
+                plugin.state = PluginState::Error;
+                plugin.error_message = Some(msg);
+            }
+            attempted.push(plugin);
+        }
+        Ok(attempted)
+    }
+
     fn set_enabled(&self, id: &str, enabled: bool) -> Result<InstalledPlugin, PluginManagerError> {
         let _guard = self.lock.lock().unwrap_or_else(|e| e.into_inner());
 
@@ -1069,6 +1114,98 @@ mod tests {
         assert!(!mgr.read_state_store().unwrap().plugins["legacy"].enabled);
         // Idempotent: a second run finds nothing (already disabled).
         assert!(mgr.reconcile_compatibility().unwrap().is_empty());
+    }
+
+    #[test]
+    fn load_enabled_plugins_loads_enabled_and_skips_disabled_and_incompatible() {
+        // A hook that records the ids it is asked to load, so we can assert the
+        // startup path fires `on_enable` for exactly the enabled+compatible ones.
+        #[derive(Default)]
+        struct RecordingHook {
+            enabled: Mutex<Vec<String>>,
+        }
+        impl PluginLifecycleHook for RecordingHook {
+            fn on_enable(&self, plugin: &InstalledPlugin) -> Result<(), String> {
+                self.enabled
+                    .lock()
+                    .unwrap()
+                    .push(plugin.manifest.id.clone());
+                Ok(())
+            }
+        }
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("plugins");
+
+        // Session 1: install three plugins with a plain (no-op) manager, then
+        // disable one and bump another to an incompatible API version — the state
+        // a previous session would persist.
+        {
+            let mgr = PluginManager::new(&root);
+            for id in ["keep-on", "turn-off", "too-new"] {
+                let pkg_dir = TempDir::new().unwrap();
+                let pkg = make_package(pkg_dir.path(), &manifest_json(id, "1.0"), &[]);
+                mgr.install(&pkg, true).unwrap();
+            }
+            mgr.disable("turn-off").unwrap();
+            // Make "too-new" incompatible by rewriting its manifest.
+            let manifest_path = root.join("too-new").join(MANIFEST_FILE_NAME);
+            std::fs::write(&manifest_path, manifest_json("too-new", "2.0")).unwrap();
+        }
+
+        // Session 2 (simulated restart): a manager with the recording hook. The
+        // startup load must fire on_enable for the enabled+compatible plugin only.
+        let hook = Arc::new(RecordingHook::default());
+        let mgr2 = PluginManager::with_hook(&root, hook.clone());
+        let loaded = mgr2.load_enabled_plugins().unwrap();
+
+        assert_eq!(
+            hook.enabled.lock().unwrap().as_slice(),
+            &["keep-on".to_string()],
+            "only the enabled, compatible plugin should be loaded"
+        );
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].manifest.id, "keep-on");
+        assert_eq!(loaded[0].state, PluginState::Installed);
+        assert!(loaded[0].error_message.is_none());
+    }
+
+    #[test]
+    fn load_enabled_plugins_surfaces_a_failure_as_error_without_aborting() {
+        // Fails to load one specific plugin; every other load succeeds.
+        struct FailFor(&'static str);
+        impl PluginLifecycleHook for FailFor {
+            fn on_enable(&self, plugin: &InstalledPlugin) -> Result<(), String> {
+                if plugin.manifest.id == self.0 {
+                    Err("boom".into())
+                } else {
+                    Ok(())
+                }
+            }
+        }
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("plugins");
+        {
+            let mgr = PluginManager::new(&root);
+            for id in ["broken", "healthy"] {
+                let pkg_dir = TempDir::new().unwrap();
+                let pkg = make_package(pkg_dir.path(), &manifest_json(id, "1.0"), &[]);
+                mgr.install(&pkg, true).unwrap();
+            }
+        }
+
+        let mgr2 = PluginManager::with_hook(&root, Arc::new(FailFor("broken")));
+        let loaded = mgr2.load_enabled_plugins().unwrap();
+
+        // Both enabled+compatible plugins were attempted; the failing one surfaces
+        // as Error with its message, the other loads cleanly — startup carried on.
+        let broken = loaded.iter().find(|p| p.manifest.id == "broken").unwrap();
+        assert_eq!(broken.state, PluginState::Error);
+        assert_eq!(broken.error_message.as_deref(), Some("boom"));
+        let healthy = loaded.iter().find(|p| p.manifest.id == "healthy").unwrap();
+        assert_eq!(healthy.state, PluginState::Installed);
+        assert!(healthy.error_message.is_none());
     }
 
     #[test]

--- a/core/tests/plugin_connection_wiring.rs
+++ b/core/tests/plugin_connection_wiring.rs
@@ -25,7 +25,9 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use termihub_core::connection::{ConnectionType, ConnectionTypeRegistry, FieldType};
-use termihub_core::plugin::{parse_manifest, InstalledPlugin, PluginHost, PluginState};
+use termihub_core::plugin::{
+    parse_manifest, HostLifecycleHook, InstalledPlugin, PluginHost, PluginManager, PluginState,
+};
 
 /// Path to the fixture plugin's `Cargo.toml` (the same echo `cdylib` the
 /// round-trip test uses).
@@ -108,8 +110,13 @@ fn install(
     std::fs::create_dir_all(&backend).expect("create plugin backend dir");
     std::fs::copy(lib, backend.join(artifact_name())).expect("copy backend library");
 
-    let manifest = parse_manifest(&manifest_json(id, name, connection_type))
-        .expect("fixture manifest should parse");
+    // Write the manifest to disk too, so a `PluginManager` scanning the root sees
+    // an installed plugin (the direct `host.load` callers use the return value and
+    // don't need it, but the startup-load test scans from disk).
+    let manifest_src = manifest_json(id, name, connection_type);
+    std::fs::write(dir.join("manifest.json"), &manifest_src).expect("write manifest");
+
+    let manifest = parse_manifest(&manifest_src).expect("fixture manifest should parse");
     manifest
         .validate()
         .expect("fixture manifest should validate");
@@ -119,6 +126,20 @@ fn install(
         error_message: None,
         installed_at: 0,
     }
+}
+
+/// Lay down a plugin `id` on disk with a valid manifest that declares a terminal
+/// backend but **no** backend library, so loading it fails with
+/// `LibraryNotFound` — used to prove a broken enabled plugin surfaces as `Error`
+/// at startup without aborting the rest of the load.
+fn write_manifest_only(root: &Path, id: &str, name: &str, connection_type: &str) {
+    let dir = root.join(id);
+    std::fs::create_dir_all(&dir).expect("create plugin dir");
+    std::fs::write(
+        dir.join("manifest.json"),
+        manifest_json(id, name, connection_type),
+    )
+    .expect("write manifest");
 }
 
 /// Drive a full terminal round trip through a connection created from the
@@ -203,6 +224,74 @@ async fn plugin_type_is_creatable_and_listed_through_the_registry() {
         .collect();
     assert!(after.contains(&"echo".to_string()));
     assert!(!after.contains(&"echo-echo-b".to_string()));
+}
+
+#[tokio::test]
+async fn already_enabled_plugin_is_loaded_at_startup_without_a_toggle() {
+    // The gap #2010 closes: the manager's scan restores a plugin's persisted
+    // enabled flag but does no loading, so an already-enabled plugin's connection
+    // type is never registered until the user toggles it off/on. Here we lay a
+    // plugin down on disk exactly as a previous session left it, then wire up a
+    // fresh manager+host over a shared registry (as `lib.rs` does at startup) and
+    // confirm `load_enabled_plugins` registers and makes the type creatable with
+    // no enable() call in sight.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let lib = build_fixture(&tmp.path().join("target"));
+    let root = tmp.path().join("plugins");
+    std::fs::create_dir_all(&root).unwrap();
+
+    // A broken enabled plugin alongside the healthy one: it declares a terminal
+    // backend but ships no backend library, so its load must fail. It must
+    // surface as `Error` and must NOT prevent the healthy plugin from loading or
+    // abort startup.
+    let _ = install(&root, &lib, "echo", "Echo", "echo");
+    write_manifest_only(&root, "broken", "Broken", "broken");
+
+    // Fresh "startup": manager wired to a real host over a shared registry.
+    // Nothing toggles either plugin — this is a cold start with both persisted as
+    // enabled (no state file → enabled by default).
+    let registry = Arc::new(Mutex::new(ConnectionTypeRegistry::new()));
+    let host = Arc::new(PluginHost::new(root.clone(), Arc::clone(&registry)));
+    let manager = PluginManager::with_hook(
+        root.clone(),
+        Arc::new(HostLifecycleHook::new(Arc::clone(&host))),
+    );
+
+    // Before the startup load, the type is not registered.
+    assert!(
+        !registry.lock().unwrap().has_type("echo"),
+        "type must not be registered before the startup load"
+    );
+
+    // Drive the startup load path.
+    let loaded = manager
+        .load_enabled_plugins()
+        .expect("startup load should not error");
+
+    // The healthy plugin's type is now registered and creatable — no toggle.
+    assert!(
+        registry.lock().unwrap().has_type("echo"),
+        "already-enabled plugin should be loaded at startup"
+    );
+    let mut conn = registry
+        .lock()
+        .unwrap()
+        .create("echo")
+        .expect("plugin type should be creatable straight after startup load");
+    round_trip(&mut conn, b"loaded at startup").await;
+    conn.disconnect().await.unwrap();
+
+    // The broken plugin surfaced as Error, but startup carried on and the healthy
+    // one still loaded.
+    let broken = loaded
+        .iter()
+        .find(|p| p.manifest.id == "broken")
+        .expect("broken plugin should be among those attempted");
+    assert_eq!(broken.state, PluginState::Error);
+    assert!(broken.error_message.is_some());
+    let echo = loaded.iter().find(|p| p.manifest.id == "echo").unwrap();
+    assert_eq!(echo.state, PluginState::Installed);
+    assert!(echo.error_message.is_none());
 }
 
 #[tokio::test]

--- a/docs/changes/dev2/feature/2010-startup-plugin-load.md
+++ b/docs/changes/dev2/feature/2010-startup-plugin-load.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Plugins that were enabled in a previous session are now loaded automatically at
+  startup, so a plugin-provided connection type is registered (and a persisted
+  connection of that type resolves) without the user toggling the plugin off and
+  on. A plugin that fails to load at startup is surfaced as `Error` and skipped
+  rather than aborting startup (#2010).

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -413,6 +413,29 @@ pub fn run() {
                     Ok(_) => {}
                     Err(e) => warn!("plugin compatibility reconciliation failed: {e}"),
                 }
+
+                // Load plugins that were already enabled in a previous session.
+                // The manager's scan restores each plugin's persisted enabled
+                // flag but does no loading, so without this an already-enabled
+                // plugin's connection type is never registered until the user
+                // toggles it off/on — a persisted connection of that type would
+                // fail to resolve after a restart (#2010). This drives the same
+                // host load path a fresh enable uses; a plugin that fails to load
+                // surfaces as `Error` and is skipped, never aborting startup.
+                match plugin_mgr.load_enabled_plugins() {
+                    Ok(loaded) => {
+                        let failed: Vec<_> = loaded
+                            .iter()
+                            .filter(|p| p.state == termihub_core::plugin::PluginState::Error)
+                            .map(|p| p.manifest.id.clone())
+                            .collect();
+                        if !failed.is_empty() {
+                            warn!("plugins that failed to load at startup: {failed:?}");
+                            let _ = app.emit(commands::plugin::EVENT_PLUGINS_CHANGED, ());
+                        }
+                    }
+                    Err(e) => warn!("loading already-enabled plugins at startup failed: {e}"),
+                }
             }
 
             // Capture path for the connections file watcher before config_dir is moved.


### PR DESCRIPTION
## Summary

The native plugin host (#1995/#1999/#2001) only loads a plugin's backend when its enabled state *transitions* (`on_enable`). At app startup, `PluginManager`'s scan restores each plugin's persisted `Enabled` flag but never fires `on_enable`, so an already-enabled plugin sat un-loaded — its `ConnectionType` was never registered, and a persisted connection of that `type_id` would fail to resolve after a restart until the user toggled the plugin off/on.

This adds `PluginManager::load_enabled_plugins`, called once at startup after `reconcile_compatibility`, which drives the **same host `on_enable` load path** a fresh enable uses for every plugin the scan resolves to `Installed` (enabled *and* compatible). It reuses the existing load path — no second loader.

## Behavior

- Enabled + compatible plugins are loaded (ABI/compat gating, permission checks, and disambiguated registry registration all happen in the existing `PluginHost::load`).
- **Disabled** plugins are skipped; **incompatible** plugins are never loaded (run `reconcile_compatibility` first to auto-disable ones that became incompatible — already wired at startup).
- A plugin whose load **fails** surfaces as `PluginState::Error` in the returned vector and is skipped — it never aborts startup. `lib.rs` logs the failed ids and emits `plugin-changed` so the UI refreshes. The plugin stays enabled and is retried on the next launch or an explicit re-enable.

## Tests

- `core/src/plugin/manager.rs` (unit): a simulated restart loads only the enabled+compatible plugin (disabled and incompatible skipped via a recording hook); a failing hook surfaces that plugin as `Error` with its message while a healthy plugin still loads.
- `core/tests/plugin_connection_wiring.rs` (integration, `plugin` feature, real `cdylib` fixture): an already-enabled plugin laid down on disk is loaded through a fresh `PluginManager` + `HostLifecycleHook` + shared registry, and its connection type is **creatable straight after the startup load with no `enable()` call**. A broken enabled plugin (no backend library) alongside it surfaces as `Error` without stopping the healthy one.

All behind the `plugin` feature. `cargo fmt`, `cargo clippy` (core + desktop), and the new tests pass locally.

Closes #2010