### PR TITLE
perf(terminal): send terminal output over IPC as base64, not JSON number-array

### DIFF
--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -44,10 +44,35 @@ const MAX_COALESCE_BYTES: usize = 32 * 1024;
 const CLEAR_WAIT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Output event emitted via Tauri events.
+///
+/// Terminal output is the app's single most important hot path — every byte of
+/// process output crosses the webview IPC boundary through this event. The
+/// `data` bytes are serialized as a **base64 string** rather than serde's
+/// default JSON number-array for `Vec<u8>` (which is a 3.3–4x byte bloat plus a
+/// per-byte array→`Uint8Array` copy on the frontend). base64 mirrors the remote
+/// protocol, is ~2.5x smaller on the wire, and decodes in one pass on the TS
+/// side (`src/services/events.ts`). The field stays `Vec<u8>` in Rust so the
+/// producer (the output reader loop) and tests are unchanged; only the wire form
+/// differs (#2072).
 #[derive(Debug, Clone, Serialize)]
 pub struct TerminalOutputEvent {
     pub session_id: String,
+    #[serde(serialize_with = "serialize_bytes_base64")]
     pub data: Vec<u8>,
+}
+
+/// Serialize a byte slice as a base64 (standard alphabet, padded) string.
+///
+/// Paired with the base64 decode in `src/services/events.ts`; the two are exact
+/// inverses, including high bytes (0x80–0xFF), UTF-8 multi-byte sequences, and
+/// empty input (which encodes to the empty string). See [`TerminalOutputEvent`].
+fn serialize_bytes_base64<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    use base64::Engine;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+    serializer.serialize_str(&encoded)
 }
 
 /// Exit event emitted when a terminal process exits.
@@ -1784,6 +1809,43 @@ mod tests {
         AgentFolderInfo, AgentRpcClient, AgentSessionInfo,
     };
     use crate::terminal::backend::{OutputSender, RemoteAgentConfig};
