### PR TITLE
fix(sftp): label sftp file-operation failures as sftp not ssh (Closes #2094)

### DIFF
--- a/docs/changes/dev1/fix/2094-sftp-error-label.md
+++ b/docs/changes/dev1/fix/2094-sftp-error-label.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- SFTP file-browser operation failures now surface with an `SFTP error:` prefix
+  instead of the misleading `SSH error:` prefix. Previously a file-transfer
+  failure showed e.g. `SSH error: readdir failed: …` even though it was an SFTP
+  operation, not a shell/SSH-session failure. Genuine SSH exec-channel failures
+  (used by the elevated-save path) keep their `SSH error:` label (#2094).

--- a/src-tauri/src/files/sftp.rs
+++ b/src-tauri/src/files/sftp.rs
@@ -28,7 +28,7 @@ use crate::utils::ssh_auth::connect_and_authenticate;
 pub fn lock_session<T>(mutex: &Mutex<T>) -> Result<MutexGuard<'_, T>, TerminalError> {
     mutex
         .lock()
-        .map_err(|_| TerminalError::SshError("SFTP session lock poisoned".to_string()))
+        .map_err(|_| TerminalError::SftpError("SFTP session lock poisoned".to_string()))
 }
 
 /// Drain every entry from a keyed session map, poison-safe, and drop the values.
@@ -219,7 +219,7 @@ impl SftpSession {
             tokio::runtime::Handle::current().block_on(async {
                 sftp::open_sftp_subsystem(&session)
                     .await
-                    .map_err(|e| TerminalError::SshError(e.to_string()))
+                    .map_err(|e| TerminalError::SftpError(e.to_string()))
             })
         })?;
 
@@ -257,7 +257,7 @@ impl SftpSession {
     pub async fn open_dedicated_sftp(&self) -> Result<RusshSftp, TerminalError> {
         sftp::open_sftp_subsystem(&self.session)
             .await
-            .map_err(|e| TerminalError::SshError(e.to_string()))
+            .map_err(|e| TerminalError::SftpError(e.to_string()))
     }
 
     /// Best-effort size (in bytes) of a remote file via SFTP `stat`.
@@ -279,7 +279,7 @@ impl SftpSession {
             tokio::runtime::Handle::current().block_on(async {
                 sftp::list_dir(&self.sftp, &path)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("readdir failed: {e}")))
+                    .map_err(|e| TerminalError::SftpError(format!("readdir failed: {e}")))
             })
         })
     }
@@ -294,17 +294,17 @@ impl SftpSession {
                     .sftp
                     .open(&remote_path)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("open remote file: {e}")))?;
+                    .map_err(|e| TerminalError::SftpError(format!("open remote file: {e}")))?;
 
                 let mut data = Vec::new();
                 remote
                     .read_to_end(&mut data)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("read failed: {e}")))?;
+                    .map_err(|e| TerminalError::SftpError(format!("read failed: {e}")))?;
 
                 tokio::fs::write(&local_path, &data)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("write local file: {e}")))?;
+                    .map_err(|e| TerminalError::SftpError(format!("write local file: {e}")))?;
 
                 Ok::<u64, TerminalError>(data.len() as u64)
             })
@@ -319,18 +319,17 @@ impl SftpSession {
             tokio::runtime::Handle::current().block_on(async {
                 let data = tokio::fs::read(&local_path)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("open local file: {e}")))?;
+                    .map_err(|e| TerminalError::SftpError(format!("open local file: {e}")))?;
 
-                let mut remote = self
-                    .sftp
-                    .create(&remote_path)
-                    .await
-                    .map_err(|e| TerminalError::SshError(format!("create remote file: {e}")))?;
+                let mut remote =
+                    self.sftp.create(&remote_path).await.map_err(|e| {
+                        TerminalError::SftpError(format!("create remote file: {e}"))
+                    })?;
 
                 remote
                     .write_all(&data)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("write failed: {e}")))?;
+                    .map_err(|e| TerminalError::SftpError(format!("write failed: {e}")))?;
 
                 Ok::<u64, TerminalError>(data.len() as u64)
             })
@@ -345,7 +344,7 @@ impl SftpSession {
                 self.sftp
                     .create_dir(&path)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("mkdir failed: {e}")))
+                    .map_err(|e| TerminalError::SftpError(format!("mkdir failed: {e}")))
             })
         })
     }
@@ -358,7 +357,7 @@ impl SftpSession {
                 self.sftp
                     .remove_file(&path)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("unlink failed: {e}")))
+                    .map_err(|e| TerminalError::SftpError(format!("unlink failed: {e}")))
             })
         })
     }
@@ -371,7 +370,7 @@ impl SftpSession {
                 self.sftp
                     .remove_dir(&path)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("rmdir failed: {e}")))
+                    .map_err(|e| TerminalError::SftpError(format!("rmdir failed: {e}")))
             })
         })
     }
@@ -385,13 +384,13 @@ impl SftpSession {
                     .sftp
                     .open(&remote_path)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("open remote file: {e}")))?;
+                    .map_err(|e| TerminalError::SftpError(format!("open remote file: {e}")))?;
 
                 let mut content = String::new();
                 remote
                     .read_to_string(&mut content)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("read failed: {e}")))?;
+                    .map_err(|e| TerminalError::SftpError(format!("read failed: {e}")))?;
 
                 Ok::<String, TerminalError>(content)
             })
@@ -416,7 +415,7 @@ impl SftpSession {
                 self.sftp
                     .rename(&old_path, &new_path)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("rename failed: {e}")))
+                    .map_err(|e| TerminalError::SftpError(format!("rename failed: {e}")))
             })
         })
     }
