### PR TITLE
refactor(sftp): remove dead SftpFileBackend FileBackend impl (refs #2104)

### DIFF
--- a/src-tauri/src/files/sftp.rs
+++ b/src-tauri/src/files/sftp.rs
@@ -10,8 +10,7 @@ use tracing::{debug, info, warn};
 
 use termihub_core::backends::ssh::handler::SshSession;
 use termihub_core::backends::ssh::{sftp, ssh_exec_with_stdin, SshExecOutput};
-use termihub_core::errors::FileError;
-use termihub_core::files::{FileBackend, FileEntry};
+use termihub_core::files::FileEntry;
 
 use crate::terminal::backend::SshConfig;
 use crate::utils::errors::TerminalError;
@@ -23,8 +22,7 @@ use crate::utils::ssh_auth::connect_and_authenticate;
 /// A prior SFTP op that panicked while holding the lock poisons the `Mutex`;
 /// a raw `.lock().unwrap()` would then abort the whole process on every
 /// subsequent command. Mapping the error keeps the session recoverable
-/// (audit GAP C1, issue #1143). Mirrors the error mapping already used by the
-/// [`SftpFileBackend`] impl.
+/// (audit GAP C1, issue #1143).
 pub fn lock_session<T>(mutex: &Mutex<T>) -> Result<MutexGuard<'_, T>, TerminalError> {
     mutex
         .lock()
@@ -491,29 +489,6 @@ impl SftpSession {
         })
     }
 
