### PR TITLE
feat(ui): add schema-driven plugin settings section (Closes #2000)

### DIFF
--- a/docs/changes/dev1/feature/2000-plugin-settings-section.md
+++ b/docs/changes/dev1/feature/2000-plugin-settings-section.md
@@ -1,0 +1,10 @@
+### Added
+
+- Settings now has a **Plugins** category listing one group per installed plugin
+  that declares `settings` in its manifest. Each group is rendered from the
+  plugin's own settings schema by the shared dynamic-form machinery and tagged
+  with a `plugin` badge; values load from and save to the plugin's stored
+  configuration automatically, with an inline "Saved" acknowledgment and a
+  recoverable error toast on failure. Plugins that declare no settings do not
+  appear. The Plugin Manager's **Settings…** action now deep-links straight into
+  this category and scrolls to the selected plugin (#2000).

--- a/src/components/ActivityBar/ActivityBar.tsx
+++ b/src/components/ActivityBar/ActivityBar.tsx
@@ -177,7 +177,7 @@ export function ActivityBar({ horizontal }: ActivityBarProps) {
                 >
                   <DropdownMenu.Item
                     className="settings-menu__item"
-                    onSelect={openSettingsTab}
+                    onSelect={() => openSettingsTab()}
                     data-testid="settings-menu-open"
                   >
                     <Settings size={14} />

--- a/src/components/Plugins/PluginDetailPanel.test.tsx
+++ b/src/components/Plugins/PluginDetailPanel.test.tsx
@@ -138,6 +138,21 @@ describe("PluginDetailPanel (#1997)", () => {
     expect(container.querySelector('[data-testid="plugin-action-settings"]')).not.toBeNull();
   });
 
+  it("deep-links the Settings… action into the Plugins settings category for this plugin", () => {
+    const openSettingsTab = vi.fn();
+    useAppStore.setState({
+      plugins: [
+        plugin("active", { settings: { ns: { type: "string", default: "", description: "" } } }),
+      ],
+      openSettingsTab,
+    });
+    render();
+
+    const btn = container.querySelector('[data-testid="plugin-action-settings"]');
+    act(() => btn!.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(openSettingsTab).toHaveBeenCalledWith({ category: "plugins", pluginId: "k8s" });
+  });
+
   it("renders a placeholder when the plugin is no longer installed", () => {
     useAppStore.setState({ plugins: [] });
     render("gone");

--- a/src/components/Plugins/PluginDetailPanel.tsx
+++ b/src/components/Plugins/PluginDetailPanel.tsx
@@ -49,7 +49,7 @@ function useActiveSessionCount(plugin: InstalledPlugin | undefined): number {
  * The plugin detail panel shown in the main area (#1997). Renders a plugin's
  * identity, extension points, requested permissions, and state-appropriate
  * actions: Enable/Disable, Retry (on error), Settings… (when the plugin declares
- * settings — the settings pane lands in a separate issue), and Uninstall.
+ * settings — deep-links into the Plugins settings category, #2000), and Uninstall.
  * Uninstall warns first when the plugin has live sessions.
  *
  * The plugin is looked up live from the store by {@link PluginDetailMeta.pluginId},
@@ -195,7 +195,7 @@ export function PluginDetailPanel({ meta, isVisible }: PluginDetailPanelProps) {
           <Button
             variant="secondary"
             icon={<SlidersHorizontal size={14} />}
-            onClick={openSettingsTab}
+            onClick={() => openSettingsTab({ category: "plugins", pluginId: manifest.id })}
             data-testid="plugin-action-settings"
           >
             Settings…

--- a/src/components/Settings/PluginSettingsSection.css
+++ b/src/components/Settings/PluginSettingsSection.css
@@ -1,0 +1,53 @@
+/* Plugins settings section (#2000): one card per plugin that declares settings. */
+
+.plugin-settings__group {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-md);
+  transition: border-color var(--transition-fast);
+}
+
+.plugin-settings__group--highlighted {
+  border-color: var(--accent-color);
+  background-color: color-mix(in srgb, var(--accent-color) 8%, transparent);
+}
+
+.plugin-settings__header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-xs);
+}
+
+.plugin-settings__icon {
+  flex-shrink: 0;
+  color: var(--text-secondary);
+}
+
+/* The per-plugin DynamicForm renders one group with an empty label; suppress
+   its heading so only the card's own name header shows. */
+.plugin-settings__group .settings-panel__category-title:empty {
+  display: none;
+}
+
+.plugin-settings__saved {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--accent-color);
+  opacity: 0;
+  transition: opacity var(--transition-normal);
+}
+
+.plugin-settings__saved--visible {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .plugin-settings__group,
+  .plugin-settings__saved {
+    transition: none;
+  }
+}

--- a/src/components/Settings/PluginSettingsSection.test.tsx
+++ b/src/components/Settings/PluginSettingsSection.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * Tests for the Plugins settings section (#2000): one group per plugin that
+ * declares settings, rendered from its manifest schema; values load via
+ * get_plugin_settings and a save round-trips through update_plugin_settings;
+ * plugins with no declared settings are omitted.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import React from "react";
+import { useAppStore } from "@/store/appStore";
+import type { InstalledPlugin, PluginManifest, PluginSettingSchema } from "@/types/plugin";
+import { PluginSettingsSection } from "./PluginSettingsSection";
+
+function manifest(
+  id: string,
+  settings: Record<string, PluginSettingSchema> | undefined,
+  overrides: Partial<PluginManifest> = {}
+): PluginManifest {
+  return {
+    id,
+    name: `Plugin ${id}`,
+    version: "1.0.0",
+    author: "acme",
+    description: `The ${id} plugin.`,
+    license: "MIT",
+    apiVersion: "1.0",
+    platforms: ["macos"],
+    permissions: ["settings"],
+    extensions: { protocolParser: { name: id, description: "", entryPoint: "index.js" } },
+    settings,
+    ...overrides,
+  };
+}
+
+function plugin(
+  id: string,
+  settings: Record<string, PluginSettingSchema> | undefined
+): InstalledPlugin {
+  return { manifest: manifest(id, settings), state: "active", installedAt: "2026-01-01T00:00:00Z" };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function query(testId: string): HTMLElement | null {
+  return container.querySelector(`[data-testid="${testId}"]`);
+}
+
+async function render(focusPluginId?: string | null) {
+  await act(async () => {
+    root.render(React.createElement(PluginSettingsSection, { focusPluginId }));
+  });
+  // Flush the async get_plugin_settings load chain (catch → then → setState).
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+const setNativeValue = (input: HTMLInputElement, value: string) => {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+};
+
+describe("PluginSettingsSection (#2000)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("renders one group per plugin that declares settings, with a badge", async () => {
+    const getPluginSettings = vi.fn(() => Promise.resolve({}));
+    useAppStore.setState({
+      plugins: [
+        plugin("log-colorizer", {
+          namespace: { type: "string", default: "default", description: "Target namespace" },
+        }),
+      ],
+      getPluginSettings,
+    });
+    await render();
+
+    const group = query("plugin-settings-log-colorizer");
+    expect(group).not.toBeNull();
+    expect(group?.textContent).toContain("Plugin log-colorizer");
+    expect(group?.textContent).toContain("plugin");
+    // The declared field renders through DynamicForm.
+    expect(query("field-namespace")).not.toBeNull();
+    expect(getPluginSettings).toHaveBeenCalledWith("log-colorizer");
+  });
+
+  it("seeds the form with stored values layered over defaults", async () => {
+    useAppStore.setState({
+      plugins: [
+        plugin("k8s", {
+          namespace: { type: "string", default: "default", description: "" },
+        }),
+      ],
+      getPluginSettings: vi.fn(() => Promise.resolve({ namespace: "kube-system" })),
+    });
+    await render();
+
+    const input = query("field-namespace") as HTMLInputElement;
+    expect(input.value).toBe("kube-system");
+  });
+
+  it("persists an edit through update_plugin_settings (save round-trip)", async () => {
+    const updatePluginSettings = vi.fn(() => Promise.resolve());
+    useAppStore.setState({
+      plugins: [
+        plugin("k8s", {
+          namespace: { type: "string", default: "default", description: "" },
+        }),
+      ],
+      getPluginSettings: vi.fn(() => Promise.resolve({ namespace: "default" })),
+      updatePluginSettings,
+    });
+    await render();
+
+    const input = query("field-namespace") as HTMLInputElement;
+    act(() => setNativeValue(input, "prod"));
+
+    // Wait out the 300ms save debounce, then flush the update promise.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 350));
+    });
+
+    expect(updatePluginSettings).toHaveBeenCalledWith(
+      "k8s",
+      expect.objectContaining({ namespace: "prod" })
+    );
+    // Inline saved acknowledgment surfaces.
+    expect(query("plugin-settings-saved-k8s")?.textContent).toContain("Saved");
+  });
+
+  it("omits plugins that declare no settings", async () => {
+    useAppStore.setState({
+      plugins: [
+        plugin("has-none", undefined),
+        plugin("has-empty", {}),
+        plugin("has-one", { flag: { type: "boolean", default: false, description: "" } }),
+      ],
+      getPluginSettings: vi.fn(() => Promise.resolve({})),
+    });
+    await render();
+
+    expect(query("plugin-settings-has-none")).toBeNull();
+    expect(query("plugin-settings-has-empty")).toBeNull();
+    expect(query("plugin-settings-has-one")).not.toBeNull();
+  });
+
+  it("shows an empty state when no plugin has configurable settings", async () => {
+    useAppStore.setState({ plugins: [plugin("plain", undefined)] });
+    await render();
+    expect(query("plugin-settings-empty")).not.toBeNull();
+  });
+});

--- a/src/components/Settings/PluginSettingsSection.tsx
+++ b/src/components/Settings/PluginSettingsSection.tsx
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check, Puzzle } from "lucide-react";
+import { useAppStore } from "@/store/appStore";
+import type { InstalledPlugin, JsonValue } from "@/types/plugin";
+import { ConnectionSettingsForm } from "@/components/DynamicForm";
+import { hasSettings, pluginTypeIcon } from "@/components/Plugins/pluginPresentation";
+import { pluginSettingsDefaults, pluginSettingsToSchema } from "./pluginSettingsSchema";
+import "./PluginSettingsSection.css";
+
+/** Debounce before a plugin's edited settings are persisted. */
+const SAVE_DEBOUNCE_MS = 300;
+/** How long the inline per-plugin "Saved" acknowledgment stays visible. */
+const SAVED_ACK_MS = 1500;
+
+interface PluginSettingsSectionProps {
+  /**
+   * When set, scroll this plugin's group into view and briefly highlight it —
+   * used when the Plugin Manager's "Settings…" action deep-links here (#2000).
+   */
+  focusPluginId?: string | null;
+}
+
+/**
+ * The Plugins settings category (#2000): one group per installed plugin that
+ * declares `settings` in its manifest, each rendered from that schema by the
+ * generic `DynamicForm` and persisted through `get_plugin_settings` /
+ * `update_plugin_settings`. Plugins that declare no settings never appear here.
+ */
+export function PluginSettingsSection({ focusPluginId }: PluginSettingsSectionProps) {
+  const plugins = useAppStore((s) => s.plugins);
+  const getPluginSettings = useAppStore((s) => s.getPluginSettings);
+  const updatePluginSettings = useAppStore((s) => s.updatePluginSettings);
+
+  // Plugins with at least one declared setting, in install-list order.
+  const configurable = useMemo(() => plugins.filter((p) => hasSettings(p.manifest)), [plugins]);
+
+  // Per-plugin form values, populated once the persisted settings load. A
+  // plugin is considered loaded exactly when it has an entry here — the form is
+  // gated on this so its (init-only) default values are the correct ones.
+  const [values, setValues] = useState<Record<string, Record<string, JsonValue>>>({});
+  const [savedAckId, setSavedAckId] = useState<string | null>(null);
+  const saveTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const ackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const groupRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  // Load each configurable plugin's persisted settings, layered over the
+  // schema defaults. Runs whenever the configurable set changes (install/enable).
+  useEffect(() => {
+    let cancelled = false;
+    for (const p of configurable) {
+      const { id, settings } = p.manifest;
+      const defaults = pluginSettingsDefaults(settings ?? {});
+      getPluginSettings(id)
+        .catch(() => ({}) as Record<string, JsonValue>)
+        .then((stored) => {
+          if (cancelled) return;
+          setValues((prev) => ({ ...prev, [id]: { ...defaults, ...stored } }));
+        });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [configurable, getPluginSettings]);
+
+  // Clear timers on unmount.
+  useEffect(() => {
+    const timers = saveTimers.current;
+    return () => {
+      for (const t of timers.values()) clearTimeout(t);
+      timers.clear();
+      if (ackTimer.current) clearTimeout(ackTimer.current);
+    };
+  }, []);
+
+  // Scroll the deep-linked plugin into view once its group has mounted.
+  useEffect(() => {
+    if (!focusPluginId) return;
+    const el = groupRefs.current.get(focusPluginId);
+    if (el) el.scrollIntoView({ block: "start", behavior: "smooth" });
+  }, [focusPluginId, values]);
+
+  const handleChange = useCallback(
+    (pluginId: string) => (next: Record<string, unknown>) => {
+      const typed = next as Record<string, JsonValue>;
+      setValues((prev) => ({ ...prev, [pluginId]: typed }));
+
+      const timers = saveTimers.current;
+      const existing = timers.get(pluginId);
+      if (existing) clearTimeout(existing);
+      timers.set(
+        pluginId,
+        setTimeout(() => {
+          timers.delete(pluginId);
+          updatePluginSettings(pluginId, typed)
+            .then(() => {
+              setSavedAckId(pluginId);
+              if (ackTimer.current) clearTimeout(ackTimer.current);
+              ackTimer.current = setTimeout(() => setSavedAckId(null), SAVED_ACK_MS);
+            })
+            .catch(() => {
+              // The store already surfaced a recoverable error toast.
+            });
+        }, SAVE_DEBOUNCE_MS)
+      );
+    },
+    [updatePluginSettings]
+  );
+
+  if (configurable.length === 0) {
+    return (
+      <div className="settings-panel__category" data-testid="plugin-settings-section">
+        <h3 className="settings-panel__category-title">Plugins</h3>
+        <div className="settings-panel__empty" data-testid="plugin-settings-empty">
+          No installed plugin has configurable settings.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-panel__category" data-testid="plugin-settings-section">
+      <h3 className="settings-panel__category-title">Plugins</h3>
+      <p className="settings-panel__description">
+        Configure settings for installed plugins that declare them. Changes are saved automatically.
+      </p>
+
+      {configurable.map((plugin) => (
+        <PluginSettingsGroup
+          key={plugin.manifest.id}
+          plugin={plugin}
+          values={values[plugin.manifest.id]}
+          saved={savedAckId === plugin.manifest.id}
+          highlighted={focusPluginId === plugin.manifest.id}
+          onChange={handleChange(plugin.manifest.id)}
+          registerRef={(el) => {
+            if (el) groupRefs.current.set(plugin.manifest.id, el);
+            else groupRefs.current.delete(plugin.manifest.id);
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface PluginSettingsGroupProps {
+  plugin: InstalledPlugin;
+  /** Loaded form values, or undefined until the persisted settings resolve. */
+  values: Record<string, JsonValue> | undefined;
+  saved: boolean;
+  highlighted: boolean;
+  onChange: (next: Record<string, unknown>) => void;
+  registerRef: (el: HTMLDivElement | null) => void;
+}
+
+/** One plugin's settings card: identity/badge header plus its `DynamicForm`. */
+function PluginSettingsGroup({
+  plugin,
+  values,
+  saved,
+  highlighted,
+  onChange,
+  registerRef,
+}: PluginSettingsGroupProps) {
+  const { manifest } = plugin;
+  const Icon = pluginTypeIcon(manifest.extensions) ?? Puzzle;
+  const schema = useMemo(
+    () => pluginSettingsToSchema(manifest.settings ?? {}, manifest.id),
+    [manifest.settings, manifest.id]
+  );
+
+  return (
+    <div
+      ref={registerRef}
+      className={`settings-panel__section plugin-settings__group${
+        highlighted ? " plugin-settings__group--highlighted" : ""
+      }`}
+      data-testid={`plugin-settings-${manifest.id}`}
+    >
+      <div className="plugin-settings__header">
+        <Icon size={16} className="plugin-settings__icon" aria-hidden="true" />
+        <h3 className="settings-panel__section-title">{manifest.name}</h3>
+        <span className="settings-panel__badge">plugin</span>
+        <span
+          className={`plugin-settings__saved${saved ? " plugin-settings__saved--visible" : ""}`}
+          role="status"
+          aria-live="polite"
+          data-testid={`plugin-settings-saved-${manifest.id}`}
+        >
+          {saved && (
+            <>
+              <Check size={12} aria-hidden="true" />
+              Saved
+            </>
+          )}
+        </span>
+      </div>
+      {manifest.description && (
+        <p className="settings-panel__description">{manifest.description}</p>
+      )}
+
+      {/* Gate the form on loaded values: ConnectionSettingsForm seeds its state
+          from `settings` only on mount, so mounting before the persisted values
+          arrive would strand them. Until then, show a light placeholder. */}
+      {values ? (
+        <ConnectionSettingsForm schema={schema} settings={values} onChange={onChange} />
+      ) : (
+        <div className="settings-panel__empty" data-testid={`plugin-settings-loading-${manifest.id}`}>
+          Loading…
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Settings/PluginSettingsSection.tsx
+++ b/src/components/Settings/PluginSettingsSection.tsx
@@ -204,7 +204,10 @@ function PluginSettingsGroup({
       {values ? (
         <ConnectionSettingsForm schema={schema} settings={values} onChange={onChange} />
       ) : (
-        <div className="settings-panel__empty" data-testid={`plugin-settings-loading-${manifest.id}`}>
+        <div
+          className="settings-panel__empty"
+          data-testid={`plugin-settings-loading-${manifest.id}`}
+        >
           Loading…
         </div>
       )}

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -10,6 +10,7 @@ import {
   FileJson,
   FileCode2,
   HardDrive,
+  Puzzle,
   Check,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -34,6 +35,7 @@ import { CustomGrammarsSettings } from "./CustomGrammarsSettings";
 import { SerialPortSettings } from "./SerialPortSettings";
 import { ShellIntegrationSettings } from "./ShellIntegrationSettings";
 import { PortableModeSettings } from "./PortableModeSettings";
+import { PluginSettingsSection } from "./PluginSettingsSection";
 import { useAppInfo } from "@/hooks/useAppInfo";
 import "./SettingsPanel.css";
 
@@ -46,6 +48,7 @@ const SETTINGS_ICONS: Record<SettingsCategory, LucideIcon> = {
   security: Shield,
   "external-files": FileJson,
   editor: FileCode2,
+  plugins: Puzzle,
   portable: HardDrive,
 };
 
@@ -67,8 +70,11 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
   const pendingCloseRequest = useAppStore((s) => s.pendingCloseRequest);
   const setPendingCloseRequest = useAppStore((s) => s.setPendingCloseRequest);
   const closeTab = useAppStore((s) => s.closeTab);
+  const pendingSettingsCategory = useAppStore((s) => s.pendingSettingsCategory);
+  const pendingSettingsPluginId = useAppStore((s) => s.pendingSettingsPluginId);
 
   const [activeCategory, setActiveCategory] = useState<SettingsCategory>("general");
+  const [focusPluginId, setFocusPluginId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [isCompact, setIsCompact] = useState(false);
   const appInfo = useAppInfo();
@@ -125,6 +131,20 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
   const handleCategoryChange = useCallback((category: SettingsCategory) => {
     setActiveCategory(category);
   }, []);
+
+  // Consume a one-shot deep-link target set by openSettingsTab (#2000): switch to
+  // the requested category and, for Plugins, remember which plugin to focus.
+  // Clearing the store fields prevents re-applying on the next unrelated open.
+  useEffect(() => {
+    if (!pendingSettingsCategory && !pendingSettingsPluginId) return;
+    if (pendingSettingsCategory) {
+      setActiveCategory(pendingSettingsCategory as SettingsCategory);
+    }
+    if (pendingSettingsPluginId) {
+      setFocusPluginId(pendingSettingsPluginId);
+    }
+    useAppStore.setState({ pendingSettingsCategory: null, pendingSettingsPluginId: null });
+  }, [pendingSettingsCategory, pendingSettingsPluginId]);
 
   // Debounced save for General/Appearance/Terminal settings
   const handleSettingsChange = useCallback(
@@ -267,6 +287,9 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
           <CustomGrammarsSettings key="custom-grammars" visibleFields={visibleFields} />
         );
       }
+      if (highlightedCategories?.has("plugins")) {
+        sections.push(<PluginSettingsSection key="plugins" focusPluginId={focusPluginId} />);
+      }
       if (highlightedCategories?.has("portable")) {
         sections.push(<PortableModeSettings key="portable" />);
       }
@@ -310,6 +333,8 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
             <CustomGrammarsSettings />
           </>
         );
+      case "plugins":
+        return <PluginSettingsSection focusPluginId={focusPluginId} />;
       case "portable":
         return <PortableModeSettings />;
     }

--- a/src/components/Settings/pluginSettingsSchema.test.ts
+++ b/src/components/Settings/pluginSettingsSchema.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for the plugin-manifest → DynamicForm adapters (#2000): key humanizing,
+ * primitive/enum → field-type mapping, single-group schema construction, and the
+ * defaults collector.
+ */
+import { describe, it, expect } from "vitest";
+import type { PluginSettingSchema } from "@/types/plugin";
+import {
+  humanizeSettingKey,
+  pluginSettingsDefaults,
+  pluginSettingsToSchema,
+} from "./pluginSettingsSchema";
+
+describe("humanizeSettingKey", () => {
+  it("splits camelCase into title-cased words", () => {
+    expect(humanizeSettingKey("maxLineLength")).toBe("Max Line Length");
+  });
+
+  it("splits snake_case and kebab-case", () => {
+    expect(humanizeSettingKey("max_line_length")).toBe("Max Line Length");
+    expect(humanizeSettingKey("color-scheme")).toBe("Color Scheme");
+  });
+
+  it("title-cases a single lowercase word", () => {
+    expect(humanizeSettingKey("namespace")).toBe("Namespace");
+  });
+});
+
+describe("pluginSettingsToSchema", () => {
+  const settings: Record<string, PluginSettingSchema> = {
+    namespace: { type: "string", default: "default", description: "Target namespace" },
+    maxLines: { type: "number", default: 500, description: "Lines to keep" },
+    verbose: { type: "boolean", default: false, description: "Verbose logging" },
+    level: {
+      type: "string",
+      default: "info",
+      description: "Log level",
+      enum: ["debug", "info", "warn"],
+    },
+  };
+
+  it("produces a single group keyed by the plugin id, preserving order", () => {
+    const schema = pluginSettingsToSchema(settings, "log-colorizer");
+    expect(schema.groups).toHaveLength(1);
+    expect(schema.groups[0].key).toBe("log-colorizer");
+    expect(schema.groups[0].fields.map((f) => f.key)).toEqual([
+      "namespace",
+      "maxLines",
+      "verbose",
+      "level",
+    ]);
+  });
+
+  it("maps primitives to the right field types and enums to a select", () => {
+    const [ns, max, verbose, level] = pluginSettingsToSchema(settings, "p").groups[0].fields;
+    expect(ns.fieldType).toEqual({ type: "text" });
+    expect(max.fieldType).toEqual({ type: "number" });
+    expect(verbose.fieldType).toEqual({ type: "boolean" });
+    expect(level.fieldType).toEqual({
+      type: "select",
+      options: [
+        { value: "debug", label: "debug" },
+        { value: "info", label: "info" },
+        { value: "warn", label: "warn" },
+      ],
+    });
+  });
+
+  it("carries description and default, and marks fields optional", () => {
+    const ns = pluginSettingsToSchema(settings, "p").groups[0].fields[0];
+    expect(ns.label).toBe("Namespace");
+    expect(ns.description).toBe("Target namespace");
+    expect(ns.default).toBe("default");
+    expect(ns.required).toBe(false);
+  });
+});
+
+describe("pluginSettingsDefaults", () => {
+  it("collects each setting's default into a flat object", () => {
+    const settings: Record<string, PluginSettingSchema> = {
+      a: { type: "string", default: "x", description: "" },
+      b: { type: "number", default: 7, description: "" },
+    };
+    expect(pluginSettingsDefaults(settings)).toEqual({ a: "x", b: 7 });
+  });
+
+  it("returns an empty object for no settings", () => {
+    expect(pluginSettingsDefaults({})).toEqual({});
+  });
+});

--- a/src/components/Settings/pluginSettingsSchema.ts
+++ b/src/components/Settings/pluginSettingsSchema.ts
@@ -1,0 +1,78 @@
+/**
+ * Adapters that turn a plugin manifest's `settings` block
+ * (`Record<string, PluginSettingSchema>`) into the shapes the generic
+ * `DynamicForm` machinery consumes: a {@link SettingsSchema} for rendering and a
+ * flat defaults object for seeding unset values.
+ *
+ * A plugin's `settings` schema is intentionally simpler than a connection's
+ * `configSchema` — each entry is a single primitive (`string`/`number`/
+ * `boolean`) with an optional `enum`, no grouping or conditional visibility — so
+ * every plugin's settings collapse into one `DynamicForm` group.
+ */
+import type { FieldType, SettingsField, SettingsSchema } from "@/types/schema";
+import type { JsonValue, PluginSettingSchema } from "@/types/plugin";
+
+/**
+ * Turn a setting key into a human-readable label: split camelCase and
+ * snake/kebab boundaries into words and title-case the result
+ * (`maxLineLength` / `max_line_length` → "Max Line Length").
+ */
+export function humanizeSettingKey(key: string): string {
+  const words = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim();
+  return words.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Map a single plugin setting schema to a {@link DynamicForm} field type. */
+function fieldTypeForSetting(schema: PluginSettingSchema): FieldType {
+  if (schema.enum && schema.enum.length > 0) {
+    return { type: "select", options: schema.enum.map((v) => ({ value: v, label: v })) };
+  }
+  switch (schema.type) {
+    case "number":
+      return { type: "number" };
+    case "boolean":
+      return { type: "boolean" };
+    case "string":
+    default:
+      return { type: "text" };
+  }
+}
+
+/**
+ * Build a single-group {@link SettingsSchema} from a plugin's declared settings,
+ * preserving declaration order. `groupKey`/`groupLabel` name the sole group the
+ * `DynamicForm` renders (the section supplies the plugin's own header, so an
+ * empty label is fine).
+ */
+export function pluginSettingsToSchema(
+  settings: Record<string, PluginSettingSchema>,
+  groupKey: string,
+  groupLabel = ""
+): SettingsSchema {
+  const fields: SettingsField[] = Object.entries(settings).map(([key, schema]) => ({
+    key,
+    label: humanizeSettingKey(key),
+    description: schema.description || undefined,
+    fieldType: fieldTypeForSetting(schema),
+    required: false,
+    default: schema.default,
+  }));
+  return { groups: [{ key: groupKey, label: groupLabel, fields }] };
+}
+
+/**
+ * Collect the `default` value of every declared setting into a flat object,
+ * used to seed the form before the persisted values (if any) are layered on top.
+ */
+export function pluginSettingsDefaults(
+  settings: Record<string, PluginSettingSchema>
+): Record<string, JsonValue> {
+  const out: Record<string, JsonValue> = {};
+  for (const [key, schema] of Object.entries(settings)) {
+    out[key] = schema.default;
+  }
+  return out;
+}

--- a/src/components/Settings/settingsRegistry.ts
+++ b/src/components/Settings/settingsRegistry.ts
@@ -7,6 +7,7 @@ export type SettingsCategory =
   | "security"
   | "external-files"
   | "editor"
+  | "plugins"
   | "portable";
 
 export interface CategoryDefinition {
@@ -31,6 +32,7 @@ export const CATEGORIES: CategoryDefinition[] = [
   { id: "security", label: "Security" },
   { id: "external-files", label: "External Files" },
   { id: "editor", label: "Editor" },
+  { id: "plugins", label: "Plugins" },
   { id: "portable", label: "Portable Mode" },
 ];
 
@@ -508,6 +510,23 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     description: "Shut down the auto-provided X server when no connection uses it",
     category: "general",
     keywords: ["x server", "x11", "idle", "stop", "shutdown", "display"],
+  },
+  {
+    id: "pluginSettings",
+    label: "Plugin Settings",
+    description: "Configure settings for installed plugins that declare them",
+    category: "plugins",
+    keywords: [
+      "plugin",
+      "plugins",
+      "extension",
+      "addon",
+      "add-on",
+      "settings",
+      "configure",
+      "manifest",
+      "schema",
+    ],
   },
   {
     id: "portableMode",

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -23,7 +23,7 @@ import type {
   WindowRestorePayload,
 } from "@/types/window";
 import type { WorkspaceTabGroupDef } from "@/types/workspace";
-import type { InstalledPlugin, PluginManifest } from "@/types/plugin";
+import type { InstalledPlugin, JsonValue, PluginManifest } from "@/types/plugin";
 import {
   SavedConnection,
   ConnectionFolder,
@@ -2398,6 +2398,23 @@ export async function enablePlugin(pluginId: string): Promise<void> {
 /** Disable the plugin with the given id. */
 export async function disablePlugin(pluginId: string): Promise<void> {
   await invoke("disable_plugin", { pluginId });
+}
+
+/**
+ * Read a plugin's stored settings as a flat key→value object (empty when the
+ * user has never configured it). Keys are the plugin's declared `settings` keys;
+ * values are the raw JSON the host persisted in `plugin-settings.json`.
+ */
+export async function getPluginSettings(pluginId: string): Promise<Record<string, JsonValue>> {
+  return await invoke<Record<string, JsonValue>>("get_plugin_settings", { id: pluginId });
+}
+
+/** Replace a plugin's stored settings with `settings` (a flat key→value object). */
+export async function updatePluginSettings(
+  pluginId: string,
+  settings: Record<string, JsonValue>
+): Promise<void> {
+  await invoke("update_plugin_settings", { id: pluginId, settings });
 }
 
 /**

--- a/src/store/appStore.plugins.test.ts
+++ b/src/store/appStore.plugins.test.ts
@@ -68,6 +68,8 @@ vi.mock("@/services/api", () => ({
   uninstallPlugin: vi.fn(() => Promise.resolve()),
   enablePlugin: vi.fn(() => Promise.resolve()),
   disablePlugin: vi.fn(() => Promise.resolve()),
+  getPluginSettings: vi.fn(() => Promise.resolve({})),
+  updatePluginSettings: vi.fn(() => Promise.resolve()),
   readPluginFile: vi.fn(() => Promise.resolve(new Uint8Array())),
 }));
 
@@ -78,6 +80,8 @@ import {
   uninstallPlugin as apiUninstallPlugin,
   enablePlugin as apiEnablePlugin,
   disablePlugin as apiDisablePlugin,
+  getPluginSettings as apiGetPluginSettings,
+  updatePluginSettings as apiUpdatePluginSettings,
   readPluginFile,
 } from "@/services/api";
 import { loadPluginThemes, setRegisteredPluginThemes } from "@/themes";
@@ -256,6 +260,34 @@ describe("appStore — plugins (#1993)", () => {
     await useAppStore.getState().enablePlugin("unknown-id");
     expect(toastLoading).toHaveBeenCalledWith("Enabling unknown-id…");
     expect(toastSuccess).toHaveBeenCalledWith("Enabled unknown-id", { id: "toast-id" });
+  });
+
+  describe("plugin settings (#2000)", () => {
+    it("getPluginSettings returns the stored settings object", async () => {
+      vi.mocked(apiGetPluginSettings).mockResolvedValueOnce({ namespace: "prod" });
+      const result = await useAppStore.getState().getPluginSettings("k8s");
+      expect(apiGetPluginSettings).toHaveBeenCalledWith("k8s");
+      expect(result).toEqual({ namespace: "prod" });
+    });
+
+    it("getPluginSettings rethrows on failure so the caller can fall back", async () => {
+      vi.mocked(apiGetPluginSettings).mockRejectedValueOnce(new Error("read failed"));
+      await expect(useAppStore.getState().getPluginSettings("k8s")).rejects.toThrow("read failed");
+    });
+
+    it("updatePluginSettings persists the values", async () => {
+      await useAppStore.getState().updatePluginSettings("k8s", { namespace: "prod" });
+      expect(apiUpdatePluginSettings).toHaveBeenCalledWith("k8s", { namespace: "prod" });
+    });
+
+    it("updatePluginSettings toasts a named error and rethrows on failure", async () => {
+      useAppStore.setState({ plugins: [makePlugin("k8s", "active")] });
+      vi.mocked(apiUpdatePluginSettings).mockRejectedValueOnce(new Error("disk full"));
+      await expect(
+        useAppStore.getState().updatePluginSettings("k8s", { namespace: "prod" })
+      ).rejects.toThrow("disk full");
+      expect(toastError).toHaveBeenCalledWith("Failed to save Plugin k8s settings: disk full");
+    });
   });
 
   describe("selectPlugin (#1997)", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1540,10 +1540,7 @@ interface AppState {
    * on failure; resolves silently on success (the settings section shows its own
    * inline "Saved" acknowledgment).
    */
-  updatePluginSettings: (
-    pluginId: string,
-    settings: Record<string, JsonValue>
-  ) => Promise<void>;
+  updatePluginSettings: (pluginId: string, settings: Record<string, JsonValue>) => Promise<void>;
   /**
    * The manifest id of the plugin currently selected in the Plugins sidebar
    * (#1997), or `null` when none is selected. Drives the sidebar row highlight.
@@ -7663,8 +7660,7 @@ export const useAppStore = create<AppState>((set, get) => {
     },
 
     updatePluginSettings: async (pluginId, settings) => {
-      const name =
-        get().plugins.find((p) => p.manifest.id === pluginId)?.manifest.name ?? pluginId;
+      const name = get().plugins.find((p) => p.manifest.id === pluginId)?.manifest.name ?? pluginId;
       try {
         await apiUpdatePluginSettings(pluginId, settings);
       } catch (err) {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -285,13 +285,15 @@ import {
 } from "@/utils/reconnectBackoff";
 import { quotePath } from "@/utils/quotePath";
 import { toast } from "@/components/ui";
-import type { InstalledPlugin, PluginBackendType } from "@/types/plugin";
+import type { InstalledPlugin, JsonValue, PluginBackendType } from "@/types/plugin";
 import {
   listPlugins as apiListPlugins,
   installPlugin as apiInstallPlugin,
   uninstallPlugin as apiUninstallPlugin,
   enablePlugin as apiEnablePlugin,
   disablePlugin as apiDisablePlugin,
+  getPluginSettings as apiGetPluginSettings,
+  updatePluginSettings as apiUpdatePluginSettings,
   readPluginFile,
 } from "@/services/api";
 import { reconcileFrontendPlugins } from "@/plugins/frontendPlugins";
@@ -642,7 +644,26 @@ interface AppState {
     agentSessionId: string,
     panelId?: string
   ) => Promise<void>;
-  openSettingsTab: () => void;
+  /**
+   * Open (or focus the existing) Settings tab. An optional `target` deep-links
+   * into a specific category — and, for the Plugins category, an optional plugin
+   * to scroll to and highlight (#2000). The target is consumed once by the
+   * settings panel via {@link pendingSettingsCategory}/{@link
+   * pendingSettingsPluginId}; passing none leaves the current category alone.
+   */
+  openSettingsTab: (target?: { category?: string; pluginId?: string }) => void;
+  /**
+   * Category the Settings panel should switch to when it next reads this, or
+   * `null` for no pending navigation. Set by {@link openSettingsTab} and cleared
+   * by the panel after it applies (#2000).
+   */
+  pendingSettingsCategory: string | null;
+  /**
+   * Plugin the Plugins settings section should scroll to and highlight when it
+   * next reads this, or `null`. Set by {@link openSettingsTab} and cleared by the
+   * panel after it applies (#2000).
+   */
+  pendingSettingsPluginId: string | null;
   openLogViewerTab: () => void;
   openNetworkDiagnosticTab: (
     tool: NetworkTool,
@@ -1508,6 +1529,21 @@ interface AppState {
   enablePlugin: (pluginId: string) => Promise<void>;
   /** Disable a plugin by id, then refresh the list. Toasts feedback; rejects on failure. */
   disablePlugin: (pluginId: string) => Promise<void>;
+  /**
+   * Read a plugin's stored settings (#2000). Resolves to the persisted key→value
+   * object (empty when unset); rejects (logging) on failure so the caller can
+   * fall back to schema defaults.
+   */
+  getPluginSettings: (pluginId: string) => Promise<Record<string, JsonValue>>;
+  /**
+   * Persist a plugin's settings (#2000). Toasts a recoverable error and rejects
+   * on failure; resolves silently on success (the settings section shows its own
+   * inline "Saved" acknowledgment).
+   */
+  updatePluginSettings: (
+    pluginId: string,
+    settings: Record<string, JsonValue>
+  ) => Promise<void>;
   /**
    * The manifest id of the plugin currently selected in the Plugins sidebar
    * (#1997), or `null` when none is selected. Drives the sidebar row highlight.
@@ -4207,8 +4243,17 @@ export const useAppStore = create<AppState>((set, get) => {
     showSpawnPicker: (request) => set({ spawnPickerVisible: true, spawnPickerRequest: request }),
     hideSpawnPicker: () => set({ spawnPickerVisible: false, spawnPickerRequest: undefined }),
 
-    openSettingsTab: () =>
+    pendingSettingsCategory: null,
+    pendingSettingsPluginId: null,
+
+    openSettingsTab: (target) =>
       set((state) => {
+        // Deep-link target (#2000): a null category leaves the panel's current
+        // category alone, so a plain open never resets it to General.
+        const nav = {
+          pendingSettingsCategory: target?.category ?? null,
+          pendingSettingsPluginId: target?.pluginId ?? null,
+        };
         const allLeaves = getAllLeaves(state.rootPanel);
 
         // Look for an existing settings tab
@@ -4221,13 +4266,13 @@ export const useAppStore = create<AppState>((set, get) => {
               tabs: l.tabs.map((t) => ({ ...t, isActive: t.id === existing.id })),
               activeTabId: existing.id,
             }));
-            return { rootPanel, activePanelId: leaf.id };
+            return { ...nav, rootPanel, activePanelId: leaf.id };
           }
         }
 
         // No existing settings tab — create one in the active panel
         const targetPanelId = state.activePanelId ?? allLeaves[0]?.id;
-        if (!targetPanelId) return state;
+        if (!targetPanelId) return { ...nav };
 
         const dummyConfig: ConnectionConfig = { type: "local", config: { shell: "zsh" } };
         const newTab = createTab("Settings", "local", dummyConfig, targetPanelId, "settings");
@@ -4236,7 +4281,7 @@ export const useAppStore = create<AppState>((set, get) => {
           tabs.push(newTab);
           return { ...leaf, tabs, activeTabId: newTab.id };
         });
-        return { rootPanel, activePanelId: targetPanelId };
+        return { ...nav, rootPanel, activePanelId: targetPanelId };
       }),
 
     openLogViewerTab: () =>
@@ -7601,6 +7646,30 @@ export const useAppStore = create<AppState>((set, get) => {
         toast.error(
           `Failed to disable ${name}: ${err instanceof Error ? err.message : String(err)}`,
           { id: toastId }
+        );
+        throw err;
+      }
+    },
+
+    getPluginSettings: async (pluginId) => {
+      try {
+        return await apiGetPluginSettings(pluginId);
+      } catch (err) {
+        // Read-only fetch: log rather than toast; the caller falls back to
+        // schema defaults so the form still renders.
+        console.error(`Failed to load settings for plugin ${pluginId}:`, err);
+        throw err;
+      }
+    },
+
+    updatePluginSettings: async (pluginId, settings) => {
+      const name =
+        get().plugins.find((p) => p.manifest.id === pluginId)?.manifest.name ?? pluginId;
+      try {
+        await apiUpdatePluginSettings(pluginId, settings);
+      } catch (err) {
+        toast.error(
+          `Failed to save ${name} settings: ${err instanceof Error ? err.message : String(err)}`
         );
         throw err;
       }


### PR DESCRIPTION
## Summary

Adds a **Plugins** category to Settings that renders one group per installed plugin declaring `settings` in its manifest — the settings half of the plugin-system concept's "Third PR" (concept §11), building on the Plugin Manager UI (#1997), the settings commands (#1992), and the plugin store (#1993).

Each plugin group is rendered from its manifest `settings` schema by the existing `DynamicForm` machinery (`ConnectionSettingsForm` + `DynamicField`), tagged with a `plugin` badge. Values load via `get_plugin_settings` and persist (debounced) via `update_plugin_settings`, with an inline "Saved" acknowledgment on success and a recoverable error toast on failure. Plugins that declare no settings are omitted entirely.

The Plugin Manager detail panel's **Settings…** action — previously a placeholder that opened the general Settings tab — now deep-links straight into the Plugins category and scrolls to the selected plugin.

## Changes

- **`PluginSettingsSection`** (`src/components/Settings/PluginSettingsSection.tsx`) + CSS — the category view: one card per configurable plugin, gated on loaded values so the form's init-only defaults are correct.
- **`pluginSettingsSchema.ts`** — pure adapters turning a manifest's `settings` (`Record<string, PluginSettingSchema>`) into a single-group `SettingsSchema` (string/number/boolean/enum → text/number/toggle/select) plus a defaults collector; setting keys are humanized for labels.
- **Store** (`appStore.ts`) — new `getPluginSettings` / `updatePluginSettings` actions (toasts a named error on save failure); `openSettingsTab(target?)` now accepts a `{ category, pluginId }` deep-link target consumed once by the panel via `pendingSettingsCategory` / `pendingSettingsPluginId`.
- **`api.ts`** — typed `get_plugin_settings` / `update_plugin_settings` wrappers.
- **Settings plumbing** — `plugins` category added to the registry (nav entry + `Puzzle` icon, searchable) and wired into `SettingsPanel` (switch + search render, deep-link effect).
- **`PluginDetailPanel`** — Settings… now deep-links into the Plugins category for that plugin.

## Tests

New vitest coverage (all green; full suite 4586 passing):

- Adapter unit tests (humanizing, primitive/enum → field-type mapping, single-group construction, defaults).
- `PluginSettingsSection`: group rendering from schema, stored-value seeding over defaults, **save round-trip** through `update_plugin_settings`, empty-settings omission, empty state.
- Store: `get`/`update` actions (success, rethrow-on-read-failure, named error toast on save failure).
- `PluginDetailPanel`: Settings… dispatches the `{ category: "plugins", pluginId }` deep-link.

## Test plan

- Open Settings → **Plugins**: a plugin declaring settings shows a badged group with its fields; editing a field saves automatically and shows "Saved"; a plugin with no settings is absent.
- From the Plugin Manager detail panel, click **Settings…** on a plugin with settings → lands on the Plugins category scrolled to that plugin.

Closes #2000

🤖 Generated with [Claude Code](https://claude.com/claude-code)