### PR TITLE
fix(backend): bound plugin decompression against zip-bomb DoS (Closes #2046)

### DIFF
--- a/core/src/plugin/manager.rs
+++ b/core/src/plugin/manager.rs
@@ -35,7 +35,6 @@
 //! read-modify-write of the state files (concept "Edge Cases").
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -45,7 +44,10 @@ use serde_json::{Map, Value};
 use thiserror::Error;
 
 use super::manifest::{parse_manifest, ApiCompatibility, PluginManifest};
-use super::package::{validate_package, PluginPackageError, MANIFEST_FILE_NAME};
+use super::package::{
+    check_package_size, read_entry_bounded, validate_package, PluginPackageError,
+    MANIFEST_FILE_NAME, MAX_DECOMPRESSED_ENTRY_BYTES, MAX_DECOMPRESSED_TOTAL_BYTES,
+};
 use super::security::{assess_trust, TrustAssessment, TrustLevel};
 use super::signature::{self, VerifiedArchive};
 use super::trust_store::{TrustStore, TrustStoreError, TrustedPublisher};
@@ -357,6 +359,13 @@ impl PluginManager {
         accept_untrusted: bool,
         trust_publisher: bool,
     ) -> Result<InstalledPlugin, PluginManagerError> {
+        // Reject an oversize (compressed) package up front, before trust
+        // assessment opens and reads the archive. The compressed-size gate used to
+        // live only inside `validate_package`, which runs *after* the trust gate —
+        // so trust assessment would decompress an unbounded archive first (#2046).
+        // Per-entry decompression is separately bounded while reading.
+        check_package_size(package_path)?;
+
         // Trust gate (concept security flowchart): assessed before touching the
         // package. A tampered signature is a hard block; an unsigned package needs
         // the risk accepted; signed/verified proceed.
@@ -791,6 +800,24 @@ fn extract_package(
     dest: &Path,
     expected_key_id: Option<&str>,
 ) -> Result<(), PluginManagerError> {
+    extract_package_with_limits(
+        package_path,
+        dest,
+        expected_key_id,
+        MAX_DECOMPRESSED_ENTRY_BYTES,
+        MAX_DECOMPRESSED_TOTAL_BYTES,
+    )
+}
+
+/// [`extract_package`] with explicit decompression limits, so the zip-bomb guard
+/// on the extraction path can be exercised in tests with tiny fixtures.
+fn extract_package_with_limits(
+    package_path: &Path,
+    dest: &Path,
+    expected_key_id: Option<&str>,
+    per_entry_limit: u64,
+    total_limit: u64,
+) -> Result<(), PluginManagerError> {
     let file = std::fs::File::open(package_path)?;
     let mut archive =
         zip::ZipArchive::new(file).map_err(|e| PluginManagerError::Extract(e.to_string()))?;
@@ -832,6 +859,7 @@ fn extract_package(
         .map(|m| m.keys().collect())
         .unwrap_or_default();
 
+    let mut remaining = total_limit;
     for i in 0..archive.len() {
         let mut entry = archive
             .by_index(i)
@@ -849,8 +877,10 @@ fn extract_package(
         if let Some(parent) = out_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
+        // Bound decompression: an over-budget entry aborts extraction (surfaced as
+        // `PluginManagerError::Io`) instead of exhausting memory/disk (#2046).
         let mut buf = Vec::new();
-        entry.read_to_end(&mut buf)?;
+        read_entry_bounded(&mut entry, per_entry_limit, &mut remaining, &mut buf)?;
 
         // Bind the exact bytes about to be written to the signed digest map. The
         // signature entry itself is not part of the signed set, so skip it.
@@ -909,7 +939,7 @@ fn write_json_atomic<T: Serialize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
+    use std::io::{Read, Write};
     use tempfile::TempDir;
     use zip::write::SimpleFileOptions;
     use zip::ZipWriter;
@@ -1456,6 +1486,63 @@ mod tests {
         let err = extract_package(&unsigned, &dest, Some("sha256:approved")).unwrap_err();
         assert!(matches!(err, PluginManagerError::SignatureTampered));
         assert!(!dest.join(MANIFEST_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn extract_rejects_an_entry_over_the_decompression_budget() {
+        // A package entry whose decompressed size exceeds the per-entry cap is
+        // rejected while extracting, not read into memory — the extraction-path
+        // half of the zip-bomb guard (#2046). Unsigned + `None` so the signature
+        // binding does not short-circuit before the read.
+        let tmp = TempDir::new().unwrap();
+        let pkg = make_package(
+            tmp.path(),
+            &manifest_json("bomb", "1.0"),
+            &[("bomb.bin", &[0u8; 4096])],
+        );
+        let dest = tmp.path().join("out");
+        let err = extract_package_with_limits(&pkg, &dest, None, 64, 1_000_000).unwrap_err();
+        assert!(
+            matches!(&err, PluginManagerError::Io(e) if e.kind() == std::io::ErrorKind::InvalidData),
+            "expected an InvalidData io error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn extract_rejects_when_total_budget_is_exhausted() {
+        // Every entry is under the per-entry cap, but their sum blows the whole-
+        // package budget — the running total must catch it on the extract path.
+        let tmp = TempDir::new().unwrap();
+        let pkg = make_package(
+            tmp.path(),
+            &manifest_json("many", "1.0"),
+            &[("a.bin", &[0u8; 400]), ("b.bin", &[0u8; 400])],
+        );
+        let dest = tmp.path().join("out");
+        let err = extract_package_with_limits(&pkg, &dest, None, 10_000, 600).unwrap_err();
+        assert!(
+            matches!(&err, PluginManagerError::Io(e) if e.kind() == std::io::ErrorKind::InvalidData),
+            "expected an InvalidData io error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn extract_accepts_content_within_the_budget() {
+        // Content comfortably under both budgets still extracts — the guard does
+        // not reject legitimate packages.
+        let tmp = TempDir::new().unwrap();
+        let pkg = make_package(
+            tmp.path(),
+            &manifest_json("ok", "1.0"),
+            &[("backend/lib.so", b"\x7fELF-small")],
+        );
+        let dest = tmp.path().join("out");
+        extract_package_with_limits(&pkg, &dest, None, 1_000_000, 1_000_000)
+            .expect("content within budget must extract");
+        assert_eq!(
+            std::fs::read(dest.join("backend/lib.so")).unwrap(),
+            b"\x7fELF-small"
+        );
     }
 
     #[test]

--- a/core/src/plugin/package.rs
+++ b/core/src/plugin/package.rs
@@ -25,6 +25,95 @@ pub const MANIFEST_FILE_NAME: &str = "manifest.json";
 /// an oversize package is rejected without any decompression.
 pub const MAX_PACKAGE_SIZE_BYTES: u64 = 50 * 1024 * 1024;
 
+/// Maximum accepted *decompressed* size of a single package entry: 128 MB.
+///
+/// The [`MAX_PACKAGE_SIZE_BYTES`] cap is on the *compressed* archive only, so it
+/// does nothing against a zip bomb — a 50 MB archive can inflate to many GB. This
+/// per-entry cap bounds how much any one entry may expand to while it is being
+/// read into memory, so a single crafted entry cannot exhaust the host's RAM.
+pub const MAX_DECOMPRESSED_ENTRY_BYTES: u64 = 128 * 1024 * 1024;
+
+/// Maximum accepted *total* decompressed size of a whole package: 256 MB.
+///
+/// Complements [`MAX_DECOMPRESSED_ENTRY_BYTES`]: even if every entry is
+/// individually under the per-entry cap, their sum is bounded so an archive of
+/// many medium entries cannot exhaust memory or disk on the digest/trust and
+/// extraction paths. Both caps are enforced *while reading* (see
+/// [`read_entry_bounded`]), so an over-budget entry aborts mid-read rather than
+/// after it has already been fully materialized.
+pub const MAX_DECOMPRESSED_TOTAL_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Compile-time sanity on the decompression caps: the per-entry cap must not
+/// exceed the whole-package budget, and the package can legitimately expand past
+/// its compressed-size cap, so the decompressed budget is the larger of the two.
+const _: () = {
+    assert!(MAX_DECOMPRESSED_ENTRY_BYTES <= MAX_DECOMPRESSED_TOTAL_BYTES);
+    assert!(MAX_DECOMPRESSED_TOTAL_BYTES >= MAX_PACKAGE_SIZE_BYTES);
+};
+
+/// Read `reader` fully into `buf`, enforcing a per-entry decompression cap and
+/// decrementing a shared whole-package budget.
+///
+/// This is the single choke point that bounds decompression on every path that
+/// reads a `.termihub-plugin` entry (trust assessment / digesting, manifest
+/// parsing, and extraction). It reads at most `per_entry_limit` bytes *and* at
+/// most `*remaining_total` bytes — whichever is smaller — plus one probe byte, so
+/// an entry that would exceed either budget is detected and rejected **while
+/// reading**, before the whole (bomb) entry is materialized. On success
+/// `*remaining_total` is reduced by the number of bytes read.
+///
+/// Returns [`std::io::ErrorKind::InvalidData`] when a limit is exceeded; callers
+/// map that into their own error type (`?` converts it via the standard
+/// `From<std::io::Error>` impls).
+pub(crate) fn read_entry_bounded<R: Read>(
+    reader: R,
+    per_entry_limit: u64,
+    remaining_total: &mut u64,
+    buf: &mut Vec<u8>,
+) -> std::io::Result<()> {
+    // Cap at the smaller of this entry's own limit and what remains of the
+    // whole-package budget; read one extra byte so hitting the cap is detectable.
+    let cap = per_entry_limit.min(*remaining_total);
+    let read = reader.take(cap.saturating_add(1)).read_to_end(buf)? as u64;
+    if read > cap {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "plugin package entry exceeds the decompression limit \
+                 (per-entry cap {per_entry_limit} bytes, remaining package \
+                 budget {remaining_total} bytes)"
+            ),
+        ));
+    }
+    *remaining_total -= read;
+    Ok(())
+}
+
+/// Reject a package whose on-disk (compressed) size exceeds
+/// [`MAX_PACKAGE_SIZE_BYTES`], without opening or decompressing it.
+///
+/// This is the cheap gate meant to run **before trust assessment**: trust
+/// assessment opens the archive and reads its entries, so the size guard must
+/// precede it rather than living only inside [`validate_package`] (which runs
+/// after the trust gate). Decompression itself is separately bounded per entry
+/// via [`read_entry_bounded`].
+pub fn check_package_size(path: &Path) -> Result<(), PluginPackageError> {
+    check_size_with_limit(path, MAX_PACKAGE_SIZE_BYTES)
+}
+
+/// Shared on-disk size check. Factored out so the limit can be exercised in tests
+/// without materializing a 50 MB fixture.
+fn check_size_with_limit(path: &Path, max_bytes: u64) -> Result<(), PluginPackageError> {
+    let metadata = std::fs::metadata(path)?;
+    if metadata.len() > max_bytes {
+        return Err(PluginPackageError::TooLarge {
+            actual: metadata.len(),
+            max: max_bytes,
+        });
+    }
+    Ok(())
+}
+
 /// Everything that can go wrong validating a `.termihub-plugin` package.
 ///
 /// [`IncompatibleApiVersion`](PluginPackageError::IncompatibleApiVersion) is a
@@ -88,13 +177,7 @@ fn validate_package_with_limit(
     path: &Path,
     max_bytes: u64,
 ) -> Result<PluginManifest, PluginPackageError> {
-    let metadata = std::fs::metadata(path)?;
-    if metadata.len() > max_bytes {
-        return Err(PluginPackageError::TooLarge {
-            actual: metadata.len(),
-            max: max_bytes,
-        });
-    }
+    check_size_with_limit(path, max_bytes)?;
 
     let file = std::fs::File::open(path)?;
     let mut archive =
@@ -108,9 +191,21 @@ fn validate_package_with_limit(
             }
             Err(e) => return Err(PluginPackageError::InvalidArchive(e.to_string())),
         };
-        let mut buf = String::new();
-        entry.read_to_string(&mut buf)?;
-        buf
+        // Bound the manifest read too: `manifest.json` is decompressed here, so an
+        // unbounded read would be a zip-bomb vector of its own.
+        let mut bytes = Vec::new();
+        let mut remaining = MAX_DECOMPRESSED_ENTRY_BYTES;
+        read_entry_bounded(
+            &mut entry,
+            MAX_DECOMPRESSED_ENTRY_BYTES,
+            &mut remaining,
+            &mut bytes,
+        )?;
+        String::from_utf8(bytes).map_err(|e| {
+            PluginPackageError::InvalidArchive(format!(
+                "`{MANIFEST_FILE_NAME}` is not valid UTF-8: {e}"
+            ))
+        })?
     };
 
     let manifest = parse_manifest(&manifest_json)?;
@@ -279,5 +374,67 @@ mod tests {
     #[test]
     fn size_limit_constant_is_50_mb() {
         assert_eq!(MAX_PACKAGE_SIZE_BYTES, 50 * 1024 * 1024);
+    }
+
+    #[test]
+    fn check_package_size_accepts_a_normal_package() {
+        let pkg = make_package(Some(&good_manifest_json()), &[]);
+        check_package_size(pkg.path()).expect("a small package is under the size cap");
+    }
+
+    #[test]
+    fn check_size_with_limit_rejects_oversize_before_opening() {
+        // The pre-trust size gate rejects on on-disk length alone, without opening
+        // the archive — proven with a tiny injected limit (#2046).
+        let pkg = make_package(Some(&good_manifest_json()), &[]);
+        let actual = std::fs::metadata(pkg.path()).unwrap().len();
+        let err = check_size_with_limit(pkg.path(), 8).unwrap_err();
+        match err {
+            PluginPackageError::TooLarge { actual: a, max } => {
+                assert_eq!(a, actual);
+                assert_eq!(max, 8);
+            }
+            other => panic!("expected TooLarge, got: {other}"),
+        }
+    }
+
+    #[test]
+    fn read_entry_bounded_accepts_within_budget_and_tracks_total() {
+        use std::io::Cursor;
+        let mut remaining = 1_000u64;
+        let mut buf = Vec::new();
+        read_entry_bounded(Cursor::new(vec![0u8; 300]), 500, &mut remaining, &mut buf)
+            .expect("300 bytes is within both budgets");
+        assert_eq!(buf.len(), 300);
+        assert_eq!(
+            remaining, 700,
+            "the total budget must be decremented by bytes read"
+        );
+    }
+
+    #[test]
+    fn read_entry_bounded_rejects_over_per_entry_cap() {
+        use std::io::Cursor;
+        let mut remaining = 1_000_000u64;
+        let mut buf = Vec::new();
+        let err = read_entry_bounded(Cursor::new(vec![0u8; 4096]), 64, &mut remaining, &mut buf)
+            .unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn read_entry_bounded_rejects_when_total_budget_exhausted() {
+        use std::io::Cursor;
+        // Under the per-entry cap but over what remains of the whole-package budget.
+        let mut remaining = 100u64;
+        let mut buf = Vec::new();
+        let err = read_entry_bounded(
+            Cursor::new(vec![0u8; 400]),
+            10_000,
+            &mut remaining,
+            &mut buf,
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 }

--- a/core/src/plugin/signature.rs
+++ b/core/src/plugin/signature.rs
@@ -45,7 +45,10 @@ use sha2::{Digest, Sha256};
 use thiserror::Error;
 use zip::ZipArchive;
 
-use super::package::MANIFEST_FILE_NAME;
+use super::package::{
+    read_entry_bounded, MANIFEST_FILE_NAME, MAX_DECOMPRESSED_ENTRY_BYTES,
+    MAX_DECOMPRESSED_TOTAL_BYTES,
+};
 
 /// The well-known signature entry at a signed package's root — present iff the
 /// package is signed, sitting beside [`MANIFEST_FILE_NAME`].
@@ -435,7 +438,22 @@ pub fn verify_signed_archive<R: Read + Seek>(
 pub fn digest_entries<R: Read + Seek>(
     archive: &mut ZipArchive<R>,
 ) -> Result<BTreeMap<String, String>, zip::result::ZipError> {
+    digest_entries_with_limits(
+        archive,
+        MAX_DECOMPRESSED_ENTRY_BYTES,
+        MAX_DECOMPRESSED_TOTAL_BYTES,
+    )
+}
+
+/// [`digest_entries`] with explicit decompression limits, so the zip-bomb guard
+/// can be exercised in tests without materializing a 128 MB fixture.
+fn digest_entries_with_limits<R: Read + Seek>(
+    archive: &mut ZipArchive<R>,
+    per_entry_limit: u64,
+    total_limit: u64,
+) -> Result<BTreeMap<String, String>, zip::result::ZipError> {
     let mut digests = BTreeMap::new();
+    let mut remaining = total_limit;
     for i in 0..archive.len() {
         let mut entry = archive.by_index(i)?;
         if entry.is_dir() {
@@ -445,8 +463,10 @@ pub fn digest_entries<R: Read + Seek>(
         if name == SIGNATURE_FILE_NAME {
             continue;
         }
+        // Bound decompression: an over-budget entry aborts here (surfaced as
+        // `ZipError::Io`) instead of exhausting memory (#2046).
         let mut buf = Vec::new();
-        entry.read_to_end(&mut buf)?;
+        read_entry_bounded(&mut entry, per_entry_limit, &mut remaining, &mut buf)?;
         digests.insert(name, sha256_digest(&buf));
     }
     Ok(digests)
@@ -462,8 +482,16 @@ fn read_entry<R: Read + Seek>(
         Err(zip::result::ZipError::FileNotFound) => return Ok(None),
         Err(e) => return Err(e),
     };
+    // Bound decompression of the named entry (e.g. `signature.json`) so it cannot
+    // be a zip-bomb vector before the signature is even parsed (#2046).
     let mut buf = Vec::new();
-    entry.read_to_end(&mut buf)?;
+    let mut remaining = MAX_DECOMPRESSED_ENTRY_BYTES;
+    read_entry_bounded(
+        &mut entry,
+        MAX_DECOMPRESSED_ENTRY_BYTES,
+        &mut remaining,
+        &mut buf,
+    )?;
     Ok(Some(buf))
 }
 
@@ -641,6 +669,49 @@ mod tests {
         // An entry the signer never saw was appended to the archive.
         let err = verify(&sig, &digests_of(&[("a", b"x"), ("evil.sh", b"rm -rf")])).unwrap_err();
         assert!(matches!(err, SignatureError::ExtraEntry(n) if n == "evil.sh"));
+    }
+
+    #[test]
+    fn digesting_rejects_an_entry_over_the_decompression_budget() {
+        // A single entry whose decompressed size exceeds the per-entry cap must be
+        // rejected while reading, not read into memory. Exercised with a tiny cap so
+        // no large fixture is needed (#2046).
+        let zip = zip_of(&[("manifest.json", b"{}"), ("bomb.bin", &[0u8; 4096])]);
+        let mut archive = ZipArchive::new(Cursor::new(zip)).unwrap();
+        let err = digest_entries_with_limits(&mut archive, 64, 1_000_000).unwrap_err();
+        assert!(
+            matches!(err, zip::result::ZipError::Io(ref e) if e.kind() == std::io::ErrorKind::InvalidData),
+            "expected an InvalidData io error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn digesting_rejects_when_total_budget_is_exhausted() {
+        // Each entry is under the per-entry cap, but together they blow the whole-
+        // package budget — the running total must catch it (#2046).
+        let zip = zip_of(&[("a.bin", &[0u8; 400]), ("b.bin", &[0u8; 400])]);
+        let mut archive = ZipArchive::new(Cursor::new(zip)).unwrap();
+        let err = digest_entries_with_limits(&mut archive, 1_000, 500).unwrap_err();
+        assert!(
+            matches!(err, zip::result::ZipError::Io(ref e) if e.kind() == std::io::ErrorKind::InvalidData),
+            "expected an InvalidData io error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn digesting_accepts_content_within_the_budget() {
+        // A normal package well under both budgets still digests successfully — the
+        // guard does not reject legitimate content.
+        let entries: &[(&str, &[u8])] = &[("manifest.json", b"{}"), ("lib.so", b"\x7fELF....")];
+        let zip = zip_of(entries);
+        let mut archive = ZipArchive::new(Cursor::new(zip)).unwrap();
+        let digests = digest_entries_with_limits(
+            &mut archive,
+            MAX_DECOMPRESSED_ENTRY_BYTES,
+            MAX_DECOMPRESSED_TOTAL_BYTES,
+        )
+        .expect("content within budget must digest");
+        assert_eq!(digests, digests_of(entries));
     }
 
     #[test]

--- a/docs/changes/dev1/fix/2046-plugin-zip-bomb.md
+++ b/docs/changes/dev1/fix/2046-plugin-zip-bomb.md
@@ -1,0 +1,9 @@
+### Security
+
+- Plugin packages are now protected against decompression (zip-bomb) denial of
+  service. Reading a `.termihub-plugin` archive is bounded by a per-entry
+  decompressed cap (128 MB) and a whole-package decompressed budget (256 MB) on
+  the trust-assessment, manifest, and extraction paths, so a small malicious
+  archive can no longer inflate to exhaust host memory. The compressed-size
+  check now also runs *before* trust assessment rather than only inside package
+  validation.

--- a/docs/changes/dev1/fix/2046-plugin-zip-bomb.md
+++ b/docs/changes/dev1/fix/2046-plugin-zip-bomb.md
@@ -5,5 +5,5 @@
   decompressed cap (128 MB) and a whole-package decompressed budget (256 MB) on
   the trust-assessment, manifest, and extraction paths, so a small malicious
   archive can no longer inflate to exhaust host memory. The compressed-size
-  check now also runs *before* trust assessment rather than only inside package
+  check now also runs _before_ trust assessment rather than only inside package
   validation.


### PR DESCRIPTION
## Summary

Fixes the pre-release audit finding **#2046** (MEDIUM): plugin package decompression was **unbounded** on the trust-assessment and extraction paths. The existing 50 MB cap is on the **compressed** archive only and ran too late — inside `validate_package`, *after* `assess_trust` had already opened and read the whole archive. A crafted `.termihub-plugin` could therefore zip-bomb the host (memory-exhaustion DoS) on file-select, before any trust decision.

**Finding confirmed** while fixing: `assess_trust` → `verify_reader` → `digest_entries` read every entry with unbounded `read_to_end` (`signature.rs`), as did `read_entry` (signature.json) and `extract_package` (`manager.rs`).

## Changes

- New shared choke point `read_entry_bounded` (`package.rs`) enforces a **per-entry cap (128 MB)** and a **running whole-package budget (256 MB)** *while reading* (via `Read::take`), so an over-budget entry aborts mid-read with a clear `InvalidData` error instead of exhausting memory — never OOM/panic.
- Applied on every decompression path: `digest_entries` / `read_entry` (trust + signature), the `manifest.json` read in `validate_package`, and `extract_package`.
- The compressed-size check now runs **before `assess_trust`** in `install()` (via `check_package_size`), not only inside `validate_package`.

### Limits chosen
| Cap | Value | Where |
| --- | --- | --- |
| Compressed archive | 50 MB (existing) | `check_package_size`, before trust |
| Decompressed per-entry | 128 MB | `read_entry_bounded` |
| Decompressed total | 256 MB | `read_entry_bounded` |

A compile-time assertion keeps `per-entry ≤ total` and `total ≥ compressed`.

## Tests (12 new)

- `package.rs`: `read_entry_bounded` accepts within budget & tracks total; rejects over per-entry cap; rejects when total budget exhausted; `check_package_size` accept + `check_size_with_limit` oversize rejection.
- `signature.rs` (digest/trust path): rejects an entry over the per-entry budget; rejects when total budget exhausted; still digests content within budget.
- `manager.rs` (extract path): rejects an entry over the per-entry budget; rejects when total exhausted; still extracts content within budget.

Limits are injectable in internal `*_with_limits` seams so the guard is proven with tiny fixtures (no multi-hundred-MB allocations in CI). Normal packages still install (existing end-to-end install/extract tests pass with the production caps).

`cargo test -p termihub-core --features plugin` green; `cargo clippy --workspace --all-targets --all-features -D warnings` and `cargo fmt --check` clean.

Closes #2046