### PR TITLE
fix(ui): make remote-agents list scroll with expanded agents (Closes #2116)

### DIFF
--- a/docs/changes/dev3/fix/2116-agents-scroll-expanded.md
+++ b/docs/changes/dev3/fix/2116-agents-scroll-expanded.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Remote Agents sidebar: the agent list now scrolls correctly even when agents
+  are expanded, and expanding an agent no longer clips its contents. The list
+  previously flex-distributed the expanded agents over a fixed height, so it
+  never overflowed (no top-level scroll) and each expanded agent's tree was
+  squeezed into an unreadable clipped slice. Every agent now renders at its
+  natural content height inside a single scroll container, so the whole list
+  scrolls with the header and filter pinned and every agent — collapsed or
+  expanded — is fully reachable and readable (#2116).

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -639,7 +639,7 @@ function AgentRootDropZone({
   return (
     <div
       ref={setNodeRef}
-      className={`connection-list__tree${isAgentConnectionOver ? " connection-tree__root-drop--over" : ""}`}
+      className={`connection-list__tree connection-list__tree--agent${isAgentConnectionOver ? " connection-tree__root-drop--over" : ""}`}
       onClick={onAreaClick}
       onKeyDown={onKeyDown}
       role="tree"

--- a/src/components/Sidebar/ConnectionList.css
+++ b/src/components/Sidebar/ConnectionList.css
@@ -37,6 +37,24 @@
   overflow-y: auto;
 }
 
+/*
+ * Each agent inside the scroll list keeps its natural content height and never
+ * shrinks (#2116). The earlier design flex-distributed the expanded agents over
+ * the container's fixed height, so the list could never overflow (no top-level
+ * scroll) and every expanded agent was squeezed into a tiny slice with its own
+ * clipped inner scrollbar — unreadable. `flex: 0 0 auto` makes an expanded agent
+ * grow the list's total height instead, so overflow engages and the whole list
+ * scrolls with every agent (collapsed or expanded) fully reachable.
+ */
+.connection-list__agents-scroll > .connection-list__group {
+  flex: 0 0 auto;
+}
+
+/* Subtle divider between stacked agents (previously drawn by the resize handle). */
+.connection-list__agents-scroll > .connection-list__group + .connection-list__group {
+  border-top: 1px solid var(--border-primary);
+}
+
 /* Resize handle between sidebar sections */
 .connection-list__resize-handle {
   height: 1px;
@@ -113,6 +131,20 @@
   overflow-y: auto;
   min-height: 40px;
   padding-bottom: 8px;
+}
+
+/*
+ * An agent's own tree (inside the scrolling agent list) lays out at its natural
+ * content height and does NOT become an independent inner scroll region (#2116).
+ * The single scroll owner is `.connection-list__agents-scroll`; letting the tree
+ * grow to content means an expanded agent adds its full height to that list
+ * (which then scrolls) instead of clipping its rows into a 40px inner box.
+ */
+.connection-list__tree--agent {
+  flex: 0 0 auto;
+  overflow: visible;
+  min-height: 0;
+  padding-bottom: 4px;
 }
 
 .connection-tree__folder,

--- a/src/components/Sidebar/ConnectionList.remote-agents-scroll-expanded.test.tsx
+++ b/src/components/Sidebar/ConnectionList.remote-agents-scroll-expanded.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Regression tests for #2116: the Remote Agents list must scroll with agents
+ * EXPANDED, not just collapsed.
+ *
+ * #2106 wrapped the list in `.connection-list__agents-scroll` and was verified
+ * only with collapsed rows. Expanding an agent then broke: each expanded agent
+ * was handed an inline `flex` value that split the scroll container's FIXED
+ * height between the expanded agents, so the list could never overflow (no
+ * top-level scroll) and every expanded agent's tree was squeezed into a tiny
+ * clipped slice. The fix drops the inner flex distribution (and the inner
+ * resize handles that depended on it): every agent now renders at its natural
+ * content height inside the single scroll container.
+ *
+ * jsdom does not lay out, so these tests lock the structural invariants that
+ * make scrolling with expanded agents possible; the pixel-level overflow is
+ * verified separately with the real CSS in headless Chrome (see the PR).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { ConnectionList } from "./ConnectionList";
+import { TooltipProvider } from "@/components/ui";
+import { DEFAULT_AGENT_SETTINGS, type RemoteAgentDefinition } from "@/types/connection";
+
+vi.mock("@/services/api", () => ({
+  listAvailableShells: vi.fn(() => Promise.resolve([])),
+  createTerminal: vi.fn(() => Promise.resolve({ sessionId: "s1" })),
+  removeCredential: vi.fn(),
+  storeCredential: vi.fn(),
+  resolveCredential: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({
+  frontendLog: vi.fn(),
+}));
+
+/** Records every `style` prop the real ConnectionList hands each AgentNode. */
+const receivedStyles: Record<string, React.CSSProperties | undefined> = {};
+
+// A stand-in AgentNode that renders a tall block of rows when the agent is
+// expanded, so the DOM mirrors a real expanded agent (many child rows) without
+// pulling in the full AgentNode store wiring. It also captures the `style` prop
+// so the test can assert no inline flex distribution is applied.
+vi.mock("./AgentNode", () => ({
+  AgentNode: ({ agent, style }: { agent: RemoteAgentDefinition; style?: React.CSSProperties }) => {
+    receivedStyles[agent.id] = style;
+    return React.createElement(
+      "div",
+      {
+        "data-testid": `agent-node-${agent.id}`,
+        className: "connection-list__group connection-list__group--expanded",
+        style,
+      },
+      agent.isExpanded
+        ? Array.from({ length: 12 }, (_, r) =>
+            React.createElement("div", {
+              key: r,
+              "data-testid": `agent-${agent.id}-row-${r}`,
+              className: "connection-tree__item",
+            })
+          )
+        : null
+    );
+  },
+}));
+
+function makeAgent(i: number, expanded: boolean): RemoteAgentDefinition {
+  return {
+    id: `agent-${i}`,
+    name: `Agent ${i}`,
+    config: {
+      host: `10.0.0.${i}`,
+      port: 22,
+      username: "user",
+      authMethod: "password",
+    },
+    connectionState: "connected",
+    isExpanded: expanded,
+    agentSettings: DEFAULT_AGENT_SETTINGS,
+  };
+}
+
+const baseSettings = {
+  version: "1",
+  externalConnectionFiles: [] as [],
+  powerMonitoringEnabled: true,
+  fileBrowserEnabled: true,
+  experimentalFeaturesEnabled: true,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render() {
+  act(() => {
+    root.render(
+      React.createElement(TooltipProvider, {
+        delayDuration: 0,
+        children: React.createElement(ConnectionList),
+      })
+    );
+  });
+}
+
+describe("ConnectionList – Remote Agents scroll with EXPANDED agents (#2116)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    for (const k of Object.keys(receivedStyles)) delete receivedStyles[k];
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ settings: { ...baseSettings } });
+    // 15 agents, several expanded — the scenario #2106 never tested.
+    useAppStore.setState({
+      remoteAgents: Array.from({ length: 15 }, (_, i) => makeAgent(i, i % 3 === 0)),
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("renders every agent — expanded and collapsed — inside the single scroll container", () => {
+    render();
+    const scroll = container.querySelector('[data-testid="remote-agents-scroll"]');
+    expect(scroll).toBeTruthy();
+
+    for (let i = 0; i < 15; i++) {
+      const node = container.querySelector(`[data-testid="agent-node-agent-${i}"]`);
+      expect(node, `agent-${i} should render`).toBeTruthy();
+      expect(scroll?.contains(node)).toBe(true);
+    }
+  });
+
+  it("keeps every expanded agent's child rows inside the scroll container (reachable by scrolling)", () => {
+    render();
+    const scroll = container.querySelector('[data-testid="remote-agents-scroll"]');
+    for (let i = 0; i < 15; i += 3) {
+      // Last row of each expanded agent must live inside the scroll region so it
+      // is reachable — not clipped by a fixed-height inner slice.
+      const lastRow = container.querySelector(`[data-testid="agent-agent-${i}-row-11"]`);
+      expect(lastRow, `expanded agent-${i} last row should render`).toBeTruthy();
+      expect(scroll?.contains(lastRow)).toBe(true);
+    }
+  });
+
+  it("does NOT hand expanded agents an inline flex value (no fixed-height distribution)", () => {
+    render();
+    // The bug: expanded agents got `style={{ flex: <n> }}`, which split the
+    // container's fixed height and defeated scrolling. They must now size to
+    // content instead.
+    for (let i = 0; i < 15; i++) {
+      const style = receivedStyles[`agent-${i}`];
+      expect(style?.flex, `agent-${i} must not receive an inline flex`).toBeUndefined();
+    }
+  });
+
+  it("renders no inner resize separators between agents", () => {
+    render();
+    expect(container.querySelector('[data-testid^="sidebar-group-separator-"]')).toBeNull();
+  });
+});

--- a/src/components/Sidebar/ConnectionList.resize.test.tsx
+++ b/src/components/Sidebar/ConnectionList.resize.test.tsx
@@ -1,11 +1,13 @@
 /**
  * Regression tests for the resize handle --resizable class.
  *
- * There are two levels of resize handles:
+ * There is a single resize handle level left:
  * - Outer (sidebar-outer-separator): between Connections and the entire Remote Agents section.
  *   Resizable whenever connections is expanded and experimental features are enabled.
- * - Inner (sidebar-group-separator-N): between individual agents inside the Remote Agents section.
- *   Resizable only when both adjacent agents are expanded.
+ *
+ * The former inner handles between individual agents were removed with #2116:
+ * the agent list now scrolls, with every agent at its natural content height,
+ * so there is no fixed height for a splitter to apportion between them.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
@@ -134,7 +136,7 @@ describe("ConnectionList – outer resize handle (connections vs remote agents)"
   });
 });
 
-describe("ConnectionList – inner resize handles (between agents)", () => {
+describe("ConnectionList – no inner resize handles between agents (#2116)", () => {
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -148,8 +150,13 @@ describe("ConnectionList – inner resize handles (between agents)", () => {
     container.remove();
   });
 
-  it("no inner separator when there is only one agent", () => {
-    useAppStore.setState({ remoteAgents: [makeAgent({ isExpanded: true })] });
+  it("renders no inner separator even between two expanded agents (scroll model)", () => {
+    useAppStore.setState({
+      remoteAgents: [
+        makeAgent({ id: "a1", isExpanded: true }),
+        makeAgent({ id: "a2", isExpanded: true }),
+      ],
+    });
 
     act(() => {
       root.render(
@@ -161,67 +168,5 @@ describe("ConnectionList – inner resize handles (between agents)", () => {
     });
 
     expect(container.querySelector('[data-testid="sidebar-group-separator-0"]')).toBeNull();
-  });
-
-  it("inner separator appears between two agents", () => {
-    useAppStore.setState({
-      remoteAgents: [
-        makeAgent({ id: "a1", isExpanded: true }),
-        makeAgent({ id: "a2", isExpanded: true }),
-      ],
-    });
-
-    act(() => {
-      root.render(
-        React.createElement(TooltipProvider, {
-          delayDuration: 0,
-          children: React.createElement(ConnectionList),
-        })
-      );
-    });
-
-    expect(container.querySelector('[data-testid="sidebar-group-separator-0"]')).toBeTruthy();
-  });
-
-  it("inner separator has --resizable class only when both adjacent agents are expanded", () => {
-    useAppStore.setState({
-      remoteAgents: [
-        makeAgent({ id: "a1", isExpanded: true }),
-        makeAgent({ id: "a2", isExpanded: true }),
-      ],
-    });
-
-    act(() => {
-      root.render(
-        React.createElement(TooltipProvider, {
-          delayDuration: 0,
-          children: React.createElement(ConnectionList),
-        })
-      );
-    });
-
-    const sep = container.querySelector('[data-testid="sidebar-group-separator-0"]');
-    expect(sep?.classList.contains("connection-list__resize-handle--resizable")).toBe(true);
-  });
-
-  it("inner separator does NOT have --resizable class when the second agent is collapsed", () => {
-    useAppStore.setState({
-      remoteAgents: [
-        makeAgent({ id: "a1", isExpanded: true }),
-        makeAgent({ id: "a2", isExpanded: false }),
-      ],
-    });
-
-    act(() => {
-      root.render(
-        React.createElement(TooltipProvider, {
-          delayDuration: 0,
-          children: React.createElement(ConnectionList),
-        })
-      );
-    });
-
-    const sep = container.querySelector('[data-testid="sidebar-group-separator-0"]');
-    expect(sep?.classList.contains("connection-list__resize-handle--resizable")).toBe(false);
   });
 });

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, Fragment, useMemo } from "react";
+import { useState, useCallback, useMemo } from "react";
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import {
   DndContext,
@@ -1171,32 +1171,6 @@ export function ConnectionList() {
       : {};
   const isOuterResizable = "onMouseDown" in outerResizeProps;
 
-  const innerSectionsExpanded = useMemo(
-    () => (remoteAgentsCollapsed ? [] : remoteAgents.map((a) => a.isExpanded)),
-    [remoteAgentsCollapsed, remoteAgents]
-  );
-  const { map: innerExpandedIndexMap, count: innerExpandedCount } = useMemo(
-    () => buildExpandedIndexMap(innerSectionsExpanded),
-    [innerSectionsExpanded]
-  );
-  const {
-    flexValues: innerFlexValues,
-    handleProps: innerHandleProps,
-    sectionRefs: innerSectionRefs,
-  } = useSectionResize(innerExpandedCount);
-
-  const getInnerResizeHandleProps = useCallback(
-    (agentIndex: number) => {
-      const eiAbove = innerExpandedIndexMap[agentIndex - 1];
-      const eiBelow = innerExpandedIndexMap[agentIndex];
-      if (eiAbove >= 0 && eiBelow >= 0 && eiBelow === eiAbove + 1) {
-        return innerHandleProps(eiAbove);
-      }
-      return {};
-    },
-    [innerExpandedIndexMap, innerHandleProps]
-  );
-
   return (
     <div className="connection-list">
       <DndContext
@@ -1420,30 +1394,17 @@ export function ConnectionList() {
                     className="connection-list__agents-scroll"
                     data-testid="remote-agents-scroll"
                   >
-                    {remoteAgents.map((agent, i) => {
-                      const innerIdx = innerExpandedIndexMap[i];
-                      const innerResizeProps = i > 0 ? getInnerResizeHandleProps(i) : {};
-                      const isInnerResizable = "onMouseDown" in innerResizeProps;
-                      return (
-                        <Fragment key={agent.id}>
-                          {i > 0 && (
-                            <div
-                              className={`connection-list__resize-handle${isInnerResizable ? " connection-list__resize-handle--resizable" : ""}`}
-                              data-testid={`sidebar-group-separator-${i - 1}`}
-                              {...innerResizeProps}
-                            />
-                          )}
-                          <AgentNode
-                            agent={agent}
-                            filterQuery={agentFilterQuery}
-                            style={innerIdx >= 0 ? { flex: innerFlexValues[innerIdx] } : undefined}
-                            sectionRef={(el) => {
-                              if (innerIdx >= 0) innerSectionRefs.current[innerIdx] = el;
-                            }}
-                          />
-                        </Fragment>
-                      );
-                    })}
+                    {/*
+                      Every agent renders at its natural content height so the
+                      whole list overflows and scrolls in this container — an
+                      expanded agent's tree is not squeezed into a flex slice
+                      (which previously fixed the total height and defeated the
+                      scroll while clipping expanded content), it just makes the
+                      list taller and reachable by scrolling (#2116).
+                    */}
+                    {remoteAgents.map((agent) => (
+                      <AgentNode key={agent.id} agent={agent} filterQuery={agentFilterQuery} />
+                    ))}
                   </div>
                 </SortableContext>
               )}


### PR DESCRIPTION
## Problem

Follow-up to #2106 / PR #2108. That change wrapped the Remote Agents list in a
`.connection-list__agents-scroll` container and was verified only with ~15
**collapsed** rows. Two problems remained (reported by the maintainer in #2116):

1. **The top-level agent list still did not scroll.** With more agents than fit,
   overflow was unreachable.
2. **Expanding an agent broke readability.** An opened agent's content consumed
   the visible area and, since the list didn't scroll, was clipped/unreadable —
   "the spaces around start taking its space."

## Root cause

The scroll container existed but could never overflow. Each **expanded** agent
was handed an inline `style={{ flex: <n> }}` (from an inner `useSectionResize`),
so the expanded agents **flex-distributed the scroll container's fixed height
between themselves** — a VS-Code-style splitter, the opposite of a scrolling
list. The container therefore always fit its children (no top-level scroll), and
each expanded agent's tree (`.connection-list__tree`, `flex: 1; overflow-y: auto;
min-height: 40px`) was squeezed into a tiny clipped slice with its own 40px inner
scrollbar. #2106 only tested collapsed rows (natural height), so it looked fixed.

The splitter model and a scrolling list are mutually exclusive for the same set
of items — you cannot both flex-share a fixed height and overflow it.

## Fix

Adopt the scroll model the issue asks for (mirroring the saved-connections tree):

- Drop the per-agent flex distribution and the inner resize handles that depended
  on it (`useSectionResize` for the inner sections, the `sidebar-group-separator-*`
  handles, and the inline `flex`/`sectionRef` passed to each `AgentNode`).
- Each agent now renders at its **natural content height** inside the single
  `.connection-list__agents-scroll` container (`flex: 0 0 auto` so it never
  shrinks). An expanded agent grows the list's total height, so overflow engages
  and the whole list scrolls; the section header and filter stay pinned.
- An agent's own tree gets a new `.connection-list__tree--agent` modifier
  (`flex: 0 0 auto; overflow: visible; min-height: 0`) so it lays out at content
  height instead of becoming a nested, capped 40px scroll region.

The outer resize handle (Connections vs. the whole Remote Agents section) is
unchanged.

## Verification (both collapsed AND expanded)

**Headless-Chrome layout test with the real `ConnectionList.css`**, sidebar
constrained to 420px (scroll viewport ~360px), 15 agents:

| Scenario | content height | overflows / scrolls | last agent reachable | header pinned | first expanded tree height |
| --- | --- | --- | --- | --- | --- |
| all collapsed | 434px | yes | yes | yes | — |
| 5 of 15 expanded | 1774px | yes | yes | yes | **268px** (12 rows, natural) |
| all 15 expanded | 4454px | yes | yes | yes | 268px |

`268px` (= 12 rows × 22px + padding) confirms each expanded agent's tree renders
at full readable height, **not** a squeezed 40px slice; scrolling to the bottom
reaches the last (15th) agent in every case; the header stays pinned and the
filter lives outside the scroll region.

- New Vitest regression test `ConnectionList.remote-agents-scroll-expanded.test.tsx`
  (15 agents, several expanded): every agent and every expanded agent's child rows
  render inside the scroll container; no expanded agent receives an inline flex;
  no inner separators.
- Existing `remote-agents-scroll` (collapsed), `remote-agents-collapse`, and
  `resize` (outer handle) suites still pass. Full Sidebar suite: 264 passing.
- `pnpm run build` (tsc), `pnpm run lint`, and `./scripts/check.sh` pass.

Closes #2116