### PR TITLE
refactor(sftp): migrate exec-capability probe into core (#2135)

### DIFF
--- a/core/src/backends/ssh/exec.rs
+++ b/core/src/backends/ssh/exec.rs
@@ -171,6 +171,42 @@ pub async fn ssh_exec_with_stdin(
     run_exec(&mut channel, command, stdin).await
 }
 
+/// Marker string echoed by the exec-capability probe.
+///
+/// A working shell/exec channel echoes it back on stdout; an SFTP-only
+/// connection (`ForceCommand internal-sftp`) or a relayed connection cannot run
+/// the command, so the marker never reaches stdout. Kept beside the probe that
+/// uses it (and consumed by the SSH exec integration tests) so the single
+/// definition can never drift.
+pub const EXEC_PROBE_MARKER: &str = "termihub_exec_probe_ok";
+
+/// Decide, from an exec probe's captured output, whether the connection can run
+/// remote commands (i.e. an exec channel is usable).
+///
+/// Keyed off the marker in stdout (not just a zero exit) so an SFTP-only server
+/// that quietly closes the forced-subsystem channel with exit 0 is still
+/// reported as not capable.
+pub fn exec_probe_indicates_capability(output: &SshExecOutput) -> bool {
+    output.exit_status == 0 && output.stdout.contains(EXEC_PROBE_MARKER)
+}
+
+/// Probe whether an exec (command) channel can be opened and used on `session`.
+///
+/// Runs a tiny command that echoes [`EXEC_PROBE_MARKER`] back over an exec
+/// channel. A normal SSH+shell connection echoes it (`true`); an SFTP-only
+/// (`ForceCommand internal-sftp`) or relayed connection cannot run the command,
+/// so the marker never appears (`false`). Any transport error is also reported
+/// as `false` — an unusable exec channel is "not capable", never a propagated
+/// error. Lets a caller know whether privilege-elevated writes — which need a
+/// shell to run `sudo` — are possible for this connection.
+pub async fn probe_exec_capability(session: &SshSession) -> bool {
+    let probe = format!("echo {EXEC_PROBE_MARKER}");
+    match ssh_exec_with_stdin(session, &probe, "").await {
+        Ok(output) => exec_probe_indicates_capability(&output),
+        Err(_) => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -314,5 +350,37 @@ mod tests {
         let err = run_exec(&mut ch, "id", "").await.unwrap_err();
 
         assert!(matches!(err, CoreError::Other(_)));
+    }
+
+    // --- Exec-capability probe discriminator (migrated from src-tauri) ---
+
+    fn probe_output(stdout: &str, exit_status: i32) -> SshExecOutput {
+        SshExecOutput {
+            stdout: stdout.to_string(),
+            exit_status,
+            ..Default::default()
+        }
+    }
+
+    /// A shell connection echoes the probe marker with exit 0 → capable.
+    #[test]
+    fn exec_probe_true_when_marker_echoed_and_exit_zero() {
+        let output = probe_output(&format!("{EXEC_PROBE_MARKER}\n"), 0);
+        assert!(exec_probe_indicates_capability(&output));
+    }
+
+    /// An SFTP-only channel yields no marker (e.g. binary SFTP bytes, even at
+    /// exit 0) → not capable.
+    #[test]
+    fn exec_probe_false_when_marker_absent() {
+        let output = probe_output("\u{0}\u{0}sftp-subsystem-bytes", 0);
+        assert!(!exec_probe_indicates_capability(&output));
+    }
+
+    /// A non-zero exit means the probe did not run cleanly → not capable.
+    #[test]
+    fn exec_probe_false_on_nonzero_exit() {
+        let output = probe_output(&format!("{EXEC_PROBE_MARKER}\n"), 1);
+        assert!(!exec_probe_indicates_capability(&output));
     }
 }

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -18,7 +18,10 @@ pub mod session_pool;
 pub mod sftp;
 pub mod x11;
 
-pub use self::exec::{ssh_exec_with_stdin, SshExecOutput};
+pub use self::exec::{
+    exec_probe_indicates_capability, probe_exec_capability, ssh_exec_with_stdin, SshExecOutput,
+    EXEC_PROBE_MARKER,
+};
 
 use std::io::Read;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/core/tests/ssh_exec_with_stdin.rs
+++ b/core/tests/ssh_exec_with_stdin.rs
@@ -2,10 +2,10 @@
 //! Integration tests for [`ssh_exec_with_stdin`] against Docker SSH fixtures.
 //!
 //! Covers the helper's three captured outputs (stdout, stderr, exit status)
-//! and stdin delivery, plus the exec-capability discriminator used by
-//! [`SftpSession::has_exec_capability`](../../src-tauri): a shell connection
-//! echoes a probe marker back on stdout (capable), while an SFTP-only
-//! (`ForceCommand internal-sftp`) connection does not (not capable).
+//! and stdin delivery, plus the shared [`probe_exec_capability`] discriminator
+//! used by `SftpSession::has_exec_capability` (in `src-tauri`): a shell
+//! connection echoes the probe marker back on stdout (capable), while an
+//! SFTP-only (`ForceCommand internal-sftp`) connection does not (not capable).
 //!
 //! Requires: `docker compose -f tests/docker/docker-compose.yml up -d`
 //! Skips gracefully if the containers are not running.
@@ -13,11 +13,9 @@
 mod common;
 
 use common::{port_ssh_password, port_ssh_sftp_only, require_docker, ssh_password_config};
-use termihub_core::backends::ssh::{auth::connect_and_authenticate, ssh_exec_with_stdin};
-
-/// Marker echoed by the exec-capability probe. Kept in sync with the probe in
-/// `src-tauri/src/files/sftp.rs`.
-const EXEC_PROBE_MARKER: &str = "termihub_exec_probe_ok";
+use termihub_core::backends::ssh::{
+    auth::connect_and_authenticate, probe_exec_capability, ssh_exec_with_stdin,
+};
 
 #[tokio::test]
 async fn exec_captures_stdout_and_zero_exit_for_id() {
@@ -94,15 +92,11 @@ async fn exec_capability_probe_true_for_shell_connection() {
         .await
         .expect("password auth should succeed");
 
-    let out = ssh_exec_with_stdin(&session, &format!("echo {EXEC_PROBE_MARKER}"), "")
-        .await
-        .expect("probe should execute on a shell connection");
-
-    assert_eq!(out.exit_status, 0);
+    // Exercise the production discriminator directly: a shell connection can
+    // open and use an exec channel, so the probe reports it as capable.
     assert!(
-        out.stdout.contains(EXEC_PROBE_MARKER),
-        "a shell connection must echo the probe marker back, got: {}",
-        out.stdout
+        probe_exec_capability(&session).await,
+        "a shell connection must be reported as exec-capable"
     );
 }
 
@@ -116,16 +110,11 @@ async fn exec_capability_probe_false_for_sftp_only_connection() {
         .expect("password auth should succeed on the sftp-only fixture");
 
     // The server forces `internal-sftp`, so the exec request is replaced by the
-    // SFTP subsystem: the probe marker never reaches stdout. The channel may
-    // still open, so we assert on the *absence of the marker*, which is exactly
-    // what `has_exec_capability` keys off.
-    let out = ssh_exec_with_stdin(&session, &format!("echo {EXEC_PROBE_MARKER}"), "").await;
-
-    let marker_present = out
-        .map(|o| o.stdout.contains(EXEC_PROBE_MARKER))
-        .unwrap_or(false);
+    // SFTP subsystem: the probe marker never reaches stdout (and the channel may
+    // still open or error). The production discriminator keys off exactly that,
+    // so it must report the connection as not exec-capable.
     assert!(
-        !marker_present,
-        "an SFTP-only connection must not echo the probe marker (no usable exec channel)"
+        !probe_exec_capability(&session).await,
+        "an SFTP-only connection must be reported as not exec-capable (no usable exec channel)"
     );
 }

--- a/src-tauri/src/files/sftp.rs
+++ b/src-tauri/src/files/sftp.rs
@@ -9,7 +9,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, info, warn};
 
 use termihub_core::backends::ssh::handler::SshSession;
-use termihub_core::backends::ssh::{sftp, ssh_exec_with_stdin, SshExecOutput};
+use termihub_core::backends::ssh::{
+    probe_exec_capability, sftp, ssh_exec_with_stdin, SshExecOutput,
+};
 use termihub_core::files::FileEntry;
 
 use crate::terminal::backend::SshConfig;
@@ -43,24 +45,6 @@ fn drain_sessions<V>(sessions: &Mutex<HashMap<String, V>>) -> usize {
     let count = guard.len();
     guard.clear();
     count
-}
-
-/// Marker echoed by the exec-capability probe.
-///
-/// A working shell/exec channel echoes it back on stdout; an SFTP-only
-/// connection (`ForceCommand internal-sftp`) or a relayed connection cannot run
-/// the command, so the marker never reaches stdout. Kept in sync with the
-/// integration test in `core/tests/ssh_exec_with_stdin.rs`.
-const EXEC_PROBE_MARKER: &str = "termihub_exec_probe_ok";
-
-/// Decide, from an exec probe's captured output, whether the connection can run
-/// remote commands (i.e. an exec channel is usable).
-///
-/// Keyed off the marker in stdout (not just a zero exit) so an SFTP-only server
-/// that quietly closes the forced-subsystem channel with exit 0 is still
-/// reported as not capable.
-fn exec_probe_indicates_capability(output: &SshExecOutput) -> bool {
-    output.exit_status == 0 && output.stdout.contains(EXEC_PROBE_MARKER)
 }
 
 /// Authoritative writability of a specific remote file, as decided by an SFTP
@@ -234,14 +218,9 @@ impl SftpSession {
     /// know whether privilege-elevated writes — which need a shell to run
     /// `sudo` — are possible for this connection.
     pub fn has_exec_capability(&self) -> bool {
-        let probe = format!("echo {EXEC_PROBE_MARKER}");
         tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                match ssh_exec_with_stdin(&self.session, &probe, "").await {
-                    Ok(output) => exec_probe_indicates_capability(&output),
-                    Err(_) => false,
-                }
-            })
+            tokio::runtime::Handle::current()
+                .block_on(async { probe_exec_capability(&self.session).await })
         })
     }
 
