### PR TITLE
fix(ui): restore undefined design tokens for search bar and borders (Closes #2052)

### DIFF
--- a/docs/changes/dev1/fix/2052-dangling-design-tokens.md
+++ b/docs/changes/dev1/fix/2052-dangling-design-tokens.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- UI: the Ctrl+F terminal search bar is visible again, and borders render across the
+  Tunnel, Workflow, Macro, Recent Sessions, Embedded Server, Update Notification and
+  Plugin Settings surfaces. A design-token migration had left `var()` references pointing
+  at token names that no longer exist (`--border-color`, `--background-secondary`,
+  `--input-background`, `--tab-bar-bg`, `--tab-hover-bg`), so those properties resolved to
+  nothing — rendering the search bar transparent and dropping borders across 13+
+  stylesheets. Each dangling reference now points at its current token.

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.css
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.css
@@ -9,7 +9,7 @@
   display: flex;
   padding: 4px 8px;
   gap: 4px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .server-sidebar__list {
@@ -67,7 +67,7 @@
 
 .server-dialog__input {
   padding: 5px 8px;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-primary);
   border-radius: var(--radius-sm);
   background: var(--bg-secondary);
   color: var(--text-primary);
@@ -99,7 +99,7 @@
 }
 
 .server-dialog__fieldset {
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-primary);
   border-radius: var(--radius-sm);
   padding: 8px 12px;
   display: flex;

--- a/src/components/MacroSidebar/MacroEditorDialog.css
+++ b/src/components/MacroSidebar/MacroEditorDialog.css
@@ -18,7 +18,7 @@
   gap: 4px;
   max-height: 320px;
   overflow-y: auto;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-primary);
   border-radius: var(--radius-sm);
   padding: 4px;
 }

--- a/src/components/MacroSidebar/MacroSidebar.css
+++ b/src/components/MacroSidebar/MacroSidebar.css
@@ -9,7 +9,7 @@
   display: flex;
   padding: 4px 8px;
   gap: 4px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .macro-sidebar__search {
@@ -17,7 +17,7 @@
   display: flex;
   align-items: center;
   padding: 6px 8px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .macro-sidebar__search-icon {

--- a/src/components/RecentSessionsSidebar/RecentSessionsSidebar.css
+++ b/src/components/RecentSessionsSidebar/RecentSessionsSidebar.css
@@ -9,7 +9,7 @@
 .recent-sessions__quick-connect {
   position: relative;
   padding: 6px 8px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .recent-sessions__quick-connect-row {
@@ -40,7 +40,7 @@
   padding: 4px;
   list-style: none;
   background: var(--bg-elevated, var(--bg-secondary));
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-primary);
   border-radius: var(--radius-md, 6px);
   box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.3));
 }
@@ -84,12 +84,12 @@
   justify-content: flex-end;
   padding: 4px 8px;
   gap: 4px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .recent-sessions__search {
   padding: 6px 8px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-primary);
 }
 
 /* --- List + rows --- */
@@ -148,7 +148,7 @@
 .recent-sessions__save-fields {
   margin: 8px 0 0;
   padding: 8px 12px 12px;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-primary);
   border-radius: var(--radius-md, 6px);
   background: var(--bg-secondary);
 }

--- a/src/components/Settings/PluginSettingsSection.css
+++ b/src/components/Settings/PluginSettingsSection.css
@@ -1,7 +1,7 @@
 /* Plugins settings section (#2000): one card per plugin that declares settings. */
 
 .plugin-settings__group {
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-primary);
   border-radius: var(--radius-md);
   padding: var(--spacing-md);
   transition: border-color var(--transition-fast);

--- a/src/components/SplitView/SplitView.css
+++ b/src/components/SplitView/SplitView.css
@@ -108,7 +108,7 @@
   align-items: center;
   gap: 8px;
   padding: 4px 8px;
-  background: var(--tab-bar-bg);
+  background: var(--tab-bg);
   border-bottom: 1px solid var(--panel-border);
   flex-shrink: 0;
 }
@@ -146,7 +146,7 @@
 }
 
 .zoom-overlay__close:hover {
-  background: var(--tab-hover-bg);
+  background: var(--bg-hover);
   color: var(--text-primary);
 }
 

