### PR TITLE
test(ui): add per-PR app-shell mount smoke (Closes #2065)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -322,6 +322,25 @@ the coverage it _can_ run rather than failing on fixtures it cannot reach. This
 Docker-daemon boundary is the same one behind the [SSH-tunnel macOS
 carve-out](#ssh-tunnel-startstop-on-macos-manual-carve-out-933) and ADR-5.
 
+### Per-PR app-shell smoke (#2065)
+
+To give the merge gate _some_ app-boot coverage without the nightly lane's build
+cost, the frontend Vitest job runs a lightweight shell-mount smoke
+([`src/App.smoke.test.tsx`](../src/App.smoke.test.tsx)). It mounts the whole
+`App` component tree in jsdom against the default store state and asserts every
+top-level region (activity bar, terminal view, status bar, sidebar) renders and
+the `ErrorBoundary` did not trip. This catches a **broad boot/wiring break** — a
+bad import, a removed provider, a hook that throws on mount, a store selector
+that crashes on the initial state — on every PR, on all three OSes (it rides the
+existing `pnpm test` matrix). It runs in a fraction of a second: a single
+React-DOM `createRoot` mount, no app build, no Docker, all Tauri IPC stubbed in
+[`src/test/setup.ts`](../src/test/setup.ts). It deliberately asserts only the
+coarse shell (fast, non-flaky); backend hydration and deep behavior stay with
+the per-component tests and the nightly integration lane. The real per-platform
+boot under CSP (#2059,
+[`tests/system/tests/test_csp.py`](../tests/system/tests/test_csp.py)) remains a
+nightly integration check — the two are complementary, not a substitute.
+
 ### Windows Agent CI Coverage
 
 The remote agent (`agent/`) is built and tested on Windows via dedicated CI jobs:

--- a/src/App.smoke.test.tsx
+++ b/src/App.smoke.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Per-PR app-shell smoke test (#2065, follow-up to #2050).
+ *
+ * The audit in #2050 found the safety net is heavily nightly/manual: the per-PR
+ * gate runs `pytest -m "not integration"` and never launches the real app, so a
+ * broad boot/wiring break — a bad import, a provider removed, a hook that throws
+ * on mount, a store selector that crashes on the initial state — could merge
+ * without any per-PR check noticing.
+ *
+ * This is the *fast per-PR* half of that safety net (the slow, real-app
+ * boot-under-CSP check lives in the nightly integration lane —
+ * tests/system/tests/test_csp.py, #2059). It mounts the whole `App` shell in
+ * jsdom against the default store state and asserts:
+ *   1. the mount does not throw, and
+ *   2. every top-level region (activity bar, terminal view, status bar,
+ *      sidebar) is present and the ErrorBoundary did not trip.
+ *
+ * All Tauri IPC/event/window/dialog/fs APIs are already stubbed globally in
+ * src/test/setup.ts, so no app build and no Docker are needed — it runs inside
+ * the existing per-PR `pnpm test` (vitest) job on all three OSes. Runtime is a
+ * fraction of a second: a single React-DOM createRoot mount, no real timers, no
+ * network. It deliberately asserts only the coarse shell so it stays fast and
+ * non-flaky; deep behavior is covered by the per-component tests and the nightly
+ * integration lane.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import App from "./App";
+
+describe("App shell smoke (#2065)", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    // Boot from the pristine store state so the smoke reflects a cold app start,
+    // independent of any state a prior test left behind. `loadFromBackend` is
+    // neutered to a resolved no-op: with the Tauri `invoke` stubbed to return
+    // `undefined` (src/test/setup.ts), the real hydration would overwrite the
+    // store's default arrays with `undefined` and crash a consumer — a mock
+    // artifact, not an app fault. Backend hydration against a real IPC is the
+    // nightly integration lane's job (#2059); this fast smoke asserts only that
+    // the shell boots and wires up against pristine state.
+    useAppStore.setState({
+      ...useAppStore.getInitialState(),
+      loadFromBackend: async () => {},
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("mounts the full app shell without throwing", async () => {
+    // `await act(async …)` renders and then flushes the mount effects (the async
+    // loadFromBackend / restore chain) so a throw from startup wiring surfaces
+    // here rather than as a late unhandled rejection.
+    await act(async () => {
+      root.render(<App />);
+    });
+
+    // The root shell rendered (ErrorBoundary did not fall back to its error UI).
+    const app = container.querySelector(".app");
+    expect(app).not.toBeNull();
+
+    // Each top-level region wired into App is present. A broken import or a hook
+    // throwing on mount would collapse one of these to null.
+    expect(container.querySelector(".activity-bar")).not.toBeNull();
+    expect(container.querySelector(".terminal-view")).not.toBeNull();
+    expect(container.querySelector('[data-testid="status-bar"]')).not.toBeNull();
+    expect(container.querySelector(".sidebar")).not.toBeNull();
+  });
+});

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -26,6 +26,27 @@ if (typeof Element !== "undefined") {
     Element.prototype.scrollIntoView = () => {};
   }
 
+  // jsdom does not implement `window.matchMedia`. uPlot (the monitoring/latency
+  // charts) calls it at *module load* to pick a pixel ratio, and the theme
+  // engine reads `prefers-color-scheme` through it — so a test that mounts any
+  // chart-bearing UI (or the whole App shell) blows up on import without this.
+  // Return an inert, listener-shaped MediaQueryList so callers can subscribe
+  // without effect. Idempotent: only installed when jsdom lacks it, so tests
+  // that stub their own matchMedia (e.g. themes/engine.test.ts) still win.
+  if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+    window.matchMedia = (query: string): MediaQueryList =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList;
+  }
+
   // @tanstack/react-virtual resets its `isScrolling` flag either from the native
   // `scrollend` event (when the environment advertises `onscrollend` and the
   // virtualizer opts in via `useScrollendEvent`) or, as a fallback, from a 150ms
@@ -205,7 +226,9 @@ vi.mock("@tauri-apps/api/window", () => ({
   getCurrentWindow: vi.fn(() => ({
     label: "main",
     onFocusChanged: vi.fn(() => Promise.resolve(() => {})),
+    onCloseRequested: vi.fn(() => Promise.resolve(() => {})),
     setSize: vi.fn(() => Promise.resolve()),
+    destroy: vi.fn(() => Promise.resolve()),
   })),
   LogicalSize: class {
     constructor(


### PR DESCRIPTION
## Summary

Follow-up to #2050. The audit found the per-PR merge gate never launches the app
(`pytest -m "not integration"` self-skips the real-app path), so a broad
app-boot / core-path break could merge green. This adds a **fast per-PR smoke**
that exercises the whole frontend shell.

Closes #2065.

## What the smoke covers

`src/App.smoke.test.tsx` mounts the entire `App` component tree in jsdom against
the pristine store state and asserts:

1. the mount does not throw, and
2. every top-level region — activity bar (`.activity-bar`), terminal view
   (`.terminal-view`), status bar (`[data-testid="status-bar"]`), sidebar
   (`.sidebar`) — is present and the `ErrorBoundary` did **not** fall back.

This catches a **broad boot/wiring break**: a bad import, a removed provider, a
hook that throws on mount, or a store selector that crashes on the initial
state — the class of regression the per-PR gate previously could not see.

## Why this shape (value vs. cost)

- **Rides the existing per-PR lane.** It runs inside the `Run Tests` matrix's
  `pnpm test` (Vitest) step, so it executes on **Linux, macOS, and Windows** on
  every PR with **zero new CI jobs** and **no new build cost** — no `tauri
  build`, no Docker fleet. That's exactly the fast/per-PR posture the #1569
  policy wants; the heavy real-boot checks stay nightly.
- **Fast + non-flaky.** A single React-DOM `createRoot` mount, no real timers,
  no network — the test body runs in **~120 ms** (measured locally; ~0.1 s of
  the frontend job). All Tauri IPC/event/window APIs are already stubbed in
  `src/test/setup.ts`.
- **Complements, does not duplicate, the nightly lane.** The real per-platform
  boot under CSP (#2059, `tests/system/tests/test_csp.py`) remains a nightly
  integration check. This smoke is the cheap early-warning net on the merge gate.

## Notes

- Two small **environment-level** additions to `src/test/setup.ts` were needed
  to mount the full shell (separate commit): a guarded `window.matchMedia` stub
  (jsdom lacks it; uPlot calls it at module load) and `onCloseRequested`/
  `destroy` on the mocked `getCurrentWindow()`. Both are idempotent and match the
  existing shim block; the full suite (500 files / 4675 tests) stays green.
- Backend hydration is neutered to a resolved no-op in the test: with `invoke`
  stubbed to return `undefined`, the real `loadFromBackend` chain would overwrite
  the store's default arrays with `undefined` and crash a consumer — a mock
  artifact, not an app fault. Real hydration is the nightly lane's job.
- Docs: a new "Per-PR app-shell smoke" subsection in `docs/testing.md` under CI
  Integration describes coverage, runtime, and how it relates to the nightly
  lane.

## Verification

- New smoke passes on the current tree; full frontend suite green
  (500 files, 4675 tests).
- `pnpm run lint`, `tsc --noEmit`, `prettier --check`, `markdownlint` all pass.