### PR TITLE
refactor(store): extract macros domain into a zustand slice (#2114)

### DIFF
--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -167,6 +167,9 @@ import {
 import { RemoteAgentConfig } from "@/types/terminal";
 import { createTunnelSlice, TunnelSlice } from "./slices/tunnelSlice";
 import { createEmbeddedServersSlice, EmbeddedServersSlice } from "./slices/embedded-serversSlice";
+import { createMacrosSlice, MacrosSlice } from "./slices/macrosSlice";
+
+export type { MacroPlaybackState, PlayMacroOptions } from "./slices/macrosSlice";
 import {
   WorkspaceSummary,
   WorkspaceDefinition,
@@ -193,20 +196,7 @@ import {
 } from "@/utils/restoreMode";
 import { probeRestoreTargets } from "@/utils/restoreReachability";
 import { probeTargetReachable } from "@/services/networkApi";
-import { Macro, MacroStep } from "@/types/macro";
-import {
-  listMacros as apiListMacros,
-  saveMacro as apiSaveMacro,
-  deleteMacro as apiDeleteMacro,
-} from "@/services/macroApi";
-import { parseMacroEnvelope, resolveImportCollisions } from "@/services/macroIo";
-import {
-  runMacroPlayback,
-  getTerminalInputInjector,
-  type MacroTimingMode,
-  type MacroInjector,
-  type MacroPlaybackHandle,
-} from "@/services/macroPlayback";
+import { runMacroPlayback, getTerminalInputInjector } from "@/services/macroPlayback";
 import { Workflow } from "@/types/workflow";
 import {
   listWorkflows as apiListWorkflows,
@@ -466,7 +456,7 @@ export interface AgentUpdatePending {
  */
 const AGENT_UPDATE_RECONNECT_BUFFER_SECS = 3;
 
-export interface AppState extends TunnelSlice, EmbeddedServersSlice {
+export interface AppState extends TunnelSlice, EmbeddedServersSlice, MacrosSlice {
   // Connection type registry (loaded from backend at startup)
   connectionTypes: ConnectionTypeInfo[];
 
@@ -1447,20 +1437,7 @@ export interface AppState extends TunnelSlice, EmbeddedServersSlice {
 
   // Embedded Servers — data + lifecycle live in EmbeddedServersSlice (#2113).
 
-  // Macros
-  macros: Macro[];
-  loadMacros: () => Promise<void>;
-  /** Save (add or update) a macro, then refresh the list. Returns the stored macro. */
-  saveMacroToBackend: (macro: Macro) => Promise<Macro>;
-  /** Delete a macro by ID; only mutates local state after the backend delete resolves. */
-  deleteMacroFromBackend: (macroId: string) => Promise<void>;
-  /**
-   * Import macros from an exported-macro file's JSON, merging them into the
-   * library. Malformed/incompatible files reject with a clear error and leave
-   * the library untouched; imported macros get fresh ids and de-duplicated
-   * names (see {@link resolveImportCollisions}). Returns the number imported.
-   */
-  importMacros: (json: string) => Promise<number>;
+  // Macros — library + recording + playback live in MacrosSlice (#2114).
 
   // Plugins (#1993 — frontend foundation for the plugin system)
   /** Installed plugins with their current install/runtime state. */
@@ -1518,59 +1495,7 @@ export interface AppState extends TunnelSlice, EmbeddedServersSlice {
    */
   selectPlugin: (pluginId: string) => void;
 
-  // Macro recording (#1674)
-  /** Whether terminal input is currently being captured into a macro. */
-  macroRecording: boolean;
-  /** The steps captured so far in the in-progress (or just-stopped) recording. */
-  macroRecordingSteps: MacroStep[];
-  /**
-   * Timestamp (ms) of the last captured chunk, used to derive the next step's
-   * `delayMs`. Internal to the recorder; `null` before the first chunk.
-   */
-  macroRecordingLastTime: number | null;
-  /** Whether the post-recording "name & save" dialog is open. */
-  macroSaveDialogOpen: boolean;
-  /** Begin a fresh recording, discarding any prior buffer. */
-  startMacroRecording: () => void;
-  /**
-   * Append one chunk of user input to the in-progress recording. No-op unless a
-   * recording is active. `delayMs` is the elapsed time since the previous chunk
-   * (0 for the first).
-   */
-  recordMacroInput: (data: string) => void;
-  /**
-   * Stop capturing. If anything was recorded, opens the save dialog; otherwise
-   * discards the empty recording and notifies the user.
-   */
-  stopMacroRecording: () => void;
-  /** Toggle recording: start if idle, stop (and prompt to save) if active. */
-  toggleMacroRecording: () => void;
-  /** Abort recording and discard the captured buffer without saving. */
-  cancelMacroRecording: () => void;
-  /** Persist the just-recorded steps as a named macro, then reset the recorder. */
-  saveRecordedMacro: (meta: {
-    name: string;
-    description?: string;
-    tags: string[];
-  }) => Promise<void>;
-  /** Close the save dialog and drop the captured buffer without persisting. */
-  discardRecordedMacro: () => void;
-
-  // Macro playback (#1675)
-  /** Metadata for the in-flight playback, or `null` when nothing is playing. */
-  macroPlayback: MacroPlaybackState | null;
-  /**
-   * Play a stored macro's recorded input into a target terminal, injecting each
-   * step through the existing `send_input` seam and honouring the timing mode.
-   * Defaults the target to the active terminal tab. Resolves when playback
-   * finishes (completed, cancelled, or errored). Only one playback runs at a
-   * time — a fresh call cancels any in-flight playback first. Surfaces a
-   * recoverable toast when the macro is missing/empty or the target terminal is
-   * not connected.
-   */
-  playMacro: (macroId: string, opts?: PlayMacroOptions) => Promise<void>;
-  /** Cancel the in-flight macro playback, if any. Idempotent. */
-  cancelMacroPlayback: () => void;
+  // Macro recording (#1674) + playback (#1675) — provided by MacrosSlice (#2114).
 
   // Broadcast input (#1955) — mirror typed input from a source terminal to many.
   /** Whether broadcast mode is currently active. */
@@ -1782,48 +1707,6 @@ export interface AppState extends TunnelSlice, EmbeddedServersSlice {
 }
 
 let tabCounter = 0;
-
-/** UI-facing metadata describing an in-flight macro playback (#1675). */
-export interface MacroPlaybackState {
-  /** The macro being played. */
-  macroId: string;
-  /** The macro's name, for the progress indicator. */
-  macroName: string;
-  /** The terminal tab receiving the injected input. */
-  tabId: string;
-  /** The timing mode this run is using. */
-  timingMode: MacroTimingMode;
-  /** Total number of steps in the macro. */
-  total: number;
-  /** Steps injected so far. */
-  played: number;
-}
-
-/** Options for {@link AppState.playMacro}. */
-export interface PlayMacroOptions {
-  /** Tab to inject into; defaults to the active terminal tab. */
-  targetTabId?: string;
-  /** Timing mode; defaults to `"real-time"`. */
-  timingMode?: MacroTimingMode;
-  /** Per-step delay (ms) for the `"fixed"` timing mode. */
-  fixedDelayMs?: number;
-}
-
-/**
- * Handle for the currently-running macro playback, held at module scope so
- * {@link AppState.cancelMacroPlayback} can stop it without threading the handle
- * through store state (it is not serializable). `null` when nothing is playing.
- */
-let activeMacroPlayback: MacroPlaybackHandle | null = null;
-
-/** Generate a unique macro id, falling back when `crypto.randomUUID` is absent. */
-function generateMacroId(): string {
-  const c = globalThis.crypto;
-  if (c && typeof c.randomUUID === "function") {
-    return `macro-${c.randomUUID()}`;
-  }
-  return `macro-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-}
 
 /**
  * Project the connection-type selector's plugin-backend entries from the
@@ -2284,7 +2167,7 @@ function resolveEditorSessionKey(
  * by the bulk-reconnect control to filter captured failed ids down to tabs that
  * still exist and can actually be re-driven (#1227).
  */
-function collectLiveTabs(state: {
+export function collectLiveTabs(state: {
   tabGroups: TabGroup[];
   activeTabGroupId: string;
   rootPanel: PanelNode;
@@ -2979,6 +2862,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
     // the root store keeps the same public shape and behavior.
     ...createTunnelSlice(set, get, store),
     ...createEmbeddedServersSlice(set, get, store),
+    ...createMacrosSlice(set, get, store),
 
     // Connection type registry — updated by loadFromBackend()
     connectionTypes: [],
@@ -7365,48 +7249,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
 
     // Embedded Servers — data + lifecycle provided by createEmbeddedServersSlice (#2113).
 
-    // Macros
-    macros: [],
-
-    loadMacros: async () => {
-      try {
-        const macros = await apiListMacros();
-        set({ macros });
-      } catch (err) {
-        frontendLog(
-          "app_store",
-          `Failed to load macros: ${err instanceof Error ? err.message : String(err)}`
-        );
-      }
-    },
-
-    saveMacroToBackend: async (macro) => {
-      const saved = await apiSaveMacro(macro);
-      await get().loadMacros();
-      return saved;
-    },
-
-    deleteMacroFromBackend: async (macroId) => {
-      // Only mutate local state after the backend delete resolves, and rethrow
-      // on failure so the caller can surface the error (mirrors workspaces).
-      await apiDeleteMacro(macroId);
-      set((state) => ({
-        macros: state.macros.filter((m) => m.id !== macroId),
-      }));
-    },
-
-    importMacros: async (json) => {
-      // Parse+validate first: a malformed file throws here, before any backend
-      // write, so a bad import can never corrupt the existing library (#1677).
-      const parsed = parseMacroEnvelope(json);
-      const prepared = resolveImportCollisions(parsed, get().macros, generateMacroId);
-      for (const macro of prepared) {
-        await apiSaveMacro(macro);
-      }
-      // Refresh once, after all saves, rather than per-macro.
-      await get().loadMacros();
-      return prepared.length;
-    },
+    // Macros — library + recording + playback provided by createMacrosSlice (#2114).
 
     // Plugins (#1993)
     plugins: [],
@@ -7585,221 +7428,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
         return { rootPanel, activePanelId: targetPanelId, selectedPluginId: pluginId };
       }),
 
-    // Macro recording (#1674)
-    macroRecording: false,
-    macroRecordingSteps: [],
-    macroRecordingLastTime: null,
-    macroSaveDialogOpen: false,
-
-    startMacroRecording: () => {
-      set({
-        macroRecording: true,
-        macroRecordingSteps: [],
-        macroRecordingLastTime: null,
-        macroSaveDialogOpen: false,
-      });
-      toast.info("Recording macro — type in the terminal, then stop to save");
-    },
-
-    recordMacroInput: (data) => {
-      const state = get();
-      if (!state.macroRecording) return;
-      const now = Date.now();
-      const last = state.macroRecordingLastTime;
-      const delayMs = last === null ? 0 : Math.max(0, now - last);
-      set({
-        macroRecordingSteps: [...state.macroRecordingSteps, { data, delayMs }],
-        macroRecordingLastTime: now,
-      });
-    },
-
-    stopMacroRecording: () => {
-      const state = get();
-      if (!state.macroRecording) return;
-      if (state.macroRecordingSteps.length === 0) {
-        // Nothing was typed — discard the empty recording rather than prompting.
-        set({
-          macroRecording: false,
-          macroRecordingLastTime: null,
-          macroSaveDialogOpen: false,
-        });
-        toast.info("No input was recorded");
-        return;
-      }
-      set({
-        macroRecording: false,
-        macroRecordingLastTime: null,
-        macroSaveDialogOpen: true,
-      });
-    },
-
-    toggleMacroRecording: () => {
-      if (get().macroRecording) {
-        get().stopMacroRecording();
-      } else {
-        get().startMacroRecording();
-      }
-    },
-
-    cancelMacroRecording: () => {
-      set({
-        macroRecording: false,
-        macroRecordingSteps: [],
-        macroRecordingLastTime: null,
-        macroSaveDialogOpen: false,
-      });
-      toast.info("Recording discarded");
-    },
-
-    saveRecordedMacro: async ({ name, description, tags }) => {
-      const steps = get().macroRecordingSteps;
-      const macro: Macro = {
-        id: generateMacroId(),
-        name,
-        description,
-        tags,
-        steps,
-        // The backend stamps authoritative created/updated timestamps.
-        createdAt: "",
-        updatedAt: "",
-      };
-      try {
-        await get().saveMacroToBackend(macro);
-        set({
-          macroRecordingSteps: [],
-          macroRecordingLastTime: null,
-          macroSaveDialogOpen: false,
-        });
-        toast.success(`Saved macro "${name}"`);
-      } catch (err) {
-        // Keep the dialog open so the user can retry without losing the capture.
-        toast.error(`Failed to save macro: ${err instanceof Error ? err.message : String(err)}`);
-        throw err;
-      }
-    },
-
-    discardRecordedMacro: () => {
-      set({
-        macroRecordingSteps: [],
-        macroRecordingLastTime: null,
-        macroSaveDialogOpen: false,
-      });
-    },
-
-    // Macro playback (#1675)
-    macroPlayback: null,
-
-    playMacro: async (macroId, opts) => {
-      const state = get();
-      const macro = state.macros.find((m) => m.id === macroId);
-      if (!macro) {
-        toast.error("Macro not found");
-        return;
-      }
-
-      const targetTabId = opts?.targetTabId ?? getActiveTab(state)?.id ?? null;
-      if (!targetTabId) {
-        toast.error("No active terminal to play the macro into");
-        return;
-      }
-
-      // Guard: only inject into a connected, non-exited terminal session.
-      const tab = collectLiveTabs(state).find((t) => t.id === targetTabId);
-      if (
-        !tab ||
-        tab.contentType !== "terminal" ||
-        !tab.sessionId ||
-        state.terminalExitedTabs[targetTabId]
-      ) {
-        toast.error("The target terminal is not connected");
-        return;
-      }
-
-      if (macro.steps.length === 0) {
-        toast.info(`Macro "${macro.name}" has no steps to play`);
-        return;
-      }
-
-      // Only one playback at a time — cancel any in-flight run first.
-      if (activeMacroPlayback) {
-        activeMacroPlayback.cancel();
-        activeMacroPlayback = null;
-      }
-
-      const timingMode = opts?.timingMode ?? "real-time";
-      const injector = getTerminalInputInjector();
-      const inject: MacroInjector = (data) => {
-        if (!injector) return false;
-        return injector(targetTabId, data);
-      };
-
-      const toastId = `macro-playback-${macroId}-${targetTabId}`;
-      const total = macro.steps.length;
-      toast.loading(`Playing macro "${macro.name}"…`, {
-        id: toastId,
-        description: `0 / ${total} steps`,
-      });
-      set({
-        macroPlayback: {
-          macroId,
-          macroName: macro.name,
-          tabId: targetTabId,
-          timingMode,
-          total,
-          played: 0,
-        },
-      });
-
-      const handle = runMacroPlayback(
-        macro.steps,
-        inject,
-        { timingMode, fixedDelayMs: opts?.fixedDelayMs },
-        {
-          onProgress: (played, stepTotal) => {
-            set((s) =>
-              s.macroPlayback &&
-              s.macroPlayback.macroId === macroId &&
-              s.macroPlayback.tabId === targetTabId
-                ? { macroPlayback: { ...s.macroPlayback, played } }
-                : {}
-            );
-            toast.loading(`Playing macro "${macro.name}"…`, {
-              id: toastId,
-              description: `${played} / ${stepTotal} steps`,
-            });
-          },
-        }
-      );
-      activeMacroPlayback = handle;
-
-      const result = await handle.done;
-
-      // Only clear shared state when this run is still the current one — a newer
-      // playMacro may have replaced it while this one was cancelled.
-      if (activeMacroPlayback === handle) {
-        activeMacroPlayback = null;
-        set({ macroPlayback: null });
-      }
-
-      if (result.status === "completed") {
-        toast.success(`Played macro "${macro.name}"`, { id: toastId });
-      } else if (result.status === "cancelled") {
-        toast.info(`Playback of "${macro.name}" cancelled`, {
-          id: toastId,
-          description: `Stopped after ${result.stepsPlayed} of ${total} steps`,
-        });
-      } else {
-        toast.error(`Could not play "${macro.name}" — the terminal is no longer connected`, {
-          id: toastId,
-        });
-      }
-    },
-
-    cancelMacroPlayback: () => {
-      if (activeMacroPlayback) {
-        activeMacroPlayback.cancel();
-      }
-    },
+    // Macro recording (#1674) + playback (#1675) provided by createMacrosSlice (#2114).
 
     // Broadcast input (#1955)
     broadcastActive: false,

--- a/src/store/slices/macrosSlice.ts
+++ b/src/store/slices/macrosSlice.ts
@@ -1,0 +1,402 @@
+import { StateCreator } from "zustand";
+
+import { toast } from "@/components/ui";
+import {
+  listMacros as apiListMacros,
+  saveMacro as apiSaveMacro,
+  deleteMacro as apiDeleteMacro,
+} from "@/services/macroApi";
+import { parseMacroEnvelope, resolveImportCollisions } from "@/services/macroIo";
+import {
+  runMacroPlayback,
+  getTerminalInputInjector,
+  type MacroTimingMode,
+  type MacroInjector,
+  type MacroPlaybackHandle,
+} from "@/services/macroPlayback";
+import { Macro, MacroStep } from "@/types/macro";
+import { frontendLog } from "@/utils/frontendLog";
+
+import { collectLiveTabs, getActiveTab, type AppState } from "../appStore";
+
+/** UI-facing metadata describing an in-flight macro playback (#1675). */
+export interface MacroPlaybackState {
+  /** The macro being played. */
+  macroId: string;
+  /** The macro's name, for the progress indicator. */
+  macroName: string;
+  /** The terminal tab receiving the injected input. */
+  tabId: string;
+  /** The timing mode this run is using. */
+  timingMode: MacroTimingMode;
+  /** Total number of steps in the macro. */
+  total: number;
+  /** Steps injected so far. */
+  played: number;
+}
+
+/** Options for {@link AppState.playMacro}. */
+export interface PlayMacroOptions {
+  /** Tab to inject into; defaults to the active terminal tab. */
+  targetTabId?: string;
+  /** Timing mode; defaults to `"real-time"`. */
+  timingMode?: MacroTimingMode;
+  /** Per-step delay (ms) for the `"fixed"` timing mode. */
+  fixedDelayMs?: number;
+}
+
+/**
+ * Handle for the currently-running macro playback, held at module scope so
+ * {@link AppState.cancelMacroPlayback} can stop it without threading the handle
+ * through store state (it is not serializable). `null` when nothing is playing.
+ */
+let activeMacroPlayback: MacroPlaybackHandle | null = null;
+
+/** Generate a unique macro id, falling back when `crypto.randomUUID` is absent. */
+function generateMacroId(): string {
+  const c = globalThis.crypto;
+  if (c && typeof c.randomUUID === "function") {
+    return `macro-${c.randomUUID()}`;
+  }
+  return `macro-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Macros domain slice (#2114): the stored-macro library plus the recording
+ * (#1674) and playback (#1675) state and the actions that drive them. Extracted
+ * verbatim from the monolithic root store as a behavior-preserving Zustand
+ * slice — every action still receives the shared `set`/`get` typed against the
+ * full {@link AppState}, so the public store shape and behavior are unchanged.
+ * Mirrors the SSH tunnel slice (#2077).
+ */
+export interface MacrosSlice {
+  // Macros
+  macros: Macro[];
+  loadMacros: () => Promise<void>;
+  /** Save (add or update) a macro, then refresh the list. Returns the stored macro. */
+  saveMacroToBackend: (macro: Macro) => Promise<Macro>;
+  /** Delete a macro by ID; only mutates local state after the backend delete resolves. */
+  deleteMacroFromBackend: (macroId: string) => Promise<void>;
+  /**
+   * Import macros from an exported-macro file's JSON, merging them into the
+   * library. Malformed/incompatible files reject with a clear error and leave
+   * the library untouched; imported macros get fresh ids and de-duplicated
+   * names (see {@link resolveImportCollisions}). Returns the number imported.
+   */
+  importMacros: (json: string) => Promise<number>;
+
+  // Macro recording (#1674)
+  /** Whether terminal input is currently being captured into a macro. */
+  macroRecording: boolean;
+  /** The steps captured so far in the in-progress (or just-stopped) recording. */
+  macroRecordingSteps: MacroStep[];
+  /**
+   * Timestamp (ms) of the last captured chunk, used to derive the next step's
+   * `delayMs`. Internal to the recorder; `null` before the first chunk.
+   */
+  macroRecordingLastTime: number | null;
+  /** Whether the post-recording "name & save" dialog is open. */
+  macroSaveDialogOpen: boolean;
+  /** Begin a fresh recording, discarding any prior buffer. */
+  startMacroRecording: () => void;
+  /**
+   * Append one chunk of user input to the in-progress recording. No-op unless a
+   * recording is active. `delayMs` is the elapsed time since the previous chunk
+   * (0 for the first).
+   */
+  recordMacroInput: (data: string) => void;
+  /**
+   * Stop capturing. If anything was recorded, opens the save dialog; otherwise
+   * discards the empty recording and notifies the user.
+   */
+  stopMacroRecording: () => void;
+  /** Toggle recording: start if idle, stop (and prompt to save) if active. */
+  toggleMacroRecording: () => void;
+  /** Abort recording and discard the captured buffer without saving. */
+  cancelMacroRecording: () => void;
+  /** Persist the just-recorded steps as a named macro, then reset the recorder. */
+  saveRecordedMacro: (meta: {
+    name: string;
+    description?: string;
+    tags: string[];
+  }) => Promise<void>;
+  /** Close the save dialog and drop the captured buffer without persisting. */
+  discardRecordedMacro: () => void;
+
+  // Macro playback (#1675)
+  /** Metadata for the in-flight playback, or `null` when nothing is playing. */
+  macroPlayback: MacroPlaybackState | null;
+  /**
+   * Play a stored macro's recorded input into a target terminal, injecting each
+   * step through the existing `send_input` seam and honouring the timing mode.
+   * Defaults the target to the active terminal tab. Resolves when playback
+   * finishes (completed, cancelled, or errored). Only one playback runs at a
+   * time — a fresh call cancels any in-flight playback first. Surfaces a
+   * recoverable toast when the macro is missing/empty or the target terminal is
+   * not connected.
+   */
+  playMacro: (macroId: string, opts?: PlayMacroOptions) => Promise<void>;
+  /** Cancel the in-flight macro playback, if any. Idempotent. */
+  cancelMacroPlayback: () => void;
+}
+
+export const createMacrosSlice: StateCreator<AppState, [], [], MacrosSlice> = (set, get) => ({
+  // Macros
+  macros: [],
+
+  loadMacros: async () => {
+    try {
+      const macros = await apiListMacros();
+      set({ macros });
+    } catch (err) {
+      frontendLog(
+        "app_store",
+        `Failed to load macros: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  },
+
+  saveMacroToBackend: async (macro) => {
+    const saved = await apiSaveMacro(macro);
+    await get().loadMacros();
+    return saved;
+  },
+
+  deleteMacroFromBackend: async (macroId) => {
+    // Only mutate local state after the backend delete resolves, and rethrow
+    // on failure so the caller can surface the error (mirrors workspaces).
+    await apiDeleteMacro(macroId);
+    set((state) => ({
+      macros: state.macros.filter((m) => m.id !== macroId),
+    }));
+  },
+
+  importMacros: async (json) => {
+    // Parse+validate first: a malformed file throws here, before any backend
+    // write, so a bad import can never corrupt the existing library (#1677).
+    const parsed = parseMacroEnvelope(json);
+    const prepared = resolveImportCollisions(parsed, get().macros, generateMacroId);
+    for (const macro of prepared) {
+      await apiSaveMacro(macro);
+    }
+    // Refresh once, after all saves, rather than per-macro.
+    await get().loadMacros();
+    return prepared.length;
+  },
+
+  // Macro recording (#1674)
+  macroRecording: false,
+  macroRecordingSteps: [],
+  macroRecordingLastTime: null,
+  macroSaveDialogOpen: false,
+
+  startMacroRecording: () => {
+    set({
+      macroRecording: true,
+      macroRecordingSteps: [],
+      macroRecordingLastTime: null,
+      macroSaveDialogOpen: false,
+    });
+    toast.info("Recording macro — type in the terminal, then stop to save");
+  },
+
+  recordMacroInput: (data) => {
+    const state = get();
+    if (!state.macroRecording) return;
+    const now = Date.now();
+    const last = state.macroRecordingLastTime;
+    const delayMs = last === null ? 0 : Math.max(0, now - last);
+    set({
+      macroRecordingSteps: [...state.macroRecordingSteps, { data, delayMs }],
+      macroRecordingLastTime: now,
+    });
+  },
+
+  stopMacroRecording: () => {
+    const state = get();
+    if (!state.macroRecording) return;
+    if (state.macroRecordingSteps.length === 0) {
+      // Nothing was typed — discard the empty recording rather than prompting.
+      set({
+        macroRecording: false,
+        macroRecordingLastTime: null,
+        macroSaveDialogOpen: false,
+      });
+      toast.info("No input was recorded");
+      return;
+    }
+    set({
+      macroRecording: false,
+      macroRecordingLastTime: null,
+      macroSaveDialogOpen: true,
+    });
+  },
+
+  toggleMacroRecording: () => {
+    if (get().macroRecording) {
+      get().stopMacroRecording();
+    } else {
+      get().startMacroRecording();
+    }
+  },
+
+  cancelMacroRecording: () => {
+    set({
+      macroRecording: false,
+      macroRecordingSteps: [],
+      macroRecordingLastTime: null,
+      macroSaveDialogOpen: false,
+    });
+    toast.info("Recording discarded");
+  },
+
+  saveRecordedMacro: async ({ name, description, tags }) => {
+    const steps = get().macroRecordingSteps;
+    const macro: Macro = {
+      id: generateMacroId(),
+      name,
+      description,
+      tags,
+      steps,
+      // The backend stamps authoritative created/updated timestamps.
+      createdAt: "",
+      updatedAt: "",
+    };
+    try {
+      await get().saveMacroToBackend(macro);
+      set({
+        macroRecordingSteps: [],
+        macroRecordingLastTime: null,
+        macroSaveDialogOpen: false,
+      });
+      toast.success(`Saved macro "${name}"`);
+    } catch (err) {
+      // Keep the dialog open so the user can retry without losing the capture.
+      toast.error(`Failed to save macro: ${err instanceof Error ? err.message : String(err)}`);
+      throw err;
+    }
+  },
+
+  discardRecordedMacro: () => {
+    set({
+      macroRecordingSteps: [],
+      macroRecordingLastTime: null,
+      macroSaveDialogOpen: false,
+    });
+  },
+
+  // Macro playback (#1675)
+  macroPlayback: null,
+
+  playMacro: async (macroId, opts) => {
+    const state = get();
+    const macro = state.macros.find((m) => m.id === macroId);
+    if (!macro) {
+      toast.error("Macro not found");
+      return;
+    }
+
+    const targetTabId = opts?.targetTabId ?? getActiveTab(state)?.id ?? null;
+    if (!targetTabId) {
+      toast.error("No active terminal to play the macro into");
+      return;
+    }
+
+    // Guard: only inject into a connected, non-exited terminal session.
+    const tab = collectLiveTabs(state).find((t) => t.id === targetTabId);
+    if (
+      !tab ||
+      tab.contentType !== "terminal" ||
+      !tab.sessionId ||
+      state.terminalExitedTabs[targetTabId]
+    ) {
+      toast.error("The target terminal is not connected");
+      return;
+    }
+
+    if (macro.steps.length === 0) {
+      toast.info(`Macro "${macro.name}" has no steps to play`);
+      return;
+    }
+
+    // Only one playback at a time — cancel any in-flight run first.
+    if (activeMacroPlayback) {
+      activeMacroPlayback.cancel();
+      activeMacroPlayback = null;
+    }
+
+    const timingMode = opts?.timingMode ?? "real-time";
+    const injector = getTerminalInputInjector();
+    const inject: MacroInjector = (data) => {
+      if (!injector) return false;
+      return injector(targetTabId, data);
+    };
+
+    const toastId = `macro-playback-${macroId}-${targetTabId}`;
+    const total = macro.steps.length;
+    toast.loading(`Playing macro "${macro.name}"…`, {
+      id: toastId,
+      description: `0 / ${total} steps`,
+    });
+    set({
+      macroPlayback: {
+        macroId,
+        macroName: macro.name,
+        tabId: targetTabId,
+        timingMode,
+        total,
+        played: 0,
+      },
+    });
+
+    const handle = runMacroPlayback(
+      macro.steps,
+      inject,
+      { timingMode, fixedDelayMs: opts?.fixedDelayMs },
+      {
+        onProgress: (played, stepTotal) => {
+          set((s) =>
+            s.macroPlayback &&
+            s.macroPlayback.macroId === macroId &&
+            s.macroPlayback.tabId === targetTabId
+              ? { macroPlayback: { ...s.macroPlayback, played } }
+              : {}
+          );
+          toast.loading(`Playing macro "${macro.name}"…`, {
+            id: toastId,
+            description: `${played} / ${stepTotal} steps`,
+          });
+        },
+      }
+    );
+    activeMacroPlayback = handle;
+
+    const result = await handle.done;
+
+    // Only clear shared state when this run is still the current one — a newer
+    // playMacro may have replaced it while this one was cancelled.
+    if (activeMacroPlayback === handle) {
+      activeMacroPlayback = null;
+      set({ macroPlayback: null });
+    }
+
+    if (result.status === "completed") {
+      toast.success(`Played macro "${macro.name}"`, { id: toastId });
+    } else if (result.status === "cancelled") {
+      toast.info(`Playback of "${macro.name}" cancelled`, {
+        id: toastId,
+        description: `Stopped after ${result.stepsPlayed} of ${total} steps`,
+      });
+    } else {
+      toast.error(`Could not play "${macro.name}" — the terminal is no longer connected`, {
+        id: toastId,
+      });
+    }
+  },
+
+  cancelMacroPlayback: () => {
+    if (activeMacroPlayback) {
+      activeMacroPlayback.cancel();
+    }
+  },
+});


### PR DESCRIPTION
## Summary

Post-release refactor (follow-up to #2077) extracting the **Macros** domain out of the `src/store/appStore.ts` monolith into a dedicated `StateCreator` slice at `src/store/slices/macrosSlice.ts`, combined into the root `create()` via spread — mirroring the SSH tunnel (#2077, PR #2112) and embedded-servers (#2113, PR #2124) slices exactly.

Closes #2114.

## What moved

- **Macro library**: `macros`, `loadMacros`, `saveMacroToBackend`, `deleteMacroFromBackend`, `importMacros`
- **Recording (#1674)**: `macroRecording`, `macroRecordingSteps`, `macroRecordingLastTime`, `macroSaveDialogOpen`, `startMacroRecording`, `recordMacroInput`, `stopMacroRecording`, `toggleMacroRecording`, `cancelMacroRecording`, `saveRecordedMacro`, `discardRecordedMacro`
- **Playback (#1675)**: `macroPlayback`, `playMacro`, `cancelMacroPlayback`
- Domain-only module state: the `generateMacroId` helper and the module-scope `activeMacroPlayback` handle
- The `MacroPlaybackState` / `PlayMacroOptions` interfaces move to the slice and are **re-exported from `appStore.ts`** to keep its export surface identical

## Behavior-preserving

Pure structural move — **zero behavior change**. The slice's `set`/`get` stay typed against the full `AppState` (`AppState extends … MacrosSlice`), so the public store shape and every action signature/behavior are unchanged; no consumer changed.

- **Nothing left behind in the root store**: no macros action creates a tab, so there is no analogue to tunnels' `openTunnelEditorTab` to keep in the panel/tab domain.
- `collectLiveTabs` is now `export`ed so the slice's `playMacro` can reuse it alongside the already-exported `getActiveTab`.
- `runMacroPlayback` / `getTerminalInputInjector` stay imported in `appStore.ts` — the workflow runner (`run-macro` step) also uses them; only the pure macros imports were removed.

## Verification

- Full frontend suite green: **497 files / 4665 tests passed** — including the dedicated `appStore.macro.test.ts`, `appStore.macroRecording.test.ts`, `appStore.macroPlayback.test.ts` which drive the store through `useAppStore` unchanged.
- `pnpm build` (tsc + vite), `pnpm run lint` (eslint), and prettier all clean.

Non-user-facing refactor — no changelog fragment.