### PR TITLE
perf(terminal): cap terminal memory growth over long sessions (Closes #2073)

### DIFF
--- a/docs/changes/dev1/perf/2073-terminal-memory.md
+++ b/docs/changes/dev1/perf/2073-terminal-memory.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Terminal memory growth over long-running sessions. Pre-subscribe terminal
+  output is now dropped when its session exits and is capped to 256 KiB per
+  session (oldest bytes discarded past the ceiling), so a session that produces
+  a lot of output before — or without — a tab attaching can no longer leak its
+  buffer. The optional syntax-highlighting engine now releases each line's
+  decoration bookkeeping when the line scrolls out of the scrollback, so its
+  internal map no longer grows without bound over a long session.

--- a/src/services/events.test.ts
+++ b/src/services/events.test.ts
@@ -401,6 +401,67 @@ describe("events service", () => {
       expect(cb).toHaveBeenCalledTimes(2);
     });
 
+    it("drops buffered pre-subscribe output when the session exits (#2073)", async () => {
+      const handlers: Record<string, (event: unknown) => void> = {};
+      mockedListen.mockImplementation((eventName, handler) => {
+        handlers[eventName as string] = handler as (event: unknown) => void;
+        return Promise.resolve(vi.fn());
+      });
+
+      await dispatcher.init();
+
+      // Output buffered before any subscriber attaches...
+      handlers["terminal-output"]({
+        payload: { session_id: "sess-gone", data: b64([1, 2, 3]) },
+      });
+      // ...then the session exits before anyone subscribed.
+      handlers["terminal-exit"]({
+        payload: { session_id: "sess-gone", exit_code: 0 },
+      });
+
+      // A late output subscriber must NOT receive the now-dropped buffer.
+      const outCb = vi.fn();
+      dispatcher.subscribeOutput("sess-gone", outCb);
+      expect(outCb).not.toHaveBeenCalled();
+
+      // The buffered exit is still delivered so the tab learns the session died.
+      const exitCb = vi.fn();
+      dispatcher.subscribeExit("sess-gone", exitCb);
+      expect(exitCb).toHaveBeenCalledWith(0);
+    });
+
+    it("caps buffered pre-subscribe output to a byte ceiling, dropping oldest chunks (#2073)", async () => {
+      const handlers: Record<string, (event: unknown) => void> = {};
+      mockedListen.mockImplementation((eventName, handler) => {
+        handlers[eventName as string] = handler as (event: unknown) => void;
+        return Promise.resolve(vi.fn());
+      });
+
+      await dispatcher.init();
+
+      const CHUNK = 100_000; // four of these (~400 KB) exceed the 256 KiB ceiling
+      const mk = (marker: number): string => b64(new Array(CHUNK).fill(marker));
+      for (const marker of [1, 2, 3, 4]) {
+        handlers["terminal-output"]({
+          payload: { session_id: "sess-big", data: mk(marker) },
+        });
+      }
+
+      const cb = vi.fn();
+      dispatcher.subscribeOutput("sess-big", cb);
+
+      const retainedBytes = cb.mock.calls.reduce(
+        (n, [chunk]) => n + (chunk as Uint8Array).length,
+        0
+      );
+      // The retained buffer stays under the 256 KiB ceiling.
+      expect(retainedBytes).toBeLessThanOrEqual(256 * 1024);
+      // The most recent chunk survived; the oldest was discarded.
+      const markers = cb.mock.calls.map(([chunk]) => (chunk as Uint8Array)[0]);
+      expect(markers).toContain(4);
+      expect(markers).not.toContain(1);
+    });
+
     it("buffers exit event for sessions with no subscriber", async () => {
       const handlers: Record<string, (event: unknown) => void> = {};
       mockedListen.mockImplementation((eventName, handler) => {

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -180,6 +180,13 @@ export class TerminalOutputDispatcher {
   private agentStateCallbacks = new Map<string, (state: string) => void>();
   /** Buffer output for sessions whose subscriber hasn't registered yet. */
   private pendingOutput = new Map<string, Uint8Array[]>();
+  /**
+   * Per-session cap on pre-subscribe buffered output (bytes). A session that
+   * emits a lot of output before (or without) a subscriber registering would
+   * otherwise grow its buffer without bound; past this ceiling the oldest chunks
+   * are dropped so long-lived sessions cannot leak memory here (#2073).
+   */
+  private static readonly MAX_PENDING_OUTPUT_BYTES = 256 * 1024;
   /** Buffer exit events for sessions whose subscriber hasn't registered yet. */
   private pendingExit = new Map<string, number | null>();
   private unlistenOutput: UnlistenFn | null = null;
@@ -223,6 +230,7 @@ export class TerminalOutputDispatcher {
           this.pendingOutput.set(session_id, buf);
         }
         buf.push(chunk);
+        this.trimPendingOutput(buf);
       }
     });
 
@@ -234,6 +242,12 @@ export class TerminalOutputDispatcher {
 
     const unlistenExit = await listen<TerminalExitPayload>("terminal-exit", (event) => {
       const { session_id, exit_code } = event.payload;
+      // The session is gone: drop any pre-subscribe output still buffered for it.
+      // A session that exits before (or without) a subscriber ever attaching would
+      // otherwise keep its buffered output alive forever (#2073). The scrollback a
+      // reattaching tab needs is restored from the backend's cached buffer, not
+      // from this live-tail buffer, so dropping it here loses nothing visible.
+      this.pendingOutput.delete(session_id);
       const cbs = this.exitCallbacks.get(session_id);
       if (cbs && cbs.size > 0) {
         for (const cb of cbs) cb(exit_code);
@@ -353,6 +367,20 @@ export class TerminalOutputDispatcher {
   /** Discard any buffered output for a session (call before writing cached buffer to avoid duplication). */
   clearPendingOutput(sessionId: string): void {
     this.pendingOutput.delete(sessionId);
+  }
+
+  /**
+   * Bounds a session's pre-subscribe buffer to
+   * {@link TerminalOutputDispatcher.MAX_PENDING_OUTPUT_BYTES}, dropping the
+   * oldest chunks once the ceiling is exceeded. Always keeps at least the most
+   * recent chunk, so a single oversized chunk is never discarded outright.
+   */
+  private trimPendingOutput(buf: Uint8Array[]): void {
+    let total = 0;
+    for (const chunk of buf) total += chunk.length;
+    while (total > TerminalOutputDispatcher.MAX_PENDING_OUTPUT_BYTES && buf.length > 1) {
+      total -= buf.shift()!.length;
+    }
   }
 
   /** Subscribe to remote state change events for a specific session. Returns an unsubscribe function. */

--- a/src/services/syntaxHighlighting.test.ts
+++ b/src/services/syntaxHighlighting.test.ts
@@ -436,4 +436,68 @@ describe("SyntaxHighlightingEngine lifecycle", () => {
 
     engine.dispose();
   });
+
+  it("drops a line's decoration-map entry when its marker disposes (#2073)", async () => {
+    // Deterministic: fake markers whose onDispose we fire ourselves, standing in
+    // for xterm trimming the line off the top of the scrollback.
+    term = await makeTerm("plain ERROR here\r\n");
+    const disposeCallbacks: Array<() => void> = [];
+    vi.spyOn(term, "registerMarker").mockImplementation(
+      (() =>
+        ({
+          id: 1,
+          line: 0,
+          isDisposed: false,
+          onDispose: (cb: () => void) => {
+            disposeCallbacks.push(cb);
+            return { dispose: () => {} };
+          },
+          dispose: () => {},
+        }) as unknown as ReturnType<typeof term.registerMarker>) as typeof term.registerMarker
+    );
+    vi.spyOn(term, "registerDecoration").mockImplementation(
+      ((opts) =>
+        ({
+          marker: opts.marker,
+          isDisposed: false,
+          onRender: () => ({ dispose: () => {} }),
+          onDispose: () => ({ dispose: () => {} }),
+          dispose: () => {},
+        }) as unknown as ReturnType<
+          typeof term.registerDecoration
+        >) as typeof term.registerDecoration
+    );
+
+    const engine = new SyntaxHighlightingEngine(term);
+    engine.enable([errorRule]);
+    expect(engine.trackedLineCount).toBe(1);
+    expect(disposeCallbacks.length).toBeGreaterThan(0);
+
+    // Simulate the line being trimmed: fire the marker's onDispose.
+    disposeCallbacks.forEach((cb) => cb());
+    expect(engine.trackedLineCount).toBe(0);
+
+    engine.dispose();
+  });
+
+  it("prunes the decoration map as matched lines scroll out of scrollback (#2073)", async () => {
+    // End-to-end against a real xterm with a tiny scrollback: the matched line is
+    // trimmed once enough output is written, disposing its marker and dropping
+    // the Map entry so `lineDisposables` cannot grow without bound.
+    term = new Terminal({ cols: 80, rows: 4, allowProposedApi: true, scrollback: 5 });
+    await new Promise<void>((r) => term.write("plain ERROR here\r\n", () => r()));
+
+    const engine = new SyntaxHighlightingEngine(term);
+    engine.enable([errorRule]);
+    expect(engine.trackedLineCount).toBe(1);
+
+    // Push far more non-matching lines than the buffer can hold (rows + scrollback),
+    // forcing the ERROR line off the top of the scrollback.
+    for (let i = 0; i < 40; i++) {
+      await new Promise<void>((r) => term.write(`filler line ${i}\r\n`, () => r()));
+    }
+
+    expect(engine.trackedLineCount).toBe(0);
+    engine.dispose();
+  });
 });

--- a/src/services/syntaxHighlighting.ts
+++ b/src/services/syntaxHighlighting.ts
@@ -396,6 +396,16 @@ export class SyntaxHighlightingEngine {
   }
 
   /**
+   * Number of logical lines currently holding decoration disposables. Exposed
+   * for observability/tests: it must stay bounded over a long session because
+   * each line's Map entry is dropped when its marker disposes (line trimmed out
+   * of scrollback) — see the `marker.onDispose` hook in {@link decorate} (#2073).
+   */
+  get trackedLineCount(): number {
+    return this.lineDisposables.size;
+  }
+
+  /**
    * Enables highlighting with the given rules: compiles them, registers the
    * write hook, and scans the current viewport so already-visible output gets
    * highlighted immediately.
@@ -581,7 +591,16 @@ export class SyntaxHighlightingEngine {
     };
 
     for (const match of matches) {
-      this.applyMatch(match, logical.rows, cols, cursorAbs, getRowLine, cellRef, disposables);
+      this.applyMatch(
+        startRow,
+        match,
+        logical.rows,
+        cols,
+        cursorAbs,
+        getRowLine,
+        cellRef,
+        disposables
+      );
     }
 
     if (disposables.length > 0) this.lineDisposables.set(startRow, disposables);
@@ -593,6 +612,7 @@ export class SyntaxHighlightingEngine {
    * server's colors always win.
    */
   private applyMatch(
+    startRow: number,
     match: RuleMatch,
     rows: number[],
     cols: number,
@@ -608,7 +628,7 @@ export class SyntaxHighlightingEngine {
 
     const flush = (): void => {
       if (runWidth <= 0) return;
-      this.decorate(runRow, runStartX, runWidth, cursorAbs, match, runText, out);
+      this.decorate(startRow, runRow, runStartX, runWidth, cursorAbs, match, runText, out);
       runWidth = 0;
       runText = "";
     };
@@ -653,6 +673,7 @@ export class SyntaxHighlightingEngine {
    * with the run's styled text on render (see {@link styleDecorationElement}).
    */
   private decorate(
+    startRow: number,
     physRow: number,
     x: number,
     width: number,
@@ -663,6 +684,18 @@ export class SyntaxHighlightingEngine {
   ): void {
     const marker = this.xterm.registerMarker(physRow - cursorAbs);
     if (!marker) return;
+
+    // When xterm trims this line off the top of the scrollback the marker
+    // disposes; drop the logical line's Map entry so `lineDisposables` cannot
+    // grow without bound over a long session (#2073). Guarded by identity: only
+    // remove the entry while it still tracks *this* marker, so a later re-scan
+    // that reused the same absolute-row key (indices shift as the scrollback
+    // trims) is never clobbered. xterm disposes the attached decoration itself
+    // when the marker goes, so this only frees our tracking Map.
+    marker.onDispose(() => {
+      const current = this.lineDisposables.get(startRow);
+      if (current && current.includes(marker)) this.lineDisposables.delete(startRow);
+    });
 
     const style = match.rule.style;
     const styled = hasTextStyle(style);


### PR DESCRIPTION
## Summary

Fixes two unbounded-memory-growth paths flagged by the pre-release audit (#2073), both over long-running terminal sessions.

### 1. `pendingOutput` buffer (`src/services/events.ts`)

`TerminalOutputDispatcher.pendingOutput` buffers terminal output for sessions whose subscriber hasn't attached yet (e.g. pre-existing agent-setup sessions). It was uncapped and never cleared when a session ended, so a session that produced output before — or without — a tab attaching leaked its buffer indefinitely.

- **Clear on exit:** the `terminal-exit` handler now `delete`s the session's `pendingOutput` entry. The scrollback a reattaching tab needs is restored from the backend's cached buffer, not from this live-tail buffer, so nothing visible is lost.
- **Byte ceiling:** each session's pending buffer is bounded to **256 KiB**; once exceeded, the oldest chunks are dropped (always keeping at least the most recent chunk). This bounds the pre-subscribe path even when a subscriber never arrives before exit.

### 2. Syntax-highlight decoration map (`src/services/syntaxHighlighting.ts`)

`SyntaxHighlightingEngine.lineDisposables` (keyed by absolute logical-line start row) grew unbounded as matched lines scrolled out of the scrollback — xterm disposed the underlying decoration+marker on trim, but the Map entry lingered.

- On marker creation the engine now registers `marker.onDispose(...)` which removes the line's Map entry when the marker is disposed (line trimmed). The removal is **identity-guarded** — it only deletes while the entry still tracks *that* marker — so a later re-scan that reused the same absolute-row key (indices shift as the scrollback trims) is never clobbered.
- Added a `trackedLineCount` getter for observability/tests.

## Tests

- `events.test.ts`: buffered pre-subscribe output is dropped on session exit (exit still delivered); the buffer is capped to the byte ceiling with oldest chunks discarded.
- `syntaxHighlighting.test.ts`: the Map entry is removed when a line's marker disposes (deterministic fake-marker test) and end-to-end when matched lines scroll out of a small real-xterm scrollback.

All frontend `tsc`, ESLint, Prettier, and the two affected Vitest suites pass locally.

Closes #2073