### PR TITLE
feat(security): restrictive CSP and gate frontend plugins as experimental (Closes #2048)

### DIFF
--- a/docs/changes/dev1/feature/2048-csp-experimental-plugins.md
+++ b/docs/changes/dev1/feature/2048-csp-experimental-plugins.md
@@ -1,0 +1,16 @@
+### Added
+
+- Frontend (JavaScript) plugins are now gated behind an explicit, off-by-default
+  experimental opt-in (Settings → Plugins → "Enable Frontend (JavaScript)
+  Plugins"). For v0.1.0 the full plugin-JS surface — protocol parsers and
+  status-bar widgets that run in the main WebView with full app access and weak
+  isolation — no longer runs unless the user knowingly enables it, with a
+  prominent trust warning. Theme-only and backend plugins are unaffected.
+  Toggling the setting loads or tears down injected plugin scripts live (#2048).
+
+### Changed
+
+- Hardened the application security posture with a restrictive Content Security
+  Policy (previously `null` / allow-all). Inline scripts are no longer permitted;
+  frontend plugin code now loads from a blob URL instead of an inline `<script>`
+  so it runs under the strict policy without weakening it (#2048).

--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -255,6 +255,10 @@ pub struct AppSettings {
     /// Whether experimental features are enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub experimental_features_enabled: Option<bool>,
+    /// Experimental opt-in for executing frontend (JavaScript) plugins (#2048).
+    /// `None`/`Some(false)` keeps the full-IPC plugin JS surface off by default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frontend_plugins_enabled: Option<bool>,
     /// Update checker configuration and state.
     #[serde(default)]
     pub updates: UpdateSettings,
@@ -337,6 +341,7 @@ impl Default for AppSettings {
             installed_language_packages: None,
             custom_language_grammars: None,
             experimental_features_enabled: None,
+            frontend_plugins_enabled: None,
             updates: UpdateSettings::default(),
             serial_port_scan_prefixes: None,
             shell_integration: ShellIntegrationSettings::default(),
@@ -1023,6 +1028,28 @@ mod tests {
         let settings = AppSettings::default();
         let json = serde_json::to_string(&settings).unwrap();
         assert!(!json.contains("experimentalFeaturesEnabled"));
+    }
+
+    #[test]
+    fn frontend_plugins_enabled_round_trip() {
+        let settings = AppSettings {
+            frontend_plugins_enabled: Some(true),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(json.contains("frontendPluginsEnabled"));
+        let deserialized: AppSettings = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.frontend_plugins_enabled, Some(true));
+    }
+
+    #[test]
+    fn frontend_plugins_enabled_defaults_off_and_omitted() {
+        // Off by default (#2048): the field is None on a fresh settings object and
+        // omitted from serialized JSON, so v0.1.0 ships with frontend plugins off.
+        let settings = AppSettings::default();
+        assert_eq!(settings.frontend_plugins_enabled, None);
+        let json = serde_json::to_string(&settings).unwrap();
+        assert!(!json.contains("frontendPluginsEnabled"));
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'"
     }
   },
   "plugins": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'"
+      "csp": "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'"
     }
   },
   "plugins": {

--- a/src/components/Settings/FrontendPluginGateSettings.tsx
+++ b/src/components/Settings/FrontendPluginGateSettings.tsx
@@ -1,0 +1,60 @@
+import { useCallback } from "react";
+import { ShieldAlert } from "lucide-react";
+import { useAppStore } from "@/store/appStore";
+import { Toggle } from "@/components/ui";
+import { SettingsField } from "./SettingsField";
+
+/**
+ * Settings → Plugins → the experimental frontend-plugin gate (#2048).
+ *
+ * Frontend (JavaScript) plugins are injected into the main WebView and run with
+ * full IPC/command access and no per-plugin permission enforcement (weak
+ * isolation; enforcement tracked in #2001). For v0.1.0 their execution is gated
+ * behind this explicit, default-off opt-in with a prominent trust warning, so the
+ * full plugin JS surface is never active unless the user knowingly accepts it.
+ * Theme-only and backend plugins are unaffected.
+ *
+ * Toggling this persists via `updateSettings`, which re-reconciles the injected
+ * plugin scripts — enabling loads active frontend plugins, disabling tears them
+ * down live.
+ */
+export function FrontendPluginGateSettings() {
+  const enabled = useAppStore((s) => s.settings.frontendPluginsEnabled ?? false);
+  const settings = useAppStore((s) => s.settings);
+  const updateSettings = useAppStore((s) => s.updateSettings);
+
+  const handleToggle = useCallback(
+    (checked: boolean) => {
+      void updateSettings({ ...settings, frontendPluginsEnabled: checked });
+    },
+    [settings, updateSettings]
+  );
+
+  return (
+    <div className="settings-panel__category">
+      <div className="settings-panel__section" data-testid="settings-frontend-plugin-gate">
+        <h3 className="settings-panel__section-title">
+          <ShieldAlert size={16} aria-hidden="true" /> Frontend Plugins (Experimental)
+        </h3>
+        <p className="settings-panel__description">
+          Frontend plugins run untrusted JavaScript inside termiHub with full access to the app and
+          your connections, and only weak isolation. Enable this only for plugins you trust. It is
+          off by default and can be turned off at any time to stop all frontend-plugin code
+          immediately.
+        </p>
+
+        <SettingsField
+          label="Enable Frontend (JavaScript) Plugins"
+          hint="Experimental. Runs plugin-provided JavaScript (protocol parsers and status-bar widgets). Theme-only and backend plugins are unaffected by this setting."
+          hintVariant="warning"
+        >
+          <Toggle
+            checked={enabled}
+            onCheckedChange={handleToggle}
+            data-testid="settings-frontend-plugins-enabled"
+          />
+        </SettingsField>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -36,6 +36,7 @@ import { SerialPortSettings } from "./SerialPortSettings";
 import { ShellIntegrationSettings } from "./ShellIntegrationSettings";
 import { PortableModeSettings } from "./PortableModeSettings";
 import { PluginSettingsSection } from "./PluginSettingsSection";
+import { FrontendPluginGateSettings } from "./FrontendPluginGateSettings";
 import { TrustedPublishersSettings } from "./TrustedPublishersSettings";
 import { useAppInfo } from "@/hooks/useAppInfo";
 import "./SettingsPanel.css";
@@ -289,6 +290,7 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
         );
       }
       if (highlightedCategories?.has("plugins")) {
+        sections.push(<FrontendPluginGateSettings key="frontend-plugin-gate" />);
         sections.push(<PluginSettingsSection key="plugins" focusPluginId={focusPluginId} />);
         sections.push(<TrustedPublishersSettings key="trusted-publishers" />);
       }
@@ -338,6 +340,7 @@ export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
       case "plugins":
         return (
           <>
+            <FrontendPluginGateSettings />
             <PluginSettingsSection focusPluginId={focusPluginId} />
             <TrustedPublishersSettings />
           </>

--- a/src/components/Settings/settingsRegistry.ts
+++ b/src/components/Settings/settingsRegistry.ts
@@ -454,6 +454,24 @@ export const SETTINGS_REGISTRY: SettingDefinition[] = [
     keywords: ["experimental", "beta", "preview", "unstable", "hidden", "features", "labs"],
   },
   {
+    id: "frontendPluginsEnabled",
+    label: "Enable Frontend (JavaScript) Plugins",
+    description:
+      "Experimental: run plugin-provided JavaScript (protocol parsers, status-bar widgets) in the app. Off by default — these plugins run with full access and weak isolation.",
+    category: "plugins",
+    keywords: [
+      "plugin",
+      "frontend",
+      "javascript",
+      "experimental",
+      "security",
+      "parser",
+      "widget",
+      "untrusted",
+      "sandbox",
+    ],
+  },
+  {
     id: "restoreLastSessionOnStartup",
     label: "Restore Last Session on Startup",
     description:

--- a/src/plugins/frontendPlugins.test.ts
+++ b/src/plugins/frontendPlugins.test.ts
@@ -12,7 +12,7 @@
  * exercised directly (via `setLoadingPlugin` + `window.termihub`) here and in
  * `pluginRuntime.test.ts`.
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { InstalledPlugin, PluginState } from "@/types/plugin";
 import {
   loadFrontendPlugin,
@@ -73,12 +73,39 @@ function registerWidgetAs(pluginId: string, widget: StatusBarWidget): void {
   makePluginApi(pluginId).registerStatusBarWidget(widget);
 }
 
+/**
+ * Injected plugin scripts load from a blob URL (not an inline body) so they run
+ * under the app's restrictive CSP (#2048). jsdom implements neither
+ * `URL.createObjectURL` nor `Blob.text()`, so we spy the `Blob` constructor to
+ * capture the exact wrapped source each script is built from and stub the object
+ * URL helpers.
+ */
+let blobParts: BlobPart[][];
+
 beforeEach(() => {
   clearRegistry();
   ensureTermiHubApi();
   resetLoadedFrontendPlugins();
   document.head.querySelectorAll("script[data-termihub-plugin]").forEach((s) => s.remove());
+
+  blobParts = [];
+  vi.spyOn(globalThis, "Blob").mockImplementation((parts?: BlobPart[]) => {
+    blobParts.push(parts ?? []);
+    return { size: 0, type: "text/javascript" } as unknown as Blob;
+  });
+  let counter = 0;
+  vi.spyOn(URL, "createObjectURL").mockImplementation(() => `blob:mock/${counter++}`);
+  vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
 });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** The wrapped source string of the nth injected plugin script (blob-captured). */
+function injectedSource(index = 0): string {
+  return String(blobParts[index]?.[0] ?? "");
+}
 
 describe("frontendEntryPoints / hasFrontendExtension", () => {
   it("collects and dedupes entry points across frontend extensions", () => {
@@ -106,7 +133,7 @@ describe("frontendEntryPoints / hasFrontendExtension", () => {
 });
 
 describe("loadFrontendPlugin", () => {
-  it("reads the entry point and injects a tagged inline script", async () => {
+  it("reads the entry point and injects a tagged blob-URL script", async () => {
     const read = reader();
     const errors = await loadFrontendPlugin(parserPlugin("p"), read);
 
@@ -116,11 +143,16 @@ describe("loadFrontendPlugin", () => {
       'script[data-termihub-plugin="p"]'
     );
     expect(script).not.toBeNull();
-    // The source is wrapped so the plugin runs against its own per-plugin API
-    // instance, bound to its id (#2020) — the original source is preserved inside.
-    expect(script?.textContent).toContain(SRC);
-    expect(script?.textContent).toContain('window.__termihubMakePluginApi("p")');
-    expect(script?.textContent).toMatch(/^\(function \(termihub\) \{/);
+    // The script loads from a blob URL rather than an inline body so it runs
+    // under the restrictive CSP (`script-src 'self' blob:`, no unsafe-inline) (#2048).
+    expect(script?.src).toMatch(/^blob:/);
+    expect(script?.textContent).toBe("");
+    // The blob's source is wrapped so the plugin runs against its own per-plugin
+    // API instance, bound to its id (#2020) — the original source is preserved.
+    const source = injectedSource();
+    expect(source).toContain(SRC);
+    expect(source).toContain('window.__termihubMakePluginApi("p")');
+    expect(source).toMatch(/^\(function \(termihub\) \{/);
     expect(loadedFrontendPluginIds()).toEqual(["p"]);
   });
 
@@ -199,5 +231,36 @@ describe("reconcileFrontendPlugins", () => {
     await reconcileFrontendPlugins(plugins, read);
     expect(document.head.querySelectorAll('script[data-termihub-plugin="p"]')).toHaveLength(1);
     expect(read).toHaveBeenCalledTimes(1);
+  });
+
+  // Experimental frontend-plugin gate (#2048): the `enabled` flag is the
+  // default-off opt-in for executing frontend plugin JS.
+  it("loads nothing when the experimental gate is disabled", async () => {
+    const read = reader();
+    const errors = await reconcileFrontendPlugins([parserPlugin("p", "active")], read, false);
+    expect(errors).toEqual([]);
+    expect(read).not.toHaveBeenCalled();
+    expect(loadedFrontendPluginIds()).toEqual([]);
+    expect(document.head.querySelectorAll('script[data-termihub-plugin="p"]')).toHaveLength(0);
+  });
+
+  it("unloads already-injected plugins when the gate is toggled off", async () => {
+    const read = reader();
+    await reconcileFrontendPlugins([parserPlugin("p", "active")], read, true);
+    expect(loadedFrontendPluginIds()).toEqual(["p"]);
+
+    await reconcileFrontendPlugins([parserPlugin("p", "active")], read, false);
+    expect(loadedFrontendPluginIds()).toEqual([]);
+    expect(document.head.querySelectorAll('script[data-termihub-plugin="p"]')).toHaveLength(0);
+  });
+
+  it("loads active plugins again when the gate is toggled back on", async () => {
+    const plugins = [parserPlugin("p", "active")];
+    const read = reader();
+    await reconcileFrontendPlugins(plugins, read, false);
+    expect(loadedFrontendPluginIds()).toEqual([]);
+
+    await reconcileFrontendPlugins(plugins, read, true);
+    expect(loadedFrontendPluginIds()).toEqual(["p"]);
   });
 });

--- a/src/plugins/frontendPlugins.test.ts
+++ b/src/plugins/frontendPlugins.test.ts
@@ -89,10 +89,12 @@ beforeEach(() => {
   document.head.querySelectorAll("script[data-termihub-plugin]").forEach((s) => s.remove());
 
   blobParts = [];
-  vi.spyOn(globalThis, "Blob").mockImplementation((parts?: BlobPart[]) => {
+  // A regular (non-arrow) function so it is usable as a constructor for
+  // `new Blob(...)`; it records the parts and returns a lightweight stand-in.
+  vi.spyOn(globalThis, "Blob").mockImplementation(function (this: unknown, parts?: BlobPart[]) {
     blobParts.push(parts ?? []);
     return { size: 0, type: "text/javascript" } as unknown as Blob;
-  });
+  } as unknown as typeof Blob);
   let counter = 0;
   vi.spyOn(URL, "createObjectURL").mockImplementation(() => `blob:mock/${counter++}`);
   vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});

--- a/src/plugins/frontendPlugins.ts
+++ b/src/plugins/frontendPlugins.ts
@@ -106,7 +106,20 @@ export async function loadFrontendPlugin(
       script.setAttribute(PLUGIN_SCRIPT_ATTR, pluginId);
       // Wrap so the plugin registers against its own per-plugin API instance,
       // making attribution independent of when register is called (#2020).
-      script.textContent = wrapPluginSource(pluginId, code);
+      const wrapped = wrapPluginSource(pluginId, code);
+      // Load the wrapped source from a blob URL rather than as an inline
+      // `<script>` body. The app ships a restrictive CSP whose `script-src` omits
+      // `'unsafe-inline'` to close the HTML-injection / XSS surface (#2048); an
+      // inline script would be blocked. `script-src 'self' blob:` still runs
+      // plugin code (creating a blob URL already requires script execution, so it
+      // is not an injection vector), so plugins load without weakening the policy.
+      const url = URL.createObjectURL(new Blob([wrapped], { type: "text/javascript" }));
+      // Revoke once the browser has fetched the source so the object URL is not
+      // leaked; the script stays live after revocation.
+      const revoke = () => URL.revokeObjectURL(url);
+      script.addEventListener("load", revoke);
+      script.addEventListener("error", revoke);
+      script.src = url;
       (doc.head ?? doc.documentElement).appendChild(script);
       scripts.push(script);
     } catch (err) {
@@ -142,20 +155,33 @@ export function unloadFrontendPlugin(pluginId: string): void {
  * loaded, and unload every previously-loaded plugin that is no longer active.
  * Returns any load errors, for logging by the caller. This is the single entry
  * point the store calls on every plugin refresh (install/enable/disable).
+ *
+ * `enabled` is the experimental frontend-plugin opt-in (#2048). Frontend plugins
+ * run with full IPC/command access in the shared WebView, so for v0.1.0 their
+ * execution is gated behind an explicit, default-off setting. When `enabled` is
+ * false this loads nothing and unloads any already-injected plugin scripts —
+ * toggling the setting off therefore tears the plugin JS down live.
  */
 export async function reconcileFrontendPlugins(
   plugins: InstalledPlugin[],
   readFile: PluginFileReader,
+  enabled = true,
   doc: Document = document
 ): Promise<FrontendPluginLoadError[]> {
   ensureTermiHubApi();
   const activeIds = new Set(
-    plugins.filter((p) => p.state === "active" && hasFrontendExtension(p)).map((p) => p.manifest.id)
+    enabled
+      ? plugins
+          .filter((p) => p.state === "active" && hasFrontendExtension(p))
+          .map((p) => p.manifest.id)
+      : []
   );
 
   for (const pluginId of [...loadedScripts.keys()]) {
     if (!activeIds.has(pluginId)) unloadFrontendPlugin(pluginId);
   }
+
+  if (!enabled) return [];
 
   const errors: FrontendPluginLoadError[] = [];
   for (const plugin of plugins) {

--- a/src/store/appStore.plugins.test.ts
+++ b/src/store/appStore.plugins.test.ts
@@ -88,6 +88,29 @@ import { loadPluginThemes, setRegisteredPluginThemes } from "@/themes";
 import { darkTheme } from "@/themes/dark";
 import type { ThemeDefinition } from "@/themes";
 import type { InstalledPlugin, PluginState } from "@/types/plugin";
+import { resetLoadedFrontendPlugins } from "@/plugins/frontendPlugins";
+
+/** A plugin declaring a frontend (JS) extension — a protocol parser entry point. */
+function frontendPlugin(id: string, state: PluginState = "active"): InstalledPlugin {
+  return {
+    manifest: {
+      id,
+      name: `Plugin ${id}`,
+      version: "1.0.0",
+      author: "tester",
+      description: "a frontend plugin",
+      license: "MIT",
+      apiVersion: "1.0",
+      platforms: ["linux"],
+      permissions: ["ui"],
+      extensions: {
+        protocolParser: { name: id, description: "d", entryPoint: "frontend/index.js" },
+      },
+    },
+    state,
+    installedAt: "2026-07-26T00:00:00Z",
+  };
+}
 
 function makePlugin(
   id: string,
@@ -179,6 +202,35 @@ describe("appStore — plugins (#1993)", () => {
     vi.mocked(apiListPlugins).mockRejectedValueOnce(new Error("backend down"));
     await expect(useAppStore.getState().loadPlugins()).resolves.toBeUndefined();
     expect(useAppStore.getState().plugins).toEqual([]);
+  });
+
+  // Frontend-plugin execution is gated behind the experimental opt-in (#2048):
+  // loadPlugins must read `settings.frontendPluginsEnabled` and only read/inject
+  // plugin JS when it is on.
+  it("loadPlugins does not execute frontend plugins while the experimental gate is off (#2048)", async () => {
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock");
+    vi.spyOn(URL, "revokeObjectURL").mockReturnValue(undefined);
+    vi.mocked(apiListPlugins).mockResolvedValueOnce([frontendPlugin("fe")]);
+
+    // Default settings leave frontendPluginsEnabled unset (off).
+    await useAppStore.getState().loadPlugins();
+
+    expect(readPluginFile).not.toHaveBeenCalled();
+    resetLoadedFrontendPlugins();
+  });
+
+  it("loadPlugins executes frontend plugins once the experimental gate is on (#2048)", async () => {
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock");
+    vi.spyOn(URL, "revokeObjectURL").mockReturnValue(undefined);
+    vi.mocked(apiListPlugins).mockResolvedValueOnce([frontendPlugin("fe")]);
+    useAppStore.setState({
+      settings: { ...useAppStore.getState().settings, frontendPluginsEnabled: true },
+    });
+
+    await useAppStore.getState().loadPlugins();
+
+    expect(readPluginFile).toHaveBeenCalledWith("fe", "frontend/index.js");
+    resetLoadedFrontendPlugins();
   });
 
   it("installPlugin installs, refreshes, and toasts success", async () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -5258,6 +5258,16 @@ export const useAppStore = create<AppState>((set, get) => {
             }
           }
         }
+        // Toggling the experimental frontend-plugin gate (#2048) reconciles the
+        // injected plugin scripts: enabling loads active frontend plugins,
+        // disabling tears them down. loadPlugins re-runs reconcile with the new
+        // flag value it reads from the just-persisted settings.
+        if (
+          (oldSettings.frontendPluginsEnabled ?? false) !==
+          (newSettings.frontendPluginsEnabled ?? false)
+        ) {
+          void get().loadPlugins();
+        }
       } catch (err) {
         console.error("Failed to save settings:", err);
       }
@@ -7570,8 +7580,15 @@ export const useAppStore = create<AppState>((set, get) => {
         set({ plugins, pluginBackendTypes: derivePluginBackendTypes(plugins), pluginThemes });
         // Load/unload frontend JS plugins — protocol parsers + status-bar
         // widgets (#1998). Reconciles the injected scripts against the active
-        // set; individual load failures are logged and skipped.
-        const frontendErrors = await reconcileFrontendPlugins(plugins, readPluginFile);
+        // set; individual load failures are logged and skipped. Frontend-plugin
+        // execution is gated behind the experimental opt-in (#2048): when it is
+        // off, reconcile loads nothing and unloads anything already injected.
+        const frontendEnabled = get().settings.frontendPluginsEnabled ?? false;
+        const frontendErrors = await reconcileFrontendPlugins(
+          plugins,
+          readPluginFile,
+          frontendEnabled
+        );
         for (const err of frontendErrors) {
           frontendLog(
             "app_store",

--- a/src/types/connection.ts
+++ b/src/types/connection.ts
@@ -625,6 +625,17 @@ export interface AppSettings {
    */
   customLanguageGrammars?: CustomLanguageGrammar[];
   experimentalFeaturesEnabled?: boolean;
+  /**
+   * Experimental opt-in for executing **frontend (JavaScript) plugins** (#2048).
+   * Defaults to `false` (off). Frontend plugins are injected into the main
+   * WebView and run with full IPC/command access and no per-plugin permission
+   * enforcement (tracked in #2001), so for the first release their execution is
+   * gated behind this explicit, security-framed toggle. When off, no frontend
+   * plugin JS is loaded regardless of a plugin's enabled state; theme and
+   * backend-only plugins are unaffected. Toggling it live loads/unloads the
+   * injected plugin scripts (see `reconcileFrontendPlugins`).
+   */
+  frontendPluginsEnabled?: boolean;
   updates?: UpdateSettings;
   /** Linux `/dev` prefixes used when scanning for serial ports. Always present after `get_settings` (expanded from built-in defaults if never saved). */
   serialPortScanPrefixes?: SerialPortScanPrefix[];


### PR DESCRIPTION
## What & why

Pre-release security audit finding #2048 (medium): `tauri.conf.json` shipped `security.csp: null` (allow-all) while third-party frontend plugins are injected as **inline** script into the main WebView and run with full IPC access. This closes both halves of that surface for v0.1.0.

Closes #2048

## Part 1 — Restrictive CSP (was `null`)

```
default-src 'self';
script-src 'self' blob: 'wasm-unsafe-eval';
style-src 'self' 'unsafe-inline';
img-src 'self' data: blob:;
font-src 'self' data:;
connect-src 'self' ipc: http://ipc.localhost ws://127.0.0.1:* ws://localhost:*;
worker-src 'self' blob:;
child-src 'self' blob:;
object-src 'none';
frame-src 'none';
base-uri 'self';
form-action 'none'
```

Inline scripts are no longer allowed (`script-src` has **no** `'unsafe-inline'`), closing the HTML-injection/XSS surface. Each directive is scoped to what the app legitimately needs:

- `'wasm-unsafe-eval'` — Shiki's oniguruma WASM (syntax highlighting).
- `style-src 'unsafe-inline'` — xterm.js / React inline styles + the inline `<style>` in `index.html` (style injection is low-risk; script injection is the dangerous vector and stays blocked).
- `blob:` in `script-src`/`worker-src`/`child-src` — frontend plugin execution (see Part 2) and Monaco/xterm workers. Creating a blob URL already requires script execution, so it is not an injection vector.
- `connect-src` — Tauri IPC (`ipc:`, `http://ipc.localhost`) plus **loopback-only** WebSockets for the system-test bridge (see note below). All app networking (updater, SSH, network tools) runs in Rust, so the WebView needs no remote `connect-src`.

**Inline plugin scripts are accommodated without weakening the policy**: the frontend-plugin loader now injects plugin code from a **blob URL** (`<script src>`) instead of an inline `<script>` body, so it runs under `script-src 'self' blob:`.

**Loopback WebSocket allowance**: the system-test harness drives a real `tauri build` artifact where the CSP is enforced, and its in-app bridge client opens `ws://127.0.0.1:<port>` out to the runner. The allowance is restricted to loopback (127.0.0.1/localhost) — no remote-exfiltration surface. Tracked for removal in the follow-up below.

## Part 2 — Frontend plugins gated experimental (default OFF)

Frontend (JavaScript) plugins run in the main WebView with full IPC/command access and weak isolation. For v0.1.0 their execution is now behind an explicit, default-off opt-in:

- New setting `frontendPluginsEnabled` (TS `AppSettings` + Rust `AppSettings`, default off / omitted).
- `reconcileFrontendPlugins(plugins, readFile, enabled)` gains an `enabled` gate: when off it loads nothing and unloads any injected plugin scripts; toggling it live loads/tears down plugin JS.
- New **Settings → Plugins → "Frontend Plugins (Experimental)"** section with a prominent trust/security warning and a default-off toggle.
- Theme-only and backend plugins are unaffected.

## Manually verified (this is critical for a CSP change — CSP only applies in production builds, not `dev`)

Built the production app (`pnpm tauri build --debug`) — Tauri validated the CSP — and drove the **real CSP-enforced WebView** via the system-test bridge. The captured app log confirms, with **zero CSP violations**:

- WebView boots; the app loads connections and initializes.
- The **test-bridge WebSocket connects** (confirms the `connect-src ws://` allowance).
- A **local shell (zsh) session spawns** and the **terminal renders** — xterm mounts and reports real dimensions back (resize to 110x34), i.e. scripts run and IPC works under the CSP.
- Many bridge-driven integration tests pass under the CSP. (Some macOS integration tests are flaky via shared-fixture instability — a documented macOS harness limitation, unrelated to this change; integration tests do not run in per-PR CI.)

## Tests

- `frontendPlugins.test.ts`: updated for blob-URL injection; new coverage for the `enabled` gate (off loads nothing / unloads live / re-enables).
- `appStore.plugins.test.ts`: the gate flows from `settings.frontendPluginsEnabled` (no plugin JS read when off; read when on).
- `settings.rs`: round-trip + default-off/omitted for `frontend_plugins_enabled`.
- Full frontend suite (4605 tests) green; Rust settings tests green; ESLint/Prettier/clippy clean.

## Follow-up

Filed **#2059** for the residual CSP tightening (sandbox frontend plugins in a Worker/iframe to drop `blob:` from `script-src`, and move the test bridge off an in-WebView WebSocket so the loopback `ws://` allowance can be removed).

