### PR TITLE
feat(plugin): host-mediated capability bridge enforcing network/filesystem permissions at runtime (Closes #2018)

### DIFF
--- a/core/src/plugin/capabilities.rs
+++ b/core/src/plugin/capabilities.rs
@@ -1,0 +1,261 @@
+//! Host side of the plugin **capability bridge** (#2018).
+//!
+//! [`build_host_bridge`] constructs the
+//! [`PluginHostBridge`](termihub_plugin_api::PluginHostBridge) the host hands to a
+//! plugin at `create_backend`. Its context owns a clone of the session's
+//! [`PermissionSet`], and its callbacks route every mediated operation through
+//! that set's guards — [`PermissionSet::require`] for network, and
+//! [`FilesystemScope::check`] (via [`PermissionSet::check_path`]) for filesystem —
+//! so `network`/`filesystem` are enforced **at runtime**, not merely validated at
+//! load (concept §13; the runtime half of the primitives added in #2001).
+//!
+//! # Enforcement boundary
+//!
+//! The bridge mediates the operations a cooperating plugin routes *through it*:
+//! for those, the host opens the socket / reads the file and refuses when the
+//! permission or path-scope check fails. It is **not** an OS sandbox — an
+//! in-process plugin could still bypass the bridge with a direct syscall, which
+//! only OS-level isolation (out of scope, no substrate today) could stop. See the
+//! [`termihub_plugin_api::capabilities`] module docs.
+
+use std::net::TcpStream;
+use std::path::Path;
+
+use termihub_plugin_api::capabilities::{
+    PluginBridgeDestroyFn, PluginOpenConnectionFn, PluginReadFileFn,
+};
+use termihub_plugin_api::{FfiOwnedBytes, FfiStr, PluginHostBridge, PluginStatus, PluginTcpStream};
+
+use super::security::{PermissionError, PermissionSet};
+use super::PluginPermission;
+
+/// Build the host capability bridge for a session granted `permissions`.
+///
+/// The returned [`PluginHostBridge`] is passed by value into the plugin's
+/// `create_backend`; the plugin owns it thereafter and drops it (running the
+/// destructor installed here, which frees the boxed permission set). Every call a
+/// plugin makes through the bridge is checked against `permissions` before the
+/// host performs it.
+#[must_use]
+pub fn build_host_bridge(permissions: PermissionSet) -> PluginHostBridge {
+    // The bridge context owns a clone of the granted permission set. Leaked as a
+    // raw pointer to cross the ABI; `bridge_destroy` reclaims it.
+    let ctx = Box::into_raw(Box::new(permissions)).cast::<core::ffi::c_void>();
+    let open_connection: PluginOpenConnectionFn = bridge_open_connection;
+    let read_file: PluginReadFileFn = bridge_read_file;
+    let destroy: PluginBridgeDestroyFn = bridge_destroy;
+    // SAFETY: `ctx` is a leaked `Box<PermissionSet>`; the three callbacks below
+    // only ever interpret it as exactly that, and `destroy` reclaims it exactly
+    // once. `PermissionSet` is `Send + Sync`, matching the bridge's bounds.
+    unsafe { PluginHostBridge::from_raw(ctx, open_connection, read_file, Some(destroy)) }
+}
+
+/// Borrow the boxed [`PermissionSet`] behind a bridge `ctx`.
+///
+/// # Safety
+///
+/// `ctx` must be a live `*mut PermissionSet` produced by [`build_host_bridge`].
+unsafe fn permissions<'a>(ctx: *mut core::ffi::c_void) -> &'a PermissionSet {
+    // SAFETY: caller guarantees `ctx` is the leaked `Box<PermissionSet>`; borrowing
+    // it shared is sound because every callback only reads it.
+    unsafe { &*ctx.cast::<PermissionSet>() }
+}
+
+/// `open_connection` callback: enforce the `network` permission, then connect.
+///
+/// # Safety
+///
+/// `ctx` must be a live bridge context; `out_stream` a valid, writable
+/// `*mut PluginTcpStream`. `host` borrows valid memory for the call.
+unsafe extern "C" fn bridge_open_connection(
+    ctx: *mut core::ffi::c_void,
+    host: FfiStr,
+    port: u16,
+    out_stream: *mut PluginTcpStream,
+) -> PluginStatus {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: upheld by this function's contract.
+        let perms = unsafe { permissions(ctx) };
+        // Runtime enforcement: refuse before touching the network if the plugin
+        // never requested `network`.
+        if perms.require(PluginPermission::Network).is_err() {
+            return PluginStatus::PermissionDenied;
+        }
+        // SAFETY: `host` is a valid borrowed `&str` for the call.
+        let host_str = unsafe { host.as_str() };
+        match TcpStream::connect((host_str, port)) {
+            Ok(stream) => {
+                let handle = PluginTcpStream::from_std(stream);
+                // SAFETY: `out_stream` is a valid, writable out-parameter.
+                unsafe { out_stream.write(handle) };
+                PluginStatus::Ok
+            }
+            Err(_) => PluginStatus::Io,
+        }
+    }));
+    result.unwrap_or(PluginStatus::Panic)
+}
+
+/// `read_file` callback: resolve the path against the plugin's declared scope,
+/// then read it.
+///
+/// # Safety
+///
+/// `ctx` must be a live bridge context; `out_bytes` a valid, writable
+/// `*mut FfiOwnedBytes`. `path` borrows valid memory for the call.
+unsafe extern "C" fn bridge_read_file(
+    ctx: *mut core::ffi::c_void,
+    path: FfiStr,
+    out_bytes: *mut FfiOwnedBytes,
+) -> PluginStatus {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: upheld by this function's contract.
+        let perms = unsafe { permissions(ctx) };
+        // SAFETY: `path` is a valid borrowed `&str` for the call.
+        let requested = unsafe { path.as_str() };
+        // Runtime enforcement: reject a missing `filesystem` permission or a path
+        // outside the declared scope before any read happens.
+        match perms.check_path(Path::new(requested)) {
+            Ok(resolved) => match std::fs::read(&resolved) {
+                Ok(bytes) => {
+                    // SAFETY: `out_bytes` is a valid, writable out-parameter.
+                    unsafe { out_bytes.write(FfiOwnedBytes::from_vec(bytes)) };
+                    PluginStatus::Ok
+                }
+                Err(_) => PluginStatus::Io,
+            },
+            Err(PermissionError::Denied(_)) | Err(PermissionError::PathOutsideScope { .. }) => {
+                PluginStatus::PermissionDenied
+            }
+            Err(_) => PluginStatus::Other,
+        }
+    }));
+    result.unwrap_or(PluginStatus::Panic)
+}
+
+/// Destructor for the bridge context: reclaim the boxed [`PermissionSet`].
+///
+/// # Safety
+///
+/// `ctx` must be the leaked `Box<PermissionSet>` from [`build_host_bridge`] and
+/// must not be used afterwards.
+unsafe extern "C" fn bridge_destroy(ctx: *mut core::ffi::c_void) {
+    if !ctx.is_null() {
+        // SAFETY: reclaims the box leaked in `build_host_bridge`, exactly once.
+        drop(unsafe { Box::from_raw(ctx.cast::<PermissionSet>()) });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    /// A permission set granting exactly `perms`, scoped to `fs_paths`.
+    fn perms(perms: &[PluginPermission], fs_paths: &[&str]) -> PermissionSet {
+        let owned: Vec<String> = fs_paths.iter().map(|s| (*s).to_owned()).collect();
+        PermissionSet::from_parts(perms.iter().copied(), &owned)
+    }
+
+    #[test]
+    fn network_is_denied_without_the_permission() {
+        // A plugin with no `network` permission cannot open a connection through
+        // the bridge — the host refuses before the socket is ever touched.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let bridge = build_host_bridge(perms(&[PluginPermission::Terminal], &[]));
+        let err = bridge.open_connection("127.0.0.1", port).unwrap_err();
+        assert!(
+            matches!(err, termihub_plugin_api::PluginError::PermissionDenied),
+            "got {err:?}"
+        );
+
+        // Nothing connected: a non-blocking accept finds no pending connection.
+        listener.set_nonblocking(true).unwrap();
+        assert!(
+            listener.accept().is_err(),
+            "denied plugin must not have opened a connection"
+        );
+    }
+
+    #[test]
+    fn network_is_mediated_when_granted() {
+        // With `network` granted the host opens the connection and hands back a
+        // mediated stream the plugin can actually use.
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let server = std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 5];
+            sock.read_exact(&mut buf).unwrap();
+            sock.write_all(b"pong").unwrap();
+            buf
+        });
+
+        let bridge = build_host_bridge(perms(&[PluginPermission::Network], &[]));
+        let mut stream = bridge.open_connection("127.0.0.1", port).expect("granted");
+        stream.write_all(b"hello").unwrap();
+        let mut reply = [0u8; 4];
+        stream.read_exact(&mut reply).unwrap();
+        assert_eq!(&reply, b"pong");
+
+        let received = server.join().unwrap();
+        assert_eq!(&received, b"hello");
+    }
+
+    #[test]
+    fn filesystem_read_is_denied_outside_the_declared_scope() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path().join("scoped");
+        std::fs::create_dir_all(&root).unwrap();
+        let inside = root.join("data.txt");
+        std::fs::write(&inside, b"in-scope contents").unwrap();
+        let outside = dir.path().join("secret.txt");
+        std::fs::write(&outside, b"top secret").unwrap();
+
+        let bridge = build_host_bridge(perms(
+            &[PluginPermission::Filesystem],
+            &[root.to_str().unwrap()],
+        ));
+
+        // In-scope read succeeds and returns the real contents.
+        let bytes = bridge
+            .read_file(inside.to_str().unwrap())
+            .expect("in scope");
+        assert_eq!(bytes, b"in-scope contents");
+
+        // A read outside the declared scope is rejected end-to-end — the host
+        // never opens the file.
+        let err = bridge.read_file(outside.to_str().unwrap()).unwrap_err();
+        assert!(
+            matches!(err, termihub_plugin_api::PluginError::PermissionDenied),
+            "got {err:?}"
+        );
+
+        // A traversal escape from an in-scope prefix is rejected too.
+        let escape = root.join("../secret.txt");
+        let err = bridge.read_file(escape.to_str().unwrap()).unwrap_err();
+        assert!(matches!(
+            err,
+            termihub_plugin_api::PluginError::PermissionDenied
+        ));
+    }
+
+    #[test]
+    fn filesystem_read_is_denied_without_the_permission() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("data.txt");
+        std::fs::write(&file, b"contents").unwrap();
+
+        // No `filesystem` permission at all → every read is refused.
+        let bridge = build_host_bridge(perms(&[PluginPermission::Terminal], &[]));
+        let err = bridge.read_file(file.to_str().unwrap()).unwrap_err();
+        assert!(matches!(
+            err,
+            termihub_plugin_api::PluginError::PermissionDenied
+        ));
+    }
+}

