### PR TITLE
refactor(sftp): converge forked sftp paths onto a shared core module

### DIFF
--- a/core/src/backends/ssh/file_browser.rs
+++ b/core/src/backends/ssh/file_browser.rs
@@ -11,20 +11,11 @@ use tokio::sync::Mutex;
 
 use crate::config::SshConfig;
 use crate::errors::FileError;
-use crate::files::utils::{chrono_from_epoch, format_permissions, writable_from_permissions};
 use crate::files::{FileBrowser, FileEntry};
 
 use super::handler::SshSession;
 use super::jump_host::{connect_target, GatewayHold};
-
-/// Derive the [`FileEntry::writable`] hint from an optional 9-char permission
-/// string, mirroring the desktop SFTP browser (#1324, #1482).
-///
-/// Returns `None` when no permission string is available; otherwise defers to
-/// [`writable_from_permissions`] (the cheap, conservative layer).
-fn writable_hint(permissions: Option<&str>) -> Option<bool> {
-    permissions.and_then(writable_from_permissions)
-}
+use super::sftp;
 
 /// State of a connected SFTP session.
 struct SftpState {
@@ -68,18 +59,9 @@ impl SftpFileBrowser {
             .await
             .map_err(|e| FileError::OperationFailed(format!("SFTP connection failed: {e}")))?;
 
-        let channel = session
-            .channel_open_session()
+        let sftp = sftp::open_sftp_subsystem(&session)
             .await
-            .map_err(|e| FileError::OperationFailed(format!("Channel open failed: {e}")))?;
-
-        channel.request_subsystem(true, "sftp").await.map_err(|e| {
-            FileError::OperationFailed(format!("SFTP subsystem request failed: {e}"))
-        })?;
-
-        let sftp = SftpSession::new(channel.into_stream())
-            .await
-            .map_err(|e| FileError::OperationFailed(format!("SFTP init failed: {e}")))?;
+            .map_err(|e| FileError::OperationFailed(e.to_string()))?;
 
         *guard = Some(SftpState {
             _session: session,
@@ -100,47 +82,9 @@ impl FileBrowser for SftpFileBrowser {
             .as_ref()
             .ok_or_else(|| FileError::OperationFailed("SFTP not connected".to_string()))?;
 
-        let entries = state
-            .sftp
-            .read_dir(path)
+        sftp::list_dir(&state.sftp, path)
             .await
-            .map_err(|e| FileError::OperationFailed(format!("readdir failed: {e}")))?;
-
-        let mut result = Vec::new();
-        for entry in entries {
-            let name = entry.file_name();
-            if name == "." || name == ".." {
-                continue;
-            }
-            let meta = entry.metadata();
-            let full_path = format!("{}/{}", path.trim_end_matches('/'), name);
-            let permissions = meta.permissions.map(format_permissions);
-            let writable = writable_hint(permissions.as_deref());
-            // `read_dir` returns lstat-style attributes, so this flags the link
-            // itself. Resolve the target with a best-effort `readlink` only for
-            // link rows — a plain file never triggers the extra round-trip.
-            let is_symlink = meta.is_symlink();
-            let symlink_target = if is_symlink {
-                state.sftp.read_link(full_path.clone()).await.ok()
-            } else {
-                None
-            };
-            result.push(FileEntry {
-                name,
-                path: full_path,
-                is_directory: meta.is_dir(),
-                size: meta.size.unwrap_or(0),
-                modified: meta
-                    .mtime
-                    .map(|t| chrono_from_epoch(t as u64))
-                    .unwrap_or_default(),
-                permissions,
-                writable,
-                is_symlink,
-                symlink_target,
-            });
-        }
-        Ok(result)
+            .map_err(|e| FileError::OperationFailed(format!("readdir failed: {e}")))
     }
 
     async fn read_file(&self, path: &str) -> Result<Vec<u8>, FileError> {
@@ -254,56 +198,8 @@ impl FileBrowser for SftpFileBrowser {
             .as_ref()
             .ok_or_else(|| FileError::OperationFailed("SFTP not connected".to_string()))?;
 
-        let meta = state
-            .sftp
-            .metadata(path)
+        sftp::stat(&state.sftp, path)
             .await
-            .map_err(|e| FileError::OperationFailed(format!("stat failed: {e}")))?;
-
-        let name = std::path::Path::new(path)
-            .file_name()
-            .map(|n| n.to_string_lossy().to_string())
-            .unwrap_or_default();
-
-        let permissions = meta.permissions.map(format_permissions);
-        let writable = writable_hint(permissions.as_deref());
-        Ok(FileEntry {
-            name,
-            path: path.to_string(),
-            is_directory: meta.is_dir(),
-            size: meta.size.unwrap_or(0),
-            modified: meta
-                .mtime
-                .map(|t| chrono_from_epoch(t as u64))
-                .unwrap_or_default(),
-            permissions,
-            writable,
-            // `metadata` follows the link, so this reports the target.
-            is_symlink: meta.is_symlink(),
-            symlink_target: None,
-        })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::writable_hint;
-
-    #[test]
-    fn writable_hint_none_without_permissions() {
-        assert_eq!(writable_hint(None), None);
-    }
-
-    #[test]
-    fn writable_hint_true_when_any_class_writable() {
-        // Owner-only write (typical `rw-r--r--`) still counts as writable.
-        assert_eq!(writable_hint(Some("rw-r--r--")), Some(true));
-        assert_eq!(writable_hint(Some("rwxr-xr-x")), Some(true));
-    }
-
-    #[test]
-    fn writable_hint_false_when_no_class_writable() {
-        assert_eq!(writable_hint(Some("r--r--r--")), Some(false));
-        assert_eq!(writable_hint(Some("r-xr-xr-x")), Some(false));
+            .map_err(|e| FileError::OperationFailed(format!("stat failed: {e}")))
     }
 }

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -15,6 +15,7 @@ pub mod jump_host;
 mod legacy_pem;
 mod monitoring;
 pub mod session_pool;
+pub mod sftp;
 pub mod x11;
 
 pub use self::exec::{ssh_exec_with_stdin, SshExecOutput};

--- a/core/src/backends/ssh/sftp.rs
+++ b/core/src/backends/ssh/sftp.rs
@@ -1,0 +1,262 @@
+//! Shared russh-sftp mechanics consumed by every SFTP path in the workspace.
+//!
+//! Two SFTP implementations historically forked the same low-level russh-sftp
+//! plumbing: the core [`SftpFileBrowser`](super::file_browser) (the
+//! [`FileBrowser`](crate::files::FileBrowser) trait path) and the desktop
+//! `SftpSession` / transfer subsystem in `src-tauri`. Both opened the SFTP
+//! subsystem the same way and mapped `readdir` / `stat` attributes into
+//! [`FileEntry`] with byte-for-byte identical logic (#2075). That duplication
+//! is what let the two paths drift.
+//!
+//! This module holds that shared mechanism once so both consume it:
+//!
+//! * [`open_sftp_subsystem`] — open a fresh SFTP subsystem channel on an
+//!   authenticated SSH session (also used by the desktop transfer subsystem's
+//!   dedicated per-transfer channel and by `remote_exec`).
+//! * [`list_dir`] / [`stat`] — turn russh-sftp attributes into [`FileEntry`]
+//!   rows, including the best-effort `readlink` for symlink rows.
+//!
+//! Capabilities that remain desktop-only (elevated `sudo` writes, the write-open
+//! writability probe, the transfer queue) stay in `src-tauri`; they are layered
+//! *on top of* these shared primitives rather than forking them.
+
+use russh_sftp::client::error::Error as RusshSftpError;
+use russh_sftp::client::SftpSession as RusshSftp;
+use russh_sftp::protocol::FileAttributes;
+
+use crate::files::utils::{chrono_from_epoch, format_permissions, writable_from_permissions};
+use crate::files::FileEntry;
+
+use super::handler::SshSession;
+
+/// Failure while opening an SFTP subsystem channel on an SSH session.
+///
+/// Distinguishes the three steps so callers can surface a precise message.
+#[derive(Debug)]
+pub enum OpenSftpError {
+    /// Opening the SSH session channel failed.
+    ChannelOpen(russh::Error),
+    /// Requesting the `sftp` subsystem on the channel failed.
+    Subsystem(russh::Error),
+    /// The SFTP protocol handshake / init failed.
+    Init(RusshSftpError),
+}
+
+impl std::fmt::Display for OpenSftpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OpenSftpError::ChannelOpen(e) => write!(f, "SFTP channel open failed: {e}"),
+            OpenSftpError::Subsystem(e) => write!(f, "SFTP subsystem request failed: {e}"),
+            OpenSftpError::Init(e) => write!(f, "SFTP init failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for OpenSftpError {}
+
+/// Open a **fresh** SFTP subsystem on the given authenticated SSH session.
+///
+/// Opens a new session channel, requests the `sftp` subsystem, and completes the
+/// russh-sftp handshake. The returned [`RusshSftp`] owns its own channel, so
+/// callers may open several independent SFTP sessions on one SSH connection
+/// (e.g. the desktop transfer subsystem's dedicated per-transfer channel, #1245,
+/// which runs a copy without holding the browsing channel's lock).
+pub async fn open_sftp_subsystem(session: &SshSession) -> Result<RusshSftp, OpenSftpError> {
+    let channel = session
+        .channel_open_session()
+        .await
+        .map_err(OpenSftpError::ChannelOpen)?;
+    channel
+        .request_subsystem(true, "sftp")
+        .await
+        .map_err(OpenSftpError::Subsystem)?;
+    RusshSftp::new(channel.into_stream())
+        .await
+        .map_err(OpenSftpError::Init)
+}
+
+/// Build a [`FileEntry`] from russh-sftp [`FileAttributes`].
+///
+/// Shared by [`list_dir`] and [`stat`] so the desktop and core paths derive the
+/// `permissions` string and the conservative `writable` hint identically. The
+/// caller supplies the entry `name`, its full `path`, and any resolved
+/// `symlink_target` (a directory-listing row resolves it via `readlink`; a
+/// `stat` never does).
+fn attrs_to_file_entry(
+    name: String,
+    path: String,
+    meta: &FileAttributes,
+    symlink_target: Option<String>,
+) -> FileEntry {
+    let permissions = meta.permissions.map(format_permissions);
+    let writable = permissions.as_deref().and_then(writable_from_permissions);
+    FileEntry {
+        name,
+        path,
+        is_directory: meta.is_dir(),
+        size: meta.size.unwrap_or(0),
+        modified: meta
+            .mtime
+            .map(|t| chrono_from_epoch(t as u64))
+            .unwrap_or_default(),
+        permissions,
+        writable,
+        is_symlink: meta.is_symlink(),
+        symlink_target,
+    }
+}
+
+/// List a remote directory, mapping each row into a [`FileEntry`].
+///
+/// Filters out `.` and `..`. `read_dir` returns lstat-style attributes, so
+/// `is_symlink` flags the link itself; for link rows only, the target is
+/// resolved with a best-effort `read_link` (a plain file never triggers the
+/// extra round-trip, and a failed `read_link` yields `None` rather than an
+/// error). Errors from `read_dir` propagate as the native russh-sftp error so
+/// each caller can wrap it in its own error type.
+pub async fn list_dir(sftp: &RusshSftp, path: &str) -> Result<Vec<FileEntry>, RusshSftpError> {
+    let entries = sftp.read_dir(path).await?;
+
+    let mut result = Vec::new();
+    for entry in entries {
+        let name = entry.file_name();
+        if name == "." || name == ".." {
+            continue;
+        }
+        let meta = entry.metadata();
+        let full_path = format!("{}/{}", path.trim_end_matches('/'), name);
+        let symlink_target = if meta.is_symlink() {
+            sftp.read_link(full_path.clone()).await.ok()
+        } else {
+            None
+        };
+        result.push(attrs_to_file_entry(name, full_path, &meta, symlink_target));
+    }
+    Ok(result)
+}
+
+/// Stat a single remote path, mapping the result into a [`FileEntry`].
+///
+/// `metadata` follows symlinks, so `is_symlink` reports the *target*'s type and
+/// no link target is resolved. The error propagates as the native russh-sftp
+/// error for the caller to wrap.
+pub async fn stat(sftp: &RusshSftp, path: &str) -> Result<FileEntry, RusshSftpError> {
+    let meta = sftp.metadata(path).await?;
+    let name = std::path::Path::new(path)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_default();
+    Ok(attrs_to_file_entry(name, path.to_string(), &meta, None))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use russh_sftp::protocol::FileMode;
+
+    /// Build attributes with a raw permission bitmask (mode bits + type bits).
+    fn attrs(perm: u32, size: u64, mtime: u32) -> FileAttributes {
+        FileAttributes {
+            size: Some(size),
+            uid: None,
+            user: None,
+            gid: None,
+            group: None,
+            permissions: Some(perm),
+            atime: None,
+            mtime: Some(mtime),
+        }
+    }
+
+    /// A regular file maps its permission string, a writable hint, size and
+    /// mtime, and carries no symlink metadata.
+    #[test]
+    fn attrs_to_file_entry_regular_file() {
+        // rw-r--r-- regular file.
+        let perm = FileMode::REG.bits() | 0o644;
+        let entry = attrs_to_file_entry(
+            "notes.txt".to_string(),
+            "/home/u/notes.txt".to_string(),
+            &attrs(perm, 1234, 1_600_000_000),
+            None,
+        );
+        assert_eq!(entry.name, "notes.txt");
+        assert_eq!(entry.path, "/home/u/notes.txt");
+        assert!(!entry.is_directory);
+        assert_eq!(entry.size, 1234);
+        assert_eq!(entry.permissions.as_deref(), Some("rw-r--r--"));
+        // Owner-write present → conservative hint says writable.
+        assert_eq!(entry.writable, Some(true));
+        assert!(!entry.is_symlink);
+        assert_eq!(entry.symlink_target, None);
+        assert!(!entry.modified.is_empty());
+    }
+
+    /// A directory sets `is_directory` from the mode's DIR bit.
+    #[test]
+    fn attrs_to_file_entry_directory() {
+        let perm = FileMode::DIR.bits() | 0o755;
+        let entry = attrs_to_file_entry(
+            "src".to_string(),
+            "/home/u/src".to_string(),
+            &attrs(perm, 4096, 1_600_000_000),
+            None,
+        );
+        assert!(entry.is_directory);
+        assert_eq!(entry.permissions.as_deref(), Some("rwxr-xr-x"));
+    }
+
+    /// A read-only-for-all file yields a `Some(false)` writable hint.
+    #[test]
+    fn attrs_to_file_entry_read_only_hint() {
+        let perm = FileMode::REG.bits() | 0o444;
+        let entry = attrs_to_file_entry(
+            "ro".to_string(),
+            "/ro".to_string(),
+            &attrs(perm, 0, 0),
+            None,
+        );
+        assert_eq!(entry.writable, Some(false));
+    }
+
+    /// A symlink row keeps the link flag and the caller-resolved target.
+    #[test]
+    fn attrs_to_file_entry_symlink_keeps_target() {
+        let perm = FileMode::LNK.bits() | 0o777;
+        let entry = attrs_to_file_entry(
+            "link".to_string(),
+            "/link".to_string(),
+            &attrs(perm, 0, 0),
+            Some("/real/target".to_string()),
+        );
+        assert!(entry.is_symlink);
+        assert_eq!(entry.symlink_target.as_deref(), Some("/real/target"));
+    }
+
+    /// Absent permissions leave both the string and the writable hint `None`.
+    #[test]
+    fn attrs_to_file_entry_missing_permissions() {
+        let meta = FileAttributes {
+            size: None,
+            uid: None,
+            user: None,
+            gid: None,
+            group: None,
+            permissions: None,
+            atime: None,
+            mtime: None,
+        };
+        let entry = attrs_to_file_entry("x".to_string(), "/x".to_string(), &meta, None);
+        assert_eq!(entry.permissions, None);
+        assert_eq!(entry.writable, None);
+        // A missing size defaults to 0 and a missing mtime to the epoch default.
+        assert_eq!(entry.size, 0);
+    }
+
+    /// `OpenSftpError` renders a distinct, step-identifying message per variant.
+    #[test]
+    fn open_sftp_error_messages_identify_the_step() {
+        let init = OpenSftpError::Init(RusshSftpError::Timeout);
+        assert!(init.to_string().starts_with("SFTP init failed:"));
+    }
+}

--- a/src-tauri/src/files/sftp.rs
+++ b/src-tauri/src/files/sftp.rs
@@ -9,11 +9,8 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, info, warn};
 
 use termihub_core::backends::ssh::handler::SshSession;
-use termihub_core::backends::ssh::{ssh_exec_with_stdin, SshExecOutput};
+use termihub_core::backends::ssh::{sftp, ssh_exec_with_stdin, SshExecOutput};
 use termihub_core::errors::FileError;
-use termihub_core::files::utils::{
-    chrono_from_epoch, format_permissions, writable_from_permissions,
-};
 use termihub_core::files::{FileBackend, FileEntry};
 
 use crate::terminal::backend::SshConfig;
@@ -220,17 +217,9 @@ impl SftpSession {
 
         let sftp = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
-                let channel = session
-                    .channel_open_session()
+                sftp::open_sftp_subsystem(&session)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("SFTP channel open: {e}")))?;
-                channel
-                    .request_subsystem(true, "sftp")
-                    .await
-                    .map_err(|e| TerminalError::SshError(format!("SFTP subsystem request: {e}")))?;
-                RusshSftp::new(channel.into_stream())
-                    .await
-                    .map_err(|e| TerminalError::SshError(format!("SFTP init: {e}")))
+                    .map_err(|e| TerminalError::SshError(e.to_string()))
             })
         })?;
 
