### PR TITLE
fix(ui): make the remote agents sidebar list scrollable

### DIFF
--- a/docs/changes/dev4/fix/2106-remote-agents-scroll.md
+++ b/docs/changes/dev4/fix/2106-remote-agents-scroll.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Remote Agents sidebar: the agent-connections list is now scrollable. With
+  more agent connections than fit the panel height the overflow rows were
+  clipped and unreachable; the list now scrolls internally while the
+  section header and the "Filter agent connections…" box stay pinned (#2106).

--- a/src/components/Sidebar/ConnectionList.css
+++ b/src/components/Sidebar/ConnectionList.css
@@ -23,6 +23,20 @@
   overflow: hidden;
 }
 
+/*
+ * Scroll container for the agent list. The header + filter above it stay
+ * pinned; only this region scrolls. `min-height: 0` lets it shrink below its
+ * content inside the flex column so it scrolls internally instead of forcing
+ * the whole Remote Agents section to overflow and clip rows (#2106).
+ */
+.connection-list__agents-scroll {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+}
+
 /* Resize handle between sidebar sections */
 .connection-list__resize-handle {
   height: 1px;

--- a/src/components/Sidebar/ConnectionList.remote-agents-scroll.test.tsx
+++ b/src/components/Sidebar/ConnectionList.remote-agents-scroll.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Regression tests for #2106: the "Remote Agents" sidebar list must be
+ * scrollable. With more agent connections than fit the panel height, the
+ * overflow rows were clipped by the section's `overflow: hidden` and could not
+ * be reached because the agent rows were rendered directly in the section with
+ * no scroll container.
+ *
+ * The fix wraps the agent rows in a dedicated
+ * `.connection-list__agents-scroll` container (`flex: 1 1 auto; min-height: 0;
+ * overflow-y: auto`) so the list scrolls internally while the section header
+ * and the filter box stay pinned above it. jsdom does not do layout, so these
+ * tests assert the structural invariants that make scrolling possible:
+ *  - every agent row renders inside the scroll container, and
+ *  - the header + filter live OUTSIDE it (so they stay pinned, not scrolled).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { ConnectionList } from "./ConnectionList";
+import { TooltipProvider } from "@/components/ui";
+import { DEFAULT_AGENT_SETTINGS, type RemoteAgentDefinition } from "@/types/connection";
+
+vi.mock("@/services/api", () => ({
+  listAvailableShells: vi.fn(() => Promise.resolve([])),
+  createTerminal: vi.fn(() => Promise.resolve({ sessionId: "s1" })),
+  removeCredential: vi.fn(),
+  storeCredential: vi.fn(),
+  resolveCredential: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({
+  frontendLog: vi.fn(),
+}));
+
+vi.mock("./AgentNode", () => ({
+  AgentNode: ({
+    agent,
+    style,
+    sectionRef,
+  }: {
+    agent: RemoteAgentDefinition;
+    style?: React.CSSProperties;
+    sectionRef?: (el: HTMLDivElement | null) => void;
+  }) =>
+    React.createElement("div", {
+      ref: sectionRef,
+      "data-testid": `agent-node-${agent.id}`,
+      style,
+    }),
+}));
+
+function makeAgent(i: number): RemoteAgentDefinition {
+  return {
+    id: `agent-${i}`,
+    name: `Agent ${i}`,
+    config: {
+      host: `10.0.0.${i}`,
+      port: 22,
+      username: "user",
+      authMethod: "password",
+    },
+    connectionState: "disconnected",
+    isExpanded: false,
+    agentSettings: DEFAULT_AGENT_SETTINGS,
+  };
+}
+
+const baseSettings = {
+  version: "1",
+  externalConnectionFiles: [] as [],
+  powerMonitoringEnabled: true,
+  fileBrowserEnabled: true,
+  experimentalFeaturesEnabled: true,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render() {
+  act(() => {
+    root.render(
+      React.createElement(TooltipProvider, {
+        delayDuration: 0,
+        children: React.createElement(ConnectionList),
+      })
+    );
+  });
+}
+
+describe("ConnectionList – Remote Agents scroll (#2106)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ settings: { ...baseSettings } });
+    useAppStore.setState({
+      remoteAgents: Array.from({ length: 15 }, (_, i) => makeAgent(i)),
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("wraps the agent list in a dedicated scroll container", () => {
+    render();
+    const scroll = container.querySelector('[data-testid="remote-agents-scroll"]');
+    expect(scroll).toBeTruthy();
+    expect(scroll?.classList.contains("connection-list__agents-scroll")).toBe(true);
+  });
+
+  it("renders every agent row inside the scroll container so overflow rows are reachable", () => {
+    render();
+    const scroll = container.querySelector('[data-testid="remote-agents-scroll"]');
+    expect(scroll).toBeTruthy();
+
+    for (let i = 0; i < 15; i++) {
+      const node = container.querySelector(`[data-testid="agent-node-agent-${i}"]`);
+      expect(node, `agent-${i} should render`).toBeTruthy();
+      // Each agent row must live inside the scroll container, not clipped above it.
+      expect(scroll?.contains(node)).toBe(true);
+    }
+  });
+
+  it("keeps the header and filter pinned outside the scroll container", () => {
+    render();
+    const scroll = container.querySelector('[data-testid="remote-agents-scroll"]');
+    const header = container.querySelector('[data-testid="sidebar-group-header-remote-agents"]');
+    const filter = container.querySelector('[data-testid="agent-filter-input"]');
+
+    expect(header).toBeTruthy();
+    expect(filter).toBeTruthy();
+    // Header + filter are siblings above the scroll region, not scrolled with it.
+    expect(scroll?.contains(header)).toBe(false);
+    expect(scroll?.contains(filter)).toBe(false);
+  });
+});

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -1416,30 +1416,35 @@ export function ConnectionList() {
                   items={remoteAgents.map((a) => a.id)}
                   strategy={verticalListSortingStrategy}
                 >
-                  {remoteAgents.map((agent, i) => {
-                    const innerIdx = innerExpandedIndexMap[i];
-                    const innerResizeProps = i > 0 ? getInnerResizeHandleProps(i) : {};
-                    const isInnerResizable = "onMouseDown" in innerResizeProps;
-                    return (
-                      <Fragment key={agent.id}>
-                        {i > 0 && (
-                          <div
-                            className={`connection-list__resize-handle${isInnerResizable ? " connection-list__resize-handle--resizable" : ""}`}
-                            data-testid={`sidebar-group-separator-${i - 1}`}
-                            {...innerResizeProps}
+                  <div
+                    className="connection-list__agents-scroll"
+                    data-testid="remote-agents-scroll"
+                  >
+                    {remoteAgents.map((agent, i) => {
+                      const innerIdx = innerExpandedIndexMap[i];
+                      const innerResizeProps = i > 0 ? getInnerResizeHandleProps(i) : {};
+                      const isInnerResizable = "onMouseDown" in innerResizeProps;
+                      return (
+                        <Fragment key={agent.id}>
+                          {i > 0 && (
+                            <div
+                              className={`connection-list__resize-handle${isInnerResizable ? " connection-list__resize-handle--resizable" : ""}`}
+                              data-testid={`sidebar-group-separator-${i - 1}`}
+                              {...innerResizeProps}
+                            />
+                          )}
+                          <AgentNode
+                            agent={agent}
+                            filterQuery={agentFilterQuery}
+                            style={innerIdx >= 0 ? { flex: innerFlexValues[innerIdx] } : undefined}
+                            sectionRef={(el) => {
+                              if (innerIdx >= 0) innerSectionRefs.current[innerIdx] = el;
+                            }}
                           />
-                        )}
-                        <AgentNode
-                          agent={agent}
-                          filterQuery={agentFilterQuery}
-                          style={innerIdx >= 0 ? { flex: innerFlexValues[innerIdx] } : undefined}
-                          sectionRef={(el) => {
-                            if (innerIdx >= 0) innerSectionRefs.current[innerIdx] = el;
-                          }}
-                        />
-                      </Fragment>
-                    );
-                  })}
+                        </Fragment>
+                      );
+                    })}
+                  </div>
                 </SortableContext>
               )}
             </div>


### PR DESCRIPTION
## Problem

The **REMOTE AGENTS** sidebar section did not scroll. With more agent connections than fit the panel height, the overflow rows were clipped by the section's `overflow: hidden` and were unreachable — the agent rows were rendered directly in the flex section with no scroll container.

## Fix

Wrap the agent-connections list in a dedicated `.connection-list__agents-scroll` container:

```css
.connection-list__agents-scroll {
  display: flex;
  flex-direction: column;
  flex: 1 1 auto;
  min-height: 0;      /* lets it shrink below content so it scrolls internally */
  overflow-y: auto;
}
```

This mirrors the proven `.connection-list__tree` pattern used by the (scrollable) Connections tree. The section **header** and the **"Filter agent connections…"** box stay pinned above the scroll region; only the agent list scrolls. The per-agent inner resize/flex behaviour is unchanged (the scroll wrapper is itself a flex column).

The truncated agent name already carries a full-name tooltip: the agent header row has `title={`Remote agent: ${agent.name}`}`, so the secondary nice-to-have is already satisfied — no change needed there.

## Verification

- New component regression test (`ConnectionList.remote-agents-scroll.test.tsx`): with 15 agents, every row renders inside the scroll container and the header + filter live outside it (pinned).
- Real-layout check in headless Chrome using the exact CSS + a height-constrained sidebar: with 15 rows the list is scrollable, the last row is reachable by scrolling, and the header stays pinned above the scroll box (measured `scrollHeight > clientHeight`, last-row in view after `scrollTop = scrollHeight`).
- `pnpm run lint`, `pnpm run build` (tsc), and the Sidebar test suite pass.

Closes #2106