--- a/core/src/plugin/connection.rs
+++ b/core/src/plugin/connection.rs
@@ -300,9 +300,14 @@ impl ConnectionType for PluginConnectionType {
         let (std_tx, std_rx) = std::sync::mpsc::channel::<Vec<u8>>();
         let output = PluginOutputSender::from_sender(std_tx);
 
+        // Hand the plugin a host capability bridge scoped to this session's granted
+        // permissions, so any network/filesystem access it performs through the
+        // bridge is enforced by the host at runtime (concept §13, #2018).
+        let bridge = super::capabilities::build_host_bridge(self.permissions.clone());
+
         let backend = self
             .library
-            .create_backend(&config_json, output)
+            .create_backend(&config_json, output, bridge)
             .map_err(map_plugin_error)?;
 
         let output_tx = Arc::clone(&self.output_tx);

--- a/core/src/plugin/host.rs
+++ b/core/src/plugin/host.rs
@@ -45,8 +45,8 @@ use termihub_plugin_api::symbols::{
     SYMBOL_PLUGIN_SHUTDOWN,
 };
 use termihub_plugin_api::{
-    LoadedBackend, PluginBackend, PluginError, PluginInfo, PluginOutputSender, PluginSessionConfig,
-    CURRENT_PLUGIN_API_VERSION,
+    LoadedBackend, PluginBackend, PluginError, PluginHostBridge, PluginInfo, PluginOutputSender,
+    PluginSessionConfig, CURRENT_PLUGIN_API_VERSION,
 };
 
 use crate::connection::ConnectionTypeRegistry;
@@ -174,30 +174,34 @@ impl LoadedLibrary {
     /// Create a new backend session from this plugin.
     ///
     /// Calls the plugin's `create_backend` entry point with the borrowed
-    /// `config_json` and the host-owned `output` sink, returning a safe
-    /// [`LoadedBackend`] wrapper on success. The returned backend borrows nothing
-    /// from `config_json` (the plugin copies what it needs before the call
-    /// returns), but it *does* depend on this library staying loaded — callers
-    /// must keep an `Arc<LoadedLibrary>` alive for the backend's lifetime.
+    /// `config_json`, the host-owned `output` sink, and the host capability
+    /// `bridge`, returning a safe [`LoadedBackend`] wrapper on success. The
+    /// `bridge` is the plugin's permission-checked route to network/filesystem
+    /// access (#2018); ownership of it transfers to the plugin. The returned
+    /// backend borrows nothing from `config_json` (the plugin copies what it needs
+    /// before the call returns), but it *does* depend on this library staying
+    /// loaded — callers must keep an `Arc<LoadedLibrary>` alive for the backend's
+    /// lifetime.
     pub fn create_backend(
         &self,
         config_json: &str,
         output: PluginOutputSender,
+        bridge: PluginHostBridge,
     ) -> Result<LoadedBackend, PluginError> {
         let config = PluginSessionConfig::new(config_json);
         let mut backend = PluginBackend {
             state: std::ptr::null_mut(),
             vtable: std::ptr::null(),
         };
-        // SAFETY: `config` outlives the call; `output` ownership is transferred to
-        // the plugin; `&mut backend` is a valid out-parameter. The plugin writes a
-        // valid `PluginBackend` on `Ok`. The call is wrapped in `catch_unwind` so a
-        // panic inside the plugin's entry point is contained rather than unwinding
-        // across the FFI boundary (undefined behavior) — a misbehaving plugin must
-        // not crash the host (concept "Error recovery").
+        // SAFETY: `config` outlives the call; `output` and `bridge` ownership are
+        // transferred to the plugin; `&mut backend` is a valid out-parameter. The
+        // plugin writes a valid `PluginBackend` on `Ok`. The call is wrapped in
+        // `catch_unwind` so a panic inside the plugin's entry point is contained
+        // rather than unwinding across the FFI boundary (undefined behavior) — a
+        // misbehaving plugin must not crash the host (concept "Error recovery").
         let create_backend = self.create_backend;
         let status = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
-            create_backend(&config, output, &mut backend)
+            create_backend(&config, output, bridge, &mut backend)
         }))
         .map_err(|_| PluginError::Panicked)?;
         status.into_result()?;

