### PR TITLE
ci(agent): build musl targets from stock ghcr cross images, not Docker Buildx

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -48,23 +48,19 @@ jobs:
           curl -fsSL https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-gnu.tar.gz \
             | sudo tar xz -C /usr/local/bin
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build custom cross-rs image
-        uses: docker/build-push-action@v7
-        with:
-          context: agent/docker
-          file: agent/docker/Dockerfile.${{ matrix.target }}
-          tags: localhost/termihub-cross:${{ matrix.target }}
-          load: true
-          cache-from: type=gha,scope=${{ matrix.target }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.target }}
-
+      # No Docker Buildx / custom cross image on CI: the flaky "Set up Docker
+      # Buildx" step pulled moby/buildkit from Docker Hub (registry-1.docker.io),
+      # which times out non-deterministically (#2056). cross-rs pulls its stock
+      # target images from GHCR, which is reliable, so we let it use the default
+      # images directly. The custom localhost/termihub-cross:* images (Cross.toml
+      # + agent/docker/) only add an lld linker + a chmod entrypoint needed for
+      # local Windows/Podman dev (DrvFs strips execute bits); neither is required
+      # on a Linux runner, so dropping CROSS_CONFIG here changes nothing but the
+      # image source. Local dev still uses Cross.toml via the build-agents scripts.
       - name: Build
         env:
           TERMIHUB_BUILD_BRANCH: ${{ github.head_ref || github.ref_name }}
-        run: CROSS_CONFIG=agent/Cross.toml cross build --release --target ${{ matrix.target }} -p termihub-agent
+        run: cross build --release --target ${{ matrix.target }} -p termihub-agent
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -7,6 +7,10 @@ on:
       - 'agent/**'
       - 'core/**'
       - 'Cargo.toml'
+      # Re-run the cross-compile legs when the build workflow itself changes, so
+      # edits to the musl build (e.g. the cross-image hardening in #2056) are
+      # exercised on their own PR instead of shipping unvalidated.
+      - '.github/workflows/agent.yml'
 
 # Cancel an in-flight agent build when a newer commit lands on the same PR.
 concurrency:

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -290,8 +290,8 @@ jobs:
           # Budget guard (#1006): agent binaries are built only post-merge and are
           # never restored by a PR build. Persisting them spent ~2 GB of the shared
           # 10 GB repo cache budget, evicting the PR-blocking Windows cache. Don't
-          # save — these non-blocking cross builds run cold. (The cross image itself
-          # is still reused via the Docker buildx gha cache below.)
+          # save — these non-blocking cross builds run cold. (The stock cross-rs
+          # image is pulled fresh from GHCR by cross itself; see the Build step.)
           save-if: false
 
       - name: Install cross-rs
@@ -299,23 +299,19 @@ jobs:
           curl -fsSL https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-gnu.tar.gz \
             | sudo tar xz -C /usr/local/bin
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build custom cross-rs image
-        uses: docker/build-push-action@v7
-        with:
-          context: agent/docker
-          file: agent/docker/Dockerfile.${{ matrix.target }}
-          tags: localhost/termihub-cross:${{ matrix.target }}
-          load: true
-          cache-from: type=gha,scope=dev-agent-${{ matrix.target }}
-          cache-to: type=gha,mode=max,scope=dev-agent-${{ matrix.target }}
-
+      # No Docker Buildx / custom cross image on CI: the flaky "Set up Docker
+      # Buildx" step pulled moby/buildkit from Docker Hub (registry-1.docker.io),
+      # which times out non-deterministically (#2056). cross-rs pulls its stock
+      # target images from GHCR, which is reliable, so we let it use the default
+      # images directly. The custom localhost/termihub-cross:* images (Cross.toml
+      # + agent/docker/) only add an lld linker + a chmod entrypoint needed for
+      # local Windows/Podman dev (DrvFs strips execute bits); neither is required
+      # on a Linux runner, so dropping CROSS_CONFIG here changes nothing but the
+      # image source. Local dev still uses Cross.toml via the build-agents scripts.
       - name: Build agent
         env:
           TERMIHUB_BUILD_BRANCH: ${{ github.ref_name }}