-    /// Read a remote file's contents as raw bytes.
-    #[allow(dead_code)]
-    pub fn read_bytes(&self, remote_path: &str) -> Result<Vec<u8>, TerminalError> {
-        let remote_path = remote_path.to_string();
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                let mut remote = self
-                    .sftp
-                    .open(&remote_path)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("open remote file: {e}")))?;
-
-                let mut data = Vec::new();
-                remote
-                    .read_to_end(&mut data)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("read failed: {e}")))?;
-
-                Ok::<Vec<u8>, TerminalError>(data)
-            })
-        })
-    }
-
     /// Write raw bytes to a remote file, creating or overwriting it.
     #[allow(dead_code)]
     pub fn write_bytes(&self, remote_path: &str, data: &[u8]) -> Result<(), TerminalError> {
@@ -613,128 +588,6 @@ impl SftpSession {
 
         debug!(remote_path, ?outcome, "SFTP elevated save: completed");
         Ok(outcome)
-    }
-}
-
-/// Map a `TerminalError` to a `FileError::OperationFailed`.
-#[allow(dead_code)]
-fn terminal_error_to_file_error(e: TerminalError) -> FileError {
-    FileError::OperationFailed(e.to_string())
-}
-
-/// Async file backend implementation backed by an SFTP session.
-#[allow(dead_code)]
-pub struct SftpFileBackend {
-    session: Arc<Mutex<SftpSession>>,
-}
-
-#[allow(dead_code)]
-impl SftpFileBackend {
-    pub fn new(session: Arc<Mutex<SftpSession>>) -> Self {
-        Self { session }
-    }
-}
-
-#[async_trait::async_trait]
-impl FileBackend for SftpFileBackend {
-    async fn list(&self, path: &str) -> Result<Vec<FileEntry>, FileError> {
-        let session = self.session.clone();
-        let path = path.to_string();
-        tauri::async_runtime::spawn_blocking(move || {
-            let sftp = session.lock().map_err(|e| {
-                FileError::OperationFailed(format!("Failed to lock SFTP session: {e}"))
-            })?;
-            sftp.list_dir(&path).map_err(terminal_error_to_file_error)
-        })
-        .await
-        .map_err(|e| FileError::OperationFailed(format!("Task join failed: {e}")))?
-    }
-
-    async fn read(&self, path: &str) -> Result<Vec<u8>, FileError> {
-        let session = self.session.clone();
-        let path = path.to_string();
-        tauri::async_runtime::spawn_blocking(move || {
-            let sftp = session.lock().map_err(|e| {
-                FileError::OperationFailed(format!("Failed to lock SFTP session: {e}"))
-            })?;
-            sftp.read_bytes(&path).map_err(terminal_error_to_file_error)
-        })
-        .await
-        .map_err(|e| FileError::OperationFailed(format!("Task join failed: {e}")))?
-    }
-
-    async fn write(&self, path: &str, data: &[u8]) -> Result<(), FileError> {
-        let session = self.session.clone();
-        let path = path.to_string();
-        let data = data.to_vec();
-        tauri::async_runtime::spawn_blocking(move || {
-            let sftp = session.lock().map_err(|e| {
-                FileError::OperationFailed(format!("Failed to lock SFTP session: {e}"))
-            })?;
-            sftp.write_bytes(&path, &data)
-                .map_err(terminal_error_to_file_error)
-        })
-        .await
-        .map_err(|e| FileError::OperationFailed(format!("Task join failed: {e}")))?
-    }
-
-    async fn delete(&self, path: &str, is_directory: bool) -> Result<(), FileError> {
-        let session = self.session.clone();
-        let path = path.to_string();
-        tauri::async_runtime::spawn_blocking(move || {
-            let sftp = session.lock().map_err(|e| {
-                FileError::OperationFailed(format!("Failed to lock SFTP session: {e}"))
-            })?;
-            if is_directory {
-                sftp.remove_dir(&path)
-            } else {
-                sftp.remove_file(&path)
-            }
-            .map_err(terminal_error_to_file_error)
-        })
-        .await
-        .map_err(|e| FileError::OperationFailed(format!("Task join failed: {e}")))?
-    }
-
-    async fn rename(&self, old_path: &str, new_path: &str) -> Result<(), FileError> {
-        let session = self.session.clone();
-        let old_path = old_path.to_string();
-        let new_path = new_path.to_string();
-        tauri::async_runtime::spawn_blocking(move || {
-            let sftp = session.lock().map_err(|e| {
-                FileError::OperationFailed(format!("Failed to lock SFTP session: {e}"))
-            })?;
-            sftp.rename(&old_path, &new_path)
-                .map_err(terminal_error_to_file_error)
-        })
-        .await
-        .map_err(|e| FileError::OperationFailed(format!("Task join failed: {e}")))?
-    }
-
-    async fn stat(&self, path: &str) -> Result<FileEntry, FileError> {
-        let session = self.session.clone();
-        let path = path.to_string();
-        tauri::async_runtime::spawn_blocking(move || {
-            let sftp = session.lock().map_err(|e| {
-                FileError::OperationFailed(format!("Failed to lock SFTP session: {e}"))
-            })?;
-            sftp.stat(&path).map_err(terminal_error_to_file_error)
-        })
-        .await
-        .map_err(|e| FileError::OperationFailed(format!("Task join failed: {e}")))?
-    }
-
-    async fn mkdir(&self, path: &str) -> Result<(), FileError> {
-        let session = self.session.clone();
-        let path = path.to_string();
-        tauri::async_runtime::spawn_blocking(move || {
-            let sftp = session.lock().map_err(|e| {
-                FileError::OperationFailed(format!("Failed to lock SFTP session: {e}"))
-            })?;
-            sftp.mkdir(&path).map_err(terminal_error_to_file_error)
-        })
-        .await
-        .map_err(|e| FileError::OperationFailed(format!("Task join failed: {e}")))?
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #2075 (PR #2103) toward the deeper SFTP convergence tracked in #2104. This is the **safe first slice**: it retires the desktop's dead parallel capability-trait implementation without touching any live SFTP behavior.

The desktop `SftpFileBackend` was an entirely `#[allow(dead_code)]` `FileBackend` implementation with **no consumers anywhere in the workspace** — the desktop file-browser and transfer command layers drive `SftpSession` directly, never this backend. It was also the only `FileBackend` impl in `src-tauri`, so removing it leaves the core `FileBrowser` trait as the single browsing trait to converge onto (progress on scope items 3 and 4).

Removed with it, as they were consumed **only** by that dead impl:
- `terminal_error_to_file_error`
- `SftpSession::read_bytes`
- the now-unused `FileBackend` / `FileError` imports

## Behavior change

**None.** Nothing referenced any of the removed symbols. Every live desktop-only capability is untouched: elevated `sudo` writes (#1323), the cancellable transfer queue + dedicated per-transfer channel (#1245), `check_writable`/`Writability`, the exec-capability probe, `realpath`, `remote_size`, and jump-host-aware connect (#939).

## What is deferred (why this is a partial, #2104 stays OPEN)

Scope items 1 & 2 — pushing the live desktop-only capabilities into core behind the trait and migrating the desktop command/transfer layer off the parallel `SftpSession` — are a live change in the **least-tested backend code** (#2050) touching file transfers and elevated writes. They must land behind the SFTP integration suite and are a big-bang risk to do in one PR, so they are deferred to a dedicated follow-up (filed, `Ready2Implement`). This PR does the reviewable, zero-risk part.

## Verification (local, dev4 offset +4000)

All run against live Docker fixtures — these suites do NOT run in per-PR CI:
- Desktop SFTP unit tests: **22 passed**
- `core/tests/sftp_stress.rs` (16 tests): **16 passed** — download 1/10/100 MB, upload roundtrip, deep trees, symlinks (valid/broken/circular), unicode/space/long filenames, permission-000 edge cases
- `src-tauri/tests/sftp_transfer.rs` (3 tests): **3 passed** — `check_writable` owner-vs-root, cancel-mid-transfer partial cleanup, browsing-stays-live-during-transfer (dedicated channel / transfer queue)
- Elevated-save Docker tests (`ssh-sudo`/`ssh-nosudo`): **5 passed** (run `--test-threads=1`; they share one root-owned target file so parallel runs race) — success rewrites root file preserving owner/mode, wrong-password leaves file untouched, no-sudo → `Other`

`cargo clippy -p termihub --all-targets -- -D warnings` is clean.

Refs #2104


---
Deferred convergence tracked in #2135.