### PR TITLE
fix(ui): per-plugin frontend api instance for async-safe registration (Closes #2020)

### DIFF
--- a/docs/changes/dev3/feature/2020-per-plugin-api-instance.md
+++ b/docs/changes/dev3/feature/2020-per-plugin-api-instance.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- Frontend JavaScript plugins now register through their **own** per-plugin
+  `termihub` API instance, so a parser or status-bar widget registered
+  **asynchronously** (from a `setTimeout`, `Promise`, or `load`/`DOMContentLoaded`
+  callback) is attributed to the correct plugin and is fully removed — script and
+  registrations — when the plugin is disabled or uninstalled. Previously only
+  synchronous, top-level registration was attributed correctly; async
+  registrations landed under an `"unknown"` id and leaked past disable. The
+  concept-mandated `window.termihub` remains available as a shared fallback.
+  (#2020)

--- a/src/components/StatusBar/PluginStatusBarWidgets.test.tsx
+++ b/src/components/StatusBar/PluginStatusBarWidgets.test.tsx
@@ -10,7 +10,7 @@ import { createRoot, Root } from "react-dom/client";
 import { PluginStatusBarWidgets } from "./PluginStatusBarWidgets";
 import {
   ensureTermiHubApi,
-  setLoadingPlugin,
+  makePluginApi,
   unregisterPlugin,
   clearRegistry,
   type StatusBarWidget,
@@ -22,9 +22,7 @@ let container: HTMLDivElement;
 let root: Root;
 
 function registerWidgetAs(pluginId: string, widget: StatusBarWidget): void {
-  setLoadingPlugin(pluginId);
-  window.termihub.registerStatusBarWidget(widget);
-  setLoadingPlugin(null);
+  makePluginApi(pluginId).registerStatusBarWidget(widget);
 }
 
 beforeEach(() => {

--- a/src/plugins/frontendPlugins.test.ts
+++ b/src/plugins/frontendPlugins.test.ts
@@ -26,7 +26,7 @@ import {
 import {
   clearRegistry,
   ensureTermiHubApi,
-  setLoadingPlugin,
+  makePluginApi,
   getStatusBarWidgets,
   type StatusBarWidget,
 } from "./pluginRuntime";
@@ -70,9 +70,7 @@ const reader = () => vi.fn(async () => new TextEncoder().encode(SRC));
 
 /** Register a widget attributed to `pluginId`, as its injected script would. */
 function registerWidgetAs(pluginId: string, widget: StatusBarWidget): void {
-  setLoadingPlugin(pluginId);
-  window.termihub.registerStatusBarWidget(widget);
-  setLoadingPlugin(null);
+  makePluginApi(pluginId).registerStatusBarWidget(widget);
 }
 
 beforeEach(() => {
@@ -118,7 +116,11 @@ describe("loadFrontendPlugin", () => {
       'script[data-termihub-plugin="p"]'
     );
     expect(script).not.toBeNull();
-    expect(script?.textContent).toBe(SRC);
+    // The source is wrapped so the plugin runs against its own per-plugin API
+    // instance, bound to its id (#2020) — the original source is preserved inside.
+    expect(script?.textContent).toContain(SRC);
+    expect(script?.textContent).toContain('window.__termihubMakePluginApi("p")');
+    expect(script?.textContent).toMatch(/^\(function \(termihub\) \{/);
     expect(loadedFrontendPluginIds()).toEqual(["p"]);
   });
 

--- a/src/plugins/frontendPlugins.ts
+++ b/src/plugins/frontendPlugins.ts
@@ -5,11 +5,12 @@
  * On plugin activation this reads the plugin's declared JS entry point via the
  * injected file reader (the `read_plugin_file` command in the app), injects it
  * as an inline `<script>` into the WebView, and lets it register extensions
- * through the `window.termihub` API in {@link ./pluginRuntime}. Registrations
- * made while the script runs are attributed to the plugin via
- * {@link setLoadingPlugin} (inline scripts execute synchronously on append, so
- * the attribution window is exactly the append). On deactivation the script is
- * removed and the plugin's registrations are torn down.
+ * through the {@link ./pluginRuntime} API. Each script is wrapped so the plugin
+ * runs against its **own** {@link makePluginApi} instance (bound to the plugin
+ * id) passed in as `termihub` — so every register call it makes, synchronous or
+ * from a later timer/promise/event callback, is attributed to that plugin and
+ * cleanly removed on unload (#2020). On deactivation the script is removed and
+ * the plugin's registrations are torn down.
  *
  * This mirrors the theme loader's "enumerate active plugins → read declared
  * files → register into a runtime registry" shape (`src/store/appStore.ts` →
@@ -22,10 +23,32 @@
  */
 
 import type { InstalledPlugin, PluginFileReader } from "@/types/plugin";
-import { ensureTermiHubApi, setLoadingPlugin, unregisterPlugin } from "./pluginRuntime";
+import { ensureTermiHubApi, unregisterPlugin } from "./pluginRuntime";
 
 /** Attribute stamped on injected plugin scripts so they can be found and removed. */
 const PLUGIN_SCRIPT_ATTR = "data-termihub-plugin";
+
+/**
+ * Wrap a plugin's entry-point source so it runs against its own per-plugin API
+ * instance. The plugin body executes inside a function whose `termihub`
+ * parameter is the instance {@link makePluginApi} builds for `pluginId` (via the
+ * `__termihubMakePluginApi` bridge {@link ensureTermiHubApi} installs on the
+ * page). That local `termihub` shadows the shared `window.termihub`, so every
+ * register call — synchronous or from a later timer/promise/event callback — is
+ * attributed to this plugin regardless of load timing (#2020). The plugin id is
+ * JSON-encoded, so it is safely quoted into the wrapper.
+ *
+ * The bridge lookup falls back to the shared `window.termihub` if the bridge is
+ * somehow absent, so evaluating the wrapper can never throw before the plugin
+ * body runs (`ensureTermiHubApi` always installs it first in production; the
+ * fallback also keeps the isolated jsdom script context used in tests inert).
+ */
+function wrapPluginSource(pluginId: string, code: string): string {
+  const api = `(window.__termihubMakePluginApi ? window.__termihubMakePluginApi(${JSON.stringify(
+    pluginId
+  )}) : window.termihub)`;
+  return `(function (termihub) {\n${code}\n})(${api});`;
+}
 
 /** A frontend entry point that failed to load, for surfacing/logging. */
 export interface FrontendPluginLoadError {
@@ -81,15 +104,10 @@ export async function loadFrontendPlugin(
       const script = doc.createElement("script");
       script.type = "text/javascript";
       script.setAttribute(PLUGIN_SCRIPT_ATTR, pluginId);
-      script.textContent = code;
-      // Inline scripts execute synchronously on append, so bracketing the append
-      // with the loading id attributes the plugin's register calls to it.
-      setLoadingPlugin(pluginId);
-      try {
-        (doc.head ?? doc.documentElement).appendChild(script);
-      } finally {
-        setLoadingPlugin(null);
-      }
+      // Wrap so the plugin registers against its own per-plugin API instance,
+      // making attribution independent of when register is called (#2020).
+      script.textContent = wrapPluginSource(pluginId, code);
+      (doc.head ?? doc.documentElement).appendChild(script);
       scripts.push(script);
     } catch (err) {
       errors.push({

--- a/src/plugins/pluginRuntime.test.ts
+++ b/src/plugins/pluginRuntime.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   ensureTermiHubApi,
-  setLoadingPlugin,
+  makePluginApi,
   applyParsers,
   transformOutput,
   hasProtocolParsers,
@@ -23,18 +23,14 @@ import {
 
 vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
 
-/** Register `parser` as though it came from `pluginId`'s entry point. */
+/** Register `parser` through `pluginId`'s own API instance, as its wrapper does. */
 function registerParserAs(pluginId: string, parser: ProtocolParser): void {
-  setLoadingPlugin(pluginId);
-  window.termihub.registerProtocolParser(parser);
-  setLoadingPlugin(null);
+  makePluginApi(pluginId).registerProtocolParser(parser);
 }
 
-/** Register `widget` as though it came from `pluginId`'s entry point. */
+/** Register `widget` through `pluginId`'s own API instance, as its wrapper does. */
 function registerWidgetAs(pluginId: string, widget: StatusBarWidget): void {
-  setLoadingPlugin(pluginId);
-  window.termihub.registerStatusBarWidget(widget);
-  setLoadingPlugin(null);
+  makePluginApi(pluginId).registerStatusBarWidget(widget);
 }
 
 const decode = (b: Uint8Array) => new TextDecoder().decode(b);
@@ -54,10 +50,67 @@ describe("window.termihub API", () => {
   });
 
   it("rejects an invalid parser without registering it", () => {
-    setLoadingPlugin("p");
     // Missing transform.
-    window.termihub.registerProtocolParser({ id: "x", name: "x" } as unknown as ProtocolParser);
-    setLoadingPlugin(null);
+    makePluginApi("p").registerProtocolParser({ id: "x", name: "x" } as unknown as ProtocolParser);
+    expect(hasProtocolParsers()).toBe(false);
+  });
+});
+
+describe("per-plugin API instance", () => {
+  const widget = (id: string): StatusBarWidget => ({
+    id,
+    position: "left",
+    render: () => document.createElement("span"),
+    dispose: () => {},
+  });
+
+  it("attributes each instance's registrations to its own plugin id", () => {
+    // Two plugins reuse the same parser id; the per-(plugin,id) keying keeps both.
+    makePluginApi("plugin-a").registerProtocolParser({
+      id: "shared",
+      name: "a",
+      transform: (d) => d + "-a",
+    });
+    makePluginApi("plugin-b").registerProtocolParser({
+      id: "shared",
+      name: "b",
+      transform: (d) => d + "-b",
+    });
+    expect(applyParsers("x", "s1")).toEqual({ text: "x-a-b", changed: true });
+
+    // Unregistering one leaves the other intact.
+    unregisterPlugin("plugin-a");
+    expect(applyParsers("x", "s1")).toEqual({ text: "x-b", changed: true });
+  });
+
+  it("attributes an async (setTimeout) registration to the right plugin and unregisters it", async () => {
+    const api = makePluginApi("async-plugin");
+    // The plugin captures its API and registers later, after any load bracket
+    // would have cleared — the failure mode the per-plugin instance fixes (#2020).
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        api.registerProtocolParser({ id: "late", name: "late", transform: (d) => d + "!" });
+        api.registerStatusBarWidget(widget("late-widget"));
+        resolve();
+      }, 0);
+    });
+
+    expect(applyParsers("hi", "s1")).toEqual({ text: "hi!", changed: true });
+    expect(getStatusBarWidgets("left").map((e) => e.key)).toEqual(["async-plugin:late-widget"]);
+
+    // The real id — not "unknown" — cleanly removes the async registrations.
+    unregisterPlugin("async-plugin");
+    expect(hasProtocolParsers()).toBe(false);
+    expect(getStatusBarWidgets("left")).toHaveLength(0);
+  });
+
+  it("attributes an async (promise callback) registration to the right plugin", async () => {
+    const api = makePluginApi("promise-plugin");
+    await Promise.resolve().then(() => {
+      api.registerProtocolParser({ id: "p", name: "p", transform: (d) => d.toUpperCase() });
+    });
+    expect(applyParsers("hi", "s1")).toEqual({ text: "HI", changed: true });
+    unregisterPlugin("promise-plugin");
     expect(hasProtocolParsers()).toBe(false);
   });
 });
@@ -220,14 +273,12 @@ describe("status-bar widget registry", () => {
   });
 
   it("rejects an invalid widget (bad position)", () => {
-    setLoadingPlugin("p");
-    window.termihub.registerStatusBarWidget({
+    makePluginApi("p").registerStatusBarWidget({
       id: "x",
       position: "middle",
       render: () => document.createElement("span"),
       dispose: () => {},
     } as unknown as StatusBarWidget);
-    setLoadingPlugin(null);
     expect(getStatusBarWidgets("left")).toHaveLength(0);
     expect(getStatusBarWidgets("right")).toHaveLength(0);
   });

--- a/src/plugins/pluginRuntime.ts
+++ b/src/plugins/pluginRuntime.ts
@@ -5,8 +5,10 @@
  * A frontend plugin is a plain JavaScript file the plugin author ships at
  * `frontend/index.js` (the `entryPoint` its `protocolParser` / `statusBarWidget`
  * extension declares). On activation the loader in {@link ./frontendPlugins}
- * injects that script into the WebView; the script calls the API exposed here on
- * `window.termihub` to register two kinds of extension:
+ * injects that script into the WebView wrapped so the plugin receives its **own**
+ * {@link TermiHubPluginAPI} instance (bound to that plugin's id via
+ * {@link makePluginApi}); the script calls that API to register two kinds of
+ * extension:
  *
  * - **Protocol parsers** — `transform(data, sessionId)` runs over each chunk of
  *   terminal output before it reaches xterm; returning `null` passes the chunk
@@ -67,7 +69,14 @@ export interface StatusBarWidget {
   dispose(): void;
 }
 
-/** The API surface exposed to frontend plugins on `window.termihub`. */
+/**
+ * The API surface exposed to frontend plugins (concept §8). Each plugin receives
+ * its **own** instance, whose register calls are permanently attributed to that
+ * plugin's id — so a registration made from a timer/promise/event callback lands
+ * under the right plugin regardless of when it fires, and is cleanly removed on
+ * unload. See {@link makePluginApi}. The concept-mandated `window.termihub` is a
+ * shared fallback instance ({@link ensureTermiHubApi}).
+ */
 export interface TermiHubPluginAPI {
   /** Register a protocol parser (concept §8). */
   registerProtocolParser(parser: ProtocolParser): void;
@@ -77,8 +86,21 @@ export interface TermiHubPluginAPI {
 
 declare global {
   interface Window {
-    /** The frontend-plugin registration API (#1998). Present once a plugin has loaded. */
+    /**
+     * The frontend-plugin registration API (#1998), typed per the concept.
+     * Present once any plugin has loaded — a shared fallback instance (its
+     * registrations attribute to {@link FALLBACK_PLUGIN_ID}). Each injected
+     * plugin instead runs against its **own** instance passed in as `termihub`,
+     * which shadows this global inside the plugin's scope.
+     */
     termihub: TermiHubPluginAPI;
+    /**
+     * Internal bridge (#2020): builds a per-plugin {@link TermiHubPluginAPI}
+     * bound to a plugin id. Installed by {@link ensureTermiHubApi} so the loader's
+     * injected wrapper can hand each plugin its own instance. Not part of the
+     * concept surface — plugin authors use the `termihub` they are passed.
+     */
+    __termihubMakePluginApi?: (pluginId: string) => TermiHubPluginAPI;
   }
 }
 
@@ -109,15 +131,13 @@ let parsers: RegisteredParser[] = [];
 let widgets: RegisteredWidget[] = [];
 
 /**
- * The plugin id currently being loaded, set by the loader around the synchronous
- * `<script>` injection so register calls made while a plugin's entry point runs
- * are attributed to it. `null` outside a load (a stray register call then lands
- * under `"unknown"`). This attributes the synchronous, top-level registration
- * the concept documents; a plugin that registers asynchronously (from a timer or
- * promise) lands under `"unknown"` and is not cleanly unregisterable — hardening
- * that is a follow-up (per-plugin API instance).
+ * Plugin id used when a registration cannot be attributed to a specific plugin —
+ * i.e. a call made through the shared `window.termihub` fallback rather than the
+ * per-plugin instance a plugin is handed. Injected plugins always register
+ * through their own {@link makePluginApi} instance, so this only catches code
+ * that reaches for the global directly.
  */
-let loadingPluginId: string | null = null;
+const FALLBACK_PLUGIN_ID = "unknown";
 
 /** Cached per-position widget snapshots for {@link getStatusBarWidgets} (stable refs for `useSyncExternalStore`). */
 let widgetSnapshot: Record<WidgetPosition, StatusBarWidgetEntry[]> = { left: [], right: [] };
@@ -133,16 +153,7 @@ function logPluginError(pluginId: string, extId: string, phase: string, err: unk
   );
 }
 
-/**
- * Set (or clear) the plugin id that subsequent register calls are attributed to.
- * Called by the loader immediately around the synchronous script injection.
- */
-export function setLoadingPlugin(pluginId: string | null): void {
-  loadingPluginId = pluginId;
-}
-
-function registerProtocolParser(parser: ProtocolParser): void {
-  const pluginId = loadingPluginId ?? "unknown";
+function registerProtocolParserFor(pluginId: string, parser: ProtocolParser): void {
   if (
     !parser ||
     typeof parser.id !== "string" ||
@@ -157,8 +168,7 @@ function registerProtocolParser(parser: ProtocolParser): void {
   parsers.push({ pluginId, parser });
 }
 
-function registerStatusBarWidget(widget: StatusBarWidget): void {
-  const pluginId = loadingPluginId ?? "unknown";
+function registerStatusBarWidgetFor(pluginId: string, widget: StatusBarWidget): void {
   if (
     !widget ||
     typeof widget.id !== "string" ||
@@ -176,20 +186,43 @@ function registerStatusBarWidget(widget: StatusBarWidget): void {
 }
 
 /**
- * Install the `window.termihub` API on the given target (defaults to the global
- * `window`). Idempotent: the same API object is reused across calls so a
- * previously-loaded plugin's captured reference stays valid.
+ * Build a {@link TermiHubPluginAPI} instance bound to `pluginId`. Every register
+ * call the returned API makes — synchronous top-level, or from a later
+ * timer/promise/event callback — is attributed to `pluginId`, so the plugin's
+ * registrations are always found and cleanly removed by
+ * {@link unregisterPlugin} on disable/uninstall. This replaces the old
+ * load-timing attribution, which mis-filed async registrations under the
+ * fallback id (#2020).
+ */
+export function makePluginApi(pluginId: string): TermiHubPluginAPI {
+  return {
+    registerProtocolParser: (parser) => registerProtocolParserFor(pluginId, parser),
+    registerStatusBarWidget: (widget) => registerStatusBarWidgetFor(pluginId, widget),
+  };
+}
+
+/** The window properties this module installs (extracted for testability). */
+type TermiHubGlobals = {
+  termihub?: TermiHubPluginAPI;
+  __termihubMakePluginApi?: (pluginId: string) => TermiHubPluginAPI;
+};
+
+/**
+ * Install the frontend-plugin globals on the given target (defaults to the global
+ * `window`): the concept-mandated `window.termihub` (a shared fallback instance)
+ * and the internal `__termihubMakePluginApi` bridge the loader uses to hand each
+ * plugin its own instance. Idempotent: the same objects are reused across calls
+ * so a previously-captured reference stays valid. Returns the shared
+ * `window.termihub` instance.
  */
 export function ensureTermiHubApi(
-  target: { termihub?: TermiHubPluginAPI } = window as unknown as {
-    termihub?: TermiHubPluginAPI;
-  }
+  target: TermiHubGlobals = window as unknown as TermiHubGlobals
 ): TermiHubPluginAPI {
   if (!target.termihub) {
-    target.termihub = {
-      registerProtocolParser,
-      registerStatusBarWidget,
-    };
+    target.termihub = makePluginApi(FALLBACK_PLUGIN_ID);
+  }
+  if (!target.__termihubMakePluginApi) {
+    target.__termihubMakePluginApi = makePluginApi;
   }
   return target.termihub;
 }
@@ -311,6 +344,5 @@ export function unregisterPlugin(pluginId: string): void {
 export function clearRegistry(): void {
   parsers = [];
   widgets = [];
-  loadingPluginId = null;
   refreshWidgetSnapshot();
 }


### PR DESCRIPTION
## Summary

Follow-up to #1998. The frontend JS plugin loader attributed a plugin's `window.termihub` registrations via a module-global "currently loading plugin" id set around the synchronous `<script>` injection. That correctly handled the concept's **synchronous, top-level** registration, but a plugin registering **asynchronously** — from a `setTimeout`, `Promise`, or `load`/`DOMContentLoaded` callback — ran after the load bracket cleared, so those parsers/widgets landed under the `"unknown"` id and leaked past disable (`unregisterPlugin(realId)` never matched them).

## Change

- **Per-plugin API instance.** New `makePluginApi(pluginId)` builds a `TermiHubPluginAPI` whose `registerProtocolParser`/`registerStatusBarWidget` are closed over the plugin id. Attribution no longer depends on load timing.
- **Wrapped injection.** The loader wraps each entry point as `(function (termihub) { <plugin code> })(makePluginApi(id))`, handing the plugin its own instance as `termihub` (shadowing the shared global). Every register call it makes — synchronous or from a later timer/promise/event callback — is attributed to that plugin, and unload cleanly removes exactly its registrations.
- **Removed** the mutable `loadingPluginId` global and the `setLoadingPlugin` bracket.
- **Kept** the concept-mandated `window.termihub` (typed on `Window`) as a shared fallback instance (`ensureTermiHubApi`), plus an internal `__termihubMakePluginApi` bridge the injected wrapper uses.

## Tests

Added vitest coverage in `pluginRuntime.test.ts` for async registration (from `setTimeout` and a promise callback) being attributed to the right plugin id and fully removed on `unregisterPlugin`, plus per-instance attribution across two plugins reusing a parser id. Updated `frontendPlugins.test.ts` / `PluginStatusBarWidgets.test.tsx` to register through per-plugin instances and to assert the wrapped injected source. Existing synchronous-registration behavior preserved.

Frontend lint, `tsc`/build, `./scripts/check.sh`, and the plugin/status-bar/store test suites all pass locally.

Closes #2020