@@ -661,36 +640,6 @@ impl SftpManager {
 mod tests {
     use super::*;
     use std::thread;
-
-    fn probe_output(stdout: &str, exit_status: i32) -> SshExecOutput {
-        SshExecOutput {
-            stdout: stdout.to_string(),
-            exit_status,
-            ..Default::default()
-        }
-    }
-
-    /// A shell connection echoes the probe marker with exit 0 → capable.
-    #[test]
-    fn exec_probe_true_when_marker_echoed_and_exit_zero() {
-        let output = probe_output(&format!("{EXEC_PROBE_MARKER}\n"), 0);
-        assert!(exec_probe_indicates_capability(&output));
-    }
-
-    /// An SFTP-only channel yields no marker (e.g. binary SFTP bytes, even at
-    /// exit 0) → not capable.
-    #[test]
-    fn exec_probe_false_when_marker_absent() {
-        let output = probe_output("\u{0}\u{0}sftp-subsystem-bytes", 0);
-        assert!(!exec_probe_indicates_capability(&output));
-    }
-
-    /// A non-zero exit means the probe did not run cleanly → not capable.
-    #[test]
-    fn exec_probe_false_on_nonzero_exit() {
-        let output = probe_output(&format!("{EXEC_PROBE_MARKER}\n"), 1);
-        assert!(!exec_probe_indicates_capability(&output));
-    }
 
     /// Build a synthetic SFTP status error for the given status code.
     fn status_error(code: StatusCode) -> RusshSftpError {


### PR DESCRIPTION
First safe slice of the #2104 SFTP convergence tracked by #2135: migrate the **exec-capability probe** onto the core SSH exec primitive it already orchestrates. One capability, behavior-preserving — the risky live paths (elevated writes, transfer queue) are untouched and deferred.

## What moved

The probe marker `termihub_exec_probe_ok`, the stdout/exit discriminator, and the probe orchestration lived only in `src-tauri/src/files/sftp.rs`, with the **same marker constant copied** into `core/tests/ssh_exec_with_stdin.rs` under a hand-maintained "keep in sync" comment. That triplication is exactly the drift the convergence targets.

- Added to `core::backends::ssh::exec` (beside `ssh_exec_with_stdin`): `EXEC_PROBE_MARKER`, `exec_probe_indicates_capability`, and a new `probe_exec_capability(session)` async helper.
- `SftpSession::has_exec_capability` now wraps the core probe in its existing `block_in_place` shim — **byte-identical logic**: same `echo termihub_exec_probe_ok` command, same decision (`exit==0 && stdout.contains(marker)`), transport error → not capable.
- The three probe-discriminator unit tests moved to core.
- The core SSH exec integration tests now exercise the real `probe_exec_capability` path (instead of re-deriving the decision) and drop their private marker copy — the single definition can no longer drift.

## Behavior change

None. No change to the probe command, the decision, or the `sftp_has_exec_capability` command surface returned to the frontend.

## Verification (ran locally, dev0 offset 0)

- `cargo test -p termihub-core --lib exec` — 3 migrated probe unit tests green.
- `cargo test -p termihub sftp` — 21 desktop SFTP unit tests green.
- `clippy -D warnings` on both crates — clean.
- **Live SFTP fixtures** (`ssh-password`, `ssh-sftp-only`, `sftp-stress` up):
  - `ssh_exec_with_stdin::exec_capability_probe_*` — 2/2 green (shell → capable, sftp-only → not capable) via the new `probe_exec_capability` production path.
  - `core/tests/sftp_stress.rs` — 16/16 green.
  - `src-tauri/tests/sftp_transfer.rs` — 3/3 green (incl. `check_writable`).

## Scope / remaining

Advances #2135; does **not** close it. Remaining desktop-only capabilities stay tracked there and are deferred as their own careful slices (see follow-up filed): elevated `sudo` writes, `check_writable`/`Writability`, `realpath`, `remote_size`, the dedicated per-transfer channel, and the command-layer migration onto the core trait (blocked on the sync/async shim + the `connect_target` jump-host behavior decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)