--- a/core/src/plugin/mod.rs
+++ b/core/src/plugin/mod.rs
@@ -59,6 +59,7 @@
 //! helpers build a backend crate's dynamic library and drive this function via
 //! the `termihub-plugin-pack` binary.
 
+mod capabilities;
 mod connection;
 mod host;
 mod manager;
@@ -67,6 +68,7 @@ mod pack;
 mod package;
 mod security;
 
+pub use capabilities::build_host_bridge;
 pub use connection::{config_schema_to_settings_schema, PluginConnectionType};
 pub use host::{
     find_backend_library, load_backend_library, HostError, HostLifecycleHook, LoadedLibrary,

--- a/core/tests/fixtures/test-plugin/Cargo.toml
+++ b/core/tests/fixtures/test-plugin/Cargo.toml
@@ -16,6 +16,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 termihub-plugin-api = { path = "../../../../plugin-api" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [features]
 # The default build exports every ABI symbol. Building with

--- a/core/tests/fixtures/test-plugin/src/lib.rs
+++ b/core/tests/fixtures/test-plugin/src/lib.rs
@@ -15,13 +15,15 @@
 //!   default), so a `--no-default-features` build omits it and exercises the
 //!   loader's missing-symbol path.
 
+use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use serde::Deserialize;
 #[cfg(feature = "export-init")]
 use termihub_plugin_api::PluginInfo;
 use termihub_plugin_api::{
-    PluginBackend, PluginError, PluginOutputSender, PluginSessionConfig, PluginStatus,
-    PluginTerminalBackend, CURRENT_PLUGIN_API_VERSION,
+    PluginBackend, PluginError, PluginHostBridge, PluginOutputSender, PluginSessionConfig,
+    PluginStatus, PluginTerminalBackend, CURRENT_PLUGIN_API_VERSION,
 };
 
 /// A backend that echoes written input straight back to the host output sink.
@@ -83,20 +85,90 @@ pub unsafe extern "C" fn termihub_plugin_init(out_info: *mut PluginInfo) -> Plug
     PluginStatus::Ok
 }
 
+/// Optional capability-bridge probe driven by the session config, so the
+/// host-loader tests can exercise the runtime permission enforcement (#2018)
+/// across the real dlopen boundary. Absent for the plain echo scenarios.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct ProbeConfig {
+    /// `"network"` or `"readfile"`; empty means "no probe, just echo".
+    probe: String,
+    /// Target host for the `network` probe.
+    probe_host: String,
+    /// Target port for the `network` probe.
+    probe_port: u16,
+    /// Target path for the `readfile` probe.
+    probe_path: String,
+}
+
+/// Run the requested capability probe through the host `bridge` and report the
+/// outcome as a single line on the `output` sink. The test asserts on this line
+/// to prove the host actually enforces (or grants) the capability end-to-end.
+fn run_probe(cfg: &ProbeConfig, bridge: &PluginHostBridge, output: &PluginOutputSender) {
+    match cfg.probe.as_str() {
+        "network" => {
+            let line = match bridge.open_connection(&cfg.probe_host, cfg.probe_port) {
+                Ok(mut stream) => {
+                    // Prove the mediated stream is usable, best-effort.
+                    let _ = stream.write_all(b"ping");
+                    b"NETWORK_OK".to_vec()
+                }
+                Err(PluginError::PermissionDenied) => b"NETWORK_DENIED".to_vec(),
+                Err(_) => b"NETWORK_ERR".to_vec(),
+            };
+            let _ = output.send(&line);
+        }
+        "readfile" => {
+            let line = match bridge.read_file(&cfg.probe_path) {
+                Ok(bytes) => {
+                    let mut line = b"READ_OK:".to_vec();
+                    line.extend_from_slice(&bytes);
+                    line
+                }
+                Err(PluginError::PermissionDenied) => b"READ_DENIED".to_vec(),
+                Err(_) => b"READ_ERR".to_vec(),
+            };
+            let _ = output.send(&line);
+        }
+        _ => {}
+    }
+}
+
 /// Create an [`EchoBackend`] session.
