### PR TITLE
feat: Service/Tool trait pair, registries, agent dispatch, run-location resolver (S1)

### DIFF
--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -18,6 +18,10 @@ use serde_json::{json, Value};
 use tokio::sync::Mutex;
 use tracing::{debug, warn};
 
+use termihub_core::service::ServiceRegistry;
+use termihub_core::tool::{CollectingHost, ToolRegistry};
+use tokio_util::sync::CancellationToken;
+
 use crate::client_registry::ConnectionRegistry;
 use crate::files::local::LocalFileBackend;
 use crate::files::{FileBackend, FileError};
@@ -89,6 +93,16 @@ struct HandlerState {
     /// Shared with [`AgentHandler::shutdown_flag`] so the transport loop can
     /// detect shutdown without re-locking the mutex after every request.
     shutdown_flag: Arc<AtomicBool>,
+    /// Registry of one-shot / streaming tools this agent can host (#2148).
+    /// Populated with the built-in network diagnostics; the `tool.*` methods
+    /// dispatch through it, mirroring how `network.*` calls the same core
+    /// functions directly.
+    tool_registry: Arc<ToolRegistry>,
+    /// Registry of long-lived services this agent can host (#2148). Empty in
+    /// S1 — moving concrete services (embedded servers, HTTP monitor) onto the
+    /// agent is S2 — but the `service.*` methods dispatch through it so the
+    /// namespace exists now.
+    service_registry: Arc<ServiceRegistry>,
 }
 
 // ── AgentHandler ───────────────────────────────────────────────────
