### PR TITLE
fix(ui): reconcile undefined-but-fallback'd design-token references (Closes #2063)

### DIFF
--- a/docs/changes/dev1/fix/2063-fallback-tokens.md
+++ b/docs/changes/dev1/fix/2063-fallback-tokens.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- Reconciled every `var(--token, <fallback>)` reference whose design token was
+  undefined (a follow-up to #2052, which fixed the fallback-less ones). Each
+  dangling name was either repointed to the correct current token or backed by a
+  newly-defined token, so the affected surfaces (connection editor, terminal
+  reconnect/disconnect prompts, SSH/RDP trust dialogs, keyboard-shortcut conflict
+  box, recent-sessions popover, connection tree/path dialogs, plugins list, and
+  the SSH-config/bulk-import dialogs) now resolve real tokens. A handful of colors
+  that had been rendering an ad-hoc fallback now track the theme correctly — dialog
+  borders, the plugin focus ring, connection status colors, and the conflict-box
+  warning tint all align to the app's semantic tokens. The token-discipline guard
+  now also flags fallback-bearing references to undefined tokens, so a fallback can
+  no longer mask a stale token rename (#2063).

--- a/src/components/ConnectionEditor/ConnectionEditor.css
+++ b/src/components/ConnectionEditor/ConnectionEditor.css
@@ -276,7 +276,7 @@
 }
 
 .jump-host__path-arrow {
-  color: var(--text-tertiary, var(--text-secondary));
+  color: var(--text-secondary);
   flex-shrink: 0;
 }
 

--- a/src/components/ConnectionEditor/SshConfigImportDialog.css
+++ b/src/components/ConnectionEditor/SshConfigImportDialog.css
@@ -48,7 +48,7 @@
 .ssh-config-import__row:hover,
 .ssh-config-import__row:focus-visible {
   background: var(--bg-hover, rgba(127, 127, 127, 0.12));
-  border-color: var(--border-color, rgba(127, 127, 127, 0.25));
+  border-color: var(--border-primary);
 }
 
 .ssh-config-import__row-icon {

--- a/src/components/Plugins/Plugins.css
+++ b/src/components/Plugins/Plugins.css
@@ -74,11 +74,11 @@
 
 .plugin-row--selected,
 .plugin-row--selected:hover {
-  background: var(--bg-selected, var(--bg-hover));
+  background: var(--bg-hover);
 }
 
 .plugin-row:focus-visible {
-  outline: 2px solid var(--border-focus, var(--text-accent));
+  outline: 2px solid var(--focus-border);
   outline-offset: -2px;
 }
 

--- a/src/components/RecentSessionsSidebar/RecentSessionsSidebar.css
+++ b/src/components/RecentSessionsSidebar/RecentSessionsSidebar.css
@@ -39,7 +39,7 @@
   margin: 0;
   padding: 4px;
   list-style: none;
-  background: var(--bg-elevated, var(--bg-secondary));
+  background: var(--bg-secondary);
   border: 1px solid var(--border-primary);
   border-radius: var(--radius-md, 6px);
   box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.3));