+///
+/// If the config declares a `probe`, first exercise the host capability `bridge`
+/// and report the outcome on `output` (the #2018 runtime-enforcement path);
+/// otherwise the `bridge` is simply dropped and the backend is a plain echo.
 ///
 /// # Safety
 ///
 /// `out_backend` must be a valid, writable `*mut PluginBackend`.
 #[no_mangle]
 pub unsafe extern "C" fn termihub_plugin_create_backend(
-    _config: *const PluginSessionConfig,
+    config: *const PluginSessionConfig,
     output: PluginOutputSender,
+    bridge: PluginHostBridge,
     out_backend: *mut PluginBackend,
 ) -> PluginStatus {
     if out_backend.is_null() {
         return PluginStatus::Other;
     }
+
+    // Parse the optional probe config (absent/empty => plain echo).
+    let cfg = if config.is_null() {
+        ProbeConfig::default()
+    } else {
+        // SAFETY: caller guarantees `config` is valid for the call; `config_json`
+        // borrows host-owned memory that outlives this function.
+        let json = unsafe { (*config).config_json.as_str() };
+        serde_json::from_str::<ProbeConfig>(json).unwrap_or_default()
+    };
+    if !cfg.probe.is_empty() {
+        run_probe(&cfg, &bridge, &output);
+    }
+    // The echo backend keeps no network/filesystem state, so the bridge is done.
+    drop(bridge);
+
     let backend = PluginBackend::from_boxed(Box::new(EchoBackend {
         output,
         alive: AtomicBool::new(true),

--- a/core/tests/plugin_capability_bridge.rs
+++ b/core/tests/plugin_capability_bridge.rs
@@ -1,0 +1,175 @@
+//! End-to-end test of the host-mediated capability bridge (#2018).
+//!
+//! Where `plugin_host_roundtrip.rs` proves a plugin *loads* and echoes, this test
+//! proves the host actually **enforces the plugin's declared permissions at
+//! runtime** on network/filesystem access routed through the bridge — across the
+//! real `dlopen` boundary, not just in-process.
+//!
+//! The fixture `cdylib` (`tests/fixtures/test-plugin`) grows an optional probe:
+//! given a `{"probe": "network"|"readfile", …}` session config it calls the host
+//! bridge and reports the outcome (`NETWORK_OK`/`NETWORK_DENIED`,
+//! `READ_OK:<bytes>`/`READ_DENIED`) as its first output line. Here we build the
+//! fixture, drive a [`PluginConnectionType`] with a chosen [`PermissionSet`], and
+//! assert the bridge grants or denies exactly as the permissions dictate.
+#![cfg(feature = "plugin")]
+
+use std::io::Read;
+use std::net::TcpListener;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use termihub_core::connection::{ConnectionType, SettingsSchema};
+use termihub_core::plugin::{load_backend_library, LoadedLibrary, PermissionSet, PluginPermission};
+
+/// Path to the fixture plugin's `Cargo.toml` (the shared echo `cdylib`).
+fn fixture_manifest() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("test-plugin")
+        .join("Cargo.toml")
+}
+
+/// The platform-specific file name cargo produces for the fixture `cdylib`.
+fn artifact_name() -> String {
+    format!(
+        "{}termihub_test_plugin{}",
+        std::env::consts::DLL_PREFIX,
+        std::env::consts::DLL_SUFFIX
+    )
+}
+
+/// Build the fixture into `target_dir`, returning the freshly-built library path.
+fn build_fixture(target_dir: &Path) -> PathBuf {
+    let status = Command::new(env!("CARGO"))
+        .arg("build")
+        .arg("--manifest-path")
+        .arg(fixture_manifest())
+        .arg("--target-dir")
+        .arg(target_dir)
+        .status()
+        .expect("failed to spawn cargo to build the fixture plugin");
+    assert!(status.success(), "building the fixture plugin failed");
+    target_dir.join("debug").join(artifact_name())
+}
+
+/// Create a plugin session scoped to `permissions`, drive it with `settings`, and
+/// return its first emitted output line (the probe result).
+async fn probe_outcome(
+    lib: &std::sync::Arc<LoadedLibrary>,
+    permissions: PermissionSet,
+    settings: serde_json::Value,
+) -> Vec<u8> {
+    let mut conn = termihub_core::plugin::PluginConnectionType::new(
+        std::sync::Arc::clone(lib),
+        "probe".to_string(),
+        "Probe".to_string(),
+        SettingsSchema { groups: vec![] },
+        permissions,
+    );
+    let mut rx = conn.subscribe_output();
+    conn.connect(settings)
+        .await
+        .expect("connect should succeed");
+    let out = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .expect("probe output should arrive within the timeout")
+        .expect("output channel should yield the probe line");
+    conn.disconnect().await.expect("disconnect should succeed");
+    out
+}
+
+#[tokio::test]
+async fn network_capability_is_enforced_through_the_bridge() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let lib = load_backend_library(&build_fixture(&tmp.path().join("target")))
+        .expect("fixture should load");
+
+    // A real listener so the *granted* probe can genuinely connect.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = std::thread::spawn(move || {
+        // Accept exactly one connection (the granted case) and read the "ping".
+        if let Ok((mut sock, _)) = listener.accept() {
+            let mut buf = [0u8; 4];
+            let _ = sock.read_exact(&mut buf);
+        }
+    });
+
+    let net_settings = serde_json::json!({
+        "probe": "network",
+        "probeHost": "127.0.0.1",
+        "probePort": port,
+    });
+
+    // Granted `network` → the host opens the connection on the plugin's behalf.
+    let granted = probe_outcome(
+        &lib,
+        PermissionSet::from_parts([PluginPermission::Network], &[]),
+        net_settings.clone(),
+    )
+    .await;
+    assert_eq!(granted, b"NETWORK_OK", "granted network should connect");
+
+    // No `network` permission → the host refuses; the plugin cannot open a
+    // connection via the bridge.
+    let denied = probe_outcome(
+        &lib,
+        PermissionSet::from_parts([PluginPermission::Terminal], &[]),
+        net_settings,
+    )
+    .await;
+    assert_eq!(denied, b"NETWORK_DENIED", "network must be denied");
+
+    let _ = server.join();
+}
+
+#[tokio::test]
+async fn filesystem_capability_is_enforced_through_the_bridge() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let lib = load_backend_library(&build_fixture(&tmp.path().join("target")))
+        .expect("fixture should load");
+
+    // A scoped root with an in-scope file, and a sibling secret outside it.
+    let root = tmp.path().join("scoped");
+    std::fs::create_dir_all(&root).unwrap();
+    let inside = root.join("data.txt");
+    std::fs::write(&inside, b"in-scope contents").unwrap();
+    let outside = tmp.path().join("secret.txt");
+    std::fs::write(&outside, b"top secret").unwrap();
+
+    let scoped = || {
+        PermissionSet::from_parts(
+            [PluginPermission::Filesystem],
+            &[root.to_str().unwrap().to_owned()],
+        )
+    };
+
+    // In-scope read is mediated and returns the real bytes.
+    let ok = probe_outcome(
+        &lib,
+        scoped(),
+        serde_json::json!({ "probe": "readfile", "probePath": inside.to_str().unwrap() }),
+    )
+    .await;
+    assert_eq!(ok, b"READ_OK:in-scope contents");
+
+    // Out-of-scope read is rejected end-to-end — the host never opens the file.
+    let denied = probe_outcome(
+        &lib,
+        scoped(),
+        serde_json::json!({ "probe": "readfile", "probePath": outside.to_str().unwrap() }),
+    )
+    .await;
+    assert_eq!(denied, b"READ_DENIED", "out-of-scope read must be denied");
+
+    // A plugin with no `filesystem` permission is denied outright.
+    let no_perm = probe_outcome(
+        &lib,
+        PermissionSet::from_parts([PluginPermission::Terminal], &[]),
+        serde_json::json!({ "probe": "readfile", "probePath": inside.to_str().unwrap() }),
+    )
+    .await;
+    assert_eq!(no_perm, b"READ_DENIED", "no filesystem permission → denied");
+}