@@ -266,18 +255,9 @@ impl SftpSession {
     /// without holding this session's `Mutex` — keeping directory listing /
     /// navigation live on the browsing channel during a transfer.
     pub async fn open_dedicated_sftp(&self) -> Result<RusshSftp, TerminalError> {
-        let channel = self
-            .session
-            .channel_open_session()
+        sftp::open_sftp_subsystem(&self.session)
             .await
-            .map_err(|e| TerminalError::SshError(format!("transfer channel open: {e}")))?;
-        channel
-            .request_subsystem(true, "sftp")
-            .await
-            .map_err(|e| TerminalError::SshError(format!("transfer subsystem request: {e}")))?;
-        RusshSftp::new(channel.into_stream())
-            .await
-            .map_err(|e| TerminalError::SshError(format!("transfer SFTP init: {e}")))
+            .map_err(|e| TerminalError::SshError(e.to_string()))
     }
 
     /// Best-effort size (in bytes) of a remote file via SFTP `stat`.
@@ -297,48 +277,9 @@ impl SftpSession {
         let path = path.to_string();
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
-                let entries = self
-                    .sftp
-                    .read_dir(&path)
+                sftp::list_dir(&self.sftp, &path)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("readdir failed: {e}")))?;
-
-                let mut result = Vec::new();
-                for entry in entries {
-                    let name = entry.file_name();
-                    if name == "." || name == ".." {
-                        continue;
-                    }
-                    let meta = entry.metadata();
-                    let full_path = format!("{}/{}", path.trim_end_matches('/'), name);
-                    let permissions = meta.permissions.map(format_permissions);
-                    let writable = permissions.as_deref().and_then(writable_from_permissions);
-                    // `read_dir` returns lstat-style attributes, so this flags
-                    // the link itself. Resolve the target with a best-effort
-                    // `readlink` only for link rows — a plain file never
-                    // triggers the extra round-trip.
-                    let is_symlink = meta.is_symlink();
-                    let symlink_target = if is_symlink {
-                        self.sftp.read_link(full_path.clone()).await.ok()
-                    } else {
-                        None
-                    };
-                    result.push(FileEntry {
-                        name,
-                        path: full_path,
-                        is_directory: meta.is_dir(),
-                        size: meta.size.unwrap_or(0),
-                        modified: meta
-                            .mtime
-                            .map(|t| chrono_from_epoch(t as u64))
-                            .unwrap_or_default(),
-                        permissions,
-                        writable,
-                        is_symlink,
-                        symlink_target,
-                    });
-                }
-                Ok::<Vec<FileEntry>, TerminalError>(result)
+                    .map_err(|e| TerminalError::SshError(format!("readdir failed: {e}")))
             })
         })
     }
