### PR TITLE
refactor(store): extract ssh tunnel domain into a zustand slice (#2077)

### DIFF
--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -165,7 +165,7 @@ import {
   type TransferSeed,
 } from "@/types/transfer";
 import { RemoteAgentConfig } from "@/types/terminal";
-import { TunnelConfig, TunnelState } from "@/types/tunnel";
+import { createTunnelSlice, TunnelSlice } from "./slices/tunnelSlice";
 import { EmbeddedServerConfig, ServerState as EmbeddedServerState } from "@/types/embeddedServer";
 import {
   listEmbeddedServers,
@@ -177,14 +177,6 @@ import {
   createAndStartServer as apiCreateAndStartServer,
 } from "@/services/embeddedServerApi";
 import { DEFAULT_PORTS, ServerType } from "@/types/embeddedServer";
-import {
-  getTunnels,
-  saveTunnel as apiSaveTunnel,
-  deleteTunnel as apiDeleteTunnel,
-  startTunnel as apiStartTunnel,
-  stopTunnel as apiStopTunnel,
-  getTunnelStatuses,
-} from "@/services/tunnelApi";
 import {
   WorkspaceSummary,
   WorkspaceDefinition,
@@ -484,7 +476,7 @@ export interface AgentUpdatePending {
  */
 const AGENT_UPDATE_RECONNECT_BUFFER_SECS = 3;
 
-interface AppState {
+export interface AppState extends TunnelSlice {
   // Connection type registry (loaded from backend at startup)
   connectionTypes: ConnectionTypeInfo[];
 
@@ -1459,17 +1451,8 @@ interface AppState {
   setRemoteDesktopResolution: (sessionId: string, width: number, height: number) => void;
   clearRemoteDesktopResolution: (sessionId: string) => void;
 
-  // SSH Tunnels
-  tunnels: TunnelConfig[];
-  tunnelStates: Record<string, TunnelState>;
-  loadTunnels: () => Promise<void>;
-  saveTunnel: (config: TunnelConfig) => Promise<void>;
-  deleteTunnel: (tunnelId: string) => Promise<void>;
-  startTunnel: (tunnelId: string) => Promise<void>;
-  stopTunnel: (tunnelId: string) => Promise<void>;
-  /** Force-reconnect a connected tunnel (stop + start), for a stale-but-green tunnel (#1243). */
-  reconnectTunnel: (tunnelId: string) => Promise<void>;
-  updateTunnelState: (state: TunnelState) => void;
+  // SSH Tunnels — tunnel data + lifecycle live in TunnelSlice (#2077); the
+  // tab-opening action stays here as it belongs to the panel/tab domain.
   openTunnelEditorTab: (tunnelId: string | null) => void;
 
   // Embedded Servers
@@ -2965,15 +2948,7 @@ function isSftpSessionDeadError(message: string): boolean {
   );
 }
 
-// In-flight guards for tunnel start/stop (GAP 4, #1141). A rapid double-click on
-// Start/Stop for a tunnel that is already `connecting` must not fire a second
-// backend call — that produces spurious "already active/connecting" error toasts
-// and can flip the visible state. We track the id of each tunnel whose start/stop
-// call has not yet resolved and no-op any re-entrant call for the same id.
-const _tunnelStartInFlight = new Set<string>();
-const _tunnelStopInFlight = new Set<string>();
-
-export const useAppStore = create<AppState>((set, get) => {
+export const useAppStore = create<AppState>((set, get, store) => {
   // Reload connections from the backend, applying the result only if this
   // reload was initiated more recently than the last applied one.
   /**
@@ -3021,6 +2996,10 @@ export const useAppStore = create<AppState>((set, get) => {
   };
 
   return {
+    // Domain slices (#2077) — extracted from this monolith, spread in first so
+    // the root store keeps the same public shape and behavior.
+    ...createTunnelSlice(set, get, store),
+
     // Connection type registry — updated by loadFromBackend()
     connectionTypes: [],
 
@@ -7348,10 +7327,6 @@ export const useAppStore = create<AppState>((set, get) => {
       await useAppStore.getState().disconnectMonitoring(key);
     },
 
-    // SSH Tunnels
-    tunnels: [],
-    tunnelStates: {},
-
     refreshConnectionTypes: async () => {
       try {
         const connectionTypes = await getConnectionTypes();
@@ -7362,149 +7337,6 @@ export const useAppStore = create<AppState>((set, get) => {
           `Failed to refresh connection types: ${err instanceof Error ? err.message : String(err)}`
         );
       }
-    },
-
-    loadTunnels: async () => {
-      try {
-        const tunnels = await getTunnels();
-        const statuses = await getTunnelStatuses();
-        const tunnelStates: Record<string, TunnelState> = {};
-        for (const s of statuses) {
-          tunnelStates[s.tunnelId] = s;
-        }
-        set({ tunnels, tunnelStates });
-      } catch (err) {
-        frontendLog(
-          "app_store",
-          `Failed to load tunnels: ${err instanceof Error ? err.message : String(err)}`
-        );
-      }
-    },
-
-    saveTunnel: async (config) => {
-      try {
-        await apiSaveTunnel(config);
-        set((state) => {
-          const exists = state.tunnels.some((t) => t.id === config.id);
-          const tunnels = exists
-            ? state.tunnels.map((t) => (t.id === config.id ? config : t))
-            : [...state.tunnels, config];
-          return { tunnels };
-        });
-      } catch (err) {
-        frontendLog(
-          "app_store",
-          `Failed to save tunnel: ${err instanceof Error ? err.message : String(err)}`
-        );
-        throw err;
-      }
-    },
-
-    deleteTunnel: async (tunnelId) => {
-      const name = get().tunnels.find((t) => t.id === tunnelId)?.name ?? "tunnel";
-      const toastId = toast.loading(`Deleting ${name}…`);
-      try {
-        await apiDeleteTunnel(tunnelId);
-        set((state) => ({
-          tunnels: state.tunnels.filter((t) => t.id !== tunnelId),
-          tunnelStates: Object.fromEntries(
-            Object.entries(state.tunnelStates).filter(([k]) => k !== tunnelId)
-          ),
-        }));
-        toast.success(`Deleted ${name}`, { id: toastId });
-      } catch (err) {
-        toast.error(
-          `Failed to delete ${name}: ${err instanceof Error ? err.message : String(err)}`,
-          { id: toastId }
-        );
-        throw err;
-      }
-    },
-
-    startTunnel: async (tunnelId) => {
-      // GAP 4 (#1141): ignore a re-entrant start while a prior start for the
-      // same tunnel is still in flight, so a rapid double-click can't fire a
-      // second backend call (spurious "already connecting/active" toast).
-      if (_tunnelStartInFlight.has(tunnelId)) return;
-      _tunnelStartInFlight.add(tunnelId);
-      const name = get().tunnels.find((t) => t.id === tunnelId)?.name ?? "tunnel";
-      const toastId = toast.loading(`Starting ${name}…`);
-      try {
-        await apiStartTunnel(tunnelId);
-        toast.success(`Started ${name}`, { id: toastId });
-      } catch (err) {
-        frontendLog(
-          "app_store",
-          `Failed to start tunnel: ${err instanceof Error ? err.message : String(err)}`
-        );
-        toast.error(
-          `Failed to start ${name}: ${err instanceof Error ? err.message : String(err)}`,
-          { id: toastId }
-        );
-        throw err;
-      } finally {
-        _tunnelStartInFlight.delete(tunnelId);
-      }
-    },
-
-    stopTunnel: async (tunnelId) => {
-      // GAP 4 (#1141): ignore a re-entrant stop while a prior stop for the same
-      // tunnel is still in flight (see startTunnel).
-      if (_tunnelStopInFlight.has(tunnelId)) return;
-      _tunnelStopInFlight.add(tunnelId);
-      const name = get().tunnels.find((t) => t.id === tunnelId)?.name ?? "tunnel";
-      const toastId = toast.loading(`Stopping ${name}…`);
-      try {
-        await apiStopTunnel(tunnelId);
-        toast.success(`Stopped ${name}`, { id: toastId });
-      } catch (err) {
-        frontendLog(
-          "app_store",
-          `Failed to stop tunnel: ${err instanceof Error ? err.message : String(err)}`
-        );
-        toast.error(`Failed to stop ${name}: ${err instanceof Error ? err.message : String(err)}`, {
-          id: toastId,
-        });
-        throw err;
-      } finally {
-        _tunnelStopInFlight.delete(tunnelId);
-      }
-    },
-
-    reconnectTunnel: async (tunnelId) => {
-      // Force-reconnect a connected tunnel: tear it down and start it again,
-      // even if the backend supervisor's liveness has not fired yet — covers a
-      // stale-but-green tunnel (#1243). Guarded by the same in-flight sets as
-      // start/stop so a rapid double-click cannot overlap the sequence.
-      if (_tunnelStartInFlight.has(tunnelId) || _tunnelStopInFlight.has(tunnelId)) return;
-      _tunnelStopInFlight.add(tunnelId);
-      _tunnelStartInFlight.add(tunnelId);
-      const name = get().tunnels.find((t) => t.id === tunnelId)?.name ?? "tunnel";
-      const toastId = toast.loading(`Reconnecting ${name}…`);
-      try {
-        await apiStopTunnel(tunnelId);
-        await apiStartTunnel(tunnelId);
-        toast.success(`Reconnected ${name}`, { id: toastId });
-      } catch (err) {
-        frontendLog(
-          "app_store",
-          `Failed to reconnect tunnel: ${err instanceof Error ? err.message : String(err)}`
-        );
-        toast.error(
-          `Failed to reconnect ${name}: ${err instanceof Error ? err.message : String(err)}`,
-          { id: toastId }
-        );
-        throw err;
-      } finally {
-        _tunnelStopInFlight.delete(tunnelId);
-        _tunnelStartInFlight.delete(tunnelId);
-      }
-    },
-
-    updateTunnelState: (state) => {
-      set((s) => ({
-        tunnelStates: { ...s.tunnelStates, [state.tunnelId]: state },
-      }));
     },
 
     openTunnelEditorTab: (tunnelId) =>

--- a/src/store/slices/tunnelSlice.ts
+++ b/src/store/slices/tunnelSlice.ts
@@ -1,0 +1,193 @@
+import { StateCreator } from "zustand";
+
+import { toast } from "@/components/ui";
+import {
+  getTunnels,
+  saveTunnel as apiSaveTunnel,
+  deleteTunnel as apiDeleteTunnel,
+  startTunnel as apiStartTunnel,
+  stopTunnel as apiStopTunnel,
+  getTunnelStatuses,
+} from "@/services/tunnelApi";
+import { TunnelConfig, TunnelState } from "@/types/tunnel";
+import { frontendLog } from "@/utils/frontendLog";
+
+import type { AppState } from "../appStore";
+
+// In-flight guards for tunnel start/stop (GAP 4, #1141). A rapid double-click on
+// Start/Stop for a tunnel that is already `connecting` must not fire a second
+// backend call — that produces spurious "already active/connecting" error toasts
+// and can flip the visible state. We track the id of each tunnel whose start/stop
+// call has not yet resolved and no-op any re-entrant call for the same id.
+const _tunnelStartInFlight = new Set<string>();
+const _tunnelStopInFlight = new Set<string>();
+
+/**
+ * SSH tunnel domain slice (#2077): the tunnel config list, live tunnel states,
+ * and the CRUD/lifecycle actions that drive them. Extracted verbatim from the
+ * monolithic root store as a behavior-preserving Zustand slice — every action
+ * still receives the shared `set`/`get` typed against the full {@link AppState},
+ * so the public store shape and behavior are unchanged.
+ *
+ * Note: `openTunnelEditorTab` is intentionally NOT part of this slice — it is a
+ * tab/panel action (it creates a tab via the root store's `createTab` factory)
+ * and moves with the panel/tab slice when that domain is extracted.
+ */
+export interface TunnelSlice {
+  tunnels: TunnelConfig[];
+  tunnelStates: Record<string, TunnelState>;
+  loadTunnels: () => Promise<void>;
+  saveTunnel: (config: TunnelConfig) => Promise<void>;
+  deleteTunnel: (tunnelId: string) => Promise<void>;
+  startTunnel: (tunnelId: string) => Promise<void>;
+  stopTunnel: (tunnelId: string) => Promise<void>;
+  /** Force-reconnect a connected tunnel (stop + start), for a stale-but-green tunnel (#1243). */
+  reconnectTunnel: (tunnelId: string) => Promise<void>;
+  updateTunnelState: (state: TunnelState) => void;
+}
+
+export const createTunnelSlice: StateCreator<AppState, [], [], TunnelSlice> = (set, get) => ({
+  tunnels: [],
+  tunnelStates: {},
+
+  loadTunnels: async () => {
+    try {
+      const tunnels = await getTunnels();
+      const statuses = await getTunnelStatuses();
+      const tunnelStates: Record<string, TunnelState> = {};
+      for (const s of statuses) {
+        tunnelStates[s.tunnelId] = s;
+      }
+      set({ tunnels, tunnelStates });
+    } catch (err) {
+      frontendLog(
+        "app_store",
+        `Failed to load tunnels: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  },
+
+  saveTunnel: async (config) => {
+    try {
+      await apiSaveTunnel(config);
+      set((state) => {
+        const exists = state.tunnels.some((t) => t.id === config.id);
+        const tunnels = exists
+          ? state.tunnels.map((t) => (t.id === config.id ? config : t))
+          : [...state.tunnels, config];
+        return { tunnels };
+      });
+    } catch (err) {
+      frontendLog(
+        "app_store",
+        `Failed to save tunnel: ${err instanceof Error ? err.message : String(err)}`
+      );
+      throw err;
+    }
+  },
+
+  deleteTunnel: async (tunnelId) => {
+    const name = get().tunnels.find((t) => t.id === tunnelId)?.name ?? "tunnel";
+    const toastId = toast.loading(`Deleting ${name}…`);
+    try {
+      await apiDeleteTunnel(tunnelId);
+      set((state) => ({
+        tunnels: state.tunnels.filter((t) => t.id !== tunnelId),
+        tunnelStates: Object.fromEntries(
+          Object.entries(state.tunnelStates).filter(([k]) => k !== tunnelId)
+        ),
+      }));
+      toast.success(`Deleted ${name}`, { id: toastId });
+    } catch (err) {
+      toast.error(`Failed to delete ${name}: ${err instanceof Error ? err.message : String(err)}`, {
+        id: toastId,
+      });
+      throw err;
+    }
+  },
+
+  startTunnel: async (tunnelId) => {
+    // GAP 4 (#1141): ignore a re-entrant start while a prior start for the
+    // same tunnel is still in flight, so a rapid double-click can't fire a
+    // second backend call (spurious "already connecting/active" toast).
+    if (_tunnelStartInFlight.has(tunnelId)) return;
+    _tunnelStartInFlight.add(tunnelId);
+    const name = get().tunnels.find((t) => t.id === tunnelId)?.name ?? "tunnel";
+    const toastId = toast.loading(`Starting ${name}…`);
+    try {
+      await apiStartTunnel(tunnelId);
+      toast.success(`Started ${name}`, { id: toastId });
+    } catch (err) {
+      frontendLog(
+        "app_store",
+        `Failed to start tunnel: ${err instanceof Error ? err.message : String(err)}`
+      );
+      toast.error(`Failed to start ${name}: ${err instanceof Error ? err.message : String(err)}`, {
+        id: toastId,
+      });
+      throw err;
+    } finally {
+      _tunnelStartInFlight.delete(tunnelId);
+    }
+  },
+
+  stopTunnel: async (tunnelId) => {
+    // GAP 4 (#1141): ignore a re-entrant stop while a prior stop for the same
+    // tunnel is still in flight (see startTunnel).
+    if (_tunnelStopInFlight.has(tunnelId)) return;
+    _tunnelStopInFlight.add(tunnelId);
+    const name = get().tunnels.find((t) => t.id === tunnelId)?.name ?? "tunnel";
+    const toastId = toast.loading(`Stopping ${name}…`);
+    try {
+      await apiStopTunnel(tunnelId);
+      toast.success(`Stopped ${name}`, { id: toastId });
+    } catch (err) {
+      frontendLog(
+        "app_store",
+        `Failed to stop tunnel: ${err instanceof Error ? err.message : String(err)}`
+      );
+      toast.error(`Failed to stop ${name}: ${err instanceof Error ? err.message : String(err)}`, {
+        id: toastId,
+      });
+      throw err;
+    } finally {
+      _tunnelStopInFlight.delete(tunnelId);
+    }
+  },
+
+  reconnectTunnel: async (tunnelId) => {
+    // Force-reconnect a connected tunnel: tear it down and start it again,
+    // even if the backend supervisor's liveness has not fired yet — covers a
+    // stale-but-green tunnel (#1243). Guarded by the same in-flight sets as
+    // start/stop so a rapid double-click cannot overlap the sequence.
+    if (_tunnelStartInFlight.has(tunnelId) || _tunnelStopInFlight.has(tunnelId)) return;
+    _tunnelStopInFlight.add(tunnelId);
+    _tunnelStartInFlight.add(tunnelId);
+    const name = get().tunnels.find((t) => t.id === tunnelId)?.name ?? "tunnel";
+    const toastId = toast.loading(`Reconnecting ${name}…`);
+    try {
+      await apiStopTunnel(tunnelId);
+      await apiStartTunnel(tunnelId);
+      toast.success(`Reconnected ${name}`, { id: toastId });
+    } catch (err) {
+      frontendLog(
+        "app_store",
+        `Failed to reconnect tunnel: ${err instanceof Error ? err.message : String(err)}`
+      );
+      toast.error(
+        `Failed to reconnect ${name}: ${err instanceof Error ? err.message : String(err)}`,
+        { id: toastId }
+      );
+      throw err;
+    } finally {
+      _tunnelStopInFlight.delete(tunnelId);
+      _tunnelStartInFlight.delete(tunnelId);
+    }
+  },
+
+  updateTunnelState: (state) => {
+    set((s) => ({
+      tunnelStates: { ...s.tunnelStates, [state.tunnelId]: state },
+    }));
+  },
+});


### PR DESCRIPTION
## Summary

First incremental slice of the `src/store/appStore.ts` monolith (~9k lines,
single ~1130-member `create<AppState>()` call) toward the Zustand **slices**
pattern, per #2077.

This PR extracts the **SSH tunnel** domain — the cleanest, lowest-coupling
domain in the store — into a dedicated `StateCreator` slice:

- New file `src/store/slices/tunnelSlice.ts` exporting `TunnelSlice` +
  `createTunnelSlice`.
- Moved: state `tunnels` / `tunnelStates`; actions `loadTunnels`, `saveTunnel`,
  `deleteTunnel`, `startTunnel`, `stopTunnel`, `reconnectTunnel`,
  `updateTunnelState`; and the module-level `_tunnelStartInFlight` /
  `_tunnelStopInFlight` re-entrancy guards (#1141).
- Combined into the root store via `...createTunnelSlice(set, get, store)`.
- `AppState` is now exported and `extends TunnelSlice`.

## Zero behavior change

Pure structural extraction. Each action still receives the shared `set`/`get`
typed against the full `AppState`, so the public store shape and every action
behave identically — no consumer changes needed.

`openTunnelEditorTab` deliberately stays in the root store: it creates a tab via
the module-local `createTab`/`tabCounter` factory, so it belongs to the
panel/tab domain and will move with that slice later (not the tunnel data
domain).

## Verification

- Full frontend test suite: **4662 tests / 496 files green**, including
  `appStore.tunnel-delete` and `appStore.tunnel-reentrancy`.
- `tsc --noEmit`, `eslint`, and `prettier --check` all clean.

## Scope

One domain per PR by design — #2077 stays **open**. Follow-ups for the remaining
domains (embedded servers, macros, plugins, transfers, …) are filed separately
and linked from #2077.