### PR TITLE
build: supply-chain hardening (deps bumps, blocking npm audit, cargo-deny yanked gate)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -267,9 +267,22 @@ jobs:
         with:
           node-version: '22'
 
-      - name: pnpm audit
+      # Blocking gate on the RUNTIME dependency tree only. A high/critical
+      # advisory that ships to users must fail CI. Scoped to `--prod` so it does
+      # not fire on the dev/build toolchain (see the advisory step below) — that
+      # split is what makes this safe to make blocking (#2074).
+      - name: pnpm audit (production deps, blocking)
+        run: pnpm audit --prod --audit-level=high
+
+      # Advisory-only visibility for the FULL tree (incl. devDependencies). These
+      # are dev/build-time highs — eslint/typescript-eslint -> minimatch ->
+      # brace-expansion, commitlint -> ajv -> fast-uri, vite -> postcss — none of
+      # which reach the shipped app. Kept non-blocking so they surface in the log
+      # without gating the release; promote a fix to the blocking step above once
+      # the upstream dev tool patches land.
+      - name: pnpm audit (full tree, advisory)
         run: pnpm audit --audit-level=moderate
-        continue-on-error: true  # Don't fail build, just warn
+        continue-on-error: true  # Dev-only advisories: warn, do not fail
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -284,6 +297,20 @@ jobs:
 
       - name: Cargo Audit
         run: cargo audit
+
+      # cargo-deny yanked/bans gate (#2074): fails CI when the workspace lockfile
+      # pins a YANKED crate (e.g. the crypto-bigint 0.7.x line pulled via russh),
+      # so a silently-yanked transitive dep surfaces loudly instead of shipping.
+      # Config: deny.toml. Only `advisories bans` run here — the `licenses` and
+      # `sources` checks are intentionally not wired (they need a full allowlist;
+      # tracked separately). cargo-audit above still covers vulnerability RUSTSECs.
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-deny
+
+      - name: Cargo Deny (yanked + bans gate)
+        run: cargo deny check advisories bans
 
   # Check conventional commits (PR only)
   commit-lint:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -1349,9 +1349,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -7636,7 +7636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,66 @@
+# cargo-deny configuration — supply-chain gate for the Rust workspace.
+# https://embarkstudios.github.io/cargo-deny/
+#
+# CI runs only `cargo deny check advisories bans` (see
+# .github/workflows/code-quality.yml -> "Security Audit"). The primary purpose
+# is the YANKED-crate gate (#2074): if the workspace lockfile ever pins a crate
+# version that has been yanked from crates.io, CI fails loudly instead of the
+# app silently shipping a withdrawn dependency.
+#
+# The `licenses` and `sources` checks are intentionally NOT wired into CI yet —
+# they need a full allowlist for the entire transitive tree, which is a
+# separate, larger piece of work. cargo-audit (also in the Security Audit job)
+# continues to cover RUSTSEC *vulnerability* advisories.
+
+[advisories]
+# A yanked crate in the lockfile fails CI. This is the headline gate: it is how
+# the crypto-bigint 0.7.x yank surfaced (crypto-bigint reached 0.7.5, a
+# non-yanked release, pulled transitively via russh 0.61 -> RustCrypto).
+yanked = "deny"
+
+# Unmaintained-crate advisories are NOT gated here. The tree carries a large,
+# tauri-bound set of them (gtk3 bindings, async-std, proc-macro-error, unic-*,
+# rustls-pemfile, serial, ...) that no local change can clear — they are tracked
+# for upstream resolution in #1037. cargo-audit (the other tool in the Security
+# Audit job) likewise does not fail on unmaintained advisories, so the two stay
+# in agreement. This keeps cargo-deny focused on yanked crates + real
+# vulnerabilities rather than churn we cannot act on.
+unmaintained = "none"
+
+# RUSTSEC advisories accepted as a conscious release sign-off. These mirror the
+# cargo-audit ignore list (.cargo/audit.toml) so the two tools agree; each has a
+# documented rationale there and is tracked for removal via #1037.
+#
+# - RUSTSEC-2023-0071: Marvin timing sidechannel in `rsa` (transitive via
+#   ssh-key). We only extract raw RSA key components and rebuild via OpenSSL;
+#   we never decrypt through this crate, so the sidechannel does not apply.
+# - RUSTSEC-2026-0194 / RUSTSEC-2026-0195: DoS advisories in `quick-xml` <0.41,
+#   transitive via plist <- tauri-utils <- tauri. `plist` only parses tauri's
+#   own bundle metadata, never external input; blocked until tauri adopts the
+#   patched quick-xml upstream.
+ignore = [
+    "RUSTSEC-2023-0071",
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+]
+
+[bans]
+# Pre-release RustCrypto stack — documented release sign-off (#2074).
+#
+# The SSH auth path pulls a pre-release RustCrypto stack via russh 0.61.1:
+# rsa 0.10.0-rc.x and ssh-key 0.7.0-rc.x (which in turn pinned the yanked
+# crypto-bigint 0.7.x line, now resolved to the non-yanked 0.7.5). These RC
+# crates are a deliberate, accepted risk for this release: russh has not yet
+# cut a stable release on the final RustCrypto 0.7/0.10 line. Upgrading to a
+# russh release built on stable RustCrypto is tracked in #1037. Until then the
+# yanked gate above guards against the versions silently regressing to a yanked
+# release, which is the concrete failure mode we care about.
+#
+# Multiple versions of a crate are common in a large tree (Cargo allows one
+# version per major) and are not a supply-chain signal on their own, so they do
+# not gate CI here.
+multiple-versions = "allow"
+wildcards = "allow"
+
+# `licenses` and `sources` are omitted deliberately — see the header note. When
+# they are added, wire `cargo deny check licenses sources` into CI as well.