@@ -486,34 +427,9 @@ impl SftpSession {
         let path = path.to_string();
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
-                let meta = self
-                    .sftp
-                    .metadata(&path)
+                sftp::stat(&self.sftp, &path)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("stat failed: {e}")))?;
-
-                let name = std::path::Path::new(&path)
-                    .file_name()
-                    .map(|n| n.to_string_lossy().to_string())
-                    .unwrap_or_default();
-
-                let permissions = meta.permissions.map(format_permissions);
-                let writable = permissions.as_deref().and_then(writable_from_permissions);
-                Ok::<FileEntry, TerminalError>(FileEntry {
-                    name,
-                    path,
-                    is_directory: meta.is_dir(),
-                    size: meta.size.unwrap_or(0),
-                    modified: meta
-                        .mtime
-                        .map(|t| chrono_from_epoch(t as u64))
-                        .unwrap_or_default(),
-                    permissions,
-                    writable,
-                    // `metadata` follows the link, so this reports the target.
-                    is_symlink: meta.is_symlink(),
-                    symlink_target: None,
-                })
+                    .map_err(|e| TerminalError::SshError(format!("stat failed: {e}")))
             })
         })
     }

--- a/src-tauri/src/utils/remote_exec.rs
+++ b/src-tauri/src/utils/remote_exec.rs
@@ -9,6 +9,7 @@ use russh_sftp::client::SftpSession;
 use tracing::debug;
 
 use termihub_core::backends::ssh::handler::SshSession;
