### PR TITLE
fix(ssh): raise default connect timeout to 45s for slow-dns hosts (Closes #2087)

### DIFF
--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -423,7 +423,9 @@ impl ConnectionType for Ssh {
                             ),
                             help_text: Some(
                                 "Bounds how long a connection to an unreachable host blocks before \
-                                 failing. Leave empty to use the default (20 s)."
+                                 failing. The budget covers DNS resolution, the TCP connect, and \
+                                 the SSH handshake — so a host with slow first-of-the-day DNS \
+                                 needs enough headroom here. Leave empty to use the default (45 s)."
                                     .to_string(),
                             ),
                             field_type: FieldType::Number {
@@ -432,7 +434,7 @@ impl ConnectionType for Ssh {
                             },
                             required: false,
                             default: None,
-                            placeholder: Some("20".to_string()),
+                            placeholder: Some("45".to_string()),
                             supports_env_expansion: false,
                             supports_tilde_expansion: false,
                             visible_when: None,

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -6,7 +6,16 @@ use std::time::Duration;
 /// Default SSH connect/handshake timeout (seconds) when a connection does not
 /// configure its own `connectTimeoutSecs`. Bounds how long a connect to an
 /// unreachable host may block before failing (#841).
-pub const DEFAULT_SSH_CONNECT_TIMEOUT_SECS: u64 = 20;
+///
+/// The budget covers the whole connect — DNS resolution, the TCP connect, and
+/// the SSH handshake all run inside it (see
+/// [`crate::backends::ssh::connect_and_authenticate`]). It was raised from the
+/// original 20 s (#2087): a host that resolves slowly on the first attempt of
+/// the day (cold DNS, e.g. a home Raspberry Pi) could spend most of a 20 s
+/// budget in resolution alone and fail before ever connecting. 45 s leaves room
+/// for a slow first resolve while still failing a genuinely dead host promptly;
+/// raise it further per connection via `connectTimeoutSecs`.
+pub const DEFAULT_SSH_CONNECT_TIMEOUT_SECS: u64 = 45;
 
 /// Return the user's home directory.
 ///
@@ -1915,6 +1924,14 @@ mod tests {
             let expanded = cfg.expand();
             assert_eq!(expanded.image, "alpine:3");
         });
+    }
+
+    #[test]
+    fn ssh_connect_timeout_default_is_forgiving() {
+        // Raised from 20 s (#2087) so a slow-first-resolve host (cold DNS) has
+        // room to connect within the budget instead of failing at 20 s of which
+        // most was DNS. Comfortably above the original 20 s.
+        assert_eq!(DEFAULT_SSH_CONNECT_TIMEOUT_SECS, 45);
     }
 
     #[test]

--- a/docs/changes/dev2/fix/2087-ssh-connect-timeout.md
+++ b/docs/changes/dev2/fix/2087-ssh-connect-timeout.md
@@ -1,0 +1,9 @@
+### Changed
+
+- The default SSH connect timeout is now **45 seconds** (raised from 20 s). The
+  budget covers the whole connect — DNS resolution, the TCP connect, and the SSH
+  handshake — so a host that resolves slowly on the first attempt of the day
+  (cold DNS, e.g. a home Raspberry Pi) no longer fails a too-tight 20 s window of
+  which most was spent resolving. The value stays configurable per connection via
+  the **Connect Timeout (s)** field (and per jump-host hop), so a slower or
+  faster budget can still be set where needed (#2087).

--- a/src/components/ConnectionEditor/JumpHostEntry.tsx
+++ b/src/components/ConnectionEditor/JumpHostEntry.tsx
@@ -175,7 +175,7 @@ export function JumpHostEntry({ hop, index, onChange, savedConnections }: JumpHo
           value={hop.connectTimeoutSecs ?? ""}
           min={1}
           max={300}
-          placeholder="Default (20 s)"
+          placeholder="Default (45 s)"
           onValueChange={(v) => onChange({ connectTimeoutSecs: v === "" ? undefined : v })}
           data-testid={tid("connect-timeout")}
         />


### PR DESCRIPTION
## Summary

A host that resolves slowly on the first attempt of the day (cold DNS — e.g. a home Raspberry Pi) could fail the SSH connect timeout because the whole connect budget was capped at **20 s**. The budget covers DNS resolution, the TCP connect, and the SSH handshake (all run inside the single `tokio::time::timeout` in `connect_and_authenticate`), so a slow first-of-day resolve could eat most of the 20 s and fail before ever connecting.

This raises the default to **45 s** — comfortably above the original 20 s while still failing a genuinely dead host promptly.

## Notes on scope

The per-connection **configurability** the issue asks for already shipped (#841 target, #951 per jump-host hop):
- Backend field `SshConfig::connect_timeout_secs: Option<u64>` + `connect_timeout()` fallback.
- Settings parsing of `connectTimeoutSecs` (`core/src/backends/ssh/mod.rs`).
- The **Connect Timeout (s)** field in the connection editor's Advanced group (Number, 1–300 s), and per-hop in the jump-host editor.

So the substantive change here is the default value; the UI help text / placeholders are updated to say 45 s, and the DNS-in-budget behaviour (already correct) is documented on the const.

## Changes

- `DEFAULT_SSH_CONNECT_TIMEOUT_SECS`: 20 → 45, with a doc comment explaining DNS is inside the budget.
- SSH schema help text + placeholder updated (20 → 45).
- Jump-host editor placeholder updated (`Default (20 s)` → `Default (45 s)`).
- Changelog fragment.

## DNS accounting

DNS resolution happens inside `tokio::net::TcpStream::connect(host:port)`, which is wrapped by the connect timeout — so resolution time is counted within the budget (verified in `core/src/backends/ssh/auth.rs`). The larger default gives a slow first resolve room to complete rather than being cut off.

## Tests

- New `ssh_connect_timeout_default_is_forgiving` locks the default at 45 s.
- Existing `ssh_connect_timeout_defaults_when_unset` / `_honours_override` still pass.
- Full core lib (477) + frontend (4613) suites, `cargo clippy`, `pnpm build`, `pnpm lint` all green.

Closes #2087