### PR TITLE
fix(security): keep style-src unsafe-inline effective under production csp

### DIFF
--- a/docs/changes/dev1/fix/2083-visual-regression.md
+++ b/docs/changes/dev1/fix/2083-visual-regression.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- Restored all app coloring after the production CSP regression: terminal ANSI
+  colors and the xterm cursor now render again, and toasts once more appear as a
+  fixed bottom-right corner overlay instead of flowing inline and consuming the
+  lower app area. The restrictive production CSP (#2048) let Tauri append the
+  `index.html` inline-`<style>` hash to `style-src`, which per CSP Level 3 makes
+  the browser ignore `'unsafe-inline'` — silently blocking the runtime `<style>`
+  elements that xterm (terminal colors/cursor) and sonner (toast overlay
+  positioning) inject. Disabling Tauri's `style-src` modification keeps
+  `'unsafe-inline'` effective for those runtime stylesheets while leaving
+  `script-src` fully hardened (#2083, #2084, #2085).

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,8 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'"
+      "csp": "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
+      "dangerousDisableAssetCspModification": ["style-src"]
     }
   },
   "plugins": {

--- a/src/styles/cspStyleSrc.test.ts
+++ b/src/styles/cspStyleSrc.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+/**
+ * CSP style-src regression guard (#2083/#2084/#2085).
+ *
+ * The app ships a restrictive production CSP (#2048/PR #2058). The terminal
+ * (xterm's DOM renderer), the toast hub (sonner) and other libraries inject
+ * their stylesheets into the document as runtime `<style>` elements, so the
+ * policy MUST keep `style-src 'unsafe-inline'` effective for them.
+ *
+ * The trap this guards against: `index.html` contains an inline `<style>`, so at
+ * build time Tauri hashes it and appends that hash to `style-src`. Per CSP Level
+ * 3, once a hash (or nonce) source is present the browser **ignores**
+ * `'unsafe-inline'` — which silently blocks every runtime-injected stylesheet,
+ * leaving the terminal monochrome/blank, the toasts flowing inline instead of as
+ * a corner overlay, and the cursor invisible. `dangerousDisableAssetCspModification`
+ * listing `"style-src"` tells Tauri NOT to touch that directive, so
+ * `'unsafe-inline'` stays effective. `script-src` is deliberately NOT listed, so
+ * it stays hardened (no `'unsafe-inline'`) — the actual XSS surface #2048 closed.
+ *
+ * This test fails if any of those invariants regress.
+ */
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const TAURI_CONF = join(REPO_ROOT, "src-tauri", "tauri.conf.json");
+const INDEX_HTML = join(REPO_ROOT, "index.html");
+
+interface TauriSecurity {
+  csp?: string | null;
+  dangerousDisableAssetCspModification?: boolean | string[];
+}
+
+function readSecurity(): TauriSecurity {
+  const conf = JSON.parse(readFileSync(TAURI_CONF, "utf8"));
+  return conf.app?.security ?? {};
+}
+
+/** Parse a CSP string into `{ directive: sources[] }`. */
+function parseCsp(csp: string): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const part of csp.split(";")) {
+    const tokens = part.trim().split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) continue;
+    const [name, ...sources] = tokens;
+    out[name] = sources;
+  }
+  return out;
+}
+
+describe("production CSP keeps runtime-injected styles working", () => {
+  const security = readSecurity();
+
+  it("still ships a restrictive CSP (not null) — #2048 hardening intact", () => {
+    expect(typeof security.csp).toBe("string");
+    expect(security.csp).toBeTruthy();
+  });
+
+  it("keeps style-src 'unsafe-inline' for xterm/sonner runtime stylesheets", () => {
+    const directives = parseCsp(security.csp as string);
+    expect(directives["style-src"]).toContain("'unsafe-inline'");
+  });
+
+  it("keeps script-src hardened — no 'unsafe-inline' (the #2048 XSS surface)", () => {
+    const directives = parseCsp(security.csp as string);
+    expect(directives["script-src"]).toBeDefined();
+    expect(directives["script-src"]).not.toContain("'unsafe-inline'");
+  });
+
+  it("disables Tauri's style-src modification so 'unsafe-inline' is not nullified", () => {
+    // Without this, Tauri appends index.html's inline-<style> hash to style-src,
+    // and CSP3 then makes the browser ignore 'unsafe-inline' — the #2083/#2084/#2085
+    // regression. script-src must NOT be disabled (it must stay Tauri-hardened).
+    const disabled = security.dangerousDisableAssetCspModification;
+    expect(Array.isArray(disabled)).toBe(true);
+    expect(disabled as string[]).toContain("style-src");
+    expect(disabled as string[]).not.toContain("script-src");
+  });
+
+  it("documents the trigger: index.html carries an inline <style>", () => {
+    // If this ever stops being true the guard above is still safe to keep, but the
+    // reason it exists changes — hence this canary rather than a silent assumption.
+    const html = readFileSync(INDEX_HTML, "utf8");
+    expect(html).toMatch(/<style[\s>]/i);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the release-blocking visual regression where the app rendered without color: terminal ANSI output was blank/monochrome, the xterm cursor was invisible, and toasts flowed inline at the bottom of the window instead of appearing as a fixed corner overlay.

## Root cause (single cause for all three)

PR #2058 (#2048) introduced a restrictive production CSP where there was `csp: null` before. `index.html` contains an inline `<style>`, so at build time Tauri hashes it and appends that `'sha256-…'` to `style-src`. **Per CSP Level 3, once a hash (or nonce) source is present the browser ignores `'unsafe-inline'`** — which silently blocked every *runtime-injected* `<style>`:

- xterm's DOM renderer injects a `<style>` for terminal cell colors + cursor → terminal blank/monochrome, cursor invisible (#2083, #2085).
- sonner injects its stylesheet, which carries the `[data-sonner-toaster]` `position: fixed` overlay rules → toasts flow inline and consume the lower app area (#2084).

This only manifests in a **production build** (the CSP does not apply under `pnpm tauri dev`), which is why the #2048 dev-time check missed it. Confirmed at the source level in `tauri::manager::set_csp` and empirically by production-build reproduction.

## Fix

Add `"dangerousDisableAssetCspModification": ["style-src"]` to `app.security`. This tells Tauri **not** to modify `style-src`, so it never appends the inline-style hash and `'unsafe-inline'` stays effective for the runtime stylesheets the app legitimately needs. `script-src` is deliberately **not** listed, so it stays fully hardened (no `'unsafe-inline'`) — the actual XSS surface #2048 closed is untouched. The `csp` string itself is unchanged.

## Verification (production `pnpm tauri build --debug`, via the system-test bridge)

Reproduced and fixed in a real production build:

- **Before:** terminal completely blank when printing ANSI-colored output; two toasts stacked full-width inline at the bottom of the window.
- **After:** ANSI colors render (verified RED/GREEN/BLUE/YELLOW background bars), the block cursor is visible at the prompt, and toasts appear as bottom-right corner overlay cards that do not affect layout.

## Tests

Added `src/styles/cspStyleSrc.test.ts` — a deterministic guard asserting: the CSP stays non-null; `style-src` keeps `'unsafe-inline'`; `script-src` stays free of `'unsafe-inline'`; and `dangerousDisableAssetCspModification` lists `style-src` (and not `script-src`). Verified it goes red without the fix.

Closes #2083
Closes #2084
Closes #2085

🤖 Generated with [Claude Code](https://claude.com/claude-code)
