### PR TITLE
feat(backend): port reconnectBackoff.ts state machine to Rust with golden-vector + property tests (Closes #2144)

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod output;
 #[cfg(feature = "plugin")]
 pub mod plugin;
 pub mod protocol;
+pub mod reconnect_backoff;
 pub mod service;
 pub mod session;
 pub mod tool;

--- a/core/src/reconnect_backoff.rs
+++ b/core/src/reconnect_backoff.rs
@@ -1,0 +1,262 @@
+//! Agentless auto-reconnect backoff state machine (#1962).
+//!
+//! A faithful Rust port of the frontend's `src/utils/reconnectBackoff.ts`: a
+//! pure, timer-free model of the "resilient reconnect" loop used for plain SSH
+//! connections over flaky links. It answers two questions the store's timer
+//! driver needs:
+//!
+//!   1. How long to wait before the next connection attempt (exponential
+//!      backoff with jitter, capped).
+//!   2. What the next phase is after each event (drop / attempt / success /
+//!      failure / cancel), including when to give up.
+//!
+//! Keeping this logic pure and injectable (`rand`) makes the backoff schedule
+//! and the give-up decision unit-testable without fake timers or a live
+//! connection. During the stateless-UI migration (#2139) the TypeScript version
+//! stays authoritative; this port runs behind it and is proven equivalent via
+//! golden-vector fixtures (`core/tests/fixtures/golden/reconnect_backoff/`)
+//! extracted from the TS test suite, and gains property tests over the backoff
+//! invariants. Phase 4 (session lifecycle) activates it server-side.
+//!
+//! No agent means the remote shell state cannot be recovered — this machine
+//! only models re-establishing the *transport*, not restoring server-side
+//! session state.
+
+use serde::{Deserialize, Serialize};
+
+/// Tunables for the exponential backoff schedule.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct BackoffConfig {
+    /// Delay before the first retry, in ms.
+    pub base_delay_ms: f64,
+    /// Multiplier applied per attempt (2 → doubles each time).
+    pub factor: f64,
+    /// Upper bound on any single delay, in ms (before jitter).
+    pub max_delay_ms: f64,
+    /// Maximum number of connection attempts before giving up. `0` means retry
+    /// forever (the user's Cancel is then the only way to stop).
+    pub max_attempts: i64,
+    /// Fraction of the computed delay applied as symmetric random jitter, in
+    /// `[0, 1]`. `0.2` spreads each delay by ±20% so a fleet of dropped tabs
+    /// does not stampede the server in lockstep. `0` disables jitter
+    /// (deterministic).
+    pub jitter_ratio: f64,
+}
+
+/// Defaults tuned for a truck-on-cellular field scenario (#1962): a quick first
+/// retry so a brief blip recovers almost instantly, doubling up to a 30 s
+/// ceiling so a long outage does not hammer the network, and a bounded attempt
+/// count so a permanently-dead host eventually surfaces the manual "Reconnect
+/// failed" overlay instead of spinning forever.
+pub const DEFAULT_BACKOFF: BackoffConfig = BackoffConfig {
+    base_delay_ms: 1_000.0,
+    factor: 2.0,
+    max_delay_ms: 30_000.0,
+    max_attempts: 10,
+    jitter_ratio: 0.2,
+};
+
+/// Phase of the auto-reconnect loop for one tab.
+///
+/// - `Idle`       — not auto-reconnecting.
+/// - `Waiting`    — backoff timer is running before the next attempt.
+/// - `Connecting` — an attempt is in flight (the transport is being
+///   re-established).
+/// - `Connected`  — the transport came back; the loop settled successfully.
+/// - `Gaveup`     — attempts exhausted or the user cancelled; hand off to the
+///   manual disconnect overlay.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ReconnectPhase {
+    Idle,
+    Waiting,
+    Connecting,
+    Connected,
+    Gaveup,
+}
+
+/// Immutable snapshot of the reconnect loop for one tab.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReconnectState {
+    pub phase: ReconnectPhase,
+    /// Number of connection attempts started so far in this loop.
+    pub attempt: i64,
+    /// Delay the current `Waiting` phase is counting down, in ms (0 otherwise).
+    pub delay_ms: i64,
+}
+
+/// Events that drive the machine:
+///
+/// - `Drop`    — the connection was lost; begin (or, from `Connected`, restart)
+///   the backoff loop.
+/// - `Attempt` — the backoff timer fired; start a connection attempt.
+/// - `Success` — the attempt connected.
+/// - `Failure` — the attempt failed; back off further or give up.
+/// - `Cancel`  — the user asked to stop retrying.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ReconnectEvent {
+    Drop,
+    Attempt,
+    Success,
+    Failure,
+    Cancel,
+}
+
+/// The starting state for a tab that is not auto-reconnecting.
+pub const INITIAL_RECONNECT_STATE: ReconnectState = ReconnectState {
+    phase: ReconnectPhase::Idle,
+    attempt: 0,
+    delay_ms: 0,
+};
+
+/// The starting state for a tab that is not auto-reconnecting (mirrors the
+/// TypeScript `initialReconnectState` export).
+pub fn initial_reconnect_state() -> ReconnectState {
+    INITIAL_RECONNECT_STATE
+}
+
+impl Default for ReconnectState {
+    fn default() -> Self {
+        INITIAL_RECONNECT_STATE
+    }
+}
+
+/// Pure exponential delay for a given attempt (1-based), before jitter and
+/// before the cap-then-jitter in [`next_reconnect_delay`]. Attempt 1 →
+/// `base_delay_ms`, attempt 2 → `base_delay_ms * factor`, and so on, clamped to
+/// `max_delay_ms`.
+///
+/// `attempt < 1` is treated as attempt 1 so a caller never gets a negative or
+/// sub-base delay.
+pub fn backoff_delay(attempt: i64, config: &BackoffConfig) -> f64 {
+    let n = attempt.max(1);
+    let raw = config.base_delay_ms * config.factor.powi((n - 1) as i32);
+    raw.min(config.max_delay_ms)
+}
+
+/// The concrete delay to wait before the given attempt (1-based), applying the
+/// cap and then symmetric jitter of `±jitter_ratio`. `rand` is injectable for
+/// deterministic tests; it must return a value in `[0, 1)`.
+///
+/// The result is clamped to `>= 0` and rounded to whole milliseconds.
+pub fn next_reconnect_delay(
+    attempt: i64,
+    config: &BackoffConfig,
+    rand: &mut dyn FnMut() -> f64,
+) -> i64 {
+    let base = backoff_delay(attempt, config);
+    if config.jitter_ratio <= 0.0 {
+        return base.round() as i64;
+    }
+    // Map rand() ∈ [0,1) to a symmetric factor in [-1, 1).
+    let swing = (rand() * 2.0 - 1.0) * config.jitter_ratio;
+    (base * (1.0 + swing)).round().max(0.0) as i64
+}
+
+/// Whether the loop should give up rather than start another attempt. With
+/// `max_attempts == 0` the loop never gives up on its own (unbounded retry).
+/// Once `attempt` attempts have already been made, a further failure gives up
+/// when `attempt >= max_attempts`.
+pub fn should_give_up(attempt: i64, config: &BackoffConfig) -> bool {
+    if config.max_attempts <= 0 {
+        return false;
+    }
+    attempt >= config.max_attempts
+}
+
+/// Pure transition for the reconnect state machine. Given the current state, an
+/// event, the config, and an injectable RNG, returns the next state. Unknown
+/// transitions are a no-op (return the same state) so a stray event cannot
+/// corrupt the loop.
+///
+/// The `delay_ms` on a `Waiting` result is the concrete jittered delay the
+/// timer driver should arm; `attempt` counts attempts that have been started.
+pub fn reconnect_reducer(
+    state: &ReconnectState,
+    event: ReconnectEvent,
+    config: &BackoffConfig,
+    rand: &mut dyn FnMut() -> f64,
+) -> ReconnectState {
+    match event {
+        // The user stops the loop from any phase.
+        ReconnectEvent::Cancel => ReconnectState {
+            phase: ReconnectPhase::Gaveup,
+            attempt: state.attempt,
+            delay_ms: 0,
+        },
+
+        ReconnectEvent::Drop => {
+            // A fresh drop (from idle or a previously-connected loop) arms the
+            // first backoff window. A drop while already waiting/connecting is
+            // ignored — the loop is already running and `Failure` handles a
+            // failed attempt.
+            if state.phase == ReconnectPhase::Idle || state.phase == ReconnectPhase::Connected {
+                let next_attempt = 1;
+                ReconnectState {
+                    phase: ReconnectPhase::Waiting,
+                    // No attempt started yet; incremented on "attempt".
+                    attempt: state.attempt,
+                    delay_ms: next_reconnect_delay(next_attempt, config, rand),
+                }
+            } else {
+                *state
+            }
+        }
+
+        ReconnectEvent::Attempt => {
+            // The backoff timer fired: begin a connection attempt.
+            if state.phase != ReconnectPhase::Waiting {
+                return *state;
+            }
+            ReconnectState {
+                phase: ReconnectPhase::Connecting,
+                attempt: state.attempt + 1,
+                delay_ms: 0,
+            }
+        }
+
+        ReconnectEvent::Success => {
+            if state.phase != ReconnectPhase::Connecting {
+                return *state;
+            }
+            ReconnectState {
+                phase: ReconnectPhase::Connected,
+                attempt: 0,
+                delay_ms: 0,
+            }
+        }
+
+        ReconnectEvent::Failure => {
+            if state.phase != ReconnectPhase::Connecting {
+                return *state;
+            }
+            // `attempt` already counts this just-failed attempt (incremented on
+            // "attempt"). Give up once we have used our budget; otherwise arm
+            // the next backoff window sized for the *next* attempt number.
+            if should_give_up(state.attempt, config) {
+                return ReconnectState {
+                    phase: ReconnectPhase::Gaveup,
+                    attempt: state.attempt,
+                    delay_ms: 0,
+                };
+            }
+            let next_attempt_number = state.attempt + 1;
+            ReconnectState {
+                phase: ReconnectPhase::Waiting,
+                attempt: state.attempt,
+                delay_ms: next_reconnect_delay(next_attempt_number, config, rand),
+            }
+        }
+    }
+}
+
+/// Whether a phase is one where the loop is actively trying (spinner/countdown).
+pub fn is_active_reconnect_phase(phase: ReconnectPhase) -> bool {
+    matches!(phase, ReconnectPhase::Waiting | ReconnectPhase::Connecting)
+}
+
+#[cfg(test)]
+mod tests;