+use termihub_core::backends::ssh::sftp;
 
 use crate::utils::errors::TerminalError;
 
@@ -209,20 +210,13 @@ pub fn remove_via_sftp(session: &SshSession, remote_path: &str) -> Result<(), Te
 }
 
 /// Open a fresh SFTP subsystem on the given session.
+///
+/// Delegates to the shared core mechanism so every SFTP path opens the
+/// subsystem the same way (#2075).
 async fn open_sftp(session: &SshSession) -> Result<SftpSession, TerminalError> {
-    let channel = session
-        .channel_open_session()
+    sftp::open_sftp_subsystem(session)
         .await
-        .map_err(|e| TerminalError::SshError(format!("SFTP channel open failed: {e}")))?;
-
-    channel
-        .request_subsystem(true, "sftp")
-        .await
-        .map_err(|e| TerminalError::SshError(format!("SFTP subsystem request failed: {e}")))?;
-
-    SftpSession::new(channel.into_stream())
-        .await
-        .map_err(|e| TerminalError::SshError(format!("SFTP init failed: {e}")))
+        .map_err(|e| TerminalError::SshError(e.to_string()))
 }
 
 // ── ELF architecture detection ───────────────────────────────────────


### PR DESCRIPTION
## What

Converges the two forked SFTP implementations onto a single shared core module, addressing the core of #2075 (the "fix once" goal undercut by byte-for-byte duplicated russh-sftp plumbing).

