### PR TITLE
feat(security): drop production ws:// CSP allowance and add a CSP-violation CI guard (part of #2059)

### DIFF
--- a/.github/workflows/system-integration.yml
+++ b/.github/workflows/system-integration.yml
@@ -139,7 +139,15 @@ jobs:
         # The integration lane launches the real app; the harness resolves the
         # debug bundle (target/debug/…) when no release build is present. Debug
         # builds far faster than release, which is what we want for a nightly.
-        run: pnpm tauri build --debug
+        #
+        # --config src-tauri/tauri.test.conf.json re-adds the loopback ws:// the
+        # bridge's in-app client needs: the production CSP no longer allows any
+        # ws:// in connect-src (#2059), and the overlay restores it for test
+        # builds only. Everything else in the CSP (script-src, style-src, …) is
+        # identical to production, so this lane still exercises the shipped
+        # rendering-relevant policy — including the CSP-violation assertion in
+        # test_csp.py.
+        run: pnpm tauri build --debug --config src-tauri/tauri.test.conf.json
 
       - name: Bring up the Docker fixtures
         # Linux only. Pre-build and start the profile-less SSH/telnet fixtures so

--- a/scripts/test-system-py.sh
+++ b/scripts/test-system-py.sh
@@ -137,10 +137,18 @@ if [ "$BUILD_ACTION" = "build" ]; then
         pnpm install
     fi
     echo "=== Building termiHub ($PROFILE) ==="
+    # The system-test bridge's in-app client connects out over a loopback
+    # WebSocket (ws://127.0.0.1:<port>), but the production CSP in
+    # tauri.conf.json no longer allows any ws:// in connect-src (#2059 — real
+    # users never run the bridge, so the app needs no WebSocket connect-src). The
+    # loopback allowance is re-added ONLY for test builds via this config overlay,
+    # which deep-merges over tauri.conf.json. A build without it cannot connect
+    # the bridge — so any test build MUST pass --config here (see also
+    # system-integration.yml and tests/system/README.md).
     if [ "$PROFILE" = "debug" ]; then
-        pnpm tauri build --debug
+        pnpm tauri build --debug --config src-tauri/tauri.test.conf.json
     else
-        pnpm tauri build
+        pnpm tauri build --config src-tauri/tauri.test.conf.json
     fi
 else
     echo "=== Build $BUILD_ACTION, using $APP_BINARY ==="

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
+      "csp": "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
       "dangerousDisableAssetCspModification": ["style-src"]
     }
   },

--- a/src-tauri/tauri.test.conf.json
+++ b/src-tauri/tauri.test.conf.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "security": {
+      "csp": "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
+      "dangerousDisableAssetCspModification": ["style-src"]
+    }
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,13 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles/global.css";
 import { registerCustomMonacoLanguages } from "./utils/monacoCustomLanguages";
+import { installCspViolationReporter } from "./security/cspViolationReporter";
+
+// Surface any Content-Security-Policy violation (LogViewer + a bridge-readable
+// DOM sink) so a real-build boot/render check can assert the shipped CSP does
+// not block anything the app needs (#2059). Inert unless the browser blocks a
+// resource; installed before React mounts so early violations are captured.
+installCspViolationReporter();
 
 // Start loading TextMate grammars via Shiki in the background.
 // Editors show uncoloured text briefly until the grammars are ready.