--- a/src/components/Terminal/TerminalSearchBar.css
+++ b/src/components/Terminal/TerminalSearchBar.css
@@ -7,8 +7,8 @@
   align-items: center;
   gap: 2px;
   padding: 4px 6px;
-  background: var(--background-secondary);
-  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-sm);
 }
@@ -16,9 +16,9 @@
 .terminal-search-bar__input {
   width: 180px;
   padding: 2px 6px;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-primary);
   border-radius: 3px;
-  background: var(--input-background);
+  background: var(--bg-input);
   color: var(--text-primary);
   font-size: 12px;
   outline: none;

--- a/src/components/TunnelEditor/TunnelDiagram.css
+++ b/src/components/TunnelEditor/TunnelDiagram.css
@@ -14,7 +14,7 @@
   justify-content: center;
   min-width: 120px;
   padding: 12px 16px;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-primary);
   border-radius: 6px;
   background: var(--bg-secondary);
   gap: 4px;

--- a/src/components/TunnelEditor/TunnelEditor.css
+++ b/src/components/TunnelEditor/TunnelEditor.css
@@ -76,7 +76,7 @@
 .tunnel-editor__type-option {
   flex: 1;
   padding: 8px 12px;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-primary);
   border-radius: 6px;
   background: var(--bg-secondary);
   color: var(--text-secondary);
@@ -120,5 +120,5 @@
   font-weight: 600;
   color: var(--text-primary);
   padding-top: 8px;
-  border-top: 1px solid var(--border-color);
+  border-top: 1px solid var(--border-primary);
 }

--- a/src/components/TunnelSidebar/TunnelSidebar.css
+++ b/src/components/TunnelSidebar/TunnelSidebar.css
@@ -9,7 +9,7 @@
   display: flex;
   padding: 4px 8px;
   gap: 4px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .tunnel-sidebar__list {

--- a/src/components/UpdateNotification/UpdateNotification.css
+++ b/src/components/UpdateNotification/UpdateNotification.css
@@ -4,7 +4,7 @@
   right: 20px;
   width: 380px;
   background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-primary);
   border-radius: 6px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
   z-index: 9000;
@@ -21,7 +21,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 10px 12px 8px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .update-notification__title-row {
@@ -88,7 +88,7 @@
   margin-top: 8px;
   max-height: 160px;
   overflow-y: auto;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-primary);
   border-radius: var(--radius-sm);
   background: var(--bg-primary);
 }
@@ -108,6 +108,6 @@
   align-items: center;
   gap: 6px;
   padding: 8px 12px 10px;
-  border-top: 1px solid var(--border-color);
+  border-top: 1px solid var(--border-primary);
   flex-wrap: wrap;
 }

--- a/src/components/WorkflowSidebar/WorkflowEditorDialog.css
+++ b/src/components/WorkflowSidebar/WorkflowEditorDialog.css
@@ -21,7 +21,7 @@
   margin: 0 0 8px;
   padding: 6px;
   list-style: none;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-primary);
   border-radius: var(--radius-sm);
 }
 
@@ -160,7 +160,7 @@
   flex-direction: column;
   gap: 6px;
   padding: 8px;
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--border-primary);
   border-radius: var(--radius-sm);
 }
 

--- a/src/components/WorkflowSidebar/WorkflowRunOutput.css
+++ b/src/components/WorkflowSidebar/WorkflowRunOutput.css
@@ -8,7 +8,7 @@
   flex-direction: column;
   flex-shrink: 0;
   max-height: 45%;
-  border-top: 1px solid var(--border-color);
+  border-top: 1px solid var(--border-primary);
   background: var(--bg-secondary);
 }
 
