### PR TITLE
fix(backend): validate plugin id in read_plugin_file to block traversal (Closes #2047)

### DIFF
--- a/core/src/plugin/manager.rs
+++ b/core/src/plugin/manager.rs
@@ -43,7 +43,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use thiserror::Error;
 
-use super::manifest::{parse_manifest, ApiCompatibility, PluginManifest};
+use super::manifest::{is_valid_plugin_id, parse_manifest, ApiCompatibility, PluginManifest};
 use super::package::{
     check_package_size, read_entry_bounded, validate_package, PluginPackageError,
     MANIFEST_FILE_NAME, MAX_DECOMPRESSED_ENTRY_BYTES, MAX_DECOMPRESSED_TOTAL_BYTES,
@@ -643,6 +643,14 @@ impl PluginManager {
     /// refused. This is the helper the (later) theme/JS loaders use to pull
     /// asset bytes out of an installed plugin.
     pub fn read_file(&self, id: &str, relative: &str) -> Result<Vec<u8>, PluginManagerError> {
+        // `id` reaches this method from the renderer over IPC (the
+        // `read_plugin_file` command), so it is untrusted. Re-validate it with
+        // the same slug rule enforced at manifest time before it is joined into
+        // a filesystem path — otherwise a traversing id (`..`, separators) would
+        // escape the plugin root and turn this into an arbitrary-file read.
+        if !is_valid_plugin_id(id) {
+            return Err(PluginManagerError::PathTraversal(id.into()));
+        }
         let dir = self.plugin_dir(id);
         if !dir.exists() {
             return Err(PluginManagerError::NotFound(id.into()));

--- a/core/src/plugin/manager.rs
+++ b/core/src/plugin/manager.rs
@@ -1197,6 +1197,49 @@ mod tests {
     }
 
     #[test]
+    fn read_file_blocks_traversing_id() {
+        let (mgr, tmp) = manager();
+        let pkg = make_package(
+            tmp.path(),
+            &manifest_json("assets", "1.0"),
+            &[("themes/dark.json", b"{\"bg\":\"#111\"}")],
+        );
+        mgr.install(&pkg, true, false).unwrap();
+
+        // A secret file living *outside* the plugin root that a traversing id
+        // would otherwise reach.
+        let secret = mgr.root().parent().unwrap().join("secret.json");
+        std::fs::write(&secret, b"top secret").unwrap();
+
+        // The `id` argument comes straight from the renderer over IPC and must
+        // be validated with the same slug rule as at manifest time: anything
+        // containing path separators, `..`, or non-slug characters is refused
+        // before it is joined into a filesystem path.
+        for bad_id in [
+            "..",
+            "../secret",
+            "../../etc",
+            "assets/../..",
+            "/etc",
+            "foo/bar",
+            "as..sets",
+            "",
+        ] {
+            assert!(
+                matches!(
+                    mgr.read_file(bad_id, "secret.json"),
+                    Err(PluginManagerError::PathTraversal(_))
+                ),
+                "id {bad_id:?} should be refused"
+            );
+        }
+
+        // The valid id still resolves normally.
+        let bytes = mgr.read_file("assets", "themes/dark.json").unwrap();
+        assert_eq!(bytes, b"{\"bg\":\"#111\"}");
+    }
+
+    #[test]
     fn extraction_rejects_zip_slip() {
         // A package whose entry tries to escape via `..`. `enclosed_name`
         // returns None for it, so install fails with UnsafePath and writes

--- a/core/src/plugin/manifest.rs
+++ b/core/src/plugin/manifest.rs
@@ -376,6 +376,15 @@ fn require_non_empty(field: &'static str, value: &str) -> Result<(), ManifestVal
     }
 }
 
+/// Whether `id` is a filesystem-safe plugin slug (the same rule enforced at
+/// manifest time). Callers that receive an `id` from an untrusted boundary — the
+/// renderer over IPC, for instance — must gate on this before joining it into a
+/// path, since a slug can never contain path separators, `..`, or other
+/// characters that would let it escape `plugins/<id>/`.
+pub(crate) fn is_valid_plugin_id(id: &str) -> bool {
+    validate_plugin_id(id).is_ok()
+}
+
 /// A plugin id must be a filesystem-safe slug: 1..=64 chars of `[a-z0-9-]`, not
 /// starting or ending with a hyphen and with no consecutive hyphens. This keeps
 /// the install directory (`plugins/<id>/`) safe from traversal and collisions.

--- a/docs/changes/dev1/fix/2047-read-plugin-file-id.md
+++ b/docs/changes/dev1/fix/2047-read-plugin-file-id.md
@@ -1,0 +1,7 @@
+### Security
+
+- The `read_plugin_file` IPC command now validates the plugin `id` with the same
+  filesystem-safe slug rule enforced at manifest install time before joining it
+  into a path. Previously a traversing `id` (one containing `..` or path
+  separators) supplied by the renderer could escape the plugin root and read
+  arbitrary files off disk; such ids are now refused.


### PR DESCRIPTION
## Summary

Fixes an arbitrary-file-read primitive in the `read_plugin_file` IPC command (pre-release security audit finding, #2047).

**Confirmed the finding.** `PluginManager::read_file` joined the renderer-supplied `id` straight into a filesystem path via `plugin_dir(id)` = `self.root.join(id)`. Only the `relative` argument was guarded (by `safe_relative`); the `id` was not re-validated at the IPC boundary. A traversing `id` such as `../../etc` therefore escaped the plugin root, letting the renderer read arbitrary files off disk.

## Fix

- Re-validate `id` inside `read_file` with the **same slug rule enforced at manifest install time** before it is joined into a path. Reused the existing validator by exposing it as `is_valid_plugin_id` (`core/src/plugin/manifest.rs`) rather than duplicating the rule. Anything containing path separators, `..`, or non-slug characters is refused with `PathTraversal`.

## Tests

- Added `read_file_blocks_traversing_id`, mirroring the existing `read_file_returns_bytes_and_blocks_traversal` but exercising traversing/invalid **ids** (`..`, `../../etc`, `assets/../..`, `/etc`, `foo/bar`, `as..sets`, empty) against a secret file planted outside the plugin root — all refused, valid id still resolves. Committed test-first (red confirmed) per the repo's TDD flow.

Closes #2047