### PR TITLE
fix(test): trust fixture ssh host keys deterministically in integration tests (Closes #2032)

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -127,6 +127,7 @@ path = "src/bin/plugin_pack.rs"
 required-features = ["plugin"]
 
 [dev-dependencies]
+async-trait = { workspace = true }
 tempfile = "3"
 temp-env = "0.3"
 tokio = { version = "1", features = ["rt", "macros", "time", "sync", "net"] }

--- a/core/tests/common/mod.rs
+++ b/core/tests/common/mod.rs
@@ -39,6 +39,13 @@ pub fn is_port_reachable(host: &str, port: u16) -> bool {
 /// existing skip convention (runtime check instead of `#[ignore]`).
 macro_rules! require_docker {
     ($port:expr) => {
+        // Trust the local Docker fixtures' SSH host keys before a test touches
+        // them. Under the strict default host-key policy (#1969) an unrecorded
+        // fixture key is refused with "Unknown server key", which made the SSH
+        // integration tests fail non-deterministically (#2032). Registering a
+        // test-only verifier that trusts the loopback fixtures makes every SSH
+        // handshake deterministic. This is a no-op when the `ssh` feature is off.
+        common::trust_fixture_host_keys();
         if !common::is_port_reachable("127.0.0.1", $port) {
             eprintln!(
                 "SKIPPED: Docker container not reachable on port {} \
@@ -50,6 +57,49 @@ macro_rules! require_docker {
     };
 }
 pub(crate) use require_docker;
+
+/// Register a process-wide host-key verifier that trusts the local Docker
+/// fixture containers, so the SSH integration tests connect deterministically
+/// under the strict default host-key policy (#1969, #2032).
+///
+/// The integration suite runs headless — there is no interactive host-key
+/// prompt — so with no verifier registered the strict default (added in #1969)
+/// trusts **only** a key already recorded in the runner's `~/.ssh/known_hosts`
+/// and refuses everything else. CI runners never have the freshly-generated
+/// fixture keys recorded, so the SSH handshake fails with "Unknown server key".
+/// `monitoring.rs` sorts first among the SSH-handshake integration binaries and
+/// `cargo test` is fail-fast at the binary level, so the whole SSH suite went
+/// red there while only the four `mon_*` tests were ever seen (#2032).
+///
+/// These tests connect only to local Docker fixtures on the loopback interface,
+/// where there is no man-in-the-middle to guard against, so a test-only verifier
+/// that trusts every fixture key is safe and deterministic. Registration is
+/// set-once and idempotent (first call wins), so calling it from every
+/// `require_docker!` site is harmless.
+#[cfg(feature = "ssh")]
+pub fn trust_fixture_host_keys() {
+    use std::sync::Arc;
+    use termihub_core::backends::ssh::host_key::{
+        set_host_key_verifier, HostKeyInfo, HostKeyVerifier,
+    };
+
+    struct TrustLocalFixtures;
+
+    #[async_trait::async_trait]
+    impl HostKeyVerifier for TrustLocalFixtures {
+        async fn verify(&self, _info: &HostKeyInfo) -> bool {
+            true
+        }
+    }
+
+    // First registration wins; any later call is a harmless no-op.
+    let _ = set_host_key_verifier(Arc::new(TrustLocalFixtures));
+}
+
+/// No-op when the `ssh` feature is disabled (e.g. the FTP-only test build), so
+/// `require_docker!` still compiles for feature-scoped integration binaries.
+#[cfg(not(feature = "ssh"))]
+pub fn trust_fixture_host_keys() {}
 
 /// Path to the `tests/fixtures/ssh-keys/` directory.
 pub fn ssh_keys_dir() -> PathBuf {


### PR DESCRIPTION
## Problem

The `core/tests against live fixtures` lane fails the four monitoring tests (`mon_01_cpu_stats` … `mon_04_stats_under_load`) at `core/tests/monitoring.rs:34` with:

```
SSH connection with monitoring should succeed: SpawnFailed("SSH handshake failed: Unknown server key")
```

Observed on ~7 unrelated PRs in one day. The lane was green through 2026-07-19 and started failing on 2026-07-26.

## Root cause

Not monitoring-specific — the whole SSH integration suite is broken by the strict headless host-key policy added in #1969. With no `HostKeyVerifier` registered, the default policy trusts **only** keys already recorded in the runner's `~/.ssh/known_hosts` and refuses everything else. CI runners never have the fixture containers' freshly-generated host keys recorded, so `check_server_key` returns `false` and russh aborts the handshake with "Unknown server key".

Only `mon_*` were ever seen because `monitoring.rs` sorts first among the SSH-handshake integration binaries and `cargo test` is fail-fast at the binary level: monitoring fails and aborts the remaining SSH binaries (`ssh_auth`, `ssh_advanced`, …) before they run. Confirmed locally — reverting this change reproduces 4/4 `mon_*` failures against the live fixtures.

## Fix

Register a process-wide, test-only host-key verifier that trusts the local loopback Docker fixtures, via the documented `set_host_key_verifier` hook (the same mechanism the desktop app uses at startup). It is wired into the shared `require_docker!` gate, so every SSH integration binary trusts its fixtures deterministically without per-test boilerplate, and it is a no-op when the `ssh` feature is off (keeps the FTP-only test build compiling). These tests connect only to local fixtures on 127.0.0.1, where there is no man-in-the-middle to guard against, so trusting the fixture keys is safe. `async-trait` is added as a dev-dependency to implement the verifier trait in the test crate.

Test-only change; no user-facing behavior changes, so no changelog fragment.

## Verification (local, against live Docker fixtures)

- **Before:** `mon_*` = 4/4 FAILED with "Unknown server key".
- **After:** monitoring **20/20 runs green** — 15 serial (`--test-threads=1`, the CI config) + 5 parallel (`--test-threads=4`), 0 failures.
- **ssh_auth** (the next SSH binary fail-fast previously hid): **15 passed, 0 failed**, confirming the broader lane is unblocked, not just monitoring.

Closes #2032