--- a/core/tests/plugin_host_roundtrip.rs
+++ b/core/tests/plugin_host_roundtrip.rs
@@ -80,7 +80,7 @@ async fn plugin_host_round_trip() {
     assert_eq!(lib.info().id, "test-echo");
     assert_eq!(lib.info().name, "Test Echo");
     assert_eq!(lib.info().version, "0.1.0");
-    assert_eq!(lib.info().api_version, 1);
+    assert_eq!(lib.info().api_version, 2);
 
     // --- 2. Full ConnectionType round trip: written input echoes to output. ---
     let mut conn = PluginConnectionType::new(
@@ -117,7 +117,7 @@ async fn plugin_host_round_trip() {
     std::env::remove_var("TERMIHUB_TEST_PLUGIN_ABI");
     match result {
         Err(HostError::IncompatibleAbi { expected, found }) => {
-            assert_eq!(expected, 1);
+            assert_eq!(expected, 2);
             assert_eq!(found, 99);
         }
         Err(other) => panic!("expected IncompatibleAbi, got {other:?}"),

--- a/docs/changes/dev2/feature/2018-capability-bridge.md
+++ b/docs/changes/dev2/feature/2018-capability-bridge.md
@@ -4,7 +4,7 @@
   `filesystem` permissions are now enforced **at runtime**, not just validated at
   load. The plugin ABI (`termihub-plugin-api`, bumped to version 2) gained a
   `PluginHostBridge` that the host passes into `create_backend`; a plugin opens
-  connections and reads files *through* the bridge, and the host checks the
+  connections and reads files _through_ the bridge, and the host checks the
   session's granted `PermissionSet` / declared filesystem scope before performing
   each operation. A plugin without `network` cannot open a connection, and a read
   outside the declared paths is refused. The bridge mediates cooperative access;

--- a/docs/changes/dev2/feature/2018-capability-bridge.md
+++ b/docs/changes/dev2/feature/2018-capability-bridge.md
@@ -1,0 +1,13 @@
+### Added
+
+- Plugin host-mediated capability bridge: a native plugin's `network` and
+  `filesystem` permissions are now enforced **at runtime**, not just validated at
+  load. The plugin ABI (`termihub-plugin-api`, bumped to version 2) gained a
+  `PluginHostBridge` that the host passes into `create_backend`; a plugin opens
+  connections and reads files *through* the bridge, and the host checks the
+  session's granted `PermissionSet` / declared filesystem scope before performing
+  each operation. A plugin without `network` cannot open a connection, and a read
+  outside the declared paths is refused. The bridge mediates cooperative access;
+  it is not an OS sandbox (a follow-up tracks full mediated write/streaming
+  surfaces). Realises concept §13, building on the permission primitives from
+  #2001 (#2018).

--- a/examples/plugins/echo-backend/src/lib.rs
+++ b/examples/plugins/echo-backend/src/lib.rs
@@ -25,8 +25,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde::Deserialize;
 use termihub_plugin_api::{
-    PluginBackend, PluginError, PluginInfo, PluginOutputSender, PluginSessionConfig, PluginStatus,
-    PluginTerminalBackend, CURRENT_PLUGIN_API_VERSION,
+    PluginBackend, PluginError, PluginHostBridge, PluginInfo, PluginOutputSender,
+    PluginSessionConfig, PluginStatus, PluginTerminalBackend, CURRENT_PLUGIN_API_VERSION,
 };
 
 /// Session configuration this backend accepts, matching the `configSchema`
@@ -121,18 +121,27 @@ pub unsafe extern "C" fn termihub_plugin_init(out_info: *mut PluginInfo) -> Plug
 }
 
 /// Create a session backend from the borrowed `config`, taking ownership of
-/// `output`, and write the resulting [`PluginBackend`] into `out_backend`.
+/// `output` and the host capability `bridge`, and write the resulting
+/// [`PluginBackend`] into `out_backend`.
+///
+/// A pure echo needs neither network nor filesystem access, so it simply drops
+/// `bridge` (releasing the host's context). A real backend would store it and
+/// route its network/filesystem operations through it so the host can enforce the
+/// plugin's declared permissions.
 ///
 /// # Safety
 ///
 /// `config` (if non-null) and `out_backend` must be valid pointers for the
-/// duration of the call; `output` is consumed.
+/// duration of the call; `output` and `bridge` are consumed.
 #[no_mangle]
 pub unsafe extern "C" fn termihub_plugin_create_backend(
     config: *const PluginSessionConfig,
     output: PluginOutputSender,
+    bridge: PluginHostBridge,
     out_backend: *mut PluginBackend,
 ) -> PluginStatus {
+    // This echo backend performs no host-mediated I/O; drop the bridge explicitly.
+    drop(bridge);
     if out_backend.is_null() {
         return PluginStatus::Other;
     }

--- a/plugin-api/src/capabilities.rs
+++ b/plugin-api/src/capabilities.rs
@@ -1,0 +1,385 @@
+//! The **host-mediated capability bridge** (#2018).
+//!
+//! A native plugin backend runs as a dynamic library *inside the host process*,
+//! so the host cannot intercept a plugin's own syscalls. The permission
+//! primitives from the security layer (`PermissionSet`, `FilesystemScope`) are
+//! therefore only enforceable at the surfaces the host itself mediates. This
+//! module defines one such surface: a [`PluginHostBridge`] the host passes into
+//! `plugin_create_backend`, through which a **cooperating** plugin performs
+//! network and filesystem access *by asking the host to do it*. The host runs the
+//! operation only after checking the plugin's declared permissions, so
+//! `network`/`filesystem` are enforced **at runtime**, not merely declared at
+//! load.
+//!
+//! ```text
+//!   plugin                         host (owns the PermissionSet)
+//!   ------                         -----------------------------
+//!   bridge.open_connection(h,p) ─▶ require(Network)?  ─ no ─▶ PermissionDenied
+//!                                        │ yes
+//!                                        ▼
+//!                                  TcpStream::connect ─▶ mediated PluginTcpStream
+//!
+//!   bridge.read_file(path)      ─▶ FilesystemScope::check(path)? ─ no ─▶ PermissionDenied
+//!                                        │ yes
+//!                                        ▼
+//!                                  std::fs::read ─▶ owned bytes
+//! ```
+//!
+//! # What this does and does not enforce
+//!
+//! This bridge mediates the operations a plugin routes *through it*: for those,
+//! the host is the one that opens the socket / reads the file, and it refuses
+//! when the permission or path-scope check fails. It is **not** an OS sandbox — a
+//! malicious plugin could still call `std::net::TcpStream::connect` or
+//! `std::fs::read` directly and bypass the bridge entirely; stopping that needs
+//! OS-level process isolation termiHub does not have (documented as future work
+//! in the security module). The bridge realises concept §13's "the host can deny
+//! network access even if requested" for the cooperative path, which is the
+//! enforceable slice today.
+//!
+//! # ABI shape
+//!
+//! Like [`crate::output::PluginOutputSender`], everything here is an opaque
+//! context pointer plus `#[repr(C)]` `extern "C"` function pointers — no `String`,
+//! `dyn Trait`, or allocator crosses the boundary. The host builds the bridge (its
+//! context owns the granted permission set) and hands it to the plugin by value;
+//! the plugin owns it thereafter and drops it, running the host-provided
+//! destructor.
+
+use core::ffi::c_void;
+use std::io::{Read, Write};
+
+use crate::error::{PluginError, PluginStatus};
+use crate::ffi::{FfiByteSlice, FfiOwnedBytes, FfiStr};
+
+/// Signature of the host callback that opens a network connection on the plugin's
+/// behalf. The host enforces the `network` permission before connecting; on
+/// success it writes a mediated [`PluginTcpStream`] into `out_stream`.
+pub type PluginOpenConnectionFn = unsafe extern "C" fn(
+    ctx: *mut c_void,
+    host: FfiStr,
+    port: u16,
+    out_stream: *mut PluginTcpStream,
+) -> PluginStatus;
+
+/// Signature of the host callback that reads a file on the plugin's behalf. The
+/// host resolves and authorizes `path` against the plugin's declared filesystem
+/// scope before reading; on success it writes the file's contents into
+/// `out_bytes`.
+pub type PluginReadFileFn = unsafe extern "C" fn(
+    ctx: *mut c_void,
+    path: FfiStr,
+    out_bytes: *mut FfiOwnedBytes,
+) -> PluginStatus;
+
+/// Signature of the destructor for the host-provided bridge context.
+pub type PluginBridgeDestroyFn = unsafe extern "C" fn(ctx: *mut c_void);
+
+/// FFI-safe handle to the host's capability bridge.
+///
+/// Constructed by the host (its `ctx` owns the session's granted permission set),
+/// passed **by value** into `plugin_create_backend`, then owned by the plugin's
+/// backend. A plugin calls [`open_connection`](PluginHostBridge::open_connection)
+/// and [`read_file`](PluginHostBridge::read_file) on it; both route through the
+/// host's permission checks. Dropping the bridge runs the host-provided
+/// `destroy`, releasing the context.
+#[repr(C)]
+pub struct PluginHostBridge {
+    ctx: *mut c_void,
+    open_connection: PluginOpenConnectionFn,
+    read_file: PluginReadFileFn,
+    destroy: Option<PluginBridgeDestroyFn>,
+}
+
+// SAFETY: the bridge uniquely owns `ctx`; the host guarantees (by constructing it
+// from a `Send + Sync` permission set and thread-safe operations) that invoking
+// the callbacks from the plugin's threads is sound. Backends run off the UI
+// thread and may be driven from several threads, so this must be `Send + Sync`.
+unsafe impl Send for PluginHostBridge {}
+unsafe impl Sync for PluginHostBridge {}
+
+impl PluginHostBridge {
+    /// Assemble a bridge from raw FFI parts.
+    ///
+    /// For the host loader (and tests wiring a bridge directly). Most host code
+    /// builds the bridge through the higher-level constructor in
+    /// `termihub_core::plugin` that binds it to a session's `PermissionSet`.
+    ///
+    /// # Safety
+    ///
+    /// * `open_connection`, `read_file` and `destroy` (if any) must be safe to
+    ///   call with `ctx`.
+    /// * `ctx` must remain valid until `destroy` is invoked; ownership of it is
+    ///   transferred to the returned bridge.
+    #[must_use]
+    pub unsafe fn from_raw(
+        ctx: *mut c_void,
+        open_connection: PluginOpenConnectionFn,
+        read_file: PluginReadFileFn,
+        destroy: Option<PluginBridgeDestroyFn>,
+    ) -> Self {
+        Self {
+            ctx,
+            open_connection,
+            read_file,
+            destroy,
+        }
+    }
+
+    /// Ask the host to open a TCP connection to `host:port`.
+    ///
+    /// The host refuses with [`PluginError::PermissionDenied`] unless the plugin
+    /// holds the `network` permission; otherwise it connects and returns a
+    /// mediated [`HostTcpStream`] the plugin can read from and write to.
+    pub fn open_connection(&self, host: &str, port: u16) -> Result<HostTcpStream, PluginError> {
+        let mut stream = PluginTcpStream::null();
+        // SAFETY: `ctx`/`open_connection` were validated at construction; `host`
+        // outlives the call; `&mut stream` is a valid out-parameter the host fills
+        // in on `Ok`.
+        let status =
+            unsafe { (self.open_connection)(self.ctx, FfiStr::new(host), port, &mut stream) };
+        status.into_result()?;
+        // SAFETY: on `Ok` the host wrote a live, host-owned stream handle whose
+        // ownership now transfers to the wrapper.
+        Ok(unsafe { HostTcpStream::from_raw(stream) })
+    }
+
+    /// Ask the host to read the file at `path`.
+    ///
+    /// The host refuses with [`PluginError::PermissionDenied`] unless the plugin
+    /// holds the `filesystem` permission *and* `path` resolves inside its declared
+    /// scope; otherwise it returns the file's contents.
+    pub fn read_file(&self, path: &str) -> Result<Vec<u8>, PluginError> {
+        let mut bytes = FfiOwnedBytes::empty();
+        // SAFETY: `ctx`/`read_file` were validated at construction; `path` outlives
+        // the call; `&mut bytes` is a valid out-parameter the host fills in on `Ok`.
+        let status = unsafe { (self.read_file)(self.ctx, FfiStr::new(path), &mut bytes) };
+        status.into_result()?;
+        Ok(bytes.into_vec())
+    }
+}
+
+impl Drop for PluginHostBridge {
+    fn drop(&mut self) {
+        if let Some(destroy) = self.destroy.take() {
+            // SAFETY: called once (guarded by taking `destroy`) with the `ctx` this
+            // bridge has owned since construction.
+            unsafe { destroy(self.ctx) };
+        }
+    }
+}
+
+/// Stable `#[repr(C)]` vtable of a host-mediated TCP stream.
+///
+/// The host owns the real socket (behind the opaque `state`); the plugin drives
+/// it through these `extern "C"` pointers, so no OS handle crosses the ABI.
+#[repr(C)]
+pub struct PluginTcpStreamVTable {
+    /// Read up to `len` bytes into `buf`, writing the count read into `out_read`
+    /// (0 at end-of-stream).
+    pub read: unsafe extern "C" fn(
+        state: *mut c_void,
+        buf: *mut u8,
+        len: usize,
+        out_read: *mut usize,
+    ) -> PluginStatus,
+    /// Write `data`, writing the count written into `out_written`.
+    pub write: unsafe extern "C" fn(
+        state: *mut c_void,
+        data: FfiByteSlice,
+        out_written: *mut usize,
+    ) -> PluginStatus,
+    /// Drop the stream and free its `state`. Called exactly once.
+    pub destroy: unsafe extern "C" fn(state: *mut c_void),
+}
+
+/// FFI-safe handle to a host-mediated TCP stream: an opaque host-owned `state`
+/// plus a pointer to its vtable. A null `state`/`vtable` denotes "no stream".
+#[repr(C)]
+pub struct PluginTcpStream {
+    /// Opaque host-owned stream state; only the host may interpret it.
+    pub state: *mut c_void,
+    /// Pointer to the vtable implementing this stream's behavior.
+    pub vtable: *const PluginTcpStreamVTable,
+}
+
+impl PluginTcpStream {
+    /// The "no stream" sentinel the plugin passes as the out-parameter.
+    #[must_use]
+    pub fn null() -> Self {
+        Self {
+            state: std::ptr::null_mut(),
+            vtable: std::ptr::null(),
+        }
+    }
+
+    /// Wrap a host-owned [`std::net::TcpStream`] into the FFI-safe handle.
+    ///
+    /// Host-side constructor: the returned handle owns the stream and frees it
+    /// when the plugin drops its [`HostTcpStream`] wrapper (via the vtable's
+    /// `destroy`).
+    #[must_use]
+    pub fn from_std(stream: std::net::TcpStream) -> Self {
+        let boxed = Box::new(stream);
+        Self {
+            state: Box::into_raw(boxed).cast::<c_void>(),
+            vtable: &TCP_STREAM_VTABLE,
+        }
+    }
+}
+
+unsafe extern "C" fn tcp_vt_read(
+    state: *mut c_void,
+    buf: *mut u8,
+    len: usize,
+    out_read: *mut usize,
+) -> PluginStatus {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: `state` is a live `*mut TcpStream` produced by `from_std`; `buf`/
+        // `len` describe a writable region the plugin owns for the call.
+        let stream = unsafe { &mut *state.cast::<std::net::TcpStream>() };
+        let slice = if len == 0 {
+            &mut [][..]
+        } else {
+            unsafe { std::slice::from_raw_parts_mut(buf, len) }
+        };
+        stream.read(slice)
+    }));
+    match result {
+        Ok(Ok(n)) => {
+            // SAFETY: `out_read` is a valid, writable pointer supplied by the plugin.
+            unsafe { out_read.write(n) };
+            PluginStatus::Ok
+        }
+        Ok(Err(_)) => PluginStatus::Io,
+        Err(_) => PluginStatus::Panic,
+    }
+}
+
+unsafe extern "C" fn tcp_vt_write(
+    state: *mut c_void,
+    data: FfiByteSlice,
+    out_written: *mut usize,
+) -> PluginStatus {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: `state` is a live `*mut TcpStream`; `data` is a valid borrowed
+        // slice for the duration of the call.
+        let stream = unsafe { &mut *state.cast::<std::net::TcpStream>() };
+        let bytes = unsafe { data.as_slice() };
+        stream.write(bytes)
+    }));
+    match result {
+        Ok(Ok(n)) => {
+            // SAFETY: `out_written` is a valid, writable pointer supplied by the plugin.
+            unsafe { out_written.write(n) };
+            PluginStatus::Ok
+        }
+        Ok(Err(_)) => PluginStatus::Io,
+        Err(_) => PluginStatus::Panic,
+    }
+}
+
+unsafe extern "C" fn tcp_vt_destroy(state: *mut c_void) {
+    if state.is_null() {
+        return;
+    }
+    // SAFETY: reclaims the box leaked in `from_std`, exactly once.
+    let boxed = unsafe { Box::from_raw(state.cast::<std::net::TcpStream>()) };
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || drop(boxed)));
+}
+
+/// The single shared TCP-stream vtable — generic-free, so one `'static` instance
+/// serves every mediated stream.
+static TCP_STREAM_VTABLE: PluginTcpStreamVTable = PluginTcpStreamVTable {
+    read: tcp_vt_read,
+    write: tcp_vt_write,
+    destroy: tcp_vt_destroy,
+};
+
+/// Safe, plugin-side wrapper over a host-mediated [`PluginTcpStream`].
+///
+/// Implements [`Read`] and [`Write`], so a plugin uses it like any socket while
+/// the host owns the underlying connection. Dropping it frees the host's stream
+/// via the vtable's `destroy`.
+pub struct HostTcpStream {
+    inner: PluginTcpStream,
+}
+
+// SAFETY: the wrapper uniquely owns the host stream state; the vtable functions
+// only touch that owned state. Backends run off the UI thread.
+unsafe impl Send for HostTcpStream {}
+
+impl HostTcpStream {
+    /// Adopt a raw [`PluginTcpStream`] returned by the host bridge.
+    ///
+    /// # Safety
+    ///
+    /// `stream.state`/`stream.vtable` must be valid and produced by a compatible
+    /// host, and ownership of them transfers to the wrapper (which calls `destroy`
+    /// exactly once, on drop).
+    #[must_use]
+    pub unsafe fn from_raw(stream: PluginTcpStream) -> Self {
+        Self { inner: stream }
+    }
+
+    fn vtable(&self) -> &PluginTcpStreamVTable {
+        // SAFETY: `vtable` is valid for the wrapper's lifetime (upheld by the
+        // `from_raw` contract; host streams point at `TCP_STREAM_VTABLE`).
+        unsafe { &*self.inner.vtable }
+    }
+}
+
+impl std::fmt::Debug for HostTcpStream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HostTcpStream").finish_non_exhaustive()
+    }
+}
+
+impl Read for HostTcpStream {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let mut n_read: usize = 0;
+        // SAFETY: `state` is owned and valid; `buf` outlives the call; `&mut n_read`
+        // is a valid out-parameter.
+        let status = unsafe {
+            (self.vtable().read)(self.inner.state, buf.as_mut_ptr(), buf.len(), &mut n_read)
+        };
+        status
+            .into_result()
+            .map(|()| n_read)
+            .map_err(std::io::Error::other)
+    }
+}
+
+impl Write for HostTcpStream {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut n_written: usize = 0;
+        // SAFETY: `state` is owned and valid; `buf` outlives the call; `&mut
+        // n_written` is a valid out-parameter.
+        let status = unsafe {
+            (self.vtable().write)(
+                self.inner.state,
+                FfiByteSlice::from_slice(buf),
+                &mut n_written,
+            )
+        };
+        status
+            .into_result()
+            .map(|()| n_written)
+            .map_err(std::io::Error::other)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        // Writes go straight to the host socket; there is no plugin-side buffer.
+        Ok(())
+    }
+}
+
+impl Drop for HostTcpStream {
+    fn drop(&mut self) {
+        if self.inner.state.is_null() || self.inner.vtable.is_null() {
+            return;
+        }
+        // SAFETY: `state` is owned and valid; `destroy` is called exactly once.
+        unsafe { (self.vtable().destroy)(self.inner.state) };
+    }
+}

