### PR TITLE
feat(plugin): mediate filesystem writes, stat and list_dir through the host bridge (Closes #2024)

### DIFF
--- a/core/src/plugin/capabilities.rs
+++ b/core/src/plugin/capabilities.rs
@@ -23,13 +23,6 @@ use std::net::{TcpStream, ToSocketAddrs};
 use std::path::Path;
 use std::time::Duration;
 
-/// Host-side connect timeout applied to every mediated `open_connection` (#2024).
-///
-/// A bare `TcpStream::connect` blocks indefinitely on a black-holed host; this
-/// per-connect ceiling is the host-side connection policy that keeps a plugin's
-/// dial-out from hanging a session forever.
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
-
 use termihub_plugin_api::capabilities::{
     PluginBridgeDestroyFn, PluginFileMetadata, PluginListDirFn, PluginOpenConnectionFn,
     PluginReadFileFn, PluginStatPathFn, PluginWriteFileFn, PluginWriteMode,
@@ -40,6 +33,13 @@ use termihub_plugin_api::{
 
 use super::security::{PermissionError, PermissionSet};
 use super::PluginPermission;
+
+/// Host-side connect timeout applied to every mediated `open_connection` (#2024).
+///
+/// A bare `TcpStream::connect` blocks indefinitely on a black-holed host; this
+/// per-connect ceiling is the host-side connection policy that keeps a plugin's
+/// dial-out from hanging a session forever.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Build the host capability bridge for a session granted `permissions`.
 ///
@@ -445,12 +445,18 @@ mod tests {
 
         // Create-or-truncate writes the file within scope.
         let target = root.join("out.txt");
-        bridge.overwrite(target.to_str().unwrap(), b"first").unwrap();
+        bridge
+            .overwrite(target.to_str().unwrap(), b"first")
+            .unwrap();
         assert_eq!(std::fs::read(&target).unwrap(), b"first");
 
         // Truncate again replaces the contents.
         bridge
-            .write_file(target.to_str().unwrap(), b"second", PluginWriteMode::Truncate)
+            .write_file(
+                target.to_str().unwrap(),
+                b"second",
+                PluginWriteMode::Truncate,
+            )
             .unwrap();
         assert_eq!(std::fs::read(&target).unwrap(), b"second");
 
@@ -473,7 +479,9 @@ mod tests {
         bridge.write_new(target.to_str().unwrap(), b"a").unwrap();
         // A second create-new on the same path is an I/O error (already exists),
         // not a permission denial.
-        let err = bridge.write_new(target.to_str().unwrap(), b"b").unwrap_err();
+        let err = bridge
+            .write_new(target.to_str().unwrap(), b"b")
+            .unwrap_err();
         assert!(
             matches!(err, termihub_plugin_api::PluginError::Io(_)),
             "got {err:?}"
@@ -493,7 +501,9 @@ mod tests {
 
         // A write outside the declared scope is refused and never creates a file.
         let outside = dir.path().join("escape.txt");
-        let err = bridge.overwrite(outside.to_str().unwrap(), b"x").unwrap_err();
+        let err = bridge
+            .overwrite(outside.to_str().unwrap(), b"x")
+            .unwrap_err();
         assert!(matches!(
             err,
             termihub_plugin_api::PluginError::PermissionDenied
@@ -502,7 +512,9 @@ mod tests {
 
         // A traversal escape from an in-scope prefix is rejected too.
         let escape = root.join("../escape2.txt");
-        let err = bridge.overwrite(escape.to_str().unwrap(), b"x").unwrap_err();
+        let err = bridge
+            .overwrite(escape.to_str().unwrap(), b"x")
+            .unwrap_err();
         assert!(matches!(
             err,
             termihub_plugin_api::PluginError::PermissionDenied
@@ -515,7 +527,9 @@ mod tests {
         // No `filesystem` permission → writes are refused before any file opens.
         let bridge = build_host_bridge(perms(&[PluginPermission::Terminal], &[]));
         let target = dir.path().join("nope.txt");
-        let err = bridge.overwrite(target.to_str().unwrap(), b"x").unwrap_err();
+        let err = bridge
+            .overwrite(target.to_str().unwrap(), b"x")
+            .unwrap_err();
         assert!(matches!(
             err,
             termihub_plugin_api::PluginError::PermissionDenied
@@ -545,7 +559,9 @@ mod tests {
         assert!(meta.exists && meta.is_dir);
 
         // In-scope but absent path: reported as absent, not an error.
-        let meta = bridge.stat(root.join("missing.txt").to_str().unwrap()).unwrap();
+        let meta = bridge
+            .stat(root.join("missing.txt").to_str().unwrap())
+            .unwrap();
         assert!(!meta.exists);
 
         // Out-of-scope stat is refused.

--- a/core/src/plugin/capabilities.rs
+++ b/core/src/plugin/capabilities.rs
@@ -18,13 +18,25 @@
 //! only OS-level isolation (out of scope, no substrate today) could stop. See the
 //! [`termihub_plugin_api::capabilities`] module docs.
 
-use std::net::TcpStream;
+use std::io::Write;
+use std::net::{TcpStream, ToSocketAddrs};
 use std::path::Path;
+use std::time::Duration;
+
+/// Host-side connect timeout applied to every mediated `open_connection` (#2024).
+///
+/// A bare `TcpStream::connect` blocks indefinitely on a black-holed host; this
+/// per-connect ceiling is the host-side connection policy that keeps a plugin's
+/// dial-out from hanging a session forever.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 use termihub_plugin_api::capabilities::{
-    PluginBridgeDestroyFn, PluginOpenConnectionFn, PluginReadFileFn,
+    PluginBridgeDestroyFn, PluginFileMetadata, PluginListDirFn, PluginOpenConnectionFn,
+    PluginReadFileFn, PluginStatPathFn, PluginWriteFileFn, PluginWriteMode,
 };
-use termihub_plugin_api::{FfiOwnedBytes, FfiStr, PluginHostBridge, PluginStatus, PluginTcpStream};
+use termihub_plugin_api::{
+    FfiByteSlice, FfiOwnedBytes, FfiStr, PluginHostBridge, PluginStatus, PluginTcpStream,
+};
 
 use super::security::{PermissionError, PermissionSet};
 use super::PluginPermission;
@@ -43,11 +55,56 @@ pub fn build_host_bridge(permissions: PermissionSet) -> PluginHostBridge {
     let ctx = Box::into_raw(Box::new(permissions)).cast::<core::ffi::c_void>();
     let open_connection: PluginOpenConnectionFn = bridge_open_connection;
     let read_file: PluginReadFileFn = bridge_read_file;
+    let write_file: PluginWriteFileFn = bridge_write_file;
+    let stat_path: PluginStatPathFn = bridge_stat_path;
+    let list_dir: PluginListDirFn = bridge_list_dir;
     let destroy: PluginBridgeDestroyFn = bridge_destroy;
-    // SAFETY: `ctx` is a leaked `Box<PermissionSet>`; the three callbacks below
-    // only ever interpret it as exactly that, and `destroy` reclaims it exactly
-    // once. `PermissionSet` is `Send + Sync`, matching the bridge's bounds.
-    unsafe { PluginHostBridge::from_raw(ctx, open_connection, read_file, Some(destroy)) }
+    // SAFETY: `ctx` is a leaked `Box<PermissionSet>`; every callback below only
+    // ever interprets it as exactly that, and `destroy` reclaims it exactly once.
+    // `PermissionSet` is `Send + Sync`, matching the bridge's bounds.
+    unsafe {
+        PluginHostBridge::from_raw(
+            ctx,
+            open_connection,
+            read_file,
+            write_file,
+            stat_path,
+            list_dir,
+            Some(destroy),
+        )
+    }
+}
+
+/// Resolve `host:port` and connect with the host-side [`CONNECT_TIMEOUT`] policy.
+///
+/// Each resolved address is tried with [`TcpStream::connect_timeout`] so a
+/// black-holed host cannot hang the connect indefinitely; the last error is
+/// returned if every address fails or resolution yields none.
+fn connect_with_timeout(host: &str, port: u16) -> std::io::Result<TcpStream> {
+    let addrs = (host, port).to_socket_addrs()?;
+    let mut last_err = std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "no addresses resolved for host",
+    );
+    for addr in addrs {
+        match TcpStream::connect_timeout(&addr, CONNECT_TIMEOUT) {
+            Ok(stream) => return Ok(stream),
+            Err(e) => last_err = e,
+        }
+    }
+    Err(last_err)
+}
+
+/// Map a filesystem-scope check failure to the status the ABI reports. A missing
+/// permission or an out-of-scope / traversal path is [`PluginStatus::PermissionDenied`];
+/// anything else is [`PluginStatus::Other`].
+fn scope_error_status(err: &PermissionError) -> PluginStatus {
+    match err {
+        PermissionError::Denied(_) | PermissionError::PathOutsideScope { .. } => {
+            PluginStatus::PermissionDenied
+        }
+        _ => PluginStatus::Other,
+    }
 }
 
 /// Borrow the boxed [`PermissionSet`] behind a bridge `ctx`.
@@ -83,7 +140,7 @@ unsafe extern "C" fn bridge_open_connection(
         }
         // SAFETY: `host` is a valid borrowed `&str` for the call.
         let host_str = unsafe { host.as_str() };
-        match TcpStream::connect((host_str, port)) {
+        match connect_with_timeout(host_str, port) {
             Ok(stream) => {
                 let handle = PluginTcpStream::from_std(stream);
                 // SAFETY: `out_stream` is a valid, writable out-parameter.
@@ -124,11 +181,127 @@ unsafe extern "C" fn bridge_read_file(
                 }
                 Err(_) => PluginStatus::Io,
             },
-            Err(PermissionError::Denied(_)) | Err(PermissionError::PathOutsideScope { .. }) => {
-                PluginStatus::PermissionDenied
-            }
-            Err(_) => PluginStatus::Other,
+            Err(e) => scope_error_status(&e),
         }
+    }));
+    result.unwrap_or(PluginStatus::Panic)
+}
+
+/// `write_file` callback: resolve the path against the plugin's declared scope,
+/// then open it per `mode` and write the supplied bytes.
+///
+/// Confining every write through [`PermissionSet::check_path`] is the whole point
+/// (#2024): an out-of-scope or traversal path is rejected before any file is
+/// created or opened, so a plugin can only write inside its declared roots.
+///
+/// # Safety
+///
+/// `ctx` must be a live bridge context; `path`/`data` borrow valid memory for the
+/// call.
+unsafe extern "C" fn bridge_write_file(
+    ctx: *mut core::ffi::c_void,
+    path: FfiStr,
+    data: FfiByteSlice,
+    mode: PluginWriteMode,
+) -> PluginStatus {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: upheld by this function's contract.
+        let perms = unsafe { permissions(ctx) };
+        // SAFETY: `path`/`data` are valid borrowed views for the call.
+        let requested = unsafe { path.as_str() };
+        let bytes = unsafe { data.as_slice() };
+        // Runtime enforcement: reject a missing `filesystem` permission or a path
+        // outside the declared scope before anything is written or created.
+        let resolved = match perms.check_path(Path::new(requested)) {
+            Ok(resolved) => resolved,
+            Err(e) => return scope_error_status(&e),
+        };
+        let mut options = std::fs::OpenOptions::new();
+        match mode {
+            PluginWriteMode::Truncate => options.create(true).write(true).truncate(true),
+            PluginWriteMode::Append => options.create(true).append(true),
+            PluginWriteMode::CreateNew => options.create_new(true).write(true),
+        };
+        match options.open(&resolved).and_then(|mut f| f.write_all(bytes)) {
+            Ok(()) => PluginStatus::Ok,
+            Err(_) => PluginStatus::Io,
+        }
+    }));
+    result.unwrap_or(PluginStatus::Panic)
+}
+
+/// `stat_path` callback: resolve the path against the plugin's declared scope,
+/// then report its metadata. An in-scope path that does not exist is reported as
+/// [`PluginFileMetadata::absent`] with [`PluginStatus::Ok`] — a legitimate query,
+/// not an error.
+///
+/// # Safety
+///
+/// `ctx` must be a live bridge context; `out_meta` a valid, writable
+/// `*mut PluginFileMetadata`; `path` borrows valid memory for the call.
+unsafe extern "C" fn bridge_stat_path(
+    ctx: *mut core::ffi::c_void,
+    path: FfiStr,
+    out_meta: *mut PluginFileMetadata,
+) -> PluginStatus {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: upheld by this function's contract.
+        let perms = unsafe { permissions(ctx) };
+        // SAFETY: `path` is a valid borrowed `&str` for the call.
+        let requested = unsafe { path.as_str() };
+        let resolved = match perms.check_path(Path::new(requested)) {
+            Ok(resolved) => resolved,
+            Err(e) => return scope_error_status(&e),
+        };
+        let meta = match std::fs::metadata(&resolved) {
+            Ok(m) => PluginFileMetadata {
+                exists: true,
+                is_dir: m.is_dir(),
+                len: m.len(),
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => PluginFileMetadata::absent(),
+            Err(_) => return PluginStatus::Io,
+        };
+        // SAFETY: `out_meta` is a valid, writable out-parameter.
+        unsafe { out_meta.write(meta) };
+        PluginStatus::Ok
+    }));
+    result.unwrap_or(PluginStatus::Panic)
+}
+
+/// `list_dir` callback: resolve the path against the plugin's declared scope,
+/// then list its entries as `\n`-separated (lossy-UTF-8) owned bytes.
+///
+/// # Safety
+///
+/// `ctx` must be a live bridge context; `out_entries` a valid, writable
+/// `*mut FfiOwnedBytes`; `path` borrows valid memory for the call.
+unsafe extern "C" fn bridge_list_dir(
+    ctx: *mut core::ffi::c_void,
+    path: FfiStr,
+    out_entries: *mut FfiOwnedBytes,
+) -> PluginStatus {
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        // SAFETY: upheld by this function's contract.
+        let perms = unsafe { permissions(ctx) };
+        // SAFETY: `path` is a valid borrowed `&str` for the call.
+        let requested = unsafe { path.as_str() };
+        let resolved = match perms.check_path(Path::new(requested)) {
+            Ok(resolved) => resolved,
+            Err(e) => return scope_error_status(&e),
+        };
+        let read_dir = match std::fs::read_dir(&resolved) {
+            Ok(rd) => rd,
+            Err(_) => return PluginStatus::Io,
+        };
+        let mut names: Vec<String> = Vec::new();
+        for entry in read_dir.flatten() {
+            names.push(entry.file_name().to_string_lossy().into_owned());
+        }
+        let joined = names.join("\n");
+        // SAFETY: `out_entries` is a valid, writable out-parameter.
+        unsafe { out_entries.write(FfiOwnedBytes::from_vec(joined.into_bytes())) };
+        PluginStatus::Ok
     }));
     result.unwrap_or(PluginStatus::Panic)
 }
@@ -253,6 +426,157 @@ mod tests {
         // No `filesystem` permission at all → every read is refused.
         let bridge = build_host_bridge(perms(&[PluginPermission::Terminal], &[]));
         let err = bridge.read_file(file.to_str().unwrap()).unwrap_err();
+        assert!(matches!(
+            err,
+            termihub_plugin_api::PluginError::PermissionDenied
+        ));
+    }
+
+    #[test]
+    fn filesystem_write_is_mediated_within_scope() {
+        use termihub_plugin_api::PluginWriteMode;
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path().join("scoped");
+        std::fs::create_dir_all(&root).unwrap();
+        let bridge = build_host_bridge(perms(
+            &[PluginPermission::Filesystem],
+            &[root.to_str().unwrap()],
+        ));
+
+        // Create-or-truncate writes the file within scope.
+        let target = root.join("out.txt");
+        bridge.overwrite(target.to_str().unwrap(), b"first").unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"first");
+
+        // Truncate again replaces the contents.
+        bridge
+            .write_file(target.to_str().unwrap(), b"second", PluginWriteMode::Truncate)
+            .unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"second");
+
+        // Append extends it.
+        bridge.append(target.to_str().unwrap(), b"-more").unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"second-more");
+    }
+
+    #[test]
+    fn filesystem_create_new_fails_when_the_file_exists() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path().join("scoped");
+        std::fs::create_dir_all(&root).unwrap();
+        let bridge = build_host_bridge(perms(
+            &[PluginPermission::Filesystem],
+            &[root.to_str().unwrap()],
+        ));
+
+        let target = root.join("new.txt");
+        bridge.write_new(target.to_str().unwrap(), b"a").unwrap();
+        // A second create-new on the same path is an I/O error (already exists),
+        // not a permission denial.
+        let err = bridge.write_new(target.to_str().unwrap(), b"b").unwrap_err();
+        assert!(
+            matches!(err, termihub_plugin_api::PluginError::Io(_)),
+            "got {err:?}"
+        );
+        assert_eq!(std::fs::read(&target).unwrap(), b"a");
+    }
+
+    #[test]
+    fn filesystem_write_is_denied_outside_scope() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path().join("scoped");
+        std::fs::create_dir_all(&root).unwrap();
+        let bridge = build_host_bridge(perms(
+            &[PluginPermission::Filesystem],
+            &[root.to_str().unwrap()],
+        ));
+
+        // A write outside the declared scope is refused and never creates a file.
+        let outside = dir.path().join("escape.txt");
+        let err = bridge.overwrite(outside.to_str().unwrap(), b"x").unwrap_err();
+        assert!(matches!(
+            err,
+            termihub_plugin_api::PluginError::PermissionDenied
+        ));
+        assert!(!outside.exists(), "denied write must not create the file");
+
+        // A traversal escape from an in-scope prefix is rejected too.
+        let escape = root.join("../escape2.txt");
+        let err = bridge.overwrite(escape.to_str().unwrap(), b"x").unwrap_err();
+        assert!(matches!(
+            err,
+            termihub_plugin_api::PluginError::PermissionDenied
+        ));
+    }
+
+    #[test]
+    fn filesystem_write_is_denied_without_the_permission() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // No `filesystem` permission → writes are refused before any file opens.
+        let bridge = build_host_bridge(perms(&[PluginPermission::Terminal], &[]));
+        let target = dir.path().join("nope.txt");
+        let err = bridge.overwrite(target.to_str().unwrap(), b"x").unwrap_err();
+        assert!(matches!(
+            err,
+            termihub_plugin_api::PluginError::PermissionDenied
+        ));
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn filesystem_stat_reports_metadata_within_scope() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path().join("scoped");
+        std::fs::create_dir_all(&root).unwrap();
+        let file = root.join("data.txt");
+        std::fs::write(&file, b"12345").unwrap();
+        let bridge = build_host_bridge(perms(
+            &[PluginPermission::Filesystem],
+            &[root.to_str().unwrap()],
+        ));
+
+        // A file: exists, not a dir, correct length.
+        let meta = bridge.stat(file.to_str().unwrap()).unwrap();
+        assert!(meta.exists && !meta.is_dir);
+        assert_eq!(meta.len, 5);
+
+        // A directory: exists, is a dir.
+        let meta = bridge.stat(root.to_str().unwrap()).unwrap();
+        assert!(meta.exists && meta.is_dir);
+
+        // In-scope but absent path: reported as absent, not an error.
+        let meta = bridge.stat(root.join("missing.txt").to_str().unwrap()).unwrap();
+        assert!(!meta.exists);
+
+        // Out-of-scope stat is refused.
+        let outside = dir.path().join("secret.txt");
+        std::fs::write(&outside, b"x").unwrap();
+        let err = bridge.stat(outside.to_str().unwrap()).unwrap_err();
+        assert!(matches!(
+            err,
+            termihub_plugin_api::PluginError::PermissionDenied
+        ));
+    }
+
+    #[test]
+    fn filesystem_list_dir_lists_entries_within_scope() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let root = dir.path().join("scoped");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("a.txt"), b"a").unwrap();
+        std::fs::write(root.join("b.txt"), b"b").unwrap();
+        std::fs::create_dir(root.join("sub")).unwrap();
+        let bridge = build_host_bridge(perms(
+            &[PluginPermission::Filesystem],
+            &[root.to_str().unwrap()],
+        ));
+
+        let mut entries = bridge.list_dir(root.to_str().unwrap()).unwrap();
+        entries.sort();
+        assert_eq!(entries, vec!["a.txt", "b.txt", "sub"]);
+
+        // Out-of-scope listing is refused.
+        let err = bridge.list_dir(dir.path().to_str().unwrap()).unwrap_err();
         assert!(matches!(
             err,
             termihub_plugin_api::PluginError::PermissionDenied

--- a/core/tests/fixtures/test-plugin/src/lib.rs
+++ b/core/tests/fixtures/test-plugin/src/lib.rs
@@ -23,7 +23,7 @@ use serde::Deserialize;
 use termihub_plugin_api::PluginInfo;
 use termihub_plugin_api::{
     PluginBackend, PluginError, PluginHostBridge, PluginOutputSender, PluginSessionConfig,
-    PluginStatus, PluginTerminalBackend, CURRENT_PLUGIN_API_VERSION,
+    PluginStatus, PluginTerminalBackend, PluginWriteMode, CURRENT_PLUGIN_API_VERSION,
 };
 
 /// A backend that echoes written input straight back to the host output sink.
@@ -91,14 +91,18 @@ pub unsafe extern "C" fn termihub_plugin_init(out_info: *mut PluginInfo) -> Plug
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 struct ProbeConfig {
-    /// `"network"` or `"readfile"`; empty means "no probe, just echo".
+    /// One of `"network"`, `"readfile"`, `"writefile"`, `"appendfile"`,
+    /// `"createfile"`, `"statpath"`, `"listdir"`; empty means "no probe, just
+    /// echo".
     probe: String,
     /// Target host for the `network` probe.
     probe_host: String,
     /// Target port for the `network` probe.
     probe_port: u16,
-    /// Target path for the `readfile` probe.
+    /// Target path for the filesystem probes.
     probe_path: String,
+    /// Bytes to write for the `writefile`/`appendfile`/`createfile` probes.
+    probe_data: String,
 }
 
 /// Run the requested capability probe through the host `bridge` and report the
@@ -127,6 +131,40 @@ fn run_probe(cfg: &ProbeConfig, bridge: &PluginHostBridge, output: &PluginOutput
                 }
                 Err(PluginError::PermissionDenied) => b"READ_DENIED".to_vec(),
                 Err(_) => b"READ_ERR".to_vec(),
+            };
+            let _ = output.send(&line);
+        }
+        "writefile" | "appendfile" | "createfile" => {
+            let mode = match cfg.probe.as_str() {
+                "appendfile" => PluginWriteMode::Append,
+                "createfile" => PluginWriteMode::CreateNew,
+                _ => PluginWriteMode::Truncate,
+            };
+            let line = match bridge.write_file(&cfg.probe_path, cfg.probe_data.as_bytes(), mode) {
+                Ok(()) => b"WRITE_OK".to_vec(),
+                Err(PluginError::PermissionDenied) => b"WRITE_DENIED".to_vec(),
+                Err(_) => b"WRITE_ERR".to_vec(),
+            };
+            let _ = output.send(&line);
+        }
+        "statpath" => {
+            let line = match bridge.stat(&cfg.probe_path) {
+                Ok(meta) if meta.exists && meta.is_dir => b"STAT_DIR".to_vec(),
+                Ok(meta) if meta.exists => format!("STAT_FILE:{}", meta.len).into_bytes(),
+                Ok(_) => b"STAT_ABSENT".to_vec(),
+                Err(PluginError::PermissionDenied) => b"STAT_DENIED".to_vec(),
+                Err(_) => b"STAT_ERR".to_vec(),
+            };
+            let _ = output.send(&line);
+        }
+        "listdir" => {
+            let line = match bridge.list_dir(&cfg.probe_path) {
+                Ok(mut entries) => {
+                    entries.sort();
+                    format!("LIST_OK:{}", entries.join(",")).into_bytes()
+                }
+                Err(PluginError::PermissionDenied) => b"LIST_DENIED".to_vec(),
+                Err(_) => b"LIST_ERR".to_vec(),
             };
             let _ = output.send(&line);
         }

