### PR TITLE
fix(credential): return corrupted error on wrong-length nonce/salt instead of panicking (Closes #2049)

### DIFF
--- a/docs/changes/dev1/fix/2049-credential-nonce-panic.md
+++ b/docs/changes/dev1/fix/2049-credential-nonce-panic.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Credential unlock no longer crashes the app when the stored credentials file
+  has a truncated or corrupted nonce or salt. The unlock path now validates the
+  nonce and salt lengths before use and reports the file as corrupted (a
+  recoverable error offering the reset-store recovery), instead of panicking
+  inside `Nonce::from_slice` (#2049).

--- a/src-tauri/src/credential/crypto.rs
+++ b/src-tauri/src/credential/crypto.rs
@@ -226,6 +226,36 @@ mod tests {
     }
 
     #[test]
+    fn wrong_length_nonce_reports_error() {
+        // A corrupted/truncated nonce must surface a recoverable error, not
+        // panic inside `Nonce::from_slice` (#2049).
+        let mut envelope = encrypt_with_password("pw", b"data").unwrap();
+        envelope.nonce = BASE64.encode([0u8; NONCE_LEN - 1]);
+
+        let result = decrypt_with_password("pw", &envelope);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .to_lowercase()
+            .contains("nonce"));
+    }
+
+    #[test]
+    fn wrong_length_salt_reports_error() {
+        let mut envelope = encrypt_with_password("pw", b"data").unwrap();
+        envelope.kdf.salt = BASE64.encode([0u8; SALT_LEN - 1]);
+
+        let result = decrypt_with_password("pw", &envelope);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .to_lowercase()
+            .contains("salt"));
+    }
+
+    #[test]
     fn unsupported_version_fails() {
         let mut envelope = encrypt_with_password("pw", b"data").unwrap();
         envelope.version = 99;

--- a/src-tauri/src/credential/crypto.rs
+++ b/src-tauri/src/credential/crypto.rs
@@ -130,6 +130,22 @@ pub fn decrypt_with_password(password: &str, envelope: &EncryptedEnvelope) -> Re
         .decode(&envelope.data)
         .context("Invalid ciphertext encoding")?;
 
+    // Validate lengths before use: a wrong-length nonce would panic inside
+    // `Nonce::from_slice`, and a corrupted salt would silently derive a wrong
+    // key. Surface both as recoverable errors instead (#2049).
+    if salt.len() != SALT_LEN {
+        anyhow::bail!(
+            "Invalid salt length: expected {SALT_LEN}, got {}",
+            salt.len()
+        );
+    }
+    if nonce_bytes.len() != NONCE_LEN {
+        anyhow::bail!(
+            "Invalid nonce length: expected {NONCE_LEN}, got {}",
+            nonce_bytes.len()
+        );
+    }
+
     let key = derive_key(password, &salt)?;
 
     let cipher = Aes256Gcm::new_from_slice(&key).context("Failed to create cipher")?;

--- a/src-tauri/src/credential/master_password.rs
+++ b/src-tauri/src/credential/master_password.rs
@@ -146,6 +146,22 @@ impl MasterPasswordStore {
             .decode(&envelope.data)
             .map_err(|e| UnlockFailure::Corrupted(format!("invalid ciphertext encoding: {e}")))?;
 
+        // Validate lengths before use: a truncated/corrupted salt would derive a
+        // wrong key (masquerading as a wrong password) and a wrong-length nonce
+        // would panic inside `Nonce::from_slice`. Report both as corruption (#2049).
+        if salt.len() != SALT_LEN {
+            return Err(UnlockFailure::Corrupted(format!(
+                "invalid salt length: expected {SALT_LEN}, got {}",
+                salt.len()
+            )));
+        }
+        if nonce_bytes.len() != NONCE_LEN {
+            return Err(UnlockFailure::Corrupted(format!(
+                "invalid nonce length: expected {NONCE_LEN}, got {}",
+                nonce_bytes.len()
+            )));
+        }
+
         let key = derive_key(password, &salt)
             .map_err(|e| UnlockFailure::Corrupted(format!("key derivation failed: {e}")))?;
 
@@ -543,6 +559,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = make_store(dir.path());
         store.setup("pw").unwrap();
+        store.lock();
 
         // Corrupt the stored nonce to a wrong (too-short) length. Before the
         // length check this panicked inside `Nonce::from_slice` (#2049).
@@ -568,6 +585,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = make_store(dir.path());
         store.setup("pw").unwrap();
+        store.lock();
 
         // Corrupt the stored salt to a wrong (too-short) length.
         let raw = fs::read_to_string(&store.file_path).unwrap();

--- a/src-tauri/src/credential/master_password.rs
+++ b/src-tauri/src/credential/master_password.rs
@@ -539,6 +539,55 @@ mod tests {
     }
 
     #[test]
+    fn unlock_classified_wrong_length_nonce_reports_corrupted() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = make_store(dir.path());
+        store.setup("pw").unwrap();
+
+        // Corrupt the stored nonce to a wrong (too-short) length. Before the
+        // length check this panicked inside `Nonce::from_slice` (#2049).
+        let raw = fs::read_to_string(&store.file_path).unwrap();
+        let mut envelope: EncryptedEnvelope = serde_json::from_str(&raw).unwrap();
+        envelope.nonce = BASE64.encode([0u8; NONCE_LEN - 1]);
+        fs::write(
+            &store.file_path,
+            serde_json::to_string(&envelope).unwrap().as_bytes(),
+        )
+        .unwrap();
+
+        let err = store.unlock_classified("pw").unwrap_err();
+        assert!(
+            matches!(err, UnlockFailure::Corrupted(_)),
+            "expected Corrupted for wrong-length nonce, got {err:?}"
+        );
+        assert!(!store.is_unlocked());
+    }
+
+    #[test]
+    fn unlock_classified_wrong_length_salt_reports_corrupted() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = make_store(dir.path());
+        store.setup("pw").unwrap();
+
+        // Corrupt the stored salt to a wrong (too-short) length.
+        let raw = fs::read_to_string(&store.file_path).unwrap();
+        let mut envelope: EncryptedEnvelope = serde_json::from_str(&raw).unwrap();
+        envelope.kdf.salt = BASE64.encode([0u8; SALT_LEN - 1]);
+        fs::write(
+            &store.file_path,
+            serde_json::to_string(&envelope).unwrap().as_bytes(),
+        )
+        .unwrap();
+
+        let err = store.unlock_classified("pw").unwrap_err();
+        assert!(
+            matches!(err, UnlockFailure::Corrupted(_)),
+            "expected Corrupted for wrong-length salt, got {err:?}"
+        );
+        assert!(!store.is_unlocked());
+    }
+
+    #[test]
     fn set_then_get_returns_value() {
         let dir = tempfile::tempdir().unwrap();
         let store = make_store(dir.path());


### PR DESCRIPTION
## Summary

Audit finding (robustness/security, medium): the credential-unlock path called `Nonce::from_slice` on the base64-decoded stored nonce without validating its length. A truncated/corrupted stored nonce (length != 12) **panicked the process** inside `generic-array` instead of surfacing a recoverable error. A corrupted salt was also not length-checked, so it silently derived a wrong key and masqueraded as a wrong-password failure.

Confirmed the finding first: the added regression tests panic without the fix (`assertion left == right / left: 11 right: 12` inside `generic-array`), exactly matching the audit.

## Changes

- `src-tauri/src/credential/master_password.rs` (`unlock_classified`): validate `salt.len() == SALT_LEN` and `nonce_bytes.len() == NONCE_LEN` before use, returning `UnlockFailure::Corrupted` on mismatch.
- `src-tauri/src/credential/crypto.rs` (`decrypt_with_password`): same length validation, returning `Err` (`anyhow::bail!`) on mismatch.
- Regression tests in both modules covering wrong-length nonce and wrong-length salt (corrupted blob → recoverable error, no panic). Committed test-first (red) before the fix (green), per TDD.

## Test plan

- `cargo test -p termihub --lib credential` — 115 pass (4 new).
- Confirmed the new tests fail (panic) without the fix.

Closes #2049