--- a/core/src/reconnect_backoff/tests.rs
+++ b/core/src/reconnect_backoff/tests.rs
@@ -1,0 +1,407 @@
+//! Unit tests (mirroring `reconnectBackoff.test.ts`) plus property tests over
+//! the backoff-schedule and state-machine invariants.
+
+use super::*;
+use proptest::prelude::*;
+
+/// Deterministic config with jitter disabled, for exact delay assertions
+/// (mirrors the `NO_JITTER` fixture in `reconnectBackoff.test.ts`).
+const NO_JITTER: BackoffConfig = BackoffConfig {
+    base_delay_ms: 1_000.0,
+    factor: 2.0,
+    max_delay_ms: 8_000.0,
+    max_attempts: 5,
+    jitter_ratio: 0.0,
+};
+
+/// A constant RNG returning `v` on every call — the Rust analogue of the TS
+/// `() => v` injected generator.
+fn rng(v: f64) -> impl FnMut() -> f64 {
+    move || v
+}
+
+// ── backoffDelay ────────────────────────────────────────────────────────────
+
+#[test]
+fn backoff_delay_returns_base_for_first_attempt() {
+    assert_eq!(backoff_delay(1, &NO_JITTER), 1_000.0);
+}
+
+#[test]
+fn backoff_delay_grows_exponentially_by_the_factor() {
+    assert_eq!(backoff_delay(2, &NO_JITTER), 2_000.0);
+    assert_eq!(backoff_delay(3, &NO_JITTER), 4_000.0);
+    assert_eq!(backoff_delay(4, &NO_JITTER), 8_000.0);
+}
+
+#[test]
+fn backoff_delay_caps_at_max_delay() {
+    // Attempt 5 would be 16_000 but is clamped to the 8_000 ceiling.
+    assert_eq!(backoff_delay(5, &NO_JITTER), 8_000.0);
+    assert_eq!(backoff_delay(50, &NO_JITTER), 8_000.0);
+}
+
+#[test]
+fn backoff_delay_treats_attempt_below_one_as_first() {
+    assert_eq!(backoff_delay(0, &NO_JITTER), 1_000.0);
+    assert_eq!(backoff_delay(-3, &NO_JITTER), 1_000.0);
+}
+
+// ── nextReconnectDelay (jitter) ─────────────────────────────────────────────
+
+#[test]
+fn next_delay_equals_plain_backoff_when_jitter_disabled() {
+    assert_eq!(next_reconnect_delay(3, &NO_JITTER, &mut rng(0.5)), 4_000);
+}
+
+#[test]
+fn next_delay_applies_symmetric_jitter() {
+    let cfg = BackoffConfig {
+        jitter_ratio: 0.2,
+        ..NO_JITTER
+    };
+    // rand=0 → factor (1 + (-0.2)) = 0.8 → 800 for base 1000.
+    assert_eq!(next_reconnect_delay(1, &cfg, &mut rng(0.0)), 800);
+    // rand→1 (upper bound) → factor (1 + 0.2) = 1.2 → 1200.
+    assert_eq!(next_reconnect_delay(1, &cfg, &mut rng(0.999999)), 1_200);
+    // rand=0.5 → no swing → exactly base.
+    assert_eq!(next_reconnect_delay(1, &cfg, &mut rng(0.5)), 1_000);
+}
+
+#[test]
+fn next_delay_never_negative() {
+    let cfg = BackoffConfig {
+        jitter_ratio: 2.0,
+        ..NO_JITTER
+    };
+    assert!(next_reconnect_delay(1, &cfg, &mut rng(0.0)) >= 0);
+}
+
+// ── shouldGiveUp ────────────────────────────────────────────────────────────
+
+#[test]
+fn should_give_up_once_attempts_reach_max() {
+    assert!(!should_give_up(4, &NO_JITTER));
+    assert!(should_give_up(5, &NO_JITTER));
+    assert!(should_give_up(6, &NO_JITTER));
+}
+
+#[test]
+fn should_give_up_never_when_unbounded() {
+    let cfg = BackoffConfig {
+        max_attempts: 0,
+        ..NO_JITTER
+    };
+    assert!(!should_give_up(1_000, &cfg));
+}
+
+// ── reconnectReducer transitions ────────────────────────────────────────────
+
+#[test]
+fn drop_from_idle_arms_first_backoff_window() {
+    let s = reconnect_reducer(
+        &initial_reconnect_state(),
+        ReconnectEvent::Drop,
+        &NO_JITTER,
+        &mut rng(0.5),
+    );
+    assert_eq!(s.phase, ReconnectPhase::Waiting);
+    assert_eq!(s.attempt, 0);
+    assert_eq!(s.delay_ms, 1_000);
+}
+
+#[test]
+fn attempt_from_waiting_starts_connection_and_counts_it() {
+    let waiting = reconnect_reducer(
+        &initial_reconnect_state(),
+        ReconnectEvent::Drop,
+        &NO_JITTER,
+        &mut rng(0.5),
+    );
+    let connecting =
+        reconnect_reducer(&waiting, ReconnectEvent::Attempt, &NO_JITTER, &mut rng(0.5));
+    assert_eq!(connecting.phase, ReconnectPhase::Connecting);
+    assert_eq!(connecting.attempt, 1);
+    assert_eq!(connecting.delay_ms, 0);
+}
+
+#[test]
+fn success_from_connecting_settles_and_resets() {
+    let mut s = reconnect_reducer(
+        &initial_reconnect_state(),
+        ReconnectEvent::Drop,
+        &NO_JITTER,
+        &mut rng(0.5),
+    );
+    s = reconnect_reducer(&s, ReconnectEvent::Attempt, &NO_JITTER, &mut rng(0.5));
+    s = reconnect_reducer(&s, ReconnectEvent::Success, &NO_JITTER, &mut rng(0.5));
+    assert_eq!(s.phase, ReconnectPhase::Connected);
+    assert_eq!(s.attempt, 0);
+}
+
+#[test]
+fn failure_from_connecting_backs_off_with_longer_delay() {
+    let mut s = reconnect_reducer(
+        &initial_reconnect_state(),
+        ReconnectEvent::Drop,
+        &NO_JITTER,
+        &mut rng(0.5),
+    );
+    s = reconnect_reducer(&s, ReconnectEvent::Attempt, &NO_JITTER, &mut rng(0.5)); // attempt 1
+    s = reconnect_reducer(&s, ReconnectEvent::Failure, &NO_JITTER, &mut rng(0.5));
+    assert_eq!(s.phase, ReconnectPhase::Waiting);
+    assert_eq!(s.attempt, 1);
+    // Next attempt is #2 → 2_000ms.
+    assert_eq!(s.delay_ms, 2_000);
+}
+
+#[test]
+fn walks_a_full_escalating_backoff_schedule_until_give_up() {
+    let mut delays: Vec<i64> = Vec::new();
+    let mut s = reconnect_reducer(
+        &initial_reconnect_state(),
+        ReconnectEvent::Drop,
+        &NO_JITTER,
+        &mut rng(0.5),
+    );
+    delays.push(s.delay_ms);
+    // 5 attempts allowed; the 5th failure gives up.
+    for _ in 0..5 {
+        s = reconnect_reducer(&s, ReconnectEvent::Attempt, &NO_JITTER, &mut rng(0.5));
+        assert_eq!(s.phase, ReconnectPhase::Connecting);
+        s = reconnect_reducer(&s, ReconnectEvent::Failure, &NO_JITTER, &mut rng(0.5));
+        if s.phase == ReconnectPhase::Waiting {
+            delays.push(s.delay_ms);
+        }
+    }
+    assert_eq!(s.phase, ReconnectPhase::Gaveup);
+    assert_eq!(s.attempt, 5);
+    // Escalating, capped at 8_000: 1000, 2000, 4000, 8000, 8000.
+    assert_eq!(delays, vec![1_000, 2_000, 4_000, 8_000, 8_000]);
+}
+
+#[test]
+fn cancel_from_any_phase_gives_up() {
+    let waiting = reconnect_reducer(
+        &initial_reconnect_state(),
+        ReconnectEvent::Drop,
+        &NO_JITTER,
+        &mut rng(0.5),
+    );
+    assert_eq!(
+        reconnect_reducer(&waiting, ReconnectEvent::Cancel, &NO_JITTER, &mut rng(0.5)).phase,
+        ReconnectPhase::Gaveup
+    );
+    let connecting =
+        reconnect_reducer(&waiting, ReconnectEvent::Attempt, &NO_JITTER, &mut rng(0.5));
+    assert_eq!(
+        reconnect_reducer(
+            &connecting,
+            ReconnectEvent::Cancel,
+            &NO_JITTER,
+            &mut rng(0.5)
+        )
+        .phase,
+        ReconnectPhase::Gaveup
+    );
+}
+
+#[test]
+fn redrop_after_reconnect_restarts_from_attempt_one() {
+    let mut s = reconnect_reducer(
+        &initial_reconnect_state(),
+        ReconnectEvent::Drop,
+        &NO_JITTER,
+        &mut rng(0.5),
+    );
+    s = reconnect_reducer(&s, ReconnectEvent::Attempt, &NO_JITTER, &mut rng(0.5));
+    s = reconnect_reducer(&s, ReconnectEvent::Success, &NO_JITTER, &mut rng(0.5));
+    assert_eq!(s.phase, ReconnectPhase::Connected);
+    s = reconnect_reducer(&s, ReconnectEvent::Drop, &NO_JITTER, &mut rng(0.5));
+    assert_eq!(s.phase, ReconnectPhase::Waiting);
+    assert_eq!(s.delay_ms, 1_000); // fresh attempt-1 delay
+}
+
+#[test]
+fn ignores_stray_events_that_do_not_match_phase() {
+    let initial = initial_reconnect_state();
+    // attempt while idle is a no-op.
+    assert_eq!(
+        reconnect_reducer(&initial, ReconnectEvent::Attempt, &NO_JITTER, &mut rng(0.5)),
+        initial
+    );
+    // success while idle is a no-op.
+    assert_eq!(
+        reconnect_reducer(&initial, ReconnectEvent::Success, &NO_JITTER, &mut rng(0.5)),
+        initial
+    );
+    // duplicate drop while waiting does not re-arm.
+    let waiting = reconnect_reducer(&initial, ReconnectEvent::Drop, &NO_JITTER, &mut rng(0.5));
+    assert_eq!(
+        reconnect_reducer(&waiting, ReconnectEvent::Drop, &NO_JITTER, &mut rng(0.5)),
+        waiting
+    );
+}
+
+#[test]
+fn unbounded_retries_never_reach_gaveup_on_failure() {
+    let cfg = BackoffConfig {
+        max_attempts: 0,
+        ..NO_JITTER
+    };
+    let mut s = reconnect_reducer(
+        &initial_reconnect_state(),
+        ReconnectEvent::Drop,
+        &cfg,
+        &mut rng(0.5),
+    );
+    for _ in 0..100 {
+        s = reconnect_reducer(&s, ReconnectEvent::Attempt, &cfg, &mut rng(0.5));
+        s = reconnect_reducer(&s, ReconnectEvent::Failure, &cfg, &mut rng(0.5));
+        assert_eq!(s.phase, ReconnectPhase::Waiting);
+    }
+    // Only Cancel stops an unbounded loop.
+    assert_eq!(
+        reconnect_reducer(&s, ReconnectEvent::Cancel, &cfg, &mut rng(0.5)).phase,
+        ReconnectPhase::Gaveup
+    );
+}
+
+// ── isActiveReconnectPhase ──────────────────────────────────────────────────
+
+#[test]
+fn is_active_true_while_waiting_or_connecting() {
+    assert!(is_active_reconnect_phase(ReconnectPhase::Waiting));
+    assert!(is_active_reconnect_phase(ReconnectPhase::Connecting));
+}
+
+#[test]
+fn is_active_false_when_idle_connected_or_gaveup() {
+    assert!(!is_active_reconnect_phase(ReconnectPhase::Idle));
+    assert!(!is_active_reconnect_phase(ReconnectPhase::Connected));
+    assert!(!is_active_reconnect_phase(ReconnectPhase::Gaveup));
+}
+
+// ── Property tests ──────────────────────────────────────────────────────────
+
+/// A well-formed config with positive, finite tunables (jitter can be zero) —
+/// the domain the backoff logic is designed for.
+fn arb_config() -> impl Strategy<Value = BackoffConfig> {
+    (
+        1.0f64..100_000.0,
+        1.0f64..4.0,
+        1.0f64..600_000.0,
+        0i64..50,
+        0.0f64..1.0,
+    )
+        .prop_map(
+            |(base_delay_ms, factor, max_delay_ms, max_attempts, jitter_ratio)| BackoffConfig {
+                base_delay_ms,
+                factor,
+                // Ensure the cap is never below the base so the curve has room
+                // to grow before clamping.
+                max_delay_ms: max_delay_ms.max(base_delay_ms),
+                max_attempts,
+                jitter_ratio,
+            },
+        )
+}
+
+proptest! {
+    /// The pre-jitter curve is monotonically non-decreasing in the attempt
+    /// number and never exceeds the cap.
+    #[test]
+    fn backoff_delay_is_monotonic_and_capped(cfg in arb_config(), a in 1i64..40) {
+        let here = backoff_delay(a, &cfg);
+        let next = backoff_delay(a + 1, &cfg);
+        prop_assert!(next >= here - 1e-6, "curve decreased: {here} -> {next}");
+        prop_assert!(here <= cfg.max_delay_ms + 1e-6, "exceeded cap: {here}");
+        prop_assert!(next <= cfg.max_delay_ms + 1e-6, "exceeded cap: {next}");
+    }
+
+    /// Attempts at or below 1 all collapse to the base delay (never sub-base,
+    /// never negative).
+    #[test]
+    fn backoff_delay_floor_is_base(cfg in arb_config(), a in -20i64..=1) {
+        prop_assert_eq!(backoff_delay(a, &cfg), backoff_delay(1, &cfg));
+        prop_assert!(backoff_delay(a, &cfg) >= 0.0);
+    }
+
+    /// The jittered delay stays within the symmetric `±jitter_ratio` band
+    /// around the pre-jitter value and is never negative, for any RNG output in
+    /// `[0, 1)`.
+    #[test]
+    fn next_delay_stays_within_jitter_band(cfg in arb_config(), a in 1i64..40, r in 0.0f64..1.0) {
+        let base = backoff_delay(a, &cfg);
+        let d = next_reconnect_delay(a, &cfg, &mut rng(r));
+        prop_assert!(d >= 0, "negative delay: {d}");
+        let lo = (base * (1.0 - cfg.jitter_ratio)).round() as i64 - 1;
+        let hi = (base * (1.0 + cfg.jitter_ratio)).round() as i64 + 1;
+        prop_assert!(d >= lo && d <= hi, "delay {d} outside [{lo}, {hi}]");
+    }
+
+    /// With jitter disabled the concrete delay is exactly the rounded curve,
+    /// independent of the RNG.
+    #[test]
+    fn next_delay_is_deterministic_without_jitter(cfg in arb_config(), a in 1i64..40, r in 0.0f64..1.0) {
+        let no_jitter = BackoffConfig { jitter_ratio: 0.0, ..cfg };
+        let expected = backoff_delay(a, &no_jitter).round() as i64;
+        prop_assert_eq!(next_reconnect_delay(a, &no_jitter, &mut rng(r)), expected);
+    }
+
+    /// `cancel` from any reachable phase always lands in `gaveup`.
+    #[test]
+    fn cancel_always_gives_up(cfg in arb_config(), phase in prop_oneof![
+        Just(ReconnectPhase::Idle),
+        Just(ReconnectPhase::Waiting),
+        Just(ReconnectPhase::Connecting),
+        Just(ReconnectPhase::Connected),
+        Just(ReconnectPhase::Gaveup),
+    ], attempt in 0i64..30) {
+        let state = ReconnectState { phase, attempt, delay_ms: 0 };
+        let next = reconnect_reducer(&state, ReconnectEvent::Cancel, &cfg, &mut rng(0.5));
+        prop_assert_eq!(next.phase, ReconnectPhase::Gaveup);
+    }
+
+    /// A drop while already waiting or connecting is idempotent — the loop is
+    /// already running and must not re-arm.
+    #[test]
+    fn drop_while_active_is_idempotent(cfg in arb_config(), attempt in 0i64..30) {
+        for phase in [ReconnectPhase::Waiting, ReconnectPhase::Connecting] {
+            let state = ReconnectState { phase, attempt, delay_ms: 4_242 };
+            let next = reconnect_reducer(&state, ReconnectEvent::Drop, &cfg, &mut rng(0.5));
+            prop_assert_eq!(next, state);
+        }
+    }
+
+    /// Stray events that do not match the current phase never mutate the state.
+    #[test]
+    fn stray_events_are_noops(cfg in arb_config(), attempt in 0i64..30) {
+        // attempt/success/failure are only meaningful from waiting/connecting.
+        let idle = ReconnectState { phase: ReconnectPhase::Idle, attempt, delay_ms: 0 };
+        for ev in [ReconnectEvent::Attempt, ReconnectEvent::Success, ReconnectEvent::Failure] {
+            prop_assert_eq!(reconnect_reducer(&idle, ev, &cfg, &mut rng(0.5)), idle);
+        }
+    }
+
+    /// A bounded loop always terminates in `gaveup` after enough failures, and
+    /// never keeps trying past `max_attempts`.
+    #[test]
+    fn bounded_loop_eventually_gives_up(cfg in arb_config().prop_filter(
+        "bounded", |c| c.max_attempts >= 1
+    )) {
+        let mut s = reconnect_reducer(
+            &initial_reconnect_state(), ReconnectEvent::Drop, &cfg, &mut rng(0.5));
+        // Drive attempt/failure cycles well past the budget.
+        for _ in 0..(cfg.max_attempts + 5) {
+            if s.phase == ReconnectPhase::Gaveup {
+                break;
+            }
+            s = reconnect_reducer(&s, ReconnectEvent::Attempt, &cfg, &mut rng(0.5));
+            s = reconnect_reducer(&s, ReconnectEvent::Failure, &cfg, &mut rng(0.5));
+        }
+        prop_assert_eq!(s.phase, ReconnectPhase::Gaveup);
+        prop_assert!(s.attempt <= cfg.max_attempts,
+            "ran {} attempts past budget {}", s.attempt, cfg.max_attempts);
+    }
+}