@@ -429,7 +428,7 @@ impl SftpSession {
             tokio::runtime::Handle::current().block_on(async {
                 sftp::stat(&self.sftp, &path)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("stat failed: {e}")))
+                    .map_err(|e| TerminalError::SftpError(format!("stat failed: {e}")))
             })
         })
     }
@@ -487,7 +486,7 @@ impl SftpSession {
                 self.sftp
                     .canonicalize(&path)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("realpath failed: {e}")))
+                    .map_err(|e| TerminalError::SftpError(format!("realpath failed: {e}")))
             })
         })
     }
@@ -502,13 +501,13 @@ impl SftpSession {
                     .sftp
                     .open(&remote_path)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("open remote file: {e}")))?;
+                    .map_err(|e| TerminalError::SftpError(format!("open remote file: {e}")))?;
 
                 let mut data = Vec::new();
                 remote
                     .read_to_end(&mut data)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("read failed: {e}")))?;
+                    .map_err(|e| TerminalError::SftpError(format!("read failed: {e}")))?;
 
                 Ok::<Vec<u8>, TerminalError>(data)
             })
@@ -522,16 +521,15 @@ impl SftpSession {
         let remote_path = remote_path.to_string();
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
-                let mut remote = self
-                    .sftp
-                    .create(&remote_path)
-                    .await
-                    .map_err(|e| TerminalError::SshError(format!("create remote file: {e}")))?;
+                let mut remote =
+                    self.sftp.create(&remote_path).await.map_err(|e| {
+                        TerminalError::SftpError(format!("create remote file: {e}"))
+                    })?;
 
                 remote
                     .write_all(&data)
                     .await
-                    .map_err(|e| TerminalError::SshError(format!("write failed: {e}")))
+                    .map_err(|e| TerminalError::SftpError(format!("write failed: {e}")))
             })
         })
     }
@@ -1300,8 +1298,14 @@ mod tests {
         // A raw `.lock().unwrap()` would panic here; the helper must not.
         let result = lock_session(&mutex);
         assert!(
-            matches!(result, Err(TerminalError::SshError(_))),
-            "poisoned lock should return a recoverable SshError, got {result:?}"
+            matches!(result, Err(TerminalError::SftpError(_))),
+            "poisoned lock should return a recoverable SftpError, got {result:?}"
+        );
+        // The failure is an SFTP-session error, not a generic SSH error (#2094).
+        let rendered = result.unwrap_err().to_string();
+        assert!(
+            rendered.starts_with("SFTP error:"),
+            "SFTP session errors must carry the SFTP label, got {rendered:?}"
         );
     }
 

--- a/src-tauri/src/utils/errors.rs
+++ b/src-tauri/src/utils/errors.rs
@@ -26,6 +26,9 @@ pub enum TerminalError {
     #[error("SSH error: {0}")]
     SshError(String),
 
+    #[error("SFTP error: {0}")]
+    SftpError(String),
+
     #[allow(dead_code)]
     #[error("Telnet error: {0}")]
     TelnetError(String),
@@ -83,5 +86,31 @@ impl serde::Serialize for TerminalError {
         S: serde::Serializer,
     {
         serializer.serialize_str(&self.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// SFTP file-operation failures must surface with an `SFTP error:` prefix,
+    /// not the misleading `SSH error:` prefix (issue #2094).
+    #[test]
+    fn sftp_error_renders_with_sftp_prefix() {
+        let err = TerminalError::SftpError("readdir failed: no such file".to_string());
+        let rendered = err.to_string();
+        assert_eq!(rendered, "SFTP error: readdir failed: no such file");
+        assert!(
+            !rendered.starts_with("SSH error:"),
+            "SFTP operation errors must not be labeled as SSH errors, got {rendered:?}"
+        );
+    }
+
+    /// The distinct `SshError` variant keeps its own prefix for genuine
+    /// SSH-session/transport failures.
+    #[test]
+    fn ssh_error_renders_with_ssh_prefix() {
+        let err = TerminalError::SshError("exec channel failed".to_string());
+        assert_eq!(err.to_string(), "SSH error: exec channel failed");
     }
 }


### PR DESCRIPTION
## Summary

SFTP file-browser operation failures were wrapped in `TerminalError::SshError`, whose `Display` (`src-tauri/src/utils/errors.rs`) renders `SSH error: {0}`. A file-transfer failure therefore surfaced to the user as e.g. `SSH error: readdir failed: …` even though it is an SFTP operation, not a shell/SSH-session failure — redundant and misleading.

## Changes

- Add a dedicated `TerminalError::SftpError(String)` variant rendered as `SFTP error: {0}`.
- Route the SFTP protocol / file-operation paths in `src-tauri/src/files/sftp.rs` through it: SFTP subsystem open, `readdir`, open/read/write of remote and local files, `mkdir`, `unlink`, `rmdir`, `rename`, `stat`, `realpath`, and the session-lock helper.
- **Deliberately left on `SshError`** (genuine SSH-session/transport ops, not SFTP file operations): the remote-shell path quoting (`cannot quote path for remote shell`) and the exec-channel failure in the elevated-save path (`exec channel failed`). Both run over a real SSH exec channel, so the SSH label is correct there.
- Errors being relabeled originate in the desktop `files/sftp.rs`, not the shared `core::backends::ssh::sftp` module (which returns its own error types that this file maps) — scope stays in the desktop backend.

## Tests

- New unit tests in `utils/errors.rs` asserting `SftpError` renders with an `SFTP error:` prefix and never `SSH error:`, and that `SshError` keeps its own prefix.
- Updated the `lock_session` poisoned-mutex regression test to expect `SftpError` and assert the `SFTP error:` label.

Closes #2094