### PR TITLE
fix(window): grant window destroy capability so the app can close (Closes #2089)

### DIFF
--- a/docs/changes/dev1/fix/2089-cannot-close-app.md
+++ b/docs/changes/dev1/fix/2089-cannot-close-app.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- The application can be closed and quit again. The close-window flow (#1903)
+  prevents the OS default close and calls `getCurrentWindow().destroy()` from
+  the frontend, but the window capability never granted
+  `core:window:allow-destroy`, so Tauri's ACL silently denied every destroy —
+  the confirm dialog would appear once and no close attempt could ever actually
+  close the window, forcing a force-kill. The default capability now grants
+  window destroy/close and applies to both the primary `main` window and the
+  secondary `win-N` windows (#2089).

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the main window",
-  "windows": ["main"],
+  "description": "Capability for the main and secondary (win-N) windows",
+  "windows": ["main", "win-*"],
   "permissions": [
     "core:default",
     "opener:default",
@@ -15,6 +15,8 @@
     "clipboard-manager:allow-read-text",
     "clipboard-manager:allow-write-text",
     "core:webview:allow-set-webview-zoom",
-    "core:window:allow-set-size"
+    "core:window:allow-set-size",
+    "core:window:allow-destroy",
+    "core:window:allow-close"
   ]
 }

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -396,7 +396,7 @@ mod tests {
             .filter_map(|w| w.as_str())
             .collect();
         assert!(
-            windows.iter().any(|w| *w == "main"),
+            windows.contains(&"main"),
             "capability must cover the primary `main` window; got {windows:?}"
         );
         assert!(

--- a/src-tauri/src/window/mod.rs
+++ b/src-tauri/src/window/mod.rs
@@ -363,6 +363,49 @@ impl WindowManager {
 mod tests {
     use super::*;
 
+    /// The window-close flow (#1903) prevents the OS default close and calls
+    /// `getCurrentWindow().destroy()` from the frontend. Under Tauri v2's ACL
+    /// that IPC is denied unless the window's capability grants
+    /// `core:window:allow-destroy` — and `core:window:default` grants only
+    /// read-only queries, not destroy. Without this permission every close is
+    /// swallowed and the app can never be quit (#2089). Guard the capability so
+    /// the grant cannot silently regress, and make sure it reaches both the
+    /// primary `main` window and the multi-window `win-N` labels.
+    #[test]
+    fn default_capability_allows_window_destroy_for_every_window() {
+        let capability: serde_json::Value =
+            serde_json::from_str(include_str!("../../capabilities/default.json"))
+                .expect("capabilities/default.json is valid JSON");
+
+        let permissions: Vec<&str> = capability["permissions"]
+            .as_array()
+            .expect("capability has a permissions array")
+            .iter()
+            .filter_map(|p| p.as_str())
+            .collect();
+        assert!(
+            permissions.contains(&"core:window:allow-destroy"),
+            "default capability must grant core:window:allow-destroy so the \
+             close-window flow can actually close the window (#2089); got {permissions:?}"
+        );
+
+        let windows: Vec<&str> = capability["windows"]
+            .as_array()
+            .expect("capability has a windows array")
+            .iter()
+            .filter_map(|w| w.as_str())
+            .collect();
+        assert!(
+            windows.iter().any(|w| *w == "main"),
+            "capability must cover the primary `main` window; got {windows:?}"
+        );
+        assert!(
+            windows.iter().any(|w| *w == "win-*" || *w == "*"),
+            "capability must cover secondary `win-N` windows so their \
+             close-window flow works too (#2089); got {windows:?}"
+        );
+    }
+
     fn record(session_id: &str) -> HandoffRecord {
         HandoffRecord {
             tab: serde_json::json!({ "sessionId": session_id }),


### PR DESCRIPTION
## Problem

**Critical regression — the app could not be closed** (had to be force-killed). On the first close attempt the close-confirm dialog appeared; every subsequent close attempt did nothing.

## Root cause

Not the CSP/style regression (#2083, already fixed) — the dialog renders and its buttons respond fine. The real cause is in the **Tauri v2 ACL**.

The close-window flow (#1903) intercepts the OS close, calls `event.preventDefault()`, and then closes the window from the frontend via `getCurrentWindow().destroy()`. Under Tauri v2 every IPC is gated by a capability. The app's `capabilities/default.json` granted only `core:window:allow-set-size`, and `core:window:default` (via `core:default`) grants **read-only** window queries — **not** `allow-destroy`. So every `destroy()` call was **silently denied**:

- Confirm-close / detach-vs-terminate decisions call `destroy()` → denied → window stays.
- The empty/all-persistent "proceed" path calls `destroy()` → denied → window stays.

The confirm dialog itself works (state clears, the Radix pointer-events lock is released after each decision — verified), but nothing can ever actually close the window, so the app can't be quit.

The capability was also scoped to `"windows": ["main"]`, so secondary multi-window (`win-N`) windows got no window permissions at all.

## Fix

`src-tauri/capabilities/default.json`:
- add `core:window:allow-destroy` (and `core:window:allow-close`)
- broaden the window scope to `["main", "win-*"]` so secondary windows can close too

## Tests

- `test(window)`: regression test asserting the default capability grants `core:window:allow-destroy` and covers both `main` and `win-*`. Fails against the old config, passes with the fix. Runs in per-PR CI.

## Verified in a production build

Built the release app (`pnpm tauri build`) and drove it through the Python bridge harness:

- Before the fix: open a local (non-persistent) terminal → close-requested raises the dialog → click **Close & end sessions** → the window is **not** destroyed (bridge stays connected). Confirms the denial.
- After the fix: same flow → the window **is** destroyed and the webview bridge disconnects, i.e. `destroy()` now succeeds and the window actually closes.
- Also confirmed the **Cancel** path releases the body pointer-events lock (outside-dialog elements go back to `pointer-events: auto`) and a second close attempt re-raises the dialog.

Closes #2089