### PR TITLE
feat(workspace): port restoreMode.ts decision logic to Rust with golden-vector + property tests

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -26,6 +26,7 @@ pub mod output;
 pub mod plugin;
 pub mod protocol;
 pub mod reconnect_backoff;
+pub mod restore_mode;
 pub mod service;
 pub mod session;
 pub mod tool;

--- a/core/src/restore_mode.rs
+++ b/core/src/restore_mode.rs
@@ -1,0 +1,582 @@
+//! Startup session-restore decision logic (#2145).
+//!
+//! A faithful Rust twin of the frontend's `src/utils/restoreMode.ts`: pure
+//! functions that decide how the previously-open tabs are handled on launch and
+//! flatten / prune a stored last session for the restore dialog. There is no
+//! DOM, store, or I/O here — every function maps saved-state + mode inputs to a
+//! decision output.
+//!
+//! During the stateless-UI migration (#2139) the TypeScript version stays
+//! authoritative; this port runs behind it and is proven equivalent via
+//! golden-vector fixtures (`core/tests/fixtures/golden/restore_mode/`) extracted
+//! from the TS suite, plus property tests over the pruning invariants.
+//!
+//! The only runtime dependency the TS module has,
+//! [`get_workspace_leaves`] (from `workspaceLayout.ts`), is ported here as the
+//! small leaf-walk helper it needs — route (a) of the issue's portability note,
+//! rather than pulling in the whole 718-line `workspaceLayout.ts`.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashSet;
+
+// ── Input types (mirror the TS type-only imports) ────────────────────────────
+
+/// Minimal projection of `AppSettings` — only the two fields the restore-mode
+/// decision reads. Unknown settings fields are ignored on deserialize.
+///
+/// `restore_last_session_mode` is kept as a raw `String` (not the
+/// [`RestoreLastSessionMode`] enum) so an out-of-range persisted value falls
+/// through to the default exactly as the TS `VALID_MODES.includes(...)` guard
+/// does, instead of failing to deserialize.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AppSettings {
+    /// Explicit restore mode; wins when it is a valid mode string.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub restore_last_session_mode: Option<String>,
+    /// Legacy boolean, migrated when the explicit mode is unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub restore_last_session_on_startup: Option<bool>,
+}
+
+/// Minimal projection of `SavedConnection` — the id used to resolve a
+/// `connectionRef`, and its connection config.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct SavedConnection {
+    /// Stable connection id referenced by [`WorkspaceTabDef::connection_ref`].
+    pub id: String,
+    /// The connection's type + config.
+    pub config: ConnectionConfig,
+}
+
+/// A connection config: a `type` discriminator plus an opaque config bag, matching
+/// the frontend `ConnectionConfig`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct ConnectionConfig {
+    /// Connection type (`"ssh"`, `"serial"`, `"telnet"`, …).
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// Type-specific settings; read opaquely to derive probe targets.
+    pub config: Value,
+}
+
+/// Inline connection config captured on a stored tab.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct InlineConfig {
+    /// Connection type discriminator.
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// Type-specific settings bag.
+    pub config: Value,
+}
+
+/// Reference to a remote agent definition on a stored tab.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRef {
+    /// The agent the definition lives on.
+    pub agent_id: String,
+    /// The agent-side definition id.
+    pub definition_id: String,
+}
+
+/// A tab definition within a workspace leaf panel.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceTabDef {
+    /// Reference to a saved connection by id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub connection_ref: Option<String>,
+    /// Inline config used when no saved connection is referenced.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inline_config: Option<InlineConfig>,
+    /// Reference to a remote agent definition.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_ref: Option<AgentRef>,
+    /// Optional tab title override.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Optional command to run after the session connects.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub initial_command: Option<String>,
+}
+
+/// A leaf panel holding one or more tabs.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct WorkspaceLeafNode {
+    /// The tabs in this leaf, in display order.
+    pub tabs: Vec<WorkspaceTabDef>,
+}
+
+/// Split direction for a container node.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SplitDirection {
+    /// Children are laid out left-to-right.
+    Horizontal,
+    /// Children are laid out top-to-bottom.
+    Vertical,
+}
+
+/// A split container with child panels.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct WorkspaceSplitNode {
+    /// Split axis.
+    pub direction: SplitDirection,
+    /// Child layout nodes.
+    pub children: Vec<WorkspaceLayoutNode>,
+    /// Optional percentage sizes per child (sums to 100, matches `children`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sizes: Option<Vec<f64>>,
+}
+
+/// Recursive layout tree for a workspace tab group, serializing to the same
+/// `{ "type": "leaf" | "split", … }` discriminated union as the TS side.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum WorkspaceLayoutNode {
+    /// A leaf panel.
+    Leaf(WorkspaceLeafNode),
+    /// A split container.
+    Split(WorkspaceSplitNode),
+}
+
+/// A single tab group within a session (name + panel layout tree).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceTabGroupDef {
+    /// Display name for the group.
+    pub name: String,
+    /// Optional accent dot color.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    /// The panel layout tree.
+    pub layout: WorkspaceLayoutNode,
+    /// Logical id of the window this group belongs to (#1905).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub window_id: Option<String>,
+}
+
+/// A native window recorded in a saved session (#1905). Preserved untouched by
+/// [`filter_session_by_selection`], so it carries every field opaquely.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct WorkspaceWindowDef {
+    /// Logical window id referenced by tab groups.
+    pub id: String,
+}
+
+/// The automatically persisted "last session".
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LastSession {
+    /// Schema version for forward compatibility.
+    pub version: String,
+    /// The captured tab groups (panel trees) of the session.
+    pub tab_groups: Vec<WorkspaceTabGroupDef>,
+    /// Index into `tab_groups` of the group that was active.
+    pub active_group_index: i64,
+    /// The windows the session spanned, in restore order (#1905).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub windows: Option<Vec<WorkspaceWindowDef>>,
+}
+
+// ── Output types ─────────────────────────────────────────────────────────────
+
+/// The three restore modes.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum RestoreLastSessionMode {
+    /// Never restore; start with a fresh empty session.
+    Never,
+    /// Show a dialog offering to restore the previous session.
+    Ask,
+    /// Restore the previous session silently.
+    Always,
+}
+
+/// How a stored tab connects, selecting the reachability check to run.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TargetKind {
+    /// TCP host target (SSH/telnet) — network-probed.
+    Host,
+    /// Serial device target — device-presence probed.
+    Serial,
+    /// Local/docker/WSL/unresolved — not network-probed.
+    Local,
+    /// Remote agent target — not network-probed.
+    Agent,
+}
+
+/// The connection target derived from a stored tab, driving the reachability probe.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RestoreTabTarget {
+    /// How the tab connects.
+    pub kind: TargetKind,
+    /// Target host for `host` targets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    /// Target TCP port for `host` targets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port: Option<i64>,
+    /// Serial device path for `serial` targets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub device: Option<String>,
+    /// Remote agent id for `agent` targets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+}
+
+/// A single restorable tab, described for the restore dialog.
+///
+/// `reachability` / `unreachable_reason` are set asynchronously by the probe,
+/// never by [`summarize_last_session`], so they are absent in this port's output
+/// (matching the TS summary output shape exactly).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RestoreTabInfo {
+    /// Human-readable tab title.
+    pub title: String,
+    /// Short connection-type label (e.g. "SSH", "Serial", "Local").
+    pub type_label: String,
+    /// The probe target derived from the stored tab.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<RestoreTabTarget>,
+    /// Reachability of `target`, set once the probe resolves.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reachability: Option<String>,
+    /// Reason shown beside the warning icon when unreachable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unreachable_reason: Option<String>,
+}
+
+/// Summary of a stored last session for the restore dialog.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RestorePrompt {
+    /// Total number of restorable tabs across all groups.
+    pub tab_count: usize,
+    /// Per-tab descriptors for display.
+    pub tabs: Vec<RestoreTabInfo>,
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Get all leaf nodes from a workspace layout tree, depth-first left-to-right.
+///
+/// Rust twin of `getWorkspaceLeaves` from `workspaceLayout.ts`, the one runtime
+/// dependency `restoreMode.ts` has. Ported here (rather than the whole
+/// `workspaceLayout.ts`) because the restore logic only needs the leaf walk.
+pub fn get_workspace_leaves(node: &WorkspaceLayoutNode) -> Vec<&WorkspaceLeafNode> {
+    match node {
+        WorkspaceLayoutNode::Leaf(leaf) => vec![leaf],
+        WorkspaceLayoutNode::Split(split) => split
+            .children
+            .iter()
+            .flat_map(get_workspace_leaves)
+            .collect(),
+    }
+}
+
+/// Resolve the effective restore mode from settings, migrating the legacy
+/// boolean `restore_last_session_on_startup` when the explicit mode is unset.
+///
+/// - explicit [`AppSettings::restore_last_session_mode`] wins when valid;
+/// - otherwise the legacy boolean `== false` maps to `Never`;
+/// - otherwise the default is `Ask`.
+pub fn resolve_restore_mode(settings: &AppSettings) -> RestoreLastSessionMode {
+    if let Some(explicit) = settings.restore_last_session_mode.as_deref() {
+        match explicit {
+            "never" => return RestoreLastSessionMode::Never,
+            "ask" => return RestoreLastSessionMode::Ask,
+            "always" => return RestoreLastSessionMode::Always,
+            _ => {}
+        }
+    }
+    if settings.restore_last_session_on_startup == Some(false) {
+        return RestoreLastSessionMode::Never;
+    }
+    RestoreLastSessionMode::Ask
+}
+
+/// Default TCP ports for host-based connection types, used when unspecified.
+fn default_host_port(type_: &str) -> Option<i64> {
+    match type_ {
+        "ssh" => Some(22),
+        "telnet" => Some(23),
+        _ => None,
+    }
+}
+
+/// Map a stored tab definition's connection type to a short display label.
+fn tab_type_label(tab: &WorkspaceTabDef) -> String {
+    if tab.agent_ref.is_some() {
+        return "Agent".to_string();
+    }
+    let type_ = tab.inline_config.as_ref().map(|c| c.type_.as_str());
+    match type_ {
+        Some("ssh") => "SSH".to_string(),
+        Some("serial") => "Serial".to_string(),
+        Some("telnet") => "Telnet".to_string(),
+        Some("docker") => "Docker".to_string(),
+        Some("wsl") => "WSL".to_string(),
+        Some("local") => "Local".to_string(),
+        Some(t) if !t.is_empty() => capitalize_first(t),
+        _ => "Terminal".to_string(),
+    }
+}
+
+/// Uppercase the first character, mirroring TS `s.charAt(0).toUpperCase() + s.slice(1)`.
+fn capitalize_first(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+/// Read a string field from a JSON config bag.
+fn config_str<'a>(config: &'a Value, key: &str) -> Option<&'a str> {
+    config.get(key).and_then(Value::as_str)
+}
+
+/// Best-effort title for a stored tab when no explicit title was captured.
+fn tab_fallback_title(tab: &WorkspaceTabDef) -> String {
+    let cfg = tab.inline_config.as_ref().map(|c| &c.config);
+    if let Some(cfg) = cfg {
+        if let Some(host) = config_str(cfg, "host") {
+            return match config_str(cfg, "username") {
+                Some(user) => format!("{user}@{host}"),
+                None => host.to_string(),
+            };
+        }
+        if let Some(device) = config_str(cfg, "device") {
+            return device.to_string();
+        }
+    }
+    tab_type_label(tab)
+}
+
+/// Resolve a stored tab's effective `(type, config)`, following a
+/// `connection_ref` into the supplied saved connections when present.
+fn resolve_tab_config<'a>(
+    tab: &'a WorkspaceTabDef,
+    connections: &'a [SavedConnection],
+) -> Option<(&'a str, &'a Value)> {
+    if let Some(inline) = &tab.inline_config {
+        return Some((inline.type_.as_str(), &inline.config));
+    }
+    if let Some(ref_id) = &tab.connection_ref {
+        if let Some(saved) = connections.iter().find(|c| &c.id == ref_id) {
+            return Some((saved.config.type_.as_str(), &saved.config.config));
+        }
+    }
+    None
+}
+
+/// Derive the reachability [`RestoreTabTarget`] for a stored tab.
+fn derive_tab_target(tab: &WorkspaceTabDef, connections: &[SavedConnection]) -> RestoreTabTarget {
+    if let Some(agent) = &tab.agent_ref {
+        return RestoreTabTarget {
+            kind: TargetKind::Agent,
+            host: None,
+            port: None,
+            device: None,
+            agent_id: Some(agent.agent_id.clone()),
+        };
+    }
+
+    let resolved = resolve_tab_config(tab, connections);
+    let type_ = resolved.map(|(t, _)| t);
+    let empty = Value::Null;
+    let config = resolved.map(|(_, c)| c).unwrap_or(&empty);
+
+    if type_ == Some("ssh") || type_ == Some("telnet") {
+        if let Some(host) = config_str(config, "host") {
+            let port = config
+                .get("port")
+                .and_then(Value::as_i64)
+                .or_else(|| default_host_port(type_.unwrap_or("")));
+            return RestoreTabTarget {
+                kind: TargetKind::Host,
+                host: Some(host.to_string()),
+                port,
+                device: None,
+                agent_id: None,
+            };
+        }
+    }
+
+    if type_ == Some("serial") {
+        let device = config_str(config, "device").or_else(|| config_str(config, "port"));
+        if let Some(device) = device {
+            return RestoreTabTarget {
+                kind: TargetKind::Serial,
+                host: None,
+                port: None,
+                device: Some(device.to_string()),
+                agent_id: None,
+            };
+        }
+    }
+
+    RestoreTabTarget {
+        kind: TargetKind::Local,
+        host: None,
+        port: None,
+        device: None,
+        agent_id: None,
+    }
+}
+
+/// Flatten a stored [`LastSession`] into a per-tab summary for the restore
+/// dialog. Iterates groups → leaves → tabs in a stable order; that same order is
+/// the tab index space used by [`filter_session_by_selection`].
+pub fn summarize_last_session(
+    session: &LastSession,
+    connections: &[SavedConnection],
+) -> RestorePrompt {
+    let mut tabs: Vec<RestoreTabInfo> = Vec::new();
+    for group in &session.tab_groups {
+        for leaf in get_workspace_leaves(&group.layout) {
+            for tab in &leaf.tabs {
+                let title = tab
+                    .title
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string)
+                    .unwrap_or_else(|| tab_fallback_title(tab));
+                tabs.push(RestoreTabInfo {
+                    title,
+                    type_label: tab_type_label(tab),
+                    target: Some(derive_tab_target(tab, connections)),
+                    reachability: None,
+                    unreachable_reason: None,
+                });
+            }
+        }
+    }
+    RestorePrompt {
+        tab_count: tabs.len(),
+        tabs,
+    }
+}
+
+/// Prune one layout node down to the selected tabs, advancing the flat tab index
+/// counter. Returns `None` when the node (and every descendant) is emptied.
+fn filter_node(
+    node: &WorkspaceLayoutNode,
+    selected: &HashSet<i64>,
+    flat_index: &mut i64,
+) -> Option<WorkspaceLayoutNode> {
+    match node {
+        WorkspaceLayoutNode::Leaf(leaf) => {
+            let tabs: Vec<WorkspaceTabDef> = leaf
+                .tabs
+                .iter()
+                .filter(|_| {
+                    let i = *flat_index;
+                    *flat_index += 1;
+                    selected.contains(&i)
+                })
+                .cloned()
+                .collect();
+            if tabs.is_empty() {
+                None
+            } else {
+                Some(WorkspaceLayoutNode::Leaf(WorkspaceLeafNode { tabs }))
+            }
+        }
+        WorkspaceLayoutNode::Split(split) => {
+            let mut kept_children: Vec<WorkspaceLayoutNode> = Vec::new();
+            let mut kept_original_indices: Vec<usize> = Vec::new();
+            for (i, child) in split.children.iter().enumerate() {
+                if let Some(filtered) = filter_node(child, selected, flat_index) {
+                    kept_children.push(filtered);
+                    kept_original_indices.push(i);
+                }
+            }
+
+            if kept_children.is_empty() {
+                return None;
+            }
+            if kept_children.len() == 1 {
+                return kept_children.into_iter().next();
+            }
+
+            let sizes = split.sizes.as_ref().and_then(|sizes| {
+                let chosen: Vec<f64> = kept_original_indices
+                    .iter()
+                    .map(|&i| sizes.get(i).copied().unwrap_or(0.0))
+                    .collect();
+                let total: f64 = chosen.iter().sum();
+                if total > 0.0 {
+                    Some(chosen.iter().map(|s| (s / total) * 100.0).collect())
+                } else {
+                    None
+                }
+            });
+
+            Some(WorkspaceLayoutNode::Split(WorkspaceSplitNode {
+                direction: split.direction,
+                children: kept_children,
+                sizes,
+            }))
+        }
+    }
+}
+
+/// Prune a stored [`LastSession`] down to the tabs the user chose to restore.
+///
+/// `selected` holds the flat tab indices to keep, in the same order
+/// [`summarize_last_session`] produced. Leaves left with no tabs are dropped,
+/// splits collapse when only one child survives (redistributing sizes), and tab
+/// groups whose layout empties out are removed. `active_group_index` is remapped
+/// to the surviving group nearest the original active one; `windows` are
+/// preserved untouched (an emptied window still round-trips, per #1902).
+pub fn filter_session_by_selection(session: &LastSession, selected: &HashSet<i64>) -> LastSession {
+    let mut flat_index = 0i64;
+
+    let mut groups: Vec<WorkspaceTabGroupDef> = Vec::new();
+    let mut kept_group_indices: Vec<i64> = Vec::new();
+    for (i, group) in session.tab_groups.iter().enumerate() {
+        if let Some(layout) = filter_node(&group.layout, selected, &mut flat_index) {
+            groups.push(WorkspaceTabGroupDef {
+                layout,
+                ..group.clone()
+            });
+            kept_group_indices.push(i as i64);
+        }
+    }
+
+    // Remap the active group to a surviving one: the same group if it survived,
+    // otherwise the nearest surviving group at or after it, else the first.
+    let mut active_group_index = 0i64;
+    if !kept_group_indices.is_empty() {
+        if let Some(exact) = kept_group_indices
+            .iter()
+            .position(|&i| i == session.active_group_index)
+        {
+            active_group_index = exact as i64;
+        } else if let Some(after) = kept_group_indices
+            .iter()
+            .position(|&i| i >= session.active_group_index)
+        {
+            active_group_index = after as i64;
+        } else {
+            active_group_index = (kept_group_indices.len() - 1) as i64;
+        }
+    }
+
+    LastSession {
+        tab_groups: groups,
+        active_group_index,
+        ..session.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/core/src/restore_mode/tests.rs
+++ b/core/src/restore_mode/tests.rs
@@ -1,0 +1,519 @@
+//! Unit tests (mirroring `restoreMode.test.ts`) plus property tests over the
+//! session-pruning invariants.
+
+use super::*;
+use proptest::prelude::*;
+use serde_json::json;
+
+/// Build an [`AppSettings`] from the two fields the decision reads.
+fn settings(mode: Option<&str>, legacy: Option<bool>) -> AppSettings {
+    AppSettings {
+        restore_last_session_mode: mode.map(str::to_string),
+        restore_last_session_on_startup: legacy,
+    }
+}
+
+/// A leaf node from a list of tabs.
+fn leaf(tabs: Vec<WorkspaceTabDef>) -> WorkspaceLayoutNode {
+    WorkspaceLayoutNode::Leaf(WorkspaceLeafNode { tabs })
+}
+
+/// A single-group session wrapping `layout`.
+fn one_group_session(layout: WorkspaceLayoutNode) -> LastSession {
+    LastSession {
+        version: "1".to_string(),
+        tab_groups: vec![WorkspaceTabGroupDef {
+            name: "Group".to_string(),
+            color: None,
+            layout,
+            window_id: None,
+        }],
+        active_group_index: 0,
+        windows: None,
+    }
+}
+
+/// An inline-config tab with an optional title.
+fn inline_tab(title: Option<&str>, type_: &str, config: serde_json::Value) -> WorkspaceTabDef {
+    WorkspaceTabDef {
+        title: title.map(str::to_string),
+        inline_config: Some(InlineConfig {
+            type_: type_.to_string(),
+            config,
+        }),
+        ..Default::default()
+    }
+}
+
+// ── resolveRestoreMode ───────────────────────────────────────────────────────
+
+#[test]
+fn resolve_returns_explicit_mode_when_set() {
+    assert_eq!(
+        resolve_restore_mode(&settings(Some("never"), None)),
+        RestoreLastSessionMode::Never
+    );
+    assert_eq!(
+        resolve_restore_mode(&settings(Some("ask"), None)),
+        RestoreLastSessionMode::Ask
+    );
+    assert_eq!(
+        resolve_restore_mode(&settings(Some("always"), None)),
+        RestoreLastSessionMode::Always
+    );
+}
+
+#[test]
+fn resolve_prefers_explicit_over_legacy_boolean() {
+    assert_eq!(
+        resolve_restore_mode(&settings(Some("always"), Some(false))),
+        RestoreLastSessionMode::Always
+    );
+}
+
+#[test]
+fn resolve_migrates_legacy_false_to_never() {
+    assert_eq!(
+        resolve_restore_mode(&settings(None, Some(false))),
+        RestoreLastSessionMode::Never
+    );
+}
+
+#[test]
+fn resolve_defaults_to_ask_when_nothing_set() {
+    assert_eq!(
+        resolve_restore_mode(&settings(None, None)),
+        RestoreLastSessionMode::Ask
+    );
+}
+
+#[test]
+fn resolve_defaults_to_ask_when_legacy_true() {
+    assert_eq!(
+        resolve_restore_mode(&settings(None, Some(true))),
+        RestoreLastSessionMode::Ask
+    );
+}
+
+#[test]
+fn resolve_falls_through_to_ask_for_out_of_range_mode() {
+    assert_eq!(
+        resolve_restore_mode(&settings(Some("bogus"), None)),
+        RestoreLastSessionMode::Ask
+    );
+}
+
+// ── summarizeLastSession ─────────────────────────────────────────────────────
+
+fn nested_session() -> LastSession {
+    one_group_session(WorkspaceLayoutNode::Split(WorkspaceSplitNode {
+        direction: SplitDirection::Horizontal,
+        children: vec![
+            leaf(vec![
+                inline_tab(Some("prod-db"), "ssh", json!({ "host": "prod-db" })),
+                inline_tab(None, "serial", json!({ "device": "/dev/ttyUSB0" })),
+            ]),
+            leaf(vec![inline_tab(None, "local", json!({ "shell": "bash" }))]),
+        ],
+        sizes: None,
+    }))
+}
+
+#[test]
+fn summarize_counts_every_tab_across_nested_leaves() {
+    assert_eq!(summarize_last_session(&nested_session(), &[]).tab_count, 3);
+}
+
+#[test]
+fn summarize_uses_title_override_and_type_labels() {
+    let tabs = summarize_last_session(&nested_session(), &[]).tabs;
+    assert_eq!(tabs[0].title, "prod-db");
+    assert_eq!(tabs[0].type_label, "SSH");
+    // No title falls back to the device path with the Serial badge.
+    assert_eq!(tabs[1].title, "/dev/ttyUSB0");
+    assert_eq!(tabs[1].type_label, "Serial");
+    assert_eq!(tabs[2].title, "Local");
+    assert_eq!(tabs[2].type_label, "Local");
+}
+
+#[test]
+fn summarize_derives_a_probe_target_per_tab() {
+    let tabs = summarize_last_session(&nested_session(), &[]).tabs;
+    assert_eq!(
+        tabs[0].target,
+        Some(RestoreTabTarget {
+            kind: TargetKind::Host,
+            host: Some("prod-db".to_string()),
+            port: Some(22),
+            device: None,
+            agent_id: None,
+        })
+    );
+    assert_eq!(
+        tabs[1].target,
+        Some(RestoreTabTarget {
+            kind: TargetKind::Serial,
+            host: None,
+            port: None,
+            device: Some("/dev/ttyUSB0".to_string()),
+            agent_id: None,
+        })
+    );
+    assert_eq!(
+        tabs[2].target.as_ref().map(|t| t.kind),
+        Some(TargetKind::Local)
+    );
+}
+
+#[test]
+fn summarize_uses_the_telnet_default_port() {
+    let session = one_group_session(leaf(vec![inline_tab(
+        None,
+        "telnet",
+        json!({ "host": "switch" }),
+    )]));
+    assert_eq!(
+        summarize_last_session(&session, &[]).tabs[0].target,
+        Some(RestoreTabTarget {
+            kind: TargetKind::Host,
+            host: Some("switch".to_string()),
+            port: Some(23),
+            device: None,
+            agent_id: None,
+        })
+    );
+}
+
+#[test]
+fn summarize_honours_an_explicit_host_port() {
+    let session = one_group_session(leaf(vec![inline_tab(
+        None,
+        "ssh",
+        json!({ "host": "h", "port": 2222 }),
+    )]));
+    assert_eq!(
+        summarize_last_session(&session, &[]).tabs[0]
+            .target
+            .as_ref()
+            .and_then(|t| t.port),
+        Some(2222)
+    );
+}
+
+#[test]
+fn summarize_resolves_a_connection_ref_target() {
+    let connections = vec![SavedConnection {
+        id: "c1".to_string(),
+        config: ConnectionConfig {
+            type_: "ssh".to_string(),
+            config: json!({ "host": "10.0.0.5", "port": 22 }),
+        },
+    }];
+    let session = one_group_session(leaf(vec![WorkspaceTabDef {
+        connection_ref: Some("c1".to_string()),
+        title: Some("prod".to_string()),
+        ..Default::default()
+    }]));
+    assert_eq!(
+        summarize_last_session(&session, &connections).tabs[0].target,
+        Some(RestoreTabTarget {
+            kind: TargetKind::Host,
+            host: Some("10.0.0.5".to_string()),
+            port: Some(22),
+            device: None,
+            agent_id: None,
+        })
+    );
+    // Without the connections the ref cannot resolve → not network-probed.
+    assert_eq!(
+        summarize_last_session(&session, &[]).tabs[0]
+            .target
+            .as_ref()
+            .map(|t| t.kind),
+        Some(TargetKind::Local)
+    );
+}
+
+#[test]
+fn summarize_derives_an_agent_target() {
+    let session = one_group_session(leaf(vec![WorkspaceTabDef {
+        agent_ref: Some(AgentRef {
+            agent_id: "a1".to_string(),
+            definition_id: "d1".to_string(),
+        }),
+        ..Default::default()
+    }]));
+    assert_eq!(
+        summarize_last_session(&session, &[]).tabs[0].target,
+        Some(RestoreTabTarget {
+            kind: TargetKind::Agent,
+            host: None,
+            port: None,
+            device: None,
+            agent_id: Some("a1".to_string()),
+        })
+    );
+    assert_eq!(
+        summarize_last_session(&session, &[]).tabs[0].type_label,
+        "Agent"
+    );
+}
+
+#[test]
+fn summarize_reports_zero_tabs_for_empty_session() {
+    let session = one_group_session(leaf(vec![]));
+    let prompt = summarize_last_session(&session, &[]);
+    assert_eq!(prompt.tab_count, 0);
+    assert!(prompt.tabs.is_empty());
+}
+
+// ── filterSessionBySelection ─────────────────────────────────────────────────
+
+fn filter_fixture_session() -> LastSession {
+    one_group_session(WorkspaceLayoutNode::Split(WorkspaceSplitNode {
+        direction: SplitDirection::Horizontal,
+        sizes: Some(vec![60.0, 40.0]),
+        children: vec![
+            leaf(vec![
+                inline_tab(Some("ssh"), "ssh", json!({ "host": "h" })),
+                inline_tab(Some("serial"), "serial", json!({ "device": "/dev/x" })),
+            ]),
+            leaf(vec![inline_tab(Some("local"), "local", json!({}))]),
+        ],
+    }))
+}
+
+fn set(indices: &[i64]) -> HashSet<i64> {
+    indices.iter().copied().collect()
+}
+
+fn collect_titles(session: &LastSession) -> Vec<String> {
+    session
+        .tab_groups
+        .iter()
+        .flat_map(|g| get_workspace_leaves(&g.layout))
+        .flat_map(|l| l.tabs.iter().filter_map(|t| t.title.clone()))
+        .collect()
+}
+
+fn count_tabs(node: &WorkspaceLayoutNode) -> usize {
+    match node {
+        WorkspaceLayoutNode::Leaf(l) => l.tabs.len(),
+        WorkspaceLayoutNode::Split(s) => s.children.iter().map(count_tabs).sum(),
+    }
+}
+
+#[test]
+fn filter_keeps_only_selected_tabs() {
+    let filtered = filter_session_by_selection(&filter_fixture_session(), &set(&[0, 2]));
+    assert_eq!(collect_titles(&filtered), vec!["ssh", "local"]);
+}
+
+#[test]
+fn filter_collapses_a_split_whose_sibling_empties() {
+    // Deselect the local tab (index 2) → second leaf empties, the split
+    // collapses to the first leaf.
+    let filtered = filter_session_by_selection(&filter_fixture_session(), &set(&[0, 1]));
+    let layout = &filtered.tab_groups[0].layout;
+    assert!(matches!(layout, WorkspaceLayoutNode::Leaf(_)));
+    assert_eq!(count_tabs(layout), 2);
+}
+
+#[test]
+fn filter_drops_a_group_whose_every_tab_was_deselected() {
+    let two_groups = LastSession {
+        version: "1".to_string(),
+        active_group_index: 1,
+        windows: None,
+        tab_groups: vec![
+            WorkspaceTabGroupDef {
+                name: "A".to_string(),
+                color: None,
+                window_id: None,
+                layout: leaf(vec![WorkspaceTabDef {
+                    title: Some("a".to_string()),
+                    ..Default::default()
+                }]),
+            },
+            WorkspaceTabGroupDef {
+                name: "B".to_string(),
+                color: None,
+                window_id: None,
+                layout: leaf(vec![WorkspaceTabDef {
+                    title: Some("b".to_string()),
+                    ..Default::default()
+                }]),
+            },
+        ],
+    };
+    // Keep only tab 0 (group A) → group B is removed, active remaps to A.
+    let filtered = filter_session_by_selection(&two_groups, &set(&[0]));
+    assert_eq!(
+        filtered
+            .tab_groups
+            .iter()
+            .map(|g| g.name.clone())
+            .collect::<Vec<_>>(),
+        vec!["A"]
+    );
+    assert_eq!(filtered.active_group_index, 0);
+}
+
+#[test]
+fn filter_yields_no_groups_when_nothing_selected() {
+    let filtered = filter_session_by_selection(&filter_fixture_session(), &HashSet::new());
+    assert!(filtered.tab_groups.is_empty());
+}
+
+#[test]
+fn filter_redistributes_sizes_when_a_child_is_dropped() {
+    // A three-way split; drop the middle child by deselecting its only tab.
+    let session = one_group_session(WorkspaceLayoutNode::Split(WorkspaceSplitNode {
+        direction: SplitDirection::Vertical,
+        sizes: Some(vec![50.0, 30.0, 20.0]),
+        children: vec![
+            leaf(vec![WorkspaceTabDef::default()]),
+            leaf(vec![WorkspaceTabDef::default()]),
+            leaf(vec![WorkspaceTabDef::default()]),
+        ],
+    }));
+    // Keep tabs 0 and 2 (drop index 1, the middle leaf).
+    let filtered = filter_session_by_selection(&session, &set(&[0, 2]));
+    match &filtered.tab_groups[0].layout {
+        WorkspaceLayoutNode::Split(s) => {
+            // 50 and 20 renormalize to 100: 50/70*100, 20/70*100.
+            let sizes = s.sizes.as_ref().expect("sizes preserved");
+            assert!((sizes[0] - 50.0 / 70.0 * 100.0).abs() < 1e-9);
+            assert!((sizes[1] - 20.0 / 70.0 * 100.0).abs() < 1e-9);
+        }
+        _ => panic!("expected a two-child split"),
+    }
+}
+
+// ── getWorkspaceLeaves ───────────────────────────────────────────────────────
+
+#[test]
+fn get_workspace_leaves_walks_depth_first() {
+    let tree = WorkspaceLayoutNode::Split(WorkspaceSplitNode {
+        direction: SplitDirection::Horizontal,
+        sizes: None,
+        children: vec![
+            leaf(vec![inline_tab(Some("a"), "local", json!({}))]),
+            WorkspaceLayoutNode::Split(WorkspaceSplitNode {
+                direction: SplitDirection::Vertical,
+                sizes: None,
+                children: vec![
+                    leaf(vec![inline_tab(Some("b"), "local", json!({}))]),
+                    leaf(vec![inline_tab(Some("c"), "local", json!({}))]),
+                ],
+            }),
+        ],
+    });
+    let leaves = get_workspace_leaves(&tree);
+    assert_eq!(leaves.len(), 3);
+    let titles: Vec<_> = leaves
+        .iter()
+        .flat_map(|l| l.tabs.iter().filter_map(|t| t.title.as_deref()))
+        .collect();
+    assert_eq!(titles, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn get_workspace_leaves_on_a_single_leaf() {
+    let tree = leaf(vec![WorkspaceTabDef::default()]);
+    assert_eq!(get_workspace_leaves(&tree).len(), 1);
+}
+
+// ── Property tests ───────────────────────────────────────────────────────────
+
+/// Assert no leaf is empty and no split has fewer than two children — the
+/// structural invariants [`filter_session_by_selection`] must uphold.
+fn assert_well_formed(node: &WorkspaceLayoutNode) -> Result<(), TestCaseError> {
+    match node {
+        WorkspaceLayoutNode::Leaf(l) => {
+            prop_assert!(!l.tabs.is_empty(), "kept leaf must be non-empty");
+        }
+        WorkspaceLayoutNode::Split(s) => {
+            prop_assert!(s.children.len() >= 2, "split must keep >= 2 children");
+            for child in &s.children {
+                assert_well_formed(child)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn arb_tab() -> impl Strategy<Value = WorkspaceTabDef> {
+    prop::option::of("[a-z]{1,4}").prop_map(|title| WorkspaceTabDef {
+        title,
+        ..Default::default()
+    })
+}
+
+fn arb_layout() -> impl Strategy<Value = WorkspaceLayoutNode> {
+    let leaf = prop::collection::vec(arb_tab(), 0..4)
+        .prop_map(|tabs| WorkspaceLayoutNode::Leaf(WorkspaceLeafNode { tabs }));
+    leaf.prop_recursive(3, 24, 4, |inner| {
+        (
+            prop::sample::select(vec![SplitDirection::Horizontal, SplitDirection::Vertical]),
+            prop::collection::vec(inner, 1..4),
+        )
+            .prop_map(|(direction, children)| {
+                WorkspaceLayoutNode::Split(WorkspaceSplitNode {
+                    direction,
+                    children,
+                    sizes: None,
+                })
+            })
+    })
+}
+
+proptest! {
+    /// Filtering keeps exactly the selected tabs and always yields a well-formed
+    /// tree (no empty leaves, no under-filled splits).
+    #[test]
+    fn prop_filter_keeps_exactly_selected(layout in arb_layout(), picks in prop::collection::vec(any::<bool>(), 0..48)) {
+        let session = one_group_session(layout.clone());
+        let total = count_tabs(&layout);
+        let selected: HashSet<i64> = (0..total as i64)
+            .filter(|i| *picks.get(*i as usize).unwrap_or(&false))
+            .collect();
+        let expected = selected.len();
+
+        let out = filter_session_by_selection(&session, &selected);
+        let got: usize = out.tab_groups.iter().map(|g| count_tabs(&g.layout)).sum();
+        prop_assert_eq!(got, expected);
+
+        for g in &out.tab_groups {
+            assert_well_formed(&g.layout)?;
+        }
+        // A group survives iff it retained at least one tab.
+        prop_assert_eq!(out.tab_groups.is_empty(), expected == 0);
+    }
+
+    /// The active-group index always points at a surviving group (or 0 when none).
+    #[test]
+    fn prop_active_index_stays_in_range(layout in arb_layout(), picks in prop::collection::vec(any::<bool>(), 0..48)) {
+        let session = one_group_session(layout.clone());
+        let total = count_tabs(&layout);
+        let selected: HashSet<i64> = (0..total as i64)
+            .filter(|i| *picks.get(*i as usize).unwrap_or(&false))
+            .collect();
+        let out = filter_session_by_selection(&session, &selected);
+        if out.tab_groups.is_empty() {
+            prop_assert_eq!(out.active_group_index, 0);
+        } else {
+            prop_assert!(out.active_group_index >= 0);
+            prop_assert!((out.active_group_index as usize) < out.tab_groups.len());
+        }
+    }
+
+    /// The summary reports one tab per leaf-tab and its count matches the tree.
+    #[test]
+    fn prop_summary_counts_all_tabs(layout in arb_layout()) {
+        let session = one_group_session(layout.clone());
+        let prompt = summarize_last_session(&session, &[]);
+        prop_assert_eq!(prompt.tab_count, count_tabs(&layout));
+        prop_assert_eq!(prompt.tabs.len(), count_tabs(&layout));
+    }
+}

--- a/core/tests/fixtures/golden/restore_mode/filter_session_by_selection.json
+++ b/core/tests/fixtures/golden/restore_mode/filter_session_by_selection.json
@@ -1,0 +1,176 @@
+{
+  "operation": "filterSessionBySelection",
+  "cases": [
+    {
+      "name": "keeps only the selected tabs across a split",
+      "input": {
+        "version": "1",
+        "activeGroupIndex": 0,
+        "tabGroups": [
+          {
+            "name": "Group",
+            "layout": {
+              "type": "split",
+              "direction": "horizontal",
+              "sizes": [60, 40],
+              "children": [
+                {
+                  "type": "leaf",
+                  "tabs": [
+                    { "title": "ssh", "inlineConfig": { "type": "ssh", "config": { "host": "h" } } },
+                    { "title": "serial", "inlineConfig": { "type": "serial", "config": { "device": "/dev/x" } } }
+                  ]
+                },
+                { "type": "leaf", "tabs": [{ "title": "local", "inlineConfig": { "type": "local", "config": {} } }] }
+              ]
+            }
+          }
+        ]
+      },
+      "args": { "selected": [0, 2] },
+      "expected": {
+        "version": "1",
+        "activeGroupIndex": 0,
+        "tabGroups": [
+          {
+            "name": "Group",
+            "layout": {
+              "type": "split",
+              "direction": "horizontal",
+              "sizes": [60, 40],
+              "children": [
+                { "type": "leaf", "tabs": [{ "title": "ssh", "inlineConfig": { "type": "ssh", "config": { "host": "h" } } }] },
+                { "type": "leaf", "tabs": [{ "title": "local", "inlineConfig": { "type": "local", "config": {} } }] }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "collapses a split whose sibling leaf empties out",
+      "input": {
+        "version": "1",
+        "activeGroupIndex": 0,
+        "tabGroups": [
+          {
+            "name": "Group",
+            "layout": {
+              "type": "split",
+              "direction": "horizontal",
+              "sizes": [60, 40],
+              "children": [
+                {
+                  "type": "leaf",
+                  "tabs": [
+                    { "title": "ssh", "inlineConfig": { "type": "ssh", "config": { "host": "h" } } },
+                    { "title": "serial", "inlineConfig": { "type": "serial", "config": { "device": "/dev/x" } } }
+                  ]
+                },
+                { "type": "leaf", "tabs": [{ "title": "local", "inlineConfig": { "type": "local", "config": {} } }] }
+              ]
+            }
+          }
+        ]
+      },
+      "args": { "selected": [0, 1] },
+      "expected": {
+        "version": "1",
+        "activeGroupIndex": 0,
+        "tabGroups": [
+          {
+            "name": "Group",
+            "layout": {
+              "type": "leaf",
+              "tabs": [
+                { "title": "ssh", "inlineConfig": { "type": "ssh", "config": { "host": "h" } } },
+                { "title": "serial", "inlineConfig": { "type": "serial", "config": { "device": "/dev/x" } } }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "drops a group whose every tab was deselected and remaps active",
+      "input": {
+        "version": "1",
+        "activeGroupIndex": 1,
+        "tabGroups": [
+          { "name": "A", "layout": { "type": "leaf", "tabs": [{ "title": "a" }] } },
+          { "name": "B", "layout": { "type": "leaf", "tabs": [{ "title": "b" }] } }
+        ]
+      },
+      "args": { "selected": [0] },
+      "expected": {
+        "version": "1",
+        "activeGroupIndex": 0,
+        "tabGroups": [{ "name": "A", "layout": { "type": "leaf", "tabs": [{ "title": "a" }] } }]
+      }
+    },
+    {
+      "name": "yields no groups when nothing is selected",
+      "input": {
+        "version": "1",
+        "activeGroupIndex": 0,
+        "tabGroups": [
+          {
+            "name": "Group",
+            "layout": {
+              "type": "split",
+              "direction": "horizontal",
+              "sizes": [60, 40],
+              "children": [
+                { "type": "leaf", "tabs": [{ "title": "ssh" }, { "title": "serial" }] },
+                { "type": "leaf", "tabs": [{ "title": "local" }] }
+              ]
+            }
+          }
+        ]
+      },
+      "args": { "selected": [] },
+      "expected": { "version": "1", "activeGroupIndex": 0, "tabGroups": [] }
+    },
+    {
+      "name": "redistributes sizes when a middle child is dropped",
+      "input": {
+        "version": "1",
+        "activeGroupIndex": 0,
+        "tabGroups": [
+          {
+            "name": "G",
+            "layout": {
+              "type": "split",
+              "direction": "vertical",
+              "sizes": [60, 20, 20],
+              "children": [
+                { "type": "leaf", "tabs": [{ "title": "x" }] },
+                { "type": "leaf", "tabs": [{ "title": "y" }] },
+                { "type": "leaf", "tabs": [{ "title": "z" }] }
+              ]
+            }
+          }
+        ]
+      },
+      "args": { "selected": [0, 2] },
+      "expected": {
+        "version": "1",
+        "activeGroupIndex": 0,
+        "tabGroups": [
+          {
+            "name": "G",
+            "layout": {
+              "type": "split",
+              "direction": "vertical",
+              "sizes": [75, 25],
+              "children": [
+                { "type": "leaf", "tabs": [{ "title": "x" }] },
+                { "type": "leaf", "tabs": [{ "title": "z" }] }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/restore_mode/get_workspace_leaves.json
+++ b/core/tests/fixtures/golden/restore_mode/get_workspace_leaves.json
@@ -1,0 +1,33 @@
+{
+  "operation": "getWorkspaceLeaves",
+  "cases": [
+    {
+      "name": "a single leaf returns itself",
+      "input": { "type": "leaf", "tabs": [{ "title": "only" }] },
+      "expected": [{ "type": "leaf", "tabs": [{ "title": "only" }] }]
+    },
+    {
+      "name": "nested splits flatten depth-first left-to-right",
+      "input": {
+        "type": "split",
+        "direction": "horizontal",
+        "children": [
+          { "type": "leaf", "tabs": [{ "title": "a" }] },
+          {
+            "type": "split",
+            "direction": "vertical",
+            "children": [
+              { "type": "leaf", "tabs": [{ "title": "b" }] },
+              { "type": "leaf", "tabs": [{ "title": "c" }] }
+            ]
+          }
+        ]
+      },
+      "expected": [
+        { "type": "leaf", "tabs": [{ "title": "a" }] },
+        { "type": "leaf", "tabs": [{ "title": "b" }] },
+        { "type": "leaf", "tabs": [{ "title": "c" }] }
+      ]
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/restore_mode/resolve_restore_mode.json
+++ b/core/tests/fixtures/golden/restore_mode/resolve_restore_mode.json
@@ -1,0 +1,45 @@
+{
+  "operation": "resolveRestoreMode",
+  "cases": [
+    {
+      "name": "explicit never wins",
+      "input": { "version": "1", "externalConnectionFiles": [], "restoreLastSessionMode": "never" },
+      "expected": "never"
+    },
+    {
+      "name": "explicit ask wins",
+      "input": { "version": "1", "externalConnectionFiles": [], "restoreLastSessionMode": "ask" },
+      "expected": "ask"
+    },
+    {
+      "name": "explicit always wins",
+      "input": { "version": "1", "externalConnectionFiles": [], "restoreLastSessionMode": "always" },
+      "expected": "always"
+    },
+    {
+      "name": "explicit mode beats the legacy boolean",
+      "input": { "version": "1", "restoreLastSessionMode": "always", "restoreLastSessionOnStartup": false },
+      "expected": "always"
+    },
+    {
+      "name": "legacy boolean false migrates to never",
+      "input": { "version": "1", "restoreLastSessionOnStartup": false },
+      "expected": "never"
+    },
+    {
+      "name": "defaults to ask when nothing is set",
+      "input": { "version": "1", "externalConnectionFiles": [] },
+      "expected": "ask"
+    },
+    {
+      "name": "legacy boolean true defaults to ask",
+      "input": { "version": "1", "restoreLastSessionOnStartup": true },
+      "expected": "ask"
+    },
+    {
+      "name": "out-of-range mode falls through to ask",
+      "input": { "version": "1", "restoreLastSessionMode": "bogus" },
+      "expected": "ask"
+    }
+  ]
+}

--- a/core/tests/fixtures/golden/restore_mode/summarize_last_session.json
+++ b/core/tests/fixtures/golden/restore_mode/summarize_last_session.json
@@ -1,0 +1,133 @@
+{
+  "operation": "summarizeLastSession",
+  "cases": [
+    {
+      "name": "nested leaves: titles, type labels and probe targets",
+      "input": {
+        "version": "1",
+        "activeGroupIndex": 0,
+        "tabGroups": [
+          {
+            "name": "Group",
+            "layout": {
+              "type": "split",
+              "direction": "horizontal",
+              "children": [
+                {
+                  "type": "leaf",
+                  "tabs": [
+                    { "title": "prod-db", "inlineConfig": { "type": "ssh", "config": { "host": "prod-db" } } },
+                    { "inlineConfig": { "type": "serial", "config": { "device": "/dev/ttyUSB0" } } }
+                  ]
+                },
+                {
+                  "type": "leaf",
+                  "tabs": [{ "inlineConfig": { "type": "local", "config": { "shell": "bash" } } }]
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "expected": {
+        "tabCount": 3,
+        "tabs": [
+          { "title": "prod-db", "typeLabel": "SSH", "target": { "kind": "host", "host": "prod-db", "port": 22 } },
+          { "title": "/dev/ttyUSB0", "typeLabel": "Serial", "target": { "kind": "serial", "device": "/dev/ttyUSB0" } },
+          { "title": "Local", "typeLabel": "Local", "target": { "kind": "local" } }
+        ]
+      }
+    },
+    {
+      "name": "telnet uses the default port when unspecified",
+      "input": {
+        "version": "1",
+        "activeGroupIndex": 0,
+        "tabGroups": [
+          {
+            "name": "G",
+            "layout": { "type": "leaf", "tabs": [{ "inlineConfig": { "type": "telnet", "config": { "host": "switch" } } }] }
+          }
+        ]
+      },
+      "expected": {
+        "tabCount": 1,
+        "tabs": [{ "title": "switch", "typeLabel": "Telnet", "target": { "kind": "host", "host": "switch", "port": 23 } }]
+      }
+    },
+    {
+      "name": "an explicit host port is honoured",
+      "input": {
+        "version": "1",
+        "activeGroupIndex": 0,
+        "tabGroups": [
+          {
+            "name": "G",
+            "layout": { "type": "leaf", "tabs": [{ "inlineConfig": { "type": "ssh", "config": { "host": "h", "port": 2222 } } }] }
+          }
+        ]
+      },
+      "expected": {
+        "tabCount": 1,
+        "tabs": [{ "title": "h", "typeLabel": "SSH", "target": { "kind": "host", "host": "h", "port": 2222 } }]
+      }
+    },
+    {
+      "name": "connectionRef resolves its target from supplied connections",
+      "input": {
+        "version": "1",
+        "activeGroupIndex": 0,
+        "tabGroups": [
+          { "name": "G", "layout": { "type": "leaf", "tabs": [{ "connectionRef": "c1", "title": "prod" }] } }
+        ]
+      },
+      "args": {
+        "connections": [{ "id": "c1", "config": { "type": "ssh", "config": { "host": "10.0.0.5", "port": 22 } } }]
+      },
+      "expected": {
+        "tabCount": 1,
+        "tabs": [{ "title": "prod", "typeLabel": "Terminal", "target": { "kind": "host", "host": "10.0.0.5", "port": 22 } }]
+      }
+    },
+    {
+      "name": "connectionRef without connections cannot resolve and is local",
+      "input": {
+        "version": "1",
+        "activeGroupIndex": 0,
+        "tabGroups": [
+          { "name": "G", "layout": { "type": "leaf", "tabs": [{ "connectionRef": "c1", "title": "prod" }] } }
+        ]
+      },
+      "expected": {
+        "tabCount": 1,
+        "tabs": [{ "title": "prod", "typeLabel": "Terminal", "target": { "kind": "local" } }]
+      }
+    },
+    {
+      "name": "agentRef yields an agent target and label",
+      "input": {
+        "version": "1",
+        "activeGroupIndex": 0,
+        "tabGroups": [
+          {
+            "name": "G",
+            "layout": { "type": "leaf", "tabs": [{ "agentRef": { "agentId": "a1", "definitionId": "d1" } }] }
+          }
+        ]
+      },
+      "expected": {
+        "tabCount": 1,
+        "tabs": [{ "title": "Agent", "typeLabel": "Agent", "target": { "kind": "agent", "agentId": "a1" } }]
+      }
+    },
+    {
+      "name": "an empty session summarises to zero tabs",
+      "input": {
+        "version": "1",
+        "activeGroupIndex": 0,
+        "tabGroups": [{ "name": "Empty", "layout": { "type": "leaf", "tabs": [] } }]
+      },
+      "expected": { "tabCount": 0, "tabs": [] }
+    }
+  ]
+}

--- a/core/tests/restore_mode_golden.rs
+++ b/core/tests/restore_mode_golden.rs
@@ -1,0 +1,140 @@
+//! Golden-vector equivalence tests for the restore-mode decision logic (#2145).
+//!
+//! Each fixture under `tests/fixtures/golden/restore_mode/*.json` names one
+//! exported function and a list of input → expected cases extracted from the
+//! authoritative TypeScript suite (`src/utils/restoreMode.test.ts`). This test
+//! runs the Rust port against every case and asserts the serialized result
+//! matches, proving the two implementations stay in lockstep.
+//!
+//! Fixture format and the shared-convention rationale live in
+//! `tests/fixtures/golden/README.md`. This reuses verbatim the directory
+//! layout, envelope, and matcher the panel-tree port (#2143) established. The
+//! optional `connections` list and the flat `selected` index array are carried
+//! per case in `args`.
+
+use serde_json::Value;
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use termihub_core::restore_mode::{
+    filter_session_by_selection, get_workspace_leaves, resolve_restore_mode,
+    summarize_last_session, AppSettings, LastSession, SavedConnection, WorkspaceLayoutNode,
+};
+
+fn fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("golden")
+        .join("restore_mode")
+}
+
+/// Deep JSON equality with the golden-vector numeric convention: numbers
+/// compare within a 1e-9 tolerance (cross-language float rounding in the
+/// size-redistribution path). Object key sets must match exactly.
+fn json_matches(expected: &Value, actual: &Value) -> bool {
+    match (expected, actual) {
+        (Value::Number(e), Value::Number(a)) => match (e.as_f64(), a.as_f64()) {
+            (Some(x), Some(y)) => (x - y).abs() < 1e-9,
+            _ => e == a,
+        },
+        (Value::Array(e), Value::Array(a)) => {
+            e.len() == a.len() && e.iter().zip(a).all(|(x, y)| json_matches(x, y))
+        }
+        (Value::Object(e), Value::Object(a)) => {
+            e.len() == a.len()
+                && e.iter()
+                    .all(|(k, v)| a.get(k).is_some_and(|av| json_matches(v, av)))
+        }
+        _ => expected == actual,
+    }
+}
+
+fn from<T: serde::de::DeserializeOwned>(v: &Value) -> T {
+    serde_json::from_value(v.clone()).expect("deserialize fixture value")
+}
+
+/// Run one case for `operation`, returning the serialized actual result.
+fn run_case(operation: &str, case: &Value) -> Value {
+    let input = &case["input"];
+    let args = &case["args"];
+    match operation {
+        "resolveRestoreMode" => {
+            let settings: AppSettings = from(input);
+            serde_json::to_value(resolve_restore_mode(&settings)).expect("serialize mode")
+        }
+        "summarizeLastSession" => {
+            let session: LastSession = from(input);
+            let connections: Vec<SavedConnection> = match args.get("connections") {
+                Some(v) if !v.is_null() => from(v),
+                _ => Vec::new(),
+            };
+            serde_json::to_value(summarize_last_session(&session, &connections))
+                .expect("serialize prompt")
+        }
+        "filterSessionBySelection" => {
+            let session: LastSession = from(input);
+            let selected: HashSet<i64> = from::<Vec<i64>>(&args["selected"]).into_iter().collect();
+            serde_json::to_value(filter_session_by_selection(&session, &selected))
+                .expect("serialize session")
+        }
+        "getWorkspaceLeaves" => {
+            let root: WorkspaceLayoutNode = from(input);
+            Value::Array(
+                get_workspace_leaves(&root)
+                    .into_iter()
+                    .map(|l| {
+                        serde_json::to_value(WorkspaceLayoutNode::Leaf(l.clone()))
+                            .expect("serialize leaf")
+                    })
+                    .collect(),
+            )
+        }
+        other => panic!("unknown golden operation: {other}"),
+    }
+}
+
+#[test]
+fn golden_vectors_match_typescript() {
+    let dir = fixture_dir();
+    let mut files: Vec<PathBuf> = fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read fixture dir {}: {e}", dir.display()))
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "json"))
+        .collect();
+    files.sort();
+    assert!(
+        !files.is_empty(),
+        "no golden fixtures found in {}",
+        dir.display()
+    );
+
+    let mut total_cases = 0usize;
+    for file in files {
+        let raw = fs::read_to_string(&file).expect("read fixture");
+        let fixture: Value =
+            serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {}: {e}", file.display()));
+        let operation = fixture["operation"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{} missing operation", file.display()));
+        let cases = fixture["cases"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{} missing cases array", file.display()));
+
+        for case in cases {
+            let name = case["name"].as_str().unwrap_or("<unnamed>");
+            let actual = run_case(operation, case);
+            let expected = &case["expected"];
+            assert!(
+                json_matches(expected, &actual),
+                "golden mismatch in {} :: {operation} :: {name}\n  expected: {}\n  actual:   {}",
+                file.display(),
+                serde_json::to_string(expected).unwrap_or_default(),
+                serde_json::to_string(&actual).unwrap_or_default(),
+            );
+            total_cases += 1;
+        }
+    }
+    // Sanity: make sure the harness actually exercised a meaningful body of cases.
+    assert!(total_cases >= 20, "only ran {total_cases} golden cases");
+}


### PR DESCRIPTION
Phase 0 of the stateless-UI migration (#2139): a faithful Rust twin of the frontend's `src/utils/restoreMode.ts` restore-mode decision logic, landed in `termihub-core` at `core/src/restore_mode.rs`.

The TypeScript version **stays authoritative** — nothing changes for the user. This port runs behind it and is proven equivalent via golden vectors extracted from the TS suite.

## Coupling check (issue portability caveat)

`restoreMode.ts` is fully **pure** — every export maps saved-state + mode inputs to a decision output, with no DOM/store/mutation. Its one runtime dependency is `getWorkspaceLeaves` from `workspaceLayout.ts`, itself a pure leaf-walk. I took **route (a)** from the issue: ported just that small leaf-walk helper (`get_workspace_leaves`) inline rather than pulling in the whole 718-line `workspaceLayout.ts`.

## What was ported

Every exported function, with identical semantics:

- `resolve_restore_mode` — explicit mode wins when valid; legacy boolean `=== false` → `never`; else `ask` (raw-string mode field so an out-of-range persisted value falls through exactly as the TS `VALID_MODES.includes` guard does).
- `summarize_last_session` — flattens groups → leaves → tabs into per-tab `{ title, typeLabel, target }`, deriving host/serial/agent/local probe targets (default SSH/telnet ports, `connectionRef` resolution against supplied connections).
- `filter_session_by_selection` — prunes to the selected flat tab indices: drops empty leaves, collapses single-child splits with size redistribution, removes emptied groups, and remaps `activeGroupIndex` to the nearest surviving group.
- `get_workspace_leaves` — the ported `workspaceLayout.ts` dependency, with its own tests.

Input types are modelled as serde structs/enums serializing to the same JSON shapes as the TS discriminated unions (`WorkspaceLayoutNode` is a `#[serde(tag = "type")]` `Leaf`/`Split` enum; `AppSettings`/`SavedConnection` are minimal projections that ignore unrelated fields).

## Test approach

Three layers, all green (`cargo test`, `clippy -D warnings`, `fmt` clean):

1. **Unit tests** (`core/src/restore_mode/tests.rs`) mirroring `restoreMode.test.ts` case-for-case.
2. **Property tests** (`proptest`) over the pruning invariants: filtering keeps exactly the selected tabs, always yields a well-formed tree (no empty leaves, no under-filled splits), the surviving-group set matches non-empty groups, and `activeGroupIndex` stays in range.
3. **Golden vectors** — the cross-language equivalence layer: 22 cases across the four functions under `core/tests/fixtures/golden/restore_mode/`, run by `core/tests/restore_mode_golden.rs`, reusing the #2143 convention verbatim.

## Notes

- `src/utils/restoreMode.ts` is untouched and stays authoritative; the existing TS suite (18 tests) still passes.
- Non-user-facing (port runs behind existing TS), so no changelog fragment.
- No `.unwrap()` in production paths.

Closes #2145
Part of #2139