### PR TITLE
fix(ui): give connection error/warning messages backend-appropriate hints (Closes #2088)

### DIFF
--- a/docs/changes/dev2/fix/2088-user-facing-messages.md
+++ b/docs/changes/dev2/fix/2088-user-facing-messages.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Connection-failure hints are now backend-appropriate. An SSH connect timeout
+  previously showed "Check that the host is reachable and the agent binary is
+  installed" — an agent-connection hint that is wrong on the SSH path (and, in
+  fact, on every path: a timeout means the transport never connected, so the
+  remote agent binary cannot be the cause). Timeout guidance is now sourced from
+  a structured per-backend table so each backend (SSH, telnet, serial, Docker,
+  local) gets a hint written for it, and the SSH ssh-agent hint no longer leaks
+  onto non-SSH backends (#2088).

--- a/docs/changes/dev2/fix/2088-user-facing-messages.md
+++ b/docs/changes/dev2/fix/2088-user-facing-messages.md
@@ -8,3 +8,8 @@
   a structured per-backend table so each backend (SSH, telnet, serial, Docker,
   local) gets a hint written for it, and the SSH ssh-agent hint no longer leaks
   onto non-SSH backends (#2088).
+- The "SSH Agent not running" hint on the connection screen now shows a
+  host-OS-appropriate command: the elevated PowerShell `Set-Service ssh-agent`
+  line on Windows, and `eval "$(ssh-agent -s)" && ssh-add` on macOS/Linux. It
+  previously showed the Windows-only command on every platform, where it was
+  meaningless (#2088).

--- a/src/components/Terminal/TerminalConnectionOverlay.platform.test.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.platform.test.tsx
@@ -112,3 +112,74 @@ describe("TerminalConnectionOverlay — platform-aware serial permission hint (#
     ).toBeNull();
   });
 });
+
+/**
+ * #2088: the SSH-agent-not-running hint used to show a Windows-only PowerShell
+ * `Set-Service ssh-agent` command on every OS, which is non-actionable on
+ * macOS/Linux (no such service exists there). The remedy must follow the host
+ * OS, mirroring ConnectionEditor's "Setup SSH Agent" button.
+ */
+describe("TerminalConnectionOverlay — platform-aware SSH-agent hint (#2088)", () => {
+  const WIN_COMMAND = "Set-Service ssh-agent";
+  const UNIX_COMMAND = 'eval "$(ssh-agent -s)" && ssh-add';
+
+  function renderAgentAuthFailure() {
+    useAppStore.setState({
+      terminalConnecting: {},
+      terminalSpawnErrors: { [TAB_ID]: "Agent auth failed" },
+      terminalAutoRetryCount: {},
+      terminalWaitingForAgent: {},
+      terminalRetryCounters: {},
+      terminalReattaching: {},
+    });
+    act(() => {
+      root.render(
+        <TerminalConnectionOverlay
+          tabId={TAB_ID}
+          panelId={PANEL_ID}
+          tabTitle="my-server"
+          isVisible={true}
+          sessionType="ssh"
+        />
+      );
+    });
+  }
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    platformMock.value = "linux";
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("shows the PowerShell service command on Windows", () => {
+    platformMock.value = "windows";
+    renderAgentAuthFailure();
+    const text = container.textContent ?? "";
+    expect(text).toContain("SSH Agent not running");
+    expect(text).toContain(WIN_COMMAND);
+    expect(text).not.toContain(UNIX_COMMAND);
+  });
+
+  it("shows the ssh-agent/ssh-add command on macOS, not the Windows one", () => {
+    platformMock.value = "macos";
+    renderAgentAuthFailure();
+    const text = container.textContent ?? "";
+    expect(text).toContain("SSH Agent not running");
+    expect(text).toContain(UNIX_COMMAND);
+    expect(text).not.toContain(WIN_COMMAND);
+  });
+
+  it("shows the ssh-agent/ssh-add command on Linux, not the Windows one", () => {
+    platformMock.value = "linux";
+    renderAgentAuthFailure();
+    const text = container.textContent ?? "";
+    expect(text).toContain(UNIX_COMMAND);
+    expect(text).not.toContain(WIN_COMMAND);
+  });
+});

