### PR TITLE
feat(plugin): dedicated ResourceLimit bridge status for connection-limit refusals (Closes #2030)

### DIFF
--- a/core/src/plugin/capabilities.rs
+++ b/core/src/plugin/capabilities.rs
@@ -270,11 +270,12 @@ unsafe fn context<'a>(ctx: *mut core::ffi::c_void) -> &'a BridgeContext {
 /// `open_connection` callback: enforce the `network` permission and the session's
 /// concurrent-connection ceiling, then connect within the policy's timeout.
 ///
-/// A refusal — missing `network`, or the session already at its connection
-/// ceiling — is reported as [`PluginStatus::PermissionDenied`]: the mediated
-/// capability was denied. Reusing the existing status keeps the ABI stable (no
-/// new [`PluginStatus`] variant, so no version bump); the two cases are
-/// distinguished by the host, not the plugin.
+/// The two refusals now carry **distinct** statuses so a plugin can tell them
+/// apart (#2030): a missing `network` permission is
+/// [`PluginStatus::PermissionDenied`], while hitting the session's
+/// concurrent-connection ceiling is [`PluginStatus::ResourceLimit`] — a
+/// well-behaved plugin can back off and retry the latter rather than treat it as
+/// a hard permission failure.
 ///
 /// # Safety
 ///
@@ -295,11 +296,13 @@ unsafe extern "C" fn bridge_open_connection(
             return PluginStatus::PermissionDenied;
         }
         // Resource enforcement: refuse if this session is already holding its
-        // maximum number of concurrent mediated connections. The reservation is
-        // released when the returned stream is dropped (or below, on connect
-        // failure).
+        // maximum number of concurrent mediated connections. Reported as
+        // `ResourceLimit`, distinct from the `PermissionDenied` above, so the
+        // plugin can tell a ceiling refusal apart from a missing permission and
+        // back off/retry (#2030). The reservation is released when the returned
+        // stream is dropped (or below, on connect failure).
         let Some(guard) = cx.try_reserve_connection() else {
-            return PluginStatus::PermissionDenied;
+            return PluginStatus::ResourceLimit;
         };
         // SAFETY: `host` is a valid borrowed `&str` for the call.
         let host_str = unsafe { host.as_str() };
@@ -582,11 +585,12 @@ mod tests {
             .open_connection("127.0.0.1", port)
             .expect("second fits");
 
-        // The third, still holding the first two, is refused as PermissionDenied.
+        // The third, still holding the first two, is refused as ResourceLimit —
+        // a ceiling refusal, distinct from a permission denial (#2030).
         let err = bridge.open_connection("127.0.0.1", port).unwrap_err();
         assert!(
-            matches!(err, termihub_plugin_api::PluginError::PermissionDenied),
-            "over-ceiling connection should be denied, got {err:?}"
+            matches!(err, termihub_plugin_api::PluginError::ResourceLimit),
+            "over-ceiling connection should hit the resource limit, got {err:?}"
         );
 
         // Dropping one frees its slot, so the next dial-out succeeds again.

--- a/core/tests/fixtures/test-plugin/src/lib.rs
+++ b/core/tests/fixtures/test-plugin/src/lib.rs
@@ -127,7 +127,11 @@ fn run_probe(cfg: &ProbeConfig, bridge: &PluginHostBridge, output: &PluginOutput
         "connlimit" => {
             // Open `probe_count` connections and hold them all open at once, so
             // the host's per-session concurrency ceiling (#2028) governs how many
-            // succeed. Report the allowed/denied split as a single line.
+            // succeed. A ceiling refusal now surfaces as the dedicated
+            // `ResourceLimit` status (#2030), distinct from a permission denial —
+            // only that status counts as `denied` here, so the assertion proves
+            // the host reports the new status on the ceiling path. Report the
+            // allowed/denied split as a single line.
             let mut held = Vec::new();
             let mut ok = 0u16;
             let mut denied = 0u16;
@@ -137,7 +141,7 @@ fn run_probe(cfg: &ProbeConfig, bridge: &PluginHostBridge, output: &PluginOutput
                         ok += 1;
                         held.push(stream);
                     }
-                    Err(PluginError::PermissionDenied) => denied += 1,
+                    Err(PluginError::ResourceLimit) => denied += 1,
                     Err(_) => {}
                 }
             }

--- a/core/tests/plugin_capability_bridge.rs
+++ b/core/tests/plugin_capability_bridge.rs
@@ -185,10 +185,13 @@ async fn connection_limit_is_enforced_through_the_bridge() {
     )
     .await;
 
-    // 2 allowed (under the ceiling), 1 denied (would exceed it).
+    // 2 allowed (under the ceiling), 1 refused (would exceed it). The probe only
+    // counts a `ResourceLimit` refusal as denied, so this split also proves the
+    // host reports the dedicated connection-limit status over the real ABI, not a
+    // `PermissionDenied` (#2030).
     assert_eq!(
         out, b"CONNLIMIT:2:1",
-        "host must cap concurrent mediated connections at the policy ceiling"
+        "host must cap concurrent mediated connections and report ResourceLimit"
     );
 
     let _ = server.join();

--- a/docs/changes/dev2/feature/2030-resource-limit-status.md
+++ b/docs/changes/dev2/feature/2030-resource-limit-status.md
@@ -1,0 +1,13 @@
+### Changed
+
+- Plugin capability bridge: connection-limit refusals now carry a **dedicated
+  status**. When a plugin's mediated `open_connection` is refused because the
+  session is already at its concurrent-connection ceiling (#2028), the host now
+  reports the new `PluginStatus::ResourceLimit` / `PluginError::ResourceLimit`
+  instead of overloading `PermissionDenied`. A plugin author can now tell "I lack
+  the `network` permission" (still `PermissionDenied`) apart from "I hit my
+  connection ceiling" and back off / retry rather than treat the refusal as a hard
+  permission failure. Because the host can now hand a plugin a status value older
+  plugins cannot decode, the plugin ABI version is bumped **3 → 4**; plugins built
+  against version 3 are rejected at load rather than fed an unknown discriminant
+  (#2030).

--- a/plugin-api/src/capabilities.rs
+++ b/plugin-api/src/capabilities.rs
@@ -227,8 +227,11 @@ impl PluginHostBridge {
     /// Ask the host to open a TCP connection to `host:port`.
     ///
     /// The host refuses with [`PluginError::PermissionDenied`] unless the plugin
-    /// holds the `network` permission; otherwise it connects and returns a
-    /// mediated [`HostTcpStream`] the plugin can read from and write to.
+    /// holds the `network` permission, and with
+    /// [`PluginError::ResourceLimit`] when the session is already at its
+    /// concurrent-connection ceiling (#2030) — distinct so the plugin can back off
+    /// and retry the latter. Otherwise it connects and returns a mediated
+    /// [`HostTcpStream`] the plugin can read from and write to.
     pub fn open_connection(&self, host: &str, port: u16) -> Result<HostTcpStream, PluginError> {
         let mut stream = PluginTcpStream::null();
         // SAFETY: `ctx`/`open_connection` were validated at construction; `host`

--- a/plugin-api/src/error.rs
+++ b/plugin-api/src/error.rs
@@ -54,6 +54,16 @@ pub enum PluginError {
     #[error("host denied a plugin capability (missing permission or out-of-scope path)")]
     PermissionDenied,
 
+    /// A host-mediated capability was refused because the session hit a resource
+    /// ceiling — not because the plugin lacks a permission. Currently raised when
+    /// a mediated `open_connection` would exceed the session's concurrent-connection
+    /// limit ([`crate::capabilities`], #2028/#2030). Distinct from
+    /// [`PermissionDenied`](Self::PermissionDenied) so a well-behaved plugin can
+    /// back off and retry rather than treat the refusal as a hard permission
+    /// failure.
+    #[error("host denied a plugin capability (resource limit reached)")]
+    ResourceLimit,
+
     /// Any other failure the plugin wishes to report.
     #[error("plugin error: {0}")]
     Other(String),
@@ -89,6 +99,13 @@ pub enum PluginStatus {
     PermissionDenied = 7,
     /// Maps to [`PluginError::Other`].
     Other = 8,
+    /// Maps to [`PluginError::ResourceLimit`]: the host refused a mediated
+    /// capability because a resource ceiling (e.g. the session's
+    /// concurrent-connection limit) was reached, not because a permission is
+    /// missing. Added in #2030; its host-returnable value is what forced the ABI
+    /// bump to version 4 (the exact-match gate rejects older plugins that could
+    /// not decode this discriminant).
+    ResourceLimit = 9,
 }
 
 impl PluginStatus {
@@ -113,6 +130,7 @@ impl PluginStatus {
             PluginError::VersionMismatch { .. } => Self::VersionMismatch,
             PluginError::Panicked => Self::Panic,
             PluginError::PermissionDenied => Self::PermissionDenied,
+            PluginError::ResourceLimit => Self::ResourceLimit,
             PluginError::Other(_) => Self::Other,
         }
     }
@@ -140,6 +158,7 @@ impl PluginStatus {
             }),
             Self::Panic => Err(PluginError::Panicked),
             Self::PermissionDenied => Err(PluginError::PermissionDenied),
+            Self::ResourceLimit => Err(PluginError::ResourceLimit),
             Self::Other => Err(PluginError::Other("reported by plugin".to_owned())),
         }
     }

--- a/plugin-api/src/lib.rs
+++ b/plugin-api/src/lib.rs
@@ -134,4 +134,11 @@ pub use output::PluginOutputSender;
 /// ([`StreamDropGuard`](capabilities::StreamDropGuard)), but it lives behind the
 /// stream's opaque `state` pointer, so no vtable or `#[repr(C)]` layout changed
 /// and version-`3` plugins stay compatible.
-pub const CURRENT_PLUGIN_API_VERSION: u32 = 3;
+///
+/// Bumped to `4` in #2030: [`PluginStatus`] gained a host-returnable
+/// [`ResourceLimit`](error::PluginStatus::ResourceLimit) variant so a plugin can
+/// tell a connection-ceiling refusal apart from a genuine permission denial.
+/// Because the host can now hand back a status discriminant a version-`3` plugin
+/// cannot decode, and the load-time gate matches the ABI version exactly, older
+/// plugins are rejected rather than fed an unknown value.
+pub const CURRENT_PLUGIN_API_VERSION: u32 = 4;

--- a/plugin-api/tests/roundtrip.rs
+++ b/plugin-api/tests/roundtrip.rs
@@ -159,4 +159,16 @@ fn status_error_mapping_is_consistent() {
         Err(PluginError::ChannelClosed),
     ));
     assert!(PluginStatus::Ok.into_result().is_ok());
+
+    // The resource-limit status (#2030) round-trips to its own error variant,
+    // distinct from a permission denial, so a plugin can tell the two apart.
+    assert_eq!(
+        PluginStatus::from_error(&PluginError::ResourceLimit),
+        PluginStatus::ResourceLimit,
+    );
+    assert!(matches!(
+        PluginStatus::ResourceLimit.into_result(),
+        Err(PluginError::ResourceLimit),
+    ));
+    assert_ne!(PluginStatus::ResourceLimit, PluginStatus::PermissionDenied);
 }


### PR DESCRIPTION
## Summary

Follow-up to #2028 (PR #2029). The mediated \`open_connection\` on the \`PluginHostBridge\` refused a connection-ceiling hit with \`PluginStatus::PermissionDenied\` — reused deliberately in #2028 to avoid an ABI bump. That left a plugin author unable to tell "I lack the \`network\` permission" apart from "I hit my connection ceiling".

This adds a **dedicated** status so the two refusals are distinguishable:

- New \`PluginStatus::ResourceLimit\` (= 9) / \`PluginError::ResourceLimit\` variant for connection-ceiling (and future resource-limit) refusals, with round-trip mapping in both directions.
- \`bridge_open_connection\` in \`core/src/plugin/capabilities.rs\` now returns \`ResourceLimit\` when \`try_reserve_connection\` fails; genuine permission denials stay on \`PermissionDenied\`.
- **\`CURRENT_PLUGIN_API_VERSION\` bumped 3 → 4.** Adding a host-returnable status value is ABI-relevant: the exact-match load gate (\`found != CURRENT_PLUGIN_API_VERSION\`) now rejects version-3 plugins rather than handing them a discriminant they cannot decode. The \`symbols.rs\` FFI-safety proof is unchanged (the enum stays a field-less \`#[repr(i32)]\`).
- \`connlimit\` fixture probe now counts only \`ResourceLimit\` as denied, so the tests assert the new status on the denied path.

## Tests

- \`plugin-api\` roundtrip: \`ResourceLimit\` maps to its own error, distinct from \`PermissionDenied\`.
- Host-side unit test \`connection_limit_rejects_once_the_ceiling_is_reached\` asserts \`ResourceLimit\`.
- Real-ABI E2E \`connection_limit_is_enforced_through_the_bridge\` (dlopen boundary) — the \`CONNLIMIT:2:1\` split now proves the host reports \`ResourceLimit\`, not \`PermissionDenied\`.

All plugin-api tests, core capabilities unit tests, the capability-bridge E2E suite, host-roundtrip, and clippy (\`-D warnings\`) pass locally.

Closes #2030

🤖 Generated with [Claude Code](https://claude.com/claude-code)