### PR TITLE
feat(agent): relay the desktop ssh-agent over the tcp agent transport (Closes #1727)

### DIFF
--- a/agent/src/daemon/transport.rs
+++ b/agent/src/daemon/transport.rs
@@ -132,7 +132,8 @@ pub async fn connect(endpoint: &str) -> io::Result<(BoxedReader, BoxedWriter)> {
 #[cfg(unix)]
 #[allow(unused_imports)]
 pub use unix_impl::{
-    endpoint_alive, open_daemon_log, open_registry_log, registry_endpoint, session_endpoint,
+    agent_forward_endpoint, endpoint_alive, ensure_agent_forward_dir, open_daemon_log,
+    open_registry_log, registry_endpoint, session_endpoint,
 };
 #[cfg(windows)]
 #[allow(unused_imports)]
@@ -150,6 +151,19 @@ mod unix_impl {
     pub fn session_endpoint(session_id: &str) -> String {
         socket_dir()
             .join(format!("session-{session_id}.sock"))
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// Compute the ssh-agent relay socket path for a session (#1727).
+    ///
+    /// A sibling of the per-session daemon socket in the same per-user `0o700`
+    /// directory. Exported to the session daemon as `SSH_AUTH_SOCK`, it lets the
+    /// daemon's core SSH bridge reach the desktop's agent over the JSON-RPC
+    /// transport as if it were a normal local agent.
+    pub fn agent_forward_endpoint(session_id: &str) -> String {
+        socket_dir()
+            .join(format!("session-{session_id}-agent.sock"))
             .to_string_lossy()
             .into_owned()
     }
@@ -186,6 +200,14 @@ mod unix_impl {
     fn socket_dir() -> PathBuf {
         let user = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
         PathBuf::from("/tmp/termihub").join(user)
+    }
+
+    /// Ensure the per-user socket directory exists (mode `0700`) so the
+    /// ssh-agent relay can bind its listener there before spawning the daemon
+    /// (#1727). The daemon's own socket dir is created lazily on first log/bind;
+    /// the relay binds first, so it must create it explicitly.
+    pub fn ensure_agent_forward_dir() -> io::Result<()> {
+        ensure_socket_dir(&socket_dir())
     }
 
     /// Ensure the socket directory exists with mode `0700`.

--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -25,13 +25,14 @@ use crate::monitoring::MonitoringManagerApi;
 use crate::network;
 use crate::protocol::errors;
 use crate::protocol::methods::{
-    AgentRequestDeferredUpdateParams, AgentRequestDeferredUpdateResult, AgentRequestUpdateParams,
-    AgentRequestUpdateResult, AgentSettings, AgentSettingsUpdateParams, AgentShutdownParams,
-    AgentShutdownResult, Capabilities, ConnectionCreateParams, ConnectionDeleteParams,
-    ConnectionInfo, ConnectionListResult, ConnectionTypesResult, ConnectionUpdateParams,
-    FilesDeleteParams, FilesListParams, FilesListResult, FilesMkdirParams, FilesReadParams,
-    FilesReadResult, FilesRenameParams, FilesStatParams, FilesWriteParams, FolderCreateParams,
-    FolderDeleteParams, FolderUpdateParams, HealthCheckResult, InitializeParams, InitializeResult,
+    AgentForwardCloseParams, AgentForwardDataParams, AgentRequestDeferredUpdateParams,
+    AgentRequestDeferredUpdateResult, AgentRequestUpdateParams, AgentRequestUpdateResult,
+    AgentSettings, AgentSettingsUpdateParams, AgentShutdownParams, AgentShutdownResult,
+    Capabilities, ConnectionCreateParams, ConnectionDeleteParams, ConnectionInfo,
+    ConnectionListResult, ConnectionTypesResult, ConnectionUpdateParams, FilesDeleteParams,
+    FilesListParams, FilesListResult, FilesMkdirParams, FilesReadParams, FilesReadResult,
+    FilesRenameParams, FilesStatParams, FilesWriteParams, FolderCreateParams, FolderDeleteParams,
+    FolderUpdateParams, HealthCheckResult, InitializeParams, InitializeResult,
     MonitoringSubscribeParams, MonitoringUnsubscribeParams, NetworkDnsLookupParams,
     NetworkPingParams, NetworkPortScanParams, NetworkTracerouteParams, NetworkWolParams,
     SessionAttachParams, SessionCloseParams, SessionCreateParams, SessionCreateResult,
@@ -54,7 +55,9 @@ use crate::update::{coordinate_update, CoordinationOutcome, ACK_TIMEOUT};
 /// `client_id` field in the `initialize` result (#1349).
 /// Bumped to 0.4.0 for the additive `agent.request_update` RPC and the
 /// `agent.update_pending` notification (#1351).
-const AGENT_PROTOCOL_VERSION: &str = "0.4.0";
+/// Bumped to 0.5.0 for the additive `agent.forward.*` ssh-agent relay methods
+/// and notifications (#1727).
+const AGENT_PROTOCOL_VERSION: &str = "0.5.0";
 
 /// Maximum response body size for jsonrpsee method calls: 32 MiB.
 ///
@@ -339,6 +342,8 @@ fn register_all(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::Result<(
     register_connection_detach(module)?;
     register_connection_write(module)?;
     register_connection_resize(module)?;
+    register_agent_forward_data(module)?;
+    register_agent_forward_close(module)?;
     register_connection_types(module)?;
     register_session_get_buffer(module)?;
     register_connections_list(module)?;
@@ -663,6 +668,48 @@ fn register_connection_resize(module: &mut RpcModule<Mutex<HandlerState>>) -> an
                     json!({"session_id": p.session_id}),
                 )
             })?;
+
+        Ok::<_, ErrorObjectOwned>(json!({}))
+    })?;
+    Ok(())
+}
+
+/// `agent.forward.data`: the desktop's ssh-agent reply bytes for a forwarded
+/// stream (#1727). Routed to the matching relay connection; unknown streams are
+/// a benign no-op (the stream may have already closed).
+fn register_agent_forward_data(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::Result<()> {
+    module.register_async_method("agent.forward.data", |params, ctx, _ext| async move {
+        let session_manager = get_session_manager(&ctx).await?;
+
+        let p: AgentForwardDataParams = params
+            .parse()
+            .map_err(|e| invalid_params("agent.forward.data", e))?;
+
+        let b64 = base64::engine::general_purpose::STANDARD;
+        let data = b64
+            .decode(&p.data)
+            .map_err(|e| rpc_err(errors::INVALID_PARAMS, format!("Invalid base64 data: {e}")))?;
+
+        session_manager
+            .agent_forward_write(&p.stream_id, data)
+            .await;
+
+        Ok::<_, ErrorObjectOwned>(json!({}))
+    })?;
+    Ok(())
+}
+
+/// `agent.forward.close`: the desktop closed a forwarded ssh-agent stream
+/// (#1727). Drops the relay connection so the daemon's bridge sees EOF.
+fn register_agent_forward_close(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::Result<()> {
+    module.register_async_method("agent.forward.close", |params, ctx, _ext| async move {
+        let session_manager = get_session_manager(&ctx).await?;
+
+        let p: AgentForwardCloseParams = params
+            .parse()
+            .map_err(|e| invalid_params("agent.forward.close", e))?;
+
+        session_manager.agent_forward_close(&p.stream_id).await;
 
         Ok::<_, ErrorObjectOwned>(json!({}))
     })?;
@@ -1985,10 +2032,68 @@ mod tests {
     }
 
     /// The RPC must be advertised, and the bump is what tells an older desktop
-    /// that `agent.update_pending` may now arrive.
+    /// which additive capabilities (`agent.update_pending`, the `agent.forward.*`
+    /// ssh-agent relay) may now arrive.
     #[tokio::test]
     async fn the_protocol_version_advertises_the_coordinated_update() {
-        assert_eq!(AGENT_PROTOCOL_VERSION, "0.4.0");
+        assert_eq!(AGENT_PROTOCOL_VERSION, "0.5.0");
+    }
+
+    // ── agent.forward.* (ssh-agent relay, #1727) ───────────────────
+
+    /// A well-formed `agent.forward.data` for an unknown stream is accepted and
+    /// succeeds (the relay silently drops it) — a stray frame for a closed
+    /// stream must never surface an error to the desktop.
+    #[tokio::test]
+    async fn agent_forward_data_routes_and_succeeds() {
+        let handler = make_handler();
+        init_handler(&handler).await;
+
+        let b64 = base64::engine::general_purpose::STANDARD;
+        let result = dispatch(
+            &handler,
+            "agent.forward.data",
+            json!({ "stream_id": "sess#1", "data": b64.encode(b"agent-bytes") }),
+            2,
+        )
+        .await;
+
+        assert!(result.get("result").is_some(), "{result}");
+    }
+
+    /// Malformed base64 in `agent.forward.data` is rejected as invalid params
+    /// rather than silently mishandled.
+    #[tokio::test]
+    async fn agent_forward_data_rejects_bad_base64() {
+        let handler = make_handler();
+        init_handler(&handler).await;
+
+        let result = dispatch(
+            &handler,
+            "agent.forward.data",
+            json!({ "stream_id": "sess#1", "data": "not*base64" }),
+            2,
+        )
+        .await;
+
+        assert_eq!(result["error"]["code"], errors::INVALID_PARAMS, "{result}");
+    }
+
+    /// `agent.forward.close` for an unknown stream is a benign success.
+    #[tokio::test]
+    async fn agent_forward_close_succeeds() {
+        let handler = make_handler();
+        init_handler(&handler).await;
+
+        let result = dispatch(
+            &handler,
+            "agent.forward.close",
+            json!({ "stream_id": "sess#1" }),
+            2,
+        )
+        .await;
+
+        assert!(result.get("result").is_some(), "{result}");
     }
 
     // ── agent.list_connections ─────────────────────────────────────
@@ -3507,6 +3612,10 @@ mod tests {
         }
 
         async fn set_persistent_buffer_size_bytes(&self, _bytes: usize) {}
+
+        async fn agent_forward_write(&self, _stream_id: &str, _data: Vec<u8>) {}
+
+        async fn agent_forward_close(&self, _stream_id: &str) {}
     }
 
     fn make_mock_handler() -> AgentHandler {

--- a/agent/src/protocol/methods.rs
+++ b/agent/src/protocol/methods.rs
@@ -215,6 +215,24 @@ pub struct SessionInputParams {
     pub data: String,
 }
 
+// ── agent.forward.* (ssh-agent relay, #1727) ───────────────────────
+
+/// Desktop → agent: reply bytes from the operator's local ssh-agent, tagged
+/// with the forwarded stream they belong to.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentForwardDataParams {
+    pub stream_id: String,
+    /// Base64-encoded ssh-agent-protocol bytes.
+    pub data: String,
+}
+
+/// Desktop → agent: a forwarded ssh-agent stream the desktop closed (its local
+/// agent went away, or the conversation finished).
+#[derive(Debug, Clone, Deserialize)]
+pub struct AgentForwardCloseParams {
+    pub stream_id: String,
+}
+
 // ── session.resize ─────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Deserialize)]

--- a/agent/src/session/agent_forward.rs
+++ b/agent/src/session/agent_forward.rs
@@ -419,4 +419,158 @@ mod tests {
             "session's streams dropped on teardown"
         );
     }
+
+    /// End-to-end proof of the relay's data path against a **real** ssh-agent:
+    /// a real `ssh-add -l` client connects to the relay socket, a stand-in
+    /// desktop bridges the tunnelled stream to a live `ssh-agent`, and the client
+    /// sees the agent's actual key — i.e. the target's `$SSH_AUTH_SOCK` (the
+    /// relay socket) exposes the operator's keys, which is the whole point of
+    /// #1727. Skips where `ssh-agent`/`ssh-add`/`ssh-keygen` are unavailable.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn relay_socket_exposes_a_real_ssh_agent_key_end_to_end() {
+        use std::collections::HashMap as Map;
+        use std::process::Command;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        fn have(bin: &str) -> bool {
+            Command::new("sh")
+                .arg("-c")
+                .arg(format!("command -v {bin}"))
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        }
+        if !(have("ssh-agent") && have("ssh-add") && have("ssh-keygen")) {
+            eprintln!("skipping: ssh-agent/ssh-add/ssh-keygen not available");
+            return;
+        }
+
+        let dir = std::env::temp_dir().join(format!("thub-1727-e2e-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let agent_sock = dir.join("agent.sock");
+        let key = dir.join("id_ed25519");
+
+        // A live ssh-agent bound to a known socket, holding one generated key.
+        let out = Command::new("ssh-agent")
+            .arg("-a")
+            .arg(&agent_sock)
+            .output()
+            .expect("spawn ssh-agent");
+        assert!(out.status.success(), "ssh-agent failed to start");
+        let agent_pid = String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .find_map(|l| l.trim().strip_prefix("SSH_AGENT_PID="))
+            .and_then(|s| s.split(';').next())
+            .map(|s| s.to_string());
+
+        let cleanup = |pid: Option<String>, dir: std::path::PathBuf| {
+            if let Some(pid) = pid {
+                let _ = Command::new("kill").arg(&pid).status();
+            }
+            let _ = std::fs::remove_dir_all(&dir);
+        };
+
+        let keygen = Command::new("ssh-keygen")
+            .args(["-t", "ed25519", "-N", "", "-C", "thub-1727-e2e"])
+            .arg("-f")
+            .arg(&key)
+            .output()
+            .expect("ssh-keygen");
+        assert!(keygen.status.success(), "ssh-keygen failed");
+
+        let add = Command::new("ssh-add")
+            .arg(&key)
+            .env("SSH_AUTH_SOCK", &agent_sock)
+            .output()
+            .expect("ssh-add");
+        assert!(add.status.success(), "ssh-add failed: {add:?}");
+
+        // The relay under test, plus a stand-in desktop that bridges each
+        // tunnelled stream to the live agent (the src-tauri DesktopAgentForward
+        // in miniature).
+        let (relay, mut rx) = test_relay();
+        let session_id = format!("afr-e2e-{}", std::process::id());
+        let relay_path = relay.start_listener(&session_id).await.expect("listener");
+
+        let desktop_relay = Arc::clone(&relay);
+        let real_sock = agent_sock.clone();
+        let desktop = tokio::spawn(async move {
+            let mut streams: Map<String, tokio::sync::mpsc::UnboundedSender<Vec<u8>>> = Map::new();
+            let b64 = base64::engine::general_purpose::STANDARD;
+            while let Some(n) = rx.recv().await {
+                let sid = n.params["stream_id"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string();
+                match n.method.as_str() {
+                    m if m == AGENT_FORWARD_OPEN => {
+                        let conn = tokio::net::UnixStream::connect(&real_sock).await.unwrap();
+                        let (mut ar, mut aw) = tokio::io::split(conn);
+                        let (tx, mut inbound) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
+                        streams.insert(sid.clone(), tx);
+                        tokio::spawn(async move {
+                            while let Some(b) = inbound.recv().await {
+                                if aw.write_all(&b).await.is_err() {
+                                    break;
+                                }
+                                let _ = aw.flush().await;
+                            }
+                            let _ = aw.shutdown().await;
+                        });
+                        let relay = Arc::clone(&desktop_relay);
+                        let sid2 = sid.clone();
+                        tokio::spawn(async move {
+                            let mut buf = vec![0u8; 4096];
+                            loop {
+                                match ar.read(&mut buf).await {
+                                    Ok(0) | Err(_) => break,
+                                    Ok(k) => relay.write(&sid2, buf[..k].to_vec()).await,
+                                }
+                            }
+                            relay.close_stream(&sid2).await;
+                        });
+                    }
+                    m if m == AGENT_FORWARD_DATA => {
+                        if let Some(tx) = streams.get(&sid) {
+                            if let Ok(d) = b64.decode(n.params["data"].as_str().unwrap_or_default())
+                            {
+                                let _ = tx.send(d);
+                            }
+                        }
+                    }
+                    m if m == AGENT_FORWARD_CLOSE => {
+                        streams.remove(&sid);
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        // The real client: `ssh-add -l` against the relay socket must list the
+        // key the live agent holds — proving the keys travelled the tunnel.
+        let listed = tokio::task::spawn_blocking({
+            let relay_path = relay_path.clone();
+            move || {
+                Command::new("ssh-add")
+                    .arg("-l")
+                    .env("SSH_AUTH_SOCK", &relay_path)
+                    .output()
+            }
+        })
+        .await
+        .unwrap()
+        .expect("ssh-add -l");
+
+        desktop.abort();
+        relay.stop_listener(&session_id).await;
+        let stdout = String::from_utf8_lossy(&listed.stdout).to_string();
+        cleanup(agent_pid, dir);
+
+        assert!(
+            listed.status.success() && stdout.contains("thub-1727-e2e"),
+            "relay socket must expose the live agent's key; got status={:?} stdout={stdout:?}",
+            listed.status
+        );
+    }
 }

--- a/agent/src/session/agent_forward.rs
+++ b/agent/src/session/agent_forward.rs
@@ -1,0 +1,422 @@
+//! Relaying the **desktop's** ssh-agent to a session daemon over the JSON-RPC
+//! transport (#1727).
+//!
+//! # The gap this fills
+//!
+//! #1719 made SSH agent forwarding work through a deployed agent by bridging the
+//! target's forwarded-agent channel to the ssh-agent **local to the agent host**
+//! (`$SSH_AUTH_SOCK`). That transparently reaches the operator's keys only when
+//! the desktop→agent leg is *itself* SSH with agent forwarding on, so the agent
+//! host's `$SSH_AUTH_SOCK` chains back to the operator. Over the **TCP
+//! (`--listen`) transport** there is no such SSH leg, so nothing on the agent
+//! host points at the operator's agent.
+//!
+//! # The relay
+//!
+//! When a session opts into `forwardAgent`, the agent worker binds a per-session
+//! Unix socket and exports it to the session daemon as `SSH_AUTH_SOCK` (see
+//! [`crate::session::manager`]). The daemon's core SSH bridge
+//! ([`termihub_core::backends::ssh::agent_forward`]) then connects to *that*
+//! socket exactly as it would a normal agent — "the target sees a normal
+//! `$SSH_AUTH_SOCK`". Each connection the daemon opens is tunnelled, byte for
+//! byte, over the desktop↔agent JSON-RPC transport to the desktop, which pumps
+//! it against the operator's own local ssh-agent. So the operator's keys reach
+//! the final target regardless of how the desktop reached the agent.
+//!
+//! The sub-protocol mirrors the PTY plumbing (`connection.output` /
+//! `connection.write`): an id-tagged stream carrying base64 chunks.
+//!
+//! - agent → desktop **notification** [`AGENT_FORWARD_OPEN`] `{stream_id}` — a
+//!   forwarded ssh-agent connection appeared on the agent host.
+//! - agent → desktop **notification** [`AGENT_FORWARD_DATA`] `{stream_id, data}`
+//!   — bytes the target's client wrote (chunked ≤ 64 KiB, like `send_output`).
+//! - desktop → agent **request** [`AGENT_FORWARD_DATA`] `{stream_id, data}` —
+//!   the operator's agent's reply bytes.
+//! - either side **`agent.forward.close`** `{stream_id}` — the stream ended.
+//!
+//! No desktop agent is a graceful no-op: the desktop answers `open` with an
+//! immediate `close`, the relay socket closes, and the daemon's bridge drops the
+//! forwarded channel — matching #1719's no-agent behaviour.
+//!
+//! Relaying is **unix-only** for now: the desktop bridge target on Windows is a
+//! fixed OpenSSH named pipe rather than a `SSH_AUTH_SOCK` we can override, so a
+//! Windows agent host keeps #1719's host-local model. [`should_relay`] gates it.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use base64::Engine;
+use serde_json::json;
+use tokio::sync::Mutex;
+use tracing::debug;
+
+use crate::io::transport::NotificationSender;
+use crate::protocol::messages::JsonRpcNotification;
+
+/// agent → desktop: a forwarded ssh-agent connection opened on the agent host.
+pub const AGENT_FORWARD_OPEN: &str = "agent.forward.open";
+/// Both directions: a chunk of ssh-agent-protocol bytes for a stream.
+pub const AGENT_FORWARD_DATA: &str = "agent.forward.data";
+/// Both directions: a forwarded ssh-agent stream ended.
+pub const AGENT_FORWARD_CLOSE: &str = "agent.forward.close";
+
+/// Max bytes per data notification — mirrors `JsonRpcOutputSink`'s 64 KiB chunk
+/// so a burst stays under the transport's 1 MiB NDJSON line cap.
+const CHUNK_SIZE: usize = 65536;
+
+/// Sender that feeds desktop→socket bytes to one accepted relay connection.
+type StreamSink = tokio::sync::mpsc::UnboundedSender<Vec<u8>>;
+
+/// Per-session listener bookkeeping so a closed session tears its socket down.
+#[cfg(unix)]
+struct ListenerGuard {
+    handle: tokio::task::JoinHandle<()>,
+    path: String,
+}
+
+/// Bridges each forwarded ssh-agent connection on the agent host to the
+/// desktop's own agent over the JSON-RPC transport.
+///
+/// One instance per [`crate::session::manager::SessionManager`]: it owns the
+/// desktop notification channel and the live-stream registry the dispatch
+/// handlers write into.
+pub struct AgentForwardRelay {
+    notification_tx: NotificationSender,
+    /// `stream_id` → sink writing bytes into that connection (desktop → socket).
+    streams: Mutex<HashMap<String, StreamSink>>,
+    /// `session_id` → its listener, so [`stop_listener`](Self::stop_listener)
+    /// can drop the socket when the session ends. Unix-only (the only relaying
+    /// platform).
+    #[cfg(unix)]
+    listeners: Mutex<HashMap<String, ListenerGuard>>,
+}
+
+impl AgentForwardRelay {
+    /// Create a relay bound to the given desktop notification channel.
+    pub fn new(notification_tx: NotificationSender) -> Arc<Self> {
+        Arc::new(Self {
+            notification_tx,
+            streams: Mutex::new(HashMap::new()),
+            #[cfg(unix)]
+            listeners: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Whether a session should get a desktop-agent relay: only an SSH session
+    /// that opted into `forwardAgent`, and only on unix (see the module docs on
+    /// the Windows limitation).
+    pub fn should_relay(type_id: &str, settings: &serde_json::Value) -> bool {
+        cfg!(unix)
+            && type_id == "ssh"
+            && settings
+                .get("forwardAgent")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(false)
+    }
+
+    /// Send a JSON-RPC notification to the desktop, ignoring a closed channel
+    /// (a disconnected desktop simply loses forwarding — never fatal).
+    fn notify(&self, method: &str, params: serde_json::Value) {
+        let _ = self
+            .notification_tx
+            .send(JsonRpcNotification::new(method, params));
+    }
+
+    /// Feed desktop-supplied bytes (the operator's agent's reply) to the
+    /// matching relay connection. Unknown/closed streams are ignored.
+    pub async fn write(&self, stream_id: &str, data: Vec<u8>) {
+        if let Some(sink) = self.streams.lock().await.get(stream_id) {
+            let _ = sink.send(data);
+        }
+    }
+
+    /// Drop a stream the desktop closed (its local agent went away, or the
+    /// conversation finished). Dropping the sink ends the writer task, which
+    /// shuts the socket's write side so the daemon's bridge sees EOF.
+    pub async fn close_stream(&self, stream_id: &str) {
+        self.streams.lock().await.remove(stream_id);
+    }
+
+    /// Start a per-session ssh-agent relay listener and return the socket path
+    /// to export as the daemon's `SSH_AUTH_SOCK`.
+    ///
+    /// The daemon connects to this socket through the same core bridge a real
+    /// agent would use; every connection is tunnelled to the desktop.
+    #[cfg(unix)]
+    pub async fn start_listener(self: &Arc<Self>, session_id: &str) -> std::io::Result<String> {
+        crate::daemon::transport::ensure_agent_forward_dir()?;
+        let path = crate::daemon::transport::agent_forward_endpoint(session_id);
+        // A stale socket from a crashed predecessor would fail the bind.
+        let _ = std::fs::remove_file(&path);
+        let listener = tokio::net::UnixListener::bind(&path)?;
+
+        let relay = Arc::clone(self);
+        let sid = session_id.to_string();
+        let handle = tokio::spawn(async move { relay.accept_loop(listener, sid).await });
+
+        self.listeners.lock().await.insert(
+            session_id.to_string(),
+            ListenerGuard {
+                handle,
+                path: path.clone(),
+            },
+        );
+        debug!(session_id, %path, "started ssh-agent relay listener");
+        Ok(path)
+    }
+
+    /// Tear a session's relay down: stop accepting, remove the socket file, and
+    /// drop any of its still-open streams. Idempotent; a no-op on non-unix.
+    pub async fn stop_listener(&self, session_id: &str) {
+        #[cfg(unix)]
+        {
+            if let Some(guard) = self.listeners.lock().await.remove(session_id) {
+                guard.handle.abort();
+                let _ = std::fs::remove_file(&guard.path);
+            }
+        }
+        let prefix = stream_prefix(session_id);
+        self.streams
+            .lock()
+            .await
+            .retain(|id, _| !id.starts_with(&prefix));
+        let _ = session_id;
+    }
+
+    /// Accept forwarded ssh-agent connections until the session ends (the task
+    /// is aborted by [`stop_listener`](Self::stop_listener)).
+    #[cfg(unix)]
+    async fn accept_loop(self: Arc<Self>, listener: tokio::net::UnixListener, session_id: String) {
+        let mut counter: u64 = 0;
+        loop {
+            match listener.accept().await {
+                Ok((conn, _)) => {
+                    counter += 1;
+                    let stream_id = format!("{}{}", stream_prefix(&session_id), counter);
+                    Arc::clone(&self).spawn_stream(conn, stream_id).await;
+                }
+                Err(e) => {
+                    debug!(session_id, "ssh-agent relay accept ended: {e}");
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Wire one accepted connection to the desktop: register a write sink,
+    /// announce it, then pump bytes socket→desktop for the life of the stream.
+    #[cfg(unix)]
+    async fn spawn_stream(self: Arc<Self>, conn: tokio::net::UnixStream, stream_id: String) {
+        let (read_half, write_half) = tokio::io::split(conn);
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
+        self.streams.lock().await.insert(stream_id.clone(), tx);
+        self.notify(AGENT_FORWARD_OPEN, json!({ "stream_id": stream_id }));
+
+        tokio::spawn(write_socket(write_half, rx));
+
+        let relay = Arc::clone(&self);
+        tokio::spawn(async move { relay.read_socket(read_half, stream_id).await });
+    }
+
+    /// Pump socket → desktop: forward each read as a data notification, and on
+    /// EOF/error deregister the stream and tell the desktop it closed.
+    #[cfg(unix)]
+    async fn read_socket(
+        self: Arc<Self>,
+        mut read_half: tokio::io::ReadHalf<tokio::net::UnixStream>,
+        stream_id: String,
+    ) {
+        use tokio::io::AsyncReadExt;
+        let b64 = base64::engine::general_purpose::STANDARD;
+        let mut buf = vec![0u8; CHUNK_SIZE];
+        loop {
+            match read_half.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => {
+                    let encoded = b64.encode(&buf[..n]);
+                    self.notify(
+                        AGENT_FORWARD_DATA,
+                        json!({ "stream_id": stream_id, "data": encoded }),
+                    );
+                }
+                Err(e) => {
+                    debug!(stream_id, "ssh-agent relay read ended: {e}");
+                    break;
+                }
+            }
+        }
+        self.streams.lock().await.remove(&stream_id);
+        self.notify(AGENT_FORWARD_CLOSE, json!({ "stream_id": stream_id }));
+    }
+}
+
+/// Prefix that ties a `stream_id` to its `session_id` for teardown matching.
+fn stream_prefix(session_id: &str) -> String {
+    format!("{session_id}#")
+}
+
+/// Pump desktop → socket: write each queued reply chunk to the connection until
+/// the desktop closes the stream (sink dropped), then shut the write side so the
+/// daemon's bridge sees EOF.
+#[cfg(unix)]
+async fn write_socket(
+    mut write_half: tokio::io::WriteHalf<tokio::net::UnixStream>,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
+) {
+    use tokio::io::AsyncWriteExt;
+    while let Some(bytes) = rx.recv().await {
+        if write_half.write_all(&bytes).await.is_err() {
+            break;
+        }
+        let _ = write_half.flush().await;
+    }
+    let _ = write_half.shutdown().await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_relay() -> (
+        Arc<AgentForwardRelay>,
+        tokio::sync::mpsc::UnboundedReceiver<JsonRpcNotification>,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        (AgentForwardRelay::new(tx), rx)
+    }
+
+    /// Relaying is gated to SSH sessions that asked for `forwardAgent` — and,
+    /// because the desktop bridge target is only overridable on unix, to unix.
+    #[test]
+    fn should_relay_only_for_ssh_forward_agent() {
+        let on = json!({ "forwardAgent": true });
+        let off = json!({ "forwardAgent": false });
+        let absent = json!({});
+
+        assert_eq!(
+            AgentForwardRelay::should_relay("ssh", &on),
+            cfg!(unix),
+            "ssh + forwardAgent relays on unix only"
+        );
+        assert!(!AgentForwardRelay::should_relay("ssh", &off));
+        assert!(!AgentForwardRelay::should_relay("ssh", &absent));
+        assert!(
+            !AgentForwardRelay::should_relay("local", &on),
+            "only ssh sessions forward an agent"
+        );
+    }
+
+    /// `write`/`close_stream` for an unknown stream are silent no-ops — a stray
+    /// desktop frame for a stream that already closed must never panic.
+    #[tokio::test]
+    async fn write_and_close_unknown_stream_are_noops() {
+        let (relay, _rx) = test_relay();
+        relay.write("nope#1", b"data".to_vec()).await;
+        relay.close_stream("nope#1").await;
+    }
+
+    /// An accepted connection announces itself with an `open` notification and
+    /// tunnels the bytes the client writes as base64 `data`; closing the client
+    /// side yields a `close`. Exercises the whole socket→desktop pump.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn accepted_connection_streams_open_data_close() {
+        use tokio::io::AsyncWriteExt;
+
+        let (relay, mut rx) = test_relay();
+        let session_id = format!("afr-test-{}", std::process::id());
+        let path = relay
+            .start_listener(&session_id)
+            .await
+            .expect("start listener");
+
+        let mut client = tokio::net::UnixStream::connect(&path)
+            .await
+            .expect("connect relay socket");
+        client.write_all(b"hello-agent").await.expect("write");
+        client.flush().await.expect("flush");
+
+        // open, then data carrying our bytes.
+        let open = rx.recv().await.expect("open notification");
+        assert_eq!(open.method, AGENT_FORWARD_OPEN);
+        let stream_id = open.params["stream_id"].as_str().unwrap().to_string();
+        assert!(stream_id.starts_with(&stream_prefix(&session_id)));
+
+        let data = rx.recv().await.expect("data notification");
+        assert_eq!(data.method, AGENT_FORWARD_DATA);
+        assert_eq!(data.params["stream_id"], stream_id);
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(data.params["data"].as_str().unwrap())
+            .unwrap();
+        assert_eq!(decoded, b"hello-agent");
+
+        // Client closes → close notification and the stream is deregistered.
+        drop(client);
+        let close = rx.recv().await.expect("close notification");
+        assert_eq!(close.method, AGENT_FORWARD_CLOSE);
+        assert_eq!(close.params["stream_id"], stream_id);
+
+        relay.stop_listener(&session_id).await;
+    }
+
+    /// Desktop-supplied reply bytes reach the connected client through `write`.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn desktop_reply_bytes_reach_the_client() {
+        use tokio::io::AsyncReadExt;
+
+        let (relay, mut rx) = test_relay();
+        let session_id = format!("afr-reply-{}", std::process::id());
+        let path = relay
+            .start_listener(&session_id)
+            .await
+            .expect("start listener");
+
+        let mut client = tokio::net::UnixStream::connect(&path)
+            .await
+            .expect("connect relay socket");
+
+        let open = rx.recv().await.expect("open notification");
+        let stream_id = open.params["stream_id"].as_str().unwrap().to_string();
+
+        relay.write(&stream_id, b"agent-reply".to_vec()).await;
+
+        let mut buf = vec![0u8; 11];
+        client.read_exact(&mut buf).await.expect("read reply");
+        assert_eq!(&buf, b"agent-reply");
+
+        relay.stop_listener(&session_id).await;
+    }
+
+    /// Tearing a session down removes its socket and any lingering stream
+    /// entries, so a later session cannot bind a stale path or route to a dead
+    /// stream.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stop_listener_removes_socket_and_streams() {
+        let (relay, _rx) = test_relay();
+        let session_id = format!("afr-stop-{}", std::process::id());
+        let path = relay
+            .start_listener(&session_id)
+            .await
+            .expect("start listener");
+        assert!(std::path::Path::new(&path).exists());
+
+        let _client = tokio::net::UnixStream::connect(&path)
+            .await
+            .expect("connect");
+        // Let the accept loop register the stream.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        relay.stop_listener(&session_id).await;
+        assert!(
+            !std::path::Path::new(&path).exists(),
+            "socket file removed on teardown"
+        );
+        assert!(
+            relay.streams.lock().await.is_empty(),
+            "session's streams dropped on teardown"
+        );
+    }
+}

--- a/agent/src/session/manager.rs
+++ b/agent/src/session/manager.rs
@@ -18,6 +18,7 @@ use tokio::sync::Mutex;
 use tracing::{info, warn};
 
 use crate::io::transport::NotificationSender;
+use crate::session::agent_forward::AgentForwardRelay;
 use crate::session::types::{SessionBackend, SessionInfo, SessionSnapshot, SessionStatus};
 use crate::transport::JsonRpcOutputSink;
 use termihub_core::connection::{ConnectionTypeRegistry, OutputReceiver};
@@ -105,6 +106,14 @@ pub trait SessionManagerApi: Send + Sync + 'static {
 
     /// Update the ring-buffer size used for future daemon spawns.
     async fn set_persistent_buffer_size_bytes(&self, bytes: usize);
+
+    /// Route desktop-supplied ssh-agent reply bytes to a forwarded stream (the
+    /// desktop→agent leg of the agent-forward relay, #1727). Unknown streams are
+    /// silently ignored.
+    async fn agent_forward_write(&self, stream_id: &str, data: Vec<u8>);
+
+    /// Close a forwarded ssh-agent stream the desktop reports as ended (#1727).
+    async fn agent_forward_close(&self, stream_id: &str);
 }
 
 /// Errors that can occur during session creation.
@@ -173,6 +182,10 @@ impl fmt::Display for DeferredUpdateError {
 #[async_trait::async_trait]
 pub trait DaemonLauncher: Send + Sync + 'static {
     /// Spawn a daemon for the given session and return the connected backend.
+    ///
+    /// `ssh_auth_sock`, when set, is exported to the daemon as `SSH_AUTH_SOCK`
+    /// so its core SSH agent-forwarding bridge reaches the desktop's agent via
+    /// the relay socket instead of the agent host's own agent (#1727).
     async fn launch(
         &self,
         session_id: &str,
@@ -180,6 +193,7 @@ pub trait DaemonLauncher: Send + Sync + 'static {
         settings: &serde_json::Value,
         notification_tx: NotificationSender,
         buffer_size_bytes: usize,
+        ssh_auth_sock: Option<String>,
     ) -> Result<SessionBackend, anyhow::Error>;
 }
 
@@ -213,6 +227,7 @@ impl DaemonLauncher for SystemDaemonLauncher {
         settings: &serde_json::Value,
         notification_tx: NotificationSender,
         buffer_size_bytes: usize,
+        ssh_auth_sock: Option<String>,
     ) -> Result<SessionBackend, anyhow::Error> {
         let endpoint = session_endpoint(session_id);
         let settings_json = serde_json::to_string(settings)?;
@@ -228,6 +243,13 @@ impl DaemonLauncher for SystemDaemonLauncher {
             .env("TERMIHUB_BUFFER_SIZE", buffer_size_bytes.to_string())
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null());
+        // Point the daemon's core SSH agent-forwarding bridge at the relay
+        // socket, so it reaches the desktop's agent rather than the agent host's
+        // own `$SSH_AUTH_SOCK` (#1727). Overriding the inherited value is the
+        // intent: over the TCP transport there is nothing useful to inherit.
+        if let Some(sock) = ssh_auth_sock {
+            command.env("SSH_AUTH_SOCK", sock);
+        }
         crate::daemon::spawn::configure_detached_stderr(&mut command, daemon_log(session_id));
         crate::daemon::spawn::configure_detachment(&mut command);
 
@@ -321,6 +343,10 @@ pub struct SessionManager {
     update_applier: Arc<dyn UpdateApplier>,
     /// Configurable ring-buffer size for daemon-backed persistent sessions.
     persistent_buffer_size: Arc<AtomicUsize>,
+    /// Relays the desktop's ssh-agent to daemons that opted into `forwardAgent`
+    /// over the JSON-RPC transport (#1727). Shared with the dispatch handlers so
+    /// desktop-supplied reply bytes route back to the right forwarded stream.
+    agent_forward: Arc<AgentForwardRelay>,
 }
 
 impl SessionManager {
@@ -392,6 +418,7 @@ impl SessionManager {
             info!("Cleared an already-applied pending agent update from persisted state");
             state.save_to(&state_path);
         }
+        let agent_forward = AgentForwardRelay::new(notification_tx.clone());
         Self {
             sessions: Mutex::new(HashMap::new()),
             notification_tx,
@@ -401,6 +428,7 @@ impl SessionManager {
             state_path,
             update_applier,
             persistent_buffer_size: Arc::new(AtomicUsize::new(DEFAULT_PERSISTENT_BUFFER_SIZE)),
+            agent_forward,
         }
     }
 
@@ -502,15 +530,62 @@ impl SessionManager {
         settings: &serde_json::Value,
     ) -> Result<SessionBackend, anyhow::Error> {
         let buffer_size = self.persistent_buffer_size.load(Ordering::Relaxed);
-        self.launcher
+
+        // For an SSH session that opted into `forwardAgent`, stand up a
+        // per-session ssh-agent relay to the desktop and hand the daemon its
+        // socket as `SSH_AUTH_SOCK` (#1727). Best-effort: if the relay can't
+        // bind we still launch, and forwarding just falls back to whatever the
+        // daemon inherits (the #1719 host-local behaviour).
+        let ssh_auth_sock = self
+            .start_agent_forward(session_id, type_id, settings)
+            .await;
+
+        let result = self
+            .launcher
             .launch(
                 session_id,
                 type_id,
                 settings,
                 self.notification_tx.clone(),
                 buffer_size,
+                ssh_auth_sock.clone(),
             )
-            .await
+            .await;
+
+        // A daemon that never launched leaves no one to talk to the relay, so
+        // don't leave the socket dangling.
+        if result.is_err() && ssh_auth_sock.is_some() {
+            self.agent_forward.stop_listener(session_id).await;
+        }
+        result
+    }
+
+    /// Start the desktop ssh-agent relay for a session when it applies, returning
+    /// the socket path to export to the daemon as `SSH_AUTH_SOCK` (#1727).
+    async fn start_agent_forward(
+        &self,
+        session_id: &str,
+        type_id: &str,
+        settings: &serde_json::Value,
+    ) -> Option<String> {
+        if !AgentForwardRelay::should_relay(type_id, settings) {
+            return None;
+        }
+        #[cfg(unix)]
+        {
+            match self.agent_forward.start_listener(session_id).await {
+                Ok(path) => Some(path),
+                Err(e) => {
+                    warn!("failed to start ssh-agent relay for {session_id}: {e}");
+                    None
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = session_id;
+            None
+        }
     }
 
     /// Return the current scrollback buffer for a session (daemon-backed only).
@@ -599,6 +674,9 @@ impl SessionManager {
             }
         };
 
+        // Tear down any ssh-agent relay this session held (#1727).
+        self.agent_forward.stop_listener(session_id).await;
+
         {
             let mut state = self.state.lock().await;
             state.sessions.remove(session_id);
@@ -638,7 +716,8 @@ impl SessionManager {
     /// In-process sessions are disconnected normally.
     pub async fn close_all(&self) {
         let mut sessions = self.sessions.lock().await;
-        for (_, mut info) in sessions.drain() {
+        for (id, mut info) in sessions.drain() {
+            self.agent_forward.stop_listener(&id).await;
             shutdown_backend(&mut info.backend).await;
         }
     }
@@ -1107,6 +1186,14 @@ impl SessionManagerApi for SessionManager {
 
     async fn set_persistent_buffer_size_bytes(&self, bytes: usize) {
         SessionManager::set_persistent_buffer_size_bytes(self, bytes);
+    }
+
+    async fn agent_forward_write(&self, stream_id: &str, data: Vec<u8>) {
+        self.agent_forward.write(stream_id, data).await;
+    }
+
+    async fn agent_forward_close(&self, stream_id: &str) {
+        self.agent_forward.close_stream(stream_id).await;
     }
 }
 
@@ -1712,6 +1799,7 @@ mod tests {
                 _settings: &serde_json::Value,
                 _notification_tx: NotificationSender,
                 _buffer_size_bytes: usize,
+                _ssh_auth_sock: Option<String>,
             ) -> Result<SessionBackend, anyhow::Error> {
                 if self.should_fail {
                     return Err(anyhow::anyhow!("mock: daemon spawn failed"));

--- a/agent/src/session/mod.rs
+++ b/agent/src/session/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_forward;
 pub mod definitions;
 pub mod manager;
 pub mod types;

--- a/core/src/backends/ssh/agent_forward.rs
+++ b/core/src/backends/ssh/agent_forward.rs
@@ -18,7 +18,30 @@
 
 use russh::client::Msg;
 use russh::Channel;
+use tokio::io::{AsyncRead, AsyncWrite};
 use tracing::debug;
+
+/// A raw, bidirectional connection to the local SSH agent, type-erased so callers
+/// in other crates can pump bytes without naming the platform stream type.
+///
+/// Implemented by whatever [`connect_local_agent`] yields on each platform
+/// (Unix domain socket, Windows named pipe). The desktop reuses this to bridge
+/// its own local agent to a session forwarded over the JSON-RPC agent transport
+/// (#1727), so that path connects to the operator's agent through the exact same
+/// logic the russh bridge uses here.
+pub trait LocalAgentStream: AsyncRead + AsyncWrite + Unpin + Send {}
+impl<T: AsyncRead + AsyncWrite + Unpin + Send> LocalAgentStream for T {}
+
+/// Open a boxed raw stream to the local SSH agent, or an error when none is
+/// reachable (`SSH_AUTH_SOCK` unset / the Windows OpenSSH agent stopped).
+///
+/// The type-erased sibling of [`connect_local_agent`] for cross-crate callers
+/// (the desktop's agent-forward relay endpoint, #1727). Absence of an agent is
+/// the caller's cue for a graceful no-op, exactly as [`local_agent_available`]
+/// gates the russh path.
+pub async fn connect_local_agent_boxed() -> std::io::Result<Box<dyn LocalAgentStream>> {
+    Ok(Box::new(connect_local_agent().await?))
+}
 
 /// Connect a raw byte stream to the local SSH agent (Unix `$SSH_AUTH_SOCK`).
 #[cfg(unix)]

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -4,7 +4,7 @@
 //! and file browsing (SFTP). This is the canonical SSH implementation,
 //! used by both the desktop and agent crates.
 
-mod agent_forward;
+pub mod agent_forward;
 pub mod auth;
 pub mod connector;
 pub mod exec;

--- a/docs/changes/dev1/feature/1727-agent-forward-tcp.md
+++ b/docs/changes/dev1/feature/1727-agent-forward-tcp.md
@@ -1,0 +1,15 @@
+### Added
+
+- SSH **agent forwarding now reaches the operator's own keys through a deployed
+  agent over the TCP (`--listen`) transport** (#1727). #1719 delivered
+  `forwardAgent` through a deployed agent using the agent-host-local ssh-agent,
+  which only chains back to the operator when the desktop→agent leg is itself SSH
+  with forwarding on. Over the TCP transport there is no such SSH leg. termiHub
+  now relays the **desktop's** local ssh-agent to the session daemon over the
+  desktop↔agent JSON-RPC transport: the daemon's SSH bridge sees a normal
+  `$SSH_AUTH_SOCK`, and each forwarded ssh-agent connection is tunnelled back to
+  the desktop's agent, so the operator's keys reach the final target regardless
+  of how the desktop reached the agent. No local agent remains a graceful no-op.
+  Relaying is unix-only for now; a Windows agent host keeps the #1719 host-local
+  model. Adds the `agent.forward.{open,data,close}` protocol messages
+  (remote-protocol 0.5.0).

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -2,7 +2,7 @@
 
 Protocol specification for communication between the termiHub desktop app and remote agents.
 
-**Version**: 0.4.0
+**Version**: 0.5.0
 **Status**: Draft
 **Issue**: #17, #360, #1349
 
@@ -266,6 +266,9 @@ The desktop sends its supported protocol version in the `initialize` request. Th
 
 | Desktop Version | Agent Version | Compatible?                                         |
 | --------------- | ------------- | --------------------------------------------------- |
+| 0.5.0           | 0.5.0         | Yes                                                 |
+| 0.5.0           | 0.4.0         | Yes (`agent.forward.*` absent — relay is a no-op)   |
+| 0.4.0           | 0.5.0         | Yes (new methods / notifications ignored)           |
 | 0.4.0           | 0.4.0         | Yes                                                 |
 | 0.4.0           | 0.3.0         | Yes (`agent.request_update` absent — see below)     |
 | 0.3.0           | 0.4.0         | Yes (new method / notification ignored)             |
@@ -274,6 +277,8 @@ The desktop sends its supported protocol version in the `initialize` request. Th
 | 0.2.0           | 0.1.0         | No (`connection.*` methods not recognized)          |
 | 0.1.0           | 0.2.0         | No (old `session.*` methods removed)                |
 | 1.0.0           | 0.4.0         | No (major mismatch)                                 |
+
+**0.5.0 (additive, minor)** — adds the ssh-agent relay: the [`agent.forward.data`](#agentforwarddata) / [`agent.forward.close`](#agentforwardclose) methods and the [`agent.forward.open`](#agentforwardopen) / [`agent.forward.data`](#agentforwarddata-notification) / [`agent.forward.close`](#agentforwardclose-notification) notifications (#1727). Backwards compatible in both directions: a 0.4.0 agent simply never opens a relay stream (SSH agent forwarding then falls back to the #1719 host-local model), and a 0.4.0 desktop ignores the notifications, so the forwarded channel is dropped as a graceful no-op — the same behaviour as no local agent.
 
 **0.4.0 (additive, minor)** — adds the [`agent.request_update`](#agentrequest_update) method and the [`agent.update_pending`](#agentupdate_pending) notification (#1351). Backwards compatible in both directions, but note what "compatible" means for a _coordinated_ update: a 0.3.0 desktop never receives `agent.update_pending`, so it gets the same hard cut it always did when another host updates the agent — it is not broken, it is merely not warned. That is the documented "older desktops remain hard-cut" behaviour, and it is why the agent proceeds on a timeout rather than waiting for an ack that such a desktop could never send.
 
@@ -619,6 +624,50 @@ Send input data to a session (keystrokes, pasted text).
 
 - `-32001` Session not found
 - `-32006` Session not running
+
+---
+
+### `agent.forward.data`
+
+Desktop → agent. Carries a chunk of the operator's local ssh-agent's **reply** bytes for a forwarded ssh-agent stream (#1727), the desktop→agent leg of the [ssh-agent relay](#agentforwardopen). Sent in response to bytes the desktop received via the [`agent.forward.data` notification](#agentforwarddata-notification), after pumping them through its local agent.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "agent.forward.data",
+  "params": {
+    "stream_id": "a1b2c3d4-...#3",
+    "data": "AAAAC3NzaC1lZDI1NTE5..."
+  }
+}
+```
+
+| Param       | Type     | Description                                 |
+| ----------- | -------- | ------------------------------------------- |
+| `stream_id` | `string` | Forwarded ssh-agent stream id (from `open`) |
+| `data`      | `string` | Base64-encoded ssh-agent-protocol bytes     |
+
+**Response**: `{}`. An unknown or already-closed `stream_id` is a benign no-op (not an error).
+
+---
+
+### `agent.forward.close`
+
+Desktop → agent. The desktop closed a forwarded ssh-agent stream — its local agent went away, or the conversation finished (#1727). The agent drops the relay connection so the daemon's forwarded-agent bridge sees EOF.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "agent.forward.close",
+  "params": { "stream_id": "a1b2c3d4-...#3" }
+}
+```
+
+| Param       | Type     | Description                   |
+| ----------- | -------- | ----------------------------- |
+| `stream_id` | `string` | Forwarded ssh-agent stream id |
+
+**Response**: `{}`. Idempotent.
 
 ---
 
@@ -1695,6 +1744,64 @@ A session-level error that does not necessarily terminate the session.
 | ------------ | -------- | -------------------------------- |
 | `session_id` | `string` | Affected session UUID            |
 | `message`    | `string` | Human-readable error description |
+
+### `agent.forward.open`
+
+SSH agent forwarding, deployed-agent + TCP transport (#1727). When a session routed through a deployed agent opts into `forwardAgent` and the desktop reaches that agent over the **TCP transport**, there is no SSH leg to piggyback forwarding on (unlike the #1719 host-local model). Instead the agent binds a per-session ssh-agent socket, hands it to the session daemon as `$SSH_AUTH_SOCK`, and tunnels every connection the daemon makes to it back to the desktop over these `agent.forward.*` messages. The desktop bridges each stream to the operator's **own** local ssh-agent, so the operator's keys reach the final target regardless of transport.
+
+`agent.forward.open` announces a new forwarded stream (a program on the target contacted its `$SSH_AUTH_SOCK`). The desktop connects its local agent and prepares to pump bytes.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "agent.forward.open",
+  "params": { "stream_id": "a1b2c3d4-...#3" }
+}
+```
+
+| Param       | Type     | Description                                             |
+| ----------- | -------- | ------------------------------------------------------- |
+| `stream_id` | `string` | Unique id for this forwarded stream (embeds session id) |
+
+If the desktop has no reachable local agent, it answers with an immediate [`agent.forward.close`](#agentforwardclose) — the forwarded channel is then dropped as a graceful no-op, matching the SSH-reached no-agent behaviour (#1699/#1719). **Relaying is unix-only**: on a Windows agent host the daemon's bridge target is a fixed OpenSSH pipe rather than an overridable `$SSH_AUTH_SOCK`, so a Windows agent keeps the #1719 host-local model.
+
+### `agent.forward.data` (notification)
+
+Agent → desktop. A chunk of the ssh-agent-protocol **request** bytes the target's client wrote, for the desktop to feed to the operator's local agent (#1727). Chunked to ≤ 64 KiB, like `connection.output`.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "agent.forward.data",
+  "params": {
+    "stream_id": "a1b2c3d4-...#3",
+    "data": "AAAAAQI="
+  }
+}
+```
+
+| Param       | Type     | Description                             |
+| ----------- | -------- | --------------------------------------- |
+| `stream_id` | `string` | Forwarded ssh-agent stream id           |
+| `data`      | `string` | Base64-encoded ssh-agent-protocol bytes |
+
+The desktop's reply bytes travel back via the [`agent.forward.data` **method**](#agentforwarddata).
+
+### `agent.forward.close` (notification)
+
+Agent → desktop. A forwarded ssh-agent stream ended on the agent host (the target closed its agent connection). The desktop drops its local-agent bridge for the stream (#1727).
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "agent.forward.close",
+  "params": { "stream_id": "a1b2c3d4-...#3" }
+}
+```
+
+| Param       | Type     | Description                   |
+| ----------- | -------- | ----------------------------- |
+| `stream_id` | `string` | Forwarded ssh-agent stream id |
 
 ### `connection.monitoring.data`
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2418,11 +2418,36 @@ verify manually:
    toggle still on — the connection must **succeed** with forwarding silently
    skipped (a debug log notes it).
 
-Limitation / future work: when the desktop reaches the agent over the **TCP
-transport** (`--listen`) rather than SSH, there is no SSH leg to piggyback, so the
-operator's agent is only reachable if the agent host runs its own agent. Relaying
-the desktop's agent to the agent host over the desktop↔agent JSON-RPC transport
-would close that gap and is tracked as a follow-up.
+### SSH agent forwarding over the TCP agent transport (#1727)
+
+Closes the #1719 gap above: when the desktop reaches a deployed agent over the
+**TCP transport** (`--listen`) rather than SSH, there is no SSH leg to piggyback
+agent forwarding on. termiHub now relays the **desktop's** own ssh-agent to the
+session daemon over the desktop↔agent JSON-RPC transport (`agent.forward.*`
+messages), so the operator's keys reach the final target with no ssh-agent on the
+agent host at all. The relay socket is handed to the daemon as `$SSH_AUTH_SOCK`,
+so the daemon's core bridge and the target see a normal agent.
+
+The relay's stream plumbing (open/data/close, the local-agent bridge, the
+no-agent no-op) is covered by **Rust unit tests**
+(`agent/src/session/agent_forward.rs`, `agent/src/handler/dispatch.rs`,
+`src-tauri/src/terminal/agent_forward.rs`). End-to-end forwarding needs a live
+agent + real SSH server reached over TCP (integration lane only, not per-PR CI),
+so verify manually — this path is **unix-only** (a Windows agent host keeps the
+host-local model from #1719):
+
+1. Ensure a local agent has a key: `ssh-add -l` lists at least one identity.
+2. Deploy the agent to an intermediate host and reach it over the **TCP
+   transport** (`--listen`) — crucially **without** SSH agent forwarding on the
+   desktop→agent leg, and with **no** ssh-agent running on the agent host itself
+   (so #1719's host-local chaining cannot mask the result).
+3. Add an agent-routed SSH connection to a final target (e.g. a `tests/docker`
+   SSH fixture), enable **Forward SSH agent**, and connect. On the target run
+   `ssh-add -l` — it must list **your desktop's** identities, and an onward `ssh`
+   from the target using an agent key must succeed.
+4. **No agent:** stop the desktop's agent (unset `SSH_AUTH_SOCK`) and reconnect
+   with the toggle still on — the connection must **succeed** with forwarding
+   silently skipped; `ssh-add -l` on the target reports no agent.
 
 ### X11 / GUI forwarding
 

--- a/src-tauri/src/terminal/agent_forward.rs
+++ b/src-tauri/src/terminal/agent_forward.rs
@@ -1,0 +1,194 @@
+//! Desktop end of the ssh-agent relay (#1727).
+//!
+//! When an SSH session routed through a deployed agent opts into `forwardAgent`
+//! and the desktop reaches that agent over the **TCP transport**, there is no
+//! SSH leg to carry agent forwarding (unlike #1719's host-local chaining). The
+//! agent instead tunnels each forwarded ssh-agent connection to the desktop over
+//! the JSON-RPC transport via `agent.forward.*` messages; this module is the
+//! desktop side of that tunnel.
+//!
+//! For each stream the agent opens, we connect to the **operator's own** local
+//! ssh-agent — through [`termihub_core::backends::ssh::agent_forward::connect_local_agent_boxed`],
+//! the exact connector the russh bridge uses — and pump bytes both ways:
+//!
+//! - `agent.forward.open`  → connect the local agent, start pumping.
+//! - `agent.forward.data`  (agent→desktop) → write to the local agent.
+//! - local agent → desktop → `agent.forward.data`/`agent.forward.close` requests
+//!   back to the agent (carried as [`AgentIoCommand`]).
+//! - `agent.forward.close` → drop the stream.
+//!
+//! No local agent is a graceful no-op: the connect fails, we answer with an
+//! immediate `agent.forward.close`, and the agent drops the forwarded channel —
+//! matching the no-agent behaviour of the SSH-reached path (#1699/#1719).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::mpsc::{self, UnboundedSender};
+use tracing::debug;
+
+use super::agent_manager::AgentIoCommand;
+
+/// Max bytes read from the local agent per relay data frame; matches the
+/// agent-side chunk so neither side exceeds the transport's NDJSON line cap.
+const CHUNK_SIZE: usize = 65536;
+
+/// Routes the desktop end of forwarded ssh-agent streams to the operator's
+/// local ssh-agent. One instance per connected agent's I/O loop.
+///
+/// Cloneable (shares one stream table) so pump tasks can deregister themselves.
+#[derive(Clone, Default)]
+pub struct DesktopAgentForward {
+    /// `stream_id` → sink feeding agent→desktop bytes into the local-agent
+    /// writer for that stream.
+    streams: Arc<Mutex<HashMap<String, UnboundedSender<Vec<u8>>>>>,
+}
+
+impl DesktopAgentForward {
+    /// Create an empty relay handler.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Handle `agent.forward.open`: register the stream and start a task that
+    /// connects to the local agent and pumps bytes for the stream's lifetime.
+    pub fn on_open(&self, stream_id: String, command_tx: UnboundedSender<AgentIoCommand>) {
+        let (tx, rx) = mpsc::unbounded_channel::<Vec<u8>>();
+        self.streams.lock().unwrap().insert(stream_id.clone(), tx);
+
+        let streams = self.streams.clone();
+        tokio::spawn(async move {
+            pump_local_agent(stream_id, rx, command_tx, streams).await;
+        });
+    }
+
+    /// Handle `agent.forward.data` from the agent: feed the bytes to the local
+    /// agent. Unknown/closed streams are ignored.
+    pub fn on_data(&self, stream_id: &str, data: Vec<u8>) {
+        if let Some(tx) = self.streams.lock().unwrap().get(stream_id) {
+            let _ = tx.send(data);
+        }
+    }
+
+    /// Handle `agent.forward.close` from the agent: drop the stream. Dropping the
+    /// sink ends the writer, which shuts the local agent connection.
+    pub fn on_close(&self, stream_id: &str) {
+        self.streams.lock().unwrap().remove(stream_id);
+    }
+}
+
+/// Connect to the operator's local ssh-agent and pump one forwarded stream both
+/// ways until either end closes.
+async fn pump_local_agent(
+    stream_id: String,
+    rx: mpsc::UnboundedReceiver<Vec<u8>>,
+    command_tx: UnboundedSender<AgentIoCommand>,
+    streams: Arc<Mutex<HashMap<String, UnboundedSender<Vec<u8>>>>>,
+) {
+    let agent = match termihub_core::backends::ssh::agent_forward::connect_local_agent_boxed().await
+    {
+        Ok(agent) => agent,
+        Err(e) => {
+            // No local agent — mirror the russh no-op: tell the agent to drop the
+            // forwarded channel, and forget the stream.
+            debug!("no local ssh-agent to answer forwarded stream {stream_id}: {e}");
+            let _ = command_tx.send(AgentIoCommand::AgentForwardClose {
+                stream_id: stream_id.clone(),
+            });
+            streams.lock().unwrap().remove(&stream_id);
+            return;
+        }
+    };
+
+    let (mut read_half, mut write_half) = tokio::io::split(agent);
+
+    // Writer: agent→desktop bytes → local agent, until the stream is closed.
+    let writer = tokio::spawn(async move {
+        let mut rx = rx;
+        while let Some(bytes) = rx.recv().await {
+            if write_half.write_all(&bytes).await.is_err() {
+                break;
+            }
+            let _ = write_half.flush().await;
+        }
+        let _ = write_half.shutdown().await;
+    });
+
+    // Reader: local agent replies → agent, as forward-data requests.
+    let mut buf = vec![0u8; CHUNK_SIZE];
+    loop {
+        match read_half.read(&mut buf).await {
+            Ok(0) => break,
+            Ok(n) => {
+                let sent = command_tx.send(AgentIoCommand::AgentForwardData {
+                    stream_id: stream_id.clone(),
+                    data: buf[..n].to_vec(),
+                });
+                if sent.is_err() {
+                    break; // agent I/O loop gone
+                }
+            }
+            Err(e) => {
+                debug!("forwarded ssh-agent stream {stream_id} read ended: {e}");
+                break;
+            }
+        }
+    }
+
+    let _ = command_tx.send(AgentIoCommand::AgentForwardClose {
+        stream_id: stream_id.clone(),
+    });
+    streams.lock().unwrap().remove(&stream_id);
+    writer.abort();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `on_data`/`on_close` for a stream that was never opened (or already
+    /// closed) are silent no-ops — a late frame must never panic.
+    #[tokio::test]
+    async fn data_and_close_for_unknown_stream_are_noops() {
+        let relay = DesktopAgentForward::new();
+        relay.on_data("ghost#1", b"bytes".to_vec());
+        relay.on_close("ghost#1");
+        assert!(relay.streams.lock().unwrap().is_empty());
+    }
+
+    /// With no local ssh-agent reachable, an opened stream answers the agent with
+    /// a `close` and deregisters itself — the graceful no-op the target sees as
+    /// "no keys forwarded".
+    #[tokio::test]
+    async fn open_without_local_agent_closes_and_deregisters() {
+        // Point SSH_AUTH_SOCK at nothing so the connect fails deterministically.
+        // SAFETY: single-threaded test; the var is restored before returning.
+        let orig = std::env::var_os("SSH_AUTH_SOCK");
+        unsafe { std::env::set_var("SSH_AUTH_SOCK", "/nonexistent/thub-1727-test.sock") };
+
+        let relay = DesktopAgentForward::new();
+        let (tx, mut rx) = mpsc::unbounded_channel::<AgentIoCommand>();
+        relay.on_open("sess#1".to_string(), tx);
+
+        // The pump task must report the stream closed …
+        let cmd = rx.recv().await.expect("a close command");
+        match cmd {
+            AgentIoCommand::AgentForwardClose { stream_id } => assert_eq!(stream_id, "sess#1"),
+            _ => panic!("expected AgentForwardClose"),
+        }
+        // … and drop it from the table.
+        for _ in 0..50 {
+            if relay.streams.lock().unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert!(relay.streams.lock().unwrap().is_empty());
+
+        match orig {
+            Some(v) => unsafe { std::env::set_var("SSH_AUTH_SOCK", v) },
+            None => unsafe { std::env::remove_var("SSH_AUTH_SOCK") },
+        }
+    }
+}

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -24,6 +24,7 @@ use termihub_core::monitoring::{MonitoringSender, SystemStats};
 
 use crate::connection::config::AgentSettings;
 use crate::terminal::agent_deploy::ConnectedHost;
+use crate::terminal::agent_forward::DesktopAgentForward;
 use crate::terminal::backend::{OutputSender, RemoteAgentConfig, RemoteStateChangeEvent};
 use crate::terminal::jsonrpc;
 use crate::utils::errors::TerminalError;
@@ -154,7 +155,7 @@ fn parse_agent_folder(v: &Value) -> Option<AgentFolderInfo> {
 }
 
 /// Commands sent to the agent I/O task.
-enum AgentIoCommand {
+pub(crate) enum AgentIoCommand {
     /// Send JSON-RPC request and get a response via a oneshot channel.
     Request {
         method: String,
@@ -183,6 +184,12 @@ enum AgentIoCommand {
     },
     /// Unregister a session's monitoring sender.
     UnregisterMonitoring { session_id: String },
+    /// Send the operator's ssh-agent reply bytes for a forwarded stream to the
+    /// agent (`agent.forward.data`, desktop→agent leg of the relay, #1727).
+    AgentForwardData { stream_id: String, data: Vec<u8> },
+    /// Tell the agent a forwarded ssh-agent stream has closed
+    /// (`agent.forward.close`, #1727).
+    AgentForwardClose { stream_id: String },
     /// Disconnect the agent.
     Disconnect,
 }
@@ -756,11 +763,16 @@ impl AgentConnectionManager {
             let settings_task = settings_clone.clone();
             let agents_weak_task = agents_weak.clone();
 
+            // A clone for the task itself: the agent-forward relay's pump tasks
+            // send reply chunks back through it (#1727). Teardown is driven by an
+            // explicit `Disconnect`, so a task-held clone does not mask it.
+            let command_tx_task = command_tx.clone();
             tokio::spawn(async move {
                 agent_io_task(
                     session,
                     channel,
                     command_rx,
+                    command_tx_task,
                     alive_clone,
                     app_handle_task,
                     agent_id_task,
@@ -1658,6 +1670,7 @@ async fn agent_io_task(
     session: SshSession,
     mut channel: russh::Channel<russh::client::Msg>,
     mut command_rx: UnboundedReceiver<AgentIoCommand>,
+    command_tx: UnboundedSender<AgentIoCommand>,
     alive: Arc<AtomicBool>,
     app_handle: AppHandle,
     agent_id: String,
@@ -1673,6 +1686,9 @@ async fn agent_io_task(
     let mut monitoring_outputs: HashMap<String, MonitoringSender> = HashMap::new();
     let mut pending_responses: HashMap<u64, oneshot::Sender<Result<Value, String>>> =
         HashMap::new();
+    // Desktop end of the ssh-agent relay (#1727): bridges forwarded ssh-agent
+    // streams the agent opens to the operator's own local agent.
+    let agent_forward = DesktopAgentForward::new();
     let mut connection_error: Option<String> = None;
 
     // Replay notifications that arrived during the `initialize` handshake before
@@ -1757,6 +1773,30 @@ async fn agent_io_task(
                                 let _ = channel.data(line.as_bytes()).await;
                             }
                         }
+                        AgentIoCommand::AgentForwardData { stream_id, data } => {
+                            request_id += 1;
+                            let encoded = b64.encode(&data);
+                            if let Ok(line) = serialize_request(
+                                request_id,
+                                "agent.forward.data",
+                                serde_json::json!({
+                                    "stream_id": stream_id,
+                                    "data": encoded,
+                                }),
+                            ) {
+                                let _ = channel.data(line.as_bytes()).await;
+                            }
+                        }
+                        AgentIoCommand::AgentForwardClose { stream_id } => {
+                            request_id += 1;
+                            if let Ok(line) = serialize_request(
+                                request_id,
+                                "agent.forward.close",
+                                serde_json::json!({ "stream_id": stream_id }),
+                            ) {
+                                let _ = channel.data(line.as_bytes()).await;
+                            }
+                        }
                         AgentIoCommand::RegisterSession { session_id, output_tx } => {
                             session_outputs.insert(session_id, output_tx);
                         }
@@ -1807,15 +1847,26 @@ async fn agent_io_task(
                                         }
                                     }
                                     Ok(jsonrpc::JsonRpcMessage::Notification { method, params }) => {
-                                        dispatch_agent_notification(
-                                            &app_handle,
-                                            &agent_id,
+                                        // The ssh-agent relay's streams (#1727)
+                                        // route to the desktop's local agent, not
+                                        // to a session output channel.
+                                        if !handle_agent_forward_notification(
+                                            &agent_forward,
+                                            &command_tx,
                                             &method,
                                             &params,
-                                            &session_outputs,
-                                            &monitoring_outputs,
                                             &b64,
-                                        );
+                                        ) {
+                                            dispatch_agent_notification(
+                                                &app_handle,
+                                                &agent_id,
+                                                &method,
+                                                &params,
+                                                &session_outputs,
+                                                &monitoring_outputs,
+                                                &b64,
+                                            );
+                                        }
                                     }
                                     Err(e) => {
                                         warn!("Agent {}: failed to parse message: {}", agent_id, e);
@@ -2020,6 +2071,43 @@ fn dispatch_agent_notification(
         emit_remote_agent_update_pending(app_handle, agent_id, params);
     }
     handle_notification(method, params, session_outputs, monitoring_outputs, b64);
+}
+
+/// Route an `agent.forward.*` ssh-agent relay notification (#1727) to the
+/// desktop relay handler, returning `true` if it was one (so the caller skips
+/// the normal session/monitoring dispatch).
+fn handle_agent_forward_notification(
+    agent_forward: &DesktopAgentForward,
+    command_tx: &UnboundedSender<AgentIoCommand>,
+    method: &str,
+    params: &Value,
+    b64: &base64::engine::GeneralPurpose,
+) -> bool {
+    match method {
+        "agent.forward.open" => {
+            if let Some(stream_id) = params["stream_id"].as_str() {
+                agent_forward.on_open(stream_id.to_string(), command_tx.clone());
+            }
+            true
+        }
+        "agent.forward.data" => {
+            if let (Some(stream_id), Some(data_b64)) =
+                (params["stream_id"].as_str(), params["data"].as_str())
+            {
+                if let Ok(data) = b64.decode(data_b64) {
+                    agent_forward.on_data(stream_id, data);
+                }
+            }
+            true
+        }
+        "agent.forward.close" => {
+            if let Some(stream_id) = params["stream_id"].as_str() {
+                agent_forward.on_close(stream_id);
+            }
+            true
+        }
+        _ => false,
+    }
 }
 
 /// Handle a notification from the agent.

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent_binary;
 pub mod agent_cancel;
 pub mod agent_deploy;
+pub mod agent_forward;
 pub mod agent_install;
 pub mod agent_manager;
 pub mod agent_setup;


### PR DESCRIPTION
Follow-up to #1719 (PR #1726), which delivered SSH agent forwarding through a deployed agent using the **agent-host-local** ssh-agent. That model only reaches the operator's keys when the desktop→agent leg is *itself* SSH with forwarding on, so the agent host's `$SSH_AUTH_SOCK` chains back. Over the **TCP (`--listen`) transport** there is no such SSH leg — this PR fills that gap.

## Tunnelling approach (the Concept "decide whether")

Rather than abstracting the core russh bridge, this exploits the fact that the daemon's bridge connects to a filesystem `$SSH_AUTH_SOCK`:

- When an SSH session opts into `forwardAgent` (unix), the agent worker binds a **per-session ssh-agent relay socket** and exports it to the session daemon as `SSH_AUTH_SOCK`. The daemon's existing core SSH bridge (`core/src/backends/ssh/agent_forward.rs`) connects to it exactly as it would a real agent — **"the target sees a normal `$SSH_AUTH_SOCK`"**, unchanged.
- Every connection the daemon makes to that socket is tunnelled byte-for-byte over the desktop↔agent JSON-RPC transport, mirroring the PTY plumbing (`connection.output`/`connection.write`): an id-tagged stream carrying base64 chunks via new `agent.forward.{open,data,close}` messages (protocol **0.5.0**).
- The **desktop** bridges each stream to the operator's **own** local ssh-agent, through the same core connector the russh path uses (`connect_local_agent_boxed`).

No local agent is a graceful no-op (desktop answers `open` with `close`; the daemon's bridge drops the channel) — matching #1719's behaviour. Relaying is **unix-only** for now (a Windows agent host's bridge target is a fixed OpenSSH pipe, not an overridable socket), so Windows keeps the #1719 host-local model; gated by `should_relay`.

## Changes

- `core` — public `connect_local_agent_boxed()` so the desktop reuses the exact russh connect logic.
- `agent` — `session::agent_forward::AgentForwardRelay` (per-session listener + stream registry), wired into daemon spawn (`SSH_AUTH_SOCK` env) and session teardown; new `agent.forward.data`/`agent.forward.close` dispatch methods; protocol bump to 0.5.0.
- `src-tauri` — `terminal::agent_forward::DesktopAgentForward` bridges the tunnelled streams to the operator's local agent; new `AgentIoCommand` variants + I/O-loop routing.
- Docs — `remote-protocol.md` (0.5.0 + method/notification specs), change fragment, `docs/testing.md` manual steps.

## Verification

- Unit tests on all three layers (relay stream open/data/close, dispatch parsing, desktop no-agent no-op).
- **Runtime end-to-end** (`relay_socket_exposes_a_real_ssh_agent_key_end_to_end`): a real `ssh-add -l` connecting to the relay socket sees a **live `ssh-agent`'s** key through a stand-in desktop bridge — proving the target's `$SSH_AUTH_SOCK` exposes the operator's keys over the tunnel. Ran locally against a real ssh-agent; skips where ssh tooling is absent.
- Manual `tests/docker` steps documented (integration lane; not per-PR CI).

Closes #1727