--- a/src/components/RemoteDesktop/RemoteDesktopCertPrompt.css
+++ b/src/components/RemoteDesktop/RemoteDesktopCertPrompt.css
@@ -8,7 +8,7 @@
 }
 
 .rd-cert__title-icon {
-  color: var(--color-accent, var(--text-primary));
+  color: var(--accent-color);
 }
 
 .rd-cert__title-icon--warn {

--- a/src/components/Settings/KeyboardSettings.css
+++ b/src/components/Settings/KeyboardSettings.css
@@ -9,7 +9,7 @@
   margin-bottom: var(--spacing-md);
   padding: var(--spacing-sm) var(--spacing-md);
   background-color: var(--bg-secondary, transparent);
-  border: 1px solid var(--border-subtle, var(--border-primary));
+  border: 1px solid var(--border-primary);
   border-radius: var(--radius-md);
   color: var(--text-primary);
   font-size: var(--font-size-sm);
@@ -90,7 +90,7 @@
 
 .keyboard-settings__table td {
   padding: var(--spacing-xs) var(--spacing-sm);
-  border-bottom: 1px solid var(--border-subtle, var(--border-primary));
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .keyboard-settings__action-cell {

--- a/src/components/Settings/SyntaxHighlightingSettings.css
+++ b/src/components/Settings/SyntaxHighlightingSettings.css
@@ -105,5 +105,5 @@
   display: flex;
   flex-shrink: 0;
   align-items: center;
-  gap: var(--spacing-2xs, var(--spacing-xs));
+  gap: var(--spacing-xs);
 }

--- a/src/components/Sidebar/BulkSshImportDialog.css
+++ b/src/components/Sidebar/BulkSshImportDialog.css
@@ -78,7 +78,7 @@
   align-items: center;
   gap: 10px;
   padding: 4px 2px;
-  border-bottom: 1px solid var(--border-color, rgba(127, 127, 127, 0.25));
+  border-bottom: 1px solid var(--border-primary);
 }
 
 .bulk-ssh-import__selectall-label {
@@ -100,5 +100,5 @@
 .bulk-ssh-import__row:hover,
 .bulk-ssh-import__row:focus-within {
   background: var(--bg-hover, rgba(127, 127, 127, 0.12));
-  border-color: var(--border-color, rgba(127, 127, 127, 0.25));
+  border-color: var(--border-primary);
 }

--- a/src/components/Sidebar/ConnectionPathDialog.css
+++ b/src/components/Sidebar/ConnectionPathDialog.css
@@ -71,11 +71,11 @@
 }
 
 .connection-path-dialog__status--connected {
-  color: var(--status-success, #4caf50);
+  color: var(--color-success);
 }
 
 .connection-path-dialog__status--failed {
-  color: var(--status-error, #f44336);
+  color: var(--color-error);
 }
 
 .connection-path-dialog__status--spin {
@@ -90,7 +90,7 @@
 
 .connection-path-dialog__error {
   margin: 2px 0 0 30px;
-  color: var(--status-error, #f44336);
+  color: var(--color-error);
   font-size: 11px;
 }
 

--- a/src/components/Sidebar/FleetOnboardDialog.css
+++ b/src/components/Sidebar/FleetOnboardDialog.css
@@ -22,5 +22,5 @@
 
 .fleet-onboard__row:hover {
   background: var(--bg-hover, rgba(127, 127, 127, 0.12));
-  border-color: var(--border-color, rgba(127, 127, 127, 0.25));
+  border-color: var(--border-primary);
 }

--- a/src/components/SshHostKeyPrompt/SshHostKeyPrompt.css
+++ b/src/components/SshHostKeyPrompt/SshHostKeyPrompt.css
@@ -9,7 +9,7 @@
 }
 
 .ssh-hostkey__title-icon {
-  color: var(--color-accent, var(--text-primary));
+  color: var(--accent-color);
 }
 
 .ssh-hostkey__title-icon--warn {

--- a/src/components/Terminal/TerminalDisconnectOverlay.css
+++ b/src/components/Terminal/TerminalDisconnectOverlay.css
@@ -90,7 +90,7 @@
    vs. what does not, rendered a step quieter than the subheading. */
 .terminal-disconnect-overlay__note {
   font-size: var(--font-size-xs);
-  color: var(--text-tertiary, var(--text-secondary));
+  color: var(--text-secondary);
   max-width: 42ch;
 }
 

--- a/src/components/Terminal/TerminalReconnectPrompt.css
+++ b/src/components/Terminal/TerminalReconnectPrompt.css
@@ -17,12 +17,12 @@
   gap: var(--spacing-md);
   padding: var(--spacing-xl) var(--spacing-2xl, 32px);
   background: var(--bg-secondary, #252526);
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.12));
+  border: 1px solid var(--border-primary);
   border-radius: var(--radius-lg, 8px);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
   text-align: center;
   max-width: 320px;
-  font-family: var(--font-sans, sans-serif);
+  font-family: var(--font-family);
 }
 
 .terminal-reconnect-prompt__icon {

--- a/src/styles/tokenDiscipline.test.ts
+++ b/src/styles/tokenDiscipline.test.ts
@@ -280,10 +280,12 @@ function collectDefinedTokens(): Set<string> {
  * and borders vanished across 13+ stylesheets), so this guard fails on any
  * bare, fallback-less `var(--token)` whose token is not defined anywhere.
  *
- * Scope note: `var(--token, <fallback>)` is deliberately EXEMPT — the fallback
- * renders, so an undefined token there degrades gracefully rather than silently
- * breaking, exactly as the raw-hex guard exempts `var(--token, #hex)`. The
- * separately-tracked cleanup of undefined-but-fallback'd tokens is a follow-up.
+ * Scope note: the fallback-bearing form `var(--token, <fallback>)` was originally
+ * EXEMPT here — the fallback renders, so an undefined token there degrades
+ * gracefully rather than silently breaking. That cleanup landed as a follow-up
+ * (#2063), which reconciled every undefined-but-fallback'd reference, so the
+ * fallback form is now guarded too (see the fallback-bearing test below) — an
+ * undefined token can no longer hide behind a fallback and mask a stale rename.
  */
 describe("undefined design-token guard (#2052)", () => {
   const definedTokens = collectDefinedTokens();
@@ -311,6 +313,47 @@ describe("undefined design-token guard (#2052)", () => {
       "Fallback-less var(--token) references must resolve to a token defined in " +
         "src/styles/variables.css (or written by the theme engine). Rename each to the " +
         `current token or add the token. Dangling in:\n  ${offenders.join("\n  ")}`
+    ).toEqual([]);
+  });
+
+  /**
+   * Fallback-bearing ratchet (#2063). A `var(--token, <fallback>)` whose token is
+   * undefined still *renders* (via the fallback), so it does not visibly break —
+   * but the token name is stale/dangling and the fallback silently masks the
+   * rename. #2063 reconciled every such reference (define the token, or repoint to
+   * the current token whose value matches), leaving this set empty. The guard is
+   * the ratchet: a newly-introduced `var(--undefined, <fallback>)` now FAILS,
+   * forcing the token to be defined rather than papered over with a fallback.
+   *
+   * FALLBACK_UNDEFINED_ALLOWLIST is a shrinking ratchet — add a repo-relative
+   * suffix (POSIX separators) only with a written justification, and remove it as
+   * the underlying token is reconciled.
+   */
+  const FALLBACK_UNDEFINED_ALLOWLIST: string[] = [];
+
+  it("has no fallback-bearing var(--token, …) reference to an undefined token", () => {
+    // `var(--token,` — a token name immediately followed by a comma (a fallback).
+    // Only the outer token name is captured; the fallback (which may itself nest
+    // var()/color-mix() with parens) is not parsed, so nesting is handled.
+    const fallbackVarRe = /var\(\s*(--[a-z0-9-]+)\s*,/gi;
+    const offenders: string[] = [];
+    for (const file of collectCssFiles(COMPONENTS_DIR)) {
+      if (FALLBACK_UNDEFINED_ALLOWLIST.some((allowed) => toPosix(file).endsWith(allowed))) {
+        continue;
+      }
+      const css = stripCssComments(readFileSync(file, "utf8"));
+      const bad = new Set<string>();
+      for (const m of css.matchAll(fallbackVarRe)) {
+        if (!definedTokens.has(m[1])) bad.add(m[1]);
+      }
+      if (bad.size > 0) offenders.push(`${toPosix(file)} → ${[...bad].join(", ")}`);
+    }
+    expect(
+      offenders,
+      "Fallback-bearing var(--token, <fallback>) references must also resolve to a defined " +
+        "token — the fallback must not mask a dangling token name. Define the token in " +
+        "src/styles/variables.css (or the theme engine) or repoint to the current token whose " +
+        `value matches the fallback. Dangling in:\n  ${offenders.join("\n  ")}`
     ).toEqual([]);
   });
 });

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -7,6 +7,10 @@
   --bg-active: #252b3a;
   --bg-input: #1a1e2c;
   --bg-dropdown: #161b24;
+  /* Selected-item background (accent-tinted, VS Code-style). Derived from
+     --accent-color so it tracks the active theme. Used by the connection tree. */
+  --bg-selected: color-mix(in srgb, var(--accent-color) 18%, transparent);
+  --bg-selected-hover: color-mix(in srgb, var(--accent-color) 28%, transparent);
 
   /* Activity bar */
   --activity-bar-bg: #0b0d12;
@@ -54,6 +58,11 @@
   --color-warning: #d4a843;
   --color-error: #ef6b5a;
   --color-info: #6db0ff;
+  /* Semantic surface tints: translucent fills/borders derived from the status
+     hues so they track the active theme instead of hardcoding a color. */
+  --color-error-bg: color-mix(in srgb, var(--color-error) 12%, transparent);
+  --bg-warning: color-mix(in srgb, var(--color-warning) 12%, transparent);
+  --border-warning: color-mix(in srgb, var(--color-warning) 45%, transparent);
   /*
    * Notice amber: brighter than --color-warning, reserved for
    * "update available" indicator dots (status bar + update notification).
@@ -91,11 +100,13 @@
   --scrollbar-width: 8px;
 
   /* Spacing */
+  --spacing-xxs: 2px;
   --spacing-xs: 4px;
   --spacing-sm: 8px;
   --spacing-md: 12px;
   --spacing-lg: 16px;
   --spacing-xl: 24px;
+  --spacing-2xl: 32px;
 
   /* Font */
   --font-family: "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
@@ -117,6 +128,7 @@
 
   /* Shadows */
   --shadow-sm: 0 1px 4px rgba(0, 0, 0, 0.5), 0 0 1px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.3);
   --shadow-dropdown:
     0 8px 28px rgba(0, 0, 0, 0.6), 0 2px 8px rgba(0, 0, 0, 0.4),
     inset 0 1px 0 rgba(255, 255, 255, 0.04);
@@ -155,6 +167,7 @@
   --transition-slow: 380ms cubic-bezier(0.16, 1, 0.3, 1);
 
   /* Z-index layers */
+  --z-dropdown: 50;
   --z-toast: 1000;
 
   /* Status bar */


### PR DESCRIPTION
Follow-up to #2052 (PR #2062). Reconciles every `var(--token, <fallback>)` reference in `src/components/**` whose token was **undefined** — the fallback rendered, so nothing was visibly broken, but each was a dangling token name that could mask a stale rename.

## Resolution

Each dangling reference was either repointed to the correct current token, or backed by a newly-defined design token whose value matches the fallback the component already rendered.

**New tokens (`src/styles/variables.css`)** — value matches the prior fallback:

| Token | Value | Was fallback in |
| --- | --- | --- |
| `--bg-selected` / `--bg-selected-hover` | accent-tinted `color-mix` (18% / 28%) | ConnectionList |
| `--color-error-bg` | `color-mix(--color-error 12%)` | FileEditor |
| `--bg-warning` / `--border-warning` | `color-mix(--color-warning 12% / 45%)` | KeyboardSettings |
| `--spacing-xxs` / `--spacing-2xl` | `2px` / `32px` | UpdateAgentDialog / TerminalReconnectPrompt |
| `--shadow-md` | `0 4px 12px rgba(0,0,0,.3)` | RecentSessionsSidebar |
| `--z-dropdown` | `50` | RecentSessionsSidebar |

The three status-surface tints are derived from the existing per-theme `--color-error` / `--color-warning`, so they now track the active theme instead of a hardcoded color.

**Repoints to existing tokens** (fallback was an alias or ad-hoc approximation of the canonical token):

| Old dangling name | Now | Files |
| --- | --- | --- |
| `--text-tertiary` | `--text-secondary` | ConnectionEditor, TerminalDisconnectOverlay |
| `--border-color` / `--border-subtle` | `--border-primary` | Ssh/BulkSsh/FleetOnboard dialogs, TerminalReconnectPrompt, KeyboardSettings |
| `--border-focus` | `--focus-border` | Plugins |
| `--bg-elevated` | `--bg-secondary` | RecentSessionsSidebar |
| `--bg-selected` (plugins) | `--bg-hover` | Plugins |
| `--color-accent` | `--accent-color` | RemoteDesktopCertPrompt, SshHostKeyPrompt |
| `--font-sans` | `--font-family` | TerminalReconnectPrompt |
| `--spacing-2xs` | `--spacing-xs` | SyntaxHighlightingSettings |
| `--status-success` / `--status-error` | `--color-success` / `--color-error` | ConnectionPathDialog |

Where the fallback exactly matched the target token's var, nothing shifts visually. Where it had been an ad-hoc value (translucent-gray dialog borders, a lighter-blue focus ring, material green/red status colors, an orange warning tint), the reference now resolves the app's semantic theme token — a small, intentional alignment rather than a regression.

## Guardrail

Tightened the `#2052` undefined-token guard (`src/styles/tokenDiscipline.test.ts`) to **also** fail on a fallback-bearing `var(--token, <fallback>)` whose token is undefined, backed by an empty shrinking-ratchet allowlist. With every current reference reconciled the new test is clean (no noise), and a fallback can no longer hide a stale token rename going forward. The nesting-safe regex captures only the outer token name, so `var(--x, var(--y))` and `var(--x, color-mix(…var(--z)…))` are handled.

## Verification

- `vitest` token-discipline suite green (17 tests); enumeration script confirms **0** undefined-but-fallback'd references remain in `src/components/**`.
- `tsc --noEmit`, ESLint, Prettier, markdownlint all clean.

Closes #2063