New module **`core::backends::ssh::sftp`** holds the mechanics both paths had forked:

- `open_sftp_subsystem()` — open a fresh SFTP subsystem channel on an authenticated SSH session.
- `list_dir()` / `stat()` — map russh-sftp `readdir`/`metadata` attributes into `FileEntry` (permission string, conservative `writable` hint, best-effort symlink `readlink`), identically for every caller.

Four call sites now consume it instead of duplicating it:

1. `core::backends::ssh::file_browser::SftpFileBrowser` (the core `FileBrowser` trait path).
2. `src-tauri` `SftpSession` — directory browsing **and** the dedicated per-transfer channel (`open_dedicated_sftp`, #1245).
3. `src-tauri` `remote_exec::open_sftp`.

## Behavior preserved

This is a behavior-preserving refactor. All desktop-only capabilities are untouched and still work — they are now layered **on top of** the shared primitives rather than forking them:

- Elevated `sudo` writes (`write_file_content_elevated`, #1323/#1328)
- The write-open writability probe (`check_writable` / `Writability`)
- The exec-capability probe (`has_exec_capability`)
- `realpath`, `remote_size`, and the cancellable transfer queue

The core path keeps its jump-host support (`connect_target`, #939). Error messages at each call site are preserved.

## Verification

- `core` unit tests: **1115 passed**; `src-tauri` unit tests: **1307 passed**.
- New unit tests for the shared mapping (regular file, directory, read-only hint, symlink target, missing permissions) — **6 passed**.
- **SFTP integration suite run locally against the live `sftp-stress` fixture: `core/tests/sftp_stress.rs` — all 16 passed** (download 1/10/100 MB, upload round-trip, wide dir listing, deep tree, valid/broken/circular symlinks, unicode/spaces/long names, dotfiles, permission-000 file/dir). This exercises the refactored `open_sftp_subsystem` / `list_dir` / `stat` / read/write end-to-end.
- Docker-backed elevated-save tests in `src-tauri/src/files/sftp.rs` pass.
- `cargo fmt --check` and `cargo clippy --all-features --all-targets` clean.

Note: `src-tauri/tests/sftp_transfer.rs` cannot run in this environment because it does not register the fixture host-key verifier that the core suite uses (`trust_fixture_host_keys`), so a freshly-built container's host key is refused pre-auth with "Unknown server key". Verified this failure reproduces identically on clean `develop` against the same container — it is a pre-existing harness gap, not introduced here. Filed as a follow-up.

## Scope / follow-ups

This is the safe first step (the issue's "extract shared russh-sftp mechanics into one core module both consume" option). The deeper trait-level convergence — pushing the desktop-only capabilities into core *behind the `FileBrowser` trait*, migrating the desktop command layer onto the core trait, and removing the dead `SftpFileBackend` — needs the integration suite and is deferred:

- Full trait-level convergence: #2104
- Desktop `sftp_transfer.rs` host-key trust gap: #2105

Part of #2075 (left open for the follow-up work above).