--- a/docs/changes/dev2/build/2074-supply-chain-hardening.md
+++ b/docs/changes/dev2/build/2074-supply-chain-hardening.md
@@ -1,0 +1,8 @@
+### Security
+
+- Hardened the dependency supply chain (#2074):
+  - Bumped `anyhow` to 1.0.104, clearing RUSTSEC-2026-0190 (unsoundness in
+    `Error::downcast_mut`).
+  - Bumped the bundled `crypto-bigint` (SSH auth path, transitive via russh) off
+    the yanked 0.7.3 to the non-yanked 0.7.5.
+  - Bumped the DOMPurify override to `>=3.4.12 <4`.

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "pnpm": {
     "overrides": {
-      "dompurify": ">=3.4.11 <4",
+      "dompurify": ">=3.4.12 <4",
       "markdown-it": ">=14.2.0 <15",
       "js-yaml": ">=4.2.0 <5",
       "serialize-javascript": ">=7.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  dompurify: '>=3.4.11 <4'
+  dompurify: '>=3.4.12 <4'
   markdown-it: '>=14.2.0 <15'
   js-yaml: '>=4.2.0 <5'
   serialize-javascript: '>=7.0.5'
@@ -2199,8 +2199,8 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -5206,7 +5206,7 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -5951,7 +5951,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.11
+      dompurify: 3.4.12
       marked: 14.0.0
 
   ms@2.1.3: {}


### PR DESCRIPTION
## Summary

Supply-chain hardening from the pre-release audit. Closes #2074.

### Dependency bumps (all verified: workspace builds, unit tests, and `pnpm build` green)
- **`anyhow` 1.0.102 → 1.0.104** — clears RUSTSEC-2026-0190 (unsoundness in `Error::downcast_mut`). One-line lockfile bump; the `= "1"` constraint already allowed it.
- **`crypto-bigint` 0.7.3 → 0.7.5** — the SSH auth path (transitive via russh 0.61 → RustCrypto) shipped the **yanked** 0.7.3. 0.7.5 is a non-yanked 0.7.x release and resolves cleanly, so this is fixed directly rather than merely documented.
- **DOMPurify override `>=3.4.11` → `>=3.4.12 <4`** — lockfile + runtime bundle now pick up 3.4.12.

### npm audit gate (`.github/workflows/code-quality.yml`)
- Added a **blocking** `pnpm audit --prod --audit-level=high` on the **runtime** tree. It passes today (prod highs: none).
- Kept the full-tree `pnpm audit --audit-level=moderate` as **advisory-only**. Documented the dev-vs-runtime split: the 7 current high advisories are all dev/build tooling (eslint/typescript-eslint → minimatch → brace-expansion, commitlint → ajv → fast-uri, vite → postcss) and never reach the shipped app.

### cargo-deny yanked/bans gate (new `deny.toml`)
- New CI step `cargo deny check advisories bans` — fails CI on any **yanked** crate (`yanked = "deny"`). Verified locally: pinning crypto-bigint back to the yanked 0.7.3 makes it fail; on 0.7.5 it passes.
- Advisory ignore list mirrors `.cargo/audit.toml` (RUSTSEC-2023-0071 rsa, RUSTSEC-2026-0194/0195 quick-xml) so the two tools agree.
- `unmaintained = "none"` — the tauri-bound unmaintained-crate set (gtk3, async-std, unic-*, …) is tracked in #1037, not gated here; cargo-audit likewise does not fail on those.
- **Documented release sign-off** for the pre-release RustCrypto RC stack (rsa 0.10.0-rc.x, ssh-key 0.7.0-rc.x via russh 0.61) in `deny.toml [bans]`: a conscious, accepted risk until russh cuts a release on stable RustCrypto — tracked in #1037.

### Deferred
- Wiring cargo-deny's `licenses` + `sources` checks needs a full tree allowlist — filed as **#2096**.

## Test plan
- `cargo build --workspace` — green.
- `cargo test --workspace --all-features` — green except one Docker **integration** test (`docker_spawn_mounts_directory_and_opens_cd_to_mount`, `--features docker`) that fails identically on unmodified `develop` (environment/isolation, not this change) and does not run in per-PR CI.
- `pnpm build` — green (bundles dompurify 3.4.12).
- `cargo deny check advisories bans` — `advisories ok, bans ok`; confirmed it fails when a yanked crate is present.