### PR TITLE
fix(ui): show persistence marker only on agent persistent shells (Closes #2099)

### DIFF
--- a/docs/changes/dev2/fix/2086-infinity-agent-only.md
+++ b/docs/changes/dev2/fix/2086-infinity-agent-only.md
@@ -1,13 +1,13 @@
 ### Changed
 
-- The persistent-connection ∞ (infinity) badge is now reserved for
-  **agent-backed** connections only — sessions that live on a remote agent and
-  survive closing termiHub _and_ powering off / restarting your machine. Its
-  tooltip now states that guarantee explicitly. **Desktop-local** persistent
-  connections (SSH/Docker/WSL/Serial run inside the app) no longer show the ∞,
-  since they only live while the app is open; they now display a distinct,
-  lesser Hourglass marker whose tooltip does not overclaim ("Runs while the app
-  is open — closing termiHub ends the session. Use a remote agent for
-  persistence across app restarts."). The same tiered marker applies to the tab
-  decoration. This removes the misleading ∞ that appeared on plain SSH and other
-  desktop-local connections (#2086).
+- The persistent-connection ∞ (infinity) badge — and the persistence run-state
+  dot — are now shown **only on agent persistent shells**: single-instance
+  sessions that live on a remote agent and survive closing termiHub _and_
+  powering off / restarting your machine. Its tooltip states that guarantee
+  explicitly. Every other connection type (SSH, local shell/CMD, serial, Docker,
+  WSL, telnet, ftp, vnc, rdp) is multi-instance and dies with the window, so it
+  now shows **no persistence marker at all** — no ∞, no hourglass, and no
+  persistence/"connected" state dot. This removes the misleading ∞ that appeared
+  on plain SSH and other desktop-local connections (#2086), and drops the brief
+  desktop-local Hourglass marker that replaced it, since those connections have
+  no persistence to advertise (#2099).

--- a/docs/concepts/implemented/persistent-connection-ux.html
+++ b/docs/concepts/implemented/persistent-connection-ux.html
@@ -42,32 +42,27 @@ in the background, or attached to one or more tabs — and act accordingly.</p>
 <hr>
 <h2 id="ui-interface">UI Interface</h2>
 <h3 id="connection-item-appearance">Connection Item Appearance</h3>
-<p>Each saved connection item in the sidebar gains two new visual elements when its type is
-persistent-capable:</p>
+<p><strong>Persistence surfacing is reserved for agent persistent shells only (#2099).</strong> Normal
+connections — SSH, local shell/CMD, serial, Docker, WSL, telnet, ftp, vnc, rdp, everything that is
+<em>not</em> an agent persistent shell — are multi-instance and always die with the window. They have
+<strong>no persistence concept</strong>, so they show <strong>nothing</strong>: no ∞, no hourglass, no
+persistence/"connected" state dot, no grey bubble. The two visual elements below therefore appear
+<strong>only on agent persistent shells</strong> (the rows under a connected agent whose saved definition
+is <code>persistent</code>), never on a plain saved connection in the sidebar:</p>
 <ol>
 <li>
-<p><strong>Persistence badge (tiered, #2086)</strong> — the badge encodes <em>how strong</em> the persistence
-   guarantee is, and the two tiers must be visually distinct so they are never confused:</p>
-<ul>
-<li><strong>∞ (infinity) — agent-backed only.</strong> Reserved for sessions that live on a remote
-  <strong>agent</strong>: they survive closing termiHub <em>and</em> powering off / restarting this
-  machine (true cross-session, cross-power persistence via the agent daemon). Its tooltip states
-  exactly that: "Persistent session — lives on the agent and survives closing termiHub and
-  restarting this machine." Rendered on the agent connection row (<code>AgentNode.tsx</code>).</li>
-<li><strong>Hourglass (⧗) — desktop-local.</strong> A saved SSH/Docker/WSL/Serial connection
-  (<code>capabilities.persistent === true</code>) whose process runs inside the desktop app. It
-  survives tab closes <em>while the app is open</em> but is lost when termiHub exits — so it must
-  <strong>not</strong> show the ∞. It gets a distinct, muted Hourglass marker whose tooltip does not
-  overclaim: "Runs while the app is open — closing termiHub ends the session. Use a remote agent
-  for persistence across app restarts." Rendered on the connection row
-  (<code>ConnectionItem</code> in <code>ConnectionList.tsx</code>).</li>
-</ul>
-<p>The marker sits to the left of the connection type chip and is always visible; it tells the user
-   both "this connection can run in the background" and <em>which persistence tier</em> it has.</p>
+<p><strong>Persistence badge — the ∞ (infinity), agent persistent shells only.</strong> The ∞ marks a
+   single-instance, genuinely persistent session that lives on the remote <strong>agent</strong>: it
+   survives closing termiHub <em>and</em> powering off / restarting this machine (true cross-session,
+   cross-power persistence via the agent daemon). Its tooltip states exactly that: "Persistent
+   session — lives on the agent and survives closing termiHub and restarting this machine." It sits
+   to the left of the connection type chip and is rendered <strong>only</strong> on the agent connection
+   row (<code>AgentNode.tsx</code>). No other connection type carries any persistence marker.</p>
 </li>
 <li>
-<p><strong>State dot</strong> — a small circle to the right of the connection name. Colour and tooltip reflect
-   the live run state:</p>
+<p><strong>State dot</strong> — a small circle to the right of an <em>agent persistent shell's</em> name.
+   Colour and tooltip reflect the live run state of that agent session (it is not shown for any
+   non-agent connection):</p>
 </li>
 </ol>
 <div class="table-wrap">
@@ -113,12 +108,12 @@ persistent-capable:</p>
 </tbody>
 </table>
 </div>
-<p>Non-persistent connections show neither element.</p>
-<p><strong>Annotated wireframe (desktop-local rows use the Hourglass marker; the ∞ appears only on an
-agent-backed row):</strong></p>
+<p>Normal (non-agent) connections show neither element — no badge and no state dot.</p>
+<p><strong>Annotated wireframe (plain connections carry no marker; the ∞ and the run-state dot appear
+only on an agent persistent shell):</strong></p>
 <pre><code>Connections
- [⧗] 🖥  My SSH Server      ssh     ● (grey — not running)
- [⧗] 🖥  Dev Docker         docker  ● (bright green, badge &quot;2&quot; — attached)
+     🖥  My SSH Server      ssh
+     🖥  Dev Docker         docker
      🖥  Local Shell        local
 Remote Agents
   ▸ prod-agent ●
@@ -174,16 +169,14 @@ node's inline buttons):</p>
 <li><strong>Transitioning (Starting / Stopping)</strong>: a spinner only, no buttons</li>
 </ul>
 <h3 id="tab-decoration">Tab Decoration</h3>
-<p>Tabs attached to a persistent session carry the same tiered marker as the sidebar (#2086), to
-signal that closing the tab will <strong>detach</strong>, not terminate, the background process — and
-which persistence tier it belongs to:</p>
-<ul>
-<li><strong>Agent-backed tab</strong> (opened as a <code>remote-session</code>) → the <code>∞</code> badge, same
-  strong tooltip as the sidebar.</li>
-<li><strong>Desktop-local persistent tab</strong> (an ssh/docker/wsl/serial tab whose process runs in the
-  app) → the muted Hourglass marker with the app-open-only tooltip.</li>
-</ul>
-<p>When the user closes such a tab via the <code>×</code> button, a one-time tooltip confirmation appears:</p>
+<p>Only a tab attached to an <strong>agent persistent shell</strong> (a tab opened as a
+<code>remote-session</code>) carries the <code>∞</code> badge, with the same strong tooltip as the
+sidebar — signalling that closing the tab will <strong>detach</strong>, not terminate, the background
+process that lives on the agent (#2099). Every other tab (a direct ssh/docker/wsl/serial/local tab)
+is multi-instance and dies when its window closes, so it carries <strong>no</strong> persistence marker
+at all — no ∞ and no hourglass.</p>
+<p>When the user closes an agent-backed persistent tab via the <code>×</code> button, a one-time tooltip
+confirmation appears:</p>
 <blockquote>
 <p>"This session will keep running in the background. Use Stop in the sidebar to terminate it."</p>
 </blockquote>
@@ -309,13 +302,13 @@ desktop does not need to know a restart occurred.</p>
 process, not via a remote agent) run inside the Tauri backend process. They persist across
 <strong>tab closes within the same app session</strong> (the new behaviour added by this concept) but are
 <strong>lost when the desktop app exits</strong>. There is no daemon subprocess layer on the desktop side.</p>
-<p>The sidebar must make this distinction clear, and a shared tooltip is not enough — the maintainer
-decision (#2086) is that the <code>∞</code> is <strong>reserved for agent-backed persistence</strong> and must
-<strong>not</strong> appear on a desktop-local row, because it overclaims a guarantee (surviving app close +
-machine restart) that the app-local session does not have. Desktop-local persistent sessions
-therefore show a <strong>distinct, lesser Hourglass marker</strong> whose tooltip does not overclaim: "Runs
-while the app is open — closing termiHub ends the session. Use a remote agent for persistence across
-app restarts."</p>
+<p>The maintainer decision (#2099) is that this weak, app-scoped lifetime is <strong>not worth surfacing
+at all</strong>: the <code>∞</code> is reserved for agent persistent shells (which survive app close + machine
+restart), and a desktop-local row must show <strong>no persistence marker of any kind</strong> — not the
+∞, and not a lesser hourglass. Any marker here was judged useless noise, because these connections
+are multi-instance and die with the window. The <code>capabilities.persistent</code> field and the
+underlying desktop session mechanism remain; only the sidebar/tab <em>markers</em> for them are
+removed.</p>
 <hr>
 <h2 id="states-sequences">States &amp; Sequences</h2>
 <h3 id="state-machine">State Machine</h3>
@@ -583,10 +576,11 @@ or terminated.</p>
 On app exit, the Tauri backend should call a new <code>shutdown_persistent_sessions()</code> that
 detaches all sessions cleanly (the processes will still be killed when the app process exits,
 but this allows graceful cleanup and correct state dot display before the window closes).</p>
-<p>Both scopes share the same run-state dot and Start/Attach/Stop lifecycle conventions, but the
-<strong>persistence badge deliberately differs by tier</strong> (#2086): agent-backed rows keep the <code>∞</code>,
-desktop-local rows use the lesser Hourglass marker. The badge is the one place the UX must
-<em>not</em> be uniform, because the two tiers make materially different persistence guarantees.</p>
+<p>The desktop-local Start/Attach/Stop lifecycle controls still exist, but the desktop-local scope
+carries <strong>no persistence badge and no run-state dot</strong> (#2099): the <code>∞</code> and the state dot
+are exclusive to agent persistent shells. Persistence surfacing is deliberately <em>not</em> uniform
+because only agent shells make a persistence guarantee worth advertising — a desktop-local session
+dies with the window.</p>
 <hr>
 <h2 id="implementation-status">Implementation Status</h2>
 <p><strong>Status: Implemented.</strong> Implementation issue
@@ -622,30 +616,34 @@ store, IPC commands, event flow, and both sidebar scopes now exist. One small mo
 </ul>
 <h3 id="what-shipped-since">What shipped since (#1881/#1882)</h3>
 <ul>
-<li><strong>Desktop-local sidebar surfacing</strong> — the persistence badge, state dot and inline
-  Start/Attach/Stop controls now render on the desktop-local saved connection item
-  (<code>ConnectionItem</code> in <code>ConnectionList.tsx</code>), so both scopes (agent-hosted
-  <code>AgentNode.tsx</code> and desktop-local) share the UX. The store's desktop-local
-  <code>startPersistentSession</code>/<code>attachPersistentSession</code> actions now have real callers.
-  Landed via <a href="https://github.com/armaxri/termiHub/issues/1881">#1881</a> (closed).</li>
+<li><strong>Desktop-local sidebar lifecycle controls</strong> — the inline Start/Attach/Stop controls
+  render on the desktop-local saved connection item (<code>ConnectionItem</code> in
+  <code>ConnectionList.tsx</code>), driving the store's desktop-local
+  <code>startPersistentSession</code>/<code>attachPersistentSession</code> actions. Landed via
+  <a href="https://github.com/armaxri/termiHub/issues/1881">#1881</a> (closed). Note: the persistence
+  badge and state dot that #1881 originally added here were later <strong>removed</strong> by #2099 — see
+  below.</li>
 <li><strong>Status-bar background-session count</strong> — the <code>PersistentSessionsIndicator</code> in
   <code>StatusBar.tsx</code> shows the count of background persistent sessions. Landed via
   <a href="https://github.com/armaxri/termiHub/issues/1882">#1882</a> (closed).</li>
-<li><strong>Tiered persistence badge</strong> — the <code>∞</code> is now reserved for <strong>agent-backed</strong>
-  persistence (survives app close + machine restart) and carries a tooltip stating exactly that;
-  <strong>desktop-local</strong> persistent connections use a distinct, muted <strong>Hourglass</strong> marker
-  (<code>.connection-tree__local-persistent-badge</code> / <code>.tab__local-persistent-badge</code>) with a
-  tooltip that does not overclaim. Applies to all three render sites — the sidebar connection row
-  (<code>ConnectionList.tsx</code>), the agent connection row (<code>AgentNode.tsx</code>), and the tab
-  decoration (<code>Tab.tsx</code>). Landed via
-  <a href="https://github.com/armaxri/termiHub/issues/2086">#2086</a>.</li>
+<li><strong>Persistence marker reserved for agent persistent shells</strong> — the <code>∞</code> is shown
+  <strong>only</strong> on agent persistent shells (survives app close + machine restart), on the agent
+  connection row (<code>AgentNode.tsx</code>) and agent-backed <code>remote-session</code> tabs
+  (<code>Tab.tsx</code>), with the run-state dot alongside. Every other connection type
+  (ssh/docker/wsl/serial/local/telnet/…) shows <strong>no persistence marker and no state dot</strong> —
+  they are multi-instance and die with the window. #2086 had briefly given desktop-local connections
+  a lesser Hourglass marker; #2099 removed that (and the desktop-local state dot) as useless noise.
+  The <code>capabilities.persistent</code> field and the session mechanism are unchanged; only the
+  markers were removed. Landed via
+  <a href="https://github.com/armaxri/termiHub/issues/2099">#2099</a>.</li>
 </ul>
 <h3 id="what-is-missing">Residual</h3>
 <ul>
 <li><strong>Attached-tab count badge on the state dot + one-time detach confirmation tooltip</strong> —
   the mockups' small numeric badge overlaying the state dot when more than one tab is attached
   (<code>●²</code>), and the one-time "this session keeps running in the background" tooltip with a
-  "don't show again" opt-out on first detach, are not built. Tracked:
+  "don't show again" opt-out on first detach, are not built. (Since #2099 the state dot exists only
+  on agent persistent shells, so this badge would apply there only.) Tracked:
   <a href="https://github.com/armaxri/termiHub/issues/1930">#1930</a>.</li>
 </ul>
 <hr>
@@ -653,17 +651,17 @@ store, IPC commands, event flow, and both sidebar scopes now exist. One small mo
 <blockquote>
 <p>Maintained by <code>/sync-concept persistent-connection-ux</code>. The concept is the source of truth; when a real constraint or decision made the original design wrong, the concept is updated instead of the code.</p>
 </blockquote>
-<p><strong>Last synced:</strong> 2026-07-27 (#2086 tiered badge) · <strong>Status:</strong> implemented. The full lifecycle shipped (#672), and both surfacing gaps landed (#1881 desktop-local sidebar, #1882 status-bar count). Per the maintainer decision on <a href="https://github.com/armaxri/termiHub/issues/2086">#2086</a>, the <code>∞</code> badge is now reserved for agent-backed persistence (survives app close + machine restart) and desktop-local persistent connections use a distinct, lesser Hourglass marker with a non-overclaiming tooltip. One mockup detail (attached-tab count badge + one-time detach tooltip) remains, tracked as #1930.</p>
+<p><strong>Last synced:</strong> 2026-07-27 (#2099 agents-only marker) · <strong>Status:</strong> implemented. The full lifecycle shipped (#672), and both surfacing gaps landed (#1881 desktop-local sidebar, #1882 status-bar count). Per the maintainer decision on <a href="https://github.com/armaxri/termiHub/issues/2099">#2099</a>, the <code>∞</code> badge — and the run-state dot — are reserved for <strong>agent persistent shells only</strong> (single-instance, survive app close + machine restart). Every other connection type is multi-instance and dies with the window, so it shows <strong>no persistence marker at all</strong>: no ∞, no hourglass, no state dot. This reverted the brief #2086 tiered-badge experiment (which had given desktop-local rows a lesser Hourglass marker) while keeping the <code>capabilities.persistent</code> field and the session mechanism intact. One mockup detail (attached-tab count badge + one-time detach tooltip) remains, tracked as #1930.</p>
 <h3 id="sync-open">Open divergences</h3>
 <div class="table-wrap">
 <table>
 <thead><tr><th>#</th><th>Artifact claim</th><th>Code reality</th><th>Type</th><th>Recommendation</th></tr></thead>
 <tbody>
-<tr><td>1</td><td>Preliminary Impl Details wire persistence into <code>ConnectionList.tsx</code>/<code>ConnectionItem</code> and the tab header</td><td><strong>Resolved</strong> — landed on <code>AgentNode.tsx</code> + <code>Tab.tsx</code> (agent-hosted) and on the desktop-local <code>ConnectionItem</code> in <code>ConnectionList.tsx</code></td><td>Resolved</td><td>Desktop-local surfacing landed via <a href="https://github.com/armaxri/termiHub/issues/1881">#1881</a> — closed</td></tr>
+<tr><td>1</td><td>Preliminary Impl Details wire persistence into <code>ConnectionList.tsx</code>/<code>ConnectionItem</code> and the tab header</td><td><strong>Resolved</strong> — the ∞ badge + run-state dot land on <code>AgentNode.tsx</code> + agent-backed <code>Tab.tsx</code>; the desktop-local <code>ConnectionItem</code> keeps only its Start/Attach/Stop lifecycle controls (no marker/dot)</td><td>Resolved</td><td>Desktop-local lifecycle controls landed via <a href="https://github.com/armaxri/termiHub/issues/1881">#1881</a>; the marker/dot were removed from that scope by <a href="https://github.com/armaxri/termiHub/issues/2099">#2099</a></td></tr>
 <tr><td>2</td><td>Status-bar count of background sessions</td><td><strong>Resolved</strong> — <code>PersistentSessionsIndicator</code> in <code>StatusBar.tsx</code></td><td>Resolved</td><td>Landed via <a href="https://github.com/armaxri/termiHub/issues/1882">#1882</a> — closed</td></tr>
 <tr><td>3</td><td>Attached-tab numeric count badge on the state dot; one-time detach confirmation tooltip</td><td>Not built</td><td>Missing</td><td>Tracked <a href="https://github.com/armaxri/termiHub/issues/1930">#1930</a></td></tr>
 <tr><td>4</td><td>Concept proposes <code>connection.start()/attach()/stop()</code> IPC commands</td><td>Shipped as <code>start_/stop_/list_persistent_session</code> plus <code>attach_/detach_/adopt_persistent_*</code> and <code>get_agent_session_buffer</code> — a superset; sessions keyed <code>${agentId}:${definitionId}</code></td><td>Divergence (naming)</td><td>Concept command list reconciled to the shipped names</td></tr>
-<tr><td>5</td><td>Original concept: desktop-local persistent sessions show the same <code>∞</code> badge as agent-backed, distinguished only by tooltip</td><td><strong>Resolved</strong> — <code>∞</code> reserved for agent-backed (<code>AgentNode.tsx</code>/<code>Tab.tsx</code>); desktop-local uses a distinct Hourglass marker (<code>ConnectionList.tsx</code>/<code>Tab.tsx</code>)</td><td>Resolved (concept updated)</td><td>Maintainer decision on <a href="https://github.com/armaxri/termiHub/issues/2086">#2086</a> — a shared badge overclaimed the desktop-local guarantee; concept + code both updated to the tiered badge</td></tr>
+<tr><td>5</td><td>Original concept: desktop-local persistent sessions show the same <code>∞</code> badge as agent-backed, distinguished only by tooltip</td><td><strong>Resolved</strong> — the <code>∞</code> and the run-state dot are shown <em>only</em> on agent persistent shells (<code>AgentNode.tsx</code> / agent-backed <code>Tab.tsx</code>); every non-agent connection shows no marker and no dot</td><td>Resolved (concept updated)</td><td>Maintainer decision on <a href="https://github.com/armaxri/termiHub/issues/2099">#2099</a> — the #2086 tiered Hourglass marker was useless noise; markers removed from all non-agent connections, session mechanism kept</td></tr>
 </tbody>
 </table>
 </div>

--- a/src/components/Sidebar/AgentNode.persistent-badge.test.tsx
+++ b/src/components/Sidebar/AgentNode.persistent-badge.test.tsx
@@ -1,11 +1,12 @@
 /**
- * Agent-backed persistence badge (#2086).
+ * Agent persistent-shell badge (#2086, refined by #2099).
  *
- * A persistent saved definition on a connected agent keeps the ∞ badge — the
- * session lives on the remote agent and survives closing termiHub AND powering
- * off / restarting this machine. The badge's tooltip states exactly that. A
- * non-persistent definition shows no badge. (The desktop-local, app-open-only
- * tier uses a different, lesser marker — see ConnectionList.persistent.test.)
+ * The ∞ badge appears ONLY on agent persistent shells. A persistent saved
+ * definition on a connected agent keeps the ∞ — the session lives on the remote
+ * agent and survives closing termiHub AND powering off / restarting this
+ * machine. The badge's tooltip states exactly that. A non-persistent definition
+ * shows no badge. Every other (non-agent) connection type shows no persistence
+ * marker at all — see ConnectionList.persistent.test / Tab.persistent-badge.test.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";

--- a/src/components/Sidebar/ConnectionList.css
+++ b/src/components/Sidebar/ConnectionList.css
@@ -467,19 +467,6 @@
   top: -3px;
 }
 
-/* Desktop-local persistence marker (#2086): a muted Hourglass, deliberately
-   distinct from the agent-backed ∞ so the two persistence tiers read as
-   different. "Bounded" (only while the app is open) vs. the unbounded ∞. */
-.connection-tree__local-persistent-badge {
-  display: inline-flex;
-  align-items: center;
-  align-self: center;
-  flex-shrink: 0;
-  margin-left: 3px;
-  color: var(--text-secondary);
-  opacity: 0.75;
-}
-
 .connection-tree__state-dot {
   display: inline-block;
   width: 7px;

--- a/src/components/Sidebar/ConnectionList.persistent.test.tsx
+++ b/src/components/Sidebar/ConnectionList.persistent.test.tsx
@@ -1,20 +1,19 @@
 /**
  * Desktop-local persistent-session controls in the connection tree (#1881),
- * updated for the tiered persistence badge (#2086).
+ * updated for the agents-only persistence marker rule (#2099).
  *
  * A saved connection whose type reports `capabilities.persistent === true`
- * surfaces a desktop-local persistence marker, a run-state dot, and
- * state-dependent Start / Attach / Stop controls (inline + context menu) wired
- * to the store's `startPersistentSession` / `attachPersistentSession` /
- * `stopPersistentSession` actions, keyed by the plain connection id.
+ * still gets its state-dependent Start / Attach / Stop lifecycle controls
+ * (inline + context menu) wired to the store's `startPersistentSession` /
+ * `attachPersistentSession` / `stopPersistentSession` actions, keyed by the
+ * plain connection id — the #1881 backend mechanism is unchanged.
  *
- * Per the #2086 maintainer decision, the desktop-local marker is NOT the ∞
- * (that is reserved for agent-backed persistence that survives app close +
- * machine restart). Desktop-local persistence lives only while the app is open,
- * so it renders a distinct, lesser Hourglass marker
- * (`local-persistent-badge-*`) whose tooltip does not overclaim. A
- * non-persistence-capable connection shows none of this and keeps the plain
- * Connect affordance.
+ * Per the #2099 maintainer decision, however, these desktop-local connections
+ * (ssh/docker/wsl/serial/local) are multi-instance and die with the window, so
+ * they carry NO persistence marker at all: no ∞, no hourglass, and no
+ * persistence/run-state dot. The ∞ is reserved for agent persistent shells
+ * (see AgentNode). A non-persistence-capable connection likewise shows none of
+ * this and keeps the plain Connect affordance.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
@@ -28,7 +27,6 @@ import type {
   PersistentSessionEntry,
   RemoteAgentDefinition,
 } from "@/types/connection";
-import type { PanelNode, TabGroup, TerminalTab } from "@/types/terminal";
 
 vi.mock("@/services/api", () => ({
   listAvailableShells: vi.fn(() => Promise.resolve([])),
@@ -85,8 +83,7 @@ function render(
     startPersistentSession: () => Promise<void>;
     attachPersistentSession: () => Promise<void>;
     stopPersistentSession: () => Promise<void>;
-  }> = {},
-  extra: Partial<{ rootPanel: PanelNode; tabGroups: TabGroup[]; activeTabGroupId: string }> = {}
+  }> = {}
 ) {
   const initial = useAppStore.getInitialState();
   useAppStore.setState({
@@ -94,7 +91,6 @@ function render(
     connections: [SSH_CONN, TELNET_CONN],
     connectionTypes: [SSH_TYPE, TELNET_TYPE],
     persistentSessions,
-    ...extra,
     ...actionOverrides,
   });
   act(() => {
@@ -111,41 +107,8 @@ function q(testid: string): HTMLElement | null {
   return container.querySelector(`[data-testid="${testid}"]`);
 }
 
-function entry(
-  state: PersistentSessionEntry["state"],
-  attachedTabIds: string[] = []
-): PersistentSessionEntry {
-  return { connectionId: "ssh-1", sessionId: "sess-1", state, attachedTabIds };
-}
-
-function tab(id: string, title: string): TerminalTab {
-  return {
-    id,
-    sessionId: "sess-1",
-    title,
-    connectionType: "ssh",
-    contentType: "terminal",
-    config: { type: "ssh", config: { host: "example.com" } },
-    panelId: "panel-1",
-    isActive: false,
-    persistentConnectionId: "ssh-1",
-  };
-}
-
-/** A single-group layout whose active group's root panel holds `tabs`. */
-function layoutWithTabs(tabs: TerminalTab[]): {
-  rootPanel: PanelNode;
-  tabGroups: TabGroup[];
-  activeTabGroupId: string;
-} {
-  const rootPanel: PanelNode = {
-    type: "leaf",
-    id: "panel-1",
-    tabs,
-    activeTabId: tabs[0]?.id ?? null,
-  };
-  const group: TabGroup = { id: "group-1", name: "Group 1", rootPanel, activePanelId: "panel-1" };
-  return { rootPanel, tabGroups: [group], activeTabGroupId: "group-1" };
+function entry(state: PersistentSessionEntry["state"]): PersistentSessionEntry {
+  return { connectionId: "ssh-1", sessionId: "sess-1", state, attachedTabIds: [] };
 }
 
 beforeEach(() => {
@@ -160,49 +123,22 @@ afterEach(() => {
 });
 
 describe("ConnectionList — desktop-local persistent controls", () => {
-  it("shows the desktop-local (Hourglass) marker — NOT the ∞ — and state dot only for a persistence-capable connection", () => {
-    render();
-    // #2086: a plain SSH (desktop-local persistent) connection gets the lesser
-    // Hourglass marker and MUST NOT carry the agent-only ∞.
-    const marker = q("local-persistent-badge-ssh-1");
-    expect(marker).not.toBeNull();
-    expect(marker!.textContent ?? "").not.toContain("∞");
-    // The ∞ badge (agent-backed testid) never renders on a desktop-local row.
-    expect(q("persistent-badge-ssh-1")).toBeNull();
-    expect(q("persistent-state-dot-ssh-1")).not.toBeNull();
-    // Telnet is not persistence-capable — neither marker nor dot.
-    expect(q("local-persistent-badge-tel-1")).toBeNull();
+  it("shows NO persistence marker and NO state dot for a plain (desktop-local) connection", () => {
+    render({ "ssh-1": entry("running") });
+    // #2099: a plain SSH connection is multi-instance and dies with the window,
+    // so it carries no persistence surfacing whatsoever.
+    expect(q("persistent-badge-ssh-1")).toBeNull(); // no ∞
+    expect(q("local-persistent-badge-ssh-1")).toBeNull(); // no hourglass
+    expect(q("persistent-state-dot-ssh-1")).toBeNull(); // no state dot
+    expect(container.textContent ?? "").not.toContain("∞");
+    // Telnet (not persistence-capable) also shows nothing.
     expect(q("persistent-badge-tel-1")).toBeNull();
+    expect(q("local-persistent-badge-tel-1")).toBeNull();
     expect(q("persistent-state-dot-tel-1")).toBeNull();
     // The non-persistent connection keeps the plain Connect affordance; the
-    // persistent one does not.
+    // persistence-capable one still hides it in favour of the lifecycle controls.
     expect(q("connection-connect-tel-1")).not.toBeNull();
     expect(q("connection-connect-ssh-1")).toBeNull();
-  });
-
-  it("the desktop-local marker tooltip does not overclaim cross-restart persistence", () => {
-    render();
-    const title = q("local-persistent-badge-ssh-1")!.getAttribute("title") ?? "";
-    expect(title).toContain("Runs while the app is open");
-    // Must steer users to an agent for stronger persistence, and must not claim
-    // it survives a machine restart.
-    expect(title.toLowerCase()).toContain("agent");
-    expect(title.toLowerCase()).not.toContain("machine");
-  });
-
-  it("reflects the run state on the state dot", () => {
-    render();
-    // No entry → stopped.
-    expect(q("persistent-state-dot-ssh-1")!.className).toContain("state-dot--stopped");
-
-    render({ "ssh-1": entry("running") });
-    expect(q("persistent-state-dot-ssh-1")!.className).toContain("state-dot--running");
-
-    render({ "ssh-1": entry("error") });
-    expect(q("persistent-state-dot-ssh-1")!.className).toContain("state-dot--error");
-
-    render({ "ssh-1": entry("starting") });
-    expect(q("persistent-state-dot-ssh-1")!.className).toContain("state-dot--transitioning");
   });
 
   it("shows Start when stopped and calls startPersistentSession", () => {
@@ -239,41 +175,14 @@ describe("ConnectionList — desktop-local persistent controls", () => {
     expect(stopPersistentSession).toHaveBeenCalledWith("ssh-1");
   });
 
-  it("hides inline lifecycle buttons while transitioning", () => {
+  it("hides inline lifecycle buttons while transitioning and still shows no marker", () => {
     render({ "ssh-1": entry("starting") });
     expect(q("persistent-start-ssh-1")).toBeNull();
     expect(q("persistent-attach-ssh-1")).toBeNull();
     expect(q("persistent-stop-ssh-1")).toBeNull();
-    // The desktop-local marker/dot still render.
-    expect(q("local-persistent-badge-ssh-1")).not.toBeNull();
-  });
-
-  describe("attached-tab count badge (#1930)", () => {
-    it("shows a count badge only when attached to more than one tab", () => {
-      const tabs = [tab("t1", "Shell"), tab("t2", "Logs")];
-      render({ "ssh-1": entry("attached", ["t1", "t2"]) }, {}, layoutWithTabs(tabs));
-      const badge = q("persistent-state-dot-ssh-1-badge");
-      expect(badge).not.toBeNull();
-      expect(badge!.textContent).toBe("2");
-    });
-
-    it("does not show the badge for a single attached tab", () => {
-      render({ "ssh-1": entry("attached", ["t1"]) }, {}, layoutWithTabs([tab("t1", "Shell")]));
-      expect(q("persistent-state-dot-ssh-1-badge")).toBeNull();
-    });
-
-    it("does not show the badge when running but not attached", () => {
-      render({ "ssh-1": entry("running", ["t1", "t2"]) });
-      expect(q("persistent-state-dot-ssh-1-badge")).toBeNull();
-    });
-
-    it("lists the attached tab names in the dot tooltip", () => {
-      const tabs = [tab("t1", "Shell"), tab("t2", "Logs")];
-      render({ "ssh-1": entry("attached", ["t1", "t2"]) }, {}, layoutWithTabs(tabs));
-      const title = q("persistent-state-dot-ssh-1")!.getAttribute("title") ?? "";
-      expect(title).toContain("2 tabs attached:");
-      expect(title).toContain("Shell");
-      expect(title).toContain("Logs");
-    });
+    // No persistence marker or dot ever renders on a desktop-local row (#2099).
+    expect(q("local-persistent-badge-ssh-1")).toBeNull();
+    expect(q("persistent-badge-ssh-1")).toBeNull();
+    expect(q("persistent-state-dot-ssh-1")).toBeNull();
   });
 });

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -34,7 +34,6 @@ import {
   FileSpreadsheet,
   Link,
   Square,
-  Hourglass,
 } from "lucide-react";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import { useAppStore } from "@/store/appStore";
@@ -62,7 +61,6 @@ import { ConfirmDeleteDialog } from "./ConfirmDeleteDialog";
 import { BulkSshImportDialog } from "./BulkSshImportDialog";
 import { FleetOnboardDialog } from "./FleetOnboardDialog";
 import { AgentNode } from "./AgentNode";
-import { PersistentStateDot } from "./PersistentStateDot";
 import { ConnectionPathDialog } from "./ConnectionPathDialog";
 import { InlineFolderInput } from "./InlineFolderInput";
 import { useExperimentalFeatures } from "@/hooks/useExperimentalFeatures";
@@ -356,14 +354,6 @@ function ConnectionItem({
   const hasPersistentError = runState === "error";
   const isPersistentStopped = !runState || runState === "stopped" || hasPersistentError;
 
-  const stateDotClass = isPersistentRunning
-    ? "connection-tree__state-dot--running"
-    : isPersistentTransitioning
-      ? "connection-tree__state-dot--transitioning"
-      : hasPersistentError
-        ? "connection-tree__state-dot--error"
-        : "connection-tree__state-dot--stopped";
-
   const handleStartPersistent = useCallback(() => {
     void startPersistentSession(connection.id);
   }, [startPersistentSession, connection.id]);
@@ -414,14 +404,6 @@ function ConnectionItem({
               onFocus={() => onRowFocus(rowIndex)}
             >
               <ConnectionIcon config={connection.config} customIcon={connection.icon} size={16} />
-              {persistentCapable && (
-                <PersistentStateDot
-                  runState={runState}
-                  stateDotClass={stateDotClass}
-                  connectionId={connection.id}
-                  dotTestId={`persistent-state-dot-${connection.id}`}
-                />
-              )}
               <span className="connection-tree__label">{connection.name}</span>
               {jumpHosts.length > 0 && (
                 <span
@@ -435,20 +417,11 @@ function ConnectionItem({
                   )}
                 </span>
               )}
-              {/* Desktop-local persistence marker (#2086). This session runs
-                  inside the app process and lives only while the app is open,
-                  so it must NOT claim the ∞ (which is reserved for agent-backed
-                  sessions that survive app close + machine restart). It gets a
-                  distinct, lesser Hourglass marker instead. */}
-              {persistentCapable && (
-                <span
-                  className="connection-tree__local-persistent-badge"
-                  title="Runs while the app is open — closing termiHub ends the session. Use a remote agent for persistence across app restarts."
-                  data-testid={`local-persistent-badge-${connection.id}`}
-                >
-                  <Hourglass size={12} />
-                </span>
-              )}
+              {/* Persistence surfacing (#2099): normal desktop-local
+                  connections (ssh/docker/wsl/serial/local) are multi-instance
+                  and die with the window, so they carry NO persistence marker —
+                  no ∞, no hourglass, no state dot. The ∞ lives only on agent
+                  persistent shells (see AgentNode.tsx). */}
               <span className="connection-tree__type">{connection.config.type}</span>
               {persistentCapable && !isPersistentTransitioning && (
                 <span className="connection-tree__persistent-actions">

--- a/src/components/Terminal/Tab.persistent-badge.test.tsx
+++ b/src/components/Terminal/Tab.persistent-badge.test.tsx
@@ -1,18 +1,15 @@
 /**
- * Tiered persistence badge on the tab (#2086).
+ * Persistence marker on the tab (#2099).
  *
- * A tab attached to a persistent session carries a marker signalling that
- * closing it will detach (not terminate) the background process — but the
- * marker differs by persistence tier:
+ * The ∞ badge — signalling that closing the tab detaches (not terminates) the
+ * background process — appears ONLY on agent persistent shells: tabs opened as
+ * a `remote-session`, whose session lives on the remote agent and survives app
+ * close + machine restart.
  *
- *  - **Agent-backed** (the tab was opened as a `remote-session`) → the ∞ badge,
- *    because the session lives on the agent and survives app close + machine
- *    restart.
- *  - **Desktop-local** (an ssh/docker/wsl/serial tab whose process runs inside
- *    the app) → a distinct, lesser Hourglass marker, because it only lives
- *    while the app is open.
- *
- * A tab with no `persistentConnectionId` shows neither.
+ * A desktop-local tab (an ssh/docker/wsl/serial tab whose process runs inside
+ * the app) is multi-instance and dies with the window, so it shows NO marker at
+ * all — no ∞ and no hourglass. A tab with no `persistentConnectionId` likewise
+ * shows nothing.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
@@ -91,7 +88,7 @@ describe("Tab — tiered persistence badge (#2086)", () => {
     expect(badge?.getAttribute("title") ?? "").toContain("restarting this machine");
   });
 
-  it("shows the lesser Hourglass marker — NOT the ∞ — for a desktop-local persistent tab", () => {
+  it("shows NO marker for a desktop-local persistent tab (#2099)", () => {
     root = renderTab(
       makeTab({
         connectionType: "ssh",
@@ -99,15 +96,14 @@ describe("Tab — tiered persistence badge (#2086)", () => {
         persistentConnectionId: "ssh-1",
       })
     );
-    const marker = document.querySelector(".tab__local-persistent-badge");
-    expect(marker).not.toBeNull();
-    // The ∞ badge must not render on a desktop-local tab.
+    // A desktop-local tab dies with the window, so it carries no persistence
+    // marker — neither the ∞ nor the old hourglass.
     expect(document.querySelector(".tab__persistent-badge")).toBeNull();
-    // Tooltip does not overclaim.
-    expect(marker?.getAttribute("title") ?? "").toContain("Runs while the app is open");
+    expect(document.querySelector(".tab__local-persistent-badge")).toBeNull();
+    expect(document.body.textContent ?? "").not.toContain("∞");
   });
 
-  it("shows neither marker for a non-persistent tab", () => {
+  it("shows no marker for a non-persistent tab", () => {
     root = renderTab(makeTab({ persistentConnectionId: undefined }));
     expect(document.querySelector(".tab__persistent-badge")).toBeNull();
     expect(document.querySelector(".tab__local-persistent-badge")).toBeNull();

--- a/src/components/Terminal/Tab.tsx
+++ b/src/components/Terminal/Tab.tsx
@@ -22,7 +22,6 @@ import {
   Plus,
   ChevronRight,
   Radio,
-  Hourglass,
 } from "lucide-react";
 import { TerminalTab } from "@/types/terminal";
 import { TabStatus } from "@/utils/tabStatus";
@@ -189,31 +188,20 @@ export function Tab({
           <Radio size={12} />
         </span>
       )}
-      {/* Persistence tier badge (#2086). The ∞ is reserved for agent-backed
-          sessions — they live on the remote agent and survive closing termiHub
-          and restarting this machine. A desktop-local persistent session (an
-          ssh/docker/wsl/serial tab whose process runs inside this app) only
-          lives while the app is open, so it gets a distinct, lesser Hourglass
-          marker that does not overclaim. Agent-backed tabs are the ones opened
-          as a `remote-session`. */}
-      {tab.persistentConnectionId &&
-        (tab.config?.type === "remote-session" ? (
-          <span
-            className="tab__persistent-badge"
-            title="Persistent session — lives on the agent and survives closing termiHub and restarting this machine."
-            data-testid={`tab-persistent-badge-${tab.id}`}
-          >
-            ∞
-          </span>
-        ) : (
-          <span
-            className="tab__local-persistent-badge"
-            title="Runs while the app is open — closing termiHub ends the session. Use a remote agent for persistence across app restarts."
-            data-testid={`tab-local-persistent-badge-${tab.id}`}
-          >
-            <Hourglass size={12} />
-          </span>
-        ))}
+      {/* Persistence marker (#2099). The ∞ is shown ONLY on agent persistent
+          shells — sessions that live on the remote agent and survive closing
+          termiHub and restarting this machine. Agent-backed tabs are the ones
+          opened as a `remote-session`. Every other connection type is
+          multi-instance and dies with the window, so it carries no marker. */}
+      {tab.persistentConnectionId && tab.config?.type === "remote-session" && (
+        <span
+          className="tab__persistent-badge"
+          title="Persistent session — lives on the agent and survives closing termiHub and restarting this machine."
+          data-testid={`tab-persistent-badge-${tab.id}`}
+        >
+          ∞
+        </span>
+      )}
       {tab.spawned && (
         <span className="tab__spawned-badge" title="Spawned container">
           Spawned

--- a/src/components/Terminal/TabBar.css
+++ b/src/components/Terminal/TabBar.css
@@ -105,18 +105,6 @@
   top: -3px;
 }
 
-/* Desktop-local persistence marker (#2086): a muted Hourglass on the tab,
-   distinct from the agent-backed ∞. Signals the session detaches (not
-   terminates) on close but only lives while the app is open. */
-.tab__local-persistent-badge {
-  display: inline-flex;
-  align-items: center;
-  flex-shrink: 0;
-  margin-left: 3px;
-  color: var(--text-secondary);
-  opacity: 0.75;
-}
-
 .tab__spawned-badge {
   flex-shrink: 0;
   margin-left: var(--spacing-xs);


### PR DESCRIPTION
## Summary

Follow-up correction to #2086 (PR #2092). That change reserved the ∞ for agents but **added an hourglass marker** for desktop-local (SSH/Docker/WSL/Serial) connections and left a persistence run-state dot on them. Maintainer feedback: that is useless noise.

**The rule (kept simple):** a persistence marker — the **∞** — appears **only on agent persistent shells** (single-instance, genuinely persistent: they survive closing termiHub _and_ powering off / restarting the machine). Every other connection type is multi-instance and dies with the window, so it shows **nothing**: no ∞, no hourglass, no persistence/"connected" state dot.

## Changes

- **ConnectionList.tsx / .css** — removed the desktop-local `Hourglass` badge (`.connection-tree__local-persistent-badge`) and the `PersistentStateDot` (grey bubble) from non-agent sidebar rows. The `Hourglass`/`PersistentStateDot` imports and the now-unused `stateDotClass` are gone.
- **Tab.tsx / TabBar.css** — a persistent tab shows the ∞ only when it is an agent-backed `remote-session` tab; desktop-local persistent tabs (ssh/docker/wsl/serial) render no marker. Removed the `.tab__local-persistent-badge` and its CSS.
- **AgentNode.tsx** — unchanged: agent persistent shells keep the ∞ (gated by `definition.persistent`) plus their run-state dot.
- **Backend untouched** — the `capabilities.persistent` field and the #1881 session mechanism (Start/Attach/Stop lifecycle controls) remain; only the UI markers were removed.

## Concept

Updated `docs/concepts/implemented/persistent-connection-ux.html` to the simplified rule (∞ = agent persistent shell only; no marker/dot on any other connection type): Connection Item Appearance, wireframe, Tab Decoration, desktop-local section, Implementation Status and Sync Ledger. Screenshot-verified it still renders.

## Tests

Rewrote the three persistence tests:
- `ConnectionList.persistent.test.tsx` — a plain SSH (and telnet) connection shows no ∞, no hourglass, and no state dot; the Start/Attach/Stop lifecycle controls still work.
- `Tab.persistent-badge.test.tsx` — agent-backed `remote-session` tab → ∞; desktop-local tab → no marker; non-persistent → no marker.
- `AgentNode.persistent-badge.test.tsx` — persistent agent definition → ∞; non-persistent → no badge.

Full frontend suite green (4649 tests), `pnpm build` (tsc) and `pnpm lint` clean; prettier + markdownlint pass.

Closes #2099