### PR TITLE
test(ssh): de-race agent-forward SSH_AUTH_SOCK tests via injectable seam

### DIFF
--- a/core/src/backends/ssh/agent_forward.rs
+++ b/core/src/backends/ssh/agent_forward.rs
@@ -46,14 +46,27 @@ pub async fn connect_local_agent_boxed() -> std::io::Result<Box<dyn LocalAgentSt
 /// Connect a raw byte stream to the local SSH agent (Unix `$SSH_AUTH_SOCK`).
 #[cfg(unix)]
 async fn connect_local_agent() -> std::io::Result<tokio::net::UnixStream> {
-    let sock = std::env::var_os("SSH_AUTH_SOCK")
-        .filter(|s| !s.is_empty())
-        .ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "SSH_AUTH_SOCK is not set (no running ssh-agent)",
-            )
-        })?;
+    connect_local_agent_at(std::env::var_os("SSH_AUTH_SOCK")).await
+}
+
+/// Connect to the local SSH agent at an explicit socket path (Unix).
+///
+/// The path-injecting core of [`connect_local_agent`], which passes the live
+/// `$SSH_AUTH_SOCK`. An empty or absent path is treated as "no agent" and yields
+/// a `NotFound` error, matching the graceful no-op the connector relies on
+/// (#1699). Keeping the env read out of this function lets tests exercise the
+/// unset / dangling-path cases by value, without mutating the process-global
+/// `SSH_AUTH_SOCK` and racing other parallel tests (#2122).
+#[cfg(unix)]
+async fn connect_local_agent_at(
+    sock: Option<std::ffi::OsString>,
+) -> std::io::Result<tokio::net::UnixStream> {
+    let sock = sock.filter(|s| !s.is_empty()).ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "SSH_AUTH_SOCK is not set (no running ssh-agent)",
+        )
+    })?;
     tokio::net::UnixStream::connect(sock).await
 }
 
@@ -166,39 +179,42 @@ pub(crate) fn spawn_forwarded_agent_bridge(channel: Channel<Msg>) {
 mod tests {
     use super::*;
 
-    /// With `SSH_AUTH_SOCK` unset, no agent is reported available — the connector
-    /// relies on this to skip the forwarding request and log a no-op (#1699).
+    /// With no socket path (`SSH_AUTH_SOCK` unset), no agent is reachable — the
+    /// connector relies on this to skip the forwarding request and log a no-op
+    /// (#1699). Exercised through the injectable seam so the test never mutates
+    /// the process-global `SSH_AUTH_SOCK` and cannot race sibling tests (#2122).
     #[cfg(unix)]
     #[tokio::test]
     async fn local_agent_unavailable_when_sock_unset() {
-        // SAFETY: single-threaded test mutating a process env var it restores.
-        let orig = std::env::var_os("SSH_AUTH_SOCK");
-        unsafe { std::env::remove_var("SSH_AUTH_SOCK") };
-        let available = local_agent_available().await;
-        if let Some(val) = orig {
-            unsafe { std::env::set_var("SSH_AUTH_SOCK", val) };
-        }
         assert!(
-            !available,
+            connect_local_agent_at(None).await.is_err(),
             "no agent should be reachable without SSH_AUTH_SOCK"
         );
     }
 
+    /// An empty socket path is treated the same as unset — a stray empty
+    /// `SSH_AUTH_SOCK` must not be taken for a live agent.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn local_agent_unavailable_when_sock_empty() {
+        assert!(
+            connect_local_agent_at(Some(std::ffi::OsString::new()))
+                .await
+                .is_err(),
+            "an empty SSH_AUTH_SOCK is not a live agent"
+        );
+    }
+
     /// A pointer to a non-existent socket path is likewise unavailable rather than
-    /// an error that could abort a connect.
+    /// an error that could abort a connect. Passed by value through the seam, so
+    /// no process env is touched (#2122).
     #[cfg(unix)]
     #[tokio::test]
     async fn local_agent_unavailable_for_dangling_sock_path() {
-        // SAFETY: single-threaded test mutating a process env var it restores.
-        let orig = std::env::var_os("SSH_AUTH_SOCK");
-        unsafe { std::env::set_var("SSH_AUTH_SOCK", "/nonexistent/thub-agent-forward-test.sock") };
-        let available = local_agent_available().await;
-        match orig {
-            Some(val) => unsafe { std::env::set_var("SSH_AUTH_SOCK", val) },
-            None => unsafe { std::env::remove_var("SSH_AUTH_SOCK") },
-        }
         assert!(
-            !available,
+            connect_local_agent_at(Some("/nonexistent/thub-agent-forward-test.sock".into()))
+                .await
+                .is_err(),
             "a dangling SSH_AUTH_SOCK path is not a live agent"
         );
     }


### PR DESCRIPTION
## Problem

`core/src/backends/ssh/agent_forward.rs`'s tests mutated the **process-global** `SSH_AUTH_SOCK` (`remove_var`/`set_var`) and read it back through `local_agent_available()`. `cargo test` runs tests in parallel threads sharing one process env, so these raced any concurrent env-touching test in the same `termihub-core` binary — notably `auth.rs`'s agent-detection test, which also mutates `SSH_AUTH_SOCK`. The result was intermittent, platform-incidental failures (surfaced on macOS but not macOS-specific), which flaked several unrelated PRs this session.

## Fix — injectable seam (preferred option from the issue)

Extract `connect_local_agent_at(sock: Option<OsString>)` as the path-injecting core of the unix `connect_local_agent()`, which now simply passes the live `$SSH_AUTH_SOCK`. **Production behavior is unchanged** — the env read still happens in exactly the same place for the real code path.

The tests now exercise the unset / empty / dangling-path cases **by value** through this seam and no longer touch process env at all, so they cannot race sibling tests regardless of `--test-threads`. Coverage: added an explicit empty-path case alongside the existing unset and dangling-path cases.

This also de-races the whole `termihub-core` binary for `SSH_AUTH_SOCK`: with agent-forward no longer mutating it, `auth.rs` is left as the sole mutator (it can't race itself).

## Verification (how I confirmed no race)

- `cargo clippy -p termihub-core --features ssh --all-targets` — clean.
- Ran the **full `termihub-core` lib suite** (620 tests, including `auth.rs`'s env-mutating test running concurrently with these) **60 iterations at `--test-threads=16`** — 620 passed every run, **0 failures, 0 panics**.

The `ssh` module is behind the `ssh` cargo feature (`default = []`), so the tests only run under `--features ssh` / `--all-features` (as CI does).

Closes #2122