--- a/src/security/cspConfig.test.ts
+++ b/src/security/cspConfig.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Static guards on the shipped Content-Security-Policy (#2048/#2059).
+ *
+ * These assert invariants on `tauri.conf.json` (the production CSP) and
+ * `tauri.test.conf.json` (the test-build overlay) as plain data, so an
+ * accidental loosening — a re-added `ws://`, an `'unsafe-inline'`/`'unsafe-eval'`
+ * creeping into `script-src` — fails fast in per-PR CI, without needing a full
+ * app build. The runtime "app boots + terminal renders + zero violations under
+ * the CSP" check lives in the integration lane (`tests/system/tests/test_csp.py`).
+ */
+
+function readCsp(relPath: string): string {
+  // Vitest runs with the repo root as cwd, so the config lives at src-tauri/<file>.
+  const path = resolve(process.cwd(), "src-tauri", relPath);
+  const conf = JSON.parse(readFileSync(path, "utf8")) as {
+    app: { security: { csp: string } };
+  };
+  return conf.app.security.csp;
+}
+
+/** Parse a CSP string into a `directive -> sources[]` map. */
+function parseCsp(csp: string): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const clause of csp.split(";")) {
+    const [directive, ...sources] = clause.trim().split(/\s+/).filter(Boolean);
+    if (directive) out[directive] = sources;
+  }
+  return out;
+}
+
+const prodCsp = readCsp("tauri.conf.json");
+const testCsp = readCsp("tauri.test.conf.json");
+const prod = parseCsp(prodCsp);
+const test = parseCsp(testCsp);
+
+describe("production CSP (tauri.conf.json)", () => {
+  it("has no 'unsafe-inline' or 'unsafe-eval' in script-src", () => {
+    expect(prod["script-src"]).toBeDefined();
+    expect(prod["script-src"]).not.toContain("'unsafe-inline'");
+    expect(prod["script-src"]).not.toContain("'unsafe-eval'");
+  });
+
+  it("allows no WebSocket (ws://) origin in connect-src — the bridge allowance is test-only (#2059)", () => {
+    expect(prod["connect-src"]).toBeDefined();
+    expect(prod["connect-src"].some((s) => s.startsWith("ws://") || s.startsWith("wss://"))).toBe(
+      false
+    );
+  });
+
+  it("keeps object-src / frame-src locked down", () => {
+    expect(prod["object-src"]).toEqual(["'none'"]);
+    expect(prod["frame-src"]).toEqual(["'none'"]);
+  });
+});
+
+describe("test-build CSP overlay (tauri.test.conf.json)", () => {
+  it("re-adds ONLY the loopback ws:// bridge allowance to connect-src", () => {
+    const added = test["connect-src"].filter((s) => !prod["connect-src"].includes(s));
+    expect(added).toEqual(["ws://127.0.0.1:*", "ws://localhost:*"]);
+  });
+
+  it("is otherwise byte-identical to production — every non-connect-src directive matches", () => {
+    // Drift lock: editing the production CSP must be mirrored in the overlay, or
+    // the test build would ship a different rendering-relevant policy than prod.
+    const directives = new Set([...Object.keys(prod), ...Object.keys(test)]);
+    for (const d of directives) {
+      if (d === "connect-src") continue;
+      expect(test[d], `directive ${d} drifted between prod and test CSP`).toEqual(prod[d]);
+    }
+  });
+});

--- a/src/security/cspViolationReporter.test.ts
+++ b/src/security/cspViolationReporter.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  CSP_VIOLATION_SINK_TESTID,
+  installCspViolationReporter,
+  resetCspViolationReporterForTests,
+} from "./cspViolationReporter";
+
+/** Dispatch a synthetic CSP violation on the document. */
+function dispatchViolation(
+  doc: Document,
+  init: Partial<SecurityPolicyViolationEventInit> = {}
+): void {
+  const event = new Event("securitypolicyviolation") as SecurityPolicyViolationEvent;
+  Object.assign(event, {
+    violatedDirective: "script-src",
+    blockedURI: "blob:",
+    sourceFile: "app.js",
+    lineNumber: 1,
+    ...init,
+  });
+  doc.dispatchEvent(event);
+}
+
+function sink(doc: Document): HTMLElement | null {
+  return doc.querySelector<HTMLElement>(`[data-testid="${CSP_VIOLATION_SINK_TESTID}"]`);
+}
+
+describe("cspViolationReporter", () => {
+  beforeEach(() => {
+    resetCspViolationReporterForTests();
+    document.body.innerHTML = "";
+  });
+
+  it("installs a hidden sink starting at zero violations", () => {
+    installCspViolationReporter(document);
+    const el = sink(document);
+    expect(el).not.toBeNull();
+    expect(el!.hidden).toBe(true);
+    expect(el!.getAttribute("data-count")).toBe("0");
+  });
+
+  it("records each violation into the sink with the blocked directive", () => {
+    installCspViolationReporter(document);
+    dispatchViolation(document, { violatedDirective: "connect-src", blockedURI: "ws://x" });
+    dispatchViolation(document, { violatedDirective: "script-src", blockedURI: "blob:" });
+    const el = sink(document)!;
+    expect(el.getAttribute("data-count")).toBe("2");
+    expect(el.textContent).toContain("connect-src blocked ws://x");
+    expect(el.textContent).toContain("script-src blocked blob:");
+  });
+
+  it("is idempotent — a second install neither duplicates the sink nor double-counts", () => {
+    installCspViolationReporter(document);
+    installCspViolationReporter(document);
+    dispatchViolation(document);
+    expect(document.querySelectorAll(`[data-testid="${CSP_VIOLATION_SINK_TESTID}"]`)).toHaveLength(
+      1
+    );
+    expect(sink(document)!.getAttribute("data-count")).toBe("1");
+  });
+});

