### PR TITLE
ci: report per-pr coverage gaps honestly and trigger integration on backend changes (Closes #2050)

### DIFF
--- a/.github/workflows/integration-fixtures.yml
+++ b/.github/workflows/integration-fixtures.yml
@@ -16,12 +16,17 @@ on:
     # 03:17 UTC daily (off the top of the hour to dodge scheduler congestion).
     - cron: "17 3 * * *"
   workflow_dispatch:
-  # Also run when the fixtures or the integration tests themselves change, so a
-  # PR that touches them gets feedback without waiting for the nightly run.
+  # Also run when the fixtures, the integration tests, or the backend *source*
+  # they exercise change — so a PR that edits the SSH/SFTP/telnet/serial/Docker
+  # backends gets integration feedback without waiting for the nightly run. The
+  # `require_docker!`-gated tests in core/tests self-skip on the per-PR gate
+  # (which runs with no containers up), so a backend change would otherwise reach
+  # `develop` with its integration path completely unexercised (#2050).
   pull_request:
     paths:
       - "tests/docker/**"
       - "core/tests/**"
+      - "core/src/backends/**"
       - ".github/workflows/integration-fixtures.yml"
 
 # A fixture run is self-contained; cancel an in-flight run when a newer commit

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -296,6 +296,17 @@ the app-launching suites still run on a cadence:
 - **Per-PR — collection + non-integration** ([`code-quality.yml`](../.github/workflows/code-quality.yml) → _System-Test Harness_). Every PR runs the bridge harness with `-m "not integration"`, so it proves the harness _collects_ all ~360 tests and the non-integration checks pass. It deliberately does **not** launch the built app or bring up Docker, keeping the check quick.
 - **Nightly — integration lane on all three platforms** ([`system-integration.yml`](../.github/workflows/system-integration.yml)). A scheduled + `workflow_dispatch` job builds the app (debug) and runs `-m integration`, which launches the **real per-platform build** and drives it through the bridge. Because the bridge needs no `tauri-driver`/WKWebView driver, this lane carries **Linux, macOS, and Windows** legs (#804/#1649) — macOS app-UI integration testing that used to be manual-only now runs in CI.
 
+> **Reading the coverage-gap report honestly (#2050).** Because the per-PR lane
+> runs `-m "not integration"`, an `integration`-marked test is **not** merge-gate
+> coverage — it only runs nightly. The test-inventory report
+> ([`scripts/build-test-inventory.py`](../scripts/build-test-inventory.py))
+> therefore classifies each test into three lanes (`automated` = per-PR,
+> `integration` = nightly, `manual` = operator) and leads with **"feature areas
+> the per-PR merge gate does not exercise"** — areas covered only by integration
+> or manual tests, where a regression can merge green. Do not read a `0` in that
+> section as "fully tested"; it means the per-PR gate touches every area, not
+> that every path is exercised.
+
 The lane runs the app natively on each OS; only the **Docker fixtures** are
 Linux-only:
 

--- a/scripts/build-test-inventory.py
+++ b/scripts/build-test-inventory.py
@@ -24,7 +24,12 @@ For each collected test it records:
 * **feature** (category) — an explicit ``@pytest.mark.category("ssh")`` marker
   when present (on the item, its class, or the module ``pytestmark``), else the
   ``test_<feature>.py`` filename stem with the ``test_`` prefix stripped.
-* **lane** — ``manual`` when the ``manual`` marker applies, else ``automated``.
+* **lane** — ``manual`` (operator-guided), ``integration`` (launches the real
+  built app/agent — **excluded from the per-PR gate**, which runs ``pytest -m
+  "not integration"``), or ``automated`` (the fast machinery suite that runs on
+  every PR). Conflating integration with automated is what let this report lie
+  with "0 coverage gaps 🎉" while the SSH/SFTP/tunnel core went unexercised on
+  the merge gate (#2050).
 * **platforms** — ``linux`` / ``macos`` / ``windows``. The harness runs on all
   three by default; a recognized ``skipif`` marker (e.g. ``skip_on_non_windows``,
   ``sys.platform == 'darwin'``) narrows the set. Best-effort and documented as
@@ -74,6 +79,13 @@ MD_PATH = SYSTEM_DIR / "test-inventory.md"
 JSON_PATH = SYSTEM_DIR / "test-inventory.json"
 
 ALL_PLATFORMS = ("linux", "macos", "windows")
+
+# The CI lanes a test can fall into, and the one that actually gates a merge.
+# ``automated`` is the only lane the per-PR system-test job runs (it invokes
+# ``pytest -m "not integration"``, and ``manual`` is skipped without --manual);
+# ``integration`` runs only in the nightly/manual system-test lanes. See #2050.
+LANES = ("automated", "integration", "manual")
+PER_PR_LANE = "automated"
 
 # Curated map of feature area -> category substrings that count as covering it.
 # This is the source of truth for "what features do we track": a feature only
@@ -355,8 +367,29 @@ def _restriction_for(mark: Mark) -> "set[str] | None":
 
 
 def lane_for(marks: "list[Mark]") -> str:
-    """``"manual"`` if any applicable mark is ``manual``, else ``"automated"``."""
-    return "manual" if any(m.name == "manual" for m in marks) else "automated"
+    """The CI lane a test runs in: ``manual`` / ``integration`` / ``automated``.
+
+    The three lanes gate very differently, and conflating them is what let this
+    report lie (#2050):
+
+    * ``manual`` — an operator-guided test (``@pytest.mark.manual``); skipped
+      unless ``--manual`` + a TTY. Never runs in CI.
+    * ``integration`` — launches the real built app/agent
+      (``@pytest.mark.integration``). **Excluded from the per-PR gate**, which
+      runs ``pytest -m "not integration"``; it runs only in the dedicated
+      nightly/manual system-test lanes. Green per-PR CI proves nothing about it.
+    * ``automated`` — everything else: the fast machinery suite that actually
+      runs on **every PR** and is therefore the real merge-gate safety net.
+
+    Precedence ``manual`` > ``integration`` > ``automated`` mirrors how pytest
+    selects: a manual test is gated manual even when also integration-marked.
+    """
+    names = {m.name for m in marks}
+    if "manual" in names:
+        return "manual"
+    if "integration" in names:
+        return "integration"
+    return "automated"
 
 
 def platforms_for(marks: "list[Mark]") -> "list[str]":
@@ -471,7 +504,13 @@ def group_by_feature(records: "list[dict]") -> "dict[str, dict]":
     for rec in records:
         group = groups.setdefault(
             rec["feature"],
-            {"automated": 0, "manual": 0, "platforms": set(), "tests": []},
+            {
+                "automated": 0,
+                "integration": 0,
+                "manual": 0,
+                "platforms": set(),
+                "tests": [],
+            },
         )
         group[rec["lane"]] += 1
         group["platforms"].update(rec["platforms"])
@@ -487,7 +526,7 @@ def coverage(records: "list[dict]", feature_areas=FEATURE_AREAS) -> "dict[str, d
     "categories": [str, ...]}``.
     """
     result = {
-        area: {"automated": 0, "manual": 0, "categories": set()}
+        area: {"automated": 0, "integration": 0, "manual": 0, "categories": set()}
         for area in feature_areas
     }
     for rec in records:
@@ -500,13 +539,35 @@ def coverage(records: "list[dict]", feature_areas=FEATURE_AREAS) -> "dict[str, d
 
 
 def coverage_gaps(records: "list[dict]", feature_areas=FEATURE_AREAS) -> "list[str]":
-    """Curated feature areas with no automated **and** no manual test."""
+    """Curated feature areas with **no test at all**, in any lane.
+
+    The strongest gap: not automated, not integration, not manual — the feature
+    is entirely untracked. (An area covered only by nightly ``integration`` or
+    operator ``manual`` tests is *not* a total gap here — see
+    :func:`per_pr_gaps` for the merge-gate view, which is the one #2050 is about.)
+    """
     cov = coverage(records, feature_areas)
     return [
         area
         for area in feature_areas
-        if cov[area]["automated"] == 0 and cov[area]["manual"] == 0
+        if cov[area]["automated"] == 0
+        and cov[area]["integration"] == 0
+        and cov[area]["manual"] == 0
     ]
+
+
+def per_pr_gaps(records: "list[dict]", feature_areas=FEATURE_AREAS) -> "list[str]":
+    """Feature areas the **per-PR merge gate** never exercises (#2050).
+
+    The per-PR system-test lane runs ``pytest -m "not integration"``, so only the
+    ``automated`` lane (:data:`PER_PR_LANE`) gates a merge. An area covered
+    *only* by ``integration`` (nightly) and/or ``manual`` (operator) tests
+    therefore has **zero** merge-gate coverage: a regression in it can merge with
+    green CI. That is the dangerous gap the old "0 coverage gaps 🎉" headline hid
+    by counting integration tests as coverage.
+    """
+    cov = coverage(records, feature_areas)
+    return [area for area in feature_areas if cov[area][PER_PR_LANE] == 0]
 
 
 def unmapped_categories(records: "list[dict]", feature_areas=FEATURE_AREAS) -> "list[str]":
@@ -553,6 +614,7 @@ def build_report(records: "list[dict]") -> dict:
             {
                 "feature": feature,
                 "automated": group["automated"],
+                "integration": group["integration"],
                 "manual": group["manual"],
                 "platforms": _fmt_platforms(group["platforms"]),
                 "tests": group["tests"],
@@ -562,11 +624,13 @@ def build_report(records: "list[dict]") -> dict:
         "total_tests": len(records),
         "total_features": len(groups),
         "features": features,
+        "per_pr_gaps": per_pr_gaps(records),
         "coverage_gaps": coverage_gaps(records),
         "unmapped_categories": unmapped_categories(records),
         "feature_areas": {
             area: {
                 "automated": cov[area]["automated"],
+                "integration": cov[area]["integration"],
                 "manual": cov[area]["manual"],
                 "categories": sorted(cov[area]["categories"]),
             }
@@ -577,35 +641,70 @@ def build_report(records: "list[dict]") -> dict:
 
 def render_markdown(records: "list[dict]") -> str:
     report = build_report(records)
+    lane_totals = {lane: 0 for lane in LANES}
+    for feature in report["features"]:
+        for lane in LANES:
+            lane_totals[lane] += feature[lane]
     lines = [
         "# Test inventory & coverage-gap report",
         "",
         "<!-- GENERATED by scripts/build-test-inventory.py — DO NOT EDIT BY HAND. -->",
         "",
         "Every collected system-harness test mapped to its **feature**, **lane** "
-        "(automated / manual), and **platforms** — plus the feature areas with "
-        "**no** coverage (#1950).",
+        "(automated / integration / manual), and **platforms** — plus the feature "
+        "areas the **per-PR merge gate does not exercise** (#1950, #2050).",
         "",
         "- **Regenerate:** `python scripts/build-test-inventory.py`",
         "- **Not committed:** a local, git-ignored artifact; CI regenerates it "
         "(non-blocking) instead of diffing a file that goes stale per-branch (#1528).",
         "",
         f"- **Tests:** {report['total_tests']}  ·  "
-        f"**Features:** {report['total_features']}  ·  "
-        f"**Coverage gaps:** {len(report['coverage_gaps'])}",
+        f"**Features:** {report['total_features']}",
+        f"- **Lanes:** {lane_totals['automated']} automated (run on every PR)  ·  "
+        f"{lane_totals['integration']} integration (nightly/manual only — **not** "
+        f"on the per-PR gate)  ·  {lane_totals['manual']} manual",
+        f"- **Merge-gate gaps:** {len(report['per_pr_gaps'])} feature area(s) with "
+        f"no per-PR automated test  ·  **Untested areas:** "
+        f"{len(report['coverage_gaps'])}",
         "",
-        "## Features with no coverage",
+        "## Feature areas the per-PR merge gate does not exercise",
         "",
     ]
+    if report["per_pr_gaps"]:
+        lines += [
+            "These curated feature areas have **no `automated` test on the per-PR "
+            'gate** (which runs `pytest -m "not integration"`). They are covered '
+            "only by `integration` (nightly) and/or `manual` (operator) tests, so "
+            "a regression in them can merge with green CI. This is the risk the "
+            'old "0 coverage gaps" headline hid by counting integration tests as '
+            "coverage (#2050).",
+            "",
+        ]
+        for area in report["per_pr_gaps"]:
+            fa = report["feature_areas"][area]
+            lines.append(
+                f"- **{area}** — {fa['integration']} integration, "
+                f"{fa['manual']} manual, **0 per-PR automated**"
+            )
+    else:
+        lines.append(
+            "None — every curated feature area has at least one automated test on "
+            "the per-PR gate. 🎉"
+        )
+    lines.append("")
+
+    lines += ["## Feature areas with no test at all", ""]
     if report["coverage_gaps"]:
         lines += [
             "Curated feature areas (`FEATURE_AREAS` in the generator) with **no "
-            "automated and no manual** test:",
+            "test in any lane** (automated, integration, or manual):",
             "",
         ]
         lines += [f"- **{area}**" for area in report["coverage_gaps"]]
     else:
-        lines.append("None — every curated feature area has at least one test. 🎉")
+        lines.append(
+            "None — every curated feature area has at least one test in some lane."
+        )
     lines.append("")
 
     if report["unmapped_categories"]:

--- a/tests/system/tests/test_test_inventory.py
+++ b/tests/system/tests/test_test_inventory.py
@@ -85,12 +85,26 @@ def test_module_level_category_marker(tmp_path, monkeypatch):
 # ── lane classification ─────────────────────────────────────────────────────
 
 
-def test_lane_is_automated_without_manual_mark():
-    assert mod.lane_for([mod.Mark("integration", None, "")]) == "automated"
+def test_lane_is_automated_without_any_lane_mark():
+    assert mod.lane_for([mod.Mark("slow", None, "")]) == "automated"
+    assert mod.lane_for([]) == "automated"
+
+
+def test_integration_mark_is_its_own_lane():
+    # #2050: integration tests do NOT run on the per-PR gate, so they must not be
+    # counted as "automated" merge-gate coverage.
+    assert mod.lane_for([mod.Mark("integration", None, "")]) == "integration"
 
 
 def test_lane_is_manual_with_manual_mark():
     assert mod.lane_for([mod.Mark("manual", None, "")]) == "manual"
+
+
+def test_manual_wins_over_integration():
+    lane = mod.lane_for(
+        [mod.Mark("integration", None, ""), mod.Mark("manual", None, "")]
+    )
+    assert lane == "manual"
 
 
 def test_module_manual_mark_applies_to_methods(tmp_path, monkeypatch):
@@ -221,10 +235,41 @@ def test_coverage_gap_flags_feature_with_no_tests():
     assert set(gaps) == {"serial", "telnet"}
 
 
-def test_coverage_gap_requires_no_automated_and_no_manual():
-    # A feature with only a manual test is NOT a gap.
+def test_coverage_gap_requires_no_test_in_any_lane():
+    # A feature with only a manual test is NOT a total gap.
     gaps = mod.coverage_gaps([_rec("serial", "manual")], _FEATURE_AREAS)
     assert "serial" not in gaps
+    # Nor is one covered only by an integration test.
+    gaps = mod.coverage_gaps([_rec("telnet", "integration")], _FEATURE_AREAS)
+    assert "telnet" not in gaps
+
+
+def test_per_pr_gap_flags_integration_only_feature():
+    # #2050: ssh covered ONLY by an integration test -> unexercised on the merge
+    # gate, so it is a per-PR gap even though it is not a total coverage gap.
+    records = [_rec("ssh", "integration")]
+    # ssh has an integration test (not a total gap) but no per-PR automated one.
+    assert "ssh" in mod.per_pr_gaps(records, _FEATURE_AREAS)
+    assert "ssh" not in mod.coverage_gaps(records, _FEATURE_AREAS)
+
+
+def test_per_pr_gap_flags_manual_only_feature():
+    records = [_rec("ssh", "manual")]
+    assert "ssh" in mod.per_pr_gaps(records, _FEATURE_AREAS)
+
+
+def test_per_pr_gap_cleared_by_an_automated_test():
+    # A single automated (per-PR) test removes the merge-gate gap.
+    records = [_rec("ssh", "automated"), _rec("ssh", "integration")]
+    assert "ssh" not in mod.per_pr_gaps(records, _FEATURE_AREAS)
+
+
+def test_coverage_counts_integration_lane():
+    cov = mod.coverage(
+        [_rec("ssh", "integration"), _rec("ssh", "automated")], _FEATURE_AREAS
+    )
+    assert cov["ssh"]["integration"] == 1
+    assert cov["ssh"]["automated"] == 1
 
 
 def test_coverage_counts_split_by_lane():
@@ -251,14 +296,18 @@ def test_live_report_is_wellformed():
     report = mod.build_report(records)
     assert report["total_tests"] == len(records)
     assert report["total_features"] == len(report["features"])
-    # Known feature areas must be covered by the real suite (no false gaps).
+    # Known feature areas have at least one test in some lane (no total gap).
     for area in ("ssh", "sftp", "serial", "telnet"):
         assert area not in report["coverage_gaps"]
+    # A per-PR gap is always a subset of "has some test" — it can never exceed
+    # the total set of tracked areas, and every per-PR gap is a real area.
+    assert set(report["per_pr_gaps"]) <= set(mod.FEATURE_AREAS)
 
 
 def test_live_markdown_has_required_sections():
     markdown = mod.render_markdown(mod.collect())
     assert "# Test inventory & coverage-gap report" in markdown
-    assert "## Features with no coverage" in markdown
+    assert "## Feature areas the per-PR merge gate does not exercise" in markdown
+    assert "## Feature areas with no test at all" in markdown
     assert "## Inventory by feature" in markdown
     assert "| test id | feature | lane | platforms |" in markdown


### PR DESCRIPTION
## Summary

Fixes the two highest-value, self-contained parts of the "hollow-green CI" audit finding: the coverage-gap tool that actively **lied** (`Coverage gaps: 0 🎉`) and the integration lane that never fired on backend source changes.

`Closes #2050`

### 1. Kill the false "0 gaps" — honest per-PR coverage reporting
`scripts/build-test-inventory.py` classified every non-manual test as `automated`, counting the **330 `integration`-marked** harness tests as coverage — even though the per-PR gate runs `pytest -m "not integration"` and never executes them. So it reported *zero gaps* while ssh/sftp/tunnel/telnet/monitoring had **no** merge-gate coverage.

- `lane_for` now returns a three-lane taxonomy: `automated` (per-PR) / `integration` (nightly-only) / `manual` (operator), precedence `manual > integration > automated`.
- New `per_pr_gaps()` surfaces feature areas with **zero per-PR automated tests**; the report now **leads** with "Feature areas the per-PR merge gate does not exercise". `coverage_gaps()` now means "no test in *any* lane".
- On the live suite this flips the headline from `Coverage gaps: 0 🎉` to **17 merge-gate gaps** (serial, telnet, sftp, tunnels, monitoring, credential store, ssh-core paths, …).
- Tests added/adjusted in `test_test_inventory.py` (24 pass).

### 2. Fire the integration lane on backend source changes
`integration-fixtures.yml` only triggered on `tests/docker/**` + `core/tests/**`. Added `core/src/backends/**`, so editing the SSH/SFTP/telnet/serial/Docker backends now runs the Docker-fixture integration suite on the PR instead of letting the `require_docker!`-gated tests silently self-skip on the per-PR gate.

### 3. Docs
`docs/testing.md` CI-lanes section now explains how to read the coverage-gap report honestly (a `0` means the gate touches every area, not that every path is exercised).

## Deferred to follow-ups (referenced below)
- **Per-PR smoke subset** (audit part 3) — needs an app build on the runner; tracked in #2065.
- **Vitest coverage thresholds** (audit part 4) — #2066.
- **Regenerate the stale manual release gate** (`docs/release-plan-0.1.0.md` still says "75 manual tests"; audit part 4) — #2067.

## Verification
- `./tests/system/pytest.sh tests/test_test_inventory.py` → 24 passed.
- Both edited workflows parse (`yaml.safe_load`) and pass `actionlint`.
- `markdownlint` clean on `docs/testing.md`.
- Ran `build-test-inventory.py --stdout`/`--json`: report renders and now reports 17 honest merge-gate gaps.

Non-user-facing (CI/tooling/docs), so no changelog fragment per `docs/changes/README.md`.

