### PR TITLE
feat(plugin): per-session connection limits and configurable connect timeout on the bridge (Closes #2028)

### DIFF
--- a/core/src/plugin/capabilities.rs
+++ b/core/src/plugin/capabilities.rs
@@ -21,6 +21,8 @@
 use std::io::Write;
 use std::net::{TcpStream, ToSocketAddrs};
 use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use termihub_plugin_api::capabilities::{
@@ -31,37 +33,181 @@ use termihub_plugin_api::{
     FfiByteSlice, FfiOwnedBytes, FfiStr, PluginHostBridge, PluginStatus, PluginTcpStream,
 };
 
+use super::manifest::ConnectionPolicyManifest;
 use super::security::{PermissionError, PermissionSet};
 use super::PluginPermission;
 
-/// Host-side connect timeout applied to every mediated `open_connection` (#2024).
+/// Default connect timeout applied to a mediated `open_connection` when the
+/// session's [`ConnectionPolicy`] does not override it (#2024).
 ///
 /// A bare `TcpStream::connect` blocks indefinitely on a black-holed host; this
-/// per-connect ceiling is the host-side connection policy that keeps a plugin's
-/// dial-out from hanging a session forever.
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+/// per-connect ceiling keeps a plugin's dial-out from hanging a session forever.
+pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Build the host capability bridge for a session granted `permissions`.
+/// Default per-session ceiling on concurrent mediated connections when the
+/// session's [`ConnectionPolicy`] does not override it (#2028).
+///
+/// Enough headroom for a plugin that legitimately fans out to a handful of
+/// endpoints, while still bounding how much host resource one cooperating session
+/// can hold open through the bridge.
+pub const DEFAULT_MAX_CONNECTIONS: usize = 8;
+
+/// Host-side policy governing the connections a plugin session may open through
+/// the capability bridge (#2028).
+///
+/// It bounds two things a cooperating plugin would otherwise control unchecked:
+/// how many mediated connections it can hold open at once
+/// ([`max_connections`](Self::max_connections)), and how long each dial-out may
+/// block ([`connect_timeout`](Self::connect_timeout)). Both have host defaults
+/// ([`DEFAULT_MAX_CONNECTIONS`], [`DEFAULT_CONNECT_TIMEOUT`]) and can be raised or
+/// lowered per plugin through the manifest's `connectionPolicy`
+/// ([`ConnectionPolicyManifest`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConnectionPolicy {
+    max_connections: usize,
+    connect_timeout: Duration,
+}
+
+impl Default for ConnectionPolicy {
+    fn default() -> Self {
+        Self {
+            max_connections: DEFAULT_MAX_CONNECTIONS,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
+        }
+    }
+}
+
+impl ConnectionPolicy {
+    /// A policy with explicit values.
+    #[must_use]
+    pub fn new(max_connections: usize, connect_timeout: Duration) -> Self {
+        Self {
+            max_connections,
+            connect_timeout,
+        }
+    }
+
+    /// Derive a policy from a manifest's optional `connectionPolicy`, falling back
+    /// to the host defaults for any field the manifest leaves unset.
+    #[must_use]
+    pub fn from_manifest(policy: Option<&ConnectionPolicyManifest>) -> Self {
+        let mut resolved = Self::default();
+        if let Some(p) = policy {
+            if let Some(max) = p.max_connections {
+                resolved.max_connections = max;
+            }
+            if let Some(ms) = p.connect_timeout_ms {
+                resolved.connect_timeout = Duration::from_millis(ms);
+            }
+        }
+        resolved
+    }
+
+    /// Maximum number of concurrent mediated connections a session may hold open.
+    #[must_use]
+    pub fn max_connections(&self) -> usize {
+        self.max_connections
+    }
+
+    /// Connect timeout applied to each mediated dial-out.
+    #[must_use]
+    pub fn connect_timeout(&self) -> Duration {
+        self.connect_timeout
+    }
+}
+
+/// Owned context behind a [`PluginHostBridge`]: the session's granted
+/// permissions, its [`ConnectionPolicy`], and the live count of mediated
+/// connections it currently holds open.
+struct BridgeContext {
+    /// The session's granted permissions, checked on every mediated operation.
+    permissions: PermissionSet,
+    /// The session's connection policy (concurrency ceiling + connect timeout).
+    policy: ConnectionPolicy,
+    /// Mediated connections currently open for this session. Shared with each
+    /// open connection's [`ConnectionGuard`], which decrements it on drop.
+    active_connections: Arc<AtomicUsize>,
+}
+
+impl BridgeContext {
+    /// Try to reserve one connection slot, returning a [`ConnectionGuard`] that
+    /// releases it on drop, or `None` if the session is already at its
+    /// concurrent-connection ceiling.
+    fn try_reserve_connection(&self) -> Option<ConnectionGuard> {
+        // Optimistically claim a slot, then roll back if that pushed the session
+        // over its ceiling. A single atomic keeps the count correct across the
+        // several threads a backend may drive the bridge from.
+        let prev = self.active_connections.fetch_add(1, Ordering::AcqRel);
+        if prev >= self.policy.max_connections {
+            self.active_connections.fetch_sub(1, Ordering::AcqRel);
+            None
+        } else {
+            Some(ConnectionGuard {
+                active_connections: Arc::clone(&self.active_connections),
+            })
+        }
+    }
+}
+
+/// Releases one reserved connection slot when the mediated stream is dropped.
+///
+/// Handed to the mediated stream as its
+/// [`StreamDropGuard`](termihub_plugin_api::StreamDropGuard), so a session's live
+/// connection count falls the instant the plugin drops a connection — freeing the
+/// slot for a later dial-out.
+struct ConnectionGuard {
+    active_connections: Arc<AtomicUsize>,
+}
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        self.active_connections.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+/// Build the host capability bridge for a session granted `permissions`, using
+/// the host's default [`ConnectionPolicy`].
+///
+/// A convenience over [`build_host_bridge_with_policy`] for callers (and tests)
+/// that do not customise the connection policy.
+#[must_use]
+pub fn build_host_bridge(permissions: PermissionSet) -> PluginHostBridge {
+    build_host_bridge_with_policy(permissions, ConnectionPolicy::default())
+}
+
+/// Build the host capability bridge for a session granted `permissions` and
+/// governed by `policy`.
 ///
 /// The returned [`PluginHostBridge`] is passed by value into the plugin's
 /// `create_backend`; the plugin owns it thereafter and drops it (running the
-/// destructor installed here, which frees the boxed permission set). Every call a
-/// plugin makes through the bridge is checked against `permissions` before the
-/// host performs it.
+/// destructor installed here, which frees the boxed context). Every call a plugin
+/// makes through the bridge is checked against `permissions` before the host
+/// performs it, and every `open_connection` is bounded by `policy` — both its
+/// concurrency ceiling and its connect timeout (#2028).
 #[must_use]
-pub fn build_host_bridge(permissions: PermissionSet) -> PluginHostBridge {
-    // The bridge context owns a clone of the granted permission set. Leaked as a
-    // raw pointer to cross the ABI; `bridge_destroy` reclaims it.
-    let ctx = Box::into_raw(Box::new(permissions)).cast::<core::ffi::c_void>();
+pub fn build_host_bridge_with_policy(
+    permissions: PermissionSet,
+    policy: ConnectionPolicy,
+) -> PluginHostBridge {
+    // The bridge context owns the granted permission set, the connection policy,
+    // and this session's live connection counter. Leaked as a raw pointer to
+    // cross the ABI; `bridge_destroy` reclaims it.
+    let ctx = Box::into_raw(Box::new(BridgeContext {
+        permissions,
+        policy,
+        active_connections: Arc::new(AtomicUsize::new(0)),
+    }))
+    .cast::<core::ffi::c_void>();
     let open_connection: PluginOpenConnectionFn = bridge_open_connection;
     let read_file: PluginReadFileFn = bridge_read_file;
     let write_file: PluginWriteFileFn = bridge_write_file;
     let stat_path: PluginStatPathFn = bridge_stat_path;
     let list_dir: PluginListDirFn = bridge_list_dir;
     let destroy: PluginBridgeDestroyFn = bridge_destroy;
-    // SAFETY: `ctx` is a leaked `Box<PermissionSet>`; every callback below only
+    // SAFETY: `ctx` is a leaked `Box<BridgeContext>`; every callback below only
     // ever interprets it as exactly that, and `destroy` reclaims it exactly once.
-    // `PermissionSet` is `Send + Sync`, matching the bridge's bounds.
+    // `BridgeContext` is `Send + Sync` (its fields are), matching the bridge's
+    // bounds.
     unsafe {
         PluginHostBridge::from_raw(
             ctx,
@@ -75,19 +221,20 @@ pub fn build_host_bridge(permissions: PermissionSet) -> PluginHostBridge {
     }
 }
 
-/// Resolve `host:port` and connect with the host-side [`CONNECT_TIMEOUT`] policy.
+/// Resolve `host:port` and connect, bounding each attempt by `timeout`.
 ///
 /// Each resolved address is tried with [`TcpStream::connect_timeout`] so a
 /// black-holed host cannot hang the connect indefinitely; the last error is
-/// returned if every address fails or resolution yields none.
-fn connect_with_timeout(host: &str, port: u16) -> std::io::Result<TcpStream> {
+/// returned if every address fails or resolution yields none. `timeout` comes
+/// from the session's [`ConnectionPolicy`] (#2028).
+fn connect_with_timeout(host: &str, port: u16, timeout: Duration) -> std::io::Result<TcpStream> {
     let addrs = (host, port).to_socket_addrs()?;
     let mut last_err = std::io::Error::new(
         std::io::ErrorKind::NotFound,
         "no addresses resolved for host",
     );
     for addr in addrs {
-        match TcpStream::connect_timeout(&addr, CONNECT_TIMEOUT) {
+        match TcpStream::connect_timeout(&addr, timeout) {
             Ok(stream) => return Ok(stream),
             Err(e) => last_err = e,
         }
@@ -107,18 +254,27 @@ fn scope_error_status(err: &PermissionError) -> PluginStatus {
     }
 }
 
-/// Borrow the boxed [`PermissionSet`] behind a bridge `ctx`.
+/// Borrow the boxed [`BridgeContext`] behind a bridge `ctx`.
 ///
 /// # Safety
 ///
-/// `ctx` must be a live `*mut PermissionSet` produced by [`build_host_bridge`].
-unsafe fn permissions<'a>(ctx: *mut core::ffi::c_void) -> &'a PermissionSet {
-    // SAFETY: caller guarantees `ctx` is the leaked `Box<PermissionSet>`; borrowing
-    // it shared is sound because every callback only reads it.
-    unsafe { &*ctx.cast::<PermissionSet>() }
+/// `ctx` must be a live `*mut BridgeContext` produced by
+/// [`build_host_bridge_with_policy`].
+unsafe fn context<'a>(ctx: *mut core::ffi::c_void) -> &'a BridgeContext {
+    // SAFETY: caller guarantees `ctx` is the leaked `Box<BridgeContext>`; borrowing
+    // it shared is sound because every callback only reads it (the connection
+    // count it holds is an atomic).
+    unsafe { &*ctx.cast::<BridgeContext>() }
 }
 
-/// `open_connection` callback: enforce the `network` permission, then connect.
+/// `open_connection` callback: enforce the `network` permission and the session's
+/// concurrent-connection ceiling, then connect within the policy's timeout.
+///
+/// A refusal — missing `network`, or the session already at its connection
+/// ceiling — is reported as [`PluginStatus::PermissionDenied`]: the mediated
+/// capability was denied. Reusing the existing status keeps the ABI stable (no
+/// new [`PluginStatus`] variant, so no version bump); the two cases are
+/// distinguished by the host, not the plugin.
 ///
 /// # Safety
 ///
@@ -132,21 +288,31 @@ unsafe extern "C" fn bridge_open_connection(
 ) -> PluginStatus {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         // SAFETY: upheld by this function's contract.
-        let perms = unsafe { permissions(ctx) };
+        let cx = unsafe { context(ctx) };
         // Runtime enforcement: refuse before touching the network if the plugin
         // never requested `network`.
-        if perms.require(PluginPermission::Network).is_err() {
+        if cx.permissions.require(PluginPermission::Network).is_err() {
             return PluginStatus::PermissionDenied;
         }
+        // Resource enforcement: refuse if this session is already holding its
+        // maximum number of concurrent mediated connections. The reservation is
+        // released when the returned stream is dropped (or below, on connect
+        // failure).
+        let Some(guard) = cx.try_reserve_connection() else {
+            return PluginStatus::PermissionDenied;
+        };
         // SAFETY: `host` is a valid borrowed `&str` for the call.
         let host_str = unsafe { host.as_str() };
-        match connect_with_timeout(host_str, port) {
+        match connect_with_timeout(host_str, port, cx.policy.connect_timeout) {
             Ok(stream) => {
-                let handle = PluginTcpStream::from_std(stream);
+                // The guard rides along with the mediated stream, so the slot is
+                // released the moment the plugin drops the connection.
+                let handle = PluginTcpStream::from_std_guarded(stream, Box::new(guard));
                 // SAFETY: `out_stream` is a valid, writable out-parameter.
                 unsafe { out_stream.write(handle) };
                 PluginStatus::Ok
             }
+            // Dropping `guard` here frees the slot the failed dial-out reserved.
             Err(_) => PluginStatus::Io,
         }
     }));
@@ -167,7 +333,7 @@ unsafe extern "C" fn bridge_read_file(
 ) -> PluginStatus {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         // SAFETY: upheld by this function's contract.
-        let perms = unsafe { permissions(ctx) };
+        let perms = unsafe { &context(ctx).permissions };
         // SAFETY: `path` is a valid borrowed `&str` for the call.
         let requested = unsafe { path.as_str() };
         // Runtime enforcement: reject a missing `filesystem` permission or a path
@@ -206,7 +372,7 @@ unsafe extern "C" fn bridge_write_file(
 ) -> PluginStatus {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         // SAFETY: upheld by this function's contract.
-        let perms = unsafe { permissions(ctx) };
+        let perms = unsafe { &context(ctx).permissions };
         // SAFETY: `path`/`data` are valid borrowed views for the call.
         let requested = unsafe { path.as_str() };
         let bytes = unsafe { data.as_slice() };
@@ -246,7 +412,7 @@ unsafe extern "C" fn bridge_stat_path(
 ) -> PluginStatus {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         // SAFETY: upheld by this function's contract.
-        let perms = unsafe { permissions(ctx) };
+        let perms = unsafe { &context(ctx).permissions };
         // SAFETY: `path` is a valid borrowed `&str` for the call.
         let requested = unsafe { path.as_str() };
         let resolved = match perms.check_path(Path::new(requested)) {
@@ -283,7 +449,7 @@ unsafe extern "C" fn bridge_list_dir(
 ) -> PluginStatus {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         // SAFETY: upheld by this function's contract.
-        let perms = unsafe { permissions(ctx) };
+        let perms = unsafe { &context(ctx).permissions };
         // SAFETY: `path` is a valid borrowed `&str` for the call.
         let requested = unsafe { path.as_str() };
         let resolved = match perms.check_path(Path::new(requested)) {
@@ -306,16 +472,17 @@ unsafe extern "C" fn bridge_list_dir(
     result.unwrap_or(PluginStatus::Panic)
 }
 
-/// Destructor for the bridge context: reclaim the boxed [`PermissionSet`].
+/// Destructor for the bridge context: reclaim the boxed [`BridgeContext`].
 ///
 /// # Safety
 ///
-/// `ctx` must be the leaked `Box<PermissionSet>` from [`build_host_bridge`] and
-/// must not be used afterwards.
+/// `ctx` must be the leaked `Box<BridgeContext>` from
+/// [`build_host_bridge_with_policy`] and must not be used afterwards.
 unsafe extern "C" fn bridge_destroy(ctx: *mut core::ffi::c_void) {
     if !ctx.is_null() {
-        // SAFETY: reclaims the box leaked in `build_host_bridge`, exactly once.
-        drop(unsafe { Box::from_raw(ctx.cast::<PermissionSet>()) });
+        // SAFETY: reclaims the box leaked in `build_host_bridge_with_policy`,
+        // exactly once.
+        drop(unsafe { Box::from_raw(ctx.cast::<BridgeContext>()) });
     }
 }
 
@@ -377,6 +544,149 @@ mod tests {
 
         let received = server.join().unwrap();
         assert_eq!(&received, b"hello");
+    }
+
+    #[test]
+    fn connection_limit_rejects_once_the_ceiling_is_reached() {
+        // A session may hold at most `max_connections` mediated connections open
+        // at once; the one that would exceed the ceiling is refused, and a slot
+        // frees again the moment an open connection is dropped (#2028).
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // Accept the dial-outs that actually reach the socket so each host-side
+        // connect succeeds — the only thing under test is the host's own
+        // concurrency ceiling. Exactly three connects succeed host-side (c1, c2,
+        // then c3 after a slot frees); the over-ceiling attempt is refused before
+        // it ever touches the network, so it is never accepted here.
+        let accepting = std::thread::spawn(move || {
+            let mut held = Vec::new();
+            for _ in 0..3 {
+                match listener.accept() {
+                    Ok((sock, _)) => held.push(sock),
+                    Err(_) => break,
+                }
+            }
+            held
+        });
+
+        let policy = ConnectionPolicy::new(2, DEFAULT_CONNECT_TIMEOUT);
+        let bridge =
+            build_host_bridge_with_policy(perms(&[PluginPermission::Network], &[]), policy);
+
+        // Two concurrent connections fit under the ceiling of 2.
+        let c1 = bridge
+            .open_connection("127.0.0.1", port)
+            .expect("first fits");
+        let c2 = bridge
+            .open_connection("127.0.0.1", port)
+            .expect("second fits");
+
+        // The third, still holding the first two, is refused as PermissionDenied.
+        let err = bridge.open_connection("127.0.0.1", port).unwrap_err();
+        assert!(
+            matches!(err, termihub_plugin_api::PluginError::PermissionDenied),
+            "over-ceiling connection should be denied, got {err:?}"
+        );
+
+        // Dropping one frees its slot, so the next dial-out succeeds again.
+        drop(c1);
+        let _c3 = bridge
+            .open_connection("127.0.0.1", port)
+            .expect("slot freed by drop");
+
+        drop(c2);
+        drop(_c3);
+        let _ = accepting.join();
+    }
+
+    #[test]
+    fn connection_slot_is_released_when_the_connect_fails() {
+        // A failed dial-out must not leak a slot: the reservation is released on
+        // the error path, so a later connect still fits under the ceiling (#2028).
+        // Bind then immediately drop a listener to get a port that refuses.
+        let refused_port = {
+            let l = TcpListener::bind("127.0.0.1:0").unwrap();
+            l.local_addr().unwrap().port()
+        };
+        let good = TcpListener::bind("127.0.0.1:0").unwrap();
+        let good_port = good.local_addr().unwrap().port();
+        let accepting = std::thread::spawn(move || good.accept().map(|(s, _)| s));
+
+        // Ceiling of 1, and a short timeout so a refusal (or drop) resolves fast.
+        let policy = ConnectionPolicy::new(1, Duration::from_secs(2));
+        let bridge =
+            build_host_bridge_with_policy(perms(&[PluginPermission::Network], &[]), policy);
+
+        // The refused connect fails with an I/O error, not a permission denial…
+        let err = bridge
+            .open_connection("127.0.0.1", refused_port)
+            .unwrap_err();
+        assert!(
+            matches!(err, termihub_plugin_api::PluginError::Io(_)),
+            "refused connect should be an I/O error, got {err:?}"
+        );
+
+        // …and it must have released its slot, so this connect (the only one held)
+        // fits under the ceiling of 1.
+        let _ok = bridge
+            .open_connection("127.0.0.1", good_port)
+            .expect("failed connect must not have leaked a slot");
+        drop(_ok);
+        let _ = accepting.join();
+    }
+
+    #[test]
+    fn connect_timeout_is_configurable_and_bounds_the_dial_out() {
+        // The timeout is no longer a hardcoded constant: the policy carries it and
+        // the mediated connect honours it (#2028). A short custom timeout against a
+        // black-holed (RFC 5737 TEST-NET-1) address returns an error well within
+        // the 30s default rather than hanging on it.
+        let policy = ConnectionPolicy::new(DEFAULT_MAX_CONNECTIONS, Duration::from_millis(300));
+        assert_eq!(policy.connect_timeout(), Duration::from_millis(300));
+        assert_eq!(policy.max_connections(), DEFAULT_MAX_CONNECTIONS);
+
+        let bridge =
+            build_host_bridge_with_policy(perms(&[PluginPermission::Network], &[]), policy);
+        let start = std::time::Instant::now();
+        let err = bridge.open_connection("192.0.2.1", 9).unwrap_err();
+        let elapsed = start.elapsed();
+        assert!(
+            matches!(err, termihub_plugin_api::PluginError::Io(_)),
+            "black-holed connect should fail with I/O, got {err:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(10),
+            "configured 300ms timeout should bound the connect, took {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn connection_policy_from_manifest_overrides_only_declared_fields() {
+        use crate::plugin::ConnectionPolicyManifest;
+
+        // No manifest policy → host defaults.
+        let d = ConnectionPolicy::from_manifest(None);
+        assert_eq!(d.max_connections(), DEFAULT_MAX_CONNECTIONS);
+        assert_eq!(d.connect_timeout(), DEFAULT_CONNECT_TIMEOUT);
+
+        // A partial declaration overrides only the field it sets.
+        let only_max = ConnectionPolicyManifest {
+            max_connections: Some(3),
+            connect_timeout_ms: None,
+        };
+        let p = ConnectionPolicy::from_manifest(Some(&only_max));
+        assert_eq!(p.max_connections(), 3);
+        assert_eq!(p.connect_timeout(), DEFAULT_CONNECT_TIMEOUT);
+
+        // Both fields declared → both overridden.
+        let both = ConnectionPolicyManifest {
+            max_connections: Some(5),
+            connect_timeout_ms: Some(1500),
+        };
+        let p = ConnectionPolicy::from_manifest(Some(&both));
+        assert_eq!(p.max_connections(), 5);
+        assert_eq!(p.connect_timeout(), Duration::from_millis(1500));
     }
 
     #[test]

--- a/core/src/plugin/connection.rs
+++ b/core/src/plugin/connection.rs
@@ -42,6 +42,7 @@ use crate::errors::SessionError;
 use crate::files::FileBrowser;
 use crate::monitoring::MonitoringProvider;
 
+use super::capabilities::ConnectionPolicy;
 use super::host::LoadedLibrary;
 use super::security::{PermissionError, PermissionSet};
 use super::PluginPermission;
@@ -64,6 +65,11 @@ pub struct PluginConnectionType {
     /// capabilities (filesystem path resolution, network, …) can enforce them
     /// per session (concept §13).
     permissions: PermissionSet,
+    /// The host-side connection policy (concurrent-connection ceiling + connect
+    /// timeout) applied to the capability bridge this session hands the plugin
+    /// (#2028). Defaults to [`ConnectionPolicy::default`]; the host derives it
+    /// from the plugin's manifest via [`with_connection_policy`](Self::with_connection_policy).
+    connection_policy: ConnectionPolicy,
     /// The active session backend, `None` until [`connect`](ConnectionType::connect).
     backend: Option<LoadedBackend>,
     /// Current output sink; swapped by
@@ -93,9 +99,23 @@ impl PluginConnectionType {
             display_name,
             settings_schema,
             permissions,
+            connection_policy: ConnectionPolicy::default(),
             backend: None,
             output_tx: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Set the host-side [`ConnectionPolicy`] for sessions of this type (#2028).
+    ///
+    /// The host derives the policy from the plugin's manifest `connectionPolicy`
+    /// once at load time and applies it to every session the factory makes, so a
+    /// plugin's declared concurrency ceiling and connect timeout are enforced on
+    /// the capability bridge. Without this call the [`ConnectionPolicy::default`]
+    /// remains in force.
+    #[must_use]
+    pub fn with_connection_policy(mut self, policy: ConnectionPolicy) -> Self {
+        self.connection_policy = policy;
+        self
     }
 
     /// The permission set this plugin session was granted.
@@ -301,9 +321,14 @@ impl ConnectionType for PluginConnectionType {
         let output = PluginOutputSender::from_sender(std_tx);
 
         // Hand the plugin a host capability bridge scoped to this session's granted
-        // permissions, so any network/filesystem access it performs through the
-        // bridge is enforced by the host at runtime (concept §13, #2018).
-        let bridge = super::capabilities::build_host_bridge(self.permissions.clone());
+        // permissions and connection policy, so any network/filesystem access it
+        // performs through the bridge is enforced by the host at runtime — including
+        // the per-session connection ceiling and connect timeout (concept §13,
+        // #2018, #2028).
+        let bridge = super::capabilities::build_host_bridge_with_policy(
+            self.permissions.clone(),
+            self.connection_policy,
+        );
 
         let backend = self
             .library

--- a/core/src/plugin/host.rs
+++ b/core/src/plugin/host.rs
@@ -51,6 +51,7 @@ use termihub_plugin_api::{
 
 use crate::connection::ConnectionTypeRegistry;
 
+use super::capabilities::ConnectionPolicy;
 use super::connection::PluginConnectionType;
 use super::manager::InstalledPlugin;
 use super::security::{PermissionError, PermissionSet, RecoveryAction, RestartTracker};
@@ -504,6 +505,11 @@ impl PluginHost {
         // so a host-mediated capability (filesystem path resolution, network, …)
         // can enforce it per session.
         let perms_for_factory = permissions.clone();
+        // Resolve the session connection policy (concurrency ceiling + connect
+        // timeout) from the manifest once at load time; every session gets it
+        // (#2028).
+        let policy_for_factory =
+            ConnectionPolicy::from_manifest(plugin.manifest.connection_policy.as_ref());
 
         {
             let mut registry = self.registry.lock().unwrap_or_else(|e| e.into_inner());
@@ -512,13 +518,16 @@ impl PluginHost {
                 &display_name,
                 "puzzle",
                 Box::new(move || {
-                    Box::new(PluginConnectionType::new(
-                        Arc::clone(&lib_for_factory),
-                        ct_for_factory.clone(),
-                        dn_for_factory.clone(),
-                        schema_for_factory.clone(),
-                        perms_for_factory.clone(),
-                    ))
+                    Box::new(
+                        PluginConnectionType::new(
+                            Arc::clone(&lib_for_factory),
+                            ct_for_factory.clone(),
+                            dn_for_factory.clone(),
+                            schema_for_factory.clone(),
+                            perms_for_factory.clone(),
+                        )
+                        .with_connection_policy(policy_for_factory),
+                    )
                 }),
             );
         }

--- a/core/src/plugin/manifest.rs
+++ b/core/src/plugin/manifest.rs
@@ -62,6 +62,28 @@ pub enum Platform {
     Macos,
 }
 
+/// The optional `connectionPolicy` object: host-side limits on the connections a
+/// plugin session may open through the capability bridge (#2028).
+///
+/// Both fields are optional; an absent field (or an absent `connectionPolicy`
+/// object entirely) leaves the host's built-in default in force
+/// ([`ConnectionPolicy`](super::ConnectionPolicy)). Declaring these lets a plugin
+/// author raise or lower the ceiling for a session — for example a plugin that
+/// legitimately fans out to many endpoints, or one deliberately restricted to a
+/// single slow dial-out.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ConnectionPolicyManifest {
+    /// Maximum number of concurrent mediated connections a session may hold open.
+    /// `None` keeps the host default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_connections: Option<usize>,
+    /// Connect timeout, in milliseconds, applied to each mediated dial-out.
+    /// `None` keeps the host default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connect_timeout_ms: Option<u64>,
+}
+
 /// The `extensions` object: which extension points a plugin provides.
 ///
 /// A plugin declares one or more of these. The individual extension bodies are
@@ -223,6 +245,11 @@ pub struct PluginManifest {
     pub filesystem_paths: Vec<String>,
     /// The extension points the plugin provides.
     pub extensions: PluginExtensions,
+    /// Optional host-side connection policy: per-session concurrent-connection
+    /// ceiling and connect timeout for the capability bridge (#2028). Absent
+    /// leaves the host defaults in force.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connection_policy: Option<ConnectionPolicyManifest>,
     /// Optional user-configurable settings, keyed by setting name.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub settings: Option<BTreeMap<String, PluginSettingSchema>>,
@@ -436,6 +463,42 @@ mod tests {
         let json = serde_json::to_string(&manifest).unwrap();
         let reparsed = parse_manifest(&json).unwrap();
         assert_eq!(manifest, reparsed);
+    }
+
+    #[test]
+    fn connection_policy_is_optional_and_parses_when_present() {
+        // Absent by default.
+        let manifest = parse_manifest(valid_manifest_json()).unwrap();
+        assert!(manifest.connection_policy.is_none());
+
+        // Present, with both fields, round-trips and deserializes as declared.
+        let json = valid_manifest_json().replace(
+            "\"permissions\": [\"terminal\", \"network\", \"filesystem\"],",
+            "\"permissions\": [\"terminal\", \"network\", \"filesystem\"],\n            \
+             \"connectionPolicy\": { \"maxConnections\": 4, \"connectTimeoutMs\": 5000 },",
+        );
+        let manifest = parse_manifest(&json).expect("should parse with connectionPolicy");
+        let policy = manifest
+            .connection_policy
+            .as_ref()
+            .expect("connectionPolicy present");
+        assert_eq!(policy.max_connections, Some(4));
+        assert_eq!(policy.connect_timeout_ms, Some(5000));
+        manifest.validate().expect("should validate");
+
+        let reparsed = parse_manifest(&serde_json::to_string(&manifest).unwrap()).unwrap();
+        assert_eq!(manifest, reparsed);
+    }
+
+    #[test]
+    fn connection_policy_rejects_unknown_field() {
+        let json = valid_manifest_json().replace(
+            "\"permissions\": [\"terminal\", \"network\", \"filesystem\"],",
+            "\"permissions\": [\"terminal\", \"network\", \"filesystem\"],\n            \
+             \"connectionPolicy\": { \"maxConns\": 4 },",
+        );
+        let err = parse_manifest(&json).unwrap_err();
+        assert!(err.to_string().contains("maxConns"), "got: {err}");
     }
 
     #[test]

--- a/core/src/plugin/mod.rs
+++ b/core/src/plugin/mod.rs
@@ -68,7 +68,10 @@ mod pack;
 mod package;
 mod security;
 
-pub use capabilities::build_host_bridge;
+pub use capabilities::{
+    build_host_bridge, build_host_bridge_with_policy, ConnectionPolicy, DEFAULT_CONNECT_TIMEOUT,
+    DEFAULT_MAX_CONNECTIONS,
+};
 pub use connection::{config_schema_to_settings_schema, PluginConnectionType};
 pub use host::{
     find_backend_library, load_backend_library, HostError, HostLifecycleHook, LoadedLibrary,
@@ -79,10 +82,10 @@ pub use manager::{
     PluginState,
 };
 pub use manifest::{
-    check_api_compatibility, parse_manifest, ApiCompatibility, ManifestParseError,
-    ManifestValidationError, Platform, PluginExtensions, PluginManifest, PluginPermission,
-    PluginSettingSchema, ProtocolParserExtension, SettingType, StatusBarWidgetExtension,
-    TerminalBackendExtension, ThemeEntry, ThemeExtension, WidgetPosition,
+    check_api_compatibility, parse_manifest, ApiCompatibility, ConnectionPolicyManifest,
+    ManifestParseError, ManifestValidationError, Platform, PluginExtensions, PluginManifest,
+    PluginPermission, PluginSettingSchema, ProtocolParserExtension, SettingType,
+    StatusBarWidgetExtension, TerminalBackendExtension, ThemeEntry, ThemeExtension, WidgetPosition,
     CURRENT_PLUGIN_API_VERSION,
 };
 pub use pack::{pack_plugin, PluginPackError};

--- a/core/tests/fixtures/test-plugin/src/lib.rs
+++ b/core/tests/fixtures/test-plugin/src/lib.rs
@@ -91,14 +91,16 @@ pub unsafe extern "C" fn termihub_plugin_init(out_info: *mut PluginInfo) -> Plug
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 struct ProbeConfig {
-    /// One of `"network"`, `"readfile"`, `"writefile"`, `"appendfile"`,
-    /// `"createfile"`, `"statpath"`, `"listdir"`; empty means "no probe, just
-    /// echo".
+    /// One of `"network"`, `"connlimit"`, `"readfile"`, `"writefile"`,
+    /// `"appendfile"`, `"createfile"`, `"statpath"`, `"listdir"`; empty means "no
+    /// probe, just echo".
     probe: String,
     /// Target host for the `network` probe.
     probe_host: String,
-    /// Target port for the `network` probe.
+    /// Target port for the `network`/`connlimit` probe.
     probe_port: u16,
+    /// Number of connections the `connlimit` probe opens and holds concurrently.
+    probe_count: u16,
     /// Target path for the filesystem probes.
     probe_path: String,
     /// Bytes to write for the `writefile`/`appendfile`/`createfile` probes.
@@ -121,6 +123,27 @@ fn run_probe(cfg: &ProbeConfig, bridge: &PluginHostBridge, output: &PluginOutput
                 Err(_) => b"NETWORK_ERR".to_vec(),
             };
             let _ = output.send(&line);
+        }
+        "connlimit" => {
+            // Open `probe_count` connections and hold them all open at once, so
+            // the host's per-session concurrency ceiling (#2028) governs how many
+            // succeed. Report the allowed/denied split as a single line.
+            let mut held = Vec::new();
+            let mut ok = 0u16;
+            let mut denied = 0u16;
+            for _ in 0..cfg.probe_count {
+                match bridge.open_connection(&cfg.probe_host, cfg.probe_port) {
+                    Ok(stream) => {
+                        ok += 1;
+                        held.push(stream);
+                    }
+                    Err(PluginError::PermissionDenied) => denied += 1,
+                    Err(_) => {}
+                }
+            }
+            let _ = output.send(format!("CONNLIMIT:{ok}:{denied}").as_bytes());
+            // Hold the streams until after the line is sent, then drop them.
+            drop(held);
         }
         "readfile" => {
             let line = match bridge.read_file(&cfg.probe_path) {

--- a/core/tests/plugin_capability_bridge.rs
+++ b/core/tests/plugin_capability_bridge.rs
@@ -23,7 +23,9 @@ use std::process::Command;
 use std::time::Duration;
 
 use termihub_core::connection::{ConnectionType, SettingsSchema};
-use termihub_core::plugin::{load_backend_library, LoadedLibrary, PermissionSet, PluginPermission};
+use termihub_core::plugin::{
+    load_backend_library, ConnectionPolicy, LoadedLibrary, PermissionSet, PluginPermission,
+};
 
 /// Path to the fixture plugin's `Cargo.toml` (the shared echo `cdylib`).
 fn fixture_manifest() -> PathBuf {
@@ -64,13 +66,26 @@ async fn probe_outcome(
     permissions: PermissionSet,
     settings: serde_json::Value,
 ) -> Vec<u8> {
+    probe_outcome_with_policy(lib, permissions, ConnectionPolicy::default(), settings).await
+}
+
+/// Like [`probe_outcome`], but with an explicit host-side [`ConnectionPolicy`] so
+/// a test can exercise the per-session connection ceiling / timeout (#2028) across
+/// the real ABI boundary.
+async fn probe_outcome_with_policy(
+    lib: &std::sync::Arc<LoadedLibrary>,
+    permissions: PermissionSet,
+    policy: ConnectionPolicy,
+    settings: serde_json::Value,
+) -> Vec<u8> {
     let mut conn = termihub_core::plugin::PluginConnectionType::new(
         std::sync::Arc::clone(lib),
         "probe".to_string(),
         "Probe".to_string(),
         SettingsSchema { groups: vec![] },
         permissions,
-    );
+    )
+    .with_connection_policy(policy);
     let mut rx = conn.subscribe_output();
     conn.connect(settings)
         .await
@@ -124,6 +139,57 @@ async fn network_capability_is_enforced_through_the_bridge() {
     )
     .await;
     assert_eq!(denied, b"NETWORK_DENIED", "network must be denied");
+
+    let _ = server.join();
+}
+
+#[tokio::test]
+async fn connection_limit_is_enforced_through_the_bridge() {
+    // Across the real dlopen boundary: a session whose policy caps concurrent
+    // mediated connections at 2 can open only 2 of 3 attempted at once; the third
+    // is refused by the host (#2028).
+    let tmp = tempfile::TempDir::new().unwrap();
+    let lib = load_backend_library(&build_fixture(&tmp.path().join("target")))
+        .expect("fixture should load");
+
+    // Accept (and hold) every connection the host actually opens, so the ceiling —
+    // not a refused socket — is what bounds the probe.
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server = std::thread::spawn(move || {
+        let mut held = Vec::new();
+        listener
+            .set_nonblocking(false)
+            .expect("blocking accept for the held connections");
+        // Only the connections under the ceiling (2) are ever opened host-side.
+        for _ in 0..2 {
+            if let Ok((sock, _)) = listener.accept() {
+                held.push(sock);
+            }
+        }
+        held
+    });
+
+    let settings = serde_json::json!({
+        "probe": "connlimit",
+        "probeHost": "127.0.0.1",
+        "probePort": port,
+        "probeCount": 3,
+    });
+
+    let out = probe_outcome_with_policy(
+        &lib,
+        PermissionSet::from_parts([PluginPermission::Network], &[]),
+        ConnectionPolicy::new(2, Duration::from_secs(30)),
+        settings,
+    )
+    .await;
+
+    // 2 allowed (under the ceiling), 1 denied (would exceed it).
+    assert_eq!(
+        out, b"CONNLIMIT:2:1",
+        "host must cap concurrent mediated connections at the policy ceiling"
+    );
 
     let _ = server.join();
 }

--- a/docs/changes/dev2/feature/2028-connection-policy.md
+++ b/docs/changes/dev2/feature/2028-connection-policy.md
@@ -1,0 +1,14 @@
+### Added
+
+- Plugin capability bridge: per-session **connection policy**. The
+  `PluginHostBridge` now enforces a per-session ceiling on how many mediated
+  connections a plugin may hold open at once (refusing further `open_connection`
+  calls with a permission denial once the ceiling is reached), and the mediated
+  connect timeout — previously a hardcoded 30s constant — is now configurable.
+  Both default to host values (8 concurrent connections, 30s timeout) and can be
+  raised or lowered per plugin through a new optional `connectionPolicy`
+  (`maxConnections`, `connectTimeoutMs`) block in `manifest.json`. This closes
+  the resource-exhaustion gap left by #2024: a cooperating plugin can no longer
+  open unbounded connections through the bridge or hang a session on a slow
+  dial-out. The plugin ABI stays at version 3 — the policy is enforced entirely
+  host-side (#2028).

--- a/plugin-api/src/capabilities.rs
+++ b/plugin-api/src/capabilities.rs
@@ -390,12 +390,58 @@ impl PluginTcpStream {
     /// `destroy`).
     #[must_use]
     pub fn from_std(stream: std::net::TcpStream) -> Self {
-        let boxed = Box::new(stream);
+        Self::from_mediated(MediatedTcpStream {
+            stream,
+            _guard: None,
+        })
+    }
+
+    /// Wrap a host-owned [`std::net::TcpStream`] together with a host-side drop
+    /// `guard` that runs when the plugin drops the stream.
+    ///
+    /// The guard lets the host release a per-session resource the connection
+    /// reserved — a concurrent-connection slot in the session's connection policy
+    /// (#2028), say — the moment the mediated stream is closed. Like the stream
+    /// itself, the guard is opaque host state behind the handle's `state` pointer:
+    /// it never crosses the FFI boundary.
+    #[must_use]
+    pub fn from_std_guarded(stream: std::net::TcpStream, guard: StreamDropGuard) -> Self {
+        Self::from_mediated(MediatedTcpStream {
+            stream,
+            _guard: Some(guard),
+        })
+    }
+
+    /// Box the host-owned [`MediatedTcpStream`] state behind the shared vtable.
+    fn from_mediated(state: MediatedTcpStream) -> Self {
         Self {
-            state: Box::into_raw(boxed).cast::<c_void>(),
+            state: Box::into_raw(Box::new(state)).cast::<c_void>(),
             vtable: &TCP_STREAM_VTABLE,
         }
     }
+}
+
+/// A host-side drop guard carried by a mediated [`PluginTcpStream`].
+///
+/// It runs (host-side) when the plugin drops the stream, so the host can release
+/// whatever per-session resource the connection reserved — for example a
+/// concurrent-connection slot in the session's connection policy (#2028). It is
+/// **opaque host state**: it lives behind the stream's `state` pointer and is
+/// never handed across the FFI boundary, so `dyn Send` here does not weaken the
+/// ABI's "no trait objects cross the boundary" guarantee.
+pub type StreamDropGuard = Box<dyn Send>;
+
+/// Host-owned state behind a mediated [`PluginTcpStream`]: the real socket plus an
+/// optional [`StreamDropGuard`].
+///
+/// Declaration order matters: `stream` is dropped **before** `_guard`, so the
+/// socket is closed before the guard releases the session resource it accounts
+/// for.
+struct MediatedTcpStream {
+    /// The host-owned socket the plugin drives through the vtable.
+    stream: std::net::TcpStream,
+    /// Optional guard dropped after `stream`; `None` for unguarded streams.
+    _guard: Option<StreamDropGuard>,
 }
 
 unsafe extern "C" fn tcp_vt_read(
@@ -405,9 +451,10 @@ unsafe extern "C" fn tcp_vt_read(
     out_read: *mut usize,
 ) -> PluginStatus {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        // SAFETY: `state` is a live `*mut TcpStream` produced by `from_std`; `buf`/
-        // `len` describe a writable region the plugin owns for the call.
-        let stream = unsafe { &mut *state.cast::<std::net::TcpStream>() };
+        // SAFETY: `state` is a live `*mut MediatedTcpStream` produced by
+        // `from_mediated`; `buf`/`len` describe a writable region the plugin owns
+        // for the call.
+        let stream = unsafe { &mut (*state.cast::<MediatedTcpStream>()).stream };
         let slice = if len == 0 {
             &mut [][..]
         } else {
@@ -432,9 +479,9 @@ unsafe extern "C" fn tcp_vt_write(
     out_written: *mut usize,
 ) -> PluginStatus {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        // SAFETY: `state` is a live `*mut TcpStream`; `data` is a valid borrowed
-        // slice for the duration of the call.
-        let stream = unsafe { &mut *state.cast::<std::net::TcpStream>() };
+        // SAFETY: `state` is a live `*mut MediatedTcpStream`; `data` is a valid
+        // borrowed slice for the duration of the call.
+        let stream = unsafe { &mut (*state.cast::<MediatedTcpStream>()).stream };
         let bytes = unsafe { data.as_slice() };
         stream.write(bytes)
     }));
@@ -453,8 +500,9 @@ unsafe extern "C" fn tcp_vt_destroy(state: *mut c_void) {
     if state.is_null() {
         return;
     }
-    // SAFETY: reclaims the box leaked in `from_std`, exactly once.
-    let boxed = unsafe { Box::from_raw(state.cast::<std::net::TcpStream>()) };
+    // SAFETY: reclaims the box leaked in `from_mediated`, exactly once. Dropping
+    // it closes the socket, then runs any [`StreamDropGuard`] the stream carried.
+    let boxed = unsafe { Box::from_raw(state.cast::<MediatedTcpStream>()) };
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || drop(boxed)));
 }
 

--- a/plugin-api/src/lib.rs
+++ b/plugin-api/src/lib.rs
@@ -104,7 +104,7 @@ pub mod symbols;
 pub use backend::{LoadedBackend, PluginBackend, PluginBackendVTable, PluginTerminalBackend};
 pub use capabilities::{
     HostTcpStream, PluginFileMetadata, PluginHostBridge, PluginTcpStream, PluginTcpStreamVTable,
-    PluginWriteMode,
+    PluginWriteMode, StreamDropGuard,
 };
 pub use error::{PluginError, PluginStatus};
 pub use ffi::{FfiByteSlice, FfiOwnedBytes, FfiStr, FfiString};
@@ -127,4 +127,11 @@ pub use output::PluginOutputSender;
 /// vtable grew mediated filesystem `write_file` (create / truncate / append),
 /// `stat_path`, and `list_dir` callbacks — a layout change that breaks plugins
 /// built against version `2`.
+///
+/// **Not** bumped for #2028 (per-session connection limits and a configurable
+/// connect timeout): that policy is enforced entirely host-side. The mediated
+/// stream gained an optional host-side drop guard
+/// ([`StreamDropGuard`](capabilities::StreamDropGuard)), but it lives behind the
+/// stream's opaque `state` pointer, so no vtable or `#[repr(C)]` layout changed
+/// and version-`3` plugins stay compatible.
 pub const CURRENT_PLUGIN_API_VERSION: u32 = 3;


### PR DESCRIPTION
Follow-up to #2024 (PR #2027). Adds the per-session **connection policy** that #2024 deliberately left out to keep that PR reviewable: a cap on how many concurrent mediated connections a plugin session may hold open, and a configurable connect timeout in place of the hardcoded 30s constant.

## What changed

- **Per-session connection ceiling** — the `PluginHostBridge` context now carries the session's `ConnectionPolicy` and a live connection counter. `open_connection` reserves a slot before dialing and refuses with `PluginStatus::PermissionDenied` once the session is at its ceiling (default **8**). The slot is released the instant the plugin drops the connection — via a host-side `StreamDropGuard` that rides on the mediated stream — or immediately if the connect itself fails, so a failed dial-out never leaks a slot.
- **Configurable connect timeout** — the previously hardcoded `CONNECT_TIMEOUT` is now `ConnectionPolicy::connect_timeout` (default **30s**), threaded into the mediated connect.
- **Manifest surface** — an optional `connectionPolicy` block (`maxConnections`, `connectTimeoutMs`) in `manifest.json` lets a plugin raise or lower either limit; any unset field falls back to the host default. `build_host_bridge_with_policy` is the new policy-aware constructor (`build_host_bridge` stays as a default-policy convenience).
- **No ABI bump** — `CURRENT_PLUGIN_API_VERSION` stays at **3**. The policy is enforced entirely host-side, and the new drop guard lives behind the mediated stream's opaque `state` pointer, so no vtable or `#[repr(C)]` layout changed and version-3 plugins remain compatible. Reusing `PermissionDenied` for the limit-exceeded case (sanctioned by the issue) avoids adding a `PluginStatus` variant that the exact-match ABI gate would otherwise force a bump for.

## Out of scope

The direct-syscall bypass (an in-process plugin calling `std::net`/`std::fs` directly) — still documented as future work in `core/src/plugin/security.rs`; only OS-level isolation could close it. This is the last planned item in the capability-bridge chain.

## Tests

- Host-side unit tests in `core/src/plugin/capabilities.rs`: ceiling reached → denied and a freed slot re-admits; a failed connect releases its slot; the configured timeout bounds a black-holed dial-out; `ConnectionPolicy::from_manifest` overrides only declared fields.
- Manifest tests: `connectionPolicy` is optional, round-trips, and rejects unknown keys.
- End-to-end test in `core/tests/plugin_capability_bridge.rs` over the real `dlopen` boundary via a new fixture `connlimit` probe: a ceiling of 2 caps 3 attempted connections at 2 allowed / 1 denied.

Closes #2028