### PR TITLE
build(config): wire cargo-deny licenses + sources checks into CI (Closes #2096)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -298,19 +298,24 @@ jobs:
       - name: Cargo Audit
         run: cargo audit
 
-      # cargo-deny yanked/bans gate (#2074): fails CI when the workspace lockfile
-      # pins a YANKED crate (e.g. the crypto-bigint 0.7.x line pulled via russh),
-      # so a silently-yanked transitive dep surfaces loudly instead of shipping.
-      # Config: deny.toml. Only `advisories bans` run here — the `licenses` and
-      # `sources` checks are intentionally not wired (they need a full allowlist;
-      # tracked separately). cargo-audit above still covers vulnerability RUSTSECs.
+      # cargo-deny supply-chain gate. Config: deny.toml. Four checks run:
+      #   - advisories: fails CI when the workspace lockfile pins a YANKED crate
+      #     (e.g. the crypto-bigint 0.7.x line pulled via russh) — a silently
+      #     withdrawn transitive dep surfaces loudly instead of shipping (#2074).
+      #   - bans: documented release sign-off for the pre-release RustCrypto stack.
+      #   - licenses: every crate must resolve to an allowed license, so an
+      #     unknown/restrictive license cannot slip into the distributed binary
+      #     unnoticed (#2096).
+      #   - sources: every crate must come from crates.io — an unexpected registry
+      #     or git source fails CI (#2096).
+      # cargo-audit above still covers vulnerability RUSTSECs.
       - name: Install cargo-deny
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-deny
 
-      - name: Cargo Deny (yanked + bans gate)
-        run: cargo deny check advisories bans
+      - name: Cargo Deny (supply-chain gate)
+        run: cargo deny check advisories bans licenses sources
 
   # Check conventional commits (PR only)
   commit-lint:

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 description = "Remote agent for termiHub — manages persistent terminal sessions on Raspberry Pi"
 authors = ["Arne Maximilian Richter <armaxri@gmail.com>"]
 edition = "2021"
+# First-party workspace crate — never published to crates.io (the repo is MIT,
+# see /LICENSE). Marks it private so cargo-deny's `[licenses] private.ignore`
+# skips its missing per-crate license field (#2096).
+publish = false
 
 [[bin]]
 name = "termihub-agent"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,6 +3,10 @@ name = "termihub-core"
 version = "0.1.0"
 description = "Shared core library for termiHub desktop and agent"
 edition = "2021"
+# First-party workspace crate — never published to crates.io (the repo is MIT,
+# see /LICENSE). Marks it private so cargo-deny's `[licenses] private.ignore`
+# skips its missing per-crate license field (#2096).
+publish = false
 build = "build.rs"
 
 # Hashing the staged `termihub-rdp-helper` externalBin to embed its SHA-256 at

--- a/deny.toml
+++ b/deny.toml
@@ -1,16 +1,18 @@
 # cargo-deny configuration — supply-chain gate for the Rust workspace.
 # https://embarkstudios.github.io/cargo-deny/
 #
-# CI runs only `cargo deny check advisories bans` (see
-# .github/workflows/code-quality.yml -> "Security Audit"). The primary purpose
-# is the YANKED-crate gate (#2074): if the workspace lockfile ever pins a crate
-# version that has been yanked from crates.io, CI fails loudly instead of the
-# app silently shipping a withdrawn dependency.
-#
-# The `licenses` and `sources` checks are intentionally NOT wired into CI yet —
-# they need a full allowlist for the entire transitive tree, which is a
-# separate, larger piece of work. cargo-audit (also in the Security Audit job)
-# continues to cover RUSTSEC *vulnerability* advisories.
+# CI runs `cargo deny check advisories bans licenses sources` (see
+# .github/workflows/code-quality.yml -> "Security Audit"). Four gates:
+#   - advisories: YANKED-crate gate (#2074) — a lockfile pinning a crate version
+#     that has been yanked from crates.io fails CI instead of the app silently
+#     shipping a withdrawn dependency.
+#   - bans: documented release sign-off for the pre-release RustCrypto stack.
+#   - licenses: license compliance for the distributed binary — every crate in
+#     the transitive tree must resolve to an explicitly allowed license (#2096).
+#   - sources: every crate must come from crates.io — an unexpected registry or
+#     git source fails CI (#2096).
+# cargo-audit (also in the Security Audit job) covers RUSTSEC *vulnerability*
+# advisories.
 
 [advisories]
 # A yanked crate in the lockfile fails CI. This is the headline gate: it is how
@@ -44,6 +46,60 @@ ignore = [
     "RUSTSEC-2026-0195",
 ]
 
+[licenses]
+# License allowlist for the distributed binary. A crate whose license does not
+# resolve to one of these fails CI, so an unknown or restrictive (e.g. GPL)
+# license cannot slip into the tree unnoticed. The set below is the standard
+# permissive family actually present in the current transitive tree
+# (enumerated via `cargo deny list`); it is deliberately NOT a blanket allow.
+#
+# Copyleft note: MPL-2.0 is included. It is a *file-level* weak copyleft — it
+# governs only the individual MPL-licensed source files (cssparser, selectors,
+# slog, ...), imposes no obligation on the rest of the binary, and is standard
+# practice to ship in a permissively-licensed distributed application. Stronger
+# copyleft (GPL/AGPL/LGPL) is intentionally NOT allowed: `r-efi` is
+# `MIT OR Apache-2.0 OR LGPL-2.1-or-later`, so it resolves to MIT/Apache and its
+# LGPL arm is never selected — a crate offering *only* (L)GPL would still fail.
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    # LLVM-exception is a permissive linking exception layered on Apache-2.0
+    # (strictly more permissive). Required by winx, which offers no other arm;
+    # rustix/cap-std/wasi/wit-bindgen all also dual-license to plain MIT/Apache.
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+
+# The workspace's own crates (termihub, termihub-core, termihub-agent,
+# termihub-plugin-api, and the example plugins) carry no `license` field and so
+# read as "Unlicensed". They are first-party, never published to crates.io, and
+# covered by the repository's MIT LICENSE — not a third-party licensing concern.
+# `ignore = true` skips these private (publish = false) workspace members so the
+# gate applies only to external dependencies.
+private = { ignore = true }
+
+[sources]
+# Every crate must come from crates.io. An unexpected registry or a git
+# dependency (a common supply-chain injection vector) fails CI. The workspace
+# currently has no git dependencies; the vendored `vnc-rs` is an in-tree path
+# member (no external source) and is not subject to this check. Add a git URL to
+# `allow-git` here if a vetted git dependency is ever introduced.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+
 [bans]
 # Pre-release RustCrypto stack — documented release sign-off (#2074).
 #
@@ -61,6 +117,3 @@ ignore = [
 # not gate CI here.
 multiple-versions = "allow"
 wildcards = "allow"
-
-# `licenses` and `sources` are omitted deliberately — see the header note. When
-# they are added, wire `cargo deny check licenses sources` into CI as well.

--- a/plugin-api/Cargo.toml
+++ b/plugin-api/Cargo.toml
@@ -7,6 +7,12 @@ name = "termihub-plugin-api"
 version = "0.1.0"
 description = "Stable ABI contract for termiHub native (dynamically-loaded) terminal-backend plugins"
 edition = "2021"
+# First-party workspace crate — not currently published to crates.io (the repo
+# is MIT, see /LICENSE). Marks it private so cargo-deny's `[licenses]
+# private.ignore` skips its missing per-crate license field (#2096). If this ABI
+# contract is ever published for third-party plugin authors, drop this and add a
+# real `license` field.
+publish = false
 
 [dependencies]
 # Only dependency: ergonomic Rust-side error type. Kept intentionally minimal —

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"
+# First-party workspace crate — never published to crates.io (the repo is MIT,
+# see /LICENSE). Marks it private so cargo-deny's `[licenses] private.ignore`
+# skips its missing per-crate license field (#2096).
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Follow-up to #2074. Extends the cargo-deny supply-chain gate from `advisories bans` to also enforce the `licenses` and `sources` checks.

## Changes
- **`deny.toml` `[licenses]`** — explicit allowlist of the permissive license family actually present in the transitive tree (enumerated via `cargo deny list`), not a blanket allow:
  - `0BSD, Apache-2.0, Apache-2.0 WITH LLVM-exception, BSD-1-Clause, BSD-2-Clause, BSD-3-Clause, BSL-1.0, CC0-1.0, CDLA-Permissive-2.0, ISC, MIT, MIT-0, MPL-2.0, Unicode-3.0, Unlicense, Zlib`
  - `Apache-2.0 WITH LLVM-exception` is required by `winx` (no other license arm); it is a permissive linking exception layered on Apache-2.0.
  - `MPL-2.0` (cssparser/selectors/slog/...) is included — file-level weak copyleft, standard to ship in a distributed app. Stronger copyleft is **not** allowed: `r-efi` is `MIT OR Apache-2.0 OR LGPL-2.1-or-later`, so its LGPL arm is never selected; a crate offering only (L)GPL would still fail CI.
  - The workspace's own first-party crates have no `license` field. They are marked `publish = false` and skipped via `private.ignore` rather than weakening the gate.
- **`deny.toml` `[sources]`** — crates.io pinned as the only allowed registry; unknown registry/git sources denied. The workspace has no git deps; the vendored `vnc-rs` is an in-tree path member (no external source).
- **`*/Cargo.toml`** — `publish = false` added to `termihub`, `termihub-core`, `termihub-agent`, `termihub-plugin-api` (echo-backend already had it) so `private.ignore` covers them.
- **`.github/workflows/code-quality.yml`** — Security Audit job now runs `cargo deny check advisories bans licenses sources`.

## Verification
Locally (cargo-deny 0.20.2):
```
cargo deny check advisories bans licenses sources
# advisories ok, bans ok, licenses ok, sources ok
```
A disallowed license or unexpected source fails the build (the initial run with an empty allowlist rejected every crate).

Closes #2096