@@ -17,7 +17,7 @@
   align-items: center;
   gap: var(--spacing-sm);
   padding: var(--spacing-xs) var(--spacing-sm);
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .workflow-run-output__spacer {
@@ -75,7 +75,7 @@
   gap: 6px;
   padding: var(--spacing-xs) var(--spacing-sm);
   color: var(--text-secondary);
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .workflow-run-output__command code {
@@ -115,7 +115,7 @@
 
 .workflow-run-output__footer {
   padding: var(--spacing-xs) var(--spacing-sm);
-  border-top: 1px solid var(--border-color);
+  border-top: 1px solid var(--border-primary);
   font-size: 11px;
   font-weight: 600;
   color: var(--text-secondary);

--- a/src/components/WorkflowSidebar/WorkflowSidebar.css
+++ b/src/components/WorkflowSidebar/WorkflowSidebar.css
@@ -10,7 +10,7 @@
   align-items: center;
   padding: 4px 8px;
   gap: 4px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .workflow-sidebar__search {
@@ -18,7 +18,7 @@
   display: flex;
   align-items: center;
   padding: 6px 8px;
-  border-bottom: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .workflow-sidebar__search-icon {

--- a/src/styles/tokenDiscipline.test.ts
+++ b/src/styles/tokenDiscipline.test.ts
@@ -12,7 +12,10 @@ import { fileURLToPath } from "url";
  * that fights the global "one scrollbar" rule.
  */
 
-const COMPONENTS_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "components");
+const SRC_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
+const COMPONENTS_DIR = join(SRC_DIR, "components");
+const STYLES_DIR = join(SRC_DIR, "styles");
+const THEMES_DIR = join(SRC_DIR, "themes");
 
 /** Absolute path of the shared primitive layer, excluded from most guards. */
 const UI_DIR = join(COMPONENTS_DIR, "ui");
@@ -242,6 +245,73 @@ describe("Design-system regression guards (#1083)", () => {
       offenders,
       "Reference a token from src/styles/variables.css instead of a raw hex literal in: " +
         `${offenders.join(", ")}`
+    ).toEqual([]);
+  });
+});
+
+/**
+ * Collect every design token DEFINED anywhere the app can define one:
+ *  - as a `--token:` custom-property declaration in any `src/**\/*.css`
+ *    (variables.css, global.css, animations.css, per-component files, …), and
+ *  - as a runtime custom property written by the theme engine
+ *    (`COLOR_TO_CSS_VAR` in src/themes/engine.ts), which sets per-theme values
+ *    on `document.documentElement` and therefore never appears as a static
+ *    `:root { --x: … }` declaration.
+ *
+ * @returns The set of every `--token` name that resolves at runtime.
+ */
+function collectDefinedTokens(): Set<string> {
+  const defined = new Set<string>();
+  const declRe = /(--[a-z0-9-]+)\s*:/gi;
+  for (const file of collectFiles(SRC_DIR, (name) => name.endsWith(".css"))) {
+    const css = stripCssComments(readFileSync(file, "utf8"));
+    for (const m of css.matchAll(declRe)) defined.add(m[1]);
+  }
+  // Runtime-defined tokens: the string literals in engine.ts's CSS-var map.
+  const engine = readFileSync(join(THEMES_DIR, "engine.ts"), "utf8");
+  for (const m of engine.matchAll(/"(--[a-z0-9-]+)"/gi)) defined.add(m[1]);
+  return defined;
+}
+
+/**
+ * Undefined-token guard (#2052). A `var(--token)` reference with **no fallback**
+ * resolves to nothing when `--token` is undefined — the property is dropped,
+ * rendering the element transparent / borderless. A token-rename migration left
+ * a cluster of these dangling (the Ctrl+F terminal search bar went transparent
+ * and borders vanished across 13+ stylesheets), so this guard fails on any
+ * bare, fallback-less `var(--token)` whose token is not defined anywhere.
+ *
+ * Scope note: `var(--token, <fallback>)` is deliberately EXEMPT — the fallback
+ * renders, so an undefined token there degrades gracefully rather than silently
+ * breaking, exactly as the raw-hex guard exempts `var(--token, #hex)`. The
+ * separately-tracked cleanup of undefined-but-fallback'd tokens is a follow-up.
+ */
+describe("undefined design-token guard (#2052)", () => {
+  const definedTokens = collectDefinedTokens();
+
+  it("defines the core tokens it depends on (sanity check)", () => {
+    for (const tok of ["--bg-secondary", "--border-primary", "--bg-input", "--tab-bg"]) {
+      expect(definedTokens.has(tok), `${tok} should be a defined token`).toBe(true);
+    }
+  });
+
+  it("has no fallback-less var(--token) reference to an undefined token", () => {
+    // `var(--token)` with no comma before the closing paren — i.e. no fallback.
+    const bareVarRe = /var\(\s*(--[a-z0-9-]+)\s*\)/gi;
+    const offenders: string[] = [];
+    for (const file of collectCssFiles(COMPONENTS_DIR)) {
+      const css = stripCssComments(readFileSync(file, "utf8"));
+      const bad = new Set<string>();
+      for (const m of css.matchAll(bareVarRe)) {
+        if (!definedTokens.has(m[1])) bad.add(m[1]);
+      }
+      if (bad.size > 0) offenders.push(`${toPosix(file)} → ${[...bad].join(", ")}`);
+    }
+    expect(
+      offenders,
+      "Fallback-less var(--token) references must resolve to a token defined in " +
+        "src/styles/variables.css (or written by the theme engine). Rename each to the " +
+        `current token or add the token. Dangling in:\n  ${offenders.join("\n  ")}`
     ).toEqual([]);
   });
 });

--- a/src/styles/tokenDiscipline.test.ts
+++ b/src/styles/tokenDiscipline.test.ts
@@ -14,7 +14,6 @@ import { fileURLToPath } from "url";
 
 const SRC_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
 const COMPONENTS_DIR = join(SRC_DIR, "components");
-const STYLES_DIR = join(SRC_DIR, "styles");
 const THEMES_DIR = join(SRC_DIR, "themes");
 
 /** Absolute path of the shared primitive layer, excluded from most guards. */


### PR DESCRIPTION
## Summary

A design-token migration left a cluster of `var()` references pointing at token names that no longer exist. Because those references had **no fallback**, the CSS properties resolved to nothing — rendering the **Ctrl+F terminal search bar effectively transparent** and **dropping borders across 13+ stylesheets**. This restores each dangling reference to its current token and adds a build-time guard so it cannot recur silently.

Closes #2052

## Dangling tokens fixed (undefined → current)

| Was (undefined) | Now (defined) | Where |
| --- | --- | --- |
| `--background-secondary` | `--bg-secondary` | TerminalSearchBar |
| `--input-background` | `--bg-input` | TerminalSearchBar |
| `--tab-bar-bg` | `--tab-bg` | SplitView (zoom overlay) |
| `--tab-hover-bg` | `--bg-hover` | SplitView (zoom overlay) |
| `--border-color` | `--border-primary` | TerminalSearchBar + 12 stylesheets: EmbeddedServerSidebar, MacroEditorDialog, MacroSidebar, RecentSessionsSidebar, PluginSettingsSection, TunnelDiagram, TunnelEditor, TunnelSidebar, UpdateNotification, WorkflowEditorDialog, WorkflowRunOutput, WorkflowSidebar |

## Guardrail

Extended `src/styles/tokenDiscipline.test.ts` (the existing token-discipline suite) with an **undefined-token guard** (`#2052`): it collects every token defined anywhere (all `src/**/*.css` declarations **plus** the runtime custom properties written by the theme engine's `COLOR_TO_CSS_VAR`), then fails on any **fallback-less** `var(--token)` in component CSS whose token is not defined.

**Scope:** the guard is deliberately limited to fallback-less references — `var(--token, <fallback>)` degrades gracefully (the fallback renders) rather than breaking silently, exactly as the existing raw-hex guard exempts `var(--token, #hex)`. The audit surfaced a separate set of undefined-but-fallback'd tokens; those do not cause the visible regression and are tracked as a follow-up (they need per-token design decisions, not a rename).

## Verification

- `pnpm test -- src/styles/tokenDiscipline.test.ts` — the new guard was **red** before the fix (listed exactly the 14 offending stylesheets) and is **green** after.
- Full `pnpm test` (4607 tests) green; `pnpm build` (tsc) and `pnpm run lint` clean.
- The search bar now resolves to defined values: `--bg-secondary` (#161b24), `--border-primary` (#2a2f40), `--bg-input` (#1a1e2c) — all present in `variables.css` and written by the theme engine across all four themes.

## Test plan

- [x] Regression guard fails without the CSS fix, passes with it
- [x] Full unit suite, lint, and tsc build pass