### PR TITLE
test(config): add modest vitest coverage thresholds to the frontend gate

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -205,7 +205,17 @@ jobs:
       - name: Run Rust tests
         run: cargo test --workspace --all-features
 
+      # Run coverage-gated tests once (Ubuntu) to enforce the vitest coverage
+      # floors from vitest.config.ts (#2066). Coverage is computed from the
+      # platform-independent TS sources, so gating on a single leg avoids
+      # per-platform coverage drift while still failing CI on a real drop. The
+      # other legs run the plain suite so every platform still exercises the tests.
+      - name: Run frontend tests with coverage
+        if: matrix.os == 'ubuntu-latest'
+        run: pnpm test:coverage
+
       - name: Run frontend tests
+        if: matrix.os != 'ubuntu-latest'
         run: pnpm test
 
   # Python system-test harness — fast "machinery" suite (issue #801).

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,18 @@ export default defineConfig({
       provider: "v8",
       include: ["src/**/*.ts"],
       exclude: ["src/test/**", "src/**/*.d.ts", "src/main.tsx"],
+      // Modest coverage floors so a real regression fails CI without blocking
+      // the current tree (#2066, follow-up to the #2050 audit). Measured on the
+      // develop tree: statements 78.5%, branches 71.5%, functions 74.6%,
+      // lines 79.7%. Each floor sits a few points below its measured value so
+      // normal fluctuation passes but a genuine drop trips the gate. Raise these
+      // (never lower) as coverage improves — they are a ratchet, not a target.
+      thresholds: {
+        lines: 75,
+        statements: 74,
+        functions: 70,
+        branches: 67,
+      },
     },
   },
 });


### PR DESCRIPTION
Follow-up to #2050 (PR #2064). The audit's part 4 (frontend half) found that `pnpm test` runs on every PR but enforces no coverage floor, so frontend coverage can silently erode.

## What changed

- **`vitest.config.ts`** — added `coverage.thresholds` set a few points below the current develop-tree coverage, so the floors ratchet rather than block:

  | Metric | Measured (develop) | Floor set |
  | --- | --- | --- |
  | Statements | 78.5% | **74** |
  | Branches | 71.5% | **67** |
  | Functions | 74.6% | **70** |
  | Lines | 79.7% | **75** |

  The margin absorbs normal fluctuation while still failing CI on a genuine drop. They are a ratchet: raise (never lower) as coverage improves.

- **`.github/workflows/code-quality.yml`** — the per-PR `Run Tests` job now runs `pnpm test:coverage` on the Ubuntu leg to enforce the floors; Windows/macOS still run plain `pnpm test`. Coverage is computed from platform-independent TS sources, so gating a single leg avoids per-platform coverage drift while still failing CI on a real regression, and adds no meaningful cost to the other legs.

## Verification (local)

- On the current merged tree (`develop` merged in): all 499 vitest suites pass and `pnpm test:coverage` exits 0 with the thresholds in place — statements 78.56 / branches 71.46 / functions 74.64 / lines 79.75, all above their floors.
- Confirmed the gate actually trips: temporarily raising the lines floor to 90 fails with `ERROR: Coverage for lines (79.72%) does not meet global threshold (90%)` and exit 1.

Closes #2066