### PR TITLE
test(sftp): trust fixture host key in sftp_transfer integration test

### DIFF
--- a/src-tauri/tests/sftp_transfer.rs
+++ b/src-tauri/tests/sftp_transfer.rs
@@ -51,9 +51,46 @@ fn is_port_reachable(port: u16) -> bool {
         .unwrap_or(false)
 }
 
+/// Register a process-wide host-key verifier that trusts the local Docker
+/// fixture containers, so these desktop SFTP integration tests connect
+/// deterministically under the strict default host-key policy (#1969, #2032).
+///
+/// `SftpSession::new` goes through the same strict host-key path as the rest of
+/// the app: with no verifier registered it trusts only keys already recorded in
+/// the runner's `~/.ssh/known_hosts` and refuses everything else with "Unknown
+/// server key". CI runners (and any freshly-(re)built fixture image) never have
+/// the generated fixture key recorded, so the handshake fails pre-auth (#2105).
+/// These tests connect only to the loopback `sftp-stress` fixture, where there
+/// is no man-in-the-middle to guard against, so a test-only verifier that trusts
+/// every fixture key is safe and deterministic. This mirrors core's
+/// `trust_fixture_host_keys()` (`core/tests/common/mod.rs`). Registration is
+/// set-once and idempotent (first call wins), so calling it from every
+/// `require_sftp_stress!` site is harmless.
+fn trust_fixture_host_keys() {
+    use termihub_core::backends::ssh::host_key::{
+        set_host_key_verifier, HostKeyInfo, HostKeyVerifier,
+    };
+
+    struct TrustLocalFixtures;
+
+    #[async_trait::async_trait]
+    impl HostKeyVerifier for TrustLocalFixtures {
+        async fn verify(&self, _info: &HostKeyInfo) -> bool {
+            true
+        }
+    }
+
+    // First registration wins; any later call is a harmless no-op.
+    let _ = set_host_key_verifier(Arc::new(TrustLocalFixtures));
+}
+
 /// Skip the current test if the sftp-stress container is not reachable.
 macro_rules! require_sftp_stress {
     ($port:expr) => {
+        // Trust the loopback fixture host key before connecting, so the strict
+        // default host-key policy (#1969) does not refuse the freshly-built
+        // fixture container with "Unknown server key" (#2105, sibling of #2032).
+        trust_fixture_host_keys();
         if !is_port_reachable($port) {
             eprintln!(
                 "SKIPPED: sftp-stress container not reachable on port {} \


### PR DESCRIPTION
## Summary

`src-tauri/tests/sftp_transfer.rs` connects to the `sftp-stress` Docker fixture through the desktop `SftpSession::new` path, which enforces the strict default host-key policy (#1969). Unlike the core integration suite, it never registered a host-key verifier trusting the loopback fixtures, so whenever the fixture container's key is not already in the runner's `~/.ssh/known_hosts` (e.g. right after the image is rebuilt), every test failed pre-auth with:

```
SSH handshake failed: Unknown server key
```

## Fix

Add a test-only `trust_fixture_host_keys()` helper that registers a process-wide `HostKeyVerifier` trusting the loopback fixtures, and call it from the `require_sftp_stress!` skip macro before any connection. This mirrors core's `trust_fixture_host_keys()` in `core/tests/common/mod.rs` (added in #2032 for the sibling monitoring flake). The core helper lives in the core crate's private test-support module and is not reachable from the desktop test crate, so the small verifier is duplicated rather than shared. Host-key verification is **not** weakened outside this test binary — the verifier is set-once and only registered inside the test process, against loopback fixtures where there is no MITM to guard against.

## Local verification (integration test — per-PR CI does not run it)

On dev2 (`TERMIHUB_TEST_PORT_OFFSET=2000`, project `termihub-test-2`, sftp-stress on host port 4210):

1. **Rebuilt the fixture image fresh** (`docker compose --profile stress build --no-cache sftp-stress`) so it carries a brand-new host key not in any `known_hosts` — the exact repro condition — then brought it up.
2. **Confirmed red without the fix**: temporarily removed the verifier call and rebuilt; all 3 tests failed with `SshError("Spawn failed: SSH handshake failed: Unknown server key")`.
3. **Confirmed green with the fix**, run 3× consecutively: `test result: ok. 3 passed; 0 failed` each time — deterministic, no manual `known_hosts` seeding.

`cargo fmt --check` and `cargo clippy -p termihub --tests --all-features` both clean.

Closes #2105