### PR TITLE
test(ssh): de-race remaining SSH_AUTH_SOCK mutations in sibling tests

### DIFF
--- a/core/src/backends/ssh/auth.rs
+++ b/core/src/backends/ssh/auth.rs
@@ -360,17 +360,29 @@ pub fn check_ssh_agent_status() -> String {
 
     #[cfg(not(target_os = "windows"))]
     {
-        use std::path::Path;
-        match std::env::var("SSH_AUTH_SOCK") {
-            Ok(sock_path) if !sock_path.is_empty() => {
-                if Path::new(&sock_path).exists() {
-                    "running".to_string()
-                } else {
-                    "stopped".to_string()
-                }
+        agent_status_for_sock(std::env::var_os("SSH_AUTH_SOCK"))
+    }
+}
+
+/// Resolve the agent status from an explicit `SSH_AUTH_SOCK` value (Unix).
+///
+/// The env-reading core of [`check_ssh_agent_status`]: an unset/empty path is
+/// `"stopped"`, a path that exists is `"running"`, and a dangling path is
+/// `"stopped"`. Keeping the env read out of this function lets tests exercise
+/// each case by value, without mutating the process-global `SSH_AUTH_SOCK` and
+/// racing other parallel tests (#2127).
+#[cfg(not(target_os = "windows"))]
+fn agent_status_for_sock(sock: Option<std::ffi::OsString>) -> String {
+    use std::path::Path;
+    match sock {
+        Some(sock_path) if !sock_path.is_empty() => {
+            if Path::new(&sock_path).exists() {
+                "running".to_string()
+            } else {
+                "stopped".to_string()
             }
-            _ => "stopped".to_string(),
         }
+        _ => "stopped".to_string(),
     }
 }
 
@@ -473,16 +485,27 @@ mod tests {
         );
     }
 
+    /// The status seam maps each `SSH_AUTH_SOCK` shape to running/stopped by
+    /// value, so these cases never touch the process-global env and cannot race
+    /// sibling tests (#2127).
     #[cfg(not(target_os = "windows"))]
     #[test]
-    fn check_ssh_agent_status_stopped_when_sock_unset() {
-        let orig = std::env::var("SSH_AUTH_SOCK").ok();
-        // SAFETY: test-only, single-threaded test runner
-        unsafe { std::env::remove_var("SSH_AUTH_SOCK") };
-        let status = check_ssh_agent_status();
-        assert_eq!(status, "stopped");
-        if let Some(val) = orig {
-            unsafe { std::env::set_var("SSH_AUTH_SOCK", val) };
-        }
+    fn agent_status_for_sock_maps_each_case() {
+        // Unset and empty are both "stopped" — no live agent.
+        assert_eq!(agent_status_for_sock(None), "stopped");
+        assert_eq!(
+            agent_status_for_sock(Some(std::ffi::OsString::new())),
+            "stopped"
+        );
+        // A path that does not exist is a dangling socket — "stopped".
+        assert_eq!(
+            agent_status_for_sock(Some("/nonexistent/thub-2127-agent.sock".into())),
+            "stopped"
+        );
+        // A path that exists reads as "running" (existence is all the check does).
+        assert_eq!(
+            agent_status_for_sock(Some(std::env::temp_dir().into_os_string())),
+            "running"
+        );
     }
 }

--- a/src-tauri/src/terminal/agent_forward.rs
+++ b/src-tauri/src/terminal/agent_forward.rs
@@ -22,8 +22,11 @@
 //! matching the no-agent behaviour of the SSH-reached path (#1699/#1719).
 
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
+use termihub_core::backends::ssh::agent_forward::{connect_local_agent_boxed, LocalAgentStream};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tracing::debug;
@@ -33,6 +36,24 @@ use super::agent_manager::AgentIoCommand;
 /// Max bytes read from the local agent per relay data frame; matches the
 /// agent-side chunk so neither side exceeds the transport's NDJSON line cap.
 const CHUNK_SIZE: usize = 65536;
+
+/// A one-shot factory that connects to the operator's local ssh-agent, yielding
+/// a duplex byte stream (or a `NotFound`-style error when no agent is
+/// reachable). Injected into the pump so tests can drive the no-local-agent path
+/// deterministically — by handing over a connector that fails — instead of
+/// pointing the process-global `SSH_AUTH_SOCK` at a dead path and racing sibling
+/// tests (#2127).
+type LocalAgentConnector = Box<
+    dyn FnOnce() -> Pin<Box<dyn Future<Output = std::io::Result<Box<dyn LocalAgentStream>>> + Send>>
+        + Send,
+>;
+
+/// The production connector: the operator's own local ssh-agent (Unix
+/// `$SSH_AUTH_SOCK` / the Windows OpenSSH named pipe), the exact connector the
+/// russh bridge uses.
+fn default_connector() -> LocalAgentConnector {
+    Box::new(|| Box::pin(connect_local_agent_boxed()))
+}
 
 /// Routes the desktop end of forwarded ssh-agent streams to the operator's
 /// local ssh-agent. One instance per connected agent's I/O loop.
@@ -54,12 +75,24 @@ impl DesktopAgentForward {
     /// Handle `agent.forward.open`: register the stream and start a task that
     /// connects to the local agent and pumps bytes for the stream's lifetime.
     pub fn on_open(&self, stream_id: String, command_tx: UnboundedSender<AgentIoCommand>) {
+        self.on_open_with(stream_id, command_tx, default_connector());
+    }
+
+    /// [`on_open`] with an injectable local-agent connector — the seam tests use
+    /// to exercise the no-local-agent path without mutating `SSH_AUTH_SOCK`
+    /// (#2127). Production calls [`on_open`], which passes [`default_connector`].
+    fn on_open_with(
+        &self,
+        stream_id: String,
+        command_tx: UnboundedSender<AgentIoCommand>,
+        connect: LocalAgentConnector,
+    ) {
         let (tx, rx) = mpsc::unbounded_channel::<Vec<u8>>();
         self.streams.lock().unwrap().insert(stream_id.clone(), tx);
 
         let streams = self.streams.clone();
         tokio::spawn(async move {
-            pump_local_agent(stream_id, rx, command_tx, streams).await;
+            pump_local_agent(stream_id, rx, command_tx, streams, connect).await;
         });
     }
 
@@ -85,9 +118,9 @@ async fn pump_local_agent(
     rx: mpsc::UnboundedReceiver<Vec<u8>>,
     command_tx: UnboundedSender<AgentIoCommand>,
     streams: Arc<Mutex<HashMap<String, UnboundedSender<Vec<u8>>>>>,
+    connect: LocalAgentConnector,
 ) {
-    let agent = match termihub_core::backends::ssh::agent_forward::connect_local_agent_boxed().await
-    {
+    let agent = match connect().await {
         Ok(agent) => agent,
         Err(e) => {
             // No local agent — mirror the russh no-op: tell the agent to drop the
@@ -162,14 +195,23 @@ mod tests {
     /// "no keys forwarded".
     #[tokio::test]
     async fn open_without_local_agent_closes_and_deregisters() {
-        // Point SSH_AUTH_SOCK at nothing so the connect fails deterministically.
-        // SAFETY: single-threaded test; the var is restored before returning.
-        let orig = std::env::var_os("SSH_AUTH_SOCK");
-        unsafe { std::env::set_var("SSH_AUTH_SOCK", "/nonexistent/thub-1727-test.sock") };
-
         let relay = DesktopAgentForward::new();
         let (tx, mut rx) = mpsc::unbounded_channel::<AgentIoCommand>();
-        relay.on_open("sess#1".to_string(), tx);
+        // Inject a connector that always fails — the no-local-agent path — so the
+        // test drives it deterministically, without pointing the process-global
+        // SSH_AUTH_SOCK at a dead path and racing sibling tests (#2127).
+        relay.on_open_with(
+            "sess#1".to_string(),
+            tx,
+            Box::new(|| {
+                Box::pin(async {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "no local ssh-agent",
+                    ))
+                })
+            }),
+        );
 
         // The pump task must report the stream closed …
         let cmd = rx.recv().await.expect("a close command");
@@ -185,10 +227,5 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
         assert!(relay.streams.lock().unwrap().is_empty());
-
-        match orig {
-            Some(v) => unsafe { std::env::set_var("SSH_AUTH_SOCK", v) },
-            None => unsafe { std::env::remove_var("SSH_AUTH_SOCK") },
-        }
     }
 }

--- a/src-tauri/src/utils/ssh_auth.rs
+++ b/src-tauri/src/utils/ssh_auth.rs
@@ -91,14 +91,14 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[test]
     fn check_ssh_agent_status_stopped_when_sock_unset() {
-        let orig = std::env::var("SSH_AUTH_SOCK").ok();
-        // SAFETY: test-only
-        unsafe { std::env::remove_var("SSH_AUTH_SOCK") };
-        let status = check_ssh_agent_status();
-        assert_eq!(status, "stopped");
-        if let Some(val) = orig {
-            unsafe { std::env::set_var("SSH_AUTH_SOCK", val) };
-        }
+        // This is a thin delegation to the core status check, which reads the
+        // env — there is no local seam to inject. `temp-env` scopes the unset to
+        // the closure, restores the original afterwards, and serializes with
+        // other `temp-env` users, so the process-global `SSH_AUTH_SOCK` is no
+        // longer mutated in a way that races sibling tests (#2127).
+        temp_env::with_var("SSH_AUTH_SOCK", None::<&str>, || {
+            assert_eq!(check_ssh_agent_status(), "stopped");
+        });
     }
 
     /// Regression guard for #828.


### PR DESCRIPTION
Follow-up to #2122 (PR #2125). Three sibling tests still mutated the process-global `SSH_AUTH_SOCK` (`set_var`/`remove_var`). They are safe **today** only because each is the sole `SSH_AUTH_SOCK` mutator in its test binary, but they remain a latent flake: any future test in the same binary that reads the var would race them. This removes all three mutations, preferring the injectable-seam approach #2122 used.

## Changes per file

- **`core/src/backends/ssh/auth.rs`** — *injectable seam.* Extract the unix env read out of `check_ssh_agent_status` into a by-value helper `agent_status_for_sock(sock: Option<OsString>)`; the public function passes `std::env::var_os("SSH_AUTH_SOCK")`. The test now covers the unset / empty / dangling-path / existing-path cases **by value**, deterministically, instead of removing the env.
- **`src-tauri/src/terminal/agent_forward.rs`** — *injectable seam (dependency injection).* Make the local-agent connector an injectable parameter (`LocalAgentConnector`) threaded through a new internal `on_open_with` into `pump_local_agent`; production `on_open` passes `default_connector` (`connect_local_agent_boxed`, unchanged). The no-local-agent test hands over a connector that always fails, so it drives the graceful-no-op path without pointing `SSH_AUTH_SOCK` at a dead path — and it is now platform-agnostic (no longer relying on an absent Windows named pipe).
- **`src-tauri/src/utils/ssh_auth.rs`** — *temp-env.* This wrapper purely delegates to core and owns no seam of its own, so the unset is scoped with `temp-env` (already a dev-dependency), which saves+restores the original value and serializes with other `temp-env` users.

**No production behavior change** — only test code and testability seams.

## Verification

- `cargo test -p termihub-core --features ssh` and `cargo test -p termihub` — all green.
- Repeated parallel runs to confirm no race:
  - core ssh lib tests **5×** at `--test-threads=16` — all ok.
  - the affected src-tauri lib tests (`ssh_auth`, `agent_forward`) **6×** at `--test-threads=24` — all ok.
- `cargo fmt --all -- --check` and `cargo clippy` clean on both crates.
- Confirmed no `SSH_AUTH_SOCK` `set_var`/`remove_var` remains anywhere under `core/src` or `src-tauri/src`.

Closes #2127