--- a/plugin-api/src/error.rs
+++ b/plugin-api/src/error.rs
@@ -46,6 +46,14 @@ pub enum PluginError {
     #[error("plugin panicked across the FFI boundary")]
     Panicked,
 
+    /// A host-mediated capability (network / filesystem, see
+    /// [`crate::capabilities`]) was refused because the plugin does not hold the
+    /// required permission or the path lies outside its declared scope. This is
+    /// the runtime side of the permission model: the host enforces the plugin's
+    /// declared permissions on every operation it mediates.
+    #[error("host denied a plugin capability (missing permission or out-of-scope path)")]
+    PermissionDenied,
+
     /// Any other failure the plugin wishes to report.
     #[error("plugin error: {0}")]
     Other(String),
@@ -75,8 +83,12 @@ pub enum PluginStatus {
     /// Maps to [`PluginError::Panicked`]; also returned when a plugin function
     /// unwinds and the wrapper contains the panic.
     Panic = 6,
+    /// Maps to [`PluginError::PermissionDenied`]: the host refused a mediated
+    /// capability because the plugin lacks the permission or the path is
+    /// out-of-scope.
+    PermissionDenied = 7,
     /// Maps to [`PluginError::Other`].
-    Other = 7,
+    Other = 8,
 }
 
 impl PluginStatus {
@@ -100,6 +112,7 @@ impl PluginStatus {
             PluginError::Io(_) => Self::Io,
             PluginError::VersionMismatch { .. } => Self::VersionMismatch,
             PluginError::Panicked => Self::Panic,
+            PluginError::PermissionDenied => Self::PermissionDenied,
             PluginError::Other(_) => Self::Other,
         }
     }
@@ -126,6 +139,7 @@ impl PluginStatus {
                 found: 0,
             }),
             Self::Panic => Err(PluginError::Panicked),
