### PR TITLE
feat(ssh): relay the desktop ssh-agent to a windows agent host over tcp (Closes #2038)

### DIFF
--- a/agent/src/daemon/transport.rs
+++ b/agent/src/daemon/transport.rs
@@ -137,7 +137,10 @@ pub use unix_impl::{
 };
 #[cfg(windows)]
 #[allow(unused_imports)]
-pub use windows_impl::{endpoint_alive, registry_endpoint, session_endpoint};
+pub use windows_impl::{
+    agent_forward_endpoint, endpoint_alive, ensure_agent_forward_dir, registry_endpoint,
+    session_endpoint,
+};
 
 // ── Unix session-path helpers ───────────────────────────────────────
 
@@ -255,6 +258,27 @@ mod windows_impl {
     /// Pipe names live in the `\\.\pipe\` namespace and are unique per session.
     pub fn session_endpoint(session_id: &str) -> String {
         format!(r"\\.\pipe\termihub-session-{session_id}")
+    }
+
+    /// Compute the ssh-agent relay pipe name for a session (#2038).
+    ///
+    /// A per-session sibling of the daemon's own pipe, uniquely named so it never
+    /// collides with the agent host's *real* `\\.\pipe\openssh-ssh-agent`.
+    /// Injected into the session daemon via
+    /// [`AGENT_PIPE_ENV`](termihub_core::backends::ssh::agent_forward::AGENT_PIPE_ENV),
+    /// it lets the daemon's core SSH bridge reach the desktop's agent over the
+    /// JSON-RPC transport as if it were a normal local agent — the Windows analog
+    /// of the unix `SSH_AUTH_SOCK` relay socket (#1727).
+    pub fn agent_forward_endpoint(session_id: &str) -> String {
+        format!(r"\\.\pipe\termihub-agent-forward-{session_id}")
+    }
+
+    /// No directory to pre-create for a named-pipe relay on Windows: the pipe
+    /// lives in the machine-global `\\.\pipe\` namespace, so binding it needs no
+    /// filesystem setup. The unix analog makes the `0o700` socket dir the relay
+    /// socket binds into; here it is a no-op that keeps the call site uniform.
+    pub fn ensure_agent_forward_dir() -> std::io::Result<()> {
+        Ok(())
     }
 
     /// Compute the pipe name for the host-wide registry daemon (ADR-11).

--- a/agent/src/session/agent_forward.rs
+++ b/agent/src/session/agent_forward.rs
@@ -14,8 +14,11 @@
 //! # The relay
 //!
 //! When a session opts into `forwardAgent`, the agent worker binds a per-session
-//! Unix socket and exports it to the session daemon as `SSH_AUTH_SOCK` (see
-//! [`crate::session::manager`]). The daemon's core SSH bridge
+//! relay endpoint — a Unix socket on unix, a named pipe on Windows (#2038) — and
+//! exports it to the session daemon (as `SSH_AUTH_SOCK` on unix, via the
+//! dedicated
+//! [`AGENT_PIPE_ENV`](termihub_core::backends::ssh::agent_forward::AGENT_PIPE_ENV)
+//! on Windows). The daemon's core SSH bridge
 //! ([`termihub_core::backends::ssh::agent_forward`]) then connects to *that*
 //! socket exactly as it would a normal agent — "the target sees a normal
 //! `$SSH_AUTH_SOCK`". Each connection the daemon opens is tunnelled, byte for
@@ -35,12 +38,13 @@
 //! - either side **`agent.forward.close`** `{stream_id}` — the stream ended.
 //!
 //! No desktop agent is a graceful no-op: the desktop answers `open` with an
-//! immediate `close`, the relay socket closes, and the daemon's bridge drops the
-//! forwarded channel — matching #1719's no-agent behaviour.
+//! immediate `close`, the relay endpoint closes, and the daemon's bridge drops
+//! the forwarded channel — matching #1719's no-agent behaviour.
 //!
-//! Relaying is **unix-only** for now: the desktop bridge target on Windows is a
-//! fixed OpenSSH named pipe rather than a `SSH_AUTH_SOCK` we can override, so a
-//! Windows agent host keeps #1719's host-local model. [`should_relay`] gates it.
+//! Both unix and Windows agent hosts relay (#1727 shipped unix; #2038 added the
+//! Windows named-pipe path). Only truly exotic targets with neither a Unix socket
+//! nor a named pipe fall back to #1719's host-local model; [`should_relay`] gates
+//! it.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -67,10 +71,16 @@ const CHUNK_SIZE: usize = 65536;
 /// Sender that feeds desktop→socket bytes to one accepted relay connection.
 type StreamSink = tokio::sync::mpsc::UnboundedSender<Vec<u8>>;
 
-/// Per-session listener bookkeeping so a closed session tears its socket down.
-#[cfg(unix)]
+/// Per-session listener bookkeeping so a closed session tears its endpoint down.
+///
+/// Aborting `handle` stops the accept loop; on unix the bound socket file must
+/// also be unlinked, whereas a Windows named pipe vanishes once its last server
+/// handle drops (the pending instance the accept task holds), so it carries no
+/// `path`.
+#[cfg(any(unix, windows))]
 struct ListenerGuard {
     handle: tokio::task::JoinHandle<()>,
+    #[cfg(unix)]
     path: String,
 }
 
@@ -85,9 +95,9 @@ pub struct AgentForwardRelay {
     /// `stream_id` → sink writing bytes into that connection (desktop → socket).
     streams: Mutex<HashMap<String, StreamSink>>,
     /// `session_id` → its listener, so [`stop_listener`](Self::stop_listener)
-    /// can drop the socket when the session ends. Unix-only (the only relaying
-    /// platform).
-    #[cfg(unix)]
+    /// can drop the endpoint when the session ends. Present on every relaying
+    /// platform (unix socket / Windows pipe).
+    #[cfg(any(unix, windows))]
     listeners: Mutex<HashMap<String, ListenerGuard>>,
 }
 
@@ -97,16 +107,17 @@ impl AgentForwardRelay {
         Arc::new(Self {
             notification_tx,
             streams: Mutex::new(HashMap::new()),
-            #[cfg(unix)]
+            #[cfg(any(unix, windows))]
             listeners: Mutex::new(HashMap::new()),
         })
     }
 
     /// Whether a session should get a desktop-agent relay: only an SSH session
-    /// that opted into `forwardAgent`, and only on unix (see the module docs on
-    /// the Windows limitation).
+    /// that opted into `forwardAgent`, and only on a platform whose bridge target
+    /// can be overridden per session (unix socket / Windows pipe — see the module
+    /// docs). Exotic targets with neither fall back to #1719's host-local model.
     pub fn should_relay(type_id: &str, settings: &serde_json::Value) -> bool {
-        cfg!(unix)
+        (cfg!(unix) || cfg!(windows))
             && type_id == "ssh"
             && settings
                 .get("forwardAgent")
@@ -165,13 +176,48 @@ impl AgentForwardRelay {
         Ok(path)
     }
 
-    /// Tear a session's relay down: stop accepting, remove the socket file, and
-    /// drop any of its still-open streams. Idempotent; a no-op on non-unix.
+    /// Start a per-session ssh-agent relay named pipe and return its name to
+    /// inject into the daemon via
+    /// [`AGENT_PIPE_ENV`](termihub_core::backends::ssh::agent_forward::AGENT_PIPE_ENV)
+    /// (#2038) — the Windows analog of the unix relay socket.
+    ///
+    /// The first server instance is bound up front so a name collision surfaces
+    /// synchronously, before the daemon is told to use it; the accept loop keeps a
+    /// fresh instance armed for each subsequent connection.
+    #[cfg(windows)]
+    pub async fn start_listener(self: &Arc<Self>, session_id: &str) -> std::io::Result<String> {
+        use tokio::net::windows::named_pipe::ServerOptions;
+
+        let pipe = crate::daemon::transport::agent_forward_endpoint(session_id);
+        let server = ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(&pipe)?;
+
+        let relay = Arc::clone(self);
+        let name = pipe.clone();
+        let sid = session_id.to_string();
+        let handle = tokio::spawn(async move { relay.accept_loop(server, name, sid).await });
+
+        self.listeners
+            .lock()
+            .await
+            .insert(session_id.to_string(), ListenerGuard { handle });
+        debug!(session_id, %pipe, "started ssh-agent relay pipe");
+        Ok(pipe)
+    }
+
+    /// Tear a session's relay down: stop accepting, remove the socket file (unix),
+    /// and drop any of its still-open streams. Idempotent; a no-op on a platform
+    /// that never relays.
     pub async fn stop_listener(&self, session_id: &str) {
-        #[cfg(unix)]
+        #[cfg(any(unix, windows))]
         {
             if let Some(guard) = self.listeners.lock().await.remove(session_id) {
+                // Aborting the accept task drops its pending pipe instance on
+                // Windows, which closes the pipe; on unix the socket file must be
+                // unlinked explicitly.
                 guard.handle.abort();
+                #[cfg(unix)]
                 let _ = std::fs::remove_file(&guard.path);
             }
         }
@@ -203,10 +249,58 @@ impl AgentForwardRelay {
         }
     }
 
+    /// Accept forwarded ssh-agent connections on the session's named pipe until
+    /// the session ends (the task is aborted by
+    /// [`stop_listener`](Self::stop_listener)).
+    ///
+    /// A Windows named-pipe server serves one client per instance, so after a
+    /// client connects the next instance is armed immediately — before the
+    /// accepted connection is handed off — so a client arriving right behind it is
+    /// not refused (the core connector also retries briefly on a busy pipe).
+    #[cfg(windows)]
+    async fn accept_loop(
+        self: Arc<Self>,
+        first: tokio::net::windows::named_pipe::NamedPipeServer,
+        pipe: String,
+        session_id: String,
+    ) {
+        use tokio::net::windows::named_pipe::ServerOptions;
+
+        let mut server = first;
+        let mut counter: u64 = 0;
+        loop {
+            if let Err(e) = server.connect().await {
+                debug!(session_id, "ssh-agent relay pipe connect ended: {e}");
+                break;
+            }
+            let connected = server;
+
+            // Arm the next instance before serving this one.
+            let next = ServerOptions::new().create(&pipe);
+            counter += 1;
+            let stream_id = format!("{}{}", stream_prefix(&session_id), counter);
+            Arc::clone(&self).spawn_stream(connected, stream_id).await;
+
+            server = match next {
+                Ok(s) => s,
+                Err(e) => {
+                    debug!(session_id, "ssh-agent relay pipe re-arm failed: {e}");
+                    break;
+                }
+            };
+        }
+    }
+
     /// Wire one accepted connection to the desktop: register a write sink,
-    /// announce it, then pump bytes socket→desktop for the life of the stream.
-    #[cfg(unix)]
-    async fn spawn_stream(self: Arc<Self>, conn: tokio::net::UnixStream, stream_id: String) {
+    /// announce it, then pump bytes endpoint→desktop for the life of the stream.
+    ///
+    /// Generic over the connection type so the unix socket and Windows pipe accept
+    /// loops share one body.
+    #[cfg(any(unix, windows))]
+    async fn spawn_stream<S>(self: Arc<Self>, conn: S, stream_id: String)
+    where
+        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + 'static,
+    {
         let (read_half, write_half) = tokio::io::split(conn);
 
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
@@ -219,14 +313,13 @@ impl AgentForwardRelay {
         tokio::spawn(async move { relay.read_socket(read_half, stream_id).await });
     }
 
-    /// Pump socket → desktop: forward each read as a data notification, and on
+    /// Pump endpoint → desktop: forward each read as a data notification, and on
     /// EOF/error deregister the stream and tell the desktop it closed.
-    #[cfg(unix)]
-    async fn read_socket(
-        self: Arc<Self>,
-        mut read_half: tokio::io::ReadHalf<tokio::net::UnixStream>,
-        stream_id: String,
-    ) {
+    #[cfg(any(unix, windows))]
+    async fn read_socket<R>(self: Arc<Self>, mut read_half: R, stream_id: String)
+    where
+        R: tokio::io::AsyncRead + Unpin + Send + 'static,
+    {
         use tokio::io::AsyncReadExt;
         let b64 = base64::engine::general_purpose::STANDARD;
         let mut buf = vec![0u8; CHUNK_SIZE];
@@ -256,14 +349,15 @@ fn stream_prefix(session_id: &str) -> String {
     format!("{session_id}#")
 }
 
-/// Pump desktop → socket: write each queued reply chunk to the connection until
+/// Pump desktop → endpoint: write each queued reply chunk to the connection until
 /// the desktop closes the stream (sink dropped), then shut the write side so the
-/// daemon's bridge sees EOF.
-#[cfg(unix)]
-async fn write_socket(
-    mut write_half: tokio::io::WriteHalf<tokio::net::UnixStream>,
-    mut rx: tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
-) {
+/// daemon's bridge sees EOF. Generic over the connection's write half so the unix
+/// socket and Windows pipe share one body.
+#[cfg(any(unix, windows))]
+async fn write_socket<W>(mut write_half: W, mut rx: tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>)
+where
+    W: tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
     use tokio::io::AsyncWriteExt;
     while let Some(bytes) = rx.recv().await {
         if write_half.write_all(&bytes).await.is_err() {
@@ -286,8 +380,9 @@ mod tests {
         (AgentForwardRelay::new(tx), rx)
     }
 
-    /// Relaying is gated to SSH sessions that asked for `forwardAgent` — and,
-    /// because the desktop bridge target is only overridable on unix, to unix.
+    /// Relaying is gated to SSH sessions that asked for `forwardAgent`, on any
+    /// platform whose bridge target is overridable per session (unix socket /
+    /// Windows pipe).
     #[test]
     fn should_relay_only_for_ssh_forward_agent() {
         let on = json!({ "forwardAgent": true });
@@ -296,8 +391,8 @@ mod tests {
 
         assert_eq!(
             AgentForwardRelay::should_relay("ssh", &on),
-            cfg!(unix),
-            "ssh + forwardAgent relays on unix only"
+            cfg!(unix) || cfg!(windows),
+            "ssh + forwardAgent relays on unix and windows"
         );
         assert!(!AgentForwardRelay::should_relay("ssh", &off));
         assert!(!AgentForwardRelay::should_relay("ssh", &absent));
@@ -571,6 +666,109 @@ mod tests {
             listed.status.success() && stdout.contains("thub-1727-e2e"),
             "relay socket must expose the live agent's key; got status={:?} stdout={stdout:?}",
             listed.status
+        );
+    }
+
+    /// Windows analog of `accepted_connection_streams_open_data_close`: a client
+    /// connecting to the per-session **named pipe** is announced with `open`, its
+    /// bytes tunnel as base64 `data`, and disconnecting yields `close`. Exercises
+    /// the whole pipe→desktop pump on the platform #2038 added.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn accepted_pipe_connection_streams_open_data_close() {
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::windows::named_pipe::ClientOptions;
+
+        let (relay, mut rx) = test_relay();
+        let session_id = format!("afr-win-{}", std::process::id());
+        let pipe = relay
+            .start_listener(&session_id)
+            .await
+            .expect("start listener");
+
+        let mut client = ClientOptions::new()
+            .open(&pipe)
+            .expect("connect relay pipe");
+        client.write_all(b"hello-agent").await.expect("write");
+        client.flush().await.expect("flush");
+
+        let open = rx.recv().await.expect("open notification");
+        assert_eq!(open.method, AGENT_FORWARD_OPEN);
+        let stream_id = open.params["stream_id"].as_str().unwrap().to_string();
+        assert!(stream_id.starts_with(&stream_prefix(&session_id)));
+
+        let data = rx.recv().await.expect("data notification");
+        assert_eq!(data.method, AGENT_FORWARD_DATA);
+        assert_eq!(data.params["stream_id"], stream_id);
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(data.params["data"].as_str().unwrap())
+            .unwrap();
+        assert_eq!(decoded, b"hello-agent");
+
+        drop(client);
+        let close = rx.recv().await.expect("close notification");
+        assert_eq!(close.method, AGENT_FORWARD_CLOSE);
+        assert_eq!(close.params["stream_id"], stream_id);
+
+        relay.stop_listener(&session_id).await;
+    }
+
+    /// Windows analog of `desktop_reply_bytes_reach_the_client`: bytes the desktop
+    /// supplies via `write` reach the client connected to the relay pipe.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn desktop_reply_bytes_reach_the_pipe_client() {
+        use tokio::io::AsyncReadExt;
+        use tokio::net::windows::named_pipe::ClientOptions;
+
+        let (relay, mut rx) = test_relay();
+        let session_id = format!("afr-win-reply-{}", std::process::id());
+        let pipe = relay
+            .start_listener(&session_id)
+            .await
+            .expect("start listener");
+
+        let mut client = ClientOptions::new()
+            .open(&pipe)
+            .expect("connect relay pipe");
+
+        // The server accepts on connect, so `open` fires without the client
+        // writing anything.
+        let open = rx.recv().await.expect("open notification");
+        let stream_id = open.params["stream_id"].as_str().unwrap().to_string();
+
+        relay.write(&stream_id, b"agent-reply".to_vec()).await;
+
+        let mut buf = vec![0u8; 11];
+        client.read_exact(&mut buf).await.expect("read reply");
+        assert_eq!(&buf, b"agent-reply");
+
+        relay.stop_listener(&session_id).await;
+    }
+
+    /// Windows analog of `stop_listener_removes_socket_and_streams`: tearing a
+    /// session down drops its still-open streams (the pipe closes when the accept
+    /// task's pending instance is aborted).
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn stop_listener_clears_streams_on_windows() {
+        use tokio::net::windows::named_pipe::ClientOptions;
+
+        let (relay, _rx) = test_relay();
+        let session_id = format!("afr-win-stop-{}", std::process::id());
+        let pipe = relay
+            .start_listener(&session_id)
+            .await
+            .expect("start listener");
+
+        let _client = ClientOptions::new().open(&pipe).expect("connect");
+        // Let the accept loop register the stream.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        relay.stop_listener(&session_id).await;
+        assert!(
+            relay.streams.lock().await.is_empty(),
+            "session's streams dropped on teardown"
         );
     }
 }

--- a/agent/src/session/manager.rs
+++ b/agent/src/session/manager.rs
@@ -183,9 +183,11 @@ impl fmt::Display for DeferredUpdateError {
 pub trait DaemonLauncher: Send + Sync + 'static {
     /// Spawn a daemon for the given session and return the connected backend.
     ///
-    /// `ssh_auth_sock`, when set, is exported to the daemon as `SSH_AUTH_SOCK`
-    /// so its core SSH agent-forwarding bridge reaches the desktop's agent via
-    /// the relay socket instead of the agent host's own agent (#1727).
+    /// `ssh_auth_sock`, when set, is the per-session relay endpoint exported to
+    /// the daemon so its core SSH agent-forwarding bridge reaches the desktop's
+    /// agent instead of the agent host's own agent — as `SSH_AUTH_SOCK` for the
+    /// unix relay socket (#1727) or the dedicated pipe-name variable for the
+    /// Windows relay pipe (#2038).
     async fn launch(
         &self,
         session_id: &str,
@@ -243,12 +245,22 @@ impl DaemonLauncher for SystemDaemonLauncher {
             .env("TERMIHUB_BUFFER_SIZE", buffer_size_bytes.to_string())
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null());
-        // Point the daemon's core SSH agent-forwarding bridge at the relay
-        // socket, so it reaches the desktop's agent rather than the agent host's
-        // own `$SSH_AUTH_SOCK` (#1727). Overriding the inherited value is the
-        // intent: over the TCP transport there is nothing useful to inherit.
-        if let Some(sock) = ssh_auth_sock {
-            command.env("SSH_AUTH_SOCK", sock);
+        // Point the daemon's core SSH agent-forwarding bridge at the per-session
+        // relay endpoint, so it reaches the desktop's agent rather than the agent
+        // host's own local agent. Overriding the inherited value is the intent:
+        // over the TCP transport there is nothing useful to inherit. The channel
+        // differs by platform — `SSH_AUTH_SOCK` for the unix relay socket (#1727),
+        // the dedicated pipe-name variable for the Windows relay pipe (#2038,
+        // kept clear of `SSH_AUTH_SOCK` so a real local OpenSSH agent is not
+        // shadowed).
+        if let Some(endpoint) = ssh_auth_sock {
+            #[cfg(windows)]
+            command.env(
+                termihub_core::backends::ssh::agent_forward::AGENT_PIPE_ENV,
+                endpoint,
+            );
+            #[cfg(not(windows))]
+            command.env("SSH_AUTH_SOCK", endpoint);
         }
         crate::daemon::spawn::configure_detached_stderr(&mut command, daemon_log(session_id));
         crate::daemon::spawn::configure_detachment(&mut command);
@@ -533,9 +545,9 @@ impl SessionManager {
 
         // For an SSH session that opted into `forwardAgent`, stand up a
         // per-session ssh-agent relay to the desktop and hand the daemon its
-        // socket as `SSH_AUTH_SOCK` (#1727). Best-effort: if the relay can't
-        // bind we still launch, and forwarding just falls back to whatever the
-        // daemon inherits (the #1719 host-local behaviour).
+        // endpoint (unix socket / Windows pipe, #1727/#2038). Best-effort: if the
+        // relay can't bind we still launch, and forwarding just falls back to
+        // whatever the daemon inherits (the #1719 host-local behaviour).
         let ssh_auth_sock = self
             .start_agent_forward(session_id, type_id, settings)
             .await;
@@ -561,7 +573,8 @@ impl SessionManager {
     }
 
     /// Start the desktop ssh-agent relay for a session when it applies, returning
-    /// the socket path to export to the daemon as `SSH_AUTH_SOCK` (#1727).
+    /// the relay endpoint (unix socket / Windows pipe) to export to the daemon
+    /// (#1727/#2038).
     async fn start_agent_forward(
         &self,
         session_id: &str,
@@ -571,17 +584,17 @@ impl SessionManager {
         if !AgentForwardRelay::should_relay(type_id, settings) {
             return None;
         }
-        #[cfg(unix)]
+        #[cfg(any(unix, windows))]
         {
             match self.agent_forward.start_listener(session_id).await {
-                Ok(path) => Some(path),
+                Ok(endpoint) => Some(endpoint),
                 Err(e) => {
                     warn!("failed to start ssh-agent relay for {session_id}: {e}");
                     None
                 }
             }
         }
-        #[cfg(not(unix))]
+        #[cfg(not(any(unix, windows)))]
         {
             let _ = session_id;
             None

--- a/core/src/backends/ssh/agent_forward.rs
+++ b/core/src/backends/ssh/agent_forward.rs
@@ -57,11 +57,56 @@ async fn connect_local_agent() -> std::io::Result<tokio::net::UnixStream> {
     tokio::net::UnixStream::connect(sock).await
 }
 
+/// Env var that overrides the Windows agent-bridge target named pipe (#2038).
+///
+/// The unix relay hands the session daemon a per-session `$SSH_AUTH_SOCK`; the
+/// Windows bridge has no such convention baked in (it opens a *fixed* OpenSSH
+/// pipe and ignores `SSH_AUTH_SOCK`), so the per-session relay pipe is injected
+/// through this dedicated variable instead — keeping it clear of a real local
+/// OpenSSH agent. Only the session daemon ever has it set, so the desktop's own
+/// [`connect_local_agent_boxed`] still reaches the operator's real agent pipe.
+#[cfg(windows)]
+pub const AGENT_PIPE_ENV: &str = "TERMIHUB_SSH_AGENT_PIPE";
+
+/// The fixed OpenSSH agent pipe used when no per-session override is injected.
+#[cfg(windows)]
+const OPENSSH_AGENT_PIPE: &str = r"\\.\pipe\openssh-ssh-agent";
+
 /// Connect a raw byte stream to the local SSH agent (Windows OpenSSH named pipe).
+///
+/// Honors [`AGENT_PIPE_ENV`] when set — the per-session relay pipe injected into
+/// the session daemon (#2038) — and otherwise the fixed OpenSSH agent pipe. When
+/// the target pipe reports every instance momentarily busy (`ERROR_PIPE_BUSY`,
+/// which the relay causes for a tiny window while it re-arms its next server
+/// instance), it retries briefly rather than failing; a genuinely absent pipe
+/// returns `NotFound` immediately, preserving the graceful no-op.
 #[cfg(windows)]
 async fn connect_local_agent() -> std::io::Result<tokio::net::windows::named_pipe::NamedPipeClient>
 {
-    tokio::net::windows::named_pipe::ClientOptions::new().open(r"\\.\pipe\openssh-ssh-agent")
+    use tokio::net::windows::named_pipe::ClientOptions;
+    use windows_sys::Win32::Foundation::ERROR_PIPE_BUSY;
+
+    let pipe = std::env::var_os(AGENT_PIPE_ENV)
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| OPENSSH_AGENT_PIPE.into());
+
+    // A handful of quick retries covers the re-arm race without hanging: at
+    // 25 ms each this is well under a second, and only ERROR_PIPE_BUSY loops —
+    // every other error (including a missing pipe) returns at once.
+    const MAX_ATTEMPTS: u32 = 20;
+    for attempt in 0..MAX_ATTEMPTS {
+        match ClientOptions::new().open(&pipe) {
+            Ok(client) => return Ok(client),
+            Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY as i32) => {
+                if attempt + 1 == MAX_ATTEMPTS {
+                    return Err(e);
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    unreachable!("loop returns on the final attempt")
 }
 
 /// Neither Unix domain sockets nor the Windows agent pipe exist on other targets;

--- a/docs/changes/dev3/feature/2038-agent-forward-windows.md
+++ b/docs/changes/dev3/feature/2038-agent-forward-windows.md
@@ -3,7 +3,7 @@
 - SSH **agent forwarding over the TCP (`--listen`) transport now works through a
   Windows agent host too** (#2038, follow-up to #1727). #1727 relayed the
   desktop's ssh-agent to a deployed agent over the JSON-RPC transport but only on
-  unix, because the daemon's core SSH bridge on Windows opened a *fixed* OpenSSH
+  unix, because the daemon's core SSH bridge on Windows opened a _fixed_ OpenSSH
   named pipe and ignored any per-session override. The bridge now honors a
   dedicated `TERMIHUB_SSH_AGENT_PIPE` variable, so the agent worker can bind a
   per-session relay **named pipe** (`\\.\pipe\termihub-agent-forward-<session>`)

--- a/docs/changes/dev3/feature/2038-agent-forward-windows.md
+++ b/docs/changes/dev3/feature/2038-agent-forward-windows.md
@@ -1,0 +1,14 @@
+### Added
+
+- SSH **agent forwarding over the TCP (`--listen`) transport now works through a
+  Windows agent host too** (#2038, follow-up to #1727). #1727 relayed the
+  desktop's ssh-agent to a deployed agent over the JSON-RPC transport but only on
+  unix, because the daemon's core SSH bridge on Windows opened a *fixed* OpenSSH
+  named pipe and ignored any per-session override. The bridge now honors a
+  dedicated `TERMIHUB_SSH_AGENT_PIPE` variable, so the agent worker can bind a
+  per-session relay **named pipe** (`\\.\pipe\termihub-agent-forward-<session>`)
+  and inject it into the daemon without shadowing a real local OpenSSH agent. A
+  session routed through a Windows agent host with **Forward SSH agent** on now
+  exposes the operator's desktop keys on the final target, matching the unix
+  behaviour; no reachable agent stays a graceful no-op. No protocol change — the
+  `agent.forward.*` messages (remote-protocol 0.5.0) are unchanged.

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -1747,7 +1747,7 @@ A session-level error that does not necessarily terminate the session.
 
 ### `agent.forward.open`
 
-SSH agent forwarding, deployed-agent + TCP transport (#1727). When a session routed through a deployed agent opts into `forwardAgent` and the desktop reaches that agent over the **TCP transport**, there is no SSH leg to piggyback forwarding on (unlike the #1719 host-local model). Instead the agent binds a per-session ssh-agent socket, hands it to the session daemon as `$SSH_AUTH_SOCK`, and tunnels every connection the daemon makes to it back to the desktop over these `agent.forward.*` messages. The desktop bridges each stream to the operator's **own** local ssh-agent, so the operator's keys reach the final target regardless of transport.
+SSH agent forwarding, deployed-agent + TCP transport (#1727, extended to Windows in #2038). When a session routed through a deployed agent opts into `forwardAgent` and the desktop reaches that agent over the **TCP transport**, there is no SSH leg to piggyback forwarding on (unlike the #1719 host-local model). Instead the agent binds a per-session ssh-agent relay endpoint — a Unix socket handed to the session daemon as `$SSH_AUTH_SOCK`, or (on Windows) a uniquely-named named pipe injected via the dedicated `TERMIHUB_SSH_AGENT_PIPE` variable — and tunnels every connection the daemon makes to it back to the desktop over these `agent.forward.*` messages. The desktop bridges each stream to the operator's **own** local ssh-agent, so the operator's keys reach the final target regardless of transport or platform.
 
 `agent.forward.open` announces a new forwarded stream (a program on the target contacted its `$SSH_AUTH_SOCK`). The desktop connects its local agent and prepares to pump bytes.
 
@@ -1763,7 +1763,7 @@ SSH agent forwarding, deployed-agent + TCP transport (#1727). When a session rou
 | ----------- | -------- | ------------------------------------------------------- |
 | `stream_id` | `string` | Unique id for this forwarded stream (embeds session id) |
 
-If the desktop has no reachable local agent, it answers with an immediate [`agent.forward.close`](#agentforwardclose) — the forwarded channel is then dropped as a graceful no-op, matching the SSH-reached no-agent behaviour (#1699/#1719). **Relaying is unix-only**: on a Windows agent host the daemon's bridge target is a fixed OpenSSH pipe rather than an overridable `$SSH_AUTH_SOCK`, so a Windows agent keeps the #1719 host-local model.
+If the desktop has no reachable local agent, it answers with an immediate [`agent.forward.close`](#agentforwardclose) — the forwarded channel is then dropped as a graceful no-op, matching the SSH-reached no-agent behaviour (#1699/#1719). **Relaying works on both unix and Windows agent hosts** (#1727 shipped unix; #2038 added the Windows named-pipe path — the daemon's core SSH bridge honors `TERMIHUB_SSH_AGENT_PIPE`, keeping the relay pipe clear of a real local OpenSSH agent). Only an exotic target with neither a Unix socket nor a named pipe falls back to the #1719 host-local model.
 
 ### `agent.forward.data` (notification)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2425,16 +2425,18 @@ Closes the #1719 gap above: when the desktop reaches a deployed agent over the
 agent forwarding on. termiHub now relays the **desktop's** own ssh-agent to the
 session daemon over the desktop↔agent JSON-RPC transport (`agent.forward.*`
 messages), so the operator's keys reach the final target with no ssh-agent on the
-agent host at all. The relay socket is handed to the daemon as `$SSH_AUTH_SOCK`,
-so the daemon's core bridge and the target see a normal agent.
+agent host at all. The relay endpoint is handed to the daemon as `$SSH_AUTH_SOCK`
+(unix) or via the dedicated `TERMIHUB_SSH_AGENT_PIPE` named-pipe variable
+(Windows, #2038), so the daemon's core bridge and the target see a normal agent.
 
 The relay's stream plumbing (open/data/close, the local-agent bridge, the
 no-agent no-op) is covered by **Rust unit tests**
 (`agent/src/session/agent_forward.rs`, `agent/src/handler/dispatch.rs`,
-`src-tauri/src/terminal/agent_forward.rs`). End-to-end forwarding needs a live
-agent + real SSH server reached over TCP (integration lane only, not per-PR CI),
-so verify manually — this path is **unix-only** (a Windows agent host keeps the
-host-local model from #1719):
+`src-tauri/src/terminal/agent_forward.rs`) — including Windows named-pipe listener
+tests that run on the Windows CI leg. End-to-end forwarding needs a live agent +
+real SSH server reached over TCP (integration lane only, not per-PR CI), so verify
+manually. The relay now works on **both unix and Windows** agent hosts (#1727
+shipped unix; #2038 added the Windows named-pipe path):
 
 1. Ensure a local agent has a key: `ssh-add -l` lists at least one identity.
 2. Deploy the agent to an intermediate host and reach it over the **TCP
@@ -2448,6 +2450,21 @@ host-local model from #1719):
 4. **No agent:** stop the desktop's agent (unset `SSH_AUTH_SOCK`) and reconnect
    with the toggle still on — the connection must **succeed** with forwarding
    silently skipped; `ssh-add -l` on the target reports no agent.
+
+**Windows agent host (#2038).** Repeat steps 1–4 with the deployed agent running
+on a **Windows** host reached over the TCP transport:
+
+- The daemon's core SSH bridge connects to the per-session relay **named pipe**
+  (`\\.\pipe\termihub-agent-forward-<session>`), injected via
+  `TERMIHUB_SSH_AGENT_PIPE` — it does **not** touch the host's real
+  `\\.\pipe\openssh-ssh-agent`, so a real local OpenSSH agent on the Windows host
+  is neither required nor shadowed. Confirm the target's `ssh-add -l` lists **your
+  desktop's** identities.
+- The desktop bridging can be exercised from either a unix or Windows desktop
+  (`connect_local_agent_boxed` reaches the desktop's own agent — `$SSH_AUTH_SOCK`
+  socket on unix, `\\.\pipe\openssh-ssh-agent` on a Windows desktop).
+- **No agent:** with no desktop agent reachable, connect with the toggle on — the
+  connection must **succeed** with forwarding silently skipped.
 
 ### X11 / GUI forwarding
 


### PR DESCRIPTION
Follow-up to #1727 (PR #2037), which relayed the desktop's ssh-agent to a deployed agent over the **TCP (`--listen`) transport** — but **unix-only**. On Windows the daemon's core SSH bridge opened a *fixed* OpenSSH named pipe (`\\.\pipe\openssh-ssh-agent`) and ignored any per-session override, so there was no relay target to inject; a Windows agent host kept #1719's host-local model. This PR closes that gap.

## Approach

- **`core`** — the Windows `connect_local_agent()` now honors a dedicated `TERMIHUB_SSH_AGENT_PIPE` variable (falling back to the fixed OpenSSH pipe). A dedicated variable rather than `SSH_AUTH_SOCK` keeps the injected per-session relay pipe **clear of a real local OpenSSH agent** — only the session daemon ever has it set, so the desktop's own `connect_local_agent_boxed` still reaches the operator's real agent. A brief `ERROR_PIPE_BUSY` retry covers the tiny window while the relay re-arms its next server instance.
- **`agent`** — `AgentForwardRelay` binds a per-session **named pipe** (`\\.\pipe\termihub-agent-forward-<session>`) on Windows, mirroring the `#[cfg(unix)]` socket listener; the session daemon gets the pipe name via `TERMIHUB_SSH_AGENT_PIPE`. The pump plumbing (open/data/close, teardown) is now generic over the connection type so the unix socket and Windows pipe share one body. `should_relay` extended to Windows. New `agent_forward_endpoint` / `ensure_agent_forward_dir` Windows transport helpers.
- No protocol change — the `agent.forward.*` messages (remote-protocol **0.5.0**) are unchanged; only the platform notes and manual steps were updated.

## Verification — what is proven vs. manual

- **Unix + platform-agnostic:** all existing `agent_forward` unit tests pass on macOS (including the real-`ssh-agent` end-to-end test), covering the generic-pump refactor and `should_relay`.
- **Windows CI legs are the bar for the new path** (this is a macOS coordinator machine — the Windows named-pipe path **cannot** be end-to-end verified locally). Added `#[cfg(windows)]` unit tests that exercise the pipe listener (open/data/close, desktop-reply-reaches-client, teardown) — these run on **`Run Tests (windows-latest)`**, and the code compiles on **`Build on windows-latest`**.
- **Cross-check done locally:** the risky Windows API surface (tokio `named_pipe` `ServerOptions`/`ClientOptions`/`connect`, the generic split-based pump, `windows_sys::…::ERROR_PIPE_BUSY`) was isolated into a scratch crate with only pure-Rust deps and typechecked clean against `--target x86_64-pc-windows-msvc`. A full cross-build is blocked locally only by a C dependency (`aws-lc-sys`) needing `windows.h`, which is unrelated to this diff.
- **Windows end-to-end forwarding is NOT verified locally** — it is documented as manual / integration-cadence in `docs/testing.md` (a Windows agent host reached over TCP, target `ssh-add -l` must list the desktop's keys; no-agent = graceful no-op).

Closes #2038