@@ -130,6 +144,13 @@ impl AgentHandler {
         let client_id = uuid::Uuid::new_v4().to_string();
         let registry_client: Arc<OnceLock<Arc<RegistryClient>>> = Arc::new(OnceLock::new());
 
+        // Built-in tool set, shared and stateless; services start empty (S2
+        // lifts concrete services onto the agent). Both are constructed here so
+        // `AgentHandler::new`'s public signature is unchanged — the registries
+        // are self-contained infrastructure, exactly like the shutdown flag.
+        let tool_registry = Arc::new(ToolRegistry::with_builtin_network_tools());
+        let service_registry = Arc::new(ServiceRegistry::new());
+
         let state = Mutex::new(HandlerState {
             session_manager,
             connection_store,
@@ -141,6 +162,8 @@ impl AgentHandler {
             client_id: client_id.clone(),
             registry_client: registry_client.clone(),
             shutdown_flag: shutdown_flag.clone(),
+            tool_registry,
+            service_registry,
         });
 
         let mut module: RpcModule<Mutex<HandlerState>> = RpcModule::new(state);
@@ -331,6 +354,26 @@ async fn get_monitoring_managers(
     Ok((s.session_manager.clone(), s.monitoring_manager.clone()))
 }
 
+async fn get_tool_registry(
+    ctx: &tokio::sync::Mutex<HandlerState>,
+) -> Result<Arc<ToolRegistry>, ErrorObjectOwned> {
+    let s = ctx.lock().await;
+    if !s.initialized {
+        return Err(not_initialized());
+    }
+    Ok(s.tool_registry.clone())
+}
+
+async fn get_service_registry(
+    ctx: &tokio::sync::Mutex<HandlerState>,
+) -> Result<Arc<ServiceRegistry>, ErrorObjectOwned> {
+    let s = ctx.lock().await;
+    if !s.initialized {
+        return Err(not_initialized());
+    }
+    Ok(s.service_registry.clone())
+}
+
 // ── Method registration ────────────────────────────────────────────
 
 fn register_all(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::Result<()> {
@@ -368,6 +411,9 @@ fn register_all(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::Result<(
     register_network_open_ports(module)?;
     register_network_traceroute(module)?;
     register_network_wol(module)?;
+    register_tool_list(module)?;
+    register_tool_run(module)?;
+    register_service_list(module)?;
     register_health_check(module)?;
     register_agent_shutdown(module)?;
     register_agent_settings_update(module)?;
@@ -1296,6 +1342,59 @@ fn register_network_wol(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::
         network::handle_wol(p)
             .map(|()| json!({}))
             .map_err(|e| rpc_err(errors::INTERNAL_ERROR, e.to_string()))
+    })?;
+    Ok(())
+}
+
+// ── tool.* / service.* ────────────────────────────────────────────
+//
+// The uniform Service/Tool substrate (#2148, part of #2139). `tool.*`
+// dispatches through the agent's ToolRegistry — the same core network
+// diagnostics `network.*` calls, now reachable behind the location-agnostic
+// trait. `service.*` exposes the (S1-empty) ServiceRegistry so the namespace
+// exists before S2 lifts concrete services onto the agent.
+
+fn register_tool_list(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::Result<()> {
+    module.register_async_method("tool.list", |_params, ctx, _ext| async move {
+        let registry = get_tool_registry(&ctx).await?;
+        Ok::<_, ErrorObjectOwned>(json!({ "tools": registry.available_tools() }))
+    })?;
+    Ok(())
+}
+
+fn register_tool_run(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::Result<()> {
+    module.register_async_method("tool.run", |params, ctx, _ext| async move {
+        let registry = get_tool_registry(&ctx).await?;
+
+        let p: Value = params
+            .parse()
+            .map_err(|e| invalid_params("tool.run", e))?;
+        let tool_id = p
+            .get("toolId")
+            .and_then(Value::as_str)
+            .ok_or_else(|| rpc_err(errors::INVALID_PARAMS, "tool.run requires 'toolId'"))?
+            .to_string();
+        let tool_params = p.get("params").cloned().unwrap_or_else(|| json!({}));
+
+        // Collect the streamed events into a single JSON-RPC response, the same
+        // way `network.*` collects its results (the NDJSON transport is
+        // request/response, not streaming). Real-time streaming to the desktop
+        // is a later phase.
+        let host = CollectingHost::new();
+        let result = registry
+            .run(&tool_id, tool_params, host.clone(), CancellationToken::new())
+            .await
+            .map_err(|e| rpc_err(errors::INTERNAL_ERROR, e.to_string()))?;
+
+        Ok::<_, ErrorObjectOwned>(json!({ "events": host.take(), "result": result }))
+    })?;
+    Ok(())
+}
+
+fn register_service_list(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::Result<()> {
+    module.register_async_method("service.list", |_params, ctx, _ext| async move {
+        let registry = get_service_registry(&ctx).await?;
+        Ok::<_, ErrorObjectOwned>(json!({ "services": registry.available_services() }))
     })?;
     Ok(())
 }
@@ -3305,6 +3404,94 @@ mod tests {
 
         let result = dispatch(&handler, "network.open_ports", json!({}), 1).await;
         assert_eq!(result["error"]["code"], errors::NOT_INITIALIZED);
+    }
+
+    // ── tool.* / service.* (#2148) ─────────────────────────────────
+
+    #[tokio::test]
+    async fn tool_list_returns_builtin_network_tools() {
+        let handler = make_handler();
+        init_handler(&handler).await;
+
+        let result = dispatch(&handler, "tool.list", json!({}), 2).await;
+        let tools = result["result"]["tools"]
+            .as_array()
+            .expect("tools array");
+        let ids: Vec<&str> = tools
+            .iter()
+            .filter_map(|t| t["toolId"].as_str())
+            .collect();
+        assert!(ids.contains(&"ping"), "tool.list must include ping: {result}");
+        assert!(ids.contains(&"port_scan"));
+        assert!(ids.contains(&"dns"));
+        assert!(ids.contains(&"wol"));
+    }
+
+    #[tokio::test]
+    async fn tool_run_open_ports_round_trip() {
+        // open_ports is network-free, so it exercises the full tool.run path
+        // (dispatch → registry → CollectingHost → response) deterministically.
+        let handler = make_handler();
+        init_handler(&handler).await;
+
+        let result = dispatch(
+            &handler,
+            "tool.run",
+            json!({ "toolId": "open_ports", "params": {} }),
+            2,
+        )
+        .await;
+        assert!(
+            result["result"]["result"]["ports"].is_array(),
+            "expected open_ports list: {result}"
+        );
+        // One-shot tool: no streamed events.
+        assert_eq!(
+            result["result"]["events"].as_array().map(Vec::len),
+            Some(0)
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_run_unknown_tool_errors() {
+        let handler = make_handler();
+        init_handler(&handler).await;
+
+        let result = dispatch(
+            &handler,
+            "tool.run",
+            json!({ "toolId": "ghost", "params": {} }),
+            2,
+        )
+        .await;
+        assert_eq!(result["error"]["code"], errors::INTERNAL_ERROR);
+    }
+
+    #[tokio::test]
+    async fn service_list_is_empty_in_s1() {
+        // The agent hosts no services yet (S2 lifts them on); the namespace
+        // exists and reports an empty set.
+        let handler = make_handler();
+        init_handler(&handler).await;
+
+        let result = dispatch(&handler, "service.list", json!({}), 2).await;
+        assert_eq!(
+            result["result"]["services"].as_array().map(Vec::len),
+            Some(0),
+            "service.list must be empty in S1: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_and_service_methods_require_initialization() {
+        let handler = make_handler();
+        for method in ["tool.list", "tool.run", "service.list"] {
+            let result = dispatch(&handler, method, json!({}), 1).await;
+            assert_eq!(
+                result["error"]["code"], errors::NOT_INITIALIZED,
+                "{method} must require initialize"
+            );
+        }
     }
 
     // ── Mock managers for DI tests ─────────────────────────────────

--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -1366,9 +1366,7 @@ fn register_tool_run(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::Res
     module.register_async_method("tool.run", |params, ctx, _ext| async move {
         let registry = get_tool_registry(&ctx).await?;
 
-        let p: Value = params
-            .parse()
-            .map_err(|e| invalid_params("tool.run", e))?;
+        let p: Value = params.parse().map_err(|e| invalid_params("tool.run", e))?;
         let tool_id = p
             .get("toolId")
             .and_then(Value::as_str)
@@ -1382,7 +1380,12 @@ fn register_tool_run(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::Res
         // is a later phase.
         let host = CollectingHost::new();
         let result = registry
-            .run(&tool_id, tool_params, host.clone(), CancellationToken::new())
+            .run(
+                &tool_id,
+                tool_params,
+                host.clone(),
+                CancellationToken::new(),
+            )
             .await
             .map_err(|e| rpc_err(errors::INTERNAL_ERROR, e.to_string()))?;
 
@@ -3414,14 +3417,12 @@ mod tests {
         init_handler(&handler).await;
 
         let result = dispatch(&handler, "tool.list", json!({}), 2).await;
-        let tools = result["result"]["tools"]
-            .as_array()
-            .expect("tools array");
-        let ids: Vec<&str> = tools
-            .iter()
-            .filter_map(|t| t["toolId"].as_str())
-            .collect();
-        assert!(ids.contains(&"ping"), "tool.list must include ping: {result}");
+        let tools = result["result"]["tools"].as_array().expect("tools array");
+        let ids: Vec<&str> = tools.iter().filter_map(|t| t["toolId"].as_str()).collect();
+        assert!(
+            ids.contains(&"ping"),
+            "tool.list must include ping: {result}"
+        );
         assert!(ids.contains(&"port_scan"));
         assert!(ids.contains(&"dns"));
         assert!(ids.contains(&"wol"));
@@ -3446,10 +3447,7 @@ mod tests {
             "expected open_ports list: {result}"
         );
         // One-shot tool: no streamed events.
-        assert_eq!(
-            result["result"]["events"].as_array().map(Vec::len),
-            Some(0)
-        );
+        assert_eq!(result["result"]["events"].as_array().map(Vec::len), Some(0));
     }
 
     #[tokio::test]
@@ -3488,7 +3486,8 @@ mod tests {
         for method in ["tool.list", "tool.run", "service.list"] {
             let result = dispatch(&handler, method, json!({}), 1).await;
             assert_eq!(
-                result["error"]["code"], errors::NOT_INITIALIZED,
+                result["error"]["code"],
+                errors::NOT_INITIALIZED,
                 "{method} must require initialize"
             );
         }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,4 +24,6 @@ pub mod output;
 #[cfg(feature = "plugin")]
 pub mod plugin;
 pub mod protocol;
+pub mod service;
 pub mod session;
+pub mod tool;

--- a/core/src/service/mod.rs
+++ b/core/src/service/mod.rs
@@ -1,0 +1,257 @@
+//! Long-lived services behind a uniform trait.
+//!
+//! A [`Service`] is a long-lived, stateful thing with a lifecycle —
+//! `start` / `stop` / `status` / `subscribe_events` — plus a
+//! [`settings_schema`](Service::settings_schema) and
+//! [`capabilities`](Service::capabilities), exactly like
+//! [`ConnectionType`](crate::connection::ConnectionType). This is the twin of
+//! the one-shot [`Tool`](crate::tool::Tool) abstraction: where a tool is
+//! *invoked*, a service *runs*.
+//!
+//! Intended implementors (moved onto the trait in later phases, per the
+//! stateless-UI concept #2139): the embedded HTTP/FTP/TFTP servers, SSH
+//! tunnels, the HTTP monitor, and system monitors. This module lands the
+//! substrate — the trait, a [`ServiceRegistry`] (twin of
+//! [`ConnectionTypeRegistry`](crate::connection::ConnectionTypeRegistry)), and a
+//! reusable [`EventChannel`] — so those services can be lifted onto it without
+//! any behaviour change now.
+//!
+//! # Architecture
+//!
+//! The core crate defines only the trait and data types. Concrete services live
+//! in the desktop (`src-tauri/`) and agent (`agent/`) crates, which register
+//! their factories with a [`ServiceRegistry`] at startup. A service streams
+//! status/stats through the core-owned [`EventChannel`] rather than a
+//! host-specific emitter, so the same implementation runs on the desktop or an
+//! agent.
+
+pub mod registry;
+
+pub use registry::{ServiceFactory, ServiceInfo, ServiceRegistry};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
+use tokio::sync::broadcast;
+
+use crate::connection::SettingsSchema;
+
+/// Default capacity of a service's event broadcast channel.
+///
+/// A slow subscriber that lags past this many buffered events will observe a
+/// [`broadcast::error::RecvError::Lagged`] on its next receive rather than
+/// stalling the emitter — status/stats events are advisory, so dropping the
+/// oldest is the right trade-off.
+const EVENT_CHANNEL_CAPACITY: usize = 256;
+
+/// Lifecycle state of a [`Service`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "state", content = "detail")]
+pub enum ServiceStatus {
+    /// Not running.
+    Stopped,
+    /// A start is in progress.
+    Starting,
+    /// Running normally.
+    Running,
+    /// A stop is in progress.
+    Stopping,
+    /// Terminated abnormally; carries a human-readable reason.
+    Failed(String),
+}
+
+/// A status/stats event emitted by a running service.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServiceEvent {
+    /// Discriminator for the payload shape, e.g. `"status"`, `"stats"`.
+    pub kind: String,
+    /// The serialized event body.
+    pub payload: Value,
+}
+
+impl ServiceEvent {
+    /// Build an event, serializing `payload` to JSON (degrading a serialization
+    /// failure to `null` rather than panicking).
+    pub fn new(kind: impl Into<String>, payload: impl Serialize) -> Self {
+        Self {
+            kind: kind.into(),
+            payload: serde_json::to_value(payload).unwrap_or(Value::Null),
+        }
+    }
+}
+
+/// Receiver end of a service's event stream.
+pub type ServiceEventReceiver = broadcast::Receiver<ServiceEvent>;
+
+/// A multi-subscriber event channel a [`Service`] emits status/stats through.
+///
+/// Services embed one and expose it via
+/// [`subscribe_events`](Service::subscribe_events). Emitting with no
+/// subscribers is a no-op, so a service may emit freely regardless of whether
+/// anyone is listening.
+#[derive(Debug, Clone)]
+pub struct EventChannel {
+    sender: broadcast::Sender<ServiceEvent>,
+}
+
+impl EventChannel {
+    /// Create a channel with the default capacity.
+    pub fn new() -> Self {
+        let (sender, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
+        Self { sender }
+    }
+
+    /// Emit an event to all current subscribers. No-op when there are none.
+    pub fn emit(&self, event: ServiceEvent) {
+        let _ = self.sender.send(event);
+    }
+
+    /// Subscribe to the event stream. Each call yields an independent receiver.
+    pub fn subscribe(&self) -> ServiceEventReceiver {
+        self.sender.subscribe()
+    }
+
+    /// Current number of active subscribers.
+    pub fn subscriber_count(&self) -> usize {
+        self.sender.receiver_count()
+    }
+}
+
+impl Default for EventChannel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Capabilities declared by a service, for UI discovery and run-location routing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServiceCapabilities {
+    /// Whether the service takes configuration (a non-empty settings schema).
+    pub configurable: bool,
+    /// Whether the service emits events on its [`EventChannel`].
+    pub emits_events: bool,
+    /// Whether this service is permanently desktop-only and must never be
+    /// offered an agent run-location.
+    ///
+    /// The permanent desktop-host set (per the stateless-UI concept's Open
+    /// Design Decision #4): credentials/keychain, spawn rendezvous, local file
+    /// watch, and OS-window management. The desktop run-location selector omits
+    /// the "agent" option for any service that sets this.
+    pub desktop_only: bool,
+}
+
+/// A long-lived, stateful service with a start/stop lifecycle.
+///
+/// # Lifecycle
+///
+/// 1. Create via [`ServiceRegistry::create`]
+/// 2. Read metadata: [`service_id`](Self::service_id),
+///    [`display_name`](Self::display_name),
+///    [`settings_schema`](Self::settings_schema),
+///    [`capabilities`](Self::capabilities)
+/// 3. [`start`](Self::start) with a config JSON value
+/// 4. Observe: [`status`](Self::status),
+///    [`subscribe_events`](Self::subscribe_events)
+/// 5. [`stop`](Self::stop)
+#[async_trait]
+pub trait Service: Send {
+    /// Machine-readable identifier (e.g. `"http_server"`).
+    fn service_id(&self) -> &str;
+
+    /// Human-readable display name (e.g. `"HTTP Server"`).
+    fn display_name(&self) -> &str;
+
+    /// Settings schema for dynamic UI form generation.
+    fn settings_schema(&self) -> SettingsSchema;
+
+    /// Capabilities of this service.
+    fn capabilities(&self) -> ServiceCapabilities;
+
+    /// Start the service using the provided config JSON.
+    async fn start(&mut self, config: Value) -> Result<(), ServiceError>;
+
+    /// Stop the service and release its resources.
+    async fn stop(&mut self) -> Result<(), ServiceError>;
+
+    /// Current lifecycle state.
+    fn status(&self) -> ServiceStatus;
+
+    /// Subscribe to the service's status/stats event stream.
+    fn subscribe_events(&self) -> ServiceEventReceiver;
+}
+
+/// Errors from a [`Service`] lifecycle operation.
+#[derive(Error, Debug)]
+pub enum ServiceError {
+    /// The config JSON was invalid for this service.
+    #[error("Invalid service configuration: {0}")]
+    InvalidConfig(String),
+
+    /// The service failed to start.
+    #[error("Service failed to start: {0}")]
+    StartFailed(String),
+
+    /// The service failed to stop cleanly.
+    #[error("Service failed to stop: {0}")]
+    StopFailed(String),
+
+    /// No service with the requested id is registered.
+    #[error("Unknown service: {0}")]
+    Unknown(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn _assert_object_safe(_: &dyn Service) {}
+    fn _assert_send<T: Send>() {}
+
+    #[test]
+    fn service_is_send() {
+        _assert_send::<Box<dyn Service>>();
+    }
+
+    #[test]
+    fn service_status_serde_roundtrip() {
+        let running = serde_json::to_value(ServiceStatus::Running).unwrap();
+        assert_eq!(running["state"], "running");
+        let failed = serde_json::to_value(ServiceStatus::Failed("boom".into())).unwrap();
+        assert_eq!(failed["state"], "failed");
+        assert_eq!(failed["detail"], "boom");
+
+        let back: ServiceStatus = serde_json::from_value(failed).unwrap();
+        assert_eq!(back, ServiceStatus::Failed("boom".into()));
+    }
+
+    #[tokio::test]
+    async fn event_channel_delivers_to_subscribers() {
+        let channel = EventChannel::new();
+        // Emitting with no subscribers is a no-op.
+        assert_eq!(channel.subscriber_count(), 0);
+        channel.emit(ServiceEvent::new("status", serde_json::json!({ "up": true })));
+
+        let mut rx = channel.subscribe();
+        assert_eq!(channel.subscriber_count(), 1);
+        channel.emit(ServiceEvent::new("stats", serde_json::json!({ "requests": 5 })));
+
+        let event = rx.recv().await.expect("event must arrive");
+        assert_eq!(event.kind, "stats");
+        assert_eq!(event.payload["requests"], 5);
+    }
+
+    #[test]
+    fn service_capabilities_camel_case() {
+        let caps = ServiceCapabilities {
+            configurable: true,
+            emits_events: true,
+            desktop_only: false,
+        };
+        let json = serde_json::to_value(&caps).unwrap();
+        assert!(json.as_object().unwrap().contains_key("emitsEvents"));
+        assert!(json.as_object().unwrap().contains_key("desktopOnly"));
+    }
+}

--- a/core/src/service/mod.rs
+++ b/core/src/service/mod.rs
@@ -232,11 +232,17 @@ mod tests {
         let channel = EventChannel::new();
         // Emitting with no subscribers is a no-op.
         assert_eq!(channel.subscriber_count(), 0);
-        channel.emit(ServiceEvent::new("status", serde_json::json!({ "up": true })));
+        channel.emit(ServiceEvent::new(
+            "status",
+            serde_json::json!({ "up": true }),
+        ));
 
         let mut rx = channel.subscribe();
         assert_eq!(channel.subscriber_count(), 1);
-        channel.emit(ServiceEvent::new("stats", serde_json::json!({ "requests": 5 })));
+        channel.emit(ServiceEvent::new(
+            "stats",
+            serde_json::json!({ "requests": 5 }),
+        ));
 
         let event = rx.recv().await.expect("event must arrive");
         assert_eq!(event.kind, "stats");

--- a/core/src/service/registry.rs
+++ b/core/src/service/registry.rs
@@ -1,0 +1,258 @@
+//! Runtime registry of available service types.
+//!
+//! Twin of [`ConnectionTypeRegistry`](crate::connection::ConnectionTypeRegistry):
+//! desktop and agent crates register service factories at startup, and the
+//! registry provides discovery (listing services with their schemas) and
+//! creation (instantiating a service by id). Because a service is stateful and
+//! created fresh per run, the registry stores a **factory** per id (unlike the
+//! stateless [`ToolRegistry`](crate::tool::ToolRegistry), which stores shared
+//! instances).
+//!
+//! # Example
+//!
+//! ```ignore
+//! let mut registry = ServiceRegistry::new();
+//! registry.register("http_server", "HTTP Server", "server",
+//!     Box::new(|| Box::new(HttpServerService::new())));
+//! let svc = registry.create("http_server")?;
+//! ```
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{Service, ServiceCapabilities, ServiceError};
+use crate::connection::SettingsSchema;
+
+/// Factory that creates a new, stopped service instance.
+pub type ServiceFactory = Box<dyn Fn() -> Box<dyn Service> + Send + Sync>;
+
+/// Metadata about a registered service type for UI discovery.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServiceInfo {
+    /// Machine-readable identifier (e.g. `"http_server"`).
+    pub service_id: String,
+    /// Human-readable display name (e.g. `"HTTP Server"`).
+    pub display_name: String,
+    /// Icon identifier for the UI.
+    pub icon: String,
+    /// Settings schema for form generation.
+    pub schema: SettingsSchema,
+    /// Capabilities of this service type.
+    pub capabilities: ServiceCapabilities,
+}
+
+struct RegistryEntry {
+    info: ServiceInfo,
+    factory: ServiceFactory,
+}
+
+/// Runtime registry of available service types.
+#[derive(Default)]
+pub struct ServiceRegistry {
+    factories: HashMap<String, RegistryEntry>,
+    /// Insertion order for deterministic listing.
+    order: Vec<String>,
+}
+
+impl ServiceRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a service type with the given metadata and factory.
+    ///
+    /// The factory is invoked once here to extract the schema and capabilities,
+    /// then again on each [`create`](Self::create).
+    pub fn register(
+        &mut self,
+        service_id: &str,
+        display_name: &str,
+        icon: &str,
+        factory: ServiceFactory,
+    ) {
+        let instance = factory();
+        let info = ServiceInfo {
+            service_id: service_id.to_string(),
+            display_name: display_name.to_string(),
+            icon: icon.to_string(),
+            schema: instance.settings_schema(),
+            capabilities: instance.capabilities(),
+        };
+        if !self.factories.contains_key(service_id) {
+            self.order.push(service_id.to_string());
+        }
+        self.factories
+            .insert(service_id.to_string(), RegistryEntry { info, factory });
+    }
+
+    /// List all registered service types, in registration order.
+    pub fn available_services(&self) -> Vec<ServiceInfo> {
+        self.order
+            .iter()
+            .filter_map(|id| self.factories.get(id).map(|e| e.info.clone()))
+            .collect()
+    }
+
+    /// Create a fresh (stopped) service instance by id.
+    pub fn create(&self, service_id: &str) -> Result<Box<dyn Service>, ServiceError> {
+        self.factories
+            .get(service_id)
+            .map(|entry| (entry.factory)())
+            .ok_or_else(|| ServiceError::Unknown(service_id.to_string()))
+    }
+
+    /// Whether a service type with the given id is registered.
+    pub fn has_service(&self, service_id: &str) -> bool {
+        self.factories.contains_key(service_id)
+    }
+
+    /// Remove a previously-registered service type. Returns `true` if removed.
+    pub fn unregister(&mut self, service_id: &str) -> bool {
+        if self.factories.remove(service_id).is_some() {
+            self.order.retain(|id| id != service_id);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::service::{EventChannel, ServiceEventReceiver, ServiceStatus};
+    use async_trait::async_trait;
+    use serde_json::Value;
+
+    /// Minimal mock service: tracks status and emits a `status` event on each
+    /// lifecycle transition. Exercises the trait + registry without any real
+    /// server.
+    struct MockService {
+        id: &'static str,
+        desktop_only: bool,
+        status: ServiceStatus,
+        events: EventChannel,
+    }
+
+    impl MockService {
+        fn new(id: &'static str, desktop_only: bool) -> Self {
+            Self {
+                id,
+                desktop_only,
+                status: ServiceStatus::Stopped,
+                events: EventChannel::new(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Service for MockService {
+        fn service_id(&self) -> &str {
+            self.id
+        }
+        fn display_name(&self) -> &str {
+            "Mock Service"
+        }
+        fn settings_schema(&self) -> SettingsSchema {
+            SettingsSchema { groups: vec![] }
+        }
+        fn capabilities(&self) -> ServiceCapabilities {
+            ServiceCapabilities {
+                configurable: false,
+                emits_events: true,
+                desktop_only: self.desktop_only,
+            }
+        }
+        async fn start(&mut self, _config: Value) -> Result<(), ServiceError> {
+            self.status = ServiceStatus::Running;
+            self.events
+                .emit(crate::service::ServiceEvent::new("status", "running"));
+            Ok(())
+        }
+        async fn stop(&mut self) -> Result<(), ServiceError> {
+            self.status = ServiceStatus::Stopped;
+            self.events
+                .emit(crate::service::ServiceEvent::new("status", "stopped"));
+            Ok(())
+        }
+        fn status(&self) -> ServiceStatus {
+            self.status.clone()
+        }
+        fn subscribe_events(&self) -> ServiceEventReceiver {
+            self.events.subscribe()
+        }
+    }
+
+    fn mock_factory(id: &'static str, desktop_only: bool) -> ServiceFactory {
+        Box::new(move || Box::new(MockService::new(id, desktop_only)))
+    }
+
+    #[test]
+    fn register_create_and_list() {
+        let mut registry = ServiceRegistry::new();
+        registry.register("http", "HTTP Server", "server", mock_factory("http", false));
+        registry.register("cred", "Credentials", "key", mock_factory("cred", true));
+
+        let services = registry.available_services();
+        assert_eq!(services.len(), 2);
+        assert_eq!(services[0].service_id, "http");
+        assert!(!services[0].capabilities.desktop_only);
+        assert!(services[1].capabilities.desktop_only);
+
+        let svc = registry.create("http").expect("create must succeed");
+        assert_eq!(svc.service_id(), "http");
+        assert_eq!(svc.status(), ServiceStatus::Stopped);
+    }
+
+    #[test]
+    fn unknown_service_returns_error() {
+        let registry = ServiceRegistry::new();
+        // `Box<dyn Service>` is not `Debug`, so match rather than `expect_err`.
+        match registry.create("ghost") {
+            Err(ServiceError::Unknown(id)) => assert_eq!(id, "ghost"),
+            Err(other) => panic!("wrong error: {other}"),
+            Ok(_) => panic!("expected error for unknown service"),
+        }
+    }
+
+    #[test]
+    fn unregister_removes_service_and_order() {
+        let mut registry = ServiceRegistry::new();
+        registry.register("a", "A", "i", mock_factory("a", false));
+        registry.register("b", "B", "i", mock_factory("b", false));
+        assert!(registry.unregister("a"));
+        assert!(!registry.has_service("a"));
+        assert!(!registry.unregister("a"));
+        let ids: Vec<String> = registry
+            .available_services()
+            .into_iter()
+            .map(|s| s.service_id)
+            .collect();
+        assert_eq!(ids, vec!["b".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn lifecycle_transitions_and_emits_events() {
+        let registry = {
+            let mut r = ServiceRegistry::new();
+            r.register("http", "HTTP Server", "server", mock_factory("http", false));
+            r
+        };
+        let mut svc = registry.create("http").unwrap();
+        let mut events = svc.subscribe_events();
+
+        assert_eq!(svc.status(), ServiceStatus::Stopped);
+        svc.start(Value::Null).await.unwrap();
+        assert_eq!(svc.status(), ServiceStatus::Running);
+        let started = events.recv().await.unwrap();
+        assert_eq!(started.payload, "running");
+
+        svc.stop().await.unwrap();
+        assert_eq!(svc.status(), ServiceStatus::Stopped);
+        let stopped = events.recv().await.unwrap();
+        assert_eq!(stopped.payload, "stopped");
+    }
+}

--- a/core/src/tool/mod.rs
+++ b/core/src/tool/mod.rs
@@ -108,7 +108,10 @@ impl CollectingHost {
 
     /// Snapshot the events collected so far without draining them.
     pub fn events(&self) -> Vec<ToolEvent> {
-        self.events.lock().expect("tool host mutex poisoned").clone()
+        self.events
+            .lock()
+            .expect("tool host mutex poisoned")
+            .clone()
     }
 
     /// Drain and return all collected events.

--- a/core/src/tool/mod.rs
+++ b/core/src/tool/mod.rs
@@ -1,0 +1,220 @@
+//! One-shot / streaming diagnostic tools behind a uniform trait.
+//!
+//! A [`Tool`] is a stateless invocation — ping, traceroute, port scan, DNS
+//! lookup, Wake-on-LAN — with no persistent lifecycle. This is the twin of the
+//! long-lived [`Service`](crate::service::Service) abstraction: where a service
+//! *runs*, a tool is *invoked*.
+//!
+//! The network diagnostics already exist as plain functions in
+//! [`crate::network`]. This module wraps each one behind a single trait so that
+//! both host processes (the desktop and the remote agent) can drive them
+//! through one uniform interface, gated only by which registry the caller
+//! reaches. The trait adds two things the bare functions lack:
+//!
+//! * a **uniform host** ([`ToolHost`]) that streamed intermediate results are
+//!   emitted through, identical whether the tool runs locally or on an agent;
+//! * a **cancellation token** so an in-flight run can be aborted.
+//!
+//! # Architecture
+//!
+//! Concrete tools live here in core so the desktop and agent share one
+//! implementation. A [`ToolRegistry`] (twin of
+//! [`ConnectionTypeRegistry`](crate::connection::ConnectionTypeRegistry)) is
+//! populated at startup — [`ToolRegistry::with_builtin_network_tools`] wires the
+//! full network-diagnostics set — and dispatches an invocation by tool id.
+//!
+//! # Example
+//!
+//! ```ignore
+//! let registry = ToolRegistry::with_builtin_network_tools();
+//! let host = CollectingHost::new();
+//! let result = registry
+//!     .run("dns", json!({ "hostname": "example.com", "recordType": "A" }),
+//!          host.clone(), CancellationToken::new())
+//!     .await?;
+//! for event in host.take() { /* streamed records */ }
+//! ```
+
+pub mod network_tools;
+pub mod registry;
+
+pub use network_tools::builtin_network_tools;
+pub use registry::{ToolInfo, ToolRegistry};
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
+use tokio_util::sync::CancellationToken;
+
+use crate::network::NetworkError;
+
+/// A single intermediate result streamed by a tool during a run.
+///
+/// Streaming tools (ping, port scan, traceroute, ping sweep) emit one event per
+/// result through the [`ToolHost`]; the final aggregate (stats / summary) is the
+/// value returned from [`Tool::run`]. One-shot tools (DNS, open ports, WoL) emit
+/// nothing and return their whole result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolEvent {
+    /// Discriminator for the payload shape, e.g. `"result"`, `"hop"`.
+    pub kind: String,
+    /// The serialized result record.
+    pub payload: Value,
+}
+
+impl ToolEvent {
+    /// Build an event, serializing `payload` to JSON.
+    ///
+    /// Serialization of the built-in result types is infallible; a payload that
+    /// somehow fails to serialize degrades to `null` rather than panicking,
+    /// keeping the emit path free of `unwrap`.
+    pub fn new(kind: impl Into<String>, payload: impl Serialize) -> Self {
+        Self {
+            kind: kind.into(),
+            payload: serde_json::to_value(payload).unwrap_or(Value::Null),
+        }
+    }
+}
+
+/// Uniform sink a [`Tool`] streams its intermediate [`ToolEvent`]s to.
+///
+/// The host is what makes a tool location-agnostic: a locally-run tool emits to
+/// a host that forwards to the desktop UI, while an agent-run tool emits to a
+/// host that relays over JSON-RPC — the tool itself is identical either way.
+pub trait ToolHost: Send + Sync {
+    /// Emit one streamed result. Must not block.
+    fn emit(&self, event: ToolEvent);
+}
+
+/// A [`ToolHost`] that buffers every emitted event in memory.
+///
+/// Used by callers that collect a whole run before responding — the agent's
+/// non-streaming `tool.run` JSON-RPC method, and unit tests.
+#[derive(Debug, Default)]
+pub struct CollectingHost {
+    events: std::sync::Mutex<Vec<ToolEvent>>,
+}
+
+impl CollectingHost {
+    /// Create an empty collecting host wrapped in an [`Arc`] ready to pass to
+    /// [`Tool::run`].
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Snapshot the events collected so far without draining them.
+    pub fn events(&self) -> Vec<ToolEvent> {
+        self.events.lock().expect("tool host mutex poisoned").clone()
+    }
+
+    /// Drain and return all collected events.
+    pub fn take(&self) -> Vec<ToolEvent> {
+        std::mem::take(&mut *self.events.lock().expect("tool host mutex poisoned"))
+    }
+}
+
+impl ToolHost for CollectingHost {
+    fn emit(&self, event: ToolEvent) {
+        self.events
+            .lock()
+            .expect("tool host mutex poisoned")
+            .push(event);
+    }
+}
+
+/// Errors from invoking a [`Tool`].
+#[derive(Error, Debug)]
+pub enum ToolError {
+    /// No tool with the requested id is registered.
+    #[error("Unknown tool: {0}")]
+    UnknownTool(String),
+
+    /// The params JSON did not match the tool's expected shape.
+    #[error("Invalid params for tool '{tool}': {reason}")]
+    InvalidParams {
+        /// The tool that rejected the params.
+        tool: String,
+        /// Why the params were rejected.
+        reason: String,
+    },
+
+    /// The run was cancelled before completing.
+    #[error("Tool '{0}' was cancelled")]
+    Cancelled(String),
+
+    /// The underlying network operation failed.
+    #[error(transparent)]
+    Network(#[from] NetworkError),
+
+    /// Any other execution failure.
+    #[error("Tool execution failed: {0}")]
+    Execution(String),
+}
+
+/// A stateless, one-shot or streaming diagnostic invocation.
+///
+/// Concrete tools are stateless singletons; a [`ToolRegistry`] holds one shared
+/// instance of each and dispatches by [`tool_id`](Self::tool_id).
+#[async_trait]
+pub trait Tool: Send + Sync {
+    /// Machine-readable identifier (e.g. `"ping"`, `"port_scan"`).
+    fn tool_id(&self) -> &str;
+
+    /// Human-readable display name (e.g. `"Ping"`).
+    fn display_name(&self) -> &str;
+
+    /// Run the tool.
+    ///
+    /// Intermediate results are streamed via `host`; the returned [`Value`] is
+    /// the run's final aggregate (stats / summary), or `{}` for tools with no
+    /// aggregate. `cancel` aborts an in-flight run — streaming tools stop early
+    /// and return whatever aggregate they have so far.
+    async fn run(
+        &self,
+        params: Value,
+        host: Arc<dyn ToolHost>,
+        cancel: CancellationToken,
+    ) -> Result<Value, ToolError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Object-safety / Send+Sync guards mirroring the connection module.
+    fn _assert_object_safe(_: &dyn Tool) {}
+    fn _assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn tool_is_send_sync() {
+        _assert_send_sync::<Box<dyn Tool>>();
+        _assert_send_sync::<Arc<dyn ToolHost>>();
+    }
+
+    #[test]
+    fn collecting_host_buffers_and_drains() {
+        let host = CollectingHost::new();
+        host.emit(ToolEvent::new("result", serde_json::json!({ "seq": 1 })));
+        host.emit(ToolEvent::new("result", serde_json::json!({ "seq": 2 })));
+        assert_eq!(host.events().len(), 2);
+
+        let drained = host.take();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].kind, "result");
+        assert_eq!(drained[0].payload["seq"], 1);
+        // Draining empties the buffer.
+        assert!(host.events().is_empty());
+    }
+
+    #[test]
+    fn tool_event_serializes_camel_case() {
+        let event = ToolEvent::new("hop", serde_json::json!({ "hop": 3 }));
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["kind"], "hop");
+        assert_eq!(json["payload"]["hop"], 3);
+    }
+}

--- a/core/src/tool/network_tools.rs
+++ b/core/src/tool/network_tools.rs
@@ -115,12 +115,11 @@ impl Tool for PortScanTool {
         cancel: CancellationToken,
     ) -> Result<Value, ToolError> {
         let p: PortScanParams = decode(self.tool_id(), params)?;
-        let port_list = port_scan::parse_port_spec(&p.ports).map_err(|e| {
-            ToolError::InvalidParams {
+        let port_list =
+            port_scan::parse_port_spec(&p.ports).map_err(|e| ToolError::InvalidParams {
                 tool: "port_scan".to_string(),
                 reason: e.to_string(),
-            }
-        })?;
+            })?;
         let sink = host.clone();
         let summary = port_scan::scan_ports(
             &p.host,
@@ -387,7 +386,10 @@ mod tests {
             "open_ports",
             "wol",
         ] {
-            assert!(ids.contains(&expected.to_string()), "missing tool {expected}");
+            assert!(
+                ids.contains(&expected.to_string()),
+                "missing tool {expected}"
+            );
         }
     }
 

--- a/core/src/tool/network_tools.rs
+++ b/core/src/tool/network_tools.rs
@@ -1,0 +1,448 @@
+//! [`Tool`] wrappers over the built-in [`crate::network`] diagnostics.
+//!
+//! Each wrapper decodes a JSON params object, calls the existing core network
+//! function, streams per-result records through the [`ToolHost`], and returns
+//! the run's aggregate. Behaviour is identical to calling the network function
+//! directly — the trait only adds the uniform host and cancellation plumbing.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tokio_util::sync::CancellationToken;
+
+use super::{Tool, ToolError, ToolEvent, ToolHost};
+use crate::network::types::DnsRecordType;
+use crate::network::{dns, open_ports, ping, ping_sweep, port_scan, traceroute, wol};
+
+/// Decode a tool's params, mapping a serde failure onto [`ToolError::InvalidParams`].
+fn decode<T: for<'de> Deserialize<'de>>(tool: &str, params: Value) -> Result<T, ToolError> {
+    serde_json::from_value(params).map_err(|e| ToolError::InvalidParams {
+        tool: tool.to_string(),
+        reason: e.to_string(),
+    })
+}
+
+/// Serialize a tool's aggregate result, mapping a failure onto
+/// [`ToolError::Execution`].
+fn aggregate(value: impl serde::Serialize) -> Result<Value, ToolError> {
+    serde_json::to_value(value).map_err(|e| ToolError::Execution(e.to_string()))
+}
+
+// ── ping ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PingParams {
+    host: String,
+    #[serde(default = "default_ping_interval")]
+    interval_ms: u64,
+    #[serde(default)]
+    count: Option<u32>,
+}
+
+fn default_ping_interval() -> u64 {
+    1000
+}
+
+/// ICMP ping (with TCP fallback), streaming one `result` event per echo.
+pub struct PingTool;
+
+#[async_trait]
+impl Tool for PingTool {
+    fn tool_id(&self) -> &str {
+        "ping"
+    }
+    fn display_name(&self) -> &str {
+        "Ping"
+    }
+    async fn run(
+        &self,
+        params: Value,
+        host: Arc<dyn ToolHost>,
+        cancel: CancellationToken,
+    ) -> Result<Value, ToolError> {
+        let p: PingParams = decode(self.tool_id(), params)?;
+        let sink = host.clone();
+        let stats = ping::ping_stream(
+            &p.host,
+            p.interval_ms,
+            p.count,
+            move |r| sink.emit(ToolEvent::new("result", r)),
+            cancel,
+        )
+        .await?;
+        aggregate(stats)
+    }
+}
+
+// ── port scan ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PortScanParams {
+    host: String,
+    ports: String,
+    #[serde(default = "default_scan_timeout")]
+    timeout_ms: u64,
+    #[serde(default = "default_scan_concurrency")]
+    concurrency: usize,
+}
+
+fn default_scan_timeout() -> u64 {
+    2000
+}
+fn default_scan_concurrency() -> usize {
+    100
+}
+
+/// TCP connect port scanner, streaming one `result` event per probed port.
+pub struct PortScanTool;
+
+#[async_trait]
+impl Tool for PortScanTool {
+    fn tool_id(&self) -> &str {
+        "port_scan"
+    }
+    fn display_name(&self) -> &str {
+        "Port Scan"
+    }
+    async fn run(
+        &self,
+        params: Value,
+        host: Arc<dyn ToolHost>,
+        cancel: CancellationToken,
+    ) -> Result<Value, ToolError> {
+        let p: PortScanParams = decode(self.tool_id(), params)?;
+        let port_list = port_scan::parse_port_spec(&p.ports).map_err(|e| {
+            ToolError::InvalidParams {
+                tool: "port_scan".to_string(),
+                reason: e.to_string(),
+            }
+        })?;
+        let sink = host.clone();
+        let summary = port_scan::scan_ports(
+            &p.host,
+            &port_list,
+            p.timeout_ms,
+            p.concurrency,
+            move |r| sink.emit(ToolEvent::new("result", r)),
+            cancel,
+        )
+        .await?;
+        aggregate(summary)
+    }
+}
+
+// ── ping sweep ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PingSweepParams {
+    targets: Vec<String>,
+    #[serde(default = "default_sweep_timeout")]
+    timeout_ms: u64,
+    #[serde(default = "default_scan_concurrency")]
+    concurrency: usize,
+    #[serde(default)]
+    resolve_hostnames: bool,
+}
+
+fn default_sweep_timeout() -> u64 {
+    1000
+}
+
+/// Subnet / IP-range ping sweep, streaming one `result` event per responding host.
+pub struct PingSweepTool;
+
+#[async_trait]
+impl Tool for PingSweepTool {
+    fn tool_id(&self) -> &str {
+        "ping_sweep"
+    }
+    fn display_name(&self) -> &str {
+        "Ping Sweep"
+    }
+    async fn run(
+        &self,
+        params: Value,
+        host: Arc<dyn ToolHost>,
+        cancel: CancellationToken,
+    ) -> Result<Value, ToolError> {
+        let p: PingSweepParams = decode(self.tool_id(), params)?;
+        let sink = host.clone();
+        let summary = ping_sweep::ping_sweep(
+            &p.targets,
+            p.timeout_ms,
+            p.concurrency,
+            p.resolve_hostnames,
+            move |r| sink.emit(ToolEvent::new("result", r)),
+            cancel,
+        )
+        .await?;
+        aggregate(summary)
+    }
+}
+
+// ── traceroute ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TracerouteParams {
+    host: String,
+    #[serde(default = "default_max_hops")]
+    max_hops: u8,
+}
+
+fn default_max_hops() -> u8 {
+    30
+}
+
+/// Hop-by-hop traceroute, streaming one `hop` event per hop.
+pub struct TracerouteTool;
+
+#[async_trait]
+impl Tool for TracerouteTool {
+    fn tool_id(&self) -> &str {
+        "traceroute"
+    }
+    fn display_name(&self) -> &str {
+        "Traceroute"
+    }
+    async fn run(
+        &self,
+        params: Value,
+        host: Arc<dyn ToolHost>,
+        cancel: CancellationToken,
+    ) -> Result<Value, ToolError> {
+        let p: TracerouteParams = decode(self.tool_id(), params)?;
+        let sink = host.clone();
+        traceroute::traceroute(
+            &p.host,
+            p.max_hops,
+            move |h| sink.emit(ToolEvent::new("hop", h)),
+            cancel,
+        )
+        .await?;
+        Ok(json!({}))
+    }
+}
+
+// ── DNS lookup ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DnsParams {
+    hostname: String,
+    #[serde(default = "default_record_type")]
+    record_type: String,
+    #[serde(default)]
+    server: Option<String>,
+}
+
+fn default_record_type() -> String {
+    "A".to_string()
+}
+
+/// DNS record lookup (one-shot; returns the whole [`DnsResult`]).
+pub struct DnsTool;
+
+#[async_trait]
+impl Tool for DnsTool {
+    fn tool_id(&self) -> &str {
+        "dns"
+    }
+    fn display_name(&self) -> &str {
+        "DNS Lookup"
+    }
+    async fn run(
+        &self,
+        params: Value,
+        _host: Arc<dyn ToolHost>,
+        _cancel: CancellationToken,
+    ) -> Result<Value, ToolError> {
+        let p: DnsParams = decode(self.tool_id(), params)?;
+        let record_type = parse_record_type(&p.record_type)?;
+        let result = dns::dns_lookup(&p.hostname, record_type, p.server.as_deref()).await?;
+        aggregate(result)
+    }
+}
+
+/// Parse a textual DNS record type into its [`DnsRecordType`] variant.
+fn parse_record_type(s: &str) -> Result<DnsRecordType, ToolError> {
+    match s.to_uppercase().as_str() {
+        "A" => Ok(DnsRecordType::A),
+        "AAAA" => Ok(DnsRecordType::Aaaa),
+        "MX" => Ok(DnsRecordType::Mx),
+        "CNAME" => Ok(DnsRecordType::Cname),
+        "NS" => Ok(DnsRecordType::Ns),
+        "TXT" => Ok(DnsRecordType::Txt),
+        "SRV" => Ok(DnsRecordType::Srv),
+        "SOA" => Ok(DnsRecordType::Soa),
+        "PTR" => Ok(DnsRecordType::Ptr),
+        "ANY" => Ok(DnsRecordType::Any),
+        other => Err(ToolError::InvalidParams {
+            tool: "dns".to_string(),
+            reason: format!("Unknown DNS record type: {other}"),
+        }),
+    }
+}
+
+// ── open ports ────────────────────────────────────────────────────────────
+
+/// Local listening ports (one-shot; returns the list under `ports`).
+pub struct OpenPortsTool;
+
+#[async_trait]
+impl Tool for OpenPortsTool {
+    fn tool_id(&self) -> &str {
+        "open_ports"
+    }
+    fn display_name(&self) -> &str {
+        "Open Ports"
+    }
+    async fn run(
+        &self,
+        _params: Value,
+        _host: Arc<dyn ToolHost>,
+        _cancel: CancellationToken,
+    ) -> Result<Value, ToolError> {
+        let ports = open_ports::list_open_ports()?;
+        aggregate(json!({ "ports": ports }))
+    }
+}
+
+// ── Wake-on-LAN ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WolParams {
+    mac: String,
+    broadcast: String,
+    #[serde(default = "default_wol_port")]
+    port: u16,
+}
+
+fn default_wol_port() -> u16 {
+    9
+}
+
+/// Send a Wake-on-LAN magic packet (one-shot; returns `{}`).
+pub struct WolTool;
+
+#[async_trait]
+impl Tool for WolTool {
+    fn tool_id(&self) -> &str {
+        "wol"
+    }
+    fn display_name(&self) -> &str {
+        "Wake-on-LAN"
+    }
+    async fn run(
+        &self,
+        params: Value,
+        _host: Arc<dyn ToolHost>,
+        _cancel: CancellationToken,
+    ) -> Result<Value, ToolError> {
+        let p: WolParams = decode(self.tool_id(), params)?;
+        wol::send_magic_packet(&p.mac, &p.broadcast, p.port)?;
+        Ok(json!({}))
+    }
+}
+
+/// Every built-in network diagnostic as a boxed [`Tool`], in a stable order.
+///
+/// Used by [`ToolRegistry::with_builtin_network_tools`](super::ToolRegistry::with_builtin_network_tools)
+/// to populate a registry on both the desktop and the agent from one source.
+pub fn builtin_network_tools() -> Vec<Arc<dyn Tool>> {
+    vec![
+        Arc::new(PingTool),
+        Arc::new(PingSweepTool),
+        Arc::new(PortScanTool),
+        Arc::new(TracerouteTool),
+        Arc::new(DnsTool),
+        Arc::new(OpenPortsTool),
+        Arc::new(WolTool),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tool::CollectingHost;
+
+    #[test]
+    fn builtin_set_covers_every_network_tool() {
+        let ids: Vec<String> = builtin_network_tools()
+            .iter()
+            .map(|t| t.tool_id().to_string())
+            .collect();
+        for expected in [
+            "ping",
+            "ping_sweep",
+            "port_scan",
+            "traceroute",
+            "dns",
+            "open_ports",
+            "wol",
+        ] {
+            assert!(ids.contains(&expected.to_string()), "missing tool {expected}");
+        }
+    }
+
+    #[tokio::test]
+    async fn wol_invalid_mac_is_invalid_params_or_network_error() {
+        // A malformed MAC must fail without touching the network — proving the
+        // params reach the wrapped `wol` function unchanged.
+        let tool = WolTool;
+        let host = CollectingHost::new();
+        let err = tool
+            .run(
+                json!({ "mac": "not-a-mac", "broadcast": "255.255.255.255" }),
+                host,
+                CancellationToken::new(),
+            )
+            .await
+            .expect_err("malformed MAC must error");
+        // The wrapped function reports it as a NetworkError::InvalidParameter.
+        assert!(matches!(err, ToolError::Network(_)));
+    }
+
+    #[tokio::test]
+    async fn missing_required_param_is_invalid_params() {
+        let tool = PingTool;
+        let host = CollectingHost::new();
+        // `host` field is required; an empty object must be rejected pre-flight.
+        let err = tool
+            .run(json!({}), host, CancellationToken::new())
+            .await
+            .expect_err("missing host must error");
+        match err {
+            ToolError::InvalidParams { tool, .. } => assert_eq!(tool, "ping"),
+            other => panic!("expected InvalidParams, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn open_ports_runs_and_returns_a_list() {
+        // Local, network-free: exercises a full one-shot round trip through the
+        // trait and confirms the aggregate shape.
+        let tool = OpenPortsTool;
+        let host = CollectingHost::new();
+        let result = tool
+            .run(json!({}), host.clone(), CancellationToken::new())
+            .await
+            .expect("open_ports must succeed locally");
+        assert!(result["ports"].is_array());
+        // One-shot tools stream nothing.
+        assert!(host.take().is_empty());
+    }
+
+    #[test]
+    fn dns_record_type_parsing() {
+        assert!(matches!(parse_record_type("a"), Ok(DnsRecordType::A)));
+        assert!(matches!(parse_record_type("AAAA"), Ok(DnsRecordType::Aaaa)));
+        assert!(parse_record_type("nonsense").is_err());
+    }
+}

--- a/core/src/tool/registry.rs
+++ b/core/src/tool/registry.rs
@@ -1,0 +1,247 @@
+//! Runtime registry of available [`Tool`]s.
+//!
+//! Twin of [`ConnectionTypeRegistry`](crate::connection::ConnectionTypeRegistry).
+//! Because tools are stateless singletons, the registry holds one shared
+//! [`Arc<dyn Tool>`] per id (rather than a per-invocation factory) and
+//! dispatches a run by id.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio_util::sync::CancellationToken;
+
+use super::network_tools::builtin_network_tools;
+use super::{Tool, ToolError, ToolHost};
+
+/// Metadata about a registered tool for UI discovery.
+///
+/// Serializable so it can be sent to the frontend or across JSON-RPC.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolInfo {
+    /// Machine-readable identifier (e.g. `"ping"`).
+    pub tool_id: String,
+    /// Human-readable display name (e.g. `"Ping"`).
+    pub display_name: String,
+}
+
+/// Runtime registry of available tools.
+///
+/// Desktop and agent crates populate this at startup — usually via
+/// [`with_builtin_network_tools`](Self::with_builtin_network_tools) — then
+/// dispatch invocations by id.
+#[derive(Default)]
+pub struct ToolRegistry {
+    tools: HashMap<String, Arc<dyn Tool>>,
+    /// Insertion order for deterministic listing.
+    order: Vec<String>,
+}
+
+impl ToolRegistry {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a registry pre-populated with every built-in network tool.
+    pub fn with_builtin_network_tools() -> Self {
+        let mut registry = Self::new();
+        for tool in builtin_network_tools() {
+            registry.register(tool);
+        }
+        registry
+    }
+
+    /// Register a tool under its own [`tool_id`](Tool::tool_id).
+    ///
+    /// Re-registering an existing id replaces the instance but keeps its
+    /// position in the listing order.
+    pub fn register(&mut self, tool: Arc<dyn Tool>) {
+        let id = tool.tool_id().to_string();
+        if !self.tools.contains_key(&id) {
+            self.order.push(id.clone());
+        }
+        self.tools.insert(id, tool);
+    }
+
+    /// List all registered tools with their metadata, in registration order.
+    pub fn available_tools(&self) -> Vec<ToolInfo> {
+        self.order
+            .iter()
+            .filter_map(|id| self.tools.get(id))
+            .map(|t| ToolInfo {
+                tool_id: t.tool_id().to_string(),
+                display_name: t.display_name().to_string(),
+            })
+            .collect()
+    }
+
+    /// Fetch a registered tool by id.
+    pub fn get(&self, tool_id: &str) -> Option<Arc<dyn Tool>> {
+        self.tools.get(tool_id).cloned()
+    }
+
+    /// Whether a tool with the given id is registered.
+    pub fn has_tool(&self, tool_id: &str) -> bool {
+        self.tools.contains_key(tool_id)
+    }
+
+    /// Remove a previously-registered tool. Returns `true` if one was removed.
+    pub fn unregister(&mut self, tool_id: &str) -> bool {
+        if self.tools.remove(tool_id).is_some() {
+            self.order.retain(|id| id != tool_id);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Dispatch a run to the tool with the given id.
+    ///
+    /// Returns [`ToolError::UnknownTool`] when no such tool is registered;
+    /// otherwise forwards to [`Tool::run`].
+    pub async fn run(
+        &self,
+        tool_id: &str,
+        params: Value,
+        host: Arc<dyn ToolHost>,
+        cancel: CancellationToken,
+    ) -> Result<Value, ToolError> {
+        let tool = self
+            .get(tool_id)
+            .ok_or_else(|| ToolError::UnknownTool(tool_id.to_string()))?;
+        tool.run(params, host, cancel).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tool::{CollectingHost, ToolEvent};
+    use async_trait::async_trait;
+    use serde_json::json;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    /// A controllable tool: emits `n` `tick` events, one per loop, stopping
+    /// early if cancelled. Lets the registry tests exercise streaming and
+    /// cancellation without any network.
+    struct CountingTool {
+        emitted: Arc<AtomicU32>,
+    }
+
+    #[async_trait]
+    impl Tool for CountingTool {
+        fn tool_id(&self) -> &str {
+            "counting"
+        }
+        fn display_name(&self) -> &str {
+            "Counting"
+        }
+        async fn run(
+            &self,
+            params: Value,
+            host: Arc<dyn ToolHost>,
+            cancel: CancellationToken,
+        ) -> Result<Value, ToolError> {
+            let n = params["n"].as_u64().unwrap_or(0);
+            let mut sent = 0u32;
+            for i in 0..n {
+                if cancel.is_cancelled() {
+                    return Err(ToolError::Cancelled(self.tool_id().to_string()));
+                }
+                host.emit(ToolEvent::new("tick", json!({ "i": i })));
+                sent += 1;
+                self.emitted.store(sent, Ordering::SeqCst);
+            }
+            Ok(json!({ "sent": sent }))
+        }
+    }
+
+    #[test]
+    fn builtin_registry_lists_network_tools_in_order() {
+        let registry = ToolRegistry::with_builtin_network_tools();
+        let ids: Vec<String> = registry
+            .available_tools()
+            .into_iter()
+            .map(|t| t.tool_id)
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["ping", "ping_sweep", "port_scan", "traceroute", "dns", "open_ports", "wol"]
+        );
+        assert!(registry.has_tool("ping"));
+        assert!(!registry.has_tool("nope"));
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_returns_error() {
+        let registry = ToolRegistry::new();
+        let host = CollectingHost::new();
+        let err = registry
+            .run("ghost", json!({}), host, CancellationToken::new())
+            .await
+            .expect_err("unknown tool must error");
+        assert!(matches!(err, ToolError::UnknownTool(id) if id == "ghost"));
+    }
+
+    #[tokio::test]
+    async fn run_streams_events_and_returns_aggregate() {
+        let mut registry = ToolRegistry::new();
+        registry.register(Arc::new(CountingTool {
+            emitted: Arc::new(AtomicU32::new(0)),
+        }));
+
+        let host = CollectingHost::new();
+        let result = registry
+            .run(
+                "counting",
+                json!({ "n": 3 }),
+                host.clone(),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("run must succeed");
+
+        assert_eq!(result["sent"], 3);
+        let events = host.take();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].kind, "tick");
+        assert_eq!(events[2].payload["i"], 2);
+    }
+
+    #[tokio::test]
+    async fn cancellation_stops_a_run() {
+        let mut registry = ToolRegistry::new();
+        registry.register(Arc::new(CountingTool {
+            emitted: Arc::new(AtomicU32::new(0)),
+        }));
+
+        // A pre-cancelled token means the tool aborts before its first emit.
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let host = CollectingHost::new();
+        let err = registry
+            .run("counting", json!({ "n": 100 }), host.clone(), cancel)
+            .await
+            .expect_err("cancelled run must error");
+        assert!(matches!(err, ToolError::Cancelled(id) if id == "counting"));
+        assert!(host.take().is_empty());
+    }
+
+    #[test]
+    fn unregister_removes_tool_and_order() {
+        let mut registry = ToolRegistry::with_builtin_network_tools();
+        assert!(registry.unregister("ping"));
+        assert!(!registry.has_tool("ping"));
+        assert!(!registry.unregister("ping"));
+        let ids: Vec<String> = registry
+            .available_tools()
+            .into_iter()
+            .map(|t| t.tool_id)
+            .collect();
+        assert!(!ids.contains(&"ping".to_string()));
+        assert!(ids.contains(&"dns".to_string()));
+    }
+}

--- a/core/src/tool/registry.rs
+++ b/core/src/tool/registry.rs
@@ -169,7 +169,15 @@ mod tests {
             .collect();
         assert_eq!(
             ids,
-            vec!["ping", "ping_sweep", "port_scan", "traceroute", "dns", "open_ports", "wol"]
+            vec![
+                "ping",
+                "ping_sweep",
+                "port_scan",
+                "traceroute",
+                "dns",
+                "open_ports",
+                "wol"
+            ]
         );
         assert!(registry.has_tool("ping"));
         assert!(!registry.has_tool("nope"));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ mod macos_clipboard;
 mod macos_services;
 mod macros;
 mod network;
+pub mod run_location;
 mod session;
 mod session_history;
 mod spawn;

--- a/src-tauri/src/run_location.rs
+++ b/src-tauri/src/run_location.rs
@@ -1,0 +1,221 @@
+//! Run-location resolver: route a service/tool invocation to the local
+//! registry or a remote agent proxy.
+//!
+//! Part of the stateless-UI / agent-empowerment S-track (S1, part of #2139).
+//! The [`Service`](termihub_core::service::Service) /
+//! [`Tool`](termihub_core::tool::Tool) traits let a service or network tool run
+//! on the desktop **or** a remote agent behind one uniform abstraction. This
+//! module is the desktop-side piece that decides *where*:
+//!
+//! * `run here` → the local `ServiceRegistry` / `ToolRegistry`;
+//! * `run there` → the agent, driven through the same JSON-RPC proxy sessions
+//!   already use (extended with the `service.*` / `tool.*` namespaces).
+//!
+//! # S1 behaviour — local by default
+//!
+//! For S1 there is **no behaviour change for users**: every invocation resolves
+//! to [`ResolvedLocation::Local`] unless the caller explicitly asks for an
+//! agent, and the run-location *selector UI* that would let them do so is S2.
+//! So in practice everything runs locally today, exactly as before.
+//!
+//! # The desktop-only boundary
+//!
+//! Some capabilities are permanently desktop-host and must never be offered an
+//! agent (concept Open Design Decision #4): credentials / keychain, spawn
+//! rendezvous, local file watch, and OS-window management. The resolver refuses
+//! an agent run-location for anything marked [`Locality::DesktopOnly`], and
+//! [`available_locations`](RunLocationResolver::available_locations) omits the
+//! agent options for it, so the selector cannot present a choice that must not
+//! exist.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Where the user asked a service/tool to run.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "kind", content = "agentId")]
+pub enum RunLocation {
+    /// The desktop host — "This computer". The default.
+    #[default]
+    ThisComputer,
+    /// A named remote agent.
+    Agent(String),
+}
+
+/// Whether a capability may run remotely, or is permanently desktop-only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Locality {
+    /// Can run on the desktop or any reachable agent.
+    LocalOrAgent,
+    /// Must run on the desktop host (credentials, spawn rendezvous, local file
+    /// watch, OS-window management). Never offered an agent.
+    DesktopOnly,
+}
+
+/// The resolved execution target for an invocation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "target", content = "agentId")]
+pub enum ResolvedLocation {
+    /// Run against the local (desktop) registry.
+    Local,
+    /// Run against the named agent via the JSON-RPC proxy.
+    Agent(String),
+}
+
+/// Why a requested run-location could not be honoured.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum RunLocationError {
+    /// An agent was requested for a capability that is permanently desktop-only.
+    #[error("'{capability}' is desktop-only and cannot run on an agent")]
+    AgentNotAllowed {
+        /// The service/tool id that was requested on an agent.
+        capability: String,
+    },
+}
+
+/// Routes service/tool invocations to the local registry or an agent proxy.
+///
+/// Stateless in S1: the agent inventory and the persisted per-capability
+/// preference arrive with the selector UI in S2. Today it encodes the two
+/// rules that hold regardless of UI — default-local, and the desktop-only
+/// boundary.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RunLocationResolver;
+
+impl RunLocationResolver {
+    /// Create a resolver.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Resolve an explicit run-location request for a capability.
+    ///
+    /// * [`RunLocation::ThisComputer`] always resolves to
+    ///   [`ResolvedLocation::Local`].
+    /// * [`RunLocation::Agent`] resolves to [`ResolvedLocation::Agent`] **only**
+    ///   when the capability is [`Locality::LocalOrAgent`]; a
+    ///   [`Locality::DesktopOnly`] capability yields
+    ///   [`RunLocationError::AgentNotAllowed`].
+    pub fn resolve(
+        &self,
+        capability: &str,
+        locality: Locality,
+        requested: &RunLocation,
+    ) -> Result<ResolvedLocation, RunLocationError> {
+        match requested {
+            RunLocation::ThisComputer => Ok(ResolvedLocation::Local),
+            RunLocation::Agent(agent_id) => match locality {
+                Locality::LocalOrAgent => Ok(ResolvedLocation::Agent(agent_id.clone())),
+                Locality::DesktopOnly => Err(RunLocationError::AgentNotAllowed {
+                    capability: capability.to_string(),
+                }),
+            },
+        }
+    }
+
+    /// Resolve using the S1 default when no explicit choice is made.
+    ///
+    /// Always [`ResolvedLocation::Local`] — the honest S1 behaviour, since the
+    /// selector that would record a non-default choice is S2. Provided so call
+    /// sites can adopt the resolver now and get today's local execution without
+    /// special-casing "no preference".
+    pub fn resolve_default(&self) -> ResolvedLocation {
+        ResolvedLocation::Local
+    }
+
+    /// The run-locations the selector may offer for a capability.
+    ///
+    /// Always includes [`RunLocation::ThisComputer`]. For a
+    /// [`Locality::LocalOrAgent`] capability each reachable agent is appended;
+    /// for a [`Locality::DesktopOnly`] capability the agents are omitted, so the
+    /// UI never presents a forbidden choice.
+    pub fn available_locations(&self, locality: Locality, agents: &[String]) -> Vec<RunLocation> {
+        let mut locations = vec![RunLocation::ThisComputer];
+        if locality == Locality::LocalOrAgent {
+            locations.extend(agents.iter().cloned().map(RunLocation::Agent));
+        }
+        locations
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn this_computer_resolves_local() {
+        let r = RunLocationResolver::new();
+        assert_eq!(
+            r.resolve("ping", Locality::LocalOrAgent, &RunLocation::ThisComputer),
+            Ok(ResolvedLocation::Local)
+        );
+        // Desktop-only on "this computer" is fine too.
+        assert_eq!(
+            r.resolve("credentials", Locality::DesktopOnly, &RunLocation::ThisComputer),
+            Ok(ResolvedLocation::Local)
+        );
+    }
+
+    #[test]
+    fn default_is_local() {
+        // S1: no explicit choice → local, so users see no behaviour change.
+        assert_eq!(
+            RunLocationResolver::new().resolve_default(),
+            ResolvedLocation::Local
+        );
+        // And the default RunLocation is This computer.
+        assert_eq!(RunLocation::default(), RunLocation::ThisComputer);
+    }
+
+    #[test]
+    fn remotable_capability_resolves_to_agent() {
+        let r = RunLocationResolver::new();
+        let requested = RunLocation::Agent("build-server".to_string());
+        assert_eq!(
+            r.resolve("port_scan", Locality::LocalOrAgent, &requested),
+            Ok(ResolvedLocation::Agent("build-server".to_string()))
+        );
+    }
+
+    #[test]
+    fn desktop_only_capability_refuses_agent() {
+        let r = RunLocationResolver::new();
+        let requested = RunLocation::Agent("build-server".to_string());
+        assert_eq!(
+            r.resolve("credentials", Locality::DesktopOnly, &requested),
+            Err(RunLocationError::AgentNotAllowed {
+                capability: "credentials".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn available_locations_includes_agents_only_when_remotable() {
+        let r = RunLocationResolver::new();
+        let agents = vec!["a1".to_string(), "a2".to_string()];
+
+        let remotable = r.available_locations(Locality::LocalOrAgent, &agents);
+        assert_eq!(
+            remotable,
+            vec![
+                RunLocation::ThisComputer,
+                RunLocation::Agent("a1".to_string()),
+                RunLocation::Agent("a2".to_string()),
+            ]
+        );
+
+        // Desktop-only: only "This computer", never an agent.
+        let desktop_only = r.available_locations(Locality::DesktopOnly, &agents);
+        assert_eq!(desktop_only, vec![RunLocation::ThisComputer]);
+    }
+
+    #[test]
+    fn run_location_serde_is_tagged() {
+        let json = serde_json::to_value(RunLocation::Agent("x".to_string())).unwrap();
+        assert_eq!(json["kind"], "agent");
+        assert_eq!(json["agentId"], "x");
+        let back: RunLocation = serde_json::from_value(json).unwrap();
+        assert_eq!(back, RunLocation::Agent("x".to_string()));
+    }
+}

--- a/src-tauri/src/run_location.rs
+++ b/src-tauri/src/run_location.rs
@@ -152,7 +152,11 @@ mod tests {
         );
         // Desktop-only on "this computer" is fine too.
         assert_eq!(
-            r.resolve("credentials", Locality::DesktopOnly, &RunLocation::ThisComputer),
+            r.resolve(
+                "credentials",
+                Locality::DesktopOnly,
+                &RunLocation::ThisComputer
+            ),
             Ok(ResolvedLocation::Local)
         );
     }


### PR DESCRIPTION
## Summary

Establishes the **S1 foundation** of the stateless-UI / agent-empowerment S-track: a uniform `Service` / `Tool` trait pair with registries in `core`, agent-side `service.*` / `tool.*` JSON-RPC dispatch, and a desktop run-location resolver. This is the substrate that lets services and network tools run on the desktop **or** a remote agent behind one abstraction. Entirely additive — **no user-facing behaviour change**.

Part of #2139. Advances #2148 (see *Deferred* below for the one remaining acceptance bullet, tracked in #2157).

## What this delivers

**`core/src/tool/`** — a `Tool` trait (one-shot / streaming invocation) with:
- a uniform `ToolHost` sink that streamed results are emitted through, identical whether a tool runs locally or on an agent, plus a `CancellationToken`;
- a `ToolRegistry` (twin of `ConnectionTypeRegistry`);
- wrappers over every existing `core/src/network` diagnostic — ping, ping_sweep, port_scan, traceroute, dns, open_ports, wol. **Behaviour is identical to calling the network functions directly**; the trait only adds the host + cancellation plumbing.

**`core/src/service/`** — a `Service` trait (long-lived `start`/`stop`/`status`/`subscribe_events` lifecycle) with:
- a reusable broadcast `EventChannel` services emit status/stats through (instead of a host-specific emitter);
- a `ServiceRegistry` (twin of `ConnectionTypeRegistry`);
- a `desktop_only` capability flag for the run-location boundary.

**`agent/src/handler/dispatch.rs`** — `tool.list` / `tool.run` / `service.list`, mirroring the existing `network.*` / `connection.*` registrations. `tool.run` collects streamed events into one response, exactly as `network.*` collects its results. The registries are built inside `AgentHandler::new` with **no change to its public signature**.

**`src-tauri/src/run_location.rs`** — the resolver that routes an invocation to the local registry or an agent proxy:
- default and explicit "This computer" always resolve `Local`, so **S1 has zero user-facing change** (the selector UI is S2);
- `DesktopOnly` capabilities (credentials, spawn rendezvous, local file watch, OS-window mgmt — Open Design Decision #4) refuse an agent run-location and are omitted from `available_locations`.

## How existing desktop tools stay behavior-identical

The network tools keep running through the exact same `core/src/network` functions; the `Tool` wrappers only decode params, forward to those functions, and stream via the host. Nothing invokes the new resolver yet, and it defaults to `Local` — so the desktop network tools resolve locally and behave exactly as before.

## Deferred (tracked in #2157)

The #2148 acceptance bullet "at least one existing service behind `Service`" is deferred: wiring a real service cleanly needs the S2 decoupling of the embedded servers / HTTP monitor from `AppHandle`/`Emitter`. Doing it in-place in S1 would risk behaviour change, so #2148 is left **open** and the lift is tracked in #2157. This PR is the clean foundation; #2157 completes the bullet.

## Tests

- `core/src/tool/`: registry list/order/unregister, unknown-tool error, streaming round-trip, cancellation stops a run, per-wrapper param decoding, WoL invalid-MAC, open_ports local round-trip (32 assertions across the module).
- `core/src/service/`: status serde, event-channel delivery, registry create/list/unregister, full mock-service lifecycle with events.
- `agent`: `tool.list` covers built-ins, `tool.run` open_ports round-trip, unknown-tool error, `service.list` empty, all require `initialize`.
- `src-tauri`: resolver default-local, remotable→agent, desktop-only refuses agent, `available_locations` omits agents for desktop-only, serde tagging.

`cargo fmt` / `clippy -D warnings` / the new unit tests are green across all three crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)