### PR TITLE
perf(terminal): skip per-flush full-viewport refresh under webgl (Closes #2107)

### DIFF
--- a/src/components/Terminal/Terminal.output-repaint.test.tsx
+++ b/src/components/Terminal/Terminal.output-repaint.test.tsx
@@ -59,6 +59,18 @@ vi.mock("@xterm/xterm", () => {
   return { Terminal: MockXTerm };
 });
 
+// This is the DOM-renderer regression (#1849): the forced full-viewport refresh
+// only runs on the DOM path (#2107). Force WebGL to be unavailable so the
+// terminal falls back to the DOM renderer and the refresh is exercised.
+vi.mock("@xterm/addon-webgl", () => {
+  class MockWebglAddon {
+    constructor() {
+      throw new Error("WebGL2 context unavailable");
+    }
+  }
+  return { WebglAddon: MockWebglAddon };
+});
+
 vi.mock("@xterm/addon-fit", () => {
   class MockFitAddon {
     fit = vi.fn();

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -305,6 +305,14 @@ export function Terminal({
   const userScrolledUpRef = useRef(false);
   const lastInputTimeRef = useRef(0);
   const contentDirtyRef = useRef(false);
+  // Whether the WebGL renderer is currently driving this terminal (#2107). The
+  // WebGL addon repaints its whole canvas each frame, so the per-flush full-
+  // viewport refresh (a DOM-renderer paint fix for #1849) is redundant work
+  // under WebGL. Gated on this ref so the refresh is skipped while WebGL is
+  // active but resumes the moment the context is lost and xterm falls back to
+  // the DOM renderer mid-session. Lives at component scope so the output-flush
+  // effect and the terminal-init effect (which owns the addon) share it.
+  const webglRendererActiveRef = useRef(false);
   const pendingCloseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isViewModeRef = useRef(false);
   // Capture existingSessionId at mount time only. After the Terminal creates a
@@ -709,12 +717,20 @@ export function Terminal({
           // rows a scroll already repaints), so it stays cheap on high-
           // throughput output. Runs regardless of scroll position so stale rows
           // are corrected even when the user has scrolled up.
+          //
+          // Skip it while the WebGL renderer is active (#2107): WebGL repaints
+          // its whole canvas each frame and never exhibits the #1849 stale-row
+          // bug, so the forced refresh is pure overhead there. The ref flips
+          // back to false on WebGL context loss, so the refresh resumes for the
+          // DOM fallback path.
           const afterWrite = () => {
             requestAnimationFrame(() => {
               if (!userScrolledUpRef.current) {
                 xterm.scrollToBottom();
               }
-              xterm.refresh(0, Math.max(0, xterm.rows - 1));
+              if (!webglRendererActiveRef.current) {
+                xterm.refresh(0, Math.max(0, xterm.rows - 1));
+              }
             });
           };
 
@@ -1050,8 +1066,10 @@ export function Terminal({
     //    xterm fall back to the DOM renderer automatically, so text keeps
     //    rendering. A one-shot fallback: we do not try to re-create the context.
     // The forced full-viewport refresh after each flush (see flushOutput) is a
-    // DOM-renderer paint fix (#1849); it is harmless under WebGL and keeps the
-    // fallback path correct, so it is intentionally left in place for both.
+    // DOM-renderer paint fix (#1849). It is skipped while WebGL is active
+    // (#2107) — tracked via webglRendererActiveRef, which mirrors the renderer
+    // state below — and resumes automatically on context-loss fallback so the
+    // DOM path stays correct.
     let webglAddon: WebglAddon | null = null;
     try {
       const addon = new WebglAddon();
@@ -1059,10 +1077,12 @@ export function Terminal({
         frontendLog("terminal", `webgl context lost tab=${tabId}; falling back to DOM renderer`);
         addon.dispose();
         webglAddon = null;
+        webglRendererActiveRef.current = false;
         el.dataset.terminalRenderer = "dom";
       });
       xterm.loadAddon(addon);
       webglAddon = addon;
+      webglRendererActiveRef.current = true;
       el.dataset.terminalRenderer = "webgl";
       frontendLog("terminal", `webgl renderer active tab=${tabId}`);
     } catch (err) {
@@ -1072,6 +1092,7 @@ export function Terminal({
       );
       webglAddon?.dispose();
       webglAddon = null;
+      webglRendererActiveRef.current = false;
       el.dataset.terminalRenderer = "dom";
     }
 
@@ -1352,6 +1373,9 @@ export function Terminal({
       // context-loss fallback, in which case it is already disposed.
       webglAddon?.dispose();
       webglAddon = null;
+      // Reset the renderer flag so a reconnect starts on the DOM-safe path
+      // (refresh enabled) until the new xterm re-activates WebGL (#2107).
+      webglRendererActiveRef.current = false;
       xterm.dispose();
       el.remove();
       terminalElRef.current = null;

--- a/src/components/Terminal/Terminal.webgl-renderer.test.tsx
+++ b/src/components/Terminal/Terminal.webgl-renderer.test.tsx
@@ -200,6 +200,23 @@ function renderTerminal() {
   });
 }
 
+// Drive one output chunk through the flush pipeline: output event → flushOutput
+// RAF → xterm.write → afterWrite → repaint RAF. Mirrors the real ordering so the
+// per-flush full-viewport refresh (#1849) fires exactly as it would in the app.
+async function pushOutputAndFlush() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 50));
+  });
+  if (outputCallback) {
+    act(() => outputCallback!(new Uint8Array([65, 66, 67])));
+  }
+  act(() => flushRaf());
+  if (capturedWriteCallback) {
+    act(() => capturedWriteCallback!());
+  }
+  act(() => flushRaf());
+}
+
 describe("Terminal WebGL renderer (#2078)", () => {
   it("loads the WebGL addon and wires up its context-loss handler", () => {
     renderTerminal();
@@ -255,5 +272,36 @@ describe("Terminal WebGL renderer (#2078)", () => {
     expect(mockRefresh).toHaveBeenCalledWith(0, 23);
     const container = document.querySelector('[data-testid="terminal-renderer-tab-1"]');
     expect(container?.getAttribute("data-terminal-renderer")).toBe("dom");
+  });
+});
+
+describe("Terminal per-flush refresh gating (#2107)", () => {
+  it("skips the full-viewport refresh while the WebGL renderer is active", async () => {
+    renderTerminal();
+
+    // Precondition: WebGL activated, so the DOM-renderer paint fix is redundant.
+    expect(h.webglInstances).toHaveLength(1);
+    const container = document.querySelector('[data-testid="terminal-renderer-tab-1"]');
+    expect(container?.getAttribute("data-terminal-renderer")).toBe("webgl");
+
+    await pushOutputAndFlush();
+
+    // Auto-scroll still runs; the redundant per-flush refresh does not.
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  it("resumes the full-viewport refresh after WebGL context loss falls back to DOM", async () => {
+    renderTerminal();
+
+    const webgl = h.webglInstances[0];
+    act(() => webgl.triggerContextLoss());
+
+    const container = document.querySelector('[data-testid="terminal-renderer-tab-1"]');
+    expect(container?.getAttribute("data-terminal-renderer")).toBe("dom");
+
+    await pushOutputAndFlush();
+
+    // Back on the DOM path, the #1849 stale-row fix must fire again.
+    expect(mockRefresh).toHaveBeenCalledWith(0, 23);
   });
 });


### PR DESCRIPTION
## What

The forced `xterm.refresh(0, rows-1)` after every output flush in `Terminal.tsx` (`flushOutput` → `afterWrite`) is the fix for the DOM renderer's stale-row paint bug (#1849). The WebGL renderer (`@xterm/addon-webgl`, added in #2078 / PR #2102) repaints its entire canvas each frame and never exhibits that bug, so under WebGL the per-flush full-viewport refresh is pure overhead on high-throughput output.

This gates the refresh on the live renderer:

- New `webglRendererActiveRef` mirrors the existing `data-terminal-renderer` dataset state — set `true` on WebGL activation, `false` on context-loss fallback, on init failure, and on teardown.
- `afterWrite` skips `xterm.refresh(...)` while the ref is `true`; the DOM path keeps the refresh **byte-for-byte unchanged**.
- Because the ref flips back to `false` in the `onContextLoss` handler, the refresh **resumes automatically** if the GPU context is lost and xterm falls back to the DOM renderer mid-session.
- `scrollToBottom` behavior is untouched.

## Tests

- `Terminal.webgl-renderer.test.tsx` (#2107 block): refresh is **skipped** while the WebGL renderer is active; refresh **resumes** (`refresh(0, 23)`) after a WebGL context loss falls back to DOM.
- `Terminal.output-repaint.test.tsx` (#1849): now mocks `@xterm/addon-webgl` as unavailable so it exercises the DOM path it is meant to cover; both existing assertions still hold.
- Full frontend suite green (4664 tests).

## Real-build verification (debug build, driven via the Python system-test bridge)

Drove 300 colored, rapidly-scrolling lines through a local shell and inspected the result, on both renderer paths:

- **WebGL active** (`data-terminal-renderer="webgl"` confirmed): with the per-flush refresh skipped, the xterm buffer is fully intact and correctly ordered (all 300 lines + end marker present, no dropped/duplicated/spliced rows), scroll-up into the backlog and scroll-back-to-bottom both behave correctly, and there is no hang or crash on the high-throughput workload. (The WebGL canvas cannot be captured by the bridge's DOM screenshot — xterm's WebGL addon uses `preserveDrawingBuffer=false`, so a capture reads blank; this is a tooling limitation, unrelated to the change.)
- **DOM fallback** (forced via a temporary local edit, `data-terminal-renderer="dom"` confirmed): with the refresh **active**, screenshots show the colored output painting correctly both pinned to the bottom and scrolled up into the backlog — no stale, spliced, or garbled rows. This confirms the fallback path still refreshes and renders correctly. The DOM path's refresh code is unchanged by this PR and is additionally locked by the unit test above.

Closes #2107