### PR TITLE
feat(ui): plugin connection-config UI + puzzle-badged type selector (Closes #2002)

### DIFF
--- a/docs/changes/dev1/feature/2002-plugin-connection-config-ui.md
+++ b/docs/changes/dev1/feature/2002-plugin-connection-config-ui.md
@@ -1,0 +1,10 @@
+### Added
+
+- Plugin connection types in the connection editor: a connection type provided
+  by an active plugin now appears in the type selector below the built-ins under
+  a puzzle-badged **Plugins** separator, so it is visually distinct from a
+  built-in backend. Selecting one renders its configuration form from the
+  plugin's manifest `configSchema` via the existing schema-driven form (no
+  hardcoded fields), and saving produces a connection carrying the plugin's type
+  id and the form's settings. Two plugins that register the same connection-type
+  name are listed with distinct, disambiguated labels (#2002).

--- a/src/components/ConnectionEditor/ConnectionEditor.css
+++ b/src/components/ConnectionEditor/ConnectionEditor.css
@@ -531,3 +531,16 @@
 .field-help-dialog__body p + p {
   margin-top: var(--spacing-sm);
 }
+
+/* A plugin-provided connection type in the type selector (#2002): its name
+   preceded by a puzzle-piece badge, distinguishing it from the built-ins. */
+.connection-editor__plugin-type {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.connection-editor__plugin-badge {
+  flex-shrink: 0;
+  color: var(--text-accent);
+}

--- a/src/components/ConnectionEditor/ConnectionEditor.plugin-types.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.plugin-types.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Plugin-provided connection types in the type picker (#2002).
+ *
+ * A plugin that registers a terminal backend (#1999) flows through the normal
+ * connection-type registry, so the picker must list those types below the
+ * built-ins under a puzzle-badged "Plugins" separator, render their config form
+ * from the manifest-derived schema via the generic DynamicForm, and save a
+ * ConnectionConfig carrying the plugin's type id and the form's settings.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { invoke } from "@tauri-apps/api/core";
+import { useAppStore } from "@/store/appStore";
+import { ConnectionEditor } from "./ConnectionEditor";
+import { TooltipProvider } from "@/components/ui";
+import type { ConnectionTypeInfo, SavedConnection } from "@/types/connection";
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+globalThis.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+} as unknown as typeof ResizeObserver;
+
+const mockedInvoke = vi.mocked(invoke);
+
+const LOCAL_TYPE: ConnectionTypeInfo = {
+  typeId: "local",
+  displayName: "Local Shell",
+  icon: "terminal",
+  schema: { groups: [] },
+  capabilities: { monitoring: false, fileBrowser: false, resize: true, persistent: false },
+};
+
+/** A plugin-provided backend: puzzle icon + a one-field manifest-derived schema. */
+const ACME_TYPE: ConnectionTypeInfo = {
+  typeId: "acme-term",
+  displayName: "Acme Terminal",
+  icon: "puzzle",
+  schema: {
+    groups: [
+      {
+        key: "connection",
+        label: "Connection",
+        fields: [
+          { key: "endpoint", label: "Endpoint", fieldType: { type: "text" }, required: false },
+        ],
+      },
+    ],
+  },
+  capabilities: { monitoring: false, fileBrowser: false, resize: true, persistent: false },
+};
+
+/** A second plugin backend whose display name was disambiguated by the backend. */
+const ACME_TYPE_B: ConnectionTypeInfo = {
+  ...ACME_TYPE,
+  typeId: "acme-term-globex",
+  displayName: "Acme Terminal (Globex)",
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderNew() {
+  const initial = useAppStore.getInitialState();
+  useAppStore.setState({
+    ...initial,
+    connections: [],
+    connectionTypes: [LOCAL_TYPE, ACME_TYPE, ACME_TYPE_B],
+  });
+  act(() => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <ConnectionEditor
+          tabId="tab-1"
+          meta={{ connectionId: "new", folderId: null }}
+          isVisible={true}
+        />
+      </TooltipProvider>
+    );
+  });
+}
+
+/** Open the Radix type-select and return its rendered option elements. */
+function openTypeOptions(): HTMLElement[] {
+  const trigger = document.querySelector(
+    '[data-testid="connection-editor-type-select"]'
+  ) as HTMLElement | null;
+  if (!trigger) throw new Error("type select trigger not found");
+  for (let i = 0; i < 3 && document.querySelectorAll(".ui-select__item").length === 0; i++) {
+    act(() => {
+      trigger.focus();
+      trigger.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", code: "Enter", keyCode: 13, bubbles: true })
+      );
+    });
+  }
+  return Array.from(document.querySelectorAll<HTMLElement>(".ui-select__item"));
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  mockedInvoke.mockImplementation(() => Promise.resolve(false));
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("ConnectionEditor — plugin connection types", () => {
+  it("lists plugin types under a puzzle-badged Plugins separator, below the built-ins", () => {
+    renderNew();
+    const options = openTypeOptions();
+    const values = options.map((o) => o.getAttribute("data-value"));
+
+    // Built-in first, then the plugin backends.
+    expect(values).toContain("local");
+    expect(values).toContain("acme-term");
+    expect(values.indexOf("local")).toBeLessThan(values.indexOf("acme-term"));
+
+    // A "Plugins" group heading separates them.
+    const groupLabel = document.querySelector(".ui-select__group-label");
+    expect(groupLabel?.textContent).toBe("Plugins");
+    expect(document.querySelector('[data-testid="connection-type-plugins-group"]')).not.toBeNull();
+
+    // Only the plugin item carries the puzzle badge.
+    const plugin = options.find((o) => o.getAttribute("data-value") === "acme-term");
+    const builtin = options.find((o) => o.getAttribute("data-value") === "local");
+    expect(plugin?.querySelector(".connection-editor__plugin-badge")).not.toBeNull();
+    expect(builtin?.querySelector(".connection-editor__plugin-badge")).toBeNull();
+    expect(plugin?.textContent).toContain("Acme Terminal");
+  });
+
+  it("renders two same-named plugin backends with distinct disambiguated labels", () => {
+    renderNew();
+    const options = openTypeOptions();
+    const labels = options
+      .filter((o) => o.getAttribute("data-value")?.startsWith("acme-term"))
+      .map((o) => o.textContent);
+    expect(labels).toContain("Acme Terminal");
+    expect(labels).toContain("Acme Terminal (Globex)");
+  });
+
+  it("renders the plugin's schema-driven config form and saves its type id + settings", async () => {
+    const existing: SavedConnection = {
+      id: "conn-acme-1",
+      name: "My Acme",
+      config: { type: "acme-term", config: { endpoint: "wss://acme.example" } },
+      folderId: null,
+    };
+    const updateConnection = vi.fn();
+    const initial = useAppStore.getInitialState();
+    useAppStore.setState({
+      ...initial,
+      connections: [existing],
+      connectionTypes: [LOCAL_TYPE, ACME_TYPE],
+      updateConnection,
+    });
+    act(() => {
+      root.render(
+        <TooltipProvider delayDuration={0}>
+          <ConnectionEditor
+            tabId="tab-edit"
+            meta={{ connectionId: "conn-acme-1", folderId: null }}
+            isVisible={true}
+          />
+        </TooltipProvider>
+      );
+    });
+
+    // The manifest-derived field renders via the generic DynamicForm — no
+    // hardcoded plugin UI.
+    const field = document.querySelector('[data-testid="field-endpoint"]');
+    expect(field).not.toBeNull();
+
+    // Saving keeps the plugin type id and forwards the settings JSON verbatim.
+    const saveBtn = document.querySelector(
+      '[data-testid="connection-editor-save"]'
+    ) as HTMLElement | null;
+    expect(saveBtn).not.toBeNull();
+    await act(async () => {
+      saveBtn!.click();
+      await Promise.resolve();
+    });
+
+    expect(updateConnection).toHaveBeenCalledTimes(1);
+    const saved = updateConnection.mock.calls[0][0] as SavedConnection;
+    expect(saved.config.type).toBe("acme-term");
+    expect(saved.config.config).toMatchObject({ endpoint: "wss://acme.example" });
+  });
+});

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -1,5 +1,14 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
-import { PlugZap, TerminalSquare, Palette, Settings, KeyRound, FileDown } from "lucide-react";
+import * as RadixSelect from "@radix-ui/react-select";
+import {
+  PlugZap,
+  TerminalSquare,
+  Palette,
+  Settings,
+  KeyRound,
+  FileDown,
+  Puzzle,
+} from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import {
@@ -30,7 +39,7 @@ import {
   SshConfigImportConnection,
 } from "@/types/connection";
 import { SettingsNav } from "@/components/Settings";
-import { Button, Input, Select, Toggle, toast } from "@/components/ui";
+import { Button, Input, Select, SelectItem, Toggle, toast } from "@/components/ui";
 import { ConnectionSettingsForm, AGENT_SCHEMA } from "@/components/DynamicForm";
 import {
   buildDefaults,
@@ -56,6 +65,7 @@ import { useEditorKeyboard } from "@/hooks/useEditorKeyboard";
 import { useAutofocusSelect } from "@/hooks/useAutofocusSelect";
 import { useExperimentalFeatures } from "@/hooks/useExperimentalFeatures";
 import { buildGatedTypeOptions } from "@/utils/experimentalTypes";
+import { partitionConnectionTypes } from "@/utils/pluginConnectionTypes";
 import { isWindows } from "@/utils/platform";
 import "./ConnectionEditor.css";
 
@@ -537,16 +547,21 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
   const [isCompact, setIsCompact] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Build type options from the effective registry, gating experimental
+  // Build the connection-type picker from the effective registry, split into
+  // built-in and plugin-provided types (#2002). Built-ins gate experimental
   // (graphical remote-desktop) types behind `experimentalFeaturesEnabled`
-  // (#1705). The currently-selected type is always kept so editing an existing
-  // experimental connection never loses its selection.
-  const typeOptions = useMemo(() => {
-    if (isAgentDefinitionMode) {
-      // Definition mode: show only agent-reported types (no "Remote Agent" entry)
-      return buildGatedTypeOptions(agentConnectionTypes, experimental, selectedType);
-    }
-    return buildGatedTypeOptions(connectionTypes, experimental, selectedType);
+  // (#1705); the currently-selected type is always kept so editing an existing
+  // experimental connection never loses its selection. Plugin-provided types
+  // (registered by active plugins via #1999) render below the built-ins under a
+  // puzzle-badged "Plugins" separator, carrying the registry's already
+  // disambiguated display names.
+  const { builtinTypeOptions, pluginTypes } = useMemo(() => {
+    const registry = isAgentDefinitionMode ? agentConnectionTypes : connectionTypes;
+    const { builtins, plugins } = partitionConnectionTypes(registry);
+    return {
+      builtinTypeOptions: buildGatedTypeOptions(builtins, experimental, selectedType),
+      pluginTypes: plugins,
+    };
   }, [isAgentDefinitionMode, agentConnectionTypes, connectionTypes, experimental, selectedType]);
 
   // Get the current schema from the effective registry
@@ -1163,11 +1178,39 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
             <Select
               value={selectedType}
               onChange={handleTypeChange}
-              options={typeOptions}
               disabled={isAgentDefinitionMode ? !!existingAgentDef : false}
               aria-label="Type"
               data-testid="connection-editor-type-select"
-            />
+            >
+              {builtinTypeOptions.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+              {pluginTypes.length > 0 && (
+                <RadixSelect.Group data-testid="connection-type-plugins-group">
+                  <RadixSelect.Separator className="ui-select__separator" />
+                  <RadixSelect.Label className="ui-select__group-label">Plugins</RadixSelect.Label>
+                  {pluginTypes.map((type) => (
+                    <SelectItem
+                      key={type.typeId}
+                      value={type.typeId}
+                      data-testid={`connection-type-plugin-${type.typeId}`}
+                    >
+                      <span className="connection-editor__plugin-type">
+                        <Puzzle
+                          className="connection-editor__plugin-badge"
+                          width={13}
+                          height={13}
+                          aria-hidden="true"
+                        />
+                        {type.displayName}
+                      </span>
+                    </SelectItem>
+                  ))}
+                </RadixSelect.Group>
+              )}
+            </Select>
           </label>
         )}
         {!isAgentTransportMode && (

--- a/src/utils/pluginConnectionTypes.test.ts
+++ b/src/utils/pluginConnectionTypes.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import {
+  PLUGIN_CONNECTION_TYPE_ICON,
+  isPluginConnectionType,
+  partitionConnectionTypes,
+} from "./pluginConnectionTypes";
+import type { ConnectionTypeInfo } from "@/types/connection";
+import type { SettingsSchema, Capabilities } from "@/types/schema";
+
+const EMPTY_SCHEMA: SettingsSchema = { groups: [] };
+const CAPS: Capabilities = {
+  monitoring: false,
+  fileBrowser: false,
+  resize: true,
+  persistent: false,
+  terminal: true,
+};
+
+function type(typeId: string, displayName: string, icon: string): ConnectionTypeInfo {
+  return { typeId, displayName, icon, schema: EMPTY_SCHEMA, capabilities: CAPS };
+}
+
+describe("isPluginConnectionType", () => {
+  it("is true only for the plugin (puzzle) icon", () => {
+    expect(isPluginConnectionType(type("acme", "Acme", PLUGIN_CONNECTION_TYPE_ICON))).toBe(true);
+    expect(isPluginConnectionType(type("ssh", "SSH", "ssh"))).toBe(false);
+    expect(isPluginConnectionType(type("local", "Local", "terminal"))).toBe(false);
+  });
+});
+
+describe("partitionConnectionTypes", () => {
+  it("splits built-in and plugin-provided types, preserving order", () => {
+    const registry = [
+      type("local", "Local", "terminal"),
+      type("ssh", "SSH", "ssh"),
+      type("acme", "Acme Terminal", PLUGIN_CONNECTION_TYPE_ICON),
+      type("serial", "Serial", "serial"),
+      type("widget", "Widget Shell", PLUGIN_CONNECTION_TYPE_ICON),
+    ];
+
+    const { builtins, plugins } = partitionConnectionTypes(registry);
+
+    expect(builtins.map((t) => t.typeId)).toEqual(["local", "ssh", "serial"]);
+    expect(plugins.map((t) => t.typeId)).toEqual(["acme", "widget"]);
+  });
+
+  it("keeps two same-named plugin backends distinct via their disambiguated ids/labels", () => {
+    // The backend suffixes colliding connectionType names before they reach the
+    // registry (#1999), so partitioning surfaces both with distinct labels.
+    const registry = [
+      type("local", "Local", "terminal"),
+      type("gopher-acme", "Gopher (Acme)", PLUGIN_CONNECTION_TYPE_ICON),
+      type("gopher-globex", "Gopher (Globex)", PLUGIN_CONNECTION_TYPE_ICON),
+    ];
+
+    const { plugins } = partitionConnectionTypes(registry);
+
+    expect(plugins.map((t) => t.typeId)).toEqual(["gopher-acme", "gopher-globex"]);
+    expect(plugins.map((t) => t.displayName)).toEqual(["Gopher (Acme)", "Gopher (Globex)"]);
+  });
+
+  it("returns an empty plugin group when no plugin types are present", () => {
+    const registry = [type("local", "Local", "terminal"), type("ssh", "SSH", "ssh")];
+    const { builtins, plugins } = partitionConnectionTypes(registry);
+    expect(plugins).toEqual([]);
+    expect(builtins).toHaveLength(2);
+  });
+});

--- a/src/utils/pluginConnectionTypes.ts
+++ b/src/utils/pluginConnectionTypes.ts
@@ -1,0 +1,46 @@
+import type { ConnectionTypeInfo } from "@/types/connection";
+
+/**
+ * Plugin-provided connection types in the connection-type selector (#2002).
+ *
+ * A plugin that declares a `terminalBackend` extension registers its connection
+ * type into the shared `ConnectionTypeRegistry` (#1999), so it flows to the
+ * frontend through the normal `get_connection_types` path alongside the
+ * built-ins — including a settings schema derived from the manifest
+ * `configSchema` (which the generic `DynamicForm` then renders) and, when the
+ * declared `connectionType` collided with a built-in or another plugin, a
+ * disambiguated `type_id` / display name suffixed by the plugin.
+ *
+ * The plugin host stamps every such registry entry with the {@link
+ * PLUGIN_CONNECTION_TYPE_ICON} icon; no built-in type uses it. That icon is the
+ * authoritative marker of a plugin-provided type — it survives the backend's
+ * disambiguation (unlike matching a raw manifest `connectionType` name against
+ * the store's `pluginBackendTypes` projection, which does not) — so the selector
+ * partitions the registry on it to list plugin types under their own separator.
+ */
+
+/** The registry icon the plugin host assigns to every plugin-provided type (#1999). */
+export const PLUGIN_CONNECTION_TYPE_ICON = "puzzle";
+
+/** Whether a connection type is plugin-provided (registered by an active plugin). */
+export function isPluginConnectionType(info: Pick<ConnectionTypeInfo, "icon">): boolean {
+  return info.icon === PLUGIN_CONNECTION_TYPE_ICON;
+}
+
+/**
+ * Split a connection-type registry into built-in and plugin-provided types,
+ * preserving each group's original registry order. The plugin group carries the
+ * types' already-disambiguated display names, so two plugins registering the
+ * same `connectionType` render distinct labels.
+ */
+export function partitionConnectionTypes(types: ConnectionTypeInfo[]): {
+  builtins: ConnectionTypeInfo[];
+  plugins: ConnectionTypeInfo[];
+} {
+  const builtins: ConnectionTypeInfo[] = [];
+  const plugins: ConnectionTypeInfo[] = [];
+  for (const type of types) {
+    (isPluginConnectionType(type) ? plugins : builtins).push(type);
+  }
+  return { builtins, plugins };
+}


### PR DESCRIPTION
## Summary

Surfaces plugin-provided terminal backends in the connection editor's type selector and renders their config form — the concept's "Sixth PR — Plugin connection config UI".

Building on **#1999**, plugin-registered `ConnectionType`s already flow to the frontend through the normal `get_connection_types` registry path, with the manifest `configSchema` translated into the `SettingsSchema` the generic `DynamicForm` renders. This PR is the UI polish on top of that:

- **Badged selector.** The connection-type `Select` now partitions the registry into built-in and plugin-provided types and lists the plugin types **below** the built-ins under a puzzle-badged **Plugins** separator, reusing the same `ui-select__separator` / `ui-select__group-label` primitives introduced for the theme selector (#1996). Plugin types are identified by the `puzzle` icon the plugin host stamps on every plugin registry entry (#1999) — an authoritative marker that survives the backend's collision disambiguation.
- **Schema-driven config form.** Selecting a plugin type renders its config form from the manifest `configSchema` via the existing `ConnectionSettingsForm`/`DynamicForm` — no hardcoded fields. This already worked via the registry path; the change keeps plugin types flowing through it unchanged.
- **Saved-config shape.** Saving produces a `ConnectionConfig` with the plugin's `type_id` and the form's settings JSON, identical to built-ins (the generic save path).
- **Disambiguation.** Two plugins registering the same connection-type name render distinct labels, because the selector uses the registry's already-disambiguated display names (the backend suffixes them in #1999).

## Scope note

The issue names a dedicated `PluginConnectionConfig` component, but under #1999's architecture the plugin's schema already renders through the shared `DynamicForm`; adding a parallel component would duplicate that logic and risk drift, so it was intentionally not created (per the schema-driven, compose-from-primitives rules). The meaningful, non-redundant UI addition is the badged selector.

## Tests

- `src/utils/pluginConnectionTypes.test.ts` — partition/marker logic, incl. two same-named backends staying distinct.
- `src/components/ConnectionEditor/ConnectionEditor.plugin-types.test.tsx` — selector lists plugin types under the puzzle-badged Plugins separator (badge only on plugin items), disambiguated labels, schema-driven form renders (`field-endpoint`), and saved config keeps the plugin `type_id` + settings.

Full frontend suite (4568 tests), `pnpm lint`, and `pnpm build` (tsc) all pass locally.

Closes #2002