### PR TITLE
fix(ui): per-panel error boundaries so one panel crash is isolated (Closes #2069)

### DIFF
--- a/docs/changes/dev2/fix/2069-per-panel-errorboundary.md
+++ b/docs/changes/dev2/fix/2069-per-panel-errorboundary.md
@@ -1,0 +1,7 @@
+### Changed
+
+- A render crash in one terminal panel no longer tears down every open session.
+  Each split-view panel (and the zoom overlay) is now wrapped in its own error
+  boundary that shows a localized fallback with a **Retry** button, so sibling
+  panels and their live sessions keep running while the failed panel recovers in
+  place. The app-wide boundary still catches anything outside the panels (#2069).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
-import { Component, useEffect } from "react";
-import type { ErrorInfo, ReactNode } from "react";
+import { useEffect } from "react";
 import { ActivityBar } from "@/components/ActivityBar";
 import { Sidebar } from "@/components/Sidebar";
 import { StatusBar } from "@/components/StatusBar";
@@ -26,7 +25,7 @@ import { CloseWindowDecisionDialog } from "@/components/Terminal/CloseWindowDeci
 import { SessionRestoreDialog } from "@/components/SessionRestoreDialog";
 import { UpdateNotification } from "@/components/UpdateNotification/UpdateNotification";
 import { XServerConnectConsent } from "@/components/OpenConnections/XServerConnectConsent";
-import { ToastProvider, TooltipProvider } from "@/components/ui";
+import { ErrorBoundary, ToastProvider, TooltipProvider } from "@/components/ui";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useTunnelEvents } from "@/hooks/useTunnelEvents";
 import { useTransferEvents } from "@/hooks/useTransferEvents";
@@ -48,71 +47,6 @@ import { listWindows } from "@/services/api";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { listen } from "@tauri-apps/api/event";
 import "./App.css";
-
-interface ErrorBoundaryState {
-  error: Error | null;
-}
-
-/**
- * Catches unhandled React rendering errors and displays them instead of
- * showing a blank grey screen.
- */
-class ErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryState> {
-  state: ErrorBoundaryState = { error: null };
-
-  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
-    return { error };
-  }
-
-  componentDidCatch(error: Error, info: ErrorInfo): void {
-    console.error("React render error:", error, info.componentStack);
-  }
-
-  render() {
-    if (this.state.error) {
-      return (
-        <div
-          style={{
-            padding: 24,
-            color: "var(--color-error)",
-            background: "var(--bg-primary)",
-            fontFamily: "monospace",
-            height: "100%",
-            overflow: "auto",
-          }}
-        >
-          <h2 style={{ color: "var(--text-primary)" }}>Something went wrong</h2>
-          <pre style={{ whiteSpace: "pre-wrap", marginTop: 12 }}>{this.state.error.message}</pre>
-          <pre
-            style={{
-              whiteSpace: "pre-wrap",
-              marginTop: 8,
-              fontSize: 12,
-              color: "var(--text-secondary)",
-            }}
-          >
-            {this.state.error.stack}
-          </pre>
-          <button
-            style={{
-              marginTop: 16,
-              padding: "6px 16px",
-              background: "var(--accent-color)",
-              color: "#fff",
-              border: "none",
-              borderRadius: 4,
-              cursor: "pointer",
-            }}
-            onClick={() => window.location.reload()}
-          >
-            Reload
-          </button>
-        </div>
-      );
-    }
-    return this.props.children;
-  }
-}
 
 function App() {
   useKeyboardShortcuts();

--- a/src/components/SplitView/PanelErrorBoundary.css
+++ b/src/components/SplitView/PanelErrorBoundary.css
@@ -1,0 +1,44 @@
+.panel-error {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  height: 100%;
+  padding: 20px;
+  overflow: auto;
+  background: var(--bg-primary);
+  color: var(--color-error);
+  font-family: monospace;
+}
+
+.panel-error__title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--font-size-lg);
+}
+
+.panel-error__message {
+  margin: 0;
+  max-width: 100%;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: var(--font-size-sm);
+}
+
+.panel-error__retry {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--accent-color);
+  color: var(--text-on-accent);
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.panel-error__retry:hover {
+  background: var(--accent-hover);
+}