+            Self::PermissionDenied => Err(PluginError::PermissionDenied),
             Self::Other => Err(PluginError::Other("reported by plugin".to_owned())),
         }
     }

--- a/plugin-api/src/ffi.rs
+++ b/plugin-api/src/ffi.rs
@@ -228,3 +228,83 @@ impl From<&str> for FfiString {
         Self::from_string(s.to_owned())
     }
 }
+
+/// An **owned**, FFI-safe byte buffer that carries its own destructor.
+///
+/// The byte counterpart of [`FfiString`] — used where the host hands *arbitrary
+/// bytes* back to a plugin (e.g. the contents a host-mediated filesystem read
+/// returns, see [`crate::capabilities`]), which may not be valid UTF-8. Like
+/// [`FfiString`] it embeds the [`FfiStringFree`] function pointer that allocated
+/// it, so whoever ends up holding the value frees it inside the module that owns
+/// the allocation — the host never frees a plugin's buffer with its own allocator
+/// and vice-versa.
+#[repr(C)]
+pub struct FfiOwnedBytes {
+    ptr: *mut u8,
+    len: usize,
+    cap: usize,
+    /// `None` for the empty buffer, which owns no allocation.
+    free: Option<FfiStringFree>,
+}
+
+// SAFETY: `FfiOwnedBytes` uniquely owns its heap buffer (move-only, no interior
+// mutability), so it is sound to send it and share `&FfiOwnedBytes` across threads.
+unsafe impl Send for FfiOwnedBytes {}
+unsafe impl Sync for FfiOwnedBytes {}
+
+impl FfiOwnedBytes {
+    /// Take ownership of a `Vec<u8>`, producing an FFI-safe owned buffer.
+    #[must_use]
+    pub fn from_vec(bytes: Vec<u8>) -> Self {
+        if bytes.is_empty() {
+            return Self::empty();
+        }
+        let mut bytes = bytes;
+        let (ptr, len, cap) = (bytes.as_mut_ptr(), bytes.len(), bytes.capacity());
+        std::mem::forget(bytes);
+        Self {
+            ptr,
+            len,
+            cap,
+            free: Some(ffi_string_free),
+        }
+    }
+
+    /// An empty owned buffer that holds no allocation.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self {
+            ptr: NonNull::dangling().as_ptr(),
+            len: 0,
+            cap: 0,
+            free: None,
+        }
+    }
+
+    /// Borrow the contents as bytes.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        if self.len == 0 {
+            &[]
+        } else {
+            // SAFETY: `ptr`/`len` describe the live, owned buffer.
+            unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+        }
+    }
+
+    /// Consume the buffer, copying its contents into an owned `Vec<u8>`.
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        self.as_bytes().to_vec()
+    }
+}
+
+impl Drop for FfiOwnedBytes {
+    fn drop(&mut self) {
+        if let Some(free) = self.free.take() {
+            // SAFETY: called exactly once (guarded by taking `free`), with the raw
+            // parts this value has owned since construction.
+            unsafe { free(self.ptr, self.len, self.cap) };
+        }
+    }
+}

