### PR TITLE
refactor(embedded-servers): extract embedded servers domain into a zustand slice

### DIFF
--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -166,17 +166,10 @@ import {
 } from "@/types/transfer";
 import { RemoteAgentConfig } from "@/types/terminal";
 import { createTunnelSlice, TunnelSlice } from "./slices/tunnelSlice";
-import { EmbeddedServerConfig, ServerState as EmbeddedServerState } from "@/types/embeddedServer";
 import {
-  listEmbeddedServers,
-  saveEmbeddedServer as apiSaveEmbeddedServer,
-  deleteEmbeddedServer as apiDeleteEmbeddedServer,
-  startEmbeddedServer as apiStartEmbeddedServer,
-  stopEmbeddedServer as apiStopEmbeddedServer,
-  getEmbeddedServerStates,
-  createAndStartServer as apiCreateAndStartServer,
-} from "@/services/embeddedServerApi";
-import { DEFAULT_PORTS, ServerType } from "@/types/embeddedServer";
+  createEmbeddedServersSlice,
+  EmbeddedServersSlice,
+} from "./slices/embedded-serversSlice";
 import {
   WorkspaceSummary,
   WorkspaceDefinition,
@@ -476,7 +469,7 @@ export interface AgentUpdatePending {
  */
 const AGENT_UPDATE_RECONNECT_BUFFER_SECS = 3;
 
-export interface AppState extends TunnelSlice {
+export interface AppState extends TunnelSlice, EmbeddedServersSlice {
   // Connection type registry (loaded from backend at startup)
   connectionTypes: ConnectionTypeInfo[];
 
@@ -1455,18 +1448,7 @@ export interface AppState extends TunnelSlice {
   // tab-opening action stays here as it belongs to the panel/tab domain.
   openTunnelEditorTab: (tunnelId: string | null) => void;
 
-  // Embedded Servers
-  embeddedServers: EmbeddedServerConfig[];
-  embeddedServerStates: Record<string, EmbeddedServerState>;
-  loadEmbeddedServers: () => Promise<void>;
-  /** Refresh only the live runtime states (stats/uptime) without reloading the config list. */
-  refreshEmbeddedServerStates: () => Promise<void>;
-  saveEmbeddedServer: (config: EmbeddedServerConfig) => Promise<void>;
-  deleteEmbeddedServer: (serverId: string) => Promise<void>;
-  startEmbeddedServer: (serverId: string) => Promise<void>;
-  stopEmbeddedServer: (serverId: string) => Promise<void>;
-  updateEmbeddedServerState: (state: EmbeddedServerState) => void;
-  quickShareServer: (path: string, protocol: ServerType) => Promise<string>;
+  // Embedded Servers — data + lifecycle live in EmbeddedServersSlice (#2113).
 
   // Macros
   macros: Macro[];
@@ -2999,6 +2981,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
     // Domain slices (#2077) — extracted from this monolith, spread in first so
     // the root store keeps the same public shape and behavior.
     ...createTunnelSlice(set, get, store),
+    ...createEmbeddedServersSlice(set, get, store),
 
     // Connection type registry — updated by loadFromBackend()
     connectionTypes: [],
@@ -7383,119 +7366,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
         return { rootPanel, activePanelId: targetPanelId };
       }),
 
-    // Embedded Servers
-    embeddedServers: [],
-    embeddedServerStates: {},
-
-    loadEmbeddedServers: async () => {
-      try {
-        const servers = await listEmbeddedServers();
-        const stateList = await getEmbeddedServerStates();
-        const embeddedServerStates: Record<string, EmbeddedServerState> = {};
-        for (const s of stateList) {
-          embeddedServerStates[s.serverId] = s;
-        }
-        set({ embeddedServers: servers, embeddedServerStates });
-      } catch (err) {
-        frontendLog(
-          "app_store",
-          `Failed to load embedded servers: ${err instanceof Error ? err.message : String(err)}`
-        );
-      }
-    },
-
-    refreshEmbeddedServerStates: async () => {
-      try {
-        const stateList = await getEmbeddedServerStates();
-        const embeddedServerStates: Record<string, EmbeddedServerState> = {};
-        for (const s of stateList) {
-          embeddedServerStates[s.serverId] = s;
-        }
-        set({ embeddedServerStates });
-      } catch (err) {
-        frontendLog("embedded_server", `Failed to refresh embedded server states: ${err}`);
-      }
-    },
-
-    saveEmbeddedServer: async (config) => {
-      try {
-        await apiSaveEmbeddedServer(config);
-        set((state) => {
-          const exists = state.embeddedServers.some((s) => s.id === config.id);
-          const embeddedServers = exists
-            ? state.embeddedServers.map((s) => (s.id === config.id ? config : s))
-            : [...state.embeddedServers, config];
-          return { embeddedServers };
-        });
-      } catch (err) {
-        frontendLog(
-          "app_store",
-          `Failed to save embedded server: ${err instanceof Error ? err.message : String(err)}`
-        );
-        throw err;
-      }
-    },
-
-    deleteEmbeddedServer: async (serverId) => {
-      try {
-        await apiDeleteEmbeddedServer(serverId);
-        set((state) => ({
-          embeddedServers: state.embeddedServers.filter((s) => s.id !== serverId),
-          embeddedServerStates: Object.fromEntries(
-            Object.entries(state.embeddedServerStates).filter(([k]) => k !== serverId)
-          ),
-        }));
-      } catch (err) {
-        // Propagate the failure so the caller (EmbeddedServerSidebar) can show
-        // an error toast — #1427. The server is only removed from the store on
-        // success above, so state stays correct on failure. Mirrors
-        // saveEmbeddedServer / deleteTunnel.
-        frontendLog("embedded_server", `Failed to delete embedded server ${serverId}: ${err}`);
-        throw err;
-      }
-    },
-
-    startEmbeddedServer: async (serverId) => {
-      try {
-        await apiStartEmbeddedServer(serverId);
-      } catch (err) {
-        frontendLog("embedded_server", `Failed to start embedded server ${serverId}: ${err}`);
-        throw err;
-      }
-    },
-
-    stopEmbeddedServer: async (serverId) => {
-      try {
-        await apiStopEmbeddedServer(serverId);
-      } catch (err) {
-        frontendLog("embedded_server", `Failed to stop embedded server ${serverId}: ${err}`);
-        throw err;
-      }
-    },
-
-    updateEmbeddedServerState: (state) => {
-      set((s) => ({
-        embeddedServerStates: { ...s.embeddedServerStates, [state.serverId]: state },
-      }));
-    },
-
-    quickShareServer: async (path, protocol) => {
-      const config: EmbeddedServerConfig = {
-        id: "",
-        name: `Quick Share (${protocol.toUpperCase()})`,
-        serverType: protocol,
-        rootDirectory: path,
-        bindHost: "127.0.0.1",
-        port: DEFAULT_PORTS[protocol],
-        autoStart: false,
-        readOnly: false,
-        directoryListing: protocol === "http" ? true : undefined,
-      };
-      const serverId = await apiCreateAndStartServer(config);
-      // Refresh server list so the new entry shows up in the sidebar.
-      await get().loadEmbeddedServers();
-      return serverId;
-    },
+    // Embedded Servers — data + lifecycle provided by createEmbeddedServersSlice (#2113).
 
     // Macros
     macros: [],

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -166,10 +166,7 @@ import {
 } from "@/types/transfer";
 import { RemoteAgentConfig } from "@/types/terminal";
 import { createTunnelSlice, TunnelSlice } from "./slices/tunnelSlice";
-import {
-  createEmbeddedServersSlice,
-  EmbeddedServersSlice,
-} from "./slices/embedded-serversSlice";
+import { createEmbeddedServersSlice, EmbeddedServersSlice } from "./slices/embedded-serversSlice";
 import {
   WorkspaceSummary,
   WorkspaceDefinition,

--- a/src/store/slices/embedded-serversSlice.ts
+++ b/src/store/slices/embedded-serversSlice.ts
@@ -1,0 +1,160 @@
+import { StateCreator } from "zustand";
+
+import {
+  listEmbeddedServers,
+  saveEmbeddedServer as apiSaveEmbeddedServer,
+  deleteEmbeddedServer as apiDeleteEmbeddedServer,
+  startEmbeddedServer as apiStartEmbeddedServer,
+  stopEmbeddedServer as apiStopEmbeddedServer,
+  getEmbeddedServerStates,
+  createAndStartServer as apiCreateAndStartServer,
+} from "@/services/embeddedServerApi";
+import {
+  DEFAULT_PORTS,
+  EmbeddedServerConfig,
+  ServerState as EmbeddedServerState,
+  ServerType,
+} from "@/types/embeddedServer";
+import { frontendLog } from "@/utils/frontendLog";
+
+import type { AppState } from "../appStore";
+
+/**
+ * Embedded HTTP/FTP/TFTP server domain slice (#2113): the embedded-server config
+ * list, live server states, and the CRUD/lifecycle actions that drive them.
+ * Extracted verbatim from the monolithic root store as a behavior-preserving
+ * Zustand slice — every action still receives the shared `set`/`get` typed
+ * against the full {@link AppState}, so the public store shape and behavior are
+ * unchanged. Mirrors the SSH tunnel slice (#2077).
+ */
+export interface EmbeddedServersSlice {
+  embeddedServers: EmbeddedServerConfig[];
+  embeddedServerStates: Record<string, EmbeddedServerState>;
+  loadEmbeddedServers: () => Promise<void>;
+  /** Refresh only the live runtime states (stats/uptime) without reloading the config list. */
+  refreshEmbeddedServerStates: () => Promise<void>;
+  saveEmbeddedServer: (config: EmbeddedServerConfig) => Promise<void>;
+  deleteEmbeddedServer: (serverId: string) => Promise<void>;
+  startEmbeddedServer: (serverId: string) => Promise<void>;
+  stopEmbeddedServer: (serverId: string) => Promise<void>;
+  updateEmbeddedServerState: (state: EmbeddedServerState) => void;
+  quickShareServer: (path: string, protocol: ServerType) => Promise<string>;
+}
+
+export const createEmbeddedServersSlice: StateCreator<AppState, [], [], EmbeddedServersSlice> = (
+  set,
+  get
+) => ({
+  embeddedServers: [],
+  embeddedServerStates: {},
+
+  loadEmbeddedServers: async () => {
+    try {
+      const servers = await listEmbeddedServers();
+      const stateList = await getEmbeddedServerStates();
+      const embeddedServerStates: Record<string, EmbeddedServerState> = {};
+      for (const s of stateList) {
+        embeddedServerStates[s.serverId] = s;
+      }
+      set({ embeddedServers: servers, embeddedServerStates });
+    } catch (err) {
+      frontendLog(
+        "app_store",
+        `Failed to load embedded servers: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  },
+
+  refreshEmbeddedServerStates: async () => {
+    try {
+      const stateList = await getEmbeddedServerStates();
+      const embeddedServerStates: Record<string, EmbeddedServerState> = {};
+      for (const s of stateList) {
+        embeddedServerStates[s.serverId] = s;
+      }
+      set({ embeddedServerStates });
+    } catch (err) {
+      frontendLog("embedded_server", `Failed to refresh embedded server states: ${err}`);
+    }
+  },
+
+  saveEmbeddedServer: async (config) => {
+    try {
+      await apiSaveEmbeddedServer(config);
+      set((state) => {
+        const exists = state.embeddedServers.some((s) => s.id === config.id);
+        const embeddedServers = exists
+          ? state.embeddedServers.map((s) => (s.id === config.id ? config : s))
+          : [...state.embeddedServers, config];
+        return { embeddedServers };
+      });
+    } catch (err) {
+      frontendLog(
+        "app_store",
+        `Failed to save embedded server: ${err instanceof Error ? err.message : String(err)}`
+      );
+      throw err;
+    }
+  },
+
+  deleteEmbeddedServer: async (serverId) => {
+    try {
+      await apiDeleteEmbeddedServer(serverId);
+      set((state) => ({
+        embeddedServers: state.embeddedServers.filter((s) => s.id !== serverId),
+        embeddedServerStates: Object.fromEntries(
+          Object.entries(state.embeddedServerStates).filter(([k]) => k !== serverId)
+        ),
+      }));
+    } catch (err) {
+      // Propagate the failure so the caller (EmbeddedServerSidebar) can show
+      // an error toast — #1427. The server is only removed from the store on
+      // success above, so state stays correct on failure. Mirrors
+      // saveEmbeddedServer / deleteTunnel.
+      frontendLog("embedded_server", `Failed to delete embedded server ${serverId}: ${err}`);
+      throw err;
+    }
+  },
+
+  startEmbeddedServer: async (serverId) => {
+    try {
+      await apiStartEmbeddedServer(serverId);
+    } catch (err) {
+      frontendLog("embedded_server", `Failed to start embedded server ${serverId}: ${err}`);
+      throw err;
+    }
+  },
+
+  stopEmbeddedServer: async (serverId) => {
+    try {
+      await apiStopEmbeddedServer(serverId);
+    } catch (err) {
+      frontendLog("embedded_server", `Failed to stop embedded server ${serverId}: ${err}`);
+      throw err;
+    }
+  },
+
+  updateEmbeddedServerState: (state) => {
+    set((s) => ({
+      embeddedServerStates: { ...s.embeddedServerStates, [state.serverId]: state },
+    }));
+  },
+
+  quickShareServer: async (path, protocol) => {
+    const config: EmbeddedServerConfig = {
+      id: "",
+      name: `Quick Share (${protocol.toUpperCase()})`,
+      serverType: protocol,
+      rootDirectory: path,
+      bindHost: "127.0.0.1",
+      port: DEFAULT_PORTS[protocol],
+      autoStart: false,
+      readOnly: false,
+      directoryListing: protocol === "http" ? true : undefined,
+    };
+    const serverId = await apiCreateAndStartServer(config);
+    // Refresh server list so the new entry shows up in the sidebar.
+    await get().loadEmbeddedServers();
+    return serverId;
+  },
+});


### PR DESCRIPTION
## Summary

Extracts the **Embedded Servers** domain out of the monolithic `src/store/appStore.ts` into a dedicated `StateCreator` slice at `src/store/slices/embedded-serversSlice.ts`, combined into the root `create()` via spread — exactly mirroring the SSH tunnel slice extraction (#2077, PR #2112).

Moved verbatim (state + actions):
- `embeddedServers`, `embeddedServerStates`
- `loadEmbeddedServers`, `refreshEmbeddedServerStates`, `saveEmbeddedServer`, `deleteEmbeddedServer`, `startEmbeddedServer`, `stopEmbeddedServer`, `updateEmbeddedServerState`, `quickShareServer`

`AppState` now `extends TunnelSlice, EmbeddedServersSlice`, so the public store shape and every action signature/behavior are unchanged. The domain has no tab-creating action, so nothing was left behind in the root store beyond the `get().loadEmbeddedServers()` call site (a normal slice consumer).

## Behavior preservation

Pure structural move — **zero behavior change, no consumer changes**. Verified:
- Full frontend test suite green: **4665 tests / 497 files pass**, including `appStore.embeddedServer-delete.test.ts`, the `EmbeddedServerSidebar` tests, and `useEmbeddedServerEvents.test.ts` — all of which exercise the slice through the combined root store.
- `pnpm build` (tsc + vite) clean; `pnpm run lint` clean.

No dedicated slice test added — same as the tunnel extraction (#2077), the behavior is fully covered through the combined store.

Closes #2113