-        run: CROSS_CONFIG=agent/Cross.toml cross build --release --target ${{ matrix.target }} -p termihub-agent
+        run: cross build --release --target ${{ matrix.target }} -p termihub-agent
 
       - name: Rename agent binary
         run: cp "target/${{ matrix.target }}/release/termihub-agent" "${{ matrix.artifact_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,21 +251,18 @@ jobs:
           curl -fsSL https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-gnu.tar.gz \
             | sudo tar xz -C /usr/local/bin
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build custom cross-rs image
-        uses: docker/build-push-action@v7
-        with:
-          context: agent/docker
-          file: agent/docker/Dockerfile.${{ matrix.target }}
-          tags: localhost/termihub-cross:${{ matrix.target }}
-          load: true
-          cache-from: type=gha,scope=${{ matrix.target }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.target }}
-
+      # No Docker Buildx / custom cross image on CI: the flaky "Set up Docker
+      # Buildx" step pulled moby/buildkit from Docker Hub (registry-1.docker.io),
+      # which times out non-deterministically (#2056) and would intermittently
+      # fail these REQUIRED release artifact builds. cross-rs pulls its stock
+      # target images from GHCR, which is reliable, so we let it use the default
+      # images directly. The custom localhost/termihub-cross:* images (Cross.toml
+      # + agent/docker/) only add an lld linker + a chmod entrypoint needed for
+      # local Windows/Podman dev (DrvFs strips execute bits); neither is required
+      # on a Linux runner, so dropping CROSS_CONFIG here changes nothing but the
+      # image source. Local dev still uses Cross.toml via the build-agents scripts.
       - name: Build agent
-        run: CROSS_CONFIG=agent/Cross.toml cross build --release --target ${{ matrix.target }} -p termihub-agent
+        run: cross build --release --target ${{ matrix.target }} -p termihub-agent
 
       - name: Upload agent binary and checksum as release assets
         run: |


### PR DESCRIPTION
## Problem

The musl cross-compile build legs (`Build (x86_64-unknown-linux-musl)`, `Build (armv7-unknown-linux-musleabihf)`, `Build (aarch64-unknown-linux-musl)`) flake non-deterministically on the **"Set up Docker Buildx"** step with `registry-1.docker.io ... context deadline exceeded`.

Root cause: `docker/setup-buildx-action` provisions a BuildKit builder using the `docker-container` driver, which pulls `moby/buildkit` from **Docker Hub** (`registry-1.docker.io`). Docker Hub's registry intermittently times out, so the step fails through no fault of the PR code.

These legs are non-required in PR CI (`agent.yml`, `dev-build.yml`) — training reviewers to ignore red build legs — but they are **required** in `release.yml`, where the same flake would intermittently fail actual release artifact builds.

## Fix

Remove the `Set up Docker Buildx` and `Build custom cross-rs image` steps and let cross-rs pull its **stock target images straight from GHCR** (`ghcr.io/cross-rs/<target>`), which is reliable. This eliminates the Docker Hub dependency entirely rather than merely retrying it.

Why this is safe and equivalent:
- cross-rs never touches Docker Hub — its images live on GHCR. Only `setup-buildx-action` needed Docker Hub (for the BuildKit builder), and cross-rs does not need BuildKit at all (it does `docker pull` + `docker run`, no image build).
- The custom `localhost/termihub-cross:*` images (`agent/Cross.toml` + `agent/docker/Dockerfile.*`) are `FROM ghcr.io/cross-rs/<target>` plus **only** an `lld` linker and a chmod entrypoint. Both are explicitly Windows/Podman-only workarounds (DrvFs strips execute bits from the bundled `rust-lld`) and are unnecessary on a Linux runner.
- Dropping `CROSS_CONFIG` on CI therefore changes nothing but the image source; the compiler and target toolchain are identical. The agent is OpenSSL-free by design (`reqwest` with `rustls-tls`), so it cross-compiles cleanly.
- Local dev is untouched: `build-agents.sh`/`.cmd` and `setup-agent-cross.sh`/`.cmd` still use `agent/Cross.toml` and its custom images.

Applied identically to all three cross-compile workflows: `agent.yml` (PR CI), `release.yml` (required release artifacts), and `dev-build.yml`.

## Validation

- `actionlint` + `yaml.safe_load` clean on all three edited workflows (only pre-existing shellcheck info/warnings on unrelated steps).
- Locally reproduced the exact new CI command (`cross build --release --target x86_64-unknown-linux-musl -p termihub-agent`, no `CROSS_CONFIG`) — cross pulls the stock GHCR image and builds the agent successfully.
- The musl build legs on this PR are the live proof the flake source is gone.

Closes #2056