--- a/src/security/cspViolationReporter.ts
+++ b/src/security/cspViolationReporter.ts
@@ -1,0 +1,73 @@
+/**
+ * Content-Security-Policy violation reporter (#2059).
+ *
+ * The app ships a restrictive CSP (`tauri.conf.json` → `app.security.csp`).
+ * CSP is only enforced in a **production** WebView build, never in `dev`, so a
+ * CSP that blocks something the app legitimately needs — the class of
+ * regression that nearly shipped in #2048 — is invisible until a real build is
+ * driven. This installs a `securitypolicyviolation` listener that makes any
+ * violation observable in two places:
+ *
+ * - the in-app **LogViewer** (via {@link frontendLog}), for a developer
+ *   inspecting a running build, and
+ * - a hidden DOM **sink** (`data-testid="csp-violations"`) whose `data-count`
+ *   attribute the system-test bridge reads, so an automated boot/render check
+ *   can assert **zero** violations under the shipped CSP (see
+ *   `tests/system/tests/test_csp.py`).
+ *
+ * The listener only ever fires when the browser actually blocks a resource, so
+ * it is inert on a healthy build and safe to install unconditionally.
+ */
+
+import { frontendLog } from "@/utils/frontendLog";
+
+/** `data-testid` of the hidden element the test bridge reads violation state from. */
+export const CSP_VIOLATION_SINK_TESTID = "csp-violations";
+
+/** Guards against double-installation (React StrictMode / HMR re-entry). */
+let installed = false;
+
+/** Create (once) the hidden sink the bridge queries; returns the existing one if present. */
+function ensureSink(doc: Document): HTMLElement {
+  const existing = doc.querySelector<HTMLElement>(`[data-testid="${CSP_VIOLATION_SINK_TESTID}"]`);
+  if (existing) return existing;
+  const sink = doc.createElement("div");
+  sink.setAttribute("data-testid", CSP_VIOLATION_SINK_TESTID);
+  sink.setAttribute("data-count", "0");
+  sink.hidden = true;
+  (doc.body ?? doc.documentElement).appendChild(sink);
+  return sink;
+}
+
+/**
+ * Record one CSP violation into the sink: bump `data-count` and append a
+ * `<directive> blocked <uri>` line to the sink's text, so a failing assertion
+ * can report *what* was blocked, not merely that something was.
+ */
+function recordViolation(sink: HTMLElement, e: SecurityPolicyViolationEvent): void {
+  const count = Number(sink.getAttribute("data-count") ?? "0") + 1;
+  sink.setAttribute("data-count", String(count));
+  const detail = `${e.violatedDirective} blocked ${e.blockedURI || "(inline)"}`;
+  sink.textContent = `${sink.textContent ?? ""}${detail}\n`;
+  frontendLog("csp", `violation: ${detail} (source ${e.sourceFile ?? "?"}:${e.lineNumber ?? 0})`);
+}
+
+/**
+ * Install the CSP-violation reporter on the given document (defaults to the
+ * global `document`). Idempotent — safe to call more than once. Returns the
+ * hidden sink element so callers/tests can inspect it directly.
+ */
+export function installCspViolationReporter(doc: Document = document): HTMLElement {
+  const sink = ensureSink(doc);
+  if (installed) return sink;
+  installed = true;
+  doc.addEventListener("securitypolicyviolation", (e) => {
+    recordViolation(sink, e as SecurityPolicyViolationEvent);
+  });
+  return sink;
+}
+
+/** Reset installation state (tests only). */
+export function resetCspViolationReporterForTests(): void {
+  installed = false;
+}

--- a/tests/system/tests/test_csp.py
+++ b/tests/system/tests/test_csp.py
@@ -1,0 +1,46 @@
+"""Content-Security-Policy guard (#2059).
+
+CSP is only enforced in a **production** WebView build (never in ``dev``), so a
+policy that blocks something the app needs — the class of regression that nearly
+shipped in #2048 — is invisible until a real build is driven. This suite closes
+that gap: it launches the built app under the enforced CSP, confirms the app
+boots and a terminal actually renders (output flows back), and asserts the
+frontend saw **zero** CSP violations.
+
+Runs on every non-macOS integration leg (Linux/Windows). The bridge itself needs
+a loopback ``ws://`` that the production CSP forbids; the test build re-adds only
+that one allowance via ``src-tauri/tauri.test.conf.json`` (see the build steps in
+``scripts/test-system-py.sh`` / ``system-integration.yml``). Every other,
+rendering-relevant directive is identical to production, so a broken shipped CSP
+still fails here.
+"""
+
+import pytest
+
+from termihub_harness import SystemTest, TerminalUi
+
+pytestmark = pytest.mark.integration
+
+# Must match CSP_VIOLATION_SINK_TESTID in src/security/cspViolationReporter.ts.
+CSP_SINK = "csp-violations"
+
+
+class TestContentSecurityPolicy(TerminalUi, SystemTest):
+    def test_app_boots_and_terminal_renders_under_csp(self):
+        # A terminal that opens, runs a command, and echoes output back proves
+        # scripts executed and IPC worked under the enforced CSP — i.e. the
+        # policy did not block the app's own bundle, xterm, or the IPC transport.
+        self.ensure_terminal()
+        self.run_command("echo csp-render-marker")
+        assert "csp-render-marker" in self.wait_for_output("csp-render-marker")
+
+    def test_no_csp_violations_were_reported(self):
+        # The reporter installs its sink before React mounts, so its presence
+        # confirms the frontend booted far enough to run main.tsx.
+        assert self.driver.exists(CSP_SINK), (
+            "CSP violation sink missing — the frontend did not boot, or the "
+            "reporter was removed from main.tsx"
+        )
+        count = self.driver.get_attribute(CSP_SINK, "data-count")
+        details = self.driver.get_text(CSP_SINK)
+        assert count == "0", f"the shipped CSP blocked {count} resource(s):\n{details}"