--- a/core/tests/fixtures/golden/README.md
+++ b/core/tests/fixtures/golden/README.md
@@ -20,7 +20,9 @@ core/tests/fixtures/golden/
 ```
 
 For the panel-tree algebra that is `golden/panel_tree/<function>.json`
-(e.g. `split_leaf.json`, `find_adjacent_leaf.json`).
+(e.g. `split_leaf.json`, `find_adjacent_leaf.json`); for the reconnect-backoff
+state machine (#2144) it is `golden/reconnect_backoff/<function>.json`
+(e.g. `backoff_delay.json`, `reconnect_reducer.json`).
 
 ## Fixture file format
 
@@ -44,7 +46,9 @@ Each file is a single JSON object:
   `LeafPanel` for `getPanelActiveSessionId`, the size array for `normalizeSizes`,
   the edge string for `edgeToSplit`.
 - **`args`** carries the rest by name (`leafId`, `targetId`, `newLeaf`,
-  `direction`, `position`, `currentLeafId`, `tabGroups`, `activeTabGroupId`, …).
+  `direction`, `position`, `currentLeafId`, `tabGroups`, `activeTabGroupId`, …;
+  for reconnect-backoff: `config`, `event`, and a constant `rand` value
+  standing in for the injected `() => number` generator).
 - **`expected`** is the function's result serialized as JSON. A returned node is
   a full `PanelNode` (`{"type":"leaf",…}` / `{"type":"split",…}`); a "not found"
   / center result is `null`; scalars are plain JSON numbers, booleans or strings.

--- a/core/tests/fixtures/golden/reconnect_backoff/backoff_delay.json
+++ b/core/tests/fixtures/golden/reconnect_backoff/backoff_delay.json
@@ -1,0 +1,53 @@
+{
+  "operation": "backoffDelay",
+  "cases": [
+    {
+      "name": "base delay for the first attempt",
+      "input": 1,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 } },
+      "expected": 1000
+    },
+    {
+      "name": "doubles on attempt 2",
+      "input": 2,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 } },
+      "expected": 2000
+    },
+    {
+      "name": "grows exponentially on attempt 3",
+      "input": 3,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 } },
+      "expected": 4000
+    },
+    {
+      "name": "reaches the cap exactly on attempt 4",
+      "input": 4,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 } },
+      "expected": 8000
+    },
+    {
+      "name": "caps at maxDelayMs on attempt 5",
+      "input": 5,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 } },
+      "expected": 8000
+    },
+    {
+      "name": "stays capped far out",
+      "input": 50,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 } },
+      "expected": 8000
+    },
+    {
+      "name": "attempt 0 is treated as the first attempt",
+      "input": 0,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 } },
+      "expected": 1000
+    },
+    {
+      "name": "negative attempt is treated as the first attempt",
+      "input": -3,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 } },
+      "expected": 1000
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/reconnect_backoff/is_active_reconnect_phase.json
+++ b/core/tests/fixtures/golden/reconnect_backoff/is_active_reconnect_phase.json
@@ -1,0 +1,10 @@
+{
+  "operation": "isActiveReconnectPhase",
+  "cases": [
+    { "name": "waiting is active", "input": "waiting", "expected": true },
+    { "name": "connecting is active", "input": "connecting", "expected": true },
+    { "name": "idle is not active", "input": "idle", "expected": false },
+    { "name": "connected is not active", "input": "connected", "expected": false },
+    { "name": "gaveup is not active", "input": "gaveup", "expected": false }
+  ]
+}

--- a/core/tests/fixtures/golden/reconnect_backoff/next_reconnect_delay.json
+++ b/core/tests/fixtures/golden/reconnect_backoff/next_reconnect_delay.json
@@ -1,0 +1,35 @@
+{
+  "operation": "nextReconnectDelay",
+  "cases": [
+    {
+      "name": "equals the plain backoff when jitter is disabled",
+      "input": 3,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 }, "rand": 0.5 },
+      "expected": 4000
+    },
+    {
+      "name": "rand=0 swings to the lower jitter bound",
+      "input": 1,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0.2 }, "rand": 0 },
+      "expected": 800
+    },
+    {
+      "name": "rand near 1 swings to the upper jitter bound",
+      "input": 1,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0.2 }, "rand": 0.999999 },
+      "expected": 1200
+    },
+    {
+      "name": "rand=0.5 yields no swing (exactly base)",
+      "input": 1,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0.2 }, "rand": 0.5 },
+      "expected": 1000
+    },
+    {
+      "name": "never returns a negative delay under extreme jitter",
+      "input": 1,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 2 }, "rand": 0 },
+      "expected": 0
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/reconnect_backoff/reconnect_reducer.json
+++ b/core/tests/fixtures/golden/reconnect_backoff/reconnect_reducer.json
@@ -1,0 +1,77 @@
+{
+  "operation": "reconnectReducer",
+  "cases": [
+    {
+      "name": "drop from idle arms the first backoff window",
+      "input": { "phase": "idle", "attempt": 0, "delayMs": 0 },
+      "args": { "event": "drop", "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 }, "rand": 0.5 },
+      "expected": { "phase": "waiting", "attempt": 0, "delayMs": 1000 }
+    },
+    {
+      "name": "attempt from waiting starts a connection and counts it",
+      "input": { "phase": "waiting", "attempt": 0, "delayMs": 1000 },
+      "args": { "event": "attempt", "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 }, "rand": 0.5 },
+      "expected": { "phase": "connecting", "attempt": 1, "delayMs": 0 }
+    },
+    {
+      "name": "success from connecting settles the loop and resets the counter",
+      "input": { "phase": "connecting", "attempt": 1, "delayMs": 0 },
+      "args": { "event": "success", "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 }, "rand": 0.5 },
+      "expected": { "phase": "connected", "attempt": 0, "delayMs": 0 }
+    },
+    {
+      "name": "failure from connecting backs off with a longer delay",
+      "input": { "phase": "connecting", "attempt": 1, "delayMs": 0 },
+      "args": { "event": "failure", "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 }, "rand": 0.5 },
+      "expected": { "phase": "waiting", "attempt": 1, "delayMs": 2000 }
+    },
+    {
+      "name": "failure gives up once the attempt budget is spent",
+      "input": { "phase": "connecting", "attempt": 5, "delayMs": 0 },
+      "args": { "event": "failure", "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 }, "rand": 0.5 },
+      "expected": { "phase": "gaveup", "attempt": 5, "delayMs": 0 }
+    },
+    {
+      "name": "cancel from waiting gives up",
+      "input": { "phase": "waiting", "attempt": 0, "delayMs": 1000 },
+      "args": { "event": "cancel", "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 }, "rand": 0.5 },
+      "expected": { "phase": "gaveup", "attempt": 0, "delayMs": 0 }
+    },
+    {
+      "name": "cancel from connecting gives up and keeps the attempt count",
+      "input": { "phase": "connecting", "attempt": 2, "delayMs": 0 },
+      "args": { "event": "cancel", "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 }, "rand": 0.5 },
+      "expected": { "phase": "gaveup", "attempt": 2, "delayMs": 0 }
+    },
+    {
+      "name": "drop after a successful reconnect restarts from attempt 1",
+      "input": { "phase": "connected", "attempt": 0, "delayMs": 0 },
+      "args": { "event": "drop", "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 }, "rand": 0.5 },
+      "expected": { "phase": "waiting", "attempt": 0, "delayMs": 1000 }
+    },
+    {
+      "name": "attempt while idle is a no-op",
+      "input": { "phase": "idle", "attempt": 0, "delayMs": 0 },
+      "args": { "event": "attempt", "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 }, "rand": 0.5 },
+      "expected": { "phase": "idle", "attempt": 0, "delayMs": 0 }
+    },
+    {
+      "name": "success while idle is a no-op",
+      "input": { "phase": "idle", "attempt": 0, "delayMs": 0 },
+      "args": { "event": "success", "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 }, "rand": 0.5 },
+      "expected": { "phase": "idle", "attempt": 0, "delayMs": 0 }
+    },
+    {
+      "name": "duplicate drop while waiting does not re-arm",
+      "input": { "phase": "waiting", "attempt": 0, "delayMs": 1000 },
+      "args": { "event": "drop", "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 }, "rand": 0.5 },
+      "expected": { "phase": "waiting", "attempt": 0, "delayMs": 1000 }
+    },
+    {
+      "name": "unbounded failure arms the next capped window instead of giving up",
+      "input": { "phase": "connecting", "attempt": 100, "delayMs": 0 },
+      "args": { "event": "failure", "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 0, "jitterRatio": 0 }, "rand": 0.5 },
+      "expected": { "phase": "waiting", "attempt": 100, "delayMs": 8000 }
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/reconnect_backoff/should_give_up.json
+++ b/core/tests/fixtures/golden/reconnect_backoff/should_give_up.json
@@ -1,0 +1,29 @@
+{
+  "operation": "shouldGiveUp",
+  "cases": [
+    {
+      "name": "keeps trying below maxAttempts",
+      "input": 4,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 } },
+      "expected": false
+    },
+    {
+      "name": "gives up once attempts reach maxAttempts",
+      "input": 5,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 } },
+      "expected": true
+    },
+    {
+      "name": "gives up past maxAttempts",
+      "input": 6,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 5, "jitterRatio": 0 } },
+      "expected": true
+    },
+    {
+      "name": "never gives up when maxAttempts is 0 (unbounded)",
+      "input": 1000,
+      "args": { "config": { "baseDelayMs": 1000, "factor": 2, "maxDelayMs": 8000, "maxAttempts": 0, "jitterRatio": 0 } },
+      "expected": false
+    }
+  ]
+}

--- a/core/tests/reconnect_backoff_golden.rs
+++ b/core/tests/reconnect_backoff_golden.rs
@@ -1,0 +1,147 @@
+//! Golden-vector equivalence tests for the reconnect-backoff state machine
+//! (#2144).
+//!
+//! Each fixture under `tests/fixtures/golden/reconnect_backoff/*.json` names one
+//! exported function and a list of input → expected cases extracted from the
+//! authoritative TypeScript suite (`src/utils/reconnectBackoff.test.ts`). This
+//! test runs the Rust port against every case and asserts the serialized result
+//! matches, proving the two implementations stay in lockstep.
+//!
+//! Fixture format and the shared-convention rationale live in
+//! `tests/fixtures/golden/README.md`. This reuses verbatim the directory
+//! layout, envelope, and matcher the panel-tree port (#2143) established. The
+//! injectable RNG is encoded per case as a constant `rand` value in `args`.
+
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+use termihub_core::reconnect_backoff::{
+    backoff_delay, is_active_reconnect_phase, next_reconnect_delay, reconnect_reducer,
+    should_give_up, BackoffConfig, ReconnectEvent, ReconnectPhase, ReconnectState,
+};
+
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("golden")
+        .join("reconnect_backoff")
+}
+
+/// Deep JSON equality with the golden-vector numeric convention: numbers
+/// compare within a 1e-9 tolerance (cross-language float rounding, and the
+/// integer-valued `f64` results the backoff curve returns).
+fn json_matches(expected: &Value, actual: &Value) -> bool {
+    match (expected, actual) {
+        (Value::Number(e), Value::Number(a)) => match (e.as_f64(), a.as_f64()) {
+            (Some(x), Some(y)) => (x - y).abs() < 1e-9,
+            _ => e == a,
+        },
+        (Value::Array(e), Value::Array(a)) => {
+            e.len() == a.len() && e.iter().zip(a).all(|(x, y)| json_matches(x, y))
+        }
+        (Value::Object(e), Value::Object(a)) => {
+            e.len() == a.len()
+                && e.iter()
+                    .all(|(k, v)| a.get(k).is_some_and(|av| json_matches(v, av)))
+        }
+        _ => expected == actual,
+    }
+}
+
+fn from<T: serde::de::DeserializeOwned>(v: &Value) -> T {
+    serde_json::from_value(v.clone()).expect("deserialize fixture value")
+}
+
+/// The per-case constant RNG (`() => rand`), defaulting to the no-swing 0.5 when
+/// a case omits it (jitter-disabled cases never read it).
+fn case_rng(args: &Value) -> impl FnMut() -> f64 {
+    let r = args["rand"].as_f64().unwrap_or(0.5);
+    move || r
+}
+
+/// Run one case for `operation`, returning the serialized actual result.
+fn run_case(operation: &str, case: &Value) -> Value {
+    let input = &case["input"];
+    let args = &case["args"];
+    match operation {
+        "backoffDelay" => {
+            let config: BackoffConfig = from(&args["config"]);
+            json!(backoff_delay(input.as_i64().expect("attempt int"), &config))
+        }
+        "nextReconnectDelay" => {
+            let config: BackoffConfig = from(&args["config"]);
+            let mut rand = case_rng(args);
+            json!(next_reconnect_delay(
+                input.as_i64().expect("attempt int"),
+                &config,
+                &mut rand
+            ))
+        }
+        "shouldGiveUp" => {
+            let config: BackoffConfig = from(&args["config"]);
+            json!(should_give_up(
+                input.as_i64().expect("attempt int"),
+                &config
+            ))
+        }
+        "reconnectReducer" => {
+            let state: ReconnectState = from(input);
+            let event: ReconnectEvent = from(&args["event"]);
+            let config: BackoffConfig = from(&args["config"]);
+            let mut rand = case_rng(args);
+            serde_json::to_value(reconnect_reducer(&state, event, &config, &mut rand))
+                .expect("serialize state")
+        }
+        "isActiveReconnectPhase" => {
+            let phase: ReconnectPhase = from(input);
+            json!(is_active_reconnect_phase(phase))
+        }
+        other => panic!("unknown golden operation: {other}"),
+    }
+}
+
+#[test]
+fn golden_vectors_match_typescript() {
+    let dir = fixture_dir();
+    let mut files: Vec<PathBuf> = fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read fixture dir {}: {e}", dir.display()))
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "json"))
+        .collect();
+    files.sort();
+    assert!(
+        !files.is_empty(),
+        "no golden fixtures found in {}",
+        dir.display()
+    );
+
+    let mut total_cases = 0usize;
+    for file in files {
+        let raw = fs::read_to_string(&file).expect("read fixture");
+        let fixture: Value =
+            serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {}: {e}", file.display()));
+        let operation = fixture["operation"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{} missing operation", file.display()));
+        let cases = fixture["cases"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{} missing cases array", file.display()));
+
+        for case in cases {
+            let name = case["name"].as_str().unwrap_or("<unnamed>");
+            let actual = run_case(operation, case);
+            let expected = &case["expected"];
+            assert!(
+                json_matches(expected, &actual),
+                "golden mismatch in {} :: {operation} :: {name}\n  expected: {}\n  actual:   {}",
+                file.display(),
+                serde_json::to_string(expected).unwrap_or_default(),
+                serde_json::to_string(&actual).unwrap_or_default(),
+            );
+            total_cases += 1;
+        }
+    }
+    // Sanity: make sure the harness actually exercised a meaningful body of cases.
+    assert!(total_cases >= 30, "only ran {total_cases} golden cases");
+}


### PR DESCRIPTION
## Summary

Phase 0 of the stateless-UI migration (#2139): a faithful Rust twin of the
frontend's `src/utils/reconnectBackoff.ts` reconnect-backoff state machine,
landed in `termihub-core` at `core/src/reconnect_backoff.rs`.

The TypeScript version **stays authoritative** — nothing changes for the user.
This port runs behind it and is proven equivalent via golden vectors extracted
from the TS test suite. `reconnectBackoff.ts` is confirmed genuinely pure (zero
imports, all pure functions).

## What was ported

Every exported symbol, with identical semantics:

- `BackoffConfig`, `DEFAULT_BACKOFF`, `ReconnectPhase`, `ReconnectState`,
  `ReconnectEvent`, `initial_reconnect_state` / `INITIAL_RECONNECT_STATE`
- `backoff_delay` (exponential curve, `attempt < 1` floored to 1, capped at
  `maxDelayMs`)
- `next_reconnect_delay` (cap-then-symmetric-jitter, clamped `>= 0`, rounded)
- `should_give_up` (unbounded when `maxAttempts <= 0`)
- `reconnect_reducer` (drop / attempt / success / failure / cancel transitions,
  stray-event no-ops, re-drop restart, bounded give-up)
- `is_active_reconnect_phase`

The injectable RNG is a `&mut dyn FnMut() -> f64`, the Rust analogue of the TS
`() => number` generator. Structs serialize to the same JSON shape the TS types
use (camelCase fields, lowercase phase/event strings) so the golden fixtures are
language-neutral.

## Test approach — reuses #2143's golden-vector convention

Same fixture location (`core/tests/fixtures/golden/<util>/<function>.json`),
same `{ operation, cases: [{ name, input, args, expected }] }` envelope, same
numeric-tolerance matcher documented in
[`core/tests/fixtures/golden/README.md`](../blob/develop/core/tests/fixtures/golden/README.md).

- **34 golden cases** across 5 fixture files under
  `core/tests/fixtures/golden/reconnect_backoff/`, extracted from
  `src/utils/reconnectBackoff.test.ts`. A shared harness
  (`core/tests/reconnect_backoff_golden.rs`) runs the port against every case
  and asserts the serialized output matches, so TS/Rust drift fails a test. The
  injected RNG is encoded per case as a constant `rand` value in `args`.
- **28 lib tests** (`core/src/reconnect_backoff/tests.rs`): unit tests mirroring
  the TS suite case-for-case, plus `proptest` invariants — monotonic capped
  curve, sub-1 attempts floor to base, jitter-band bounds and non-negativity,
  deterministic-without-jitter, cancel-always-gives-up, drop-idempotence while
  active, stray-event no-ops, and bounded-loop termination within budget.

`cargo test`, `clippy -D warnings`, and `fmt` are all green; no `.unwrap()` in
production paths.

## Notes

- Non-user-facing (port runs behind existing TS), so no changelog fragment —
  matching #2143.
- `src/utils/reconnectBackoff.ts` is untouched and stays authoritative.

Closes #2144
Part of #2139