--- a/src/components/Terminal/TerminalConnectionOverlay.test.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.test.tsx
@@ -449,6 +449,70 @@ describe("TerminalConnectionOverlay — failed state", () => {
     expect(container.textContent).toContain("timed out");
   });
 
+  // Regression for #2088: an SSH connect timeout must give SSH-appropriate,
+  // reachability-focused guidance — it must NOT tell the user to check "the
+  // agent binary" (that hint belongs to agent connections, and a timeout means
+  // the transport never connected in the first place).
+  it("gives an SSH-appropriate timeout hint, not the agent-binary one", () => {
+    useAppStore.setState({
+      terminalSpawnErrors: { [TAB_ID]: "Connection timed out after 45s" },
+    });
+    act(() => {
+      root.render(
+        <TerminalConnectionOverlay
+          tabId={TAB_ID}
+          panelId={PANEL_ID}
+          tabTitle="my-server"
+          isVisible={true}
+          sessionType="ssh"
+        />
+      );
+    });
+    const text = container.textContent ?? "";
+    expect(text).not.toContain("agent binary");
+    expect(text).toContain("SSH");
+    expect(text).toContain("reachable");
+  });
+
+  it("gives a telnet timeout hint free of any agent-binary mention", () => {
+    useAppStore.setState({
+      terminalSpawnErrors: { [TAB_ID]: "TCP connect failed: connection timed out" },
+    });
+    act(() => {
+      root.render(
+        <TerminalConnectionOverlay
+          tabId={TAB_ID}
+          panelId={PANEL_ID}
+          tabTitle="my-telnet"
+          isVisible={true}
+          sessionType="telnet"
+        />
+      );
+    });
+    const text = container.textContent ?? "";
+    expect(text).not.toContain("agent binary");
+    expect(text).toContain("reachable");
+  });
+
+  // #2088: the SSH ssh-agent hint (remedy: start ssh-agent) is SSH-specific and
+  // must not leak onto other backends even if their raw error happens to contain
+  // the "Agent auth failed" marker.
+  it("does not show the SSH-agent hint on a non-SSH backend", () => {
+    useAppStore.setState({ terminalSpawnErrors: { [TAB_ID]: "Agent auth failed" } });
+    act(() => {
+      root.render(
+        <TerminalConnectionOverlay
+          tabId={TAB_ID}
+          panelId={PANEL_ID}
+          tabTitle="my-telnet"
+          isVisible={true}
+          sessionType="telnet"
+        />
+      );
+    });
+    expect(container.textContent).not.toContain("SSH Agent not running");
+  });
+
   it("shows serial not-found hint for serial sessionType", () => {
     useAppStore.setState({
       terminalSpawnErrors: { [TAB_ID]: "Serial port '/dev/ttyUSB0' not found — check connected" },

--- a/src/components/Terminal/TerminalConnectionOverlay.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.tsx
@@ -6,6 +6,7 @@ import { toast } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
 import { useElapsed } from "@/hooks/useElapsed";
 import { getPlatform } from "@/utils/platform";
+import { backendFamilyFromSessionType, connectionErrorHint } from "@/utils/connectionErrorHints";
 import "./TerminalConnectionOverlay.css";
 
 interface TerminalConnectionOverlayProps {
@@ -187,8 +188,18 @@ export function TerminalConnectionOverlay({
   // The serial permission remediation is host-OS specific: only Linux has the
   // dialout group, so the `usermod` fix must not be shown on Windows/macOS (#1831).
   const platform = getPlatform();
-  const isAgentAuth = error.includes(SSH_AGENT_PATTERN);
+  // Resolve the backend family so every failure hint is chosen for the backend
+  // that actually raised it, not shown blanket across all backends (#2088).
+  const backendFamily = backendFamilyFromSessionType(sessionType);
+  // "Agent auth failed" is an SSH ssh-agent (key-auth) failure, so its remedy
+  // (starting ssh-agent) only makes sense on the SSH path — gate it to the SSH
+  // family so the SSH-agent hint can't leak onto telnet/serial/etc. (#2088).
+  const isAgentAuth = backendFamily === "ssh" && error.includes(SSH_AGENT_PATTERN);
   const isTimeout = error.includes(TIMEOUT_PATTERN) && !isAgentAuth;
+  // Backend-appropriate timeout guidance, sourced from the structured per-backend
+  // table rather than an inline string, so it can never again describe the wrong
+  // backend (e.g. the old "agent binary is installed" hint on an SSH timeout).
+  const timeoutHint = isTimeout ? connectionErrorHint(backendFamily, "timeout") : null;
   const isSerialNotFound = isSerial && SERIAL_NOT_FOUND_PATTERNS.some((p) => error.includes(p));
   const isSerialPermission = isSerial && error.includes(SERIAL_PERMISSION_PATTERN);
   const isSerialBusy =
@@ -402,11 +413,8 @@ export function TerminalConnectionOverlay({
           </div>
         )}
 
-        {isTimeout && (
-          <p className="terminal-connection-overlay__hint-text">
-            The connection timed out. Check that the host is reachable and the agent binary is
-            installed.
-          </p>
+        {isTimeout && timeoutHint && (
+          <p className="terminal-connection-overlay__hint-text">{timeoutHint}</p>
         )}
 
         {isSerialNotFound && (

--- a/src/components/Terminal/TerminalConnectionOverlay.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.tsx
@@ -7,6 +7,7 @@ import { useAppStore } from "@/store/appStore";
 import { useElapsed } from "@/hooks/useElapsed";
 import { getPlatform } from "@/utils/platform";
 import { backendFamilyFromSessionType, connectionErrorHint } from "@/utils/connectionErrorHints";
+import { sshAgentStartCommand } from "@/utils/sshAgentSetup";
 import "./TerminalConnectionOverlay.css";
 
 interface TerminalConnectionOverlayProps {
@@ -407,7 +408,7 @@ export function TerminalConnectionOverlay({
               run:
             </p>
             <CommandBlock
-              command="Start-Process powershell -Verb RunAs -ArgumentList 'Set-Service ssh-agent -StartupType Manual; Start-Service ssh-agent'"
+              command={sshAgentStartCommand(platform)}
               testId="terminal-connection-agent-copy-btn"
             />
           </div>

--- a/src/utils/connectionErrorHints.test.ts
+++ b/src/utils/connectionErrorHints.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import {
+  backendFamilyFromSessionType,
+  connectionErrorHint,
+  type BackendFamily,
+} from "./connectionErrorHints";
+
+describe("backendFamilyFromSessionType", () => {
+  it("maps known session types to their family", () => {
+    expect(backendFamilyFromSessionType("ssh")).toBe("ssh");
+    expect(backendFamilyFromSessionType("telnet")).toBe("telnet");
+    expect(backendFamilyFromSessionType("serial")).toBe("serial");
+    expect(backendFamilyFromSessionType("docker")).toBe("docker");
+    expect(backendFamilyFromSessionType("local")).toBe("local");
+  });
+
+  it("falls back to 'unknown' for empty or unrecognised types", () => {
+    expect(backendFamilyFromSessionType("")).toBe("unknown");
+    expect(backendFamilyFromSessionType("wsl")).toBe("unknown");
+    expect(backendFamilyFromSessionType("something-new")).toBe("unknown");
+  });
+});
+
+describe("connectionErrorHint — timeout", () => {
+  const families: BackendFamily[] = ["ssh", "telnet", "serial", "docker", "local", "unknown"];
+
+  it("returns a hint for every backend family", () => {
+    for (const family of families) {
+      expect(connectionErrorHint(family, "timeout")).toBeTruthy();
+    }
+  });
+
+  // #2088: a timeout means the transport never connected, so no timeout hint may
+  // ever blame the remote agent binary — the exact wording that leaked onto the
+  // SSH path in the reported bug.
+  it("never mentions the agent binary on any backend", () => {
+    for (const family of families) {
+      expect(connectionErrorHint(family, "timeout")).not.toMatch(/agent binary/i);
+    }
+  });
+
+  it("gives SSH an SSH-appropriate, reachability-focused hint", () => {
+    const hint = connectionErrorHint("ssh", "timeout") ?? "";
+    expect(hint).toMatch(/ssh/i);
+    expect(hint).toMatch(/reachable/i);
+    expect(hint).not.toMatch(/agent binary/i);
+  });
+
+  it("gives serial device-oriented guidance, not host reachability", () => {
+    const hint = connectionErrorHint("serial", "timeout") ?? "";
+    expect(hint).toMatch(/serial|device|baud/i);
+  });
+
+  it("gives docker container guidance", () => {
+    expect(connectionErrorHint("docker", "timeout") ?? "").toMatch(/docker|container/i);
+  });
+});

--- a/src/utils/connectionErrorHints.ts
+++ b/src/utils/connectionErrorHints.ts
@@ -1,0 +1,89 @@
+/**
+ * Structured, per-backend mapping from a connection-failure *situation* to the
+ * user-facing hint shown on the terminal connection overlay.
+ *
+ * ## Why this exists (#2088)
+ *
+ * User-facing hints used to be ad-hoc strings inlined at the render site, which
+ * let a hint written for one backend surface on an unrelated one. The reported
+ * case: an **SSH** connect timeout showed *"Check that the host is reachable and
+ * the agent binary is installed."* — an **agent**-connection hint that is wrong
+ * on the SSH path (and, in fact, wrong on *every* path: a timeout means the
+ * connection was never established, so the remote agent binary — which only
+ * matters *after* the transport connects — cannot be the cause).
+ *
+ * Routing hints through this table gives a single reviewable place where each
+ * hint is visibly tied to the backend family and situation that raises it, so a
+ * hint can no longer be silently attached to the wrong backend. New backends or
+ * situations extend the table rather than adding another inline string.
+ */
+
+/**
+ * Backend families we tailor connection-failure guidance for. Derived from a
+ * tab's effective `sessionType` (the inner session type for remote/agent-hosted
+ * tabs, the connection type for direct ones). `unknown` is the safe default —
+ * its guidance is correct for any backend and never names a backend-specific
+ * component.
+ */
+export type BackendFamily = "ssh" | "telnet" | "serial" | "docker" | "local" | "unknown";
+
+/** The connection-failure situations that carry a curated, backend-aware hint. */
+export type ConnectionErrorKind = "timeout";
+
+/**
+ * Map a tab's effective `sessionType` string to a {@link BackendFamily}.
+ * Anything unrecognised (including the empty string used for agent-transport
+ * tabs with no inner session type) maps to `unknown`, which yields a generic,
+ * always-correct reachability hint.
+ */
+export function backendFamilyFromSessionType(sessionType: string): BackendFamily {
+  switch (sessionType) {
+    case "ssh":
+      return "ssh";
+    case "telnet":
+      return "telnet";
+    case "serial":
+      return "serial";
+    case "docker":
+      return "docker";
+    case "local":
+      return "local";
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Per-backend timeout guidance. Every entry describes reachability/handshake
+ * causes appropriate to that backend and deliberately never mentions the remote
+ * agent binary — a timeout means the transport never connected, so the agent
+ * binary cannot be the cause (#2088).
+ */
+const TIMEOUT_HINTS: Record<BackendFamily, string> = {
+  ssh: "The connection timed out before the SSH session was established. Check that the host is reachable, the address and port are correct, and that no firewall is blocking the connection.",
+  telnet:
+    "The connection timed out. Check that the host is reachable, the address and port are correct, and that no firewall is blocking the connection.",
+  serial:
+    "The serial port did not respond in time. Check that the device is connected and that the baud rate matches the device.",
+  docker:
+    "The connection timed out. Check that Docker is running and that the container is reachable.",
+  local:
+    "Starting the local shell timed out. Check that the configured shell exists and is executable.",
+  unknown:
+    "The connection timed out. Check that the host is reachable, the address and port are correct, and that no firewall is blocking the connection.",
+};
+
+const HINTS: Record<ConnectionErrorKind, Record<BackendFamily, string>> = {
+  timeout: TIMEOUT_HINTS,
+};
+
+/**
+ * Resolve the user-facing hint for a connection-failure situation on a given
+ * backend family. Returns `null` when no curated hint applies.
+ */
+export function connectionErrorHint(
+  family: BackendFamily,
+  kind: ConnectionErrorKind
+): string | null {
+  return HINTS[kind]?.[family] ?? null;
+}

--- a/src/utils/sshAgentSetup.test.ts
+++ b/src/utils/sshAgentSetup.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { sshAgentStartCommand } from "./sshAgentSetup";
+
+describe("sshAgentStartCommand", () => {
+  it("returns the elevated PowerShell service command on Windows", () => {
+    const cmd = sshAgentStartCommand("windows");
+    expect(cmd).toContain("Set-Service ssh-agent");
+    expect(cmd).toContain("Start-Service ssh-agent");
+  });
+
+  // #2088: the Windows service command is meaningless on macOS/Linux — those
+  // platforms start an agent for the shell and add keys instead.
+  it("returns the ssh-agent/ssh-add command on macOS", () => {
+    expect(sshAgentStartCommand("macos")).toBe('eval "$(ssh-agent -s)" && ssh-add');
+  });
+
+  it("returns the ssh-agent/ssh-add command on Linux", () => {
+    expect(sshAgentStartCommand("linux")).toBe('eval "$(ssh-agent -s)" && ssh-add');
+  });
+
+  it("never returns the Windows service command on non-Windows platforms", () => {
+    expect(sshAgentStartCommand("macos")).not.toContain("Set-Service");
+    expect(sshAgentStartCommand("linux")).not.toContain("Set-Service");
+  });
+});

--- a/src/utils/sshAgentSetup.ts
+++ b/src/utils/sshAgentSetup.ts
@@ -1,0 +1,25 @@
+import { getPlatform } from "@/utils/platform";
+
+type Platform = ReturnType<typeof getPlatform>;
+
+/**
+ * Copyable shell command that starts the local SSH agent so key auth can
+ * succeed, tailored to the host OS.
+ *
+ * The remedy differs fundamentally by platform, so a single hardcoded command is
+ * wrong on the others (#2088): Windows' `ssh-agent` is a disabled service that
+ * must be enabled and started (elevated), whereas macOS/Linux have no such
+ * service — the user starts an agent for the shell and adds keys. Showing the
+ * Windows PowerShell `Set-Service ssh-agent` line on macOS/Linux is
+ * non-actionable, so callers must branch on {@link getPlatform}.
+ *
+ * `ConnectionEditor`'s "Setup SSH Agent" button launches these same remedies in
+ * a shell tab; this helper is the copyable-hint form shown on the connection
+ * overlay. Keeping the wording here means the two surfaces can't silently drift.
+ */
+export function sshAgentStartCommand(platform: Platform = getPlatform()): string {
+  if (platform === "windows") {
+    return "Start-Process powershell -Verb RunAs -ArgumentList 'Set-Service ssh-agent -StartupType Manual; Start-Service ssh-agent'";
+  }
+  return 'eval "$(ssh-agent -s)" && ssh-add';
+}


### PR DESCRIPTION
## Summary

An **SSH** connect timeout showed *"Check that the host is reachable and the agent binary is installed."* — an **agent**-connection hint that is wrong on the SSH path (and, as it turns out, on *every* path: a timeout means the transport never connected, so the remote agent binary — which only matters *after* the transport connects — cannot be the cause). The maintainer noted this was not the first message to surface on the wrong backend, so this PR fixes the specific bug, audits the surrounding user-facing messages, and introduces a structured seam so a hint can no longer be attached to the wrong backend.

Closes #2088.

## The anti-recurrence seam

New `src/utils/connectionErrorHints.ts`: a structured, per-**backend-family** table (`ssh | telnet | serial | docker | local | unknown`) mapping a failure *situation* to its user-facing hint, plus `backendFamilyFromSessionType()`. The connection overlay now sources its timeout hint from this table instead of an inline string, so every hint is visibly tied to the backend that raises it and new backends/situations extend the table rather than adding another ad-hoc string. `unknown` is the safe default — a generic, always-correct reachability hint that never names a backend-specific component.

## Offenders found & fixed

1. **(the trigger — HIGH)** `TerminalConnectionOverlay.tsx` timeout hint told the user to check *"the agent binary is installed"* on **every** backend (any error containing "timed out", any `sessionType`). Now routed through the per-backend table: SSH gets reachability/handshake guidance, telnet/docker/serial/local each get situation-appropriate wording, and **no** timeout hint mentions the agent binary.
2. **(HIGH)** The **"SSH Agent not running"** hint hardcoded a Windows-only PowerShell `Set-Service ssh-agent` command shown on **all** platforms, where it is non-actionable on macOS/Linux (no such service exists there). Now branches on host OS via new `sshAgentStartCommand(platform)` — `eval "$(ssh-agent -s)" && ssh-add` on macOS/Linux — mirroring `ConnectionEditor`'s already-correct "Setup SSH Agent" button.
3. **(hardening)** The SSH **ssh-agent** auth hint (`"Agent auth failed"`) was shown regardless of backend; gated to the SSH family so it can no longer leak onto telnet/serial/etc.

## Audit — areas checked and cleared (not offenders)

A full sweep of the connection/backend/agent/tunnel/sftp/credential message paths (Rust + TS) found the rest already backend-gated:
- `classifyAgentError.ts` — used only on agent connections (`AgentNode.tsx`); SSH/agent wording is correct there.
- Overlay serial not-found/permission/busy hints — all gated by `isSerial`; slow-connect note is generic.
- `connectTimeoutMessage` (client-side timeouts) — backend-neutral wording.
- `core/src/backends/{ssh,docker,serial,ftp,telnet}` — each names its own backend and runs only on that backend's path (FTP's timeout message is a good model).
- `agent/src/**` — "agent binary" wording appears only on agent-deploy/update/self-update paths (agent-specific).
- Core/tauri error enums — backend-named `Display` variants are used only on matching paths.

## Deferred (follow-up #2094)

One lower-priority wording nit: SFTP file-operation failures are wrapped in `TerminalError::SshError` and render as `SSH error: SFTP …`. SFTP runs over SSH so it is not a wrong-backend leak, but an `SFTP error:` label would be clearer. It needs a new error variant touching `errors.rs`, so it was deferred to keep this PR focused and low-risk. Filed as **#2094** (`Ready2Implement`).

## Tests

- New `connectionErrorHints.test.ts` — every family yields a hint; no timeout hint mentions the agent binary; SSH/serial/docker hints are appropriate.
- New `sshAgentSetup.test.ts` — Windows vs macOS/Linux ssh-agent command.
- `TerminalConnectionOverlay.test.tsx` — SSH & telnet timeouts give reachability guidance (not agent-binary); ssh-agent hint doesn't leak onto non-SSH backends.
- `TerminalConnectionOverlay.platform.test.tsx` — platform-appropriate ssh-agent command (Windows vs macOS/Linux).
- Full frontend suite green (4655 tests).

## Test plan
- On an SSH connection that times out, confirm the hint is reachability-oriented and never mentions the agent binary.
- On an SSH ssh-agent auth failure, confirm the copyable command matches the host OS (PowerShell on Windows; `eval "$(ssh-agent -s)" && ssh-add` on macOS/Linux).