### PR DESCRIPTION
Safe subset of #2059 (follow-up to #2048/#2058). It tightens the shipped CSP and adds a guard against the #2048 class of regression — a CSP that breaks rendering, which only surfaces in a production build. The frontend-plugin sandbox and the `blob:` removal from `script-src` are **deferred** to a Ready2Implement follow-up (rationale below), so this does **not** close #2059.

## What shipped

### 1. Remove the `ws://` allowance from the production `connect-src`
Real users never run the system-test bridge, so the production WebView needs no WebSocket `connect-src`. The bridge's in-app client still connects out over a loopback `ws://127.0.0.1:<port>`, so that one allowance is re-added **for test builds only** via a config overlay (`src-tauri/tauri.test.conf.json`) applied with `--config`, wired into `scripts/test-system-py.sh` and `system-integration.yml`. Every other (rendering-relevant) directive is byte-identical to production.

**Production `connect-src` before → after:**
```
before: connect-src 'self' ipc: http://ipc.localhost ws://127.0.0.1:* ws://localhost:*
after:  connect-src 'self' ipc: http://ipc.localhost
```
`script-src` and all other directives are unchanged.

### 2. CSP-violation reporter + CI guard
- `src/security/cspViolationReporter.ts` installs a `securitypolicyviolation` listener before React mounts. Any violation is surfaced in the LogViewer and in a hidden, bridge-readable DOM sink (`data-testid="csp-violations"`, `data-count`).
- `tests/system/tests/test_csp.py` (integration lane, non-macOS included) boots the built app under the enforced CSP, confirms a terminal renders (output flows back → scripts + IPC work), and asserts **zero** CSP violations. Placed in the existing nightly integration lane — where a real build already happens — to respect the owner's fast-per-PR policy (#1569).
- `src/security/cspConfig.test.ts` is a per-PR static guard locking the invariants: no `'unsafe-inline'`/`'unsafe-eval'` in `script-src`, no `ws://` in the production `connect-src`, and the test overlay differing **only** by the loopback ws:// allowance (drift lock).

## What was deferred, and why — filed as #2136 (Ready2Implement)
The issue's headline (sandbox frontend plugins → drop `blob:` from `script-src`) is substantial and touches the plugin API:
- Protocol parsers run **synchronously** in the terminal output hot path (`Terminal.tsx` → `transformOutput`); moving execution out of the main context makes `transform` async and needs an ordered per-session pipeline in the renderer.
- Status-bar widgets mount `render(): HTMLElement` **directly into the main status bar**; an opaque-origin sandbox cannot hand back a live main-document element, so widget DOM must be re-homed (API change).
- The `plugin-system` concept currently documents weak isolation as accepted and calls Workers/iframes a **future improvement** — so it would need updating.

Doing that hastily risks regressing terminal rendering or silently breaking the (experimental, default-off) frontend-plugin feature. Frontend plugins remain gated behind `frontendPluginsEnabled` (default off), so the residual `blob:` in `script-src` is not exposed by default.

## Verified in a real production-style build (CSP only applies to a built WebView, not `dev`)
Built the debug app **with the test overlay** (`pnpm tauri build --debug --config src-tauri/tauri.test.conf.json`) and drove it via the system-test bridge:
- App boots under the enforced CSP; frontend reaches `main.tsx` (the violation sink is installed).
- **Terminal renders** — `echo`/`pwd` run and their output flows back (`test_terminal_basics`, `test_csp`), i.e. scripts execute and IPC works under the CSP.
- **Bridge reconnects** over the re-added loopback ws:// (`test_app_lifecycle::test_restart_reacquires_bridge`) — the overlay works.
- **Zero CSP violations** reported (`test_no_csp_violations_were_reported`).
- 7 integration tests passed against the real build; full frontend suite green (**4673** tests); `tsc`, eslint, prettier clean.

Note: this change does not touch `script-src`/`blob:` or the frontend-plugin loader, so plugin loading under the CSP is unchanged from the #2048-verified baseline; the zero-violation assertion would also catch any new plugin-related violation.

Refs #2059
Follow-up: #2136