--- a/core/tests/plugin_capability_bridge.rs
+++ b/core/tests/plugin_capability_bridge.rs
@@ -1,4 +1,4 @@
-//! End-to-end test of the host-mediated capability bridge (#2018).
+//! End-to-end test of the host-mediated capability bridge (#2018, #2024).
 //!
 //! Where `plugin_host_roundtrip.rs` proves a plugin *loads* and echoes, this test
 //! proves the host actually **enforces the plugin's declared permissions at
@@ -6,11 +6,14 @@
 //! real `dlopen` boundary, not just in-process.
 //!
 //! The fixture `cdylib` (`tests/fixtures/test-plugin`) grows an optional probe:
-//! given a `{"probe": "network"|"readfile", …}` session config it calls the host
-//! bridge and reports the outcome (`NETWORK_OK`/`NETWORK_DENIED`,
-//! `READ_OK:<bytes>`/`READ_DENIED`) as its first output line. Here we build the
+//! given a `{"probe": "network"|"readfile"|"writefile"|"appendfile"|
+//! "createfile"|"statpath"|"listdir", …}` session config it calls the host bridge
+//! and reports the outcome (`NETWORK_OK`/`NETWORK_DENIED`, `READ_OK:<bytes>`/
+//! `READ_DENIED`, `WRITE_OK`/`WRITE_DENIED`, `STAT_FILE:<len>`/`STAT_DENIED`,
+//! `LIST_OK:<names>`/`LIST_DENIED`) as its first output line. Here we build the
 //! fixture, drive a [`PluginConnectionType`] with a chosen [`PermissionSet`], and
