### PR TITLE
fix(config): surface store load/persist failures instead of invisible console.error (Closes #2068)

### DIFF
--- a/docs/changes/dev1/fix/2068-surface-store-errors.md
+++ b/docs/changes/dev1/fix/2068-surface-store-errors.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Store load and persist failures are no longer swallowed by an invisible
+  `console.error`. Every catch block in the app store now routes through the
+  in-app logger (`frontend::app_store`), so failures are visible in the
+  LogViewer, and the user-facing cases — failing to load connections at
+  startup, save settings, or reload external connection files — now also raise a
+  recoverable error toast instead of failing silently (#2068).

--- a/src/store/appStore.credential.test.ts
+++ b/src/store/appStore.credential.test.ts
@@ -3,6 +3,7 @@ import { CredentialStoreStatusInfo } from "@/types/credential";
 import type { SavedConnection, RemoteAgentDefinition } from "@/types/connection";
 import { DEFAULT_AGENT_SETTINGS } from "@/types/connection";
 import type { WorkspaceDefinition } from "@/types/workspace";
+import { onFrontendLog } from "@/utils/frontendLog";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
@@ -94,17 +95,20 @@ describe("appStore credential store state", () => {
   });
 
   it("loadCredentialStoreStatus handles errors gracefully", async () => {
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // #2068: the failure must reach the LogViewer via frontendLog, not vanish
+    // into an invisible console.error.
+    const logs: string[] = [];
+    const unsubscribe = onFrontendLog((entry) => {
+      if (entry.target === "frontend::app_store") logs.push(entry.message);
+    });
     mockedInvoke.mockRejectedValueOnce(new Error("Backend error"));
 
     await useAppStore.getState().loadCredentialStoreStatus();
 
     expect(useAppStore.getState().credentialStoreStatus).toBeNull();
-    expect(consoleSpy).toHaveBeenCalledWith(
-      "Failed to load credential store status:",
-      expect.any(Error)
-    );
-    consoleSpy.mockRestore();
+    expect(logs.some((m) => m.includes("Failed to load credential store status"))).toBe(true);
+    expect(logs.some((m) => m.includes("Backend error"))).toBe(true);
+    unsubscribe();
   });
 
   // Unlock dialog state

--- a/src/store/appStore.storeErrorSurfacing.test.ts
+++ b/src/store/appStore.storeErrorSurfacing.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * Regression suite for #2068 — store load/persist failures must not vanish into
+ * an invisible `console.error`. Every catch block in appStore now routes through
+ * `frontendLog("app_store", …)` so the failure reaches the LogViewer, and the
+ * user-facing load/persist failures additionally surface a recoverable
+ * `toast.error`. These tests lock in both behaviours:
+ *   - failures are logged via frontendLog (never a bare console.error), and
+ *   - user-facing load/persist failures toast, while best-effort background
+ *     loads log only (no toast spam).
+ */
+
+// Mock the toast hub so we can assert (or assert the absence of) feedback.
+const toastError = vi.fn((_message: unknown, _opts?: unknown) => undefined);
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: vi.fn(),
+    error: (message: unknown, opts?: unknown) =>
+      opts === undefined ? toastError(message) : toastError(message, opts),
+    loading: vi.fn(() => "toast-id"),
+    info: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+  persistConnection: vi.fn(() => Promise.resolve("id")),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/services/api", () => ({
+  getConnectionTypes: vi.fn(() => Promise.resolve([])),
+  listAvailableShells: vi.fn(() => Promise.resolve([])),
+  getDefaultShell: vi.fn(() => Promise.resolve(null)),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+vi.mock("@/services/workspaceApi", () => ({
+  getWorkspaces: vi.fn(() => Promise.resolve([])),
+}));
+
+import { useAppStore } from "./appStore";
+import { onFrontendLog } from "@/utils/frontendLog";
+import type { LogEntry } from "@/types/terminal";
+import { loadConnections, saveSettings, reloadExternalConnections } from "@/services/storage";
+import { getWorkspaces } from "@/services/workspaceApi";
+
+/** Flush the fire-and-forget promise chains. */
+async function flush() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+let logs: LogEntry[] = [];
+let unsubscribe: () => void = () => {};
+
+function logged(substring: string): boolean {
+  return logs.some((e) => e.target === "frontend::app_store" && e.message.includes(substring));
+}
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  vi.clearAllMocks();
+  logs = [];
+  unsubscribe = onFrontendLog((entry) => logs.push(entry));
+});
+
+afterEach(() => {
+  unsubscribe();
+});
+
+describe("#2068 — user-facing load/persist failures log and toast", () => {
+  it("loadFromBackend logs and toasts when connections fail to load", async () => {
+    vi.mocked(loadConnections).mockRejectedValueOnce(new Error("db corrupt"));
+
+    await useAppStore.getState().loadFromBackend();
+    await flush();
+
+    expect(logged("Failed to load connections from backend")).toBe(true);
+    expect(logged("db corrupt")).toBe(true);
+    expect(toastError).toHaveBeenCalledWith(
+      expect.stringContaining("db corrupt"),
+      expect.objectContaining({ id: "load-connections-error" })
+    );
+  });
+
+  it("updateSettings logs and toasts when the save fails", async () => {
+    vi.mocked(saveSettings).mockRejectedValueOnce(new Error("disk full"));
+
+    await useAppStore.getState().updateSettings({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    });
+    await flush();
+
+    expect(logged("Failed to save settings")).toBe(true);
+    expect(toastError).toHaveBeenCalledWith(
+      expect.stringContaining("disk full"),
+      expect.objectContaining({ id: "save-settings-error" })
+    );
+  });
+
+  it("reloadExternalConnections logs and toasts on failure", async () => {
+    vi.mocked(reloadExternalConnections).mockRejectedValueOnce(new Error("bad file"));
+
+    await useAppStore.getState().reloadExternalConnections();
+    await flush();
+
+    expect(logged("Failed to reload external connections")).toBe(true);
+    expect(toastError).toHaveBeenCalledWith(
+      expect.stringContaining("bad file"),
+      expect.objectContaining({ id: "reload-external-connections-error" })
+    );
+  });
+});
+
+describe("#2068 — best-effort background loads log only, no toast", () => {
+  it("loadWorkspaces logs the failure but does not toast", async () => {
+    vi.mocked(getWorkspaces).mockRejectedValueOnce(new Error("no dir"));
+
+    await useAppStore.getState().loadWorkspaces();
+    await flush();
+
+    expect(logged("Failed to load workspaces")).toBe(true);
+    expect(logged("no dir")).toBe(true);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -5044,7 +5044,10 @@ export const useAppStore = create<AppState>((set, get) => {
       layoutPersistTimer = setTimeout(() => {
         const current = get();
         persistSettings({ ...current.settings, layout: updated }).catch((err) =>
-          console.error("Failed to persist layout config:", err)
+          frontendLog(
+            "app_store",
+            `Failed to persist layout config: ${err instanceof Error ? err.message : String(err)}`
+          )
         );
       }, 300);
     },
@@ -5057,7 +5060,10 @@ export const useAppStore = create<AppState>((set, get) => {
       layoutPersistTimer = setTimeout(() => {
         const current = get();
         persistSettings({ ...current.settings, layout: config }).catch((err) =>
-          console.error("Failed to persist layout preset:", err)
+          frontendLog(
+            "app_store",
+            `Failed to persist layout preset: ${err instanceof Error ? err.message : String(err)}`
+          )
         );
       }, 300);
     },
@@ -5079,7 +5085,10 @@ export const useAppStore = create<AppState>((set, get) => {
       layoutPersistTimer = setTimeout(() => {
         const current = get();
         persistSettings({ ...current.settings, layout: updated }).catch((err) =>
-          console.error("Failed to persist layout config:", err)
+          frontendLog(
+            "app_store",
+            `Failed to persist layout config: ${err instanceof Error ? err.message : String(err)}`
+          )
         );
       }, 300);
     },
@@ -5096,7 +5105,7 @@ export const useAppStore = create<AppState>((set, get) => {
         }));
         if (externalErrors.length > 0) {
           for (const err of externalErrors) {
-            console.error(`Failed to load external file ${err.filePath}: ${err.error}`);
+            frontendLog("app_store", `Failed to load external file ${err.filePath}: ${err.error}`);
           }
         }
         const layoutConfig = settings.layout ?? DEFAULT_LAYOUT;
@@ -5135,14 +5144,24 @@ export const useAppStore = create<AppState>((set, get) => {
           set({});
         });
       } catch (err) {
-        console.error("Failed to load connections from backend:", err);
+        frontendLog(
+          "app_store",
+          `Failed to load connections from backend: ${err instanceof Error ? err.message : String(err)}`
+        );
+        toast.error(
+          `Failed to load connections: ${err instanceof Error ? err.message : String(err)}`,
+          { id: "load-connections-error" }
+        );
       }
       // Load connection type registry
       try {
         const connectionTypes = await getConnectionTypes();
         set({ connectionTypes });
       } catch (err) {
-        console.error("Failed to load connection types:", err);
+        frontendLog(
+          "app_store",
+          `Failed to load connection types: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
       // Detect platform default shell
       try {
@@ -5154,7 +5173,10 @@ export const useAppStore = create<AppState>((set, get) => {
           set({ defaultShell: shells[0] as ShellType });
         }
       } catch (err) {
-        console.error("Failed to detect available shells:", err);
+        frontendLog(
+          "app_store",
+          `Failed to detect available shells: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
       // Load SSH tunnels
       get().loadTunnels();
@@ -5181,7 +5203,10 @@ export const useAppStore = create<AppState>((set, get) => {
           set({ recoveryWarnings: warnings, recoveryDialogOpen: true });
         }
       } catch (err) {
-        console.error("Failed to load recovery warnings:", err);
+        frontendLog(
+          "app_store",
+          `Failed to load recovery warnings: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
       // Subscribe to persistent session state changes from the backend
       onPersistentSessionStateChanged((change) => {
@@ -5269,7 +5294,14 @@ export const useAppStore = create<AppState>((set, get) => {
           void get().loadPlugins();
         }
       } catch (err) {
-        console.error("Failed to save settings:", err);
+        frontendLog(
+          "app_store",
+          `Failed to save settings: ${err instanceof Error ? err.message : String(err)}`
+        );
+        toast.error(
+          `Failed to save settings: ${err instanceof Error ? err.message : String(err)}`,
+          { id: "save-settings-error" }
+        );
       }
     },
 
@@ -5299,7 +5331,14 @@ export const useAppStore = create<AppState>((set, get) => {
           return { connections: [...mainConns, ...externalConns] };
         });
       } catch (err) {
-        console.error("Failed to reload external connections:", err);
+        frontendLog(
+          "app_store",
+          `Failed to reload external connections: ${err instanceof Error ? err.message : String(err)}`
+        );
+        toast.error(
+          `Failed to reload external connections: ${err instanceof Error ? err.message : String(err)}`,
+          { id: "reload-external-connections-error" }
+        );
       }
     },
 
@@ -5312,7 +5351,10 @@ export const useAppStore = create<AppState>((set, get) => {
         const toggled = folders.find((f) => f.id === folderId);
         if (toggled) {
           persistFolder(toggled).catch((err) => {
-            console.error("Failed to persist folder toggle:", err);
+            frontendLog(
+              "app_store",
+              `Failed to persist folder toggle: ${err instanceof Error ? err.message : String(err)}`
+            );
             toast.error(
               `Failed to save folder state: ${err instanceof Error ? err.message : String(err)}`
             );
@@ -5391,7 +5433,10 @@ export const useAppStore = create<AppState>((set, get) => {
           return applyConnectionReload();
         })
         .catch((err) => {
-          console.error("Failed to persist new connection:", err);
+          frontendLog(
+            "app_store",
+            `Failed to persist new connection: ${err instanceof Error ? err.message : String(err)}`
+          );
           toast.error(
             `Failed to save ${connection.name}: ${err instanceof Error ? err.message : String(err)}`
           );
@@ -5419,7 +5464,10 @@ export const useAppStore = create<AppState>((set, get) => {
           return applyConnectionReload();
         })
         .catch((err) => {
-          console.error("Failed to persist imported connections:", err);
+          frontendLog(
+            "app_store",
+            `Failed to persist imported connections: ${err instanceof Error ? err.message : String(err)}`
+          );
           toast.error(
             `Failed to import connections: ${err instanceof Error ? err.message : String(err)}`
           );
@@ -5440,7 +5488,10 @@ export const useAppStore = create<AppState>((set, get) => {
           return applyConnectionReload();
         })
         .catch((err) => {
-          console.error("Failed to persist connection update:", err);
+          frontendLog(
+            "app_store",
+            `Failed to persist connection update: ${err instanceof Error ? err.message : String(err)}`
+          );
           toast.error(
             `Failed to save ${connection.name}: ${err instanceof Error ? err.message : String(err)}`
           );
@@ -5460,7 +5511,10 @@ export const useAppStore = create<AppState>((set, get) => {
           return applyConnectionReload();
         })
         .catch((err) => {
-          console.error("Failed to persist connection deletion:", err);
+          frontendLog(
+            "app_store",
+            `Failed to persist connection deletion: ${err instanceof Error ? err.message : String(err)}`
+          );
           toast.error(
             `Failed to delete ${conn?.name ?? "connection"}: ${err instanceof Error ? err.message : String(err)}`
           );
@@ -5486,7 +5540,10 @@ export const useAppStore = create<AppState>((set, get) => {
           return applyConnectionReload();
         })
         .catch((err) => {
-          console.error("Failed to persist bulk connection deletion:", err);
+          frontendLog(
+            "app_store",
+            `Failed to persist bulk connection deletion: ${err instanceof Error ? err.message : String(err)}`
+          );
           toast.error(
             `Failed to delete connections: ${err instanceof Error ? err.message : String(err)}`
           );
@@ -5499,7 +5556,10 @@ export const useAppStore = create<AppState>((set, get) => {
       persistFolder(folder)
         .then(() => applyConnectionReload())
         .catch((err) => {
-          console.error("Failed to persist new folder:", err);
+          frontendLog(
+            "app_store",
+            `Failed to persist new folder: ${err instanceof Error ? err.message : String(err)}`
+          );
           toast.error(
             `Failed to create folder ${folder.name}: ${err instanceof Error ? err.message : String(err)}`
           );
@@ -5525,7 +5585,10 @@ export const useAppStore = create<AppState>((set, get) => {
       removeFolder(folderId)
         .then(() => applyConnectionReload())
         .catch((err) => {
-          console.error("Failed to persist folder deletion:", err);
+          frontendLog(
+            "app_store",
+            `Failed to persist folder deletion: ${err instanceof Error ? err.message : String(err)}`
+          );
           toast.error(
             `Failed to delete folder: ${err instanceof Error ? err.message : String(err)}`
           );
@@ -5546,7 +5609,10 @@ export const useAppStore = create<AppState>((set, get) => {
       persistConnection(stripPassword(duplicate))
         .then(() => applyConnectionReload())
         .catch((err) => {
-          console.error("Failed to persist duplicated connection:", err);
+          frontendLog(
+            "app_store",
+            `Failed to persist duplicated connection: ${err instanceof Error ? err.message : String(err)}`
+          );
           toast.error(
             `Failed to duplicate ${original.name}: ${err instanceof Error ? err.message : String(err)}`
           );
@@ -5564,7 +5630,10 @@ export const useAppStore = create<AppState>((set, get) => {
           connections: state.connections.map((c) => (c.id === connectionId ? updated : c)),
         }));
       } catch (err) {
-        console.error("Failed to move connection to file:", err);
+        frontendLog(
+          "app_store",
+          `Failed to move connection to file: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(
           `Failed to move ${conn.name}: ${err instanceof Error ? err.message : String(err)}`
         );
@@ -5585,7 +5654,10 @@ export const useAppStore = create<AppState>((set, get) => {
         persistConnection(stripPassword(moved))
           .then(() => applyConnectionReload())
           .catch((err) => {
-            console.error("Failed to persist connection move:", err);
+            frontendLog(
+              "app_store",
+              `Failed to persist connection move: ${err instanceof Error ? err.message : String(err)}`
+            );
             toast.error(
               `Failed to move ${moved.name}: ${err instanceof Error ? err.message : String(err)}`
             );
@@ -5610,7 +5682,10 @@ export const useAppStore = create<AppState>((set, get) => {
       Promise.all(moved.map((conn) => persistConnection(stripPassword(conn))))
         .then(() => applyConnectionReload())
         .catch((err) => {
-          console.error("Failed to persist bulk connection move:", err);
+          frontendLog(
+            "app_store",
+            `Failed to persist bulk connection move: ${err instanceof Error ? err.message : String(err)}`
+          );
           toast.error(
             `Failed to move connections: ${err instanceof Error ? err.message : String(err)}`
           );
@@ -6505,7 +6580,10 @@ export const useAppStore = create<AppState>((set, get) => {
         config: agent.config,
         agentSettings: agent.agentSettings,
       }).catch((err) => {
-        console.error("Failed to persist new agent:", err);
+        frontendLog(
+          "app_store",
+          `Failed to persist new agent: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(
           `Failed to save agent ${agent.name}: ${err instanceof Error ? err.message : String(err)}`
         );
@@ -6522,7 +6600,10 @@ export const useAppStore = create<AppState>((set, get) => {
         config: agent.config,
         agentSettings: agent.agentSettings,
       }).catch((err) => {
-        console.error("Failed to persist agent update:", err);
+        frontendLog(
+          "app_store",
+          `Failed to persist agent update: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(
           `Failed to save agent ${agent.name}: ${err instanceof Error ? err.message : String(err)}`
         );
@@ -6538,7 +6619,10 @@ export const useAppStore = create<AppState>((set, get) => {
       });
       const agentIds = get().remoteAgents.map((a) => a.id);
       persistAgentOrder(agentIds).catch((err) => {
-        console.error("Failed to persist agent reorder:", err);
+        frontendLog(
+          "app_store",
+          `Failed to persist agent reorder: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(
           `Failed to save agent order: ${err instanceof Error ? err.message : String(err)}`
         );
@@ -6565,7 +6649,10 @@ export const useAppStore = create<AppState>((set, get) => {
         ),
       }));
       removeAgent(agentId).catch((err) => {
-        console.error("Failed to persist agent deletion:", err);
+        frontendLog(
+          "app_store",
+          `Failed to persist agent deletion: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(
           `Failed to delete agent ${agent?.name ?? ""}: ${err instanceof Error ? err.message : String(err)}`
         );
@@ -6612,7 +6699,10 @@ export const useAppStore = create<AppState>((set, get) => {
         // (`setAgentConnectionState`), so it runs exactly once per connect and
         // also covers the reconnect path — do not refresh here (de-dup, G4).
       } catch (err) {
-        console.error(`Failed to connect agent ${agentId}:`, err);
+        frontendLog(
+          "app_store",
+          `Failed to connect agent ${agentId}: ${err instanceof Error ? err.message : String(err)}`
+        );
         // No optimistic "disconnected" write: the backend emits "disconnected"
         // on every connect-failure path, so the event will drive the state.
         throw err;
@@ -6623,7 +6713,10 @@ export const useAppStore = create<AppState>((set, get) => {
       try {
         await apiDisconnectAgent(agentId);
       } catch (err) {
-        console.error(`Failed to disconnect agent ${agentId}:`, err);
+        frontendLog(
+          "app_store",
+          `Failed to disconnect agent ${agentId}: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(
           `Failed to disconnect agent: ${err instanceof Error ? err.message : String(err)}`
         );
@@ -6717,7 +6810,10 @@ export const useAppStore = create<AppState>((set, get) => {
           agentFolders: { ...s.agentFolders, [agentId]: connectionsData.folders },
         }));
       } catch (err) {
-        console.error(`Failed to refresh agent sessions for ${agentId}:`, err);
+        frontendLog(
+          "app_store",
+          `Failed to refresh agent sessions for ${agentId}: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(
           `Failed to load agent sessions: ${err instanceof Error ? err.message : String(err)}`
         );
@@ -6737,7 +6833,10 @@ export const useAppStore = create<AppState>((set, get) => {
           },
         }));
       } catch (err) {
-        console.error(`Failed to save agent definition on ${agentId}:`, err);
+        frontendLog(
+          "app_store",
+          `Failed to save agent definition on ${agentId}: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(
           `Failed to save connection: ${err instanceof Error ? err.message : String(err)}`
         );
@@ -6770,7 +6869,10 @@ export const useAppStore = create<AppState>((set, get) => {
           },
         }));
       } catch (err) {
-        console.error(`Failed to delete agent definition on ${agentId}:`, err);
+        frontendLog(
+          "app_store",
+          `Failed to delete agent definition on ${agentId}: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(
           `Failed to delete connection: ${err instanceof Error ? err.message : String(err)}`
         );
@@ -6789,7 +6891,10 @@ export const useAppStore = create<AppState>((set, get) => {
           },
         }));
       } catch (err) {
-        console.error(`Failed to update agent definition on ${agentId}:`, err);
+        frontendLog(
+          "app_store",
+          `Failed to update agent definition on ${agentId}: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(
           `Failed to update connection: ${err instanceof Error ? err.message : String(err)}`
         );
@@ -6817,7 +6922,10 @@ export const useAppStore = create<AppState>((set, get) => {
         }));
         toast.success(`Created folder ${folder.name}`);
       } catch (err) {
-        console.error(`Failed to create agent folder on ${agentId}:`, err);
+        frontendLog(
+          "app_store",
+          `Failed to create agent folder on ${agentId}: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(`Failed to create folder: ${err instanceof Error ? err.message : String(err)}`);
       }
     },
@@ -6838,7 +6946,10 @@ export const useAppStore = create<AppState>((set, get) => {
         }));
         if (isRename) toast.success(`Renamed folder to ${updated.name}`);
       } catch (err) {
-        console.error(`Failed to update agent folder on ${agentId}:`, err);
+        frontendLog(
+          "app_store",
+          `Failed to update agent folder on ${agentId}: ${err instanceof Error ? err.message : String(err)}`
+        );
         if (isRename) {
           toast.error(
             `Failed to rename folder: ${err instanceof Error ? err.message : String(err)}`
@@ -6864,7 +6975,10 @@ export const useAppStore = create<AppState>((set, get) => {
           },
         }));
       } catch (err) {
-        console.error(`Failed to delete agent folder on ${agentId}:`, err);
+        frontendLog(
+          "app_store",
+          `Failed to delete agent folder on ${agentId}: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(`Failed to delete folder: ${err instanceof Error ? err.message : String(err)}`);
       }
     },
@@ -7030,7 +7144,10 @@ export const useAppStore = create<AppState>((set, get) => {
         const available = await checkVscode();
         set({ vscodeAvailable: available });
       } catch (err) {
-        console.error("Failed to check VS Code availability:", err);
+        frontendLog(
+          "app_store",
+          `Failed to check VS Code availability: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 
@@ -7240,7 +7357,10 @@ export const useAppStore = create<AppState>((set, get) => {
         const connectionTypes = await getConnectionTypes();
         set({ connectionTypes });
       } catch (err) {
-        console.error("Failed to refresh connection types:", err);
+        frontendLog(
+          "app_store",
+          `Failed to refresh connection types: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 
@@ -7254,7 +7374,10 @@ export const useAppStore = create<AppState>((set, get) => {
         }
         set({ tunnels, tunnelStates });
       } catch (err) {
-        console.error("Failed to load tunnels:", err);
+        frontendLog(
+          "app_store",
+          `Failed to load tunnels: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 
@@ -7269,7 +7392,10 @@ export const useAppStore = create<AppState>((set, get) => {
           return { tunnels };
         });
       } catch (err) {
-        console.error("Failed to save tunnel:", err);
+        frontendLog(
+          "app_store",
+          `Failed to save tunnel: ${err instanceof Error ? err.message : String(err)}`
+        );
         throw err;
       }
     },
@@ -7307,7 +7433,10 @@ export const useAppStore = create<AppState>((set, get) => {
         await apiStartTunnel(tunnelId);
         toast.success(`Started ${name}`, { id: toastId });
       } catch (err) {
-        console.error("Failed to start tunnel:", err);
+        frontendLog(
+          "app_store",
+          `Failed to start tunnel: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(
           `Failed to start ${name}: ${err instanceof Error ? err.message : String(err)}`,
           { id: toastId }
@@ -7329,7 +7458,10 @@ export const useAppStore = create<AppState>((set, get) => {
         await apiStopTunnel(tunnelId);
         toast.success(`Stopped ${name}`, { id: toastId });
       } catch (err) {
-        console.error("Failed to stop tunnel:", err);
+        frontendLog(
+          "app_store",
+          `Failed to stop tunnel: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(`Failed to stop ${name}: ${err instanceof Error ? err.message : String(err)}`, {
           id: toastId,
         });
@@ -7354,7 +7486,10 @@ export const useAppStore = create<AppState>((set, get) => {
         await apiStartTunnel(tunnelId);
         toast.success(`Reconnected ${name}`, { id: toastId });
       } catch (err) {
-        console.error("Failed to reconnect tunnel:", err);
+        frontendLog(
+          "app_store",
+          `Failed to reconnect tunnel: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(
           `Failed to reconnect ${name}: ${err instanceof Error ? err.message : String(err)}`,
           { id: toastId }
@@ -7430,7 +7565,10 @@ export const useAppStore = create<AppState>((set, get) => {
         }
         set({ embeddedServers: servers, embeddedServerStates });
       } catch (err) {
-        console.error("Failed to load embedded servers:", err);
+        frontendLog(
+          "app_store",
+          `Failed to load embedded servers: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 
@@ -7458,7 +7596,10 @@ export const useAppStore = create<AppState>((set, get) => {
           return { embeddedServers };
         });
       } catch (err) {
-        console.error("Failed to save embedded server:", err);
+        frontendLog(
+          "app_store",
+          `Failed to save embedded server: ${err instanceof Error ? err.message : String(err)}`
+        );
         throw err;
       }
     },
@@ -7532,7 +7673,10 @@ export const useAppStore = create<AppState>((set, get) => {
         const macros = await apiListMacros();
         set({ macros });
       } catch (err) {
-        console.error("Failed to load macros:", err);
+        frontendLog(
+          "app_store",
+          `Failed to load macros: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 
@@ -7602,7 +7746,10 @@ export const useAppStore = create<AppState>((set, get) => {
         applyTheme(theme, customThemes);
       } catch (err) {
         // Read-only refresh: log rather than toast, matching loadMacros.
-        console.error("Failed to load plugins:", err);
+        frontendLog(
+          "app_store",
+          `Failed to load plugins: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 
@@ -7675,7 +7822,10 @@ export const useAppStore = create<AppState>((set, get) => {
       } catch (err) {
         // Read-only fetch: log rather than toast; the caller falls back to
         // schema defaults so the form still renders.
-        console.error(`Failed to load settings for plugin ${pluginId}:`, err);
+        frontendLog(
+          "app_store",
+          `Failed to load settings for plugin ${pluginId}: ${err instanceof Error ? err.message : String(err)}`
+        );
         throw err;
       }
     },
@@ -8067,7 +8217,10 @@ export const useAppStore = create<AppState>((set, get) => {
         const workflows = await apiListWorkflows();
         set({ workflows });
       } catch (err) {
-        console.error("Failed to load workflows:", err);
+        frontendLog(
+          "app_store",
+          `Failed to load workflows: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 
@@ -8409,7 +8562,10 @@ export const useAppStore = create<AppState>((set, get) => {
         const workspaces = await apiGetWorkspaces();
         set({ workspaces });
       } catch (err) {
-        console.error("Failed to load workspaces:", err);
+        frontendLog(
+          "app_store",
+          `Failed to load workspaces: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 
@@ -8418,7 +8574,10 @@ export const useAppStore = create<AppState>((set, get) => {
         await apiSaveWorkspace(definition);
         await get().loadWorkspaces();
       } catch (err) {
-        console.error("Failed to save workspace:", err);
+        frontendLog(
+          "app_store",
+          `Failed to save workspace: ${err instanceof Error ? err.message : String(err)}`
+        );
         throw err;
       }
     },
@@ -8440,7 +8599,10 @@ export const useAppStore = create<AppState>((set, get) => {
         await get().loadWorkspaces();
         toast.success("Duplicated workspace");
       } catch (err) {
-        console.error("Failed to duplicate workspace:", err);
+        frontendLog(
+          "app_store",
+          `Failed to duplicate workspace: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(
           `Failed to duplicate workspace: ${err instanceof Error ? err.message : String(err)}`
         );
@@ -8733,7 +8895,10 @@ export const useAppStore = create<AppState>((set, get) => {
         await get().loadWorkspaces();
         set({ activeWorkspaceName: name });
       } catch (err) {
-        console.error("Failed to save current layout as workspace:", err);
+        frontendLog(
+          "app_store",
+          `Failed to save current layout as workspace: ${err instanceof Error ? err.message : String(err)}`
+        );
         throw err;
       }
     },
@@ -8779,7 +8944,10 @@ export const useAppStore = create<AppState>((set, get) => {
           ...(totalTabs > 0 && windows ? { windows } : {}),
         });
       } catch (err) {
-        console.error("Failed to save last session:", err);
+        frontendLog(
+          "app_store",
+          `Failed to save last session: ${err instanceof Error ? err.message : String(err)}`
+        );
         // Auto-save fires on every layout change (debounced); use a stable id so
         // repeated failures collapse into a single, replaceable toast.
         toast.error(`Failed to save session: ${err instanceof Error ? err.message : String(err)}`, {
@@ -8894,7 +9062,10 @@ export const useAppStore = create<AppState>((set, get) => {
       try {
         await apiClearLastSession();
       } catch (err) {
-        console.error("Failed to clear last session:", err);
+        frontendLog(
+          "app_store",
+          `Failed to clear last session: ${err instanceof Error ? err.message : String(err)}`
+        );
         toast.error(
           `Failed to clear saved session: ${err instanceof Error ? err.message : String(err)}`
         );
@@ -8957,7 +9128,10 @@ export const useAppStore = create<AppState>((set, get) => {
         const status = await apiGetCredentialStoreStatus();
         set({ credentialStoreStatus: status });
       } catch (err) {
-        console.error("Failed to load credential store status:", err);
+        frontendLog(
+          "app_store",
+          `Failed to load credential store status: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
     unlockDialogOpen: false,
@@ -9001,7 +9175,10 @@ export const useAppStore = create<AppState>((set, get) => {
         const info = await apiGetAppMode();
         set({ isPortableMode: info.isPortable, portableDataDir: info.dataDir });
       } catch (err) {
-        console.error("Failed to load app mode:", err);
+        frontendLog(
+          "app_store",
+          `Failed to load app mode: ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     },
 


### PR DESCRIPTION
## Summary

~58 catch blocks in `src/store/appStore.ts` logged only to `console.error`, which is invisible in the Tauri webview — so store load/persist failures vanished silently.

This routes every one of those catch blocks through the in-app logger `frontendLog("app_store", …)` so failures reach the **LogViewer**, and adds a recoverable `toast.error` to the user-facing load/persist failures that were previously silent.

## Changes

- **All ~56 `console.error` calls** in `appStore.ts` now emit via `frontendLog("app_store", …)`. Existing `toast.error` calls (connection/agent/tunnel/workspace mutations) are preserved unchanged — only the invisible console log was swapped.
- **New toasts** on the user-facing load/persist failures that had none:
  - failing to load connections at startup (`loadFromBackend`)
  - failing to save settings (`updateSettings`)
  - failing to reload external connection files (`reloadExternalConnections`)

  Each uses a stable toast id so repeated failures collapse into one replaceable toast.
- **Criterion for toasting:** log *all* failures via `frontendLog`; toast only the ones a user would want to know about (failed load/save of their data). Best-effort background reads (connection-type registry, shell detection, tunnels/embedded-servers/macros/plugins/workflows/workspaces list loads, VS Code probe, app mode, credential-store status) log only — no toast spam. Rethrowing actions whose callers already toast were left to their callers.

## Tests

- New `appStore.storeErrorSurfacing.test.ts`: asserts the three user-facing failures both log via `frontendLog` and toast (with the expected stable id), and that a best-effort background load (`loadWorkspaces`) logs only, no toast.
- Updated `appStore.credential.test.ts` to assert `frontendLog` routing instead of the removed `console.error`.
- Full store suite green (640 tests), `tsc --noEmit` clean, eslint clean.

Closes #2068