--- a/src/components/SplitView/PanelErrorBoundary.test.tsx
+++ b/src/components/SplitView/PanelErrorBoundary.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { PanelErrorBoundary } from "./PanelErrorBoundary";
+
+let container: HTMLDivElement;
+let root: Root;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+function render(ui: React.ReactElement) {
+  act(() => {
+    root.render(ui);
+  });
+}
+
+function byTestId(id: string): HTMLElement | null {
+  return container.querySelector(`[data-testid="${id}"]`);
+}
+
+/** Throws during render when `shouldThrow` is set — simulates a panel crash. */
+function Boom({ shouldThrow }: { shouldThrow: boolean }): React.ReactElement {
+  if (shouldThrow) throw new Error("panel boom");
+  return <div data-testid="boom-recovered">recovered</div>;
+}
+
+describe("PanelErrorBoundary", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    // React logs caught render errors to console.error; silence to keep output clean.
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    errorSpy.mockRestore();
+  });
+
+  it("renders the fallback for a throwing child without unmounting a sibling panel", () => {
+    const siblingUnmount = vi.fn();
+    function Sibling(): React.ReactElement {
+      React.useEffect(() => siblingUnmount, []);
+      return <div data-testid="sibling">alive</div>;
+    }
+
+    render(
+      <>
+        <PanelErrorBoundary label="panel-a">
+          <Boom shouldThrow />
+        </PanelErrorBoundary>
+        <PanelErrorBoundary label="panel-b">
+          <Sibling />
+        </PanelErrorBoundary>
+      </>
+    );
+
+    // The crashing panel shows its localized fallback...
+    expect(byTestId("panel-error-boundary")).not.toBeNull();
+    expect(byTestId("boom-recovered")).toBeNull();
+
+    // ...while the sibling panel stays mounted and is never torn down.
+    expect(byTestId("sibling")).not.toBeNull();
+    expect(siblingUnmount).not.toHaveBeenCalled();
+  });
+
+  it("re-mounts the panel subtree when the localized retry is clicked", () => {
+    let throwNow = true;
+    function Maybe(): React.ReactElement {
+      if (throwNow) throw new Error("panel boom");
+      return <div data-testid="panel-content">ok</div>;
+    }
+
+    render(
+      <PanelErrorBoundary>
+        <Maybe />
+      </PanelErrorBoundary>
+    );
+
+    expect(byTestId("panel-error-boundary")).not.toBeNull();
+    expect(byTestId("panel-content")).toBeNull();
+
+    // Underlying cause cleared; retry should re-render the children successfully.
+    throwNow = false;
+    act(() => {
+      (byTestId("panel-error-retry") as HTMLButtonElement).click();
+    });
+
+    expect(byTestId("panel-content")).not.toBeNull();
+    expect(byTestId("panel-error-boundary")).toBeNull();
+  });
+});

--- a/src/components/SplitView/PanelErrorBoundary.tsx
+++ b/src/components/SplitView/PanelErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import { RotateCcw } from "lucide-react";
+import type { ReactNode } from "react";
+import { ErrorBoundary } from "@/components/ui";
+import "./PanelErrorBoundary.css";
+
+interface PanelErrorBoundaryProps {
+  children: ReactNode;
+  /** Context for the logged error — the panel id whose subtree is guarded. */
+  label?: string;
+}
+
+/**
+ * Per-panel error boundary. Wrapping each split-view leaf (and the zoom
+ * overlay) in its own boundary means a render throw in one panel shows a
+ * localized fallback instead of propagating to the app-wide boundary, which
+ * would unmount the whole tree and destroy every live session in the other
+ * panels. The fallback offers a localized retry that re-mounts only this
+ * panel's subtree.
+ */
+export function PanelErrorBoundary({ children, label }: PanelErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      label={label}
+      fallback={(error, reset) => (
+        <div className="panel-error" role="alert" data-testid="panel-error-boundary">
+          <h3 className="panel-error__title">This panel crashed</h3>
+          <pre className="panel-error__message">{error.message}</pre>
+          <button
+            type="button"
+            className="panel-error__retry"
+            onClick={reset}
+            data-testid="panel-error-retry"
+          >
+            <RotateCcw size={14} />
+            Retry
+          </button>
+        </div>
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -63,6 +63,7 @@ import { TerminalViewModeBanner } from "@/components/Terminal/TerminalViewModeBa
 import { TerminalReconnectPrompt } from "@/components/Terminal/TerminalReconnectPrompt";
 import { PanelDropZone } from "./PanelDropZone";
 import { EmptyWindowState } from "./EmptyWindowState";
+import { PanelErrorBoundary } from "./PanelErrorBoundary";
 import "./SplitView.css";
 
 export function SplitView() {
@@ -396,98 +397,105 @@ export function SplitView() {
               </ContextMenu.Portal>
             </ContextMenu.Root>
             <div className="zoom-overlay__content">
-              {zoomedTab.contentType === "terminal" &&
-              (terminalSpawnErrors[zoomedTabId] ||
-                terminalConnecting[zoomedTabId] ||
-                (terminalAutoRetryCountZoom[zoomedTabId] ?? 0) > 0 ||
-                !!terminalWaitingForAgentZoom[zoomedTabId] ||
-                !!terminalReattachingZoom[zoomedTabId]) ? (
-                <TerminalConnectionOverlay
-                  key={`zoom-${zoomedTabId}`}
-                  tabId={zoomedTabId}
-                  panelId={zoomedTab.panelId}
-                  tabTitle={zoomedTab.title}
-                  isVisible={true}
-                  sessionType={
-                    zoomedTab.config.type === "remote-session"
-                      ? ((zoomedTab.config.config as { sessionType?: string }).sessionType ?? "")
-                      : zoomedTab.config.type
-                  }
-                />
-              ) : zoomedTab.contentType === "terminal" ? (
-                <>
-                  <TerminalSearchBar tabId={zoomedTabId} />
-                  {/* key forces a fresh mount on each zoomed-tab change so the
+              <PanelErrorBoundary label={`zoom ${zoomedTabId}`}>
+                {zoomedTab.contentType === "terminal" &&
+                (terminalSpawnErrors[zoomedTabId] ||
+                  terminalConnecting[zoomedTabId] ||
+                  (terminalAutoRetryCountZoom[zoomedTabId] ?? 0) > 0 ||
+                  !!terminalWaitingForAgentZoom[zoomedTabId] ||
+                  !!terminalReattachingZoom[zoomedTabId]) ? (
+                  <TerminalConnectionOverlay
+                    key={`zoom-${zoomedTabId}`}
+                    tabId={zoomedTabId}
+                    panelId={zoomedTab.panelId}
+                    tabTitle={zoomedTab.title}
+                    isVisible={true}
+                    sessionType={
+                      zoomedTab.config.type === "remote-session"
+                        ? ((zoomedTab.config.config as { sessionType?: string }).sessionType ?? "")
+                        : zoomedTab.config.type
+                    }
+                  />
+                ) : zoomedTab.contentType === "terminal" ? (
+                  <>
+                    <TerminalSearchBar tabId={zoomedTabId} />
+                    {/* key forces a fresh mount on each zoomed-tab change so the
                       adoption lifecycle always matches the initial-zoom case. */}
-                  <TerminalSlot
-                    key={`zoom-slot-${zoomedTabId}`}
+                    <TerminalSlot
+                      key={`zoom-slot-${zoomedTabId}`}
+                      tabId={zoomedTabId}
+                      isVisible={true}
+                    />
+                  </>
+                ) : zoomedTab.contentType === "settings" ? (
+                  <SettingsPanel tabId={zoomedTabId} isVisible={true} />
+                ) : zoomedTab.contentType === "log-viewer" ? (
+                  <LogViewer isVisible={true} />
+                ) : zoomedTab.contentType === "editor" && zoomedTab.editorMeta ? (
+                  <FileEditor
+                    key={`zoom-${zoomedTabId}`}
+                    tabId={zoomedTabId}
+                    meta={zoomedTab.editorMeta}
+                    isVisible={true}
+                    keepModel={true}
+                  />
+                ) : zoomedTab.contentType === "connection-editor" &&
+                  zoomedTab.connectionEditorMeta ? (
+                  <ConnectionEditor
+                    key={`zoom-${zoomedTabId}`}
+                    tabId={zoomedTabId}
+                    meta={zoomedTab.connectionEditorMeta}
+                    isVisible={true}
+                  />
+                ) : zoomedTab.contentType === "tunnel-editor" && zoomedTab.tunnelEditorMeta ? (
+                  <TunnelEditor
+                    key={`zoom-${zoomedTabId}`}
+                    tabId={zoomedTabId}
+                    meta={zoomedTab.tunnelEditorMeta}
+                    isVisible={true}
+                  />
+                ) : zoomedTab.contentType === "workspace-editor" &&
+                  zoomedTab.workspaceEditorMeta ? (
+                  <WorkspaceEditor
+                    key={`zoom-${zoomedTabId}`}
+                    tabId={zoomedTabId}
+                    meta={zoomedTab.workspaceEditorMeta}
+                    isVisible={true}
+                  />
+                ) : zoomedTab.contentType === "network-diagnostic" &&
+                  zoomedTab.networkDiagnosticMeta ? (
+                  <NetworkDiagnosticPanel
+                    key={`zoom-${zoomedTabId}`}
+                    meta={zoomedTab.networkDiagnosticMeta}
+                    isVisible={true}
+                  />
+                ) : zoomedTab.contentType === "plugin-detail" && zoomedTab.pluginDetailMeta ? (
+                  <PluginDetailPanel
+                    key={`zoom-${zoomedTabId}`}
+                    meta={zoomedTab.pluginDetailMeta}
+                    isVisible={true}
+                  />
+                ) : zoomedTab.contentType === "agent-error" && zoomedTab.agentErrorMeta ? (
+                  <AgentErrorTab
+                    key={`zoom-${zoomedTabId}`}
+                    tabId={zoomedTabId}
+                    meta={zoomedTab.agentErrorMeta}
+                    isVisible={true}
+                  />
+                ) : zoomedTab.contentType === "file-browser" ? (
+                  <FileBrowserTab
+                    key={`zoom-${zoomedTabId}`}
                     tabId={zoomedTabId}
                     isVisible={true}
                   />
-                </>
-              ) : zoomedTab.contentType === "settings" ? (
-                <SettingsPanel tabId={zoomedTabId} isVisible={true} />
-              ) : zoomedTab.contentType === "log-viewer" ? (
-                <LogViewer isVisible={true} />
-              ) : zoomedTab.contentType === "editor" && zoomedTab.editorMeta ? (
-                <FileEditor
-                  key={`zoom-${zoomedTabId}`}
-                  tabId={zoomedTabId}
-                  meta={zoomedTab.editorMeta}
-                  isVisible={true}
-                  keepModel={true}
-                />
-              ) : zoomedTab.contentType === "connection-editor" &&
-                zoomedTab.connectionEditorMeta ? (
-                <ConnectionEditor
-                  key={`zoom-${zoomedTabId}`}
-                  tabId={zoomedTabId}
-                  meta={zoomedTab.connectionEditorMeta}
-                  isVisible={true}
-                />
-              ) : zoomedTab.contentType === "tunnel-editor" && zoomedTab.tunnelEditorMeta ? (
-                <TunnelEditor
-                  key={`zoom-${zoomedTabId}`}
-                  tabId={zoomedTabId}
-                  meta={zoomedTab.tunnelEditorMeta}
-                  isVisible={true}
-                />
-              ) : zoomedTab.contentType === "workspace-editor" && zoomedTab.workspaceEditorMeta ? (
-                <WorkspaceEditor
-                  key={`zoom-${zoomedTabId}`}
-                  tabId={zoomedTabId}
-                  meta={zoomedTab.workspaceEditorMeta}
-                  isVisible={true}
-                />
-              ) : zoomedTab.contentType === "network-diagnostic" &&
-                zoomedTab.networkDiagnosticMeta ? (
-                <NetworkDiagnosticPanel
-                  key={`zoom-${zoomedTabId}`}
-                  meta={zoomedTab.networkDiagnosticMeta}
-                  isVisible={true}
-                />
-              ) : zoomedTab.contentType === "plugin-detail" && zoomedTab.pluginDetailMeta ? (
-                <PluginDetailPanel
-                  key={`zoom-${zoomedTabId}`}
-                  meta={zoomedTab.pluginDetailMeta}
-                  isVisible={true}
-                />
-              ) : zoomedTab.contentType === "agent-error" && zoomedTab.agentErrorMeta ? (
-                <AgentErrorTab
-                  key={`zoom-${zoomedTabId}`}
-                  tabId={zoomedTabId}
-                  meta={zoomedTab.agentErrorMeta}
-                  isVisible={true}
-                />
-              ) : zoomedTab.contentType === "file-browser" ? (
-                <FileBrowserTab key={`zoom-${zoomedTabId}`} tabId={zoomedTabId} isVisible={true} />
-              ) : zoomedTab.contentType === "remote-desktop" ? (
-                <RemoteDesktopTab
-                  key={`zoom-${zoomedTabId}`}
-                  tabId={zoomedTabId}
-                  isVisible={true}
-                />
-              ) : null}
+                ) : zoomedTab.contentType === "remote-desktop" ? (
+                  <RemoteDesktopTab
+                    key={`zoom-${zoomedTabId}`}
+                    tabId={zoomedTabId}
+                    isVisible={true}
+                  />
+                ) : null}
+              </PanelErrorBoundary>
             </div>
           </div>
         </div>
@@ -527,8 +535,13 @@ interface PanelNodeRendererProps {
 
 function PanelNodeRenderer({ node, setActivePanel, activeDragTab }: PanelNodeRendererProps) {
   if (node.type === "leaf") {
+    // Per-panel boundary (#2069): a render throw in one leaf is caught here and
+    // shown as a localized fallback, so it cannot propagate to the app-wide
+    // boundary and tear down the sibling panels' live sessions.
     return (
-      <LeafPanelView panel={node} setActivePanel={setActivePanel} activeDragTab={activeDragTab} />
+      <PanelErrorBoundary label={`panel ${node.id}`}>
+        <LeafPanelView panel={node} setActivePanel={setActivePanel} activeDragTab={activeDragTab} />
+      </PanelErrorBoundary>
     );
   }
 

--- a/src/components/ui/ErrorBoundary.tsx
+++ b/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,108 @@
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+
+export interface ErrorBoundaryProps {
+  children: ReactNode;
+  /**
+   * Custom fallback UI. Receives the caught error and a `reset` callback that
+   * clears the boundary so its subtree re-mounts and re-renders (a localized
+   * retry). When omitted, a full-height "Something went wrong" panel with a
+   * window reload is shown.
+   */
+  fallback?: (error: Error, reset: () => void) => ReactNode;
+  /**
+   * Human-readable context (e.g. a panel id) prepended to the logged error so a
+   * crash can be traced to the boundary that caught it.
+   */
+  label?: string;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Catches unhandled React rendering errors in its subtree and renders a
+ * fallback instead of letting the throw propagate to an ancestor boundary
+ * (which would tear the whole tree down).
+ *
+ * Place a boundary around each independently-recoverable region — e.g. each
+ * split-view panel — so one region's render crash is isolated from its
+ * siblings. Provide a {@link ErrorBoundaryProps.fallback} that calls its
+ * `reset` argument for a localized retry; the default fallback reloads the
+ * window and is meant for the app-wide root boundary only.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    const scope = this.props.label ? ` (${this.props.label})` : "";
+    console.error(`React render error${scope}:`, error, info.componentStack);
+  }
+
+  /** Clear the caught error so the subtree is attempted again. */
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (error) {
+      if (this.props.fallback) return this.props.fallback(error, this.reset);
+      return <DefaultErrorFallback error={error} />;
+    }
+    return this.props.children;
+  }
+}
+
+/**
+ * Full-height fallback for the app-wide root boundary: shows the error and
+ * offers a window reload. Panel-level boundaries pass their own compact
+ * fallback with a localized retry instead.
+ */
+function DefaultErrorFallback({ error }: { error: Error }): ReactNode {
+  return (
+    <div
+      role="alert"
+      style={{
+        padding: 24,
+        color: "var(--color-error)",
+        background: "var(--bg-primary)",
+        fontFamily: "monospace",
+        height: "100%",
+        overflow: "auto",
+      }}
+    >
+      <h2 style={{ color: "var(--text-primary)" }}>Something went wrong</h2>
+      <pre style={{ whiteSpace: "pre-wrap", marginTop: 12 }}>{error.message}</pre>
+      <pre
+        style={{
+          whiteSpace: "pre-wrap",
+          marginTop: 8,
+          fontSize: 12,
+          color: "var(--text-secondary)",
+        }}
+      >
+        {error.stack}
+      </pre>
+      <button
+        style={{
+          marginTop: 16,
+          padding: "6px 16px",
+          background: "var(--accent-color)",
+          color: "var(--text-on-accent)",
+          border: "none",
+          borderRadius: 4,
+          cursor: "pointer",
+        }}
+        onClick={() => window.location.reload()}
+      >
+        Reload
+      </button>
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -47,3 +47,6 @@ export type { ProgressProps } from "./Progress";
 
 export { ToastProvider, toast } from "./Toast";
 export type { ToastApi, ToastOptions, ToastPromiseMessages } from "./Toast";
+
+export { ErrorBoundary } from "./ErrorBoundary";
+export type { ErrorBoundaryProps } from "./ErrorBoundary";


### PR DESCRIPTION
## Summary

A single app-wide `ErrorBoundary` wrapped the whole tree, so a render throw in any panel unmounted the entire app and destroyed every live session. This adds a lightweight per-panel boundary so one panel can fail without taking down its siblings.

Closes #2069

## Changes

- **Extracted** the inline `ErrorBoundary` from `App.tsx` into a reusable `src/components/ui/ErrorBoundary` primitive. It accepts a custom `fallback(error, reset)` render prop for a **localized retry** (clears the caught error and re-mounts the subtree); the default fallback keeps the app-root full-screen reload behavior.
- **Added** `PanelErrorBoundary` (SplitView) rendering a compact "This panel crashed" fallback with a **Retry** button.
- **Wrapped** each split-view leaf panel and the zoom overlay in a `PanelErrorBoundary`. A render throw in one panel is now caught locally; sibling panels — and all terminal sessions, which live in the sibling `TerminalHost` subtree — survive.
- **Fixed** the `#fff` → `var(--text-on-accent)` token nit in the fallback button (called out in the issue).

## Where the boundaries went

- `SplitView.tsx` `PanelNodeRenderer` → each `leaf` node wrapped in `PanelErrorBoundary` (covers terminal panels, connection editor, and every other in-panel tab type).
- `SplitView.tsx` zoom-overlay content wrapped in `PanelErrorBoundary`.
- `App.tsx` root keeps the app-wide `ErrorBoundary` (default reload fallback) for anything outside the panels.

## Test

`src/components/SplitView/PanelErrorBoundary.test.tsx`:
- A throwing child in one panel boundary renders the fallback **without unmounting a sibling panel** (sibling stays in the DOM and its unmount cleanup is never called).
- Clicking **Retry** re-mounts the panel subtree once the underlying cause clears.

## Verification

- `pnpm test` — full suite green (4609 tests).
- `tsc --noEmit`, `eslint`, `prettier --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)