--- a/plugin-api/src/lib.rs
+++ b/plugin-api/src/lib.rs
@@ -94,6 +94,7 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 pub mod backend;
+pub mod capabilities;
 pub mod error;
 pub mod ffi;
 pub mod info;
@@ -101,8 +102,9 @@ pub mod output;
 pub mod symbols;
 
 pub use backend::{LoadedBackend, PluginBackend, PluginBackendVTable, PluginTerminalBackend};
+pub use capabilities::{HostTcpStream, PluginHostBridge, PluginTcpStream, PluginTcpStreamVTable};
 pub use error::{PluginError, PluginStatus};
-pub use ffi::{FfiByteSlice, FfiStr, FfiString};
+pub use ffi::{FfiByteSlice, FfiOwnedBytes, FfiStr, FfiString};
 pub use info::{PluginInfo, PluginSessionConfig};
 pub use output::PluginOutputSender;
 
@@ -113,4 +115,8 @@ pub use output::PluginOutputSender;
 /// to load a plugin whose value is incompatible with its own. Bump this whenever
 /// the ABI changes in a way that breaks previously-built plugins — it is the
 /// machine-readable half of this crate's compatibility promise.
-pub const CURRENT_PLUGIN_API_VERSION: u32 = 1;
+///
+/// Bumped to `2` in #2018: `plugin_create_backend` gained a
+/// [`PluginHostBridge`](capabilities::PluginHostBridge) parameter through which
+/// the host mediates and permission-checks network/filesystem access at runtime.
+pub const CURRENT_PLUGIN_API_VERSION: u32 = 2;

--- a/plugin-api/src/symbols.rs
+++ b/plugin-api/src/symbols.rs
@@ -30,9 +30,12 @@
 //! pub unsafe extern "C" fn termihub_plugin_create_backend(
 //!     config: *const PluginSessionConfig,
 //!     output: PluginOutputSender,
+//!     bridge: PluginHostBridge,
 //!     out_backend: *mut PluginBackend,
 //! ) -> PluginStatus {
-//!     // parse `(*config).config_json`, spawn the session, then:
+//!     // parse `(*config).config_json`, spawn the session — routing any network or
+//!     // filesystem access through `bridge` so the host enforces this plugin's
+//!     // declared permissions — then:
 //!     let backend = PluginBackend::from_boxed(Box::new(my_backend));
 //!     unsafe { out_backend.write(backend); }
 //!     PluginStatus::Ok
@@ -43,6 +46,7 @@
 //! ```
 
 use crate::backend::PluginBackend;
+use crate::capabilities::PluginHostBridge;
 use crate::error::PluginStatus;
 use crate::info::{PluginInfo, PluginSessionConfig};
 use crate::output::PluginOutputSender;
@@ -67,11 +71,17 @@ pub type PluginAbiVersionFn = unsafe extern "C" fn() -> u32;
 pub type PluginInitFn = unsafe extern "C" fn(out_info: *mut PluginInfo) -> PluginStatus;
 
 /// Type of [`SYMBOL_PLUGIN_CREATE_BACKEND`]: creates a session backend from the
-/// borrowed `config`, taking ownership of `output`, and writes the resulting
-/// [`PluginBackend`] into `out_backend`.
+/// borrowed `config`, taking ownership of `output` and the host capability
+/// `bridge`, and writes the resulting [`PluginBackend`] into `out_backend`.
+///
+/// The `bridge` ([`PluginHostBridge`]) is the plugin's only sanctioned route to
+/// network/filesystem access: operations run through it are permission-checked by
+/// the host at runtime (#2018). Ownership of `bridge` transfers to the plugin,
+/// which stores it in its backend and drops it with the session.
 pub type PluginCreateBackendFn = unsafe extern "C" fn(
     config: *const PluginSessionConfig,
     output: PluginOutputSender,
+    bridge: PluginHostBridge,
     out_backend: *mut PluginBackend,
 ) -> PluginStatus;
 
@@ -101,6 +111,7 @@ mod ffi_safety_check {
     unsafe extern "C" fn _create(
         _config: *const PluginSessionConfig,
         _output: PluginOutputSender,
+        _bridge: PluginHostBridge,
         _out: *mut PluginBackend,
     ) -> PluginStatus {
         PluginStatus::Ok


### PR DESCRIPTION
## What

Native plugin backends run **in the host process**, so after #2001 the `network`/`filesystem` permissions were checked at load but never enforced on a plugin's own runtime I/O. This adds the host-mediated capability bridge the concept (§13, "the host can deny network access even if requested") calls for.

`PluginHostBridge` — an opaque context + `#[repr(C)]` `extern "C"` callbacks, the same FFI-safe pattern as `PluginOutputSender` (no `String`/`dyn Trait`/allocator crosses) — is handed to the plugin at `create_backend`. A cooperating plugin performs network/filesystem access **through** the bridge, and the host routes every call through the session's `PermissionSet::require` / `FilesystemScope::check` before acting.

- `bridge.open_connection(host, port)` → host enforces `network`, then connects and returns a mediated `HostTcpStream` (`Read`/`Write`).
- `bridge.read_file(path)` → host resolves the path through the declared filesystem scope, then reads it.
- New `PluginStatus::PermissionDenied`; ABI bumped to **v2** (create_backend gained the bridge parameter).

## What is now runtime-enforced vs still advisory

- **Enforced at runtime:** any network/filesystem access a plugin routes through the bridge. A plugin without `network` cannot open a connection; a read outside the declared paths (including `..` escapes) is refused — proven end-to-end across a real `dlopen`.
- **Still advisory (documented, not silently pretended):** an in-process plugin could bypass the bridge with a direct `std::net`/`std::fs` call. Preventing that needs OS-level process isolation termiHub has no substrate for — out of scope here, called out in the module docs and tracked as follow-up.

## Tests

- `core/src/plugin/capabilities.rs` unit tests: network/filesystem allow + deny through `build_host_bridge`.
- `core/tests/plugin_capability_bridge.rs`: builds and `dlopen`s the fixture (which gained an optional bridge probe) and asserts grant/deny end-to-end over the real ABI, with a live TCP listener and scoped tempdir.
- Existing round-trip / wiring tests updated for ABI v2 and the new `create_backend` signature.

`cargo test` (plugin-api + core `--features plugin`), `clippy -D warnings`, and `fmt --check` all green locally.

## Follow-ups

Filed separately: full mediated **write**/streaming filesystem + a persistent mediated socket API (this PR mediates connection establishment + one-shot read), and OS-level sandboxing to close the direct-syscall bypass.

Closes #2018