-//! assert the bridge grants or denies exactly as the permissions dictate.
+//! assert the bridge grants or denies exactly as the permissions dictate — for
+//! the read/connect surface of #2018 and the write/stat/list surface of #2024.
 #![cfg(feature = "plugin")]
 
 use std::io::Read;
@@ -172,4 +175,145 @@ async fn filesystem_capability_is_enforced_through_the_bridge() {
     )
     .await;
     assert_eq!(no_perm, b"READ_DENIED", "no filesystem permission → denied");
+}
+
+#[tokio::test]
+async fn filesystem_write_is_enforced_through_the_bridge() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let lib = load_backend_library(&build_fixture(&tmp.path().join("target")))
+        .expect("fixture should load");
+
+    let root = tmp.path().join("scoped");
+    std::fs::create_dir_all(&root).unwrap();
+    let outside = tmp.path().join("escape.txt");
+
+    let scoped = || {
+        PermissionSet::from_parts(
+            [PluginPermission::Filesystem],
+            &[root.to_str().unwrap().to_owned()],
+        )
+    };
+
+    // In-scope create-or-truncate write is mediated and lands on disk.
+    let inside = root.join("out.txt");
+    let ok = probe_outcome(
+        &lib,
+        scoped(),
+        serde_json::json!({
+            "probe": "writefile",
+            "probePath": inside.to_str().unwrap(),
+            "probeData": "hello",
+        }),
+    )
+    .await;
+    assert_eq!(ok, b"WRITE_OK");
+    assert_eq!(std::fs::read(&inside).unwrap(), b"hello");
+
+    // In-scope append extends the same file.
+    let appended = probe_outcome(
+        &lib,
+        scoped(),
+        serde_json::json!({
+            "probe": "appendfile",
+            "probePath": inside.to_str().unwrap(),
+            "probeData": "-more",
+        }),
+    )
+    .await;
+    assert_eq!(appended, b"WRITE_OK");
+    assert_eq!(std::fs::read(&inside).unwrap(), b"hello-more");
+
+    // Out-of-scope write is rejected end-to-end — the host never creates the file.
+    let denied = probe_outcome(
+        &lib,
+        scoped(),
+        serde_json::json!({
+            "probe": "writefile",
+            "probePath": outside.to_str().unwrap(),
+            "probeData": "x",
+        }),
+    )
+    .await;
+    assert_eq!(denied, b"WRITE_DENIED", "out-of-scope write must be denied");
+    assert!(!outside.exists(), "denied write must not create the file");
+
+    // No `filesystem` permission → every write is refused.
+    let no_perm = probe_outcome(
+        &lib,
+        PermissionSet::from_parts([PluginPermission::Terminal], &[]),
+        serde_json::json!({
+            "probe": "writefile",
+            "probePath": inside.to_str().unwrap(),
+            "probeData": "x",
+        }),
+    )
+    .await;
+    assert_eq!(
+        no_perm, b"WRITE_DENIED",
+        "no filesystem permission → denied"
+    );
+}
+
+#[tokio::test]
+async fn filesystem_stat_and_list_are_enforced_through_the_bridge() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let lib = load_backend_library(&build_fixture(&tmp.path().join("target")))
+        .expect("fixture should load");
+
+    let root = tmp.path().join("scoped");
+    std::fs::create_dir_all(&root).unwrap();
+    let file = root.join("data.txt");
+    std::fs::write(&file, b"12345").unwrap();
+    std::fs::write(root.join("other.txt"), b"y").unwrap();
+    let outside = tmp.path().join("secret.txt");
+    std::fs::write(&outside, b"top secret").unwrap();
+
+    let scoped = || {
+        PermissionSet::from_parts(
+            [PluginPermission::Filesystem],
+            &[root.to_str().unwrap().to_owned()],
+        )
+    };
+
+    // In-scope stat of a file reports its length.
+    let stat = probe_outcome(
+        &lib,
+        scoped(),
+        serde_json::json!({ "probe": "statpath", "probePath": file.to_str().unwrap() }),
+    )
+    .await;
+    assert_eq!(stat, b"STAT_FILE:5");
+
+    // Out-of-scope stat is refused.
+    let stat_denied = probe_outcome(
+        &lib,
+        scoped(),
+        serde_json::json!({ "probe": "statpath", "probePath": outside.to_str().unwrap() }),
+    )
+    .await;
+    assert_eq!(
+        stat_denied, b"STAT_DENIED",
+        "out-of-scope stat must be denied"
+    );
+
+    // In-scope directory listing returns the entry names.
+    let list = probe_outcome(
+        &lib,
+        scoped(),
+        serde_json::json!({ "probe": "listdir", "probePath": root.to_str().unwrap() }),
+    )
+    .await;
+    assert_eq!(list, b"LIST_OK:data.txt,other.txt");
+
+    // Out-of-scope listing is refused.
+    let list_denied = probe_outcome(
+        &lib,
+        scoped(),
+        serde_json::json!({ "probe": "listdir", "probePath": tmp.path().to_str().unwrap() }),
+    )
+    .await;
+    assert_eq!(
+        list_denied, b"LIST_DENIED",
+        "out-of-scope list must be denied"
+    );
 }