+
+    /// The `data` field of a serialized [`TerminalOutputEvent`] must be a base64
+    /// string that decodes byte-for-byte back to the original bytes — the exact
+    /// inverse of the `base64ToBytes` decoder in `src/services/events.ts`. This
+    /// is the terminal's hot path, so a mismatch means corrupted/dropped output.
+    /// Covers high bytes (0x80–0xFF), UTF-8 multi-byte sequences, all 256 byte
+    /// values, and the empty chunk (#2072).
+    #[test]
+    fn terminal_output_event_serializes_data_as_base64() {
+        use base64::Engine;
+        let engine = base64::engine::general_purpose::STANDARD;
+
+        let cases: Vec<Vec<u8>> = vec![
+            Vec::new(),                              // empty chunk → ""
+            b"hello".to_vec(),                       // plain ASCII
+            vec![0x1b, b'[', b'3', b'1', b'm'],      // ANSI color escape
+            "héllo — 日本語 🎉".as_bytes().to_vec(), // UTF-8 multi-byte
+            vec![0x00, 0x7f, 0x80, 0xfe, 0xff],      // boundary + high bytes
+            (0u16..=255).map(|b| b as u8).collect(), // every byte value
+        ];
+
+        for bytes in cases {
+            let event = TerminalOutputEvent {
+                session_id: "s1".to_string(),
+                data: bytes.clone(),
+            };
+            let json: Value = serde_json::to_value(&event).unwrap();
+
+            // Wire form is a string (not a JSON number-array).
+            let encoded = json["data"].as_str().expect("data must serialize to a string");
+            assert_eq!(encoded, engine.encode(&bytes));
+
+            // Round-trip: decoding the wire string yields the original bytes.
+            let decoded = engine.decode(encoded).unwrap();
+            assert_eq!(decoded, bytes, "base64 round-trip must be byte-for-byte");
+        }
+    }
 
     /// A minimal mock connection without file browser capability. When `writes`
     /// is `Some`, every byte passed to `write` is recorded into it so tests can

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -1838,7 +1838,9 @@ mod tests {
             let json: Value = serde_json::to_value(&event).unwrap();
 
             // Wire form is a string (not a JSON number-array).
-            let encoded = json["data"].as_str().expect("data must serialize to a string");
+            let encoded = json["data"]
+                .as_str()
+                .expect("data must serialize to a string");
             assert_eq!(encoded, engine.encode(&bytes));
 
             // Round-trip: decoding the wire string yields the original bytes.

--- a/src/services/events.test.ts
+++ b/src/services/events.test.ts
@@ -9,6 +9,7 @@ import {
   onCredentialStoreLocked,
   onCredentialStoreUnlocked,
   onCredentialStoreStatusChanged,
+  base64ToBytes,
 } from "./events";
 
 vi.mock("@tauri-apps/api/event", () => ({
@@ -16,6 +17,16 @@ vi.mock("@tauri-apps/api/event", () => ({
 }));
 
 const mockedListen = vi.mocked(listen);
+
+/**
+ * Encode a byte array as a base64 string — matches the backend wire form for
+ * terminal-output payloads (#2072), so tests can feed realistic payloads.
+ */
+function b64(bytes: number[]): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
 
 describe("events service", () => {
   beforeEach(() => {
@@ -46,12 +57,30 @@ describe("events service", () => {
 
       // Simulate Tauri event
       capturedHandler!({
-        payload: { session_id: "sess-1", data: [72, 101, 108, 108, 111] },
+        payload: { session_id: "sess-1", data: b64([72, 101, 108, 108, 111]) },
       });
 
       expect(callback).toHaveBeenCalledWith("sess-1", expect.any(Uint8Array));
       const data = callback.mock.calls[0][1] as Uint8Array;
       expect(Array.from(data)).toEqual([72, 101, 108, 108, 111]);
+    });
+  });
+
+  describe("base64ToBytes (terminal-output decode, #2072)", () => {
+    it("decodes an empty string to a zero-length array", () => {
+      expect(base64ToBytes("")).toEqual(new Uint8Array(0));
+    });
+
+    it("round-trips every byte value 0x00–0xFF byte-for-byte", () => {
+      const all = Array.from({ length: 256 }, (_, i) => i);
+      expect(Array.from(base64ToBytes(b64(all)))).toEqual(all);
+    });
+
+    it("preserves high bytes and UTF-8 multi-byte sequences", () => {
+      // "é🎉" as UTF-8 bytes, plus raw high/boundary bytes.
+      const utf8 = Array.from(new TextEncoder().encode("é🎉"));
+      const bytes = [0x00, 0x7f, 0x80, 0xfe, 0xff, ...utf8];
+      expect(Array.from(base64ToBytes(b64(bytes)))).toEqual(bytes);
     });
   });
 
@@ -233,7 +262,7 @@ describe("events service", () => {
 
       // Emit event for sess-1
       handlers["terminal-output"]({
-        payload: { session_id: "sess-1", data: [65, 66] },
+        payload: { session_id: "sess-1", data: b64([65, 66]) },
       });
 
       expect(cb1).toHaveBeenCalledTimes(1);
@@ -294,14 +323,14 @@ describe("events service", () => {
 
       // First event should be delivered
       handlers["terminal-output"]({
-        payload: { session_id: "sess-1", data: [1] },
+        payload: { session_id: "sess-1", data: b64([1]) },
       });
       expect(cb).toHaveBeenCalledTimes(1);
 
       // After unsubscribe, no delivery
       unsub();
       handlers["terminal-output"]({
-        payload: { session_id: "sess-1", data: [2] },
+        payload: { session_id: "sess-1", data: b64([2]) },
       });
       expect(cb).toHaveBeenCalledTimes(1);
     });
@@ -317,7 +346,7 @@ describe("events service", () => {
 
       // No callback registered for "sess-unknown" — should not throw
       handlers["terminal-output"]({
-        payload: { session_id: "sess-unknown", data: [1] },
+        payload: { session_id: "sess-unknown", data: b64([1]) },
       });
     });
 
@@ -332,10 +361,10 @@ describe("events service", () => {
 
       // Emit output BEFORE any subscriber registers
       handlers["terminal-output"]({
-        payload: { session_id: "sess-pre", data: [72, 101] },
+        payload: { session_id: "sess-pre", data: b64([72, 101]) },
       });
       handlers["terminal-output"]({
-        payload: { session_id: "sess-pre", data: [108, 108, 111] },
+        payload: { session_id: "sess-pre", data: b64([108, 108, 111]) },
       });
 
       // Now subscribe — should receive the buffered chunks immediately
@@ -358,7 +387,7 @@ describe("events service", () => {
 
       // Buffer one chunk before subscriber
       handlers["terminal-output"]({
-        payload: { session_id: "sess-x", data: [1] },
+        payload: { session_id: "sess-x", data: b64([1]) },
       });
 
       const cb = vi.fn();
@@ -367,7 +396,7 @@ describe("events service", () => {
 
       // New event after subscription — should only deliver once
       handlers["terminal-output"]({
-        payload: { session_id: "sess-x", data: [2] },
+        payload: { session_id: "sess-x", data: b64([2]) },
       });
       expect(cb).toHaveBeenCalledTimes(2);
     });
@@ -489,7 +518,7 @@ describe("events service", () => {
       dispatcher.subscribeOutput("sess-a", cb1);
 
       handlers["terminal-output"]({
-        payload: { session_id: "sess-a", data: [10] },
+        payload: { session_id: "sess-a", data: b64([10]) },
       });
       expect(cb1).toHaveBeenCalledTimes(1);
 
@@ -660,7 +689,7 @@ describe("events service", () => {
       // Fire terminal-output through all ACTIVE handlers only (simulates Tauri
       // delivering events only to registered listeners). Without the fix, two
       // handlers would remain active and the callback would fire twice.
-      const event = { payload: { session_id: "sess-1", data: [65] } };
+      const event = { payload: { session_id: "sess-1", data: b64([65]) } };
       for (const l of outputListeners) {
         if (l.active) l.handler(event);
       }

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -20,7 +20,36 @@ import type {
 
 interface TerminalOutputPayload {
   session_id: string;
-  data: number[];
+  /**
+   * Terminal output bytes as a base64 (standard alphabet, padded) string.
+   *
+   * Terminal output is the app's most important hot path. The backend encodes
+   * the raw `Vec<u8>` as base64 (see `TerminalOutputEvent` in
+   * `src-tauri/src/session/manager.rs`) instead of serde's default JSON
+   * number-array — that was a 3.3–4x byte bloat plus a per-byte copy on every
+   * flush. Decode with {@link base64ToBytes}, which is the exact inverse of the
+   * Rust encoder for all byte values including high bytes and empty input
+   * (#2072).
+   */
+  data: string;
+}
+
+/**
+ * Decode a base64 (standard alphabet, padded) string into a `Uint8Array`.
+ *
+ * Exact inverse of the backend's base64 encoding of terminal-output bytes
+ * (`serialize_bytes_base64` in `src-tauri/src/session/manager.rs`). Byte-for-byte
+ * faithful for all values 0x00–0xFF (high bytes and UTF-8 multi-byte sequences
+ * survive intact); an empty string decodes to a zero-length array (#2072).
+ */
+export function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const len = binary.length;
+  const bytes = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
 }
 
 interface TerminalExitPayload {
@@ -44,7 +73,7 @@ export async function onTerminalOutput(
 ): Promise<UnlistenFn> {
   return await listen<TerminalOutputPayload>("terminal-output", (event) => {
     const { session_id, data } = event.payload;
-    callback(session_id, new Uint8Array(data));
+    callback(session_id, base64ToBytes(data));
   });
 }
 
@@ -182,8 +211,8 @@ export class TerminalOutputDispatcher {
     const unlistenOutput = await listen<TerminalOutputPayload>("terminal-output", (event) => {
       const { session_id, data } = event.payload;
       const cbs = this.outputCallbacks.get(session_id);
+      const chunk = base64ToBytes(data);
       if (cbs && cbs.size > 0) {
-        const chunk = new Uint8Array(data);
         for (const cb of cbs) cb(chunk);
       } else {
         // Buffer output for sessions whose subscriber hasn't registered yet
@@ -193,7 +222,7 @@ export class TerminalOutputDispatcher {
           buf = [];
           this.pendingOutput.set(session_id, buf);
         }
-        buf.push(new Uint8Array(data));
+        buf.push(chunk);
       }
     });
 

--- a/tests/system/tests/test_terminal_output_ipc.py
+++ b/tests/system/tests/test_terminal_output_ipc.py
@@ -1,0 +1,61 @@
+"""End-to-end verification of the terminal-output IPC byte transport (#2072).
+
+Terminal output crosses the webview IPC boundary as a base64 string (encoded in
+`src-tauri/src/session/manager.rs`, decoded in `src/services/events.ts`) rather
+than the old JSON number-array. This is the app's single most important hot
+path, so a transport bug shows up as blank / garbled / dropped terminal output.
+
+These tests drive the **real built app** and read back the rendered xterm buffer
+(`read_terminal`), which is the full path: PTY bytes → base64 IPC event → TS
+decode → xterm. They assert byte-fidelity for the cases most likely to expose a
+transport bug: UTF-8 multi-byte sequences (any dropped/corrupted byte becomes a
+replacement glyph), ANSI color escapes (ESC = 0x1b, a high-ish control byte
+surrounded by text), and a high-throughput burst (large coalesced flush).
+
+The command generates the tricky bytes shell-side via `printf '\\xNN'` so only
+ASCII is typed as input — isolating the **output** path this change touches.
+"""
+
+import pytest
+
+from termihub_harness import SystemTest, TerminalUi
+
+pytestmark = pytest.mark.integration
+
+
+class TestTerminalOutputIpc(TerminalUi, SystemTest):
+    def test_utf8_multibyte_round_trips(self):
+        """Japanese + accented + emoji bytes must render intact, not as U+FFFD."""
+        self.ensure_terminal()
+        # 日本語 = e6 97 a5 / e6 9c ac / e8 aa 9e ; é = c3 a9 ; 🎉 = f0 9f 8e 89
+        self.run_command(
+            r"printf 'IPCUTF:h\xc3\xa9llo-\xe6\x97\xa5\xe6\x9c\xac\xe8\xaa\x9e-\xf0\x9f\x8e\x89:END\n'"
+        )
+        out = self.wait_for_output("IPCUTF:")
+        assert "IPCUTF:héllo-日本語-🎉:END" in out, out
+
+    def test_ansi_color_escapes_round_trip(self):
+        """ESC-based color sequences must not corrupt the surrounding text."""
+        self.ensure_terminal()
+        self.run_command(
+            r"printf 'IPCCLR:\x1b[31mR\x1b[32mG\x1b[34mB\x1b[0m:END\n'"
+        )
+        out = self.wait_for_output("IPCCLR:")
+        # xterm strips the color escapes from the buffer text; the visible letters
+        # must survive verbatim and in order.
+        assert "IPCCLR:RGB:END" in out, out
+
+    def test_high_throughput_burst_is_not_dropped(self):
+        """A large single burst must arrive whole — start, middle, and end."""
+        self.ensure_terminal()
+        # ~5000 comma-joined numbers emitted in one burst → a big coalesced flush.
+        self.run_command(
+            "printf 'IPCHT:'; seq 1 5000 | tr '\\n' ','; printf ':END\\n'"
+        )
+        # Wait on the tail, which is unique to the rendered output — ":END" alone
+        # also appears in the echoed command line and would match too early.
+        out = self.wait_for_output("5000,:END", timeout=30.0)
+        assert "IPCHT:" in out, out
+        # Tail integrity: the last numbers and the end marker must be present,
+        # proving nothing was truncated mid-flush.
+        assert "4999,5000,:END" in out, out


### PR DESCRIPTION
## Summary

Terminal output crossed the webview IPC boundary as a **JSON number-array** (serde's default for `Vec<u8>`) — a measured **3.3–4x byte bloat** plus a full array→`Uint8Array` copy on **every** output flush. This is the app's single most important hot path.

This moves the transport to **base64** (standard alphabet, padded — mirroring the remote protocol and the base64 decode already used elsewhere in the session manager), roughly ~2.5x smaller on the wire and decoded in one pass on the TS side.

### Approach (minimal-risk)
- Rust: a `#[serde(serialize_with = ...)]` base64-encodes `TerminalOutputEvent.data`. The field **stays `Vec<u8>`**, so every emit site in the output reader loop and every existing test is unchanged — only the wire form differs.
- TS: `base64ToBytes()` in `src/services/events.ts` decodes the string back to a `Uint8Array`. It is the **exact inverse** of the Rust encoder; downstream consumers (`subscribeOutput`/`onTerminalOutput`) still receive a `Uint8Array`, so nothing below the decode changed.
- No change to ordering or backpressure — the existing backpressured event pipeline is untouched; only the payload encoding of the same events changed.

### Round-trip guarantee
Byte-for-byte faithful for all 256 byte values, including high bytes (0x80–0xFF), UTF-8 multi-byte sequences, and empty chunks (which encode to `""`).

- Rust unit test: serializes `TerminalOutputEvent` and asserts the `data` field is the expected base64 and decodes back to the original bytes — covers empty, ASCII, ANSI escape, UTF-8 multibyte, boundary/high bytes, and all 256 values.
- TS unit test: `base64ToBytes` round-trips every byte 0x00–0xFF, high bytes, and UTF-8; empty string → zero-length array.

### Real-build verification (mandatory for this hot path)
Built the app (`--debug`) and drove it through the Python system-test bridge, reading back the **rendered xterm buffer** (the full path: PTY bytes → base64 IPC event → TS decode → xterm). Added `tests/system/tests/test_terminal_output_ipc.py` (integration-marked). All three pass against the real build:

- **UTF-8 multibyte** — `IPCUTF:héllo-日本語-🎉:END` renders byte-perfect (no U+FFFD, no dropped bytes).
- **ANSI color escapes** — `IPCCLR:RGB:END` renders intact (ESC sequences don't corrupt surrounding text).
- **High-throughput burst** — a single ~5000-number burst arrives whole, tail (`4999,5000,:END`) intact (no truncation on a large coalesced flush).

Note: integration tests don't run in per-PR CI, so this was verified **locally** against the built app.

Closes #2072