### PR TITLE
feat(ui): port panelTree.ts algebra to Rust with golden-vector + property tests (Closes #2143)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5483,6 +5483,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "proxy-protocol"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5497,6 +5516,12 @@ name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -5664,6 +5689,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -6160,6 +6194,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -7636,7 +7682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -7773,6 +7819,7 @@ dependencies = [
  "p521",
  "pnet_packet 0.35.0",
  "portable-pty",
+ "proptest",
  "rand 0.8.6",
  "ringbuf",
  "rmp-serde",
@@ -7880,7 +7927,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg 0.5.15",
 ]
@@ -8316,6 +8363,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unftp-sbe-fs"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8573,6 +8626,15 @@ checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
 dependencies = [
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -158,6 +158,9 @@ temp-env = "0.3"
 tokio = { version = "1", features = ["rt", "macros", "time", "sync", "net"] }
 serde_json = { workspace = true }
 russh = { workspace = true }
+# Property-based testing for the panel-tree algebra (#2143) — its pure-function
+# tree operations have a clean invariant shape ideal for proptest.
+proptest = "1"
 # Serializes integration tests that mutate shared single-instance container
 # state (e.g. the network-fault-proxy's `tc` qdisc) so the suite is parallel-safe
 # regardless of `--test-threads` (#864).

--- a/core/src/layout/mod.rs
+++ b/core/src/layout/mod.rs
@@ -1,0 +1,10 @@
+//! Layout algebra shared between the desktop UI and the future Rust
+//! `LayoutStore`.
+//!
+//! This is the Rust twin of the frontend's `src/utils/panelTree.ts`. During the
+//! stateless-UI migration (#2139) the TypeScript version stays authoritative;
+//! this port runs behind it and is proven equivalent via golden-vector fixtures
+//! (`core/tests/fixtures/golden/panel_tree/`) that both suites consume. Phase 3
+//! (#2151) activates the Rust side.
+
+pub mod panel_tree;

--- a/core/src/layout/panel_tree.rs
+++ b/core/src/layout/panel_tree.rs
@@ -1,0 +1,676 @@
+//! Panel-tree algebra — the pure functions that split, merge, insert, remove
+//! and navigate the terminal panel layout.
+//!
+//! This is a faithful Rust port of the frontend's `src/utils/panelTree.ts`.
+//! Every exported function mirrors its TypeScript twin's semantics exactly. The
+//! TypeScript version stays authoritative during the stateless-UI migration
+//! (#2139); this port is proven equivalent through golden-vector fixtures
+//! (`core/tests/fixtures/golden/panel_tree/`) extracted from the TS test suite,
+//! and gains property tests over the tree invariants. Phase 3 (#2151) activates
+//! it as the backing `LayoutStore`.
+//!
+//! The tree is an immutable persistent structure: every transforming function
+//! takes `&PanelNode` and returns a fresh tree, never mutating its input.
+
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// A terminal tab. Only the fields the panel-tree algebra reads are modelled
+/// here (`id`, `sessionId`, `contentType`); the full frontend `TerminalTab`
+/// carries many more, but none affect any layout operation. Keeping this a
+/// minimal projection keeps the golden fixtures small and the equivalence
+/// precise.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Tab {
+    pub id: String,
+    /// Session bound to the tab, or `None` while it is still connecting.
+    #[serde(default)]
+    pub session_id: Option<String>,
+    /// Tab content kind (`"terminal"`, `"settings"`, …); drives drop routing.
+    pub content_type: String,
+}
+
+/// A leaf panel: a single pane holding a stack of tabs.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LeafPanel {
+    pub id: String,
+    pub tabs: Vec<Tab>,
+    #[serde(default)]
+    pub active_tab_id: Option<String>,
+}
+
+/// A split container: an ordered row/column of child nodes.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SplitContainer {
+    pub id: String,
+    pub direction: Direction,
+    pub children: Vec<PanelNode>,
+    /// Percentage sizes for each child (sum to 100, length matches `children`).
+    /// Absent when the split has never been resized.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sizes: Option<Vec<f64>>,
+    /// The last leaf focused within this subtree; steers directional navigation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_active_leaf_id: Option<String>,
+}
+
+/// A node in the panel tree: either a leaf pane or a split container.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum PanelNode {
+    Leaf(LeafPanel),
+    Split(SplitContainer),
+}
+
+/// A workspace-level tab group with its own independent panel tree. Only the
+/// fields the empty-window helpers read are modelled.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TabGroup {
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    pub root_panel: PanelNode,
+    #[serde(default)]
+    pub active_panel_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+}
+
+/// Split axis.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Direction {
+    Horizontal,
+    Vertical,
+}
+
+/// Insertion side relative to a target when splitting.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Position {
+    Before,
+    After,
+}
+
+/// The edge of a drop target a drag was released on.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DropEdge {
+    Left,
+    Right,
+    Top,
+    Bottom,
+    Center,
+}
+
+/// Direction of a directional-focus move.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum FocusDirection {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+/// The split direction + position an edge resolves to (`None` = center).
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SplitSpec {
+    pub direction: Direction,
+    pub position: Position,
+}
+
+/// Which edge leaf to descend to when entering a subtree.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EdgeSide {
+    First,
+    Last,
+}
+
+/// Total number of tabs across every leaf of a panel tree.
+pub fn count_tabs_in_tree(root: &PanelNode) -> usize {
+    get_all_leaves(root)
+        .iter()
+        .map(|leaf| leaf.tabs.len())
+        .sum()
+}
+
+/// Whether a native window holds zero tabs across every tab group — the
+/// empty-window first-class state (#1902). The active group's live tree is
+/// passed separately (it is authoritative over the stale copy stored in
+/// `tab_groups`); inactive groups use their stored `root_panel`.
+pub fn is_window_empty(
+    active_root_panel: &PanelNode,
+    tab_groups: &[TabGroup],
+    active_tab_group_id: Option<&str>,
+) -> bool {
+    if count_tabs_in_tree(active_root_panel) > 0 {
+        return false;
+    }
+    tab_groups
+        .iter()
+        .filter(|g| Some(g.id.as_str()) != active_tab_group_id)
+        .all(|g| count_tabs_in_tree(&g.root_panel) == 0)
+}
+
+/// Normalize an array of sizes so they sum to exactly 100.
+pub fn normalize_sizes(sizes: &[f64]) -> Vec<f64> {
+    let total: f64 = sizes.iter().sum();
+    if total == 0.0 {
+        let n = sizes.len();
+        return sizes.iter().map(|_| 100.0 / n as f64).collect();
+    }
+    sizes.iter().map(|s| (s / total) * 100.0).collect()
+}
+
+static PANEL_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Generate a unique panel ID (mirrors the TS `panel-<ts>-<n>-<rand>` shape).
+pub fn generate_panel_id() -> String {
+    let n = PANEL_COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let suffix: String = (0..4)
+        .map(|_| {
+            let v = rand::random::<u32>() % 36;
+            char::from_digit(v, 36).unwrap_or('0')
+        })
+        .collect();
+    format!("panel-{millis}-{n}-{suffix}")
+}
+
+/// Create a new empty leaf panel.
+pub fn create_leaf_panel() -> LeafPanel {
+    LeafPanel {
+        id: generate_panel_id(),
+        tabs: Vec::new(),
+        active_tab_id: None,
+    }
+}
+
+/// Find a leaf by ID.
+pub fn find_leaf<'a>(root: &'a PanelNode, leaf_id: &str) -> Option<&'a LeafPanel> {
+    match root {
+        PanelNode::Leaf(leaf) => {
+            if leaf.id == leaf_id {
+                Some(leaf)
+            } else {
+                None
+            }
+        }
+        PanelNode::Split(split) => {
+            for child in &split.children {
+                if let Some(found) = find_leaf(child, leaf_id) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+    }
+}
+
+/// Find the leaf containing a specific tab.
+pub fn find_leaf_by_tab<'a>(root: &'a PanelNode, tab_id: &str) -> Option<&'a LeafPanel> {
+    match root {
+        PanelNode::Leaf(leaf) => {
+            if leaf.tabs.iter().any(|t| t.id == tab_id) {
+                Some(leaf)
+            } else {
+                None
+            }
+        }
+        PanelNode::Split(split) => {
+            for child in &split.children {
+                if let Some(found) = find_leaf_by_tab(child, tab_id) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+    }
+}
+
+/// Resolve the session ID of the terminal tab currently shown in a leaf panel.
+///
+/// Returns `None` when the panel is empty, its active tab is not a terminal, or
+/// the terminal has not connected yet. Used to route OS file drops to the
+/// session of the pane under the cursor so each pane is its own drop target.
+pub fn get_panel_active_session_id(panel: &LeafPanel) -> Option<&str> {
+    let active_tab = panel
+        .tabs
+        .iter()
+        .find(|t| Some(t.id.as_str()) == panel.active_tab_id.as_deref())?;
+    if active_tab.content_type != "terminal" {
+        return None;
+    }
+    active_tab.session_id.as_deref()
+}
+
+/// Get a flat list of all leaves in the tree, left-to-right.
+pub fn get_all_leaves(root: &PanelNode) -> Vec<&LeafPanel> {
+    match root {
+        PanelNode::Leaf(leaf) => vec![leaf],
+        PanelNode::Split(split) => {
+            let mut result = Vec::new();
+            for child in &split.children {
+                result.extend(get_all_leaves(child));
+            }
+            result
+        }
+    }
+}
+
+/// Immutably update a single leaf by ID.
+pub fn update_leaf<F>(root: &PanelNode, leaf_id: &str, updater: F) -> PanelNode
+where
+    F: Fn(&LeafPanel) -> LeafPanel,
+{
+    update_leaf_inner(root, leaf_id, &updater)
+}
+
+fn update_leaf_inner(
+    root: &PanelNode,
+    leaf_id: &str,
+    updater: &dyn Fn(&LeafPanel) -> LeafPanel,
+) -> PanelNode {
+    match root {
+        PanelNode::Leaf(leaf) => {
+            if leaf.id == leaf_id {
+                PanelNode::Leaf(updater(leaf))
+            } else {
+                PanelNode::Leaf(leaf.clone())
+            }
+        }
+        PanelNode::Split(split) => PanelNode::Split(SplitContainer {
+            id: split.id.clone(),
+            direction: split.direction,
+            children: split
+                .children
+                .iter()
+                .map(|child| update_leaf_inner(child, leaf_id, updater))
+                .collect(),
+            sizes: split.sizes.clone(),
+            last_active_leaf_id: split.last_active_leaf_id.clone(),
+        }),
+    }
+}
+
+/// Remove a leaf from the tree and unwrap single-child splits.
+/// Returns `None` if the removed leaf was the root.
+pub fn remove_leaf(root: &PanelNode, leaf_id: &str) -> Option<PanelNode> {
+    let split = match root {
+        PanelNode::Leaf(leaf) => {
+            return if leaf.id == leaf_id {
+                None
+            } else {
+                Some(PanelNode::Leaf(leaf.clone()))
+            };
+        }
+        PanelNode::Split(split) => split,
+    };
+
+    let results: Vec<Option<PanelNode>> = split
+        .children
+        .iter()
+        .map(|child| remove_leaf(child, leaf_id))
+        .collect();
+    let mut new_children: Vec<PanelNode> = results.iter().flatten().cloned().collect();
+
+    if new_children.is_empty() {
+        return None;
+    }
+    if new_children.len() == 1 {
+        return Some(new_children.remove(0));
+    }
+
+    // Recalculate sizes if present.
+    let new_sizes = split.sizes.as_ref().map(|sizes| {
+        let mut kept: Vec<f64> = Vec::new();
+        let mut removed_size = 0.0;
+        for (i, result) in results.iter().enumerate() {
+            let size = sizes.get(i).copied().unwrap_or(0.0);
+            if result.is_none() {
+                removed_size += size;
+            } else {
+                kept.push(size);
+            }
+        }
+        if !kept.is_empty() && removed_size > 0.0 {
+            let remaining_total: f64 = kept.iter().sum();
+            if remaining_total > 0.0 {
+                let grown: Vec<f64> = kept
+                    .iter()
+                    .map(|s| s + (removed_size * s) / remaining_total)
+                    .collect();
+                normalize_sizes(&grown)
+            } else {
+                let len = kept.len();
+                kept.iter().map(|_| 100.0 / len as f64).collect()
+            }
+        } else {
+            kept
+        }
+    });
+
+    Some(PanelNode::Split(SplitContainer {
+        id: split.id.clone(),
+        direction: split.direction,
+        children: new_children,
+        sizes: new_sizes,
+        last_active_leaf_id: split.last_active_leaf_id.clone(),
+    }))
+}
+
+/// Split a leaf by wrapping it in a `SplitContainer` with a new leaf.
+/// If the parent already splits in the same direction, inserts as a sibling
+/// instead of nesting.
+pub fn split_leaf(
+    root: &PanelNode,
+    target_id: &str,
+    new_leaf: &LeafPanel,
+    direction: Direction,
+    position: Position,
+) -> PanelNode {
+    let split = match root {
+        PanelNode::Leaf(leaf) => {
+            if leaf.id != target_id {
+                return PanelNode::Leaf(leaf.clone());
+            }
+            let children = match position {
+                Position::Before => vec![
+                    PanelNode::Leaf(new_leaf.clone()),
+                    PanelNode::Leaf(leaf.clone()),
+                ],
+                Position::After => vec![
+                    PanelNode::Leaf(leaf.clone()),
+                    PanelNode::Leaf(new_leaf.clone()),
+                ],
+            };
+            return PanelNode::Split(SplitContainer {
+                id: generate_panel_id(),
+                direction,
+                children,
+                sizes: None,
+                last_active_leaf_id: None,
+            });
+        }
+        PanelNode::Split(split) => split,
+    };
+
+    // Check if target is a direct leaf child and directions match — insert as
+    // a sibling.
+    let target_index = split
+        .children
+        .iter()
+        .position(|c| matches!(c, PanelNode::Leaf(l) if l.id == target_id));
+    if let Some(target_index) = target_index {
+        if split.direction == direction {
+            let insert_idx = match position {
+                Position::Before => target_index,
+                Position::After => target_index + 1,
+            };
+            let mut new_children = split.children.clone();
+            new_children.insert(insert_idx, PanelNode::Leaf(new_leaf.clone()));
+            // Recalculate sizes: halve the target child's size for the new sibling.
+            let new_sizes = split.sizes.as_ref().map(|sizes| {
+                let mut ns = sizes.clone();
+                let half_size = ns.get(target_index).copied().unwrap_or(f64::NAN) / 2.0;
+                if target_index < ns.len() {
+                    ns[target_index] = half_size;
+                }
+                ns.insert(insert_idx.min(ns.len()), half_size);
+                ns
+            });
+            return PanelNode::Split(SplitContainer {
+                id: split.id.clone(),
+                direction: split.direction,
+                children: new_children,
+                sizes: new_sizes,
+                last_active_leaf_id: split.last_active_leaf_id.clone(),
+            });
+        }
+    }
+
+    // Recurse into children.
+    PanelNode::Split(SplitContainer {
+        id: split.id.clone(),
+        direction: split.direction,
+        children: split
+            .children
+            .iter()
+            .map(|child| split_leaf(child, target_id, new_leaf, direction, position))
+            .collect(),
+        sizes: split.sizes.clone(),
+        last_active_leaf_id: split.last_active_leaf_id.clone(),
+    })
+}
+
+/// Flatten same-direction nesting and unwrap single-child containers.
+pub fn simplify_tree(root: &PanelNode) -> PanelNode {
+    let split = match root {
+        PanelNode::Leaf(leaf) => return PanelNode::Leaf(leaf.clone()),
+        PanelNode::Split(split) => split,
+    };
+
+    // First simplify children.
+    let simplified: Vec<PanelNode> = split.children.iter().map(simplify_tree).collect();
+
+    // Flatten children that split in the same direction.
+    let mut flattened: Vec<PanelNode> = Vec::new();
+    for child in simplified {
+        match &child {
+            PanelNode::Split(child_split) if child_split.direction == split.direction => {
+                flattened.extend(child_split.children.iter().cloned());
+            }
+            _ => flattened.push(child),
+        }
+    }
+
+    if flattened.is_empty() {
+        return PanelNode::Leaf(create_leaf_panel());
+    }
+    if flattened.len() == 1 {
+        return flattened.remove(0);
+    }
+    PanelNode::Split(SplitContainer {
+        id: split.id.clone(),
+        direction: split.direction,
+        children: flattened,
+        sizes: split.sizes.clone(),
+        last_active_leaf_id: split.last_active_leaf_id.clone(),
+    })
+}
+
+/// Convert a `DropEdge` to split direction and position, or `None` for center.
+pub fn edge_to_split(edge: DropEdge) -> Option<SplitSpec> {
+    match edge {
+        DropEdge::Left => Some(SplitSpec {
+            direction: Direction::Horizontal,
+            position: Position::Before,
+        }),
+        DropEdge::Right => Some(SplitSpec {
+            direction: Direction::Horizontal,
+            position: Position::After,
+        }),
+        DropEdge::Top => Some(SplitSpec {
+            direction: Direction::Vertical,
+            position: Position::Before,
+        }),
+        DropEdge::Bottom => Some(SplitSpec {
+            direction: Direction::Vertical,
+            position: Position::After,
+        }),
+        DropEdge::Center => None,
+    }
+}
+
+/// One step on the path from root to a leaf: the split and the child index taken.
+struct PathEntry<'a> {
+    node: &'a SplitContainer,
+    child_index: usize,
+}
+
+/// Build the path from root to a leaf, returning the ancestor splits and the
+/// child index at each level. `Some(vec![])` means the root itself is the leaf.
+fn build_path<'a>(root: &'a PanelNode, leaf_id: &str) -> Option<Vec<PathEntry<'a>>> {
+    match root {
+        PanelNode::Leaf(leaf) => {
+            if leaf.id == leaf_id {
+                Some(Vec::new())
+            } else {
+                None
+            }
+        }
+        PanelNode::Split(split) => {
+            for (i, child) in split.children.iter().enumerate() {
+                if let Some(mut sub) = build_path(child, leaf_id) {
+                    let mut path = vec![PathEntry {
+                        node: split,
+                        child_index: i,
+                    }];
+                    path.append(&mut sub);
+                    return Some(path);
+                }
+            }
+            None
+        }
+    }
+}
+
+/// Mark every ancestor `SplitContainer` of the given leaf with
+/// `last_active_leaf_id`. Returns a new tree. If the leaf is not found, returns
+/// a structural copy of the tree unchanged.
+pub fn mark_active_leaf(root: &PanelNode, leaf_id: &str) -> PanelNode {
+    let split = match root {
+        PanelNode::Leaf(leaf) => return PanelNode::Leaf(leaf.clone()),
+        PanelNode::Split(split) => split,
+    };
+
+    let mut changed = false;
+    let new_children: Vec<PanelNode> = split
+        .children
+        .iter()
+        .map(|child| {
+            let updated = mark_active_leaf(child, leaf_id);
+            if &updated != child {
+                changed = true;
+            }
+            updated
+        })
+        .collect();
+
+    // Check if the leaf is somewhere in this subtree.
+    let contains_leaf = find_leaf(root, leaf_id).is_some();
+    if !contains_leaf {
+        if changed {
+            return PanelNode::Split(SplitContainer {
+                id: split.id.clone(),
+                direction: split.direction,
+                children: new_children,
+                sizes: split.sizes.clone(),
+                last_active_leaf_id: split.last_active_leaf_id.clone(),
+            });
+        }
+        return PanelNode::Split(split.clone());
+    }
+
+    // Already marked and nothing below changed → unchanged.
+    if split.last_active_leaf_id.as_deref() == Some(leaf_id) && !changed {
+        return PanelNode::Split(split.clone());
+    }
+
+    PanelNode::Split(SplitContainer {
+        id: split.id.clone(),
+        direction: split.direction,
+        children: new_children,
+        sizes: split.sizes.clone(),
+        last_active_leaf_id: Some(leaf_id.to_string()),
+    })
+}
+
+/// Get the first/last leaf by walking into the first/last child recursively.
+fn edge_leaf(node: &PanelNode, side: EdgeSide) -> &LeafPanel {
+    match node {
+        PanelNode::Leaf(leaf) => leaf,
+        PanelNode::Split(split) => {
+            let idx = match side {
+                EdgeSide::First => 0,
+                EdgeSide::Last => split.children.len().saturating_sub(1),
+            };
+            edge_leaf(&split.children[idx], side)
+        }
+    }
+}
+
+/// Return the preferred leaf when entering a subtree: if the node remembers a
+/// `last_active_leaf_id` that still exists, return that leaf; otherwise fall
+/// back to the edge leaf (first or last).
+fn preferred_leaf(node: &PanelNode, fallback_side: EdgeSide) -> &LeafPanel {
+    match node {
+        PanelNode::Leaf(leaf) => leaf,
+        PanelNode::Split(split) => {
+            if let Some(remembered_id) = &split.last_active_leaf_id {
+                if let Some(remembered) = find_leaf(node, remembered_id) {
+                    return remembered;
+                }
+            }
+            edge_leaf(node, fallback_side)
+        }
+    }
+}
+
+/// Find the adjacent leaf panel in the given direction, or `None` if there is
+/// no panel that way.
+///
+/// When entering a subtree, prefers the last-focused leaf within it (via
+/// `last_active_leaf_id`), falling back to the nearest edge leaf. `left`/`right`
+/// navigate across horizontal splits; `up`/`down` across vertical splits.
+pub fn find_adjacent_leaf<'a>(
+    root: &'a PanelNode,
+    current_leaf_id: &str,
+    direction: FocusDirection,
+) -> Option<&'a LeafPanel> {
+    let path = build_path(root, current_leaf_id)?;
+
+    let axis = match direction {
+        FocusDirection::Left | FocusDirection::Right => Direction::Horizontal,
+        FocusDirection::Up | FocusDirection::Down => Direction::Vertical,
+    };
+    let delta: i64 = match direction {
+        FocusDirection::Right | FocusDirection::Down => 1,
+        FocusDirection::Left | FocusDirection::Up => -1,
+    };
+
+    // Walk up the path to the nearest ancestor split matching the axis.
+    for entry in path.iter().rev() {
+        if entry.node.direction != axis {
+            continue;
+        }
+        let sibling_index = entry.child_index as i64 + delta;
+        if sibling_index < 0 || sibling_index as usize >= entry.node.children.len() {
+            continue;
+        }
+        let fallback_side = if delta > 0 {
+            EdgeSide::First
+        } else {
+            EdgeSide::Last
+        };
+        return Some(preferred_leaf(
+            &entry.node.children[sibling_index as usize],
+            fallback_side,
+        ));
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests;

--- a/core/src/layout/panel_tree/tests.rs
+++ b/core/src/layout/panel_tree/tests.rs
@@ -1,0 +1,1054 @@
+//! Unit tests (mirroring `panelTree.test.ts` / `panelTree.fileDrop.test.ts`)
+//! plus property tests over the tree-algebra invariants.
+
+use super::*;
+use proptest::prelude::*;
+use std::collections::HashSet;
+
+// ── Test builders ───────────────────────────────────────────────────────────
+
+fn make_tab(id: &str) -> Tab {
+    Tab {
+        id: id.to_string(),
+        session_id: None,
+        content_type: "terminal".to_string(),
+    }
+}
+
+fn make_leaf(id: &str, tab_ids: &[&str]) -> LeafPanel {
+    let tabs: Vec<Tab> = tab_ids.iter().map(|t| make_tab(t)).collect();
+    let active_tab_id = tabs.first().map(|t| t.id.clone());
+    LeafPanel {
+        id: id.to_string(),
+        tabs,
+        active_tab_id,
+    }
+}
+
+fn leaf_node(id: &str, tab_ids: &[&str]) -> PanelNode {
+    PanelNode::Leaf(make_leaf(id, tab_ids))
+}
+
+fn make_split(id: &str, direction: Direction, children: Vec<PanelNode>) -> SplitContainer {
+    SplitContainer {
+        id: id.to_string(),
+        direction,
+        children,
+        sizes: None,
+        last_active_leaf_id: None,
+    }
+}
+
+fn split_node(id: &str, direction: Direction, children: Vec<PanelNode>) -> PanelNode {
+    PanelNode::Split(make_split(id, direction, children))
+}
+
+// ── createLeafPanel ─────────────────────────────────────────────────────────
+
+#[test]
+fn create_leaf_panel_returns_empty_leaf() {
+    let leaf = create_leaf_panel();
+    assert!(!leaf.id.is_empty());
+    assert!(leaf.tabs.is_empty());
+    assert!(leaf.active_tab_id.is_none());
+}
+
+#[test]
+fn create_leaf_panel_generates_unique_ids() {
+    let a = create_leaf_panel();
+    let b = create_leaf_panel();
+    assert_ne!(a.id, b.id);
+}
+
+// ── findLeaf ────────────────────────────────────────────────────────────────
+
+#[test]
+fn find_leaf_single() {
+    let leaf = leaf_node("leaf-1", &[]);
+    assert_eq!(find_leaf(&leaf, "leaf-1").unwrap().id, "leaf-1");
+}
+
+#[test]
+fn find_leaf_nested() {
+    let split = split_node(
+        "split-1",
+        Direction::Horizontal,
+        vec![leaf_node("leaf-1", &[]), leaf_node("leaf-2", &[])],
+    );
+    assert_eq!(find_leaf(&split, "leaf-2").unwrap().id, "leaf-2");
+}
+
+#[test]
+fn find_leaf_unknown() {
+    let leaf = leaf_node("leaf-1", &[]);
+    assert!(find_leaf(&leaf, "unknown").is_none());
+}
+
+// ── findLeafByTab ───────────────────────────────────────────────────────────
+
+#[test]
+fn find_leaf_by_tab_found() {
+    let leaf = leaf_node("leaf-1", &["tab-a", "tab-b"]);
+    assert_eq!(find_leaf_by_tab(&leaf, "tab-b").unwrap().id, "leaf-1");
+}
+
+#[test]
+fn find_leaf_by_tab_unknown() {
+    let leaf = leaf_node("leaf-1", &["tab-a"]);
+    assert!(find_leaf_by_tab(&leaf, "tab-unknown").is_none());
+}
+
+// ── getAllLeaves ────────────────────────────────────────────────────────────
+
+#[test]
+fn get_all_leaves_single() {
+    let leaf = leaf_node("leaf-1", &[]);
+    let leaves = get_all_leaves(&leaf);
+    assert_eq!(leaves.len(), 1);
+    assert_eq!(leaves[0].id, "leaf-1");
+}
+
+#[test]
+fn get_all_leaves_nested_in_order() {
+    let inner = split_node(
+        "s-inner",
+        Direction::Vertical,
+        vec![leaf_node("leaf-2", &[]), leaf_node("leaf-3", &[])],
+    );
+    let root = split_node(
+        "s-root",
+        Direction::Horizontal,
+        vec![leaf_node("leaf-1", &[]), inner],
+    );
+    let ids: Vec<&str> = get_all_leaves(&root)
+        .iter()
+        .map(|l| l.id.as_str())
+        .collect();
+    assert_eq!(ids, vec!["leaf-1", "leaf-2", "leaf-3"]);
+}
+
+// ── updateLeaf ──────────────────────────────────────────────────────────────
+
+#[test]
+fn update_leaf_updates_match() {
+    let leaf = leaf_node("leaf-1", &["tab-1"]);
+    let updated = update_leaf(&leaf, "leaf-1", |l| LeafPanel {
+        active_tab_id: Some("tab-1".to_string()),
+        ..l.clone()
+    });
+    match updated {
+        PanelNode::Leaf(l) => assert_eq!(l.active_tab_id.as_deref(), Some("tab-1")),
+        _ => panic!("expected leaf"),
+    }
+}
+
+#[test]
+fn update_leaf_leaves_non_match_unchanged() {
+    let leaf = leaf_node("leaf-1", &[]);
+    let result = update_leaf(&leaf, "other", |l| LeafPanel {
+        active_tab_id: Some("changed".to_string()),
+        ..l.clone()
+    });
+    assert_eq!(result, leaf);
+}
+
+// ── removeLeaf ──────────────────────────────────────────────────────────────
+
+#[test]
+fn remove_leaf_root_returns_none() {
+    let leaf = leaf_node("leaf-1", &[]);
+    assert!(remove_leaf(&leaf, "leaf-1").is_none());
+}
+
+#[test]
+fn remove_leaf_non_match_unchanged() {
+    let leaf = leaf_node("leaf-1", &[]);
+    assert_eq!(remove_leaf(&leaf, "other").unwrap(), leaf);
+}
+
+#[test]
+fn remove_leaf_unwraps_single_child() {
+    let leaf2 = leaf_node("leaf-2", &[]);
+    let split = split_node(
+        "split-1",
+        Direction::Horizontal,
+        vec![leaf_node("leaf-1", &[]), leaf2.clone()],
+    );
+    assert_eq!(remove_leaf(&split, "leaf-1").unwrap(), leaf2);
+}
+
+#[test]
+fn remove_leaf_redistributes_sizes() {
+    let root = PanelNode::Split(SplitContainer {
+        sizes: Some(vec![50.0, 25.0, 25.0]),
+        ..make_split(
+            "split-1",
+            Direction::Horizontal,
+            vec![
+                leaf_node("leaf-1", &[]),
+                leaf_node("leaf-2", &[]),
+                leaf_node("leaf-3", &[]),
+            ],
+        )
+    });
+    let result = remove_leaf(&root, "leaf-1").unwrap();
+    match result {
+        PanelNode::Split(s) => {
+            assert_eq!(s.children.len(), 2);
+            let total: f64 = s.sizes.as_ref().unwrap().iter().sum();
+            assert!((total - 100.0).abs() < 1e-9);
+        }
+        _ => panic!("expected split"),
+    }
+}
+
+#[test]
+fn remove_leaf_collapses_sized_two_child_split() {
+    let leaf2 = leaf_node("leaf-2", &[]);
+    let root = PanelNode::Split(SplitContainer {
+        sizes: Some(vec![70.0, 30.0]),
+        ..make_split(
+            "split-1",
+            Direction::Horizontal,
+            vec![leaf_node("leaf-1", &[]), leaf2.clone()],
+        )
+    });
+    assert_eq!(remove_leaf(&root, "leaf-1").unwrap(), leaf2);
+}
+
+// ── splitLeaf ───────────────────────────────────────────────────────────────
+
+#[test]
+fn split_leaf_wraps_in_container() {
+    let existing = leaf_node("leaf-1", &[]);
+    let new_leaf = make_leaf("new-leaf", &[]);
+    let result = split_leaf(
+        &existing,
+        "leaf-1",
+        &new_leaf,
+        Direction::Horizontal,
+        Position::After,
+    );
+    match result {
+        PanelNode::Split(s) => {
+            assert_eq!(s.direction, Direction::Horizontal);
+            assert_eq!(s.children.len(), 2);
+            assert!(matches!(&s.children[0], PanelNode::Leaf(l) if l.id == "leaf-1"));
+            assert!(matches!(&s.children[1], PanelNode::Leaf(l) if l.id == "new-leaf"));
+        }
+        _ => panic!("expected split"),
+    }
+}
+
+#[test]
+fn split_leaf_before() {
+    let existing = leaf_node("leaf-1", &[]);
+    let new_leaf = make_leaf("new-leaf", &[]);
+    let result = split_leaf(
+        &existing,
+        "leaf-1",
+        &new_leaf,
+        Direction::Vertical,
+        Position::Before,
+    );
+    match result {
+        PanelNode::Split(s) => {
+            assert!(matches!(&s.children[0], PanelNode::Leaf(l) if l.id == "new-leaf"));
+            assert!(matches!(&s.children[1], PanelNode::Leaf(l) if l.id == "leaf-1"));
+        }
+        _ => panic!("expected split"),
+    }
+}
+
+#[test]
+fn split_leaf_inserts_as_sibling_when_directions_match() {
+    let split = split_node(
+        "split-1",
+        Direction::Horizontal,
+        vec![leaf_node("leaf-1", &[]), leaf_node("leaf-2", &[])],
+    );
+    let new_leaf = make_leaf("new-leaf", &[]);
+    let result = split_leaf(
+        &split,
+        "leaf-1",
+        &new_leaf,
+        Direction::Horizontal,
+        Position::After,
+    );
+    match result {
+        PanelNode::Split(s) => {
+            let ids: Vec<&str> = s
+                .children
+                .iter()
+                .map(|c| match c {
+                    PanelNode::Leaf(l) => l.id.as_str(),
+                    _ => "split",
+                })
+                .collect();
+            assert_eq!(ids, vec!["leaf-1", "new-leaf", "leaf-2"]);
+        }
+        _ => panic!("expected split"),
+    }
+}
+
+#[test]
+fn split_leaf_halves_size_of_sized_sibling() {
+    let root = PanelNode::Split(SplitContainer {
+        sizes: Some(vec![60.0, 40.0]),
+        ..make_split(
+            "split-1",
+            Direction::Horizontal,
+            vec![leaf_node("leaf-1", &[]), leaf_node("leaf-2", &[])],
+        )
+    });
+    let new_leaf = make_leaf("new-leaf", &[]);
+    let result = split_leaf(
+        &root,
+        "leaf-1",
+        &new_leaf,
+        Direction::Horizontal,
+        Position::After,
+    );
+    match result {
+        PanelNode::Split(s) => {
+            let sizes = s.sizes.unwrap();
+            assert_eq!(sizes.len(), 3);
+            assert!((sizes[0] - 30.0).abs() < 1e-9);
+            assert!((sizes[1] - 30.0).abs() < 1e-9);
+            assert!((sizes[2] - 40.0).abs() < 1e-9);
+        }
+        _ => panic!("expected split"),
+    }
+}
+
+#[test]
+fn split_leaf_no_sizes_when_parent_has_none() {
+    let root = split_node(
+        "split-1",
+        Direction::Horizontal,
+        vec![leaf_node("leaf-1", &[]), leaf_node("leaf-2", &[])],
+    );
+    let new_leaf = make_leaf("new-leaf", &[]);
+    let result = split_leaf(
+        &root,
+        "leaf-1",
+        &new_leaf,
+        Direction::Horizontal,
+        Position::After,
+    );
+    match result {
+        PanelNode::Split(s) => assert!(s.sizes.is_none()),
+        _ => panic!("expected split"),
+    }
+}
+
+// ── simplifyTree ────────────────────────────────────────────────────────────
+
+#[test]
+fn simplify_tree_leaf_unchanged() {
+    let leaf = leaf_node("leaf-1", &[]);
+    assert_eq!(simplify_tree(&leaf), leaf);
+}
+
+#[test]
+fn simplify_tree_flattens_same_direction() {
+    let inner = split_node(
+        "inner",
+        Direction::Horizontal,
+        vec![leaf_node("leaf-2", &[]), leaf_node("leaf-3", &[])],
+    );
+    let outer = split_node(
+        "outer",
+        Direction::Horizontal,
+        vec![leaf_node("leaf-1", &[]), inner],
+    );
+    match simplify_tree(&outer) {
+        PanelNode::Split(s) => assert_eq!(s.children.len(), 3),
+        _ => panic!("expected split"),
+    }
+}
+
+#[test]
+fn simplify_tree_unwraps_single_child() {
+    let leaf = leaf_node("leaf-1", &[]);
+    let split = split_node("split-1", Direction::Horizontal, vec![leaf.clone()]);
+    assert_eq!(simplify_tree(&split), leaf);
+}
+
+// ── edgeToSplit ─────────────────────────────────────────────────────────────
+
+#[test]
+fn edge_to_split_mappings() {
+    assert_eq!(
+        edge_to_split(DropEdge::Left),
+        Some(SplitSpec {
+            direction: Direction::Horizontal,
+            position: Position::Before
+        })
+    );
+    assert_eq!(
+        edge_to_split(DropEdge::Right),
+        Some(SplitSpec {
+            direction: Direction::Horizontal,
+            position: Position::After
+        })
+    );
+    assert_eq!(
+        edge_to_split(DropEdge::Top),
+        Some(SplitSpec {
+            direction: Direction::Vertical,
+            position: Position::Before
+        })
+    );
+    assert_eq!(
+        edge_to_split(DropEdge::Bottom),
+        Some(SplitSpec {
+            direction: Direction::Vertical,
+            position: Position::After
+        })
+    );
+    assert_eq!(edge_to_split(DropEdge::Center), None);
+}
+
+// ── findAdjacentLeaf ────────────────────────────────────────────────────────
+
+#[test]
+fn find_adjacent_leaf_single_is_none() {
+    let leaf = leaf_node("leaf-1", &[]);
+    for dir in [
+        FocusDirection::Left,
+        FocusDirection::Right,
+        FocusDirection::Up,
+        FocusDirection::Down,
+    ] {
+        assert!(find_adjacent_leaf(&leaf, "leaf-1", dir).is_none());
+    }
+}
+
+#[test]
+fn find_adjacent_leaf_horizontal() {
+    let root = split_node(
+        "s",
+        Direction::Horizontal,
+        vec![leaf_node("leaf-1", &[]), leaf_node("leaf-2", &[])],
+    );
+    assert_eq!(
+        find_adjacent_leaf(&root, "leaf-1", FocusDirection::Right)
+            .unwrap()
+            .id,
+        "leaf-2"
+    );
+    assert_eq!(
+        find_adjacent_leaf(&root, "leaf-2", FocusDirection::Left)
+            .unwrap()
+            .id,
+        "leaf-1"
+    );
+    assert!(find_adjacent_leaf(&root, "leaf-1", FocusDirection::Left).is_none());
+    assert!(find_adjacent_leaf(&root, "leaf-2", FocusDirection::Right).is_none());
+    assert!(find_adjacent_leaf(&root, "leaf-1", FocusDirection::Up).is_none());
+}
+
+#[test]
+fn find_adjacent_leaf_nested() {
+    let inner = split_node(
+        "v",
+        Direction::Vertical,
+        vec![leaf_node("leaf-2", &[]), leaf_node("leaf-3", &[])],
+    );
+    let root = split_node(
+        "h",
+        Direction::Horizontal,
+        vec![leaf_node("leaf-1", &[]), inner],
+    );
+    assert_eq!(
+        find_adjacent_leaf(&root, "leaf-1", FocusDirection::Right)
+            .unwrap()
+            .id,
+        "leaf-2"
+    );
+    assert_eq!(
+        find_adjacent_leaf(&root, "leaf-2", FocusDirection::Left)
+            .unwrap()
+            .id,
+        "leaf-1"
+    );
+    assert_eq!(
+        find_adjacent_leaf(&root, "leaf-3", FocusDirection::Left)
+            .unwrap()
+            .id,
+        "leaf-1"
+    );
+    assert_eq!(
+        find_adjacent_leaf(&root, "leaf-2", FocusDirection::Down)
+            .unwrap()
+            .id,
+        "leaf-3"
+    );
+    assert_eq!(
+        find_adjacent_leaf(&root, "leaf-3", FocusDirection::Up)
+            .unwrap()
+            .id,
+        "leaf-2"
+    );
+}
+
+#[test]
+fn find_adjacent_leaf_enters_subtree_at_correct_edge() {
+    let inner = split_node(
+        "v",
+        Direction::Vertical,
+        vec![leaf_node("leaf-1", &[]), leaf_node("leaf-2", &[])],
+    );
+    let root = split_node(
+        "h",
+        Direction::Horizontal,
+        vec![inner, leaf_node("leaf-3", &[])],
+    );
+    // leaf-3 left enters the vertical split, picks the last child (leaf-2).
+    assert_eq!(
+        find_adjacent_leaf(&root, "leaf-3", FocusDirection::Left)
+            .unwrap()
+            .id,
+        "leaf-2"
+    );
+}
+
+#[test]
+fn find_adjacent_leaf_uses_last_active() {
+    let inner = PanelNode::Split(SplitContainer {
+        last_active_leaf_id: Some("leaf-3".to_string()),
+        ..make_split(
+            "v",
+            Direction::Vertical,
+            vec![leaf_node("leaf-2", &[]), leaf_node("leaf-3", &[])],
+        )
+    });
+    let root = split_node(
+        "h",
+        Direction::Horizontal,
+        vec![leaf_node("leaf-1", &[]), inner],
+    );
+    assert_eq!(
+        find_adjacent_leaf(&root, "leaf-1", FocusDirection::Right)
+            .unwrap()
+            .id,
+        "leaf-3"
+    );
+}
+
+#[test]
+fn find_adjacent_leaf_falls_back_when_last_active_stale() {
+    let inner = PanelNode::Split(SplitContainer {
+        last_active_leaf_id: Some("removed-leaf".to_string()),
+        ..make_split(
+            "v",
+            Direction::Vertical,
+            vec![leaf_node("leaf-2", &[]), leaf_node("leaf-3", &[])],
+        )
+    });
+    let root = split_node(
+        "h",
+        Direction::Horizontal,
+        vec![leaf_node("leaf-1", &[]), inner],
+    );
+    assert_eq!(
+        find_adjacent_leaf(&root, "leaf-1", FocusDirection::Right)
+            .unwrap()
+            .id,
+        "leaf-2"
+    );
+}
+
+#[test]
+fn find_adjacent_leaf_uses_last_active_deeply_nested() {
+    let deep = PanelNode::Split(SplitContainer {
+        last_active_leaf_id: Some("leaf-4".to_string()),
+        ..make_split(
+            "deep-h",
+            Direction::Horizontal,
+            vec![leaf_node("leaf-3", &[]), leaf_node("leaf-4", &[])],
+        )
+    });
+    let inner = PanelNode::Split(SplitContainer {
+        last_active_leaf_id: Some("leaf-4".to_string()),
+        ..make_split(
+            "v",
+            Direction::Vertical,
+            vec![leaf_node("leaf-2", &[]), deep],
+        )
+    });
+    let root = split_node(
+        "h",
+        Direction::Horizontal,
+        vec![leaf_node("leaf-1", &[]), inner],
+    );
+    assert_eq!(
+        find_adjacent_leaf(&root, "leaf-1", FocusDirection::Right)
+            .unwrap()
+            .id,
+        "leaf-4"
+    );
+}
+
+// ── markActiveLeaf ──────────────────────────────────────────────────────────
+
+#[test]
+fn mark_active_leaf_marks_all_ancestors() {
+    let inner = split_node(
+        "v",
+        Direction::Vertical,
+        vec![leaf_node("leaf-2", &[]), leaf_node("leaf-3", &[])],
+    );
+    let root = split_node(
+        "h",
+        Direction::Horizontal,
+        vec![leaf_node("leaf-1", &[]), inner],
+    );
+    match mark_active_leaf(&root, "leaf-3") {
+        PanelNode::Split(s) => {
+            assert_eq!(s.last_active_leaf_id.as_deref(), Some("leaf-3"));
+            match &s.children[1] {
+                PanelNode::Split(inner) => {
+                    assert_eq!(inner.last_active_leaf_id.as_deref(), Some("leaf-3"))
+                }
+                _ => panic!("expected split"),
+            }
+        }
+        _ => panic!("expected split"),
+    }
+}
+
+#[test]
+fn mark_active_leaf_skips_unrelated_splits() {
+    let left = split_node(
+        "left",
+        Direction::Vertical,
+        vec![leaf_node("leaf-1", &[]), leaf_node("leaf-2", &[])],
+    );
+    let root = split_node(
+        "h",
+        Direction::Horizontal,
+        vec![left, leaf_node("leaf-3", &[])],
+    );
+    match mark_active_leaf(&root, "leaf-3") {
+        PanelNode::Split(s) => {
+            assert_eq!(s.last_active_leaf_id.as_deref(), Some("leaf-3"));
+            match &s.children[0] {
+                PanelNode::Split(left) => assert!(left.last_active_leaf_id.is_none()),
+                _ => panic!("expected split"),
+            }
+        }
+        _ => panic!("expected split"),
+    }
+}
+
+#[test]
+fn mark_active_leaf_unchanged_when_not_found() {
+    let root = split_node("h", Direction::Horizontal, vec![leaf_node("leaf-1", &[])]);
+    assert_eq!(mark_active_leaf(&root, "nonexistent"), root);
+}
+
+#[test]
+fn mark_active_leaf_unchanged_when_already_marked() {
+    let root = PanelNode::Split(SplitContainer {
+        last_active_leaf_id: Some("leaf-1".to_string()),
+        ..make_split("h", Direction::Horizontal, vec![leaf_node("leaf-1", &[])])
+    });
+    assert_eq!(mark_active_leaf(&root, "leaf-1"), root);
+}
+
+// ── normalizeSizes ──────────────────────────────────────────────────────────
+
+#[test]
+fn normalize_sizes_sums_to_100() {
+    let result = normalize_sizes(&[30.0, 20.0, 50.0]);
+    let total: f64 = result.iter().sum();
+    assert!((total - 100.0).abs() < 1e-9);
+    assert!((result[0] - 30.0).abs() < 1e-9);
+}
+
+#[test]
+fn normalize_sizes_scales_up_and_down() {
+    let up = normalize_sizes(&[10.0, 10.0]);
+    assert!((up[0] - 50.0).abs() < 1e-9);
+    let down = normalize_sizes(&[100.0, 100.0]);
+    assert!((down[0] - 50.0).abs() < 1e-9);
+}
+
+#[test]
+fn normalize_sizes_zero_total_distributes_equally() {
+    let result = normalize_sizes(&[0.0, 0.0, 0.0]);
+    for v in result {
+        assert!((v - 100.0 / 3.0).abs() < 1e-9);
+    }
+}
+
+// ── countTabsInTree / isWindowEmpty ─────────────────────────────────────────
+
+fn make_group(id: &str, root: PanelNode) -> TabGroup {
+    TabGroup {
+        id: id.to_string(),
+        name: id.to_string(),
+        root_panel: root,
+        active_panel_id: None,
+        color: None,
+    }
+}
+
+#[test]
+fn count_tabs_empty_and_split() {
+    assert_eq!(count_tabs_in_tree(&leaf_node("leaf-1", &[])), 0);
+    let tree = split_node(
+        "split-1",
+        Direction::Horizontal,
+        vec![
+            leaf_node("leaf-1", &["a", "b"]),
+            leaf_node("leaf-2", &["c"]),
+        ],
+    );
+    assert_eq!(count_tabs_in_tree(&tree), 3);
+}
+
+#[test]
+fn is_window_empty_various() {
+    let active = leaf_node("leaf-1", &[]);
+    assert!(is_window_empty(
+        &active,
+        &[make_group("g1", active.clone())],
+        Some("g1")
+    ));
+
+    let active_with_tab = leaf_node("leaf-1", &["a"]);
+    assert!(!is_window_empty(
+        &active_with_tab,
+        &[make_group("g1", active_with_tab.clone())],
+        Some("g1")
+    ));
+
+    let inactive = leaf_node("leaf-2", &["a"]);
+    assert!(!is_window_empty(
+        &active,
+        &[make_group("g1", active.clone()), make_group("g2", inactive)],
+        Some("g1")
+    ));
+
+    assert!(is_window_empty(
+        &active,
+        &[
+            make_group("g1", active.clone()),
+            make_group("g2", leaf_node("leaf-2", &[]))
+        ],
+        Some("g1")
+    ));
+
+    // Uses the live active tree, not the stale stored copy.
+    let live_active = leaf_node("leaf-1", &["a"]);
+    let stale_stored = leaf_node("leaf-1", &[]);
+    assert!(!is_window_empty(
+        &live_active,
+        &[make_group("g1", stale_stored)],
+        Some("g1")
+    ));
+}
+
+// ── getPanelActiveSessionId (per-pane file drop routing) ─────────────────────
+
+fn tab_with(id: &str, session: Option<&str>, content: &str) -> Tab {
+    Tab {
+        id: id.to_string(),
+        session_id: session.map(str::to_string),
+        content_type: content.to_string(),
+    }
+}
+
+fn leaf_with_tabs(tabs: Vec<Tab>, active: Option<&str>) -> LeafPanel {
+    LeafPanel {
+        id: "panel-1".to_string(),
+        tabs,
+        active_tab_id: active.map(str::to_string),
+    }
+}
+
+#[test]
+fn panel_active_session_returns_active_terminal_session() {
+    let panel = leaf_with_tabs(
+        vec![
+            tab_with("a", Some("sess-a"), "terminal"),
+            tab_with("b", Some("sess-b"), "terminal"),
+        ],
+        Some("b"),
+    );
+    assert_eq!(get_panel_active_session_id(&panel), Some("sess-b"));
+}
+
+#[test]
+fn panel_active_session_none_when_connecting() {
+    let panel = leaf_with_tabs(vec![tab_with("a", None, "terminal")], Some("a"));
+    assert_eq!(get_panel_active_session_id(&panel), None);
+}
+
+#[test]
+fn panel_active_session_none_when_not_terminal() {
+    let panel = leaf_with_tabs(vec![tab_with("a", Some("sess-a"), "settings")], Some("a"));
+    assert_eq!(get_panel_active_session_id(&panel), None);
+}
+
+#[test]
+fn panel_active_session_none_for_empty_or_missing() {
+    assert_eq!(
+        get_panel_active_session_id(&leaf_with_tabs(vec![], None)),
+        None
+    );
+    let panel = leaf_with_tabs(
+        vec![tab_with("a", Some("sess-a"), "terminal")],
+        Some("gone"),
+    );
+    assert_eq!(get_panel_active_session_id(&panel), None);
+}
+
+// ── Property tests ──────────────────────────────────────────────────────────
+
+/// A structural tree shape, independent of ids. Converted to a `PanelNode` with
+/// globally-unique ids in traversal order so `find_leaf` behaves deterministically.
+#[derive(Clone, Debug)]
+enum Shape {
+    Leaf(usize),
+    Split(Direction, Vec<Shape>),
+}
+
+fn shape_strategy() -> impl Strategy<Value = Shape> {
+    let leaf = (0usize..3).prop_map(Shape::Leaf);
+    leaf.prop_recursive(4, 24, 4, |inner| {
+        (
+            prop_oneof![Just(Direction::Horizontal), Just(Direction::Vertical)],
+            prop::collection::vec(inner, 2..=4),
+        )
+            .prop_map(|(dir, children)| Shape::Split(dir, children))
+    })
+}
+
+fn build_tree(shape: &Shape, next_leaf: &mut usize, next_split: &mut usize) -> PanelNode {
+    match shape {
+        Shape::Leaf(tab_count) => {
+            let id = format!("leaf-{next_leaf}");
+            let leaf_idx = *next_leaf;
+            *next_leaf += 1;
+            let tabs: Vec<Tab> = (0..*tab_count)
+                .map(|t| make_tab(&format!("tab-{leaf_idx}-{t}")))
+                .collect();
+            let active_tab_id = tabs.first().map(|t| t.id.clone());
+            PanelNode::Leaf(LeafPanel {
+                id,
+                tabs,
+                active_tab_id,
+            })
+        }
+        Shape::Split(dir, children) => {
+            let id = format!("split-{next_split}");
+            *next_split += 1;
+            let built: Vec<PanelNode> = children
+                .iter()
+                .map(|c| build_tree(c, next_leaf, next_split))
+                .collect();
+            PanelNode::Split(SplitContainer {
+                id,
+                direction: *dir,
+                children: built,
+                sizes: None,
+                last_active_leaf_id: None,
+            })
+        }
+    }
+}
+
+fn tree_strategy() -> impl Strategy<Value = PanelNode> {
+    shape_strategy().prop_map(|shape| {
+        let mut next_leaf = 0;
+        let mut next_split = 0;
+        build_tree(&shape, &mut next_leaf, &mut next_split)
+    })
+}
+
+fn leaf_ids(root: &PanelNode) -> Vec<String> {
+    get_all_leaves(root).iter().map(|l| l.id.clone()).collect()
+}
+
+/// Every split in a well-formed tree has at least two children.
+fn assert_no_singleton_splits(node: &PanelNode) {
+    if let PanelNode::Split(s) = node {
+        assert!(s.children.len() >= 2, "split {} has <2 children", s.id);
+        for child in &s.children {
+            assert_no_singleton_splits(child);
+        }
+    }
+}
+
+proptest! {
+    #[test]
+    fn prop_leaf_ids_are_unique(tree in tree_strategy()) {
+        let ids = leaf_ids(&tree);
+        let unique: HashSet<&String> = ids.iter().collect();
+        prop_assert_eq!(ids.len(), unique.len());
+    }
+
+    #[test]
+    fn prop_count_tabs_matches_leaves(tree in tree_strategy()) {
+        let by_leaves: usize = get_all_leaves(&tree).iter().map(|l| l.tabs.len()).sum();
+        prop_assert_eq!(count_tabs_in_tree(&tree), by_leaves);
+    }
+
+    #[test]
+    fn prop_every_leaf_is_findable(tree in tree_strategy()) {
+        for id in leaf_ids(&tree) {
+            prop_assert!(find_leaf(&tree, &id).is_some());
+        }
+    }
+
+    #[test]
+    fn prop_remove_leaf_drops_exactly_one(tree in tree_strategy()) {
+        let ids = leaf_ids(&tree);
+        for target in &ids {
+            match remove_leaf(&tree, target) {
+                None => {
+                    // Only valid when the target was the whole tree.
+                    prop_assert_eq!(ids.len(), 1);
+                }
+                Some(result) => {
+                    let mut expected: Vec<String> =
+                        ids.iter().filter(|i| *i != target).cloned().collect();
+                    let mut got = leaf_ids(&result);
+                    expected.sort();
+                    got.sort();
+                    prop_assert_eq!(got, expected);
+                    // No orphaned single-child splits remain.
+                    assert_no_singleton_splits(&result);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn prop_split_then_remove_round_trips(tree in tree_strategy()) {
+        let ids = leaf_ids(&tree);
+        let new_leaf = make_leaf("inserted-leaf", &[]);
+        for target in &ids {
+            for (dir, pos) in [
+                (Direction::Horizontal, Position::After),
+                (Direction::Vertical, Position::Before),
+            ] {
+                let split = split_leaf(&tree, target, &new_leaf, dir, pos);
+                // The inserted leaf exists and total leaf count grew by one.
+                prop_assert!(find_leaf(&split, "inserted-leaf").is_some());
+                prop_assert_eq!(leaf_ids(&split).len(), ids.len() + 1);
+                // Removing it again restores the original leaf-id set.
+                let restored = remove_leaf(&split, "inserted-leaf")
+                    .expect("tree still has the original leaves");
+                let mut got = leaf_ids(&restored);
+                let mut expected = ids.clone();
+                got.sort();
+                expected.sort();
+                prop_assert_eq!(got, expected);
+            }
+        }
+    }
+
+    #[test]
+    fn prop_simplify_is_idempotent_and_wellformed(tree in tree_strategy()) {
+        let once = simplify_tree(&tree);
+        let twice = simplify_tree(&once);
+        prop_assert_eq!(&once, &twice);
+        // Simplify preserves the leaf set.
+        let mut before = leaf_ids(&tree);
+        let mut after = leaf_ids(&once);
+        before.sort();
+        after.sort();
+        prop_assert_eq!(after, before);
+        assert_no_singleton_splits(&once);
+        // No split child shares its parent's direction.
+        assert_flattened(&once);
+    }
+
+    #[test]
+    fn prop_mark_active_marks_ancestors_only(tree in tree_strategy()) {
+        for id in leaf_ids(&tree) {
+            let marked = mark_active_leaf(&tree, &id);
+            // Structure/leaf-set unchanged.
+            let mut before = leaf_ids(&tree);
+            let mut after = leaf_ids(&marked);
+            before.sort();
+            after.sort();
+            prop_assert_eq!(after, before);
+            assert_ancestors_marked(&marked, &id);
+        }
+    }
+
+    #[test]
+    fn prop_find_adjacent_returns_existing_other_leaf(tree in tree_strategy()) {
+        let ids: HashSet<String> = leaf_ids(&tree).into_iter().collect();
+        for id in &ids {
+            for dir in [
+                FocusDirection::Left,
+                FocusDirection::Right,
+                FocusDirection::Up,
+                FocusDirection::Down,
+            ] {
+                if let Some(found) = find_adjacent_leaf(&tree, id, dir) {
+                    prop_assert!(ids.contains(&found.id));
+                    prop_assert_ne!(&found.id, id);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn prop_normalize_sizes_sums_to_100(raw in prop::collection::vec(0.0f64..1000.0, 1..8)) {
+        let normalized = normalize_sizes(&raw);
+        prop_assert_eq!(normalized.len(), raw.len());
+        let total: f64 = normalized.iter().sum();
+        prop_assert!((total - 100.0).abs() < 1e-6);
+    }
+}
+
+/// Assert no split node has a child split of the same direction (post-simplify).
+fn assert_flattened(node: &PanelNode) {
+    if let PanelNode::Split(s) = node {
+        for child in &s.children {
+            if let PanelNode::Split(cs) = child {
+                assert_ne!(
+                    cs.direction, s.direction,
+                    "unflattened same-direction nesting"
+                );
+            }
+            assert_flattened(child);
+        }
+    }
+}
+
+/// Assert every split containing `leaf_id` is marked with it and no split that
+/// does not contain it is.
+fn assert_ancestors_marked(node: &PanelNode, leaf_id: &str) {
+    if let PanelNode::Split(s) = node {
+        let contains = find_leaf(node, leaf_id).is_some();
+        if contains {
+            assert_eq!(
+                s.last_active_leaf_id.as_deref(),
+                Some(leaf_id),
+                "ancestor split {} of {} not marked",
+                s.id,
+                leaf_id
+            );
+        } else {
+            assert_ne!(
+                s.last_active_leaf_id.as_deref(),
+                Some(leaf_id),
+                "non-ancestor split {} marked with {}",
+                s.id,
+                leaf_id
+            );
+        }
+        for child in &s.children {
+            assert_ancestors_marked(child, leaf_id);
+        }
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod connection;
 pub mod errors;
 pub mod files;
 pub mod ipc;
+pub mod layout;
 pub mod monitoring;
 #[cfg(any(feature = "telnet", feature = "ssh"))]
 pub mod net;

--- a/core/tests/fixtures/golden/README.md
+++ b/core/tests/fixtures/golden/README.md
@@ -1,0 +1,73 @@
+# Golden-vector fixtures
+
+Cross-language equivalence fixtures for the stateless-UI Rust ports (#2139,
+Phase 0). Each pure TypeScript util that is ported to `termihub-core` keeps a
+set of **golden vectors** here: input → expected-output cases extracted from the
+util's authoritative TypeScript test suite. The Rust port runs against the same
+vectors and must produce identical output, so any drift between the two
+implementations fails a test.
+
+The panel-tree port (#2143) established this convention; the sibling ports
+(#2144–#2147) reuse it verbatim.
+
+## Layout
+
+```
+core/tests/fixtures/golden/
+  README.md                 # this file
+  <util>/                   # one directory per ported util
+    <function>.json         # one fixture file per exported function
+```
+
+For the panel-tree algebra that is `golden/panel_tree/<function>.json`
+(e.g. `split_leaf.json`, `find_adjacent_leaf.json`).
+
+## Fixture file format
+
+Each file is a single JSON object:
+
+```jsonc
+{
+  "operation": "splitLeaf",        // the exported function under test
+  "cases": [
+    {
+      "name": "human-readable case description",
+      "input": <primary argument>,  // the tree / panel / value the fn operates on
+      "args":  { ... },             // remaining named arguments (omit if none)
+      "expected": <serialized result>
+    }
+  ]
+}
+```
+
+- **`input`** is the primary argument — the `PanelNode` tree for tree ops, the
+  `LeafPanel` for `getPanelActiveSessionId`, the size array for `normalizeSizes`,
+  the edge string for `edgeToSplit`.
+- **`args`** carries the rest by name (`leafId`, `targetId`, `newLeaf`,
+  `direction`, `position`, `currentLeafId`, `tabGroups`, `activeTabGroupId`, …).
+- **`expected`** is the function's result serialized as JSON. A returned node is
+  a full `PanelNode` (`{"type":"leaf",…}` / `{"type":"split",…}`); a "not found"
+  / center result is `null`; scalars are plain JSON numbers, booleans or strings.
+
+Nodes use the same shape both languages serialize to:
+
+- **leaf**: `{"type":"leaf","id":…,"tabs":[…],"activeTabId":… }`
+- **split**: `{"type":"split","id":…,"direction":"horizontal|vertical","children":[…]}`
+  plus optional `"sizes"` and `"lastActiveLeafId"` (present only when set).
+- **tab** (minimal projection the algebra reads):
+  `{"id":…,"sessionId":…|null,"contentType":"terminal"|…}`
+
+## Matcher conventions
+
+The Rust harness (`core/tests/panel_tree_golden.rs`) compares `expected` to the
+serialized actual result structurally, with two deliberate relaxations:
+
+1. **`"__GENERATED__"`** as an expected string matches any string in the actual
+   output. Use it for freshly generated panel ids (`splitLeaf` wrapping a leaf,
+   `simplifyTree` collapsing to a new empty leaf) whose value is
+   non-deterministic by design.
+2. **Numbers** compare within `1e-9`, absorbing cross-language float rounding in
+   `normalizeSizes` / size redistribution.
+
+Object key sets must match exactly — so omit optional fields (`sizes`,
+`lastActiveLeafId`) from `expected` whenever the function does not set them.

--- a/core/tests/fixtures/golden/panel_tree/count_tabs_in_tree.json
+++ b/core/tests/fixtures/golden/panel_tree/count_tabs_in_tree.json
@@ -1,0 +1,36 @@
+{
+  "operation": "countTabsInTree",
+  "cases": [
+    {
+      "name": "zero for an empty leaf",
+      "input": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+      "expected": 0
+    },
+    {
+      "name": "sums tabs across every leaf in a split tree",
+      "input": {
+        "type": "split",
+        "id": "split-1",
+        "direction": "horizontal",
+        "children": [
+          {
+            "type": "leaf",
+            "id": "leaf-1",
+            "activeTabId": "a",
+            "tabs": [
+              { "id": "a", "sessionId": null, "contentType": "terminal" },
+              { "id": "b", "sessionId": null, "contentType": "terminal" }
+            ]
+          },
+          {
+            "type": "leaf",
+            "id": "leaf-2",
+            "activeTabId": "c",
+            "tabs": [{ "id": "c", "sessionId": null, "contentType": "terminal" }]
+          }
+        ]
+      },
+      "expected": 3
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/panel_tree/edge_to_split.json
+++ b/core/tests/fixtures/golden/panel_tree/edge_to_split.json
@@ -1,0 +1,30 @@
+{
+  "operation": "edgeToSplit",
+  "cases": [
+    {
+      "name": "left maps to horizontal/before",
+      "input": "left",
+      "expected": { "direction": "horizontal", "position": "before" }
+    },
+    {
+      "name": "right maps to horizontal/after",
+      "input": "right",
+      "expected": { "direction": "horizontal", "position": "after" }
+    },
+    {
+      "name": "top maps to vertical/before",
+      "input": "top",
+      "expected": { "direction": "vertical", "position": "before" }
+    },
+    {
+      "name": "bottom maps to vertical/after",
+      "input": "bottom",
+      "expected": { "direction": "vertical", "position": "after" }
+    },
+    {
+      "name": "center returns null",
+      "input": "center",
+      "expected": null
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/panel_tree/find_adjacent_leaf.json
+++ b/core/tests/fixtures/golden/panel_tree/find_adjacent_leaf.json
@@ -1,0 +1,165 @@
+{
+  "operation": "findAdjacentLeaf",
+  "cases": [
+    {
+      "name": "single leaf has no neighbor",
+      "input": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+      "args": { "currentLeafId": "leaf-1", "direction": "right" },
+      "expected": null
+    },
+    {
+      "name": "navigates right in a horizontal split",
+      "input": {
+        "type": "split",
+        "id": "s",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+        ]
+      },
+      "args": { "currentLeafId": "leaf-1", "direction": "right" },
+      "expected": { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+    },
+    {
+      "name": "returns null at the left edge of a horizontal split",
+      "input": {
+        "type": "split",
+        "id": "s",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+        ]
+      },
+      "args": { "currentLeafId": "leaf-1", "direction": "left" },
+      "expected": null
+    },
+    {
+      "name": "returns null for up/down in a horizontal split",
+      "input": {
+        "type": "split",
+        "id": "s",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+        ]
+      },
+      "args": { "currentLeafId": "leaf-1", "direction": "up" },
+      "expected": null
+    },
+    {
+      "name": "enters a nested vertical split at its first child",
+      "input": {
+        "type": "split",
+        "id": "h",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          {
+            "type": "split",
+            "id": "v",
+            "direction": "vertical",
+            "children": [
+              { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null },
+              { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+            ]
+          }
+        ]
+      },
+      "args": { "currentLeafId": "leaf-1", "direction": "right" },
+      "expected": { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+    },
+    {
+      "name": "exits a nested vertical split to the left neighbor",
+      "input": {
+        "type": "split",
+        "id": "h",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          {
+            "type": "split",
+            "id": "v",
+            "direction": "vertical",
+            "children": [
+              { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null },
+              { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+            ]
+          }
+        ]
+      },
+      "args": { "currentLeafId": "leaf-3", "direction": "left" },
+      "expected": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null }
+    },
+    {
+      "name": "enters a subtree at its last child",
+      "input": {
+        "type": "split",
+        "id": "h",
+        "direction": "horizontal",
+        "children": [
+          {
+            "type": "split",
+            "id": "v",
+            "direction": "vertical",
+            "children": [
+              { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+              { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+            ]
+          },
+          { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+        ]
+      },
+      "args": { "currentLeafId": "leaf-3", "direction": "left" },
+      "expected": { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+    },
+    {
+      "name": "prefers lastActiveLeafId when entering a subtree",
+      "input": {
+        "type": "split",
+        "id": "h",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          {
+            "type": "split",
+            "id": "v",
+            "direction": "vertical",
+            "lastActiveLeafId": "leaf-3",
+            "children": [
+              { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null },
+              { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+            ]
+          }
+        ]
+      },
+      "args": { "currentLeafId": "leaf-1", "direction": "right" },
+      "expected": { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+    },
+    {
+      "name": "falls back to the edge when lastActiveLeafId is stale",
+      "input": {
+        "type": "split",
+        "id": "h",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          {
+            "type": "split",
+            "id": "v",
+            "direction": "vertical",
+            "lastActiveLeafId": "removed-leaf",
+            "children": [
+              { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null },
+              { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+            ]
+          }
+        ]
+      },
+      "args": { "currentLeafId": "leaf-1", "direction": "right" },
+      "expected": { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/panel_tree/find_leaf.json
+++ b/core/tests/fixtures/golden/panel_tree/find_leaf.json
@@ -1,0 +1,31 @@
+{
+  "operation": "findLeaf",
+  "cases": [
+    {
+      "name": "finds a single leaf by id",
+      "input": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+      "args": { "leafId": "leaf-1" },
+      "expected": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null }
+    },
+    {
+      "name": "finds a leaf in a nested split",
+      "input": {
+        "type": "split",
+        "id": "split-1",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+        ]
+      },
+      "args": { "leafId": "leaf-2" },
+      "expected": { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+    },
+    {
+      "name": "returns null for unknown id",
+      "input": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+      "args": { "leafId": "unknown" },
+      "expected": null
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/panel_tree/find_leaf_by_tab.json
+++ b/core/tests/fixtures/golden/panel_tree/find_leaf_by_tab.json
@@ -1,0 +1,38 @@
+{
+  "operation": "findLeafByTab",
+  "cases": [
+    {
+      "name": "finds leaf containing a tab",
+      "input": {
+        "type": "leaf",
+        "id": "leaf-1",
+        "activeTabId": "tab-a",
+        "tabs": [
+          { "id": "tab-a", "sessionId": null, "contentType": "terminal" },
+          { "id": "tab-b", "sessionId": null, "contentType": "terminal" }
+        ]
+      },
+      "args": { "tabId": "tab-b" },
+      "expected": {
+        "type": "leaf",
+        "id": "leaf-1",
+        "activeTabId": "tab-a",
+        "tabs": [
+          { "id": "tab-a", "sessionId": null, "contentType": "terminal" },
+          { "id": "tab-b", "sessionId": null, "contentType": "terminal" }
+        ]
+      }
+    },
+    {
+      "name": "returns null for unknown tab",
+      "input": {
+        "type": "leaf",
+        "id": "leaf-1",
+        "activeTabId": "tab-a",
+        "tabs": [{ "id": "tab-a", "sessionId": null, "contentType": "terminal" }]
+      },
+      "args": { "tabId": "tab-unknown" },
+      "expected": null
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/panel_tree/get_all_leaves.json
+++ b/core/tests/fixtures/golden/panel_tree/get_all_leaves.json
@@ -1,0 +1,35 @@
+{
+  "operation": "getAllLeaves",
+  "cases": [
+    {
+      "name": "returns single leaf in array",
+      "input": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+      "expected": [{ "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null }]
+    },
+    {
+      "name": "returns all leaves from a nested tree in order",
+      "input": {
+        "type": "split",
+        "id": "s-root",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          {
+            "type": "split",
+            "id": "s-inner",
+            "direction": "vertical",
+            "children": [
+              { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null },
+              { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+            ]
+          }
+        ]
+      },
+      "expected": [
+        { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+        { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null },
+        { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+      ]
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/panel_tree/get_panel_active_session_id.json
+++ b/core/tests/fixtures/golden/panel_tree/get_panel_active_session_id.json
@@ -1,0 +1,53 @@
+{
+  "operation": "getPanelActiveSessionId",
+  "cases": [
+    {
+      "name": "returns the session of the panel's active terminal tab",
+      "input": {
+        "type": "leaf",
+        "id": "panel-1",
+        "activeTabId": "b",
+        "tabs": [
+          { "id": "a", "sessionId": "sess-a", "contentType": "terminal" },
+          { "id": "b", "sessionId": "sess-b", "contentType": "terminal" }
+        ]
+      },
+      "expected": "sess-b"
+    },
+    {
+      "name": "null when the active tab has no session yet",
+      "input": {
+        "type": "leaf",
+        "id": "panel-1",
+        "activeTabId": "a",
+        "tabs": [{ "id": "a", "sessionId": null, "contentType": "terminal" }]
+      },
+      "expected": null
+    },
+    {
+      "name": "null when the active tab is not a terminal",
+      "input": {
+        "type": "leaf",
+        "id": "panel-1",
+        "activeTabId": "a",
+        "tabs": [{ "id": "a", "sessionId": "sess-a", "contentType": "settings" }]
+      },
+      "expected": null
+    },
+    {
+      "name": "null for an empty panel",
+      "input": { "type": "leaf", "id": "panel-1", "tabs": [], "activeTabId": null },
+      "expected": null
+    },
+    {
+      "name": "null when activeTabId points to a missing tab",
+      "input": {
+        "type": "leaf",
+        "id": "panel-1",
+        "activeTabId": "gone",
+        "tabs": [{ "id": "a", "sessionId": "sess-a", "contentType": "terminal" }]
+      },
+      "expected": null
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/panel_tree/is_window_empty.json
+++ b/core/tests/fixtures/golden/panel_tree/is_window_empty.json
@@ -1,0 +1,117 @@
+{
+  "operation": "isWindowEmpty",
+  "cases": [
+    {
+      "name": "empty when the only group's active tree has no tabs",
+      "input": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+      "args": {
+        "tabGroups": [
+          {
+            "id": "g1",
+            "name": "g1",
+            "activePanelId": null,
+            "rootPanel": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null }
+          }
+        ],
+        "activeTabGroupId": "g1"
+      },
+      "expected": true
+    },
+    {
+      "name": "not empty when the active group holds a tab",
+      "input": {
+        "type": "leaf",
+        "id": "leaf-1",
+        "activeTabId": "a",
+        "tabs": [{ "id": "a", "sessionId": null, "contentType": "terminal" }]
+      },
+      "args": {
+        "tabGroups": [
+          {
+            "id": "g1",
+            "name": "g1",
+            "activePanelId": null,
+            "rootPanel": {
+              "type": "leaf",
+              "id": "leaf-1",
+              "activeTabId": "a",
+              "tabs": [{ "id": "a", "sessionId": null, "contentType": "terminal" }]
+            }
+          }
+        ],
+        "activeTabGroupId": "g1"
+      },
+      "expected": false
+    },
+    {
+      "name": "not empty when an inactive group still holds tabs",
+      "input": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+      "args": {
+        "tabGroups": [
+          {
+            "id": "g1",
+            "name": "g1",
+            "activePanelId": null,
+            "rootPanel": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null }
+          },
+          {
+            "id": "g2",
+            "name": "g2",
+            "activePanelId": null,
+            "rootPanel": {
+              "type": "leaf",
+              "id": "leaf-2",
+              "activeTabId": "a",
+              "tabs": [{ "id": "a", "sessionId": null, "contentType": "terminal" }]
+            }
+          }
+        ],
+        "activeTabGroupId": "g1"
+      },
+      "expected": false
+    },
+    {
+      "name": "empty when every group across the window is empty",
+      "input": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+      "args": {
+        "tabGroups": [
+          {
+            "id": "g1",
+            "name": "g1",
+            "activePanelId": null,
+            "rootPanel": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null }
+          },
+          {
+            "id": "g2",
+            "name": "g2",
+            "activePanelId": null,
+            "rootPanel": { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+          }
+        ],
+        "activeTabGroupId": "g1"
+      },
+      "expected": true
+    },
+    {
+      "name": "uses the live active tree, not the stale stored copy",
+      "input": {
+        "type": "leaf",
+        "id": "leaf-1",
+        "activeTabId": "a",
+        "tabs": [{ "id": "a", "sessionId": null, "contentType": "terminal" }]
+      },
+      "args": {
+        "tabGroups": [
+          {
+            "id": "g1",
+            "name": "g1",
+            "activePanelId": null,
+            "rootPanel": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null }
+          }
+        ],
+        "activeTabGroupId": "g1"
+      },
+      "expected": false
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/panel_tree/mark_active_leaf.json
+++ b/core/tests/fixtures/golden/panel_tree/mark_active_leaf.json
@@ -1,0 +1,100 @@
+{
+  "operation": "markActiveLeaf",
+  "cases": [
+    {
+      "name": "marks all ancestor splits with the leaf id",
+      "input": {
+        "type": "split",
+        "id": "h",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          {
+            "type": "split",
+            "id": "v",
+            "direction": "vertical",
+            "children": [
+              { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null },
+              { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+            ]
+          }
+        ]
+      },
+      "args": { "leafId": "leaf-3" },
+      "expected": {
+        "type": "split",
+        "id": "h",
+        "direction": "horizontal",
+        "lastActiveLeafId": "leaf-3",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          {
+            "type": "split",
+            "id": "v",
+            "direction": "vertical",
+            "lastActiveLeafId": "leaf-3",
+            "children": [
+              { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null },
+              { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "does not mark splits that do not contain the leaf",
+      "input": {
+        "type": "split",
+        "id": "h",
+        "direction": "horizontal",
+        "children": [
+          {
+            "type": "split",
+            "id": "left",
+            "direction": "vertical",
+            "children": [
+              { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+              { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+            ]
+          },
+          { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+        ]
+      },
+      "args": { "leafId": "leaf-3" },
+      "expected": {
+        "type": "split",
+        "id": "h",
+        "direction": "horizontal",
+        "lastActiveLeafId": "leaf-3",
+        "children": [
+          {
+            "type": "split",
+            "id": "left",
+            "direction": "vertical",
+            "children": [
+              { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+              { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+            ]
+          },
+          { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+        ]
+      }
+    },
+    {
+      "name": "returns the tree unchanged when the leaf is not found",
+      "input": {
+        "type": "split",
+        "id": "h",
+        "direction": "horizontal",
+        "children": [{ "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null }]
+      },
+      "args": { "leafId": "nonexistent" },
+      "expected": {
+        "type": "split",
+        "id": "h",
+        "direction": "horizontal",
+        "children": [{ "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null }]
+      }
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/panel_tree/normalize_sizes.json
+++ b/core/tests/fixtures/golden/panel_tree/normalize_sizes.json
@@ -1,0 +1,25 @@
+{
+  "operation": "normalizeSizes",
+  "cases": [
+    {
+      "name": "already summing to 100 is preserved",
+      "input": [30, 20, 50],
+      "expected": [30, 20, 50]
+    },
+    {
+      "name": "scales up when sum is less than 100",
+      "input": [10, 10],
+      "expected": [50, 50]
+    },
+    {
+      "name": "scales down when sum exceeds 100",
+      "input": [100, 100],
+      "expected": [50, 50]
+    },
+    {
+      "name": "zero total distributes equally",
+      "input": [0, 0, 0],
+      "expected": [33.33333333333333, 33.33333333333333, 33.33333333333333]
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/panel_tree/remove_leaf.json
+++ b/core/tests/fixtures/golden/panel_tree/remove_leaf.json
@@ -1,0 +1,71 @@
+{
+  "operation": "removeLeaf",
+  "cases": [
+    {
+      "name": "returns null when removing the root leaf",
+      "input": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+      "args": { "leafId": "leaf-1" },
+      "expected": null
+    },
+    {
+      "name": "returns non-matching leaf unchanged",
+      "input": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+      "args": { "leafId": "other" },
+      "expected": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null }
+    },
+    {
+      "name": "unwraps single-child parent after removal",
+      "input": {
+        "type": "split",
+        "id": "split-1",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+        ]
+      },
+      "args": { "leafId": "leaf-1" },
+      "expected": { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+    },
+    {
+      "name": "redistributes sizes when removing from a sized split",
+      "input": {
+        "type": "split",
+        "id": "split-1",
+        "direction": "horizontal",
+        "sizes": [50, 25, 25],
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+        ]
+      },
+      "args": { "leafId": "leaf-1" },
+      "expected": {
+        "type": "split",
+        "id": "split-1",
+        "direction": "horizontal",
+        "sizes": [50, 50],
+        "children": [
+          { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+        ]
+      }
+    },
+    {
+      "name": "collapses to single child when removing from a sized 2-child split",
+      "input": {
+        "type": "split",
+        "id": "split-1",
+        "direction": "horizontal",
+        "sizes": [70, 30],
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+        ]
+      },
+      "args": { "leafId": "leaf-1" },
+      "expected": { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/panel_tree/simplify_tree.json
+++ b/core/tests/fixtures/golden/panel_tree/simplify_tree.json
@@ -1,0 +1,50 @@
+{
+  "operation": "simplifyTree",
+  "cases": [
+    {
+      "name": "returns a leaf unchanged",
+      "input": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+      "expected": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null }
+    },
+    {
+      "name": "flattens same-direction nesting",
+      "input": {
+        "type": "split",
+        "id": "outer",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          {
+            "type": "split",
+            "id": "inner",
+            "direction": "horizontal",
+            "children": [
+              { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null },
+              { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+            ]
+          }
+        ]
+      },
+      "expected": {
+        "type": "split",
+        "id": "outer",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-3", "tabs": [], "activeTabId": null }
+        ]
+      }
+    },
+    {
+      "name": "unwraps single-child containers",
+      "input": {
+        "type": "split",
+        "id": "split-1",
+        "direction": "horizontal",
+        "children": [{ "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null }]
+      },
+      "expected": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null }
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/panel_tree/split_leaf.json
+++ b/core/tests/fixtures/golden/panel_tree/split_leaf.json
@@ -1,0 +1,101 @@
+{
+  "operation": "splitLeaf",
+  "cases": [
+    {
+      "name": "wraps a leaf in a split container with the new leaf after",
+      "input": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+      "args": {
+        "targetId": "leaf-1",
+        "newLeaf": { "type": "leaf", "id": "new-leaf", "tabs": [], "activeTabId": null },
+        "direction": "horizontal",
+        "position": "after"
+      },
+      "expected": {
+        "type": "split",
+        "id": "__GENERATED__",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "new-leaf", "tabs": [], "activeTabId": null }
+        ]
+      }
+    },
+    {
+      "name": "inserts before when position is before",
+      "input": { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+      "args": {
+        "targetId": "leaf-1",
+        "newLeaf": { "type": "leaf", "id": "new-leaf", "tabs": [], "activeTabId": null },
+        "direction": "vertical",
+        "position": "before"
+      },
+      "expected": {
+        "type": "split",
+        "id": "__GENERATED__",
+        "direction": "vertical",
+        "children": [
+          { "type": "leaf", "id": "new-leaf", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null }
+        ]
+      }
+    },
+    {
+      "name": "inserts as a sibling when directions match",
+      "input": {
+        "type": "split",
+        "id": "split-1",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+        ]
+      },
+      "args": {
+        "targetId": "leaf-1",
+        "newLeaf": { "type": "leaf", "id": "new-leaf", "tabs": [], "activeTabId": null },
+        "direction": "horizontal",
+        "position": "after"
+      },
+      "expected": {
+        "type": "split",
+        "id": "split-1",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "new-leaf", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+        ]
+      }
+    },
+    {
+      "name": "halves target size when splitting as sibling in a sized split",
+      "input": {
+        "type": "split",
+        "id": "split-1",
+        "direction": "horizontal",
+        "sizes": [60, 40],
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+        ]
+      },
+      "args": {
+        "targetId": "leaf-1",
+        "newLeaf": { "type": "leaf", "id": "new-leaf", "tabs": [], "activeTabId": null },
+        "direction": "horizontal",
+        "position": "after"
+      },
+      "expected": {
+        "type": "split",
+        "id": "split-1",
+        "direction": "horizontal",
+        "sizes": [30, 30, 40],
+        "children": [
+          { "type": "leaf", "id": "leaf-1", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "new-leaf", "tabs": [], "activeTabId": null },
+          { "type": "leaf", "id": "leaf-2", "tabs": [], "activeTabId": null }
+        ]
+      }
+    }
+  ]
+}

--- a/core/tests/panel_tree_golden.rs
+++ b/core/tests/panel_tree_golden.rs
@@ -1,0 +1,200 @@
+//! Golden-vector equivalence tests for the panel-tree algebra (#2143).
+//!
+//! Each fixture under `tests/fixtures/golden/panel_tree/*.json` names one
+//! exported function and a list of input → expected cases extracted from the
+//! authoritative TypeScript suite (`src/utils/panelTree.test.ts`,
+//! `panelTree.fileDrop.test.ts`). This test runs the Rust port against every
+//! case and asserts the serialized result matches, proving the two
+//! implementations stay in lockstep.
+//!
+//! Fixture format and the shared-convention rationale live in
+//! `tests/fixtures/golden/README.md`. This is the first Phase-0 port; the
+//! sibling util ports (#2144–#2147) reuse the same directory layout, envelope,
+//! and matcher.
+
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+use termihub_core::layout::panel_tree::{
+    count_tabs_in_tree, edge_to_split, find_adjacent_leaf, find_leaf, find_leaf_by_tab,
+    get_all_leaves, get_panel_active_session_id, is_window_empty, mark_active_leaf,
+    normalize_sizes, remove_leaf, simplify_tree, split_leaf, Direction, DropEdge, FocusDirection,
+    LeafPanel, PanelNode, Position, TabGroup,
+};
+
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("golden")
+        .join("panel_tree")
+}
+
+/// Deep JSON equality with two golden-vector conventions:
+///   * the string `"__GENERATED__"` in `expected` matches any string in
+///     `actual` (freshly generated panel ids are non-deterministic);
+///   * numbers compare within a 1e-9 tolerance (cross-language float rounding).
+fn json_matches(expected: &Value, actual: &Value) -> bool {
+    match (expected, actual) {
+        (Value::String(e), _) if e == "__GENERATED__" => actual.is_string(),
+        (Value::Number(e), Value::Number(a)) => match (e.as_f64(), a.as_f64()) {
+            (Some(x), Some(y)) => (x - y).abs() < 1e-9,
+            _ => e == a,
+        },
+        (Value::Array(e), Value::Array(a)) => {
+            e.len() == a.len() && e.iter().zip(a).all(|(x, y)| json_matches(x, y))
+        }
+        (Value::Object(e), Value::Object(a)) => {
+            e.len() == a.len()
+                && e.iter()
+                    .all(|(k, v)| a.get(k).is_some_and(|av| json_matches(v, av)))
+        }
+        _ => expected == actual,
+    }
+}
+
+fn leaf_opt_to_value(leaf: Option<&LeafPanel>) -> Value {
+    match leaf {
+        Some(l) => serde_json::to_value(PanelNode::Leaf(l.clone())).expect("serialize leaf"),
+        None => Value::Null,
+    }
+}
+
+fn node_opt_to_value(node: Option<PanelNode>) -> Value {
+    match node {
+        Some(n) => serde_json::to_value(n).expect("serialize node"),
+        None => Value::Null,
+    }
+}
+
+fn from<T: serde::de::DeserializeOwned>(v: &Value) -> T {
+    serde_json::from_value(v.clone()).expect("deserialize fixture value")
+}
+
+/// Run one case for `operation`, returning the serialized actual result.
+fn run_case(operation: &str, case: &Value) -> Value {
+    let input = &case["input"];
+    let args = &case["args"];
+    match operation {
+        "countTabsInTree" => json!(count_tabs_in_tree(&from::<PanelNode>(input))),
+        "isWindowEmpty" => {
+            let root: PanelNode = from(input);
+            let groups: Vec<TabGroup> = from(&args["tabGroups"]);
+            let active = args["activeTabGroupId"].as_str();
+            json!(is_window_empty(&root, &groups, active))
+        }
+        "normalizeSizes" => json!(normalize_sizes(&from::<Vec<f64>>(input))),
+        "findLeaf" => {
+            let root: PanelNode = from(input);
+            leaf_opt_to_value(find_leaf(&root, args["leafId"].as_str().unwrap()))
+        }
+        "findLeafByTab" => {
+            let root: PanelNode = from(input);
+            leaf_opt_to_value(find_leaf_by_tab(&root, args["tabId"].as_str().unwrap()))
+        }
+        "getPanelActiveSessionId" => {
+            let panel: LeafPanel = from(input);
+            match get_panel_active_session_id(&panel) {
+                Some(s) => json!(s),
+                None => Value::Null,
+            }
+        }
+        "getAllLeaves" => {
+            let root: PanelNode = from(input);
+            Value::Array(
+                get_all_leaves(&root)
+                    .into_iter()
+                    .map(|l| serde_json::to_value(PanelNode::Leaf(l.clone())).expect("serialize"))
+                    .collect(),
+            )
+        }
+        "removeLeaf" => {
+            let root: PanelNode = from(input);
+            node_opt_to_value(remove_leaf(&root, args["leafId"].as_str().unwrap()))
+        }
+        "splitLeaf" => {
+            let root: PanelNode = from(input);
+            let new_leaf: LeafPanel = from(&args["newLeaf"]);
+            let direction: Direction = from(&args["direction"]);
+            let position: Position = from(&args["position"]);
+            serde_json::to_value(split_leaf(
+                &root,
+                args["targetId"].as_str().unwrap(),
+                &new_leaf,
+                direction,
+                position,
+            ))
+            .expect("serialize")
+        }
+        "simplifyTree" => {
+            serde_json::to_value(simplify_tree(&from::<PanelNode>(input))).expect("s")
+        }
+        "edgeToSplit" => {
+            let edge: DropEdge = from(input);
+            match edge_to_split(edge) {
+                Some(spec) => serde_json::to_value(spec).expect("serialize"),
+                None => Value::Null,
+            }
+        }
+        "findAdjacentLeaf" => {
+            let root: PanelNode = from(input);
+            let direction: FocusDirection = from(&args["direction"]);
+            leaf_opt_to_value(find_adjacent_leaf(
+                &root,
+                args["currentLeafId"].as_str().unwrap(),
+                direction,
+            ))
+        }
+        "markActiveLeaf" => {
+            let root: PanelNode = from(input);
+            serde_json::to_value(mark_active_leaf(&root, args["leafId"].as_str().unwrap()))
+                .expect("serialize")
+        }
+        other => panic!("unknown golden operation: {other}"),
+    }
+}
+
+#[test]
+fn golden_vectors_match_typescript() {
+    let dir = fixture_dir();
+    let mut files: Vec<PathBuf> = fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read fixture dir {}: {e}", dir.display()))
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "json"))
+        .collect();
+    files.sort();
+    assert!(
+        !files.is_empty(),
+        "no golden fixtures found in {}",
+        dir.display()
+    );
+
+    let mut total_cases = 0usize;
+    for file in files {
+        let raw = fs::read_to_string(&file).expect("read fixture");
+        let fixture: Value =
+            serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {}: {e}", file.display()));
+        let operation = fixture["operation"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{} missing operation", file.display()));
+        let cases = fixture["cases"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{} missing cases array", file.display()));
+
+        for case in cases {
+            let name = case["name"].as_str().unwrap_or("<unnamed>");
+            let actual = run_case(operation, case);
+            let expected = &case["expected"];
+            assert!(
+                json_matches(expected, &actual),
+                "golden mismatch in {} :: {operation} :: {name}\n  expected: {}\n  actual:   {}",
+                file.display(),
+                serde_json::to_string(expected).unwrap_or_default(),
+                serde_json::to_string(&actual).unwrap_or_default(),
+            );
+            total_cases += 1;
+        }
+    }
+    // Sanity: make sure the harness actually exercised a meaningful body of cases.
+    assert!(total_cases >= 40, "only ran {total_cases} golden cases");
+}


### PR DESCRIPTION
## Summary

Phase 0 of the stateless-UI migration (#2139): a faithful Rust twin of the
frontend's `src/utils/panelTree.ts` panel-tree algebra, landed in
`termihub-core` at `core/src/layout/panel_tree.rs`.

The TypeScript version **stays authoritative** — nothing changes for the user.
This port runs behind it and is proven equivalent via golden vectors; Phase 3
(#2151) will activate it as the backing `LayoutStore`.

## What was ported

Every exported function, with identical semantics:

- `count_tabs_in_tree`, `is_window_empty` (empty-window state, #1902)
- `normalize_sizes`, `generate_panel_id`, `create_leaf_panel`
- `find_leaf`, `find_leaf_by_tab`, `get_panel_active_session_id`, `get_all_leaves`
- `update_leaf`, `remove_leaf` (with size redistribution), `split_leaf`
  (leaf-wrap + same-direction sibling insert + size halving), `simplify_tree`
- `edge_to_split`, `mark_active_leaf`, `find_adjacent_leaf`
  (`lastActiveLeafId` preference + edge fallback)

The tree is modelled as a serde-tagged `PanelNode` enum (`Leaf`/`Split`)
serializing to the same JSON shape as the TS discriminated union. `Tab` is a
minimal projection (`id`, `sessionId`, `contentType`) — the only fields any
layout operation reads.

## Test approach

Three layers, all green (`cargo test`, `clippy -D warnings`, `fmt` clean):

1. **Unit tests** mirroring `panelTree.test.ts` / `panelTree.fileDrop.test.ts`
   case-for-case.
2. **Property tests** (`proptest`, added as a dev-dependency) over the algebra
   invariants: unique leaf ids, tab-count identity, `remove_leaf` drops exactly
   one leaf and leaves no orphaned single-child splits, split/remove
   round-trips, `simplify_tree` idempotence + flattening, `mark_active_leaf`
   marks ancestors only, adjacency stays in-tree.
3. **Golden vectors** — the cross-language equivalence layer.

## Golden-vector convention (for the sibling ports)

Established here for #2144–#2147 to reuse verbatim. Documented in
[`core/tests/fixtures/golden/README.md`](../blob/develop/core/tests/fixtures/golden/README.md):

- Language-neutral JSON fixtures at
  `core/tests/fixtures/golden/<util>/<function>.json`, one file per exported
  function, each an `{ operation, cases: [{ name, input, args, expected }] }`
  envelope. Cases are extracted from the util's authoritative TS test suite.
- A shared Rust harness (`core/tests/panel_tree_golden.rs`) runs the port
  against every case and asserts the serialized output matches — so TS/Rust
  drift fails a test.
- Two deliberate matcher relaxations: the string `"__GENERATED__"` matches any
  freshly generated panel id, and numbers compare within `1e-9` for float
  rounding. Optional fields (`sizes`, `lastActiveLeafId`) are omitted from
  `expected` when unset, so key sets must match exactly.

52 golden cases across 13 fixture files.

## Notes

- `panelTree.ts` confirmed genuinely pure — imports only types from
  `@/types/terminal`, no React/DOM.
- Non-user-facing (port runs behind existing TS), so no changelog fragment.
- `src/utils/panelTree.ts` is untouched and stays authoritative.

Closes #2143
Part of #2139