### PR TITLE
fix(ui): reserve the persistent infinity badge for agent-backed connections (Closes #2086)

### DIFF
--- a/docs/changes/dev2/fix/2086-infinity-agent-only.md
+++ b/docs/changes/dev2/fix/2086-infinity-agent-only.md
@@ -1,0 +1,13 @@
+### Changed
+
+- The persistent-connection ∞ (infinity) badge is now reserved for
+  **agent-backed** connections only — sessions that live on a remote agent and
+  survive closing termiHub _and_ powering off / restarting your machine. Its
+  tooltip now states that guarantee explicitly. **Desktop-local** persistent
+  connections (SSH/Docker/WSL/Serial run inside the app) no longer show the ∞,
+  since they only live while the app is open; they now display a distinct,
+  lesser Hourglass marker whose tooltip does not overclaim ("Runs while the app
+  is open — closing termiHub ends the session. Use a remote agent for
+  persistence across app restarts."). The same tiered marker applies to the tab
+  decoration. This removes the misleading ∞ that appeared on plain SSH and other
+  desktop-local connections (#2086).

--- a/docs/concepts/implemented/persistent-connection-ux.html
+++ b/docs/concepts/implemented/persistent-connection-ux.html
@@ -46,9 +46,24 @@ in the background, or attached to one or more tabs — and act accordingly.</p>
 persistent-capable:</p>
 <ol>
 <li>
-<p><strong>Persistence badge</strong> — a small pill or icon (e.g., <code>∞</code> infinity symbol or the label <code>PRS</code>)
-   shown to the left of the connection type chip. It is always visible and tells the user "this
-   connection can run in the background."</p>
+<p><strong>Persistence badge (tiered, #2086)</strong> — the badge encodes <em>how strong</em> the persistence
+   guarantee is, and the two tiers must be visually distinct so they are never confused:</p>
+<ul>
+<li><strong>∞ (infinity) — agent-backed only.</strong> Reserved for sessions that live on a remote
+  <strong>agent</strong>: they survive closing termiHub <em>and</em> powering off / restarting this
+  machine (true cross-session, cross-power persistence via the agent daemon). Its tooltip states
+  exactly that: "Persistent session — lives on the agent and survives closing termiHub and
+  restarting this machine." Rendered on the agent connection row (<code>AgentNode.tsx</code>).</li>
+<li><strong>Hourglass (⧗) — desktop-local.</strong> A saved SSH/Docker/WSL/Serial connection
+  (<code>capabilities.persistent === true</code>) whose process runs inside the desktop app. It
+  survives tab closes <em>while the app is open</em> but is lost when termiHub exits — so it must
+  <strong>not</strong> show the ∞. It gets a distinct, muted Hourglass marker whose tooltip does not
+  overclaim: "Runs while the app is open — closing termiHub ends the session. Use a remote agent
+  for persistence across app restarts." Rendered on the connection row
+  (<code>ConnectionItem</code> in <code>ConnectionList.tsx</code>).</li>
+</ul>
+<p>The marker sits to the left of the connection type chip and is always visible; it tells the user
+   both "this connection can run in the background" and <em>which persistence tier</em> it has.</p>
 </li>
 <li>
 <p><strong>State dot</strong> — a small circle to the right of the connection name. Colour and tooltip reflect
@@ -99,10 +114,15 @@ persistent-capable:</p>
 </table>
 </div>
 <p>Non-persistent connections show neither element.</p>
-<p><strong>Annotated wireframe (stopped vs. attached state):</strong></p>
-<pre><code> [∞] 🖥  My SSH Server      ssh  ● (grey)
- [∞] 🖥  Dev Docker         docker  ● (bright green, badge &quot;2&quot;)
+<p><strong>Annotated wireframe (desktop-local rows use the Hourglass marker; the ∞ appears only on an
+agent-backed row):</strong></p>
+<pre><code>Connections
+ [⧗] 🖥  My SSH Server      ssh     ● (grey — not running)
+ [⧗] 🖥  Dev Docker         docker  ● (bright green, badge &quot;2&quot; — attached)
      🖥  Local Shell        local
+Remote Agents
+  ▸ prod-agent ●
+      [∞] 🖥  Build shell    ● (green — running on the agent)
 </code></pre>
 <h3 id="attached-tab-count-badge">Attached-Tab Count Badge</h3>
 <p>When <code>attached</code> and more than one tab is connected to the same session, a small numeric badge
@@ -154,8 +174,15 @@ node's inline buttons):</p>
 <li><strong>Transitioning (Starting / Stopping)</strong>: a spinner only, no buttons</li>
 </ul>
 <h3 id="tab-decoration">Tab Decoration</h3>
-<p>Tabs that are attached to a persistent session display a small <code>∞</code> superscript on the tab title
-to signal that closing the tab will <strong>detach</strong>, not terminate, the background process.</p>
+<p>Tabs attached to a persistent session carry the same tiered marker as the sidebar (#2086), to
+signal that closing the tab will <strong>detach</strong>, not terminate, the background process — and
+which persistence tier it belongs to:</p>
+<ul>
+<li><strong>Agent-backed tab</strong> (opened as a <code>remote-session</code>) → the <code>∞</code> badge, same
+  strong tooltip as the sidebar.</li>
+<li><strong>Desktop-local persistent tab</strong> (an ssh/docker/wsl/serial tab whose process runs in the
+  app) → the muted Hourglass marker with the app-open-only tooltip.</li>
+</ul>
 <p>When the user closes such a tab via the <code>×</code> button, a one-time tooltip confirmation appears:</p>
 <blockquote>
 <p>"This session will keep running in the background. Use Stop in the sidebar to terminate it."</p>
@@ -282,9 +309,13 @@ desktop does not need to know a restart occurred.</p>
 process, not via a remote agent) run inside the Tauri backend process. They persist across
 <strong>tab closes within the same app session</strong> (the new behaviour added by this concept) but are
 <strong>lost when the desktop app exits</strong>. There is no daemon subprocess layer on the desktop side.</p>
-<p>The sidebar must make this distinction clear: desktop-local persistent sessions show the <code>∞</code>
-badge but the tooltip clarifies "Runs while the app is open. Use an agent for across-session
-persistence."</p>
+<p>The sidebar must make this distinction clear, and a shared tooltip is not enough — the maintainer
+decision (#2086) is that the <code>∞</code> is <strong>reserved for agent-backed persistence</strong> and must
+<strong>not</strong> appear on a desktop-local row, because it overclaims a guarantee (surviving app close +
+machine restart) that the app-local session does not have. Desktop-local persistent sessions
+therefore show a <strong>distinct, lesser Hourglass marker</strong> whose tooltip does not overclaim: "Runs
+while the app is open — closing termiHub ends the session. Use a remote agent for persistence across
+app restarts."</p>
 <hr>
 <h2 id="states-sequences">States &amp; Sequences</h2>
 <h3 id="state-machine">State Machine</h3>
@@ -552,8 +583,10 @@ or terminated.</p>
 On app exit, the Tauri backend should call a new <code>shutdown_persistent_sessions()</code> that
 detaches all sessions cleanly (the processes will still be killed when the app process exits,
 but this allows graceful cleanup and correct state dot display before the window closes).</p>
-<p>Both scopes should use the same CSS classes, badge, and tooltip conventions so the UX is
-uniform regardless of whether a connection runs locally or through an agent.</p>
+<p>Both scopes share the same run-state dot and Start/Attach/Stop lifecycle conventions, but the
+<strong>persistence badge deliberately differs by tier</strong> (#2086): agent-backed rows keep the <code>∞</code>,
+desktop-local rows use the lesser Hourglass marker. The badge is the one place the UX must
+<em>not</em> be uniform, because the two tiers make materially different persistence guarantees.</p>
 <hr>
 <h2 id="implementation-status">Implementation Status</h2>
 <p><strong>Status: Implemented.</strong> Implementation issue
@@ -598,6 +631,14 @@ store, IPC commands, event flow, and both sidebar scopes now exist. One small mo
 <li><strong>Status-bar background-session count</strong> — the <code>PersistentSessionsIndicator</code> in
   <code>StatusBar.tsx</code> shows the count of background persistent sessions. Landed via
   <a href="https://github.com/armaxri/termiHub/issues/1882">#1882</a> (closed).</li>
+<li><strong>Tiered persistence badge</strong> — the <code>∞</code> is now reserved for <strong>agent-backed</strong>
+  persistence (survives app close + machine restart) and carries a tooltip stating exactly that;
+  <strong>desktop-local</strong> persistent connections use a distinct, muted <strong>Hourglass</strong> marker
+  (<code>.connection-tree__local-persistent-badge</code> / <code>.tab__local-persistent-badge</code>) with a
+  tooltip that does not overclaim. Applies to all three render sites — the sidebar connection row
+  (<code>ConnectionList.tsx</code>), the agent connection row (<code>AgentNode.tsx</code>), and the tab
+  decoration (<code>Tab.tsx</code>). Landed via
+  <a href="https://github.com/armaxri/termiHub/issues/2086">#2086</a>.</li>
 </ul>
 <h3 id="what-is-missing">Residual</h3>
 <ul>
@@ -612,7 +653,7 @@ store, IPC commands, event flow, and both sidebar scopes now exist. One small mo
 <blockquote>
 <p>Maintained by <code>/sync-concept persistent-connection-ux</code>. The concept is the source of truth; when a real constraint or decision made the original design wrong, the concept is updated instead of the code.</p>
 </blockquote>
-<p><strong>Last synced:</strong> 2026-07-25 (status reconciliation) · <strong>Status:</strong> implemented. The full lifecycle shipped (#672), and both surfacing gaps landed (#1881 desktop-local sidebar, #1882 status-bar count). One mockup detail (attached-tab count badge + one-time detach tooltip) remains, tracked as #1930. Concept moved <code>partial/</code> → <code>implemented/</code>.</p>
+<p><strong>Last synced:</strong> 2026-07-27 (#2086 tiered badge) · <strong>Status:</strong> implemented. The full lifecycle shipped (#672), and both surfacing gaps landed (#1881 desktop-local sidebar, #1882 status-bar count). Per the maintainer decision on <a href="https://github.com/armaxri/termiHub/issues/2086">#2086</a>, the <code>∞</code> badge is now reserved for agent-backed persistence (survives app close + machine restart) and desktop-local persistent connections use a distinct, lesser Hourglass marker with a non-overclaiming tooltip. One mockup detail (attached-tab count badge + one-time detach tooltip) remains, tracked as #1930.</p>
 <h3 id="sync-open">Open divergences</h3>
 <div class="table-wrap">
 <table>
@@ -622,6 +663,7 @@ store, IPC commands, event flow, and both sidebar scopes now exist. One small mo
 <tr><td>2</td><td>Status-bar count of background sessions</td><td><strong>Resolved</strong> — <code>PersistentSessionsIndicator</code> in <code>StatusBar.tsx</code></td><td>Resolved</td><td>Landed via <a href="https://github.com/armaxri/termiHub/issues/1882">#1882</a> — closed</td></tr>
 <tr><td>3</td><td>Attached-tab numeric count badge on the state dot; one-time detach confirmation tooltip</td><td>Not built</td><td>Missing</td><td>Tracked <a href="https://github.com/armaxri/termiHub/issues/1930">#1930</a></td></tr>
 <tr><td>4</td><td>Concept proposes <code>connection.start()/attach()/stop()</code> IPC commands</td><td>Shipped as <code>start_/stop_/list_persistent_session</code> plus <code>attach_/detach_/adopt_persistent_*</code> and <code>get_agent_session_buffer</code> — a superset; sessions keyed <code>${agentId}:${definitionId}</code></td><td>Divergence (naming)</td><td>Concept command list reconciled to the shipped names</td></tr>
+<tr><td>5</td><td>Original concept: desktop-local persistent sessions show the same <code>∞</code> badge as agent-backed, distinguished only by tooltip</td><td><strong>Resolved</strong> — <code>∞</code> reserved for agent-backed (<code>AgentNode.tsx</code>/<code>Tab.tsx</code>); desktop-local uses a distinct Hourglass marker (<code>ConnectionList.tsx</code>/<code>Tab.tsx</code>)</td><td>Resolved (concept updated)</td><td>Maintainer decision on <a href="https://github.com/armaxri/termiHub/issues/2086">#2086</a> — a shared badge overclaimed the desktop-local guarantee; concept + code both updated to the tiered badge</td></tr>
 </tbody>
 </table>
 </div>

--- a/src/components/Sidebar/AgentNode.persistent-badge.test.tsx
+++ b/src/components/Sidebar/AgentNode.persistent-badge.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * Agent-backed persistence badge (#2086).
+ *
+ * A persistent saved definition on a connected agent keeps the ∞ badge — the
+ * session lives on the remote agent and survives closing termiHub AND powering
+ * off / restarting this machine. The badge's tooltip states exactly that. A
+ * non-persistent definition shows no badge. (The desktop-local, app-open-only
+ * tier uses a different, lesser marker — see ConnectionList.persistent.test.)
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { AgentNode } from "./AgentNode";
+import { DEFAULT_AGENT_SETTINGS, type RemoteAgentDefinition } from "@/types/connection";
+import type { AgentDefinitionInfo } from "@/services/api";
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  useDraggable: () => ({ attributes: {}, listeners: {}, setNodeRef: vi.fn(), isDragging: false }),
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+  useDndContext: () => ({ active: null }),
+  useDndMonitor: () => {},
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => "" } },
+}));
+
+vi.mock("@/services/api", () => ({
+  removeCredential: vi.fn(() => Promise.resolve()),
+  storeCredential: vi.fn(() => Promise.resolve()),
+  cancelConnectAgent: vi.fn(() => Promise.resolve()),
+  disconnectAgent: vi.fn(() => Promise.resolve()),
+  shutdownAgent: vi.fn(() => Promise.resolve(0)),
+  listAgentDefinitions: vi.fn(() => Promise.resolve([])),
+  listAgentConnections: vi.fn(() => Promise.resolve({ connections: [], folders: [] })),
+  saveAgentDefinition: vi.fn(),
+  updateAgentDefinition: vi.fn(),
+  deleteAgentDefinition: vi.fn(() => Promise.resolve()),
+  createAgentFolder: vi.fn(),
+  updateAgentFolder: vi.fn(),
+  deleteAgentFolder: vi.fn(() => Promise.resolve()),
+}));
+
+// Passthrough Tooltip so the isolated render needs no app-root TooltipProvider.
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>();
+  return {
+    ...actual,
+    Tooltip: ({ children }: { children: React.ReactNode }) => children,
+    toast: {
+      success: vi.fn(),
+      error: vi.fn(),
+      loading: vi.fn(),
+      dismiss: vi.fn(),
+      promise: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+vi.mock("./AgentSetupDialog", () => ({ AgentSetupDialog: () => null }));
+vi.mock("./ConnectionErrorDialog", () => ({ ConnectionErrorDialog: () => null }));
+vi.mock("./InlineFolderInput", () => ({ InlineFolderInput: () => null }));
+
+const AGENT_ID = "agent-badge-test";
+
+function makeAgent(overrides: Partial<RemoteAgentDefinition> = {}): RemoteAgentDefinition {
+  return {
+    id: AGENT_ID,
+    name: "Test Agent",
+    config: { host: "host.example.com", port: 22, username: "user", authMethod: "password" },
+    connectionState: "connected",
+    isExpanded: true,
+    agentSettings: DEFAULT_AGENT_SETTINGS,
+    capabilities: {
+      connectionTypes: [],
+      maxSessions: 10,
+      availableShells: ["bash"],
+      availableSerialPorts: [],
+      availableDockerImages: [],
+    },
+    ...overrides,
+  };
+}
+
+function makeDef(overrides: Partial<AgentDefinitionInfo> = {}): AgentDefinitionInfo {
+  return {
+    id: "def-1",
+    name: "Build Shell",
+    sessionType: "shell",
+    config: {},
+    persistent: true,
+    folderId: null,
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(): void {
+  act(() => {
+    root.render(React.createElement(AgentNode, { agent: makeAgent() }));
+  });
+}
+
+describe("AgentNode — agent-backed persistence badge (#2086)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders the ∞ badge with a survives-restart tooltip for a persistent definition", () => {
+    useAppStore.setState({
+      remoteAgents: [makeAgent()],
+      agentDefinitions: { [AGENT_ID]: [makeDef({ persistent: true })] },
+    });
+    render();
+    const badge = container.querySelector('[data-testid="persistent-badge-def-1"]');
+    expect(badge).not.toBeNull();
+    expect(badge!.textContent).toContain("∞");
+    expect(badge!.getAttribute("title") ?? "").toContain("restarting this machine");
+    // Agent-backed rows must not use the desktop-local marker.
+    expect(container.querySelector(".tab__local-persistent-badge")).toBeNull();
+    expect(container.querySelector(".connection-tree__local-persistent-badge")).toBeNull();
+  });
+
+  it("renders no ∞ badge for a non-persistent definition", () => {
+    useAppStore.setState({
+      remoteAgents: [makeAgent()],
+      agentDefinitions: { [AGENT_ID]: [makeDef({ persistent: false })] },
+    });
+    render();
+    expect(container.querySelector('[data-testid="persistent-badge-def-1"]')).toBeNull();
+  });
+});

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -259,7 +259,20 @@ function AgentConnectionItem({
             />
           )}
           <span className="connection-tree__label">{definition.name}</span>
-          {definition.persistent && <span className="connection-tree__persistent-badge">∞</span>}
+          {/* Agent-backed persistence (#2086): the ∞ is reserved for sessions
+              that live on the remote agent and survive closing termiHub AND
+              powering off / restarting this machine. The tooltip states exactly
+              that so the strong claim is never confused with the desktop-local
+              (app-open-only) tier. */}
+          {definition.persistent && (
+            <span
+              className="connection-tree__persistent-badge"
+              title="Persistent session — lives on the agent and survives closing termiHub and restarting this machine."
+              data-testid={`persistent-badge-${definition.id}`}
+            >
+              ∞
+            </span>
+          )}
           {definition.persistent ? (
             <span className="connection-tree__persistent-actions">
               {!runState || runState === "stopped" || runState === "error" ? (

--- a/src/components/Sidebar/ConnectionList.css
+++ b/src/components/Sidebar/ConnectionList.css
@@ -467,6 +467,19 @@
   top: -3px;
 }
 
+/* Desktop-local persistence marker (#2086): a muted Hourglass, deliberately
+   distinct from the agent-backed ∞ so the two persistence tiers read as
+   different. "Bounded" (only while the app is open) vs. the unbounded ∞. */
+.connection-tree__local-persistent-badge {
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  flex-shrink: 0;
+  margin-left: 3px;
+  color: var(--text-secondary);
+  opacity: 0.75;
+}
+
 .connection-tree__state-dot {
   display: inline-block;
   width: 7px;

--- a/src/components/Sidebar/ConnectionList.persistent.test.tsx
+++ b/src/components/Sidebar/ConnectionList.persistent.test.tsx
@@ -1,12 +1,20 @@
 /**
- * Desktop-local persistent-session controls in the connection tree (#1881).
+ * Desktop-local persistent-session controls in the connection tree (#1881),
+ * updated for the tiered persistence badge (#2086).
  *
  * A saved connection whose type reports `capabilities.persistent === true`
- * surfaces the ∞ persistence badge, a run-state dot, and state-dependent
- * Start / Attach / Stop controls (inline + context menu) wired to the store's
- * `startPersistentSession` / `attachPersistentSession` / `stopPersistentSession`
- * actions, keyed by the plain connection id. A non-persistence-capable
- * connection shows none of this and keeps the plain Connect affordance.
+ * surfaces a desktop-local persistence marker, a run-state dot, and
+ * state-dependent Start / Attach / Stop controls (inline + context menu) wired
+ * to the store's `startPersistentSession` / `attachPersistentSession` /
+ * `stopPersistentSession` actions, keyed by the plain connection id.
+ *
+ * Per the #2086 maintainer decision, the desktop-local marker is NOT the ∞
+ * (that is reserved for agent-backed persistence that survives app close +
+ * machine restart). Desktop-local persistence lives only while the app is open,
+ * so it renders a distinct, lesser Hourglass marker
+ * (`local-persistent-badge-*`) whose tooltip does not overclaim. A
+ * non-persistence-capable connection shows none of this and keeps the plain
+ * Connect affordance.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
@@ -152,17 +160,34 @@ afterEach(() => {
 });
 
 describe("ConnectionList — desktop-local persistent controls", () => {
-  it("shows the ∞ badge and state dot only for a persistence-capable connection", () => {
+  it("shows the desktop-local (Hourglass) marker — NOT the ∞ — and state dot only for a persistence-capable connection", () => {
     render();
-    expect(q("persistent-badge-ssh-1")).not.toBeNull();
+    // #2086: a plain SSH (desktop-local persistent) connection gets the lesser
+    // Hourglass marker and MUST NOT carry the agent-only ∞.
+    const marker = q("local-persistent-badge-ssh-1");
+    expect(marker).not.toBeNull();
+    expect(marker!.textContent ?? "").not.toContain("∞");
+    // The ∞ badge (agent-backed testid) never renders on a desktop-local row.
+    expect(q("persistent-badge-ssh-1")).toBeNull();
     expect(q("persistent-state-dot-ssh-1")).not.toBeNull();
-    // Telnet is not persistence-capable.
+    // Telnet is not persistence-capable — neither marker nor dot.
+    expect(q("local-persistent-badge-tel-1")).toBeNull();
     expect(q("persistent-badge-tel-1")).toBeNull();
     expect(q("persistent-state-dot-tel-1")).toBeNull();
     // The non-persistent connection keeps the plain Connect affordance; the
     // persistent one does not.
     expect(q("connection-connect-tel-1")).not.toBeNull();
     expect(q("connection-connect-ssh-1")).toBeNull();
+  });
+
+  it("the desktop-local marker tooltip does not overclaim cross-restart persistence", () => {
+    render();
+    const title = q("local-persistent-badge-ssh-1")!.getAttribute("title") ?? "";
+    expect(title).toContain("Runs while the app is open");
+    // Must steer users to an agent for stronger persistence, and must not claim
+    // it survives a machine restart.
+    expect(title.toLowerCase()).toContain("agent");
+    expect(title.toLowerCase()).not.toContain("machine");
   });
 
   it("reflects the run state on the state dot", () => {
@@ -219,8 +244,8 @@ describe("ConnectionList — desktop-local persistent controls", () => {
     expect(q("persistent-start-ssh-1")).toBeNull();
     expect(q("persistent-attach-ssh-1")).toBeNull();
     expect(q("persistent-stop-ssh-1")).toBeNull();
-    // The badge/dot still render.
-    expect(q("persistent-badge-ssh-1")).not.toBeNull();
+    // The desktop-local marker/dot still render.
+    expect(q("local-persistent-badge-ssh-1")).not.toBeNull();
   });
 
   describe("attached-tab count badge (#1930)", () => {

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -34,6 +34,7 @@ import {
   FileSpreadsheet,
   Link,
   Square,
+  Hourglass,
 } from "lucide-react";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import { useAppStore } from "@/store/appStore";
@@ -434,13 +435,18 @@ function ConnectionItem({
                   )}
                 </span>
               )}
+              {/* Desktop-local persistence marker (#2086). This session runs
+                  inside the app process and lives only while the app is open,
+                  so it must NOT claim the ∞ (which is reserved for agent-backed
+                  sessions that survive app close + machine restart). It gets a
+                  distinct, lesser Hourglass marker instead. */}
               {persistentCapable && (
                 <span
-                  className="connection-tree__persistent-badge"
-                  title="Runs while the app is open. Use an agent for across-session persistence."
-                  data-testid={`persistent-badge-${connection.id}`}
+                  className="connection-tree__local-persistent-badge"
+                  title="Runs while the app is open — closing termiHub ends the session. Use a remote agent for persistence across app restarts."
+                  data-testid={`local-persistent-badge-${connection.id}`}
                 >
-                  ∞
+                  <Hourglass size={12} />
                 </span>
               )}
               <span className="connection-tree__type">{connection.config.type}</span>

--- a/src/components/Terminal/Tab.persistent-badge.test.tsx
+++ b/src/components/Terminal/Tab.persistent-badge.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Tiered persistence badge on the tab (#2086).
+ *
+ * A tab attached to a persistent session carries a marker signalling that
+ * closing it will detach (not terminate) the background process — but the
+ * marker differs by persistence tier:
+ *
+ *  - **Agent-backed** (the tab was opened as a `remote-session`) → the ∞ badge,
+ *    because the session lives on the agent and survives app close + machine
+ *    restart.
+ *  - **Desktop-local** (an ssh/docker/wsl/serial tab whose process runs inside
+ *    the app) → a distinct, lesser Hourglass marker, because it only lives
+ *    while the app is open.
+ *
+ * A tab with no `persistentConnectionId` shows neither.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Tab } from "./Tab";
+import { TooltipProvider } from "@/components/ui";
+import { TerminalTab } from "@/types/terminal";
+
+// Stub the dnd-kit sortable wrapper so the Tab mounts without a DndContext.
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => {},
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+const PANEL_ID = "panel-1";
+
+function makeTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: "t1",
+    sessionId: "sess-1",
+    title: "My Session",
+    connectionType: "ssh",
+    contentType: "terminal",
+    config: { type: "ssh", config: { host: "example.com" } },
+    panelId: PANEL_ID,
+    isActive: true,
+    ...overrides,
+  };
+}
+
+function renderTab(tab: TerminalTab) {
+  const root = createRoot(document.body.appendChild(document.createElement("div")));
+  act(() => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <Tab tab={tab} onActivate={() => {}} onClose={() => {}} />
+      </TooltipProvider>
+    );
+  });
+  return root;
+}
+
+describe("Tab — tiered persistence badge (#2086)", () => {
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    if (root) act(() => root!.unmount());
+    root = null;
+    document.body.innerHTML = "";
+  });
+
+  it("shows the ∞ badge for an agent-backed (remote-session) persistent tab", () => {
+    root = renderTab(
+      makeTab({
+        connectionType: "remote-session",
+        config: { type: "remote-session", config: { agentId: "a1", sessionType: "shell" } },
+        persistentConnectionId: "a1:def-1",
+      })
+    );
+    const badge = document.querySelector(".tab__persistent-badge");
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toContain("∞");
+    // Never the desktop-local marker for an agent-backed tab.
+    expect(document.querySelector(".tab__local-persistent-badge")).toBeNull();
+    // Tooltip makes the strong (cross-restart) claim.
+    expect(badge?.getAttribute("title") ?? "").toContain("restarting this machine");
+  });
+
+  it("shows the lesser Hourglass marker — NOT the ∞ — for a desktop-local persistent tab", () => {
+    root = renderTab(
+      makeTab({
+        connectionType: "ssh",
+        config: { type: "ssh", config: { host: "example.com" } },
+        persistentConnectionId: "ssh-1",
+      })
+    );
+    const marker = document.querySelector(".tab__local-persistent-badge");
+    expect(marker).not.toBeNull();
+    // The ∞ badge must not render on a desktop-local tab.
+    expect(document.querySelector(".tab__persistent-badge")).toBeNull();
+    // Tooltip does not overclaim.
+    expect(marker?.getAttribute("title") ?? "").toContain("Runs while the app is open");
+  });
+
+  it("shows neither marker for a non-persistent tab", () => {
+    root = renderTab(makeTab({ persistentConnectionId: undefined }));
+    expect(document.querySelector(".tab__persistent-badge")).toBeNull();
+    expect(document.querySelector(".tab__local-persistent-badge")).toBeNull();
+  });
+});

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -22,6 +22,7 @@ import {
   Plus,
   ChevronRight,
   Radio,
+  Hourglass,
 } from "lucide-react";
 import { TerminalTab } from "@/types/terminal";
 import { TabStatus } from "@/utils/tabStatus";
@@ -188,7 +189,31 @@ export function Tab({
           <Radio size={12} />
         </span>
       )}
-      {tab.persistentConnectionId && <span className="tab__persistent-badge">∞</span>}
+      {/* Persistence tier badge (#2086). The ∞ is reserved for agent-backed
+          sessions — they live on the remote agent and survive closing termiHub
+          and restarting this machine. A desktop-local persistent session (an
+          ssh/docker/wsl/serial tab whose process runs inside this app) only
+          lives while the app is open, so it gets a distinct, lesser Hourglass
+          marker that does not overclaim. Agent-backed tabs are the ones opened
+          as a `remote-session`. */}
+      {tab.persistentConnectionId &&
+        (tab.config?.type === "remote-session" ? (
+          <span
+            className="tab__persistent-badge"
+            title="Persistent session — lives on the agent and survives closing termiHub and restarting this machine."
+            data-testid={`tab-persistent-badge-${tab.id}`}
+          >
+            ∞
+          </span>
+        ) : (
+          <span
+            className="tab__local-persistent-badge"
+            title="Runs while the app is open — closing termiHub ends the session. Use a remote agent for persistence across app restarts."
+            data-testid={`tab-local-persistent-badge-${tab.id}`}
+          >
+            <Hourglass size={12} />
+          </span>
+        ))}
       {tab.spawned && (
         <span className="tab__spawned-badge" title="Spawned container">
           Spawned

--- a/src/components/Terminal/TabBar.css
+++ b/src/components/Terminal/TabBar.css
@@ -105,6 +105,18 @@
   top: -3px;
 }
 
+/* Desktop-local persistence marker (#2086): a muted Hourglass on the tab,
+   distinct from the agent-backed ∞. Signals the session detaches (not
+   terminates) on close but only lives while the app is open. */
+.tab__local-persistent-badge {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-left: 3px;
+  color: var(--text-secondary);
+  opacity: 0.75;
+}
+
 .tab__spawned-badge {
   flex-shrink: 0;
   margin-left: var(--spacing-xs);


### PR DESCRIPTION
## Summary

The ∞ (infinity) persistent badge was being shown for **non-agent** connections — plain SSH, Docker, WSL and Serial — which overclaims persistence. Those desktop-local sessions run inside the app process and only survive while the app is open; they are lost on app close, and certainly on a machine restart.

Per the maintainer decision on #2086, this reserves **∞ for agent-backed persistence only** and gives desktop-local persistence a distinct, lesser marker.

## The two tiers

- **∞ (infinity) = agent-backed only** — the session lives on the remote agent and survives closing termiHub **and** powering off / restarting the local machine. It now carries a tooltip stating exactly that. Rendered on `AgentNode.tsx` (agent connection rows) and on agent-backed (`remote-session`) tabs in `Tab.tsx`.
- **Hourglass (lesser marker) = desktop-local** — SSH/Docker/WSL/Serial saved connections (`capabilities.persistent === true`) that run inside the app. They now show a muted lucide **Hourglass** marker (chosen as a "bounded lifetime" contrast to the unbounded ∞) with a non-overclaiming tooltip: *"Runs while the app is open — closing termiHub ends the session. Use a remote agent for persistence across app restarts."* Rendered on `ConnectionList.tsx` (the sidebar row that was showing ∞ on plain SSH) and on desktop-local persistent tabs.

Tab tier is distinguished by whether the tab was opened as a `remote-session` (agent-backed) vs. a direct ssh/docker/wsl/serial tab (desktop-local).

## Connected dot

Verified the run-state dot: the green/`running`/`attached` dot only renders when the store holds a real backend persistent-session entry in that state; a persistence-capable-but-not-started connection shows the by-design grey "not running" dot per the concept, never a false "connected". No connected-dot bug found at the render layer; left unchanged.

## Concept (source of truth)

Updated `docs/concepts/implemented/persistent-connection-ux.html`: the Persistence badge spec is now tiered (∞ = agent, Hourglass = desktop-local), the wireframe, Tab Decoration, and desktop-local sections reflect it, and the Implementation Status + Sync Ledger record the #2086 decision. Screenshot-verified it still renders.

## Tests

- Rewrote `ConnectionList.persistent.test.tsx`: a plain SSH connection shows the Hourglass marker and **no ∞**; tooltip does not overclaim.
- New `Tab.persistent-badge.test.tsx`: agent-backed (`remote-session`) tab → ∞ with survives-restart tooltip; desktop-local tab → Hourglass marker, no ∞.
- New `AgentNode.persistent-badge.test.tsx`: persistent agent definition → ∞ with the strong tooltip; non-persistent → no badge.

Full frontend suite green (4633 tests), `pnpm build` (tsc) and `pnpm lint` clean.

Closes #2086