--- a/core/tests/plugin_host_roundtrip.rs
+++ b/core/tests/plugin_host_roundtrip.rs
@@ -80,7 +80,10 @@ async fn plugin_host_round_trip() {
     assert_eq!(lib.info().id, "test-echo");
     assert_eq!(lib.info().name, "Test Echo");
     assert_eq!(lib.info().version, "0.1.0");
-    assert_eq!(lib.info().api_version, 2);
+    assert_eq!(
+        lib.info().api_version,
+        termihub_plugin_api::CURRENT_PLUGIN_API_VERSION
+    );
 
     // --- 2. Full ConnectionType round trip: written input echoes to output. ---
     let mut conn = PluginConnectionType::new(
@@ -117,7 +120,7 @@ async fn plugin_host_round_trip() {
     std::env::remove_var("TERMIHUB_TEST_PLUGIN_ABI");
     match result {
         Err(HostError::IncompatibleAbi { expected, found }) => {
-            assert_eq!(expected, 2);
+            assert_eq!(expected, termihub_plugin_api::CURRENT_PLUGIN_API_VERSION);
             assert_eq!(found, 99);
         }
         Err(other) => panic!("expected IncompatibleAbi, got {other:?}"),

--- a/docs/changes/dev2/feature/2024-bridge-fs-writes.md
+++ b/docs/changes/dev2/feature/2024-bridge-fs-writes.md
@@ -1,0 +1,12 @@
+### Added
+
+- Plugin capability bridge: mediated filesystem **writes** and **directory
+  inspection**. Building on the read/connect surface from #2018, the
+  `PluginHostBridge` now also mediates `write_file` (create / truncate / append),
+  `stat`, and `list_dir` — each routed through the session's declared
+  `FilesystemScope`, so a plugin can only write to, stat, or list paths inside its
+  granted roots and out-of-scope or `..`-traversal paths are refused before the
+  host performs any I/O. The mediated `open_connection` also gained a host-side
+  connect timeout so a plugin's dial-out to a black-holed host can no longer hang
+  a session. The plugin ABI (`termihub-plugin-api`) is bumped to version 3 to
+  reflect the grown bridge vtable (#2024).

--- a/plugin-api/src/capabilities.rs
+++ b/plugin-api/src/capabilities.rs
@@ -23,7 +23,22 @@
 //!                                        │ yes
 //!                                        ▼
 //!                                  std::fs::read ─▶ owned bytes
+//!
+//!   bridge.write_file(p,d,mode) ─▶ FilesystemScope::check(p)?    ─ no ─▶ PermissionDenied
+//!                                        │ yes
+//!                                        ▼
+//!                                  OpenOptions(mode) + write_all
+//!
+//!   bridge.stat(path)           ─▶ FilesystemScope::check(path)? ─ no ─▶ PermissionDenied
+//!   bridge.list_dir(path)       ─▶ FilesystemScope::check(path)? ─ no ─▶ PermissionDenied
 //! ```
+//!
+//! Every filesystem operation — read, write, append, create, stat, list —
+//! resolves its path through the same [`FilesystemScope::check`] guard, so a
+//! plugin can only touch paths inside its declared roots (out-of-scope and `..`
+//! traversal are rejected before the host performs any I/O).
+//!
+//! [`FilesystemScope::check`]: https://docs.rs/termihub-core
 //!
 //! # What this does and does not enforce
 //!
@@ -72,6 +87,79 @@ pub type PluginReadFileFn = unsafe extern "C" fn(
     out_bytes: *mut FfiOwnedBytes,
 ) -> PluginStatus;
 
+/// How a mediated filesystem write should open its target file.
+///
+/// A `#[repr(i32)]` field-less enum so it is FFI-safe and stable across the ABI.
+/// Every variant is confined to the plugin's declared scope by the host before
+/// any file is opened.
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PluginWriteMode {
+    /// Create the file if absent, **truncate** it if present, then write.
+    Truncate = 0,
+    /// Create the file if absent, **append** to it if present.
+    Append = 1,
+    /// **Create a new** file, failing with an I/O error if it already exists.
+    CreateNew = 2,
+}
+
+/// Signature of the host callback that writes a file on the plugin's behalf. The
+/// host resolves and authorizes `path` against the plugin's declared filesystem
+/// scope, then opens it per `mode` and writes `data`.
+pub type PluginWriteFileFn = unsafe extern "C" fn(
+    ctx: *mut c_void,
+    path: FfiStr,
+    data: FfiByteSlice,
+    mode: PluginWriteMode,
+) -> PluginStatus;
+
+/// FFI-safe filesystem metadata returned by a mediated [`stat`](PluginHostBridge::stat).
+///
+/// `#[repr(C)]` with only FFI-safe scalar fields. When `exists` is `false` the
+/// other fields are meaningless (`is_dir == false`, `len == 0`).
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PluginFileMetadata {
+    /// Whether anything exists at the (in-scope) path.
+    pub exists: bool,
+    /// Whether the path is a directory. Only meaningful when `exists`.
+    pub is_dir: bool,
+    /// File size in bytes. `0` for directories and non-existent paths.
+    pub len: u64,
+}
+
+impl PluginFileMetadata {
+    /// The "nothing here" metadata for an in-scope path that does not exist.
+    #[must_use]
+    pub fn absent() -> Self {
+        Self {
+            exists: false,
+            is_dir: false,
+            len: 0,
+        }
+    }
+}
+
+/// Signature of the host callback that stats a path on the plugin's behalf. The
+/// host authorizes `path` against the plugin's declared scope, then writes the
+/// resolved [`PluginFileMetadata`] into `out_meta`. An in-scope but non-existent
+/// path is **not** an error: it yields [`PluginFileMetadata::absent`].
+pub type PluginStatPathFn = unsafe extern "C" fn(
+    ctx: *mut c_void,
+    path: FfiStr,
+    out_meta: *mut PluginFileMetadata,
+) -> PluginStatus;
+
+/// Signature of the host callback that lists a directory on the plugin's behalf.
+/// The host authorizes `path` against the plugin's declared scope, then writes
+/// the directory's entry names — one per line, `\n`-separated, UTF-8
+/// (lossily-encoded) — into `out_entries` as owned bytes.
+pub type PluginListDirFn = unsafe extern "C" fn(
+    ctx: *mut c_void,
+    path: FfiStr,
+    out_entries: *mut FfiOwnedBytes,
+) -> PluginStatus;
+
 /// Signature of the destructor for the host-provided bridge context.
 pub type PluginBridgeDestroyFn = unsafe extern "C" fn(ctx: *mut c_void);
 
@@ -88,6 +176,9 @@ pub struct PluginHostBridge {
     ctx: *mut c_void,
     open_connection: PluginOpenConnectionFn,
     read_file: PluginReadFileFn,
+    write_file: PluginWriteFileFn,
+    stat_path: PluginStatPathFn,
+    list_dir: PluginListDirFn,
     destroy: Option<PluginBridgeDestroyFn>,
 }
 
@@ -107,21 +198,28 @@ impl PluginHostBridge {
     ///
     /// # Safety
     ///
-    /// * `open_connection`, `read_file` and `destroy` (if any) must be safe to
-    ///   call with `ctx`.
+    /// * `open_connection`, `read_file`, `write_file`, `stat_path`, `list_dir`
+    ///   and `destroy` (if any) must be safe to call with `ctx`.
     /// * `ctx` must remain valid until `destroy` is invoked; ownership of it is
     ///   transferred to the returned bridge.
     #[must_use]
+    #[allow(clippy::too_many_arguments)]
     pub unsafe fn from_raw(
         ctx: *mut c_void,
         open_connection: PluginOpenConnectionFn,
         read_file: PluginReadFileFn,
+        write_file: PluginWriteFileFn,
+        stat_path: PluginStatPathFn,
+        list_dir: PluginListDirFn,
         destroy: Option<PluginBridgeDestroyFn>,
     ) -> Self {
         Self {
             ctx,
             open_connection,
             read_file,
+            write_file,
+            stat_path,
+            list_dir,
             destroy,
         }
     }
@@ -156,6 +254,78 @@ impl PluginHostBridge {
         let status = unsafe { (self.read_file)(self.ctx, FfiStr::new(path), &mut bytes) };
         status.into_result()?;
         Ok(bytes.into_vec())
+    }
+
+    /// Ask the host to write `data` to the file at `path`, opening it per `mode`.
+    ///
+    /// The host refuses with [`PluginError::PermissionDenied`] unless the plugin
+    /// holds the `filesystem` permission *and* `path` resolves inside its declared
+    /// scope. Prefer the [`write_new`](Self::write_new), [`overwrite`](Self::overwrite)
+    /// and [`append`](Self::append) convenience wrappers.
+    pub fn write_file(
+        &self,
+        path: &str,
+        data: &[u8],
+        mode: PluginWriteMode,
+    ) -> Result<(), PluginError> {
+        // SAFETY: `ctx`/`write_file` were validated at construction; `path` and
+        // `data` outlive the call.
+        let status = unsafe {
+            (self.write_file)(
+                self.ctx,
+                FfiStr::new(path),
+                FfiByteSlice::from_slice(data),
+                mode,
+            )
+        };
+        status.into_result()
+    }
+
+    /// Create-or-truncate the file at `path` and write `data`
+    /// ([`PluginWriteMode::Truncate`]).
+    pub fn overwrite(&self, path: &str, data: &[u8]) -> Result<(), PluginError> {
+        self.write_file(path, data, PluginWriteMode::Truncate)
+    }
+
+    /// Append `data` to the file at `path`, creating it if absent
+    /// ([`PluginWriteMode::Append`]).
+    pub fn append(&self, path: &str, data: &[u8]) -> Result<(), PluginError> {
+        self.write_file(path, data, PluginWriteMode::Append)
+    }
+
+    /// Create a **new** file at `path` and write `data`, failing if it already
+    /// exists ([`PluginWriteMode::CreateNew`]).
+    pub fn write_new(&self, path: &str, data: &[u8]) -> Result<(), PluginError> {
+        self.write_file(path, data, PluginWriteMode::CreateNew)
+    }
+
+    /// Ask the host for filesystem metadata about `path`.
+    ///
+    /// The host refuses with [`PluginError::PermissionDenied`] unless `path`
+    /// resolves inside the plugin's declared scope. An in-scope path that does
+    /// not exist is reported as [`PluginFileMetadata::absent`], not an error.
+    pub fn stat(&self, path: &str) -> Result<PluginFileMetadata, PluginError> {
+        let mut meta = PluginFileMetadata::absent();
+        // SAFETY: `ctx`/`stat_path` were validated at construction; `path` outlives
+        // the call; `&mut meta` is a valid out-parameter the host fills in on `Ok`.
+        let status = unsafe { (self.stat_path)(self.ctx, FfiStr::new(path), &mut meta) };
+        status.into_result()?;
+        Ok(meta)
+    }
+
+    /// Ask the host to list the directory at `path`, returning its entry names.
+    ///
+    /// The host refuses with [`PluginError::PermissionDenied`] unless `path`
+    /// resolves inside the plugin's declared scope. Entry names are the final
+    /// path component only, in the host's directory order.
+    pub fn list_dir(&self, path: &str) -> Result<Vec<String>, PluginError> {
+        let mut entries = FfiOwnedBytes::empty();
+        // SAFETY: `ctx`/`list_dir` were validated at construction; `path` outlives
+        // the call; `&mut entries` is a valid out-parameter the host fills in on `Ok`.
+        let status = unsafe { (self.list_dir)(self.ctx, FfiStr::new(path), &mut entries) };
+        status.into_result()?;
+        let joined = String::from_utf8_lossy(&entries.into_vec()).into_owned();
+        Ok(joined.lines().map(str::to_owned).collect())
     }
 }
 

--- a/plugin-api/src/lib.rs
+++ b/plugin-api/src/lib.rs
@@ -102,7 +102,10 @@ pub mod output;
 pub mod symbols;
 
 pub use backend::{LoadedBackend, PluginBackend, PluginBackendVTable, PluginTerminalBackend};
-pub use capabilities::{HostTcpStream, PluginHostBridge, PluginTcpStream, PluginTcpStreamVTable};
+pub use capabilities::{
+    HostTcpStream, PluginFileMetadata, PluginHostBridge, PluginTcpStream, PluginTcpStreamVTable,
+    PluginWriteMode,
+};
 pub use error::{PluginError, PluginStatus};
 pub use ffi::{FfiByteSlice, FfiOwnedBytes, FfiStr, FfiString};
 pub use info::{PluginInfo, PluginSessionConfig};
@@ -119,4 +122,9 @@ pub use output::PluginOutputSender;
 /// Bumped to `2` in #2018: `plugin_create_backend` gained a
 /// [`PluginHostBridge`](capabilities::PluginHostBridge) parameter through which
 /// the host mediates and permission-checks network/filesystem access at runtime.
-pub const CURRENT_PLUGIN_API_VERSION: u32 = 2;
+///
+/// Bumped to `3` in #2024: the [`PluginHostBridge`](capabilities::PluginHostBridge)
+/// vtable grew mediated filesystem `write_file` (create / truncate / append),
+/// `stat_path`, and `list_dir` callbacks — a layout change that breaks plugins
+/// built against version `2`.
+pub const CURRENT_PLUGIN_API_VERSION: u32 = 3;

--- a/plugin-api/src/symbols.rs
+++ b/plugin-api/src/symbols.rs
@@ -99,7 +99,10 @@ pub type PluginShutdownFn = unsafe extern "C" fn();
 #[allow(dead_code)]
 mod ffi_safety_check {
     use super::*;
-    use crate::ffi::FfiByteSlice;
+    use crate::capabilities::{
+        PluginFileMetadata, PluginListDirFn, PluginStatPathFn, PluginWriteFileFn, PluginWriteMode,
+    };
+    use crate::ffi::{FfiByteSlice, FfiOwnedBytes, FfiStr};
 
     // Exported entry points, exactly matching the type aliases above.
     unsafe extern "C" fn _abi_version() -> u32 {
@@ -129,6 +132,30 @@ mod ffi_safety_check {
         true
     }
 
+    // Capability-bridge callback shapes (#2018, #2024).
+    unsafe extern "C" fn _write_file(
+        _c: *mut core::ffi::c_void,
+        _p: FfiStr,
+        _d: FfiByteSlice,
+        _m: PluginWriteMode,
+    ) -> PluginStatus {
+        PluginStatus::Ok
+    }
+    unsafe extern "C" fn _stat_path(
+        _c: *mut core::ffi::c_void,
+        _p: FfiStr,
+        _o: *mut PluginFileMetadata,
+    ) -> PluginStatus {
+        PluginStatus::Ok
+    }
+    unsafe extern "C" fn _list_dir(
+        _c: *mut core::ffi::c_void,
+        _p: FfiStr,
+        _o: *mut FfiOwnedBytes,
+    ) -> PluginStatus {
+        PluginStatus::Ok
+    }
+
     // Assert the aliases accept the definitions (another layer of the same check).
     const _: PluginAbiVersionFn = _abi_version;
     const _: PluginInitFn = _init;
@@ -137,4 +164,7 @@ mod ffi_safety_check {
     const _: unsafe extern "C" fn(*mut core::ffi::c_void, FfiByteSlice) -> PluginStatus =
         _write_input;
     const _: unsafe extern "C" fn(*mut core::ffi::c_void) -> bool = _is_alive;
+    const _: PluginWriteFileFn = _write_file;
+    const _: PluginStatPathFn = _stat_path;
+    const _: PluginListDirFn = _list_dir;
 }


### PR DESCRIPTION
Follow-up to #2018 (PR #2023). Extends the deliberately-minimal host-mediated capability bridge (`PluginHostBridge`) with the write/inspect filesystem surface the read-only slice deferred.

## What changed

- **Mediated filesystem writes** — the bridge gains `write_file(path, data, mode)` with a `PluginWriteMode` of `Truncate` (create-or-overwrite), `Append`, or `CreateNew`. Every write resolves its path through `FilesystemScope::check` (via `PermissionSet::check_path`), so a plugin can only write inside its declared roots; out-of-scope and `..`-traversal paths are refused before any file is created or opened. Ergonomic plugin-side wrappers: `overwrite`, `append`, `write_new`.
- **Mediated directory inspection** — `stat(path)` returns FFI-safe `PluginFileMetadata` (exists / is_dir / len; an in-scope-but-absent path is reported as absent, not an error), and `list_dir(path)` returns the scoped directory's entry names. Both go through the same scope guard.
- **Host-side connection policy** — the mediated `open_connection` now applies a 30s host-side connect timeout (`connect_timeout` over resolved addresses), so a plugin's dial-out to a black-holed host can no longer hang a session.
- **ABI bump to 3** — the `PluginHostBridge` vtable grew three `#[repr(C)]` `extern "C"` callbacks, a layout change that breaks version-2 plugins, so `CURRENT_PLUGIN_API_VERSION` is bumped and the FFI-safety compile-time proof in `symbols.rs` covers the new shapes. The stable-ABI approach is preserved — no `dyn Trait`, `String`, or allocator crosses the boundary.

## Tests

- Host-side unit tests in `core/src/plugin/capabilities.rs` for write/append/create-new, stat, and list — each with allow **and** deny (out-of-scope, no-permission) paths.
- End-to-end tests in `core/tests/plugin_capability_bridge.rs` exercise the new operations over the **real `dlopen` boundary** via the fixture `cdylib` (new `writefile`/`appendfile`/`createfile`/`statpath`/`listdir` probes), asserting allow and deny for each.
- The host round-trip test's ABI-version assertions now reference the crate constant instead of a literal, so future bumps stay green.

## Out of scope

Closing the direct-syscall bypass (an in-process plugin calling `std::fs`/`std::net` directly) — that needs OS-level process isolation termiHub has no substrate for, and stays documented as future work in `core/src/plugin/security.rs`. See the follow-up below for per-session connection limits.

Closes #2024