### PR TITLE
fix(ui): raise text-muted/warning contrast to AA and add reduced-motion backstop (Closes #2070)

### DIFF
--- a/docs/changes/dev1/fix/2070-a11y-contrast-motion.md
+++ b/docs/changes/dev1/fix/2070-a11y-contrast-motion.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- Accessibility: several theme text colors now meet the WCAG 2.2 AA minimum
+  contrast ratio (4.5:1) for normal text. The muted text color (`--text-muted`)
+  was too faint in both built-in themes and the light theme's warning color was
+  too light for text use; they were adjusted so they pass AA against both the
+  primary and sidebar backgrounds (dark `--text-muted` `#7d7d7d` → `#909090`,
+  light `--text-muted` `#858a90` → `#686d74`, light `--color-warning` `#b08800`
+  → `#856900`) (#2070).
+- Accessibility: added a global `prefers-reduced-motion: reduce` backstop so
+  that when the operating system requests reduced motion, animations and
+  transitions that were not individually guarded are neutralized instead of
+  played (#2070).

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -39,3 +39,22 @@
     transform: translateY(0);
   }
 }
+
+/* === Reduced-motion backstop ===
+   Global safety net for users who ask the OS to minimize non-essential motion
+   (`prefers-reduced-motion: reduce`). Per-component guards still take precedence
+   where they exist; this block guarantees that any animation or transition that
+   was NOT individually guarded is neutralized rather than played. Durations
+   collapse to a single frame (kept non-zero so `animationend`/`transitionend`
+   listeners still fire), iteration counts drop to one, and smooth scrolling is
+   disabled. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/themes/contrast.test.ts
+++ b/src/themes/contrast.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { darkTheme } from "./dark";
+import { lightTheme } from "./light";
+
+/**
+ * WCAG contrast regression test (accessibility audit, #2070).
+ *
+ * Guards the built-in dark/light theme tokens that are used as *text* colors
+ * against dropping below the WCAG 2.2 AA minimum contrast ratio of 4.5:1 for
+ * normal-size text. `--text-muted` and (in the light theme) `--color-warning`
+ * both previously failed AA and were darkened/lightened here; this test locks
+ * that in so a future palette tweak cannot silently regress it.
+ *
+ * The two surfaces checked are the primary background and the sidebar
+ * background — the two backgrounds these tokens actually render on across the
+ * app's 18 consuming CSS files.
+ *
+ * Note: the Solarized themes are intentionally excluded — Solarized is a
+ * fixed, well-known palette whose muted tones do not meet AA by design, and
+ * #2070 scopes the fix to the built-in dark/light themes only.
+ */
+
+const AA_NORMAL_TEXT = 4.5;
+
+/** sRGB relative luminance per WCAG 2.x, from a `#rrggbb` hex string. */
+function relativeLuminance(hex: string): number {
+  const int = parseInt(hex.slice(1), 16);
+  const channels = [(int >> 16) & 0xff, (int >> 8) & 0xff, int & 0xff].map((c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  });
+  const [r, g, b] = channels;
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** WCAG contrast ratio between two `#rrggbb` colors (always >= 1). */
+function contrastRatio(a: string, b: string): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const hi = Math.max(la, lb);
+  const lo = Math.min(la, lb);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+describe("theme text contrast (WCAG 2.2 AA)", () => {
+  const cases = [
+    { theme: darkTheme, token: "textMuted" as const },
+    { theme: lightTheme, token: "textMuted" as const },
+    { theme: lightTheme, token: "colorWarning" as const },
+  ];
+
+  for (const { theme, token } of cases) {
+    const fg = theme.colors[token];
+    const surfaces: [string, string][] = [
+      ["bgPrimary", theme.colors.bgPrimary],
+      ["sidebarBg", theme.colors.sidebarBg],
+    ];
+
+    for (const [surfaceName, bg] of surfaces) {
+      it(`${theme.id} ${token} (${fg}) meets AA on ${surfaceName} (${bg})`, () => {
+        const ratio = contrastRatio(fg, bg);
+        expect(ratio).toBeGreaterThanOrEqual(AA_NORMAL_TEXT);
+      });
+    }
+  }
+});

--- a/src/themes/dark.ts
+++ b/src/themes/dark.ts
@@ -33,7 +33,7 @@ export const darkTheme: ThemeDefinition = {
     // Text
     textPrimary: "#cccccc",
     textSecondary: "#969696",
-    textMuted: "#7d7d7d",
+    textMuted: "#909090",
     textDisabled: "#5a5a5a",
     textAccent: "#4fc1ff",
     textLink: "#3794ff",

--- a/src/themes/light.ts
+++ b/src/themes/light.ts
@@ -33,7 +33,7 @@ export const lightTheme: ThemeDefinition = {
     // Text
     textPrimary: "#383a42",
     textSecondary: "#6a737d",
-    textMuted: "#858a90",
+    textMuted: "#686d74",
     textDisabled: "#a0a0a0",
     textAccent: "#0366d6",
     textLink: "#0366d6",
@@ -49,7 +49,7 @@ export const lightTheme: ThemeDefinition = {
 
     // Status
     colorSuccess: "#22863a",
-    colorWarning: "#b08800",
+    colorWarning: "#856900",
     colorError: "#cb2431",
     colorInfo: "#0366d6",
 


### PR DESCRIPTION
## Summary

Accessibility fixes from the pre-release V&V audit (#2070):

1. **`--text-muted` failed WCAG AA 4.5:1 in both themes.** Fixed to values that clear AA against **both** the primary and sidebar backgrounds.
2. **Light `--color-warning` (`#b08800`) failed AA for text.** Darkened for text use.
3. **No global reduced-motion backstop.** `src/styles/animations.css` had zero `prefers-reduced-motion` rules; added a global `@media (prefers-reduced-motion: reduce)` block that neutralizes un-guarded animations/transitions (per-component guards still take precedence).

## Computed contrast ratios (WCAG 2.x, normal text needs ≥ 4.5:1)

| Token | Theme | Old → New | vs `bgPrimary` | vs `sidebarBg` |
|---|---|---|---|---|
| `--text-muted` | dark | `#7d7d7d` → `#909090` | 4.05 → **5.22** | 3.72 → **4.80** |
| `--text-muted` | light | `#858a90` → `#686d74` | 3.48 → **5.21** | 3.14 → **4.70** |
| `--color-warning` | light | `#b08800` → `#856900` | 3.30 → **5.23** | 2.97 → **4.71** |

All new values clear 4.5:1 on both surfaces. The originally-suggested `#6e747c` / `#8a6d00` were rejected because they fell **below 4.5** against the sidebar background (4.25 and 4.43 respectively); the chosen values were computed to pass both.

Scope note: the Solarized themes are intentionally excluded — Solarized is a fixed, well-known palette whose muted tones do not meet AA by design.

## Reduced-motion block added (`src/styles/animations.css`)

```css
@media (prefers-reduced-motion: reduce) {
  *, *::before, *::after {
    animation-duration: 0.01ms !important;
    animation-iteration-count: 1 !important;
    transition-duration: 0.01ms !important;
    scroll-behavior: auto !important;
  }
}
```

Durations collapse to a single frame (kept non-zero so `animationend`/`transitionend` listeners still fire).

## Tests

- New `src/themes/contrast.test.ts` — a WCAG contrast-ratio regression test asserting the fixed tokens stay ≥ 4.5:1 against both surfaces for the built-in dark/light themes.
- `pnpm test` (4617 tests), `pnpm run lint`, `pnpm run format:check`, `tsc --noEmit` all green locally.

Closes #2070