### PR TITLE
feat(backend): stateless-ui projection substrate — dispatch/subscribe channels (Closes #2149)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7713,6 +7713,7 @@ dependencies = [
  "dirs",
  "hex",
  "if-addrs",
+ "json-patch",
  "keyring",
  "libc",
  "libunftp",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@xterm/addon-unicode11": "^0.9.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
+    "fast-json-patch": "^3.1.1",
     "html-to-image": "^1.11.13",
     "lucide-react": "^0.563.0",
     "match-sorter": "^8.3.0",
@@ -58,6 +59,7 @@
     "react-resizable-panels": "^4.11.2",
     "shiki": "^4.1.0",
     "sonner": "^2.0.7",
+    "ulid": "^3.0.2",
     "uplot": "^1.6.32",
     "zod": "^4.4.3",
     "zustand": "^5.0.13"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@xterm/xterm':
         specifier: ^6.0.0
         version: 6.0.0
+      fast-json-patch:
+        specifier: ^3.1.1
+        version: 3.1.1
       html-to-image:
         specifier: ^1.11.13
         version: 1.11.13
@@ -140,6 +143,9 @@ importers:
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      ulid:
+        specifier: ^3.0.2
+        version: 3.0.2
       uplot:
         specifier: ^1.6.32
         version: 1.6.32
@@ -2320,6 +2326,9 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-json-patch@3.1.1:
+    resolution: {integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -3157,6 +3166,10 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  ulid@3.0.2:
+    resolution: {integrity: sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==}
+    hasBin: true
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
@@ -5391,6 +5404,8 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-json-patch@3.1.1: {}
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
@@ -6317,6 +6332,8 @@ snapshots:
   typescript@5.6.3: {}
 
   uc.micro@2.1.0: {}
+
+  ulid@3.0.2: {}
 
   undici-types@7.19.2: {}
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -65,6 +65,10 @@ sha2 = "0.10"
 # delimiter handling delegated to the maintained crate rather than hand-rolled.
 csv = "1"
 serde_json = { workspace = true }
+# RFC 6902 JSON-Patch: structural diff (produce) + apply for the stateless-UI
+# projection substrate (#2149). Library-backed per the repo's "prefer libraries"
+# rule rather than a hand-rolled differ; `diff()` emits only add/remove/replace.
+json-patch = "3"
 portable-pty = "0.8"
 russh = { workspace = true }
 russh-sftp = { workspace = true }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod macros;
 pub mod network;
 pub mod plugin;
 pub mod portable;
+pub mod projection;
 pub mod remote_desktop;
 pub mod session;
 pub mod session_history;

--- a/src-tauri/src/commands/projection.rs
+++ b/src-tauri/src/commands/projection.rs
@@ -1,0 +1,106 @@
+//! Tauri command wiring for the stateless-UI projection substrate (#2149).
+//!
+//! Rides the desktop IPC transport: `intent_dispatch` answers with an
+//! [`IntentAck`]; `projection_subscribe` returns the region's current
+//! [`SnapshotFrame`] and opens a per-region `tauri::ipc::Channel` for the diff
+//! stream (efficient per-region push, avoiding a global event fan-in). The
+//! terminal `terminal-output` byte stream is a separate, untouched channel.
+//!
+//! Phase 1 wires an **empty** handler registry (mechanism only; no domain
+//! migrated yet) — the channels exist and round-trip, and intents for
+//! unregistered kinds are rejected with `unknown_intent`. Domains register
+//! routes as they migrate (Phase 2+, #2150).
+
+use std::sync::Arc;
+
+use tauri::ipc::Channel;
+use tauri::State;
+
+use crate::projection::{
+    Dispatcher, HandlerRegistry, Intent, IntentAck, ProjectionError, ProjectionFrame,
+    ProjectionSink, Projector, SnapshotFrame,
+};
+
+/// Managed Tauri state holding the projector and the intent dispatcher.
+pub struct ProjectionState {
+    pub projector: Arc<Projector>,
+    pub dispatcher: Arc<Dispatcher>,
+}
+
+impl ProjectionState {
+    pub fn new() -> Self {
+        let projector = Arc::new(Projector::new());
+        let dispatcher = Arc::new(Dispatcher::new(
+            projector.clone(),
+            Arc::new(HandlerRegistry::new()),
+        ));
+        Self {
+            projector,
+            dispatcher,
+        }
+    }
+}
+
+impl Default for ProjectionState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A [`ProjectionSink`] backed by a per-region Tauri IPC channel.
+struct ChannelSink(Channel<ProjectionFrame>);
+
+impl ProjectionSink for ChannelSink {
+    fn deliver(&self, frame: &ProjectionFrame) -> Result<(), ProjectionError> {
+        self.0
+            .send(frame.clone())
+            .map_err(|e| ProjectionError::SinkClosed(e.to_string()))
+    }
+}
+
+/// Channel 1 — dispatch a user intent; returns the ack receipt. The result of
+/// an accepted intent arrives separately as a projection diff.
+#[tauri::command]
+pub fn intent_dispatch(intent: Intent, state: State<'_, ProjectionState>) -> IntentAck {
+    state.dispatcher.dispatch(intent)
+}
+
+/// Channel 2 — attach to a region. Returns the current snapshot and begins the
+/// diff stream on `channel`. `subscription_id` is client-generated and passed
+/// again to `projection_unsubscribe` to detach.
+#[tauri::command]
+pub fn projection_subscribe(
+    region: String,
+    subscription_id: String,
+    client_id: String,
+    channel: Channel<ProjectionFrame>,
+    state: State<'_, ProjectionState>,
+) -> SnapshotFrame {
+    state.projector.subscribe(
+        &region,
+        subscription_id,
+        client_id,
+        Arc::new(ChannelSink(channel)),
+    )
+}
+
+/// Detach a subscription. Idempotent.
+#[tauri::command]
+pub fn projection_unsubscribe(
+    region: String,
+    subscription_id: String,
+    state: State<'_, ProjectionState>,
+) {
+    state.projector.unsubscribe(&region, &subscription_id);
+}
+
+/// Re-baseline a region after a detected gap or reconnect. Returns `None` when
+/// `have` already matches the region's current version.
+#[tauri::command]
+pub fn projection_resync(
+    region: String,
+    have: Option<u64>,
+    state: State<'_, ProjectionState>,
+) -> Option<SnapshotFrame> {
+    state.projector.resync(&region, have)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,10 @@ mod macos_clipboard;
 mod macos_services;
 mod macros;
 mod network;
+/// Stateless-UI projection substrate (#2149): server-authoritative per-region
+/// versioned diff channels with multi-subscriber fan-out. Public so integration
+/// tests can drive the projector directly.
+pub mod projection;
 pub mod run_location;
 mod session;
 mod session_history;
@@ -285,6 +289,9 @@ pub fn run() {
         .manage(window::WindowManager::new())
         .manage(commands::connection_path::ProbeRegistry::default())
         .manage(commands::local_process::LocalProcessRegistry::default())
+        // Stateless-UI projection substrate (#2149) — projector + intent
+        // dispatcher, wired beside the existing typed commands (strangler).
+        .manage(commands::projection::ProjectionState::new())
         .manage(crate::terminal::agent_cancel::AgentDeployCancellation::default())
         .manage(log_buffer);
 
@@ -875,6 +882,11 @@ pub fn run() {
             commands::ssh_host_key::ssh_host_key_decision,
             commands::ssh_host_key::ssh_trust_list,
             commands::ssh_host_key::ssh_trust_forget,
+            // Stateless-UI projection substrate (#2149)
+            commands::projection::intent_dispatch,
+            commands::projection::projection_subscribe,
+            commands::projection::projection_unsubscribe,
+            commands::projection::projection_resync,
             // Plugin management layer (#1992)
             commands::plugin::list_plugins,
             commands::plugin::validate_plugin,

--- a/src-tauri/src/projection/frame.rs
+++ b/src-tauri/src/projection/frame.rs
@@ -1,0 +1,184 @@
+//! Wire envelopes for the stateless-UI projection substrate (#2149).
+//!
+//! These `serde` structs are the twin of the TypeScript envelopes in
+//! `src/services/transport/types.ts`. They are transport-neutral: identical
+//! whether they ride Tauri IPC (desktop) or JSON-RPC over WebSocket
+//! (remote-client mode). See the design concept
+//! `docs/concepts/future/stateless-ui-projection-substrate.html`.
+//!
+//! The substrate carries two new generic channels:
+//!
+//! * **channel 1 — `dispatch(intent)`** (UI → backend): one serialisable
+//!   [`Intent`], answered by an [`IntentAck`] receipt.
+//! * **channel 2 — `subscribe(region)`** (backend → UI): an initial
+//!   [`SnapshotFrame`] then an ordered stream of [`DiffFrame`]s.
+//!
+//! The terminal byte stream (`terminal-output`) is channel 3 and is wholly
+//! independent of this module.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// A user intent dispatched by a client (channel 1, UI → backend).
+///
+/// The result of an intent is never returned inline; it is always a projection
+/// diff on the affected region(s). The [`IntentAck`] is only a receipt.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Intent {
+    /// Client-generated ULID; correlates the ack (and any optimistic echo).
+    pub intent_id: String,
+    /// Dotted `<domain>.<action>`, e.g. `"tunnel.start"`, `"layout.moveTab"`.
+    pub kind: String,
+    /// Kind-specific, serialisable payload; validated backend-side.
+    pub payload: Value,
+    /// Which attached client dispatched it (fan-out / audit identity).
+    pub client_id: String,
+}
+
+/// Whether the dispatcher accepted or rejected an [`Intent`].
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum IntentStatus {
+    Accepted,
+    Rejected,
+}
+
+/// Error detail attached to a rejected [`IntentAck`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IntentErrorInfo {
+    pub code: String,
+    pub message: String,
+}
+
+/// A region advanced by an intent, so a client can await the confirming diff
+/// before clearing an optimistic echo.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProducedRegion {
+    pub region: String,
+    pub version: u64,
+}
+
+/// Receipt for a dispatched [`Intent`] (channel 1 reply).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct IntentAck {
+    /// Echoes the request's `intentId`.
+    pub intent_id: String,
+    pub status: IntentStatus,
+    /// Present iff `status == rejected`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<IntentErrorInfo>,
+    /// Regions this intent advanced. Empty for no-op / query intents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub produced: Option<Vec<ProducedRegion>>,
+}
+
+impl IntentAck {
+    /// Build an `accepted` ack listing the regions the intent advanced.
+    pub fn accepted(intent_id: impl Into<String>, produced: Vec<ProducedRegion>) -> Self {
+        Self {
+            intent_id: intent_id.into(),
+            status: IntentStatus::Accepted,
+            error: None,
+            produced: Some(produced),
+        }
+    }
+
+    /// Build a `rejected` ack carrying an error code and message.
+    pub fn rejected(
+        intent_id: impl Into<String>,
+        code: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            intent_id: intent_id.into(),
+            status: IntentStatus::Rejected,
+            error: Some(IntentErrorInfo {
+                code: code.into(),
+                message: message.into(),
+            }),
+            produced: None,
+        }
+    }
+}
+
+/// A projection frame pushed to a subscriber (channel 2, backend → UI).
+///
+/// Internally tagged by `kind`, matching the TypeScript discriminated union
+/// `{ kind: "snapshot" | "diff", ... }`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum ProjectionFrame {
+    Snapshot(SnapshotFrame),
+    Diff(DiffFrame),
+}
+
+impl ProjectionFrame {
+    /// The region this frame belongs to.
+    pub fn region(&self) -> &str {
+        match self {
+            ProjectionFrame::Snapshot(f) => &f.region,
+            ProjectionFrame::Diff(f) => &f.region,
+        }
+    }
+
+    /// The version the cache holds after applying this frame.
+    pub fn version(&self) -> u64 {
+        match self {
+            ProjectionFrame::Snapshot(f) => f.version,
+            ProjectionFrame::Diff(f) => f.version,
+        }
+    }
+}
+
+/// The complete, render-ready view model for a region at a baseline version.
+///
+/// Emitted on attach and on resync only; steady state is [`DiffFrame`]s.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotFrame {
+    pub region: String,
+    /// `u64` monotonic; the cache adopts this as its baseline.
+    pub version: u64,
+    /// The complete, render-ready view model for the region.
+    pub view: Value,
+}
+
+/// An ordered mutation of a region's cached view model.
+///
+/// `baseVersion` MUST equal the cache's current version, else the client
+/// detects a gap and calls `resync`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DiffFrame {
+    pub region: String,
+    /// MUST equal the cache's current version, else it is a gap.
+    pub base_version: u64,
+    /// `== base_version + 1`.
+    pub version: u64,
+    /// Ordered mutations to apply to the cached view model.
+    pub ops: Vec<DiffOp>,
+}
+
+/// A single diff operation.
+///
+/// The default shape is an RFC 6902 JSON-Patch subset (`add` / `remove` /
+/// `replace`). [`DiffOp::Semantic`] is the per-domain compact-op escape hatch
+/// reserved by the design; it is **unused** in Phase 1.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "op", rename_all = "lowercase")]
+pub enum DiffOp {
+    /// RFC 6902 `replace`.
+    Replace { path: String, value: Value },
+    /// RFC 6902 `add`.
+    Add { path: String, value: Value },
+    /// RFC 6902 `remove`.
+    Remove { path: String },
+    /// Escape hatch: a compact per-domain semantic op. Reserved, unused in
+    /// Phase 1; has no RFC 6902 mapping and is never emitted by the default
+    /// structural differ.
+    Semantic { name: String, data: Value },
+}

--- a/src-tauri/src/projection/mod.rs
+++ b/src-tauri/src/projection/mod.rs
@@ -1,0 +1,419 @@
+//! The stateless-UI projection substrate (#2149, Phase 1 of #2139).
+//!
+//! Server-authoritative, per-region **versioned diff channels** with
+//! multi-subscriber fan-out. The backend is the single authoritative writer:
+//! it applies an intent once, bumps the region version once, computes the diff
+//! once, and fans that one diff out to every current subscriber. See the design
+//! concept `docs/concepts/future/stateless-ui-projection-substrate.html`.
+//!
+//! This module is the transport-neutral core — it does not depend on Tauri, so
+//! the whole loop (subscribe → snapshot, intent → diff fan-out, gap → resync)
+//! is exercised in-memory by the test harness below. The Tauri command wiring
+//! that rides a `tauri::ipc::Channel` lives in
+//! [`crate::commands::projection`].
+//!
+//! # Scope (Phase 1)
+//!
+//! Mechanism only — no real domain is migrated onto the substrate. The two
+//! generic channels land **beside** the existing ~206 typed commands and ~36
+//! events (strangler migration); the terminal `terminal-output` byte stream is
+//! a separate, untouched channel.
+
+mod frame;
+mod region;
+
+pub use frame::{
+    DiffFrame, DiffOp, Intent, IntentAck, IntentErrorInfo, IntentStatus, ProducedRegion,
+    ProjectionFrame, SnapshotFrame,
+};
+pub use region::ProjectedStore;
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use serde_json::Value;
+
+/// Errors raised while producing, delivering, or applying projection frames.
+#[derive(Debug, thiserror::Error)]
+pub enum ProjectionError {
+    /// A subscriber's delivery sink is gone (closed channel / dead socket).
+    #[error("subscriber sink closed: {0}")]
+    SinkClosed(String),
+    /// The semantic-op escape hatch has no RFC 6902 mapping and cannot be
+    /// applied by the default structural applier.
+    #[error("cannot apply semantic diff op '{0}' via RFC 6902")]
+    UnsupportedSemanticOp(String),
+    /// Applying a diff to a cached view model failed.
+    #[error("failed to apply diff: {0}")]
+    Apply(String),
+}
+
+// ── Structural diff / apply (RFC 6902, library-backed) ──────────────────────
+
+/// Compute the ordered [`DiffOp`]s that turn `old` into `new`.
+///
+/// Backed by the `json-patch` crate's RFC 6902 differ, whose `diff` emits only
+/// `add` / `remove` / `replace` — exactly the substrate's default op subset.
+/// An empty result means the two view models are identical (a no-op change,
+/// which the projector never emits a frame for).
+pub fn compute_ops(old: &Value, new: &Value) -> Vec<DiffOp> {
+    json_patch::diff(old, new)
+        .0
+        .into_iter()
+        .filter_map(diffop_from_patch)
+        .collect()
+}
+
+fn diffop_from_patch(op: json_patch::PatchOperation) -> Option<DiffOp> {
+    use json_patch::PatchOperation as P;
+    match op {
+        P::Add(a) => Some(DiffOp::Add {
+            path: a.path.as_str().to_string(),
+            value: a.value,
+        }),
+        P::Remove(r) => Some(DiffOp::Remove {
+            path: r.path.as_str().to_string(),
+        }),
+        P::Replace(r) => Some(DiffOp::Replace {
+            path: r.path.as_str().to_string(),
+            value: r.value,
+        }),
+        // `json_patch::diff` never emits move/copy/test; ignore defensively.
+        _ => None,
+    }
+}
+
+/// Apply ordered [`DiffOp`]s to a cached view model in place.
+///
+/// This is the reference applier the client cache mirrors (the TypeScript
+/// [`ProjectionClient`] uses `fast-json-patch`). It rejects the semantic-op
+/// escape hatch, which has no RFC 6902 mapping.
+pub fn apply_ops(view: &mut Value, ops: &[DiffOp]) -> Result<(), ProjectionError> {
+    let patch = ops_to_patch(ops)?;
+    json_patch::patch(view, &patch).map_err(|e| ProjectionError::Apply(e.to_string()))
+}
+
+fn ops_to_patch(ops: &[DiffOp]) -> Result<json_patch::Patch, ProjectionError> {
+    // Reject the semantic escape hatch up front; the rest of the subset shares
+    // its serde shape with `json_patch::PatchOperation`, so a JSON round-trip
+    // converts without a direct `jsonptr` dependency.
+    if let Some(DiffOp::Semantic { name, .. }) =
+        ops.iter().find(|op| matches!(op, DiffOp::Semantic { .. }))
+    {
+        return Err(ProjectionError::UnsupportedSemanticOp(name.clone()));
+    }
+    let json = serde_json::to_value(ops).map_err(|e| ProjectionError::Apply(e.to_string()))?;
+    serde_json::from_value(json).map_err(|e| ProjectionError::Apply(e.to_string()))
+}
+
+// ── Subscription fan-out ────────────────────────────────────────────────────
+
+/// A delivery handle for a region's diff stream.
+///
+/// Implemented by a `tauri::ipc::Channel<ProjectionFrame>` on desktop and a
+/// WebSocket send half in remote-client mode. An `Err` return marks the
+/// subscriber dead; the projector reaps it on the emit path.
+pub trait ProjectionSink: Send + Sync {
+    /// Deliver one frame. Returns `Err` if the sink is gone.
+    fn deliver(&self, frame: &ProjectionFrame) -> Result<(), ProjectionError>;
+}
+
+struct Subscriber {
+    /// Caller-owned subscription id (the frontend generates it and passes the
+    /// same value to `subscribe` and `unsubscribe`).
+    id: String,
+    client_id: String,
+    sink: Arc<dyn ProjectionSink>,
+}
+
+struct RegionState {
+    version: u64,
+    /// The current authoritative view model (the last emitted snapshot).
+    view: Value,
+    subscribers: Vec<Subscriber>,
+}
+
+impl RegionState {
+    fn new(view: Value) -> Self {
+        Self {
+            version: 0,
+            view,
+            subscribers: Vec::new(),
+        }
+    }
+
+    fn snapshot(&self, region: &str) -> SnapshotFrame {
+        SnapshotFrame {
+            region: region.to_string(),
+            version: self.version,
+            view: self.view.clone(),
+        }
+    }
+}
+
+/// The projector: owns the subscription registry (`region → subscribers`), the
+/// per-region monotonic version counters, and the coalescing/diff step.
+///
+/// A single mutex over the region map gives the concept's "snapshot capture and
+/// subscriber insertion under one region lock" guarantee, so a late joiner can
+/// neither miss a diff that lands during attach nor receive one that predates
+/// its snapshot.
+#[derive(Default)]
+pub struct Projector {
+    regions: Mutex<HashMap<String, RegionState>>,
+}
+
+impl Projector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Seed a region's initial view model at version 0.
+    ///
+    /// Optional: `subscribe`/`publish` lazily create an absent region with a
+    /// `null` view. Seeding lets a domain publish its real baseline before the
+    /// first subscriber attaches.
+    pub fn register_region(&self, region: &str, initial_view: Value) {
+        let mut regions = self.lock();
+        regions
+            .entry(region.to_string())
+            .or_insert_with(|| RegionState::new(initial_view));
+    }
+
+    /// Attach a subscriber and return the region's current snapshot.
+    ///
+    /// Snapshot capture and subscriber insertion happen under one lock, so the
+    /// returned baseline and the diff stream that follows cannot interleave
+    /// (invariant 1: snapshot-on-attach). Idempotent per `subscription_id`: a
+    /// repeated id replaces the existing subscriber's sink.
+    pub fn subscribe(
+        &self,
+        region: &str,
+        subscription_id: impl Into<String>,
+        client_id: impl Into<String>,
+        sink: Arc<dyn ProjectionSink>,
+    ) -> SnapshotFrame {
+        let subscription_id = subscription_id.into();
+        let mut regions = self.lock();
+        let state = regions
+            .entry(region.to_string())
+            .or_insert_with(|| RegionState::new(Value::Null));
+        state.subscribers.retain(|s| s.id != subscription_id);
+        state.subscribers.push(Subscriber {
+            id: subscription_id,
+            client_id: client_id.into(),
+            sink,
+        });
+        state.snapshot(region)
+    }
+
+    /// Detach a subscriber. Idempotent — a missing id is a no-op.
+    pub fn unsubscribe(&self, region: &str, subscription_id: &str) {
+        let mut regions = self.lock();
+        if let Some(state) = regions.get_mut(region) {
+            state.subscribers.retain(|s| s.id != subscription_id);
+        }
+    }
+
+    /// Detach every subscription a client holds on a region (e.g. on client
+    /// disconnect, when its individual subscription ids are not known here).
+    /// Idempotent.
+    pub fn unsubscribe_client(&self, region: &str, client_id: &str) {
+        let mut regions = self.lock();
+        if let Some(state) = regions.get_mut(region) {
+            state.subscribers.retain(|s| s.client_id != client_id);
+        }
+    }
+
+    /// Publish a region's new authoritative view model.
+    ///
+    /// Diffs the new view against the last emitted one; if nothing changed,
+    /// returns `None` and emits no frame. Otherwise bumps the version by one,
+    /// stores the new view, and fans a single [`DiffFrame`]
+    /// (`base_version = V`, `version = V + 1`) out to every current subscriber,
+    /// reaping any whose sink has gone. Returns the new version.
+    ///
+    /// Because the diff is computed against the *last emitted* view, many
+    /// mutations collapsed into one `publish` call produce one diff — the
+    /// concept's burst-coalescing, for free.
+    pub fn publish(&self, region: &str, new_view: Value) -> Option<u64> {
+        let mut regions = self.lock();
+        let state = regions
+            .entry(region.to_string())
+            .or_insert_with(|| RegionState::new(Value::Null));
+
+        let ops = compute_ops(&state.view, &new_view);
+        if ops.is_empty() {
+            return None;
+        }
+        let base_version = state.version;
+        let version = base_version + 1;
+        state.version = version;
+        state.view = new_view;
+
+        let frame = ProjectionFrame::Diff(DiffFrame {
+            region: region.to_string(),
+            base_version,
+            version,
+            ops,
+        });
+        Self::fan_out(state, &frame);
+        Some(version)
+    }
+
+    /// Publish the current snapshot of a [`ProjectedStore`].
+    pub fn publish_store(&self, store: &dyn ProjectedStore) -> Option<u64> {
+        self.publish(store.region_id(), store.snapshot())
+    }
+
+    /// The region's current snapshot (creates an empty region if absent).
+    pub fn snapshot(&self, region: &str) -> SnapshotFrame {
+        let mut regions = self.lock();
+        let state = regions
+            .entry(region.to_string())
+            .or_insert_with(|| RegionState::new(Value::Null));
+        state.snapshot(region)
+    }
+
+    /// Re-baseline a region after a detected gap or a reconnect.
+    ///
+    /// Returns `None` if the caller's `have` already matches the region's
+    /// current version (nothing to send); otherwise the current snapshot.
+    pub fn resync(&self, region: &str, have: Option<u64>) -> Option<SnapshotFrame> {
+        let mut regions = self.lock();
+        let state = regions
+            .entry(region.to_string())
+            .or_insert_with(|| RegionState::new(Value::Null));
+        if have == Some(state.version) {
+            return None;
+        }
+        Some(state.snapshot(region))
+    }
+
+    /// Number of live subscribers on a region (test / diagnostics helper).
+    pub fn subscriber_count(&self, region: &str) -> usize {
+        self.lock()
+            .get(region)
+            .map(|s| s.subscribers.len())
+            .unwrap_or(0)
+    }
+
+    /// The region's current version, if it exists (test / diagnostics helper).
+    pub fn region_version(&self, region: &str) -> Option<u64> {
+        self.lock().get(region).map(|s| s.version)
+    }
+
+    fn fan_out(state: &mut RegionState, frame: &ProjectionFrame) {
+        // Deliver to every subscriber; reap any whose sink is gone.
+        state
+            .subscribers
+            .retain(|sub| sub.sink.deliver(frame).is_ok());
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, HashMap<String, RegionState>> {
+        // The map is only ever locked for the short body of a projector call;
+        // a poisoned lock means another thread panicked mid-mutation, which is
+        // a bug — recover the guard rather than cascade the panic.
+        self.regions.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+// ── Intent dispatch (single writer) ─────────────────────────────────────────
+
+/// Handles a validated [`Intent`]: mutates authoritative domain state and
+/// publishes the affected region(s) via the [`Projector`].
+///
+/// Returns the regions advanced (for the ack's `produced` list) on success, or
+/// an error `(code, message)` to reject with.
+pub trait IntentHandler: Send + Sync {
+    fn handle(
+        &self,
+        intent: &Intent,
+        projector: &Projector,
+    ) -> Result<Vec<ProducedRegion>, (String, String)>;
+}
+
+/// Serialises intents onto a single writer and turns handler results into
+/// [`IntentAck`] receipts.
+///
+/// A write mutex guards the whole read-decide-mutate-publish step so intents
+/// never interleave — the substrate's single-writer guarantee. The result of
+/// an accepted intent reaches the UI as a projection diff, never inline.
+pub struct Dispatcher {
+    projector: Arc<Projector>,
+    handler: Arc<dyn IntentHandler>,
+    write_lock: Mutex<()>,
+}
+
+impl Dispatcher {
+    pub fn new(projector: Arc<Projector>, handler: Arc<dyn IntentHandler>) -> Self {
+        Self {
+            projector,
+            handler,
+            write_lock: Mutex::new(()),
+        }
+    }
+
+    /// Dispatch one intent and return its receipt.
+    pub fn dispatch(&self, intent: Intent) -> IntentAck {
+        let _writer = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
+        match self.handler.handle(&intent, &self.projector) {
+            Ok(produced) => IntentAck::accepted(intent.intent_id, produced),
+            Err((code, message)) => IntentAck::rejected(intent.intent_id, code, message),
+        }
+    }
+}
+
+/// Routes intents to a handler chosen by exact [`Intent::kind`].
+///
+/// The Phase-1 app registers an empty registry: the two channels exist and are
+/// wired, but no real domain is served yet, so every intent is rejected with
+/// `unknown_intent`. Domains register routes as they migrate (Phase 2+).
+#[derive(Default)]
+pub struct HandlerRegistry {
+    #[allow(clippy::type_complexity)]
+    routes: HashMap<
+        String,
+        Box<
+            dyn Fn(&Intent, &Projector) -> Result<Vec<ProducedRegion>, (String, String)>
+                + Send
+                + Sync,
+        >,
+    >,
+}
+
+impl HandlerRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a handler for an exact intent `kind`.
+    pub fn route<F>(&mut self, kind: impl Into<String>, handler: F)
+    where
+        F: Fn(&Intent, &Projector) -> Result<Vec<ProducedRegion>, (String, String)>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.routes.insert(kind.into(), Box::new(handler));
+    }
+}
+
+impl IntentHandler for HandlerRegistry {
+    fn handle(
+        &self,
+        intent: &Intent,
+        projector: &Projector,
+    ) -> Result<Vec<ProducedRegion>, (String, String)> {
+        match self.routes.get(&intent.kind) {
+            Some(route) => route(intent, projector),
+            None => Err((
+                "unknown_intent".to_string(),
+                format!("no handler registered for intent kind '{}'", intent.kind),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src-tauri/src/projection/region.rs
+++ b/src-tauri/src/projection/region.rs
@@ -1,0 +1,35 @@
+//! The [`ProjectedStore`] trait a domain store implements to be projected.
+//!
+//! A region is a slice of authoritative backend state exposed to the UI as a
+//! render-ready view model. The [`Projector`](super::Projector) diffs
+//! consecutive snapshots of a store (the default path) and fans the resulting
+//! [`DiffFrame`](super::DiffFrame)s out to every subscriber.
+//!
+//! Phase 1 (#2149) ships the trait and the projection mechanism only; no real
+//! domain is migrated onto it — that is Phase 2 (#2150), starting with SSH
+//! tunnels.
+
+use serde_json::Value;
+
+/// A domain store that can be projected as a versioned region.
+///
+/// The natural first seam is the existing app-side authority (e.g.
+/// `SessionManager`), which a region wraps rather than replaces. The projector
+/// calls [`snapshot`](ProjectedStore::snapshot) to obtain the current
+/// render-ready view model and diffs it against the last emitted view.
+pub trait ProjectedStore: Send + Sync {
+    /// The region id this store projects onto.
+    ///
+    /// `"<domain>"` for globally-shared regions (e.g. `"tunnels"`) or
+    /// `"<domain>@<clientId>"` for client-scoped regions (e.g.
+    /// `"layout@client-7"`). The `@client` suffix is the only thing that
+    /// distinguishes a shared region from a per-client one; the envelope and
+    /// versioning rules are identical for both.
+    fn region_id(&self) -> &str;
+
+    /// The complete, render-ready view model for the region right now.
+    ///
+    /// Must be a pure function of authoritative state, computed without side
+    /// effects so the projector can diff two snapshots safely.
+    fn snapshot(&self) -> Value;
+}

--- a/src-tauri/src/projection/tests.rs
+++ b/src-tauri/src/projection/tests.rs
@@ -1,0 +1,479 @@
+//! Worked in-memory harness for the projection substrate (#2149).
+//!
+//! Proves the full loop against a synthetic SSH-tunnels region (the parent
+//! concept's Phase-2 pilot domain) without any Tauri dependency:
+//!
+//! * subscribe → snapshot baseline, identical for every subscriber;
+//! * dispatch(intent) → a single diff fanned out to two subscribers, both
+//!   caches converging on the authoritative view;
+//! * a forced version gap → `resync` → re-baseline, with no stale diff applied.
+//!
+//! It also unit-tests the diff/apply helpers, the versioning invariants,
+//! subscriber lifecycle, and the envelope serde shapes that mirror the
+//! TypeScript types.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::{json, Value};
+
+use super::*;
+
+// ── Test doubles ────────────────────────────────────────────────────────────
+
+/// An in-memory [`ProjectionSink`] that records delivered frames and can be
+/// "killed" to simulate a closed channel / dead socket.
+struct VecSink {
+    frames: Mutex<Vec<ProjectionFrame>>,
+    alive: AtomicBool,
+}
+
+impl VecSink {
+    fn new() -> Self {
+        Self {
+            frames: Mutex::new(Vec::new()),
+            alive: AtomicBool::new(true),
+        }
+    }
+
+    fn kill(&self) {
+        self.alive.store(false, Ordering::SeqCst);
+    }
+
+    /// Every diff this sink received, in delivery order.
+    fn diffs(&self) -> Vec<DiffFrame> {
+        self.frames
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|f| match f {
+                ProjectionFrame::Diff(d) => Some(d.clone()),
+                ProjectionFrame::Snapshot(_) => None,
+            })
+            .collect()
+    }
+}
+
+impl ProjectionSink for VecSink {
+    fn deliver(&self, frame: &ProjectionFrame) -> Result<(), ProjectionError> {
+        if !self.alive.load(Ordering::SeqCst) {
+            return Err(ProjectionError::SinkClosed("test sink killed".into()));
+        }
+        self.frames.lock().unwrap().push(frame.clone());
+        Ok(())
+    }
+}
+
+/// A simulated client-side cache: holds `{ version, view }`, applies ordered
+/// diffs, detects gaps, and re-baselines from a snapshot. Mirrors the
+/// TypeScript `ProjectionClient`.
+struct ClientCache {
+    version: u64,
+    view: Value,
+}
+
+impl ClientCache {
+    fn from_snapshot(s: &SnapshotFrame) -> Self {
+        Self {
+            version: s.version,
+            view: s.view.clone(),
+        }
+    }
+
+    /// Apply a diff iff it fits (`base_version == version`); otherwise report a
+    /// gap without mutating the cache.
+    fn apply(&mut self, diff: &DiffFrame) -> Result<(), Gap> {
+        if diff.base_version != self.version {
+            return Err(Gap);
+        }
+        apply_ops(&mut self.view, &diff.ops).expect("diff applies cleanly");
+        self.version = diff.version;
+        Ok(())
+    }
+
+    fn rebaseline(&mut self, s: &SnapshotFrame) {
+        self.version = s.version;
+        self.view = s.view.clone();
+    }
+}
+
+/// A detected version gap: the incoming diff did not fit the cache.
+#[derive(Debug, PartialEq, Eq)]
+struct Gap;
+
+/// Synthetic authoritative tunnel store — the substrate's worked domain.
+struct TunnelStore {
+    view: Mutex<Value>,
+}
+
+impl TunnelStore {
+    fn new() -> Self {
+        Self {
+            view: Mutex::new(json!({
+                "tunnels": [
+                    { "id": "t1", "label": "db → localhost:5432", "kind": "local",
+                      "status": "connected", "bind": "127.0.0.1:5432" },
+                    { "id": "t2", "label": "socks", "kind": "dynamic",
+                      "status": "stopped", "bind": "127.0.0.1:1080" }
+                ]
+            })),
+        }
+    }
+
+    fn set_status(&self, id: &str, status: &str) {
+        let mut view = self.view.lock().unwrap();
+        if let Some(tunnels) = view["tunnels"].as_array_mut() {
+            for t in tunnels {
+                if t["id"] == json!(id) {
+                    t["status"] = json!(status);
+                }
+            }
+        }
+    }
+}
+
+impl ProjectedStore for TunnelStore {
+    fn region_id(&self) -> &str {
+        "tunnels"
+    }
+    fn snapshot(&self) -> Value {
+        self.view.lock().unwrap().clone()
+    }
+}
+
+/// Intent handler for the tunnel region: `tunnel.start` moves a tunnel to
+/// `connecting` and publishes the region.
+struct TunnelHandler {
+    store: Arc<TunnelStore>,
+}
+
+impl IntentHandler for TunnelHandler {
+    fn handle(
+        &self,
+        intent: &Intent,
+        projector: &Projector,
+    ) -> Result<Vec<ProducedRegion>, (String, String)> {
+        match intent.kind.as_str() {
+            "tunnel.start" => {
+                let id = intent.payload["id"]
+                    .as_str()
+                    .ok_or_else(|| ("bad_payload".to_string(), "missing tunnel id".to_string()))?;
+                self.store.set_status(id, "connecting");
+                let produced = match projector.publish_store(&*self.store) {
+                    Some(version) => vec![ProducedRegion {
+                        region: "tunnels".to_string(),
+                        version,
+                    }],
+                    None => vec![],
+                };
+                Ok(produced)
+            }
+            other => Err((
+                "unknown_intent".to_string(),
+                format!("tunnel handler cannot handle '{other}'"),
+            )),
+        }
+    }
+}
+
+fn intent(kind: &str, payload: Value) -> Intent {
+    Intent {
+        intent_id: format!("01J-{kind}"),
+        kind: kind.to_string(),
+        payload,
+        client_id: "A".to_string(),
+    }
+}
+
+// ── The worked full-loop scenario ───────────────────────────────────────────
+
+#[test]
+fn full_loop_subscribe_dispatch_fanout_and_forced_gap_resync() {
+    let projector = Arc::new(Projector::new());
+    let store = Arc::new(TunnelStore::new());
+    projector.register_region("tunnels", store.snapshot());
+    let dispatcher = Dispatcher::new(
+        projector.clone(),
+        Arc::new(TunnelHandler {
+            store: store.clone(),
+        }),
+    );
+
+    // 1 · Attach two subscribers (desktop A + browser B). Both get the same
+    //     baseline snapshot at version 0.
+    let sink_a = Arc::new(VecSink::new());
+    let sink_b = Arc::new(VecSink::new());
+    let snap_a = projector.subscribe("tunnels", "sub-a", "A", sink_a.clone());
+    let snap_b = projector.subscribe("tunnels", "sub-b", "B", sink_b.clone());
+    assert_eq!(snap_a.version, 0);
+    assert_eq!(snap_a, snap_b, "late joiner gets an identical baseline");
+    assert_eq!(projector.subscriber_count("tunnels"), 2);
+    let mut cache_a = ClientCache::from_snapshot(&snap_a);
+    let mut cache_b = ClientCache::from_snapshot(&snap_b);
+
+    // 2 · A dispatches tunnel.start(t2). The ack is a receipt naming the region
+    //     it advanced; the *result* arrives as a diff.
+    let ack = dispatcher.dispatch(intent("tunnel.start", json!({ "id": "t2" })));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(
+        ack.produced,
+        Some(vec![ProducedRegion {
+            region: "tunnels".into(),
+            version: 1
+        }])
+    );
+
+    // 3 · One diff (base 0 → version 1) is fanned out to BOTH subscribers.
+    let diff_a = sink_a.diffs();
+    let diff_b = sink_b.diffs();
+    assert_eq!(diff_a.len(), 1);
+    assert_eq!(diff_b.len(), 1);
+    assert_eq!(diff_a[0], diff_b[0], "identical diff to every subscriber");
+    assert_eq!(diff_a[0].base_version, 0);
+    assert_eq!(diff_a[0].version, 1);
+
+    // Both caches apply it and converge on the authoritative view.
+    cache_a.apply(&diff_a[0]).unwrap();
+    cache_b.apply(&diff_b[0]).unwrap();
+    assert_eq!(cache_a.view, cache_b.view);
+    assert_eq!(cache_a.view, store.snapshot());
+    assert_eq!(
+        cache_a.view.pointer("/tunnels/1/status").unwrap(),
+        &json!("connecting")
+    );
+
+    // 4 · B goes away (backgrounded). Backend advances twice while B is gone:
+    //     real completion t2→connected (v2) and then A stops t1 (v3).
+    sink_b.kill();
+    store.set_status("t2", "connected");
+    assert_eq!(projector.publish_store(&*store), Some(2));
+    store.set_status("t1", "stopped");
+    assert_eq!(projector.publish_store(&*store), Some(3));
+
+    // B's dead sink was reaped on the emit path; A still receives everything.
+    assert_eq!(projector.subscriber_count("tunnels"), 1);
+    let diff_a = sink_a.diffs();
+    assert_eq!(diff_a.len(), 3);
+    cache_a.apply(&diff_a[1]).unwrap();
+    cache_a.apply(&diff_a[2]).unwrap();
+    assert_eq!(cache_a.version, 3);
+
+    // 5 · B reconnects. It is still at version 1; the only frame it now sees is
+    //     the latest diff (base 2), which does NOT fit — a forced gap.
+    let latest = diff_a.last().unwrap();
+    assert_eq!(cache_b.version, 1);
+    assert_eq!(cache_b.apply(latest), Err(Gap), "gap detected, not applied");
+
+    // B resyncs from its known version; backend is ahead, so it re-baselines
+    // from a fresh snapshot and reconverges — never having applied a stale diff.
+    let snap = projector
+        .resync("tunnels", Some(cache_b.version))
+        .expect("region advanced, snapshot returned");
+    assert_eq!(snap.version, 3);
+    cache_b.rebaseline(&snap);
+    assert_eq!(cache_b.version, 3);
+    assert_eq!(cache_b.view, cache_a.view);
+    assert_eq!(cache_b.view, store.snapshot());
+
+    // A current client asking to resync is told there is nothing to send.
+    assert!(projector.resync("tunnels", Some(3)).is_none());
+}
+
+// ── Diff / apply helpers ────────────────────────────────────────────────────
+
+#[test]
+fn compute_ops_then_apply_roundtrips() {
+    let old = json!({ "a": 1, "list": [ { "s": "x" } ], "gone": true });
+    let new = json!({ "a": 2, "list": [ { "s": "x" }, { "s": "y" } ] });
+    let ops = compute_ops(&old, &new);
+    assert!(!ops.is_empty());
+    let mut applied = old.clone();
+    apply_ops(&mut applied, &ops).unwrap();
+    assert_eq!(applied, new);
+}
+
+#[test]
+fn compute_ops_is_empty_for_identical_views() {
+    let v = json!({ "a": [1, 2, 3] });
+    assert!(compute_ops(&v, &v).is_empty());
+}
+
+#[test]
+fn semantic_op_is_rejected_by_the_applier() {
+    let ops = vec![DiffOp::Semantic {
+        name: "tunnelStatusChanged".into(),
+        data: json!({ "id": "t2", "status": "connecting" }),
+    }];
+    let mut view = json!({});
+    let err = apply_ops(&mut view, &ops).unwrap_err();
+    assert!(matches!(err, ProjectionError::UnsupportedSemanticOp(_)));
+}
+
+// ── Versioning & lifecycle ──────────────────────────────────────────────────
+
+#[test]
+fn publish_without_change_is_a_noop() {
+    let projector = Projector::new();
+    projector.register_region("r", json!({ "x": 1 }));
+    assert_eq!(projector.region_version("r"), Some(0));
+    assert_eq!(projector.publish("r", json!({ "x": 1 })), None);
+    assert_eq!(projector.region_version("r"), Some(0), "version unchanged");
+}
+
+#[test]
+fn each_change_advances_version_by_exactly_one() {
+    let projector = Projector::new();
+    projector.register_region("r", json!({ "n": 0 }));
+    assert_eq!(projector.publish("r", json!({ "n": 1 })), Some(1));
+    assert_eq!(projector.publish("r", json!({ "n": 2 })), Some(2));
+    assert_eq!(projector.publish("r", json!({ "n": 3 })), Some(3));
+}
+
+#[test]
+fn unsubscribe_stops_delivery_and_is_idempotent() {
+    let projector = Projector::new();
+    projector.register_region("r", json!({ "n": 0 }));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe("r", "sub-1", "A", sink.clone());
+    projector.publish("r", json!({ "n": 1 }));
+    assert_eq!(sink.diffs().len(), 1);
+
+    projector.unsubscribe("r", "sub-1");
+    projector.unsubscribe("r", "sub-1"); // idempotent
+    assert_eq!(projector.subscriber_count("r"), 0);
+    projector.publish("r", json!({ "n": 2 }));
+    assert_eq!(sink.diffs().len(), 1, "no frames after unsubscribe");
+}
+
+#[test]
+fn unsubscribe_client_detaches_all_of_a_clients_subscriptions() {
+    let projector = Projector::new();
+    projector.register_region("r", json!({ "n": 0 }));
+    // One client with two subscriptions (e.g. two windows), plus another client.
+    projector.subscribe("r", "sub-1", "A", Arc::new(VecSink::new()));
+    projector.subscribe("r", "sub-2", "A", Arc::new(VecSink::new()));
+    let other = Arc::new(VecSink::new());
+    projector.subscribe("r", "sub-3", "B", other.clone());
+    assert_eq!(projector.subscriber_count("r"), 3);
+
+    projector.unsubscribe_client("r", "A");
+    projector.unsubscribe_client("r", "A"); // idempotent
+    assert_eq!(projector.subscriber_count("r"), 1);
+
+    projector.publish("r", json!({ "n": 1 }));
+    assert_eq!(other.diffs().len(), 1, "client B still receives");
+}
+
+#[test]
+fn resubscribe_with_same_id_replaces_the_sink() {
+    let projector = Projector::new();
+    projector.register_region("r", json!({ "n": 0 }));
+    let first = Arc::new(VecSink::new());
+    let second = Arc::new(VecSink::new());
+    projector.subscribe("r", "sub-1", "A", first.clone());
+    projector.subscribe("r", "sub-1", "A", second.clone());
+    assert_eq!(projector.subscriber_count("r"), 1);
+    projector.publish("r", json!({ "n": 1 }));
+    assert_eq!(first.diffs().len(), 0);
+    assert_eq!(second.diffs().len(), 1);
+}
+
+// ── Dispatch / ack ──────────────────────────────────────────────────────────
+
+#[test]
+fn unknown_intent_is_rejected_by_the_empty_registry() {
+    let projector = Arc::new(Projector::new());
+    let dispatcher = Dispatcher::new(projector, Arc::new(HandlerRegistry::new()));
+    let ack = dispatcher.dispatch(intent("nope.doIt", json!({})));
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "unknown_intent");
+    assert!(ack.produced.is_none());
+}
+
+#[test]
+fn registry_routes_by_exact_kind() {
+    let projector = Arc::new(Projector::new());
+    projector.register_region("r", json!({ "hit": false }));
+    let mut registry = HandlerRegistry::new();
+    registry.route("thing.do", |_intent, proj| {
+        let v = proj.publish("r", json!({ "hit": true })).unwrap_or(0);
+        Ok(vec![ProducedRegion {
+            region: "r".into(),
+            version: v,
+        }])
+    });
+    let dispatcher = Dispatcher::new(projector, Arc::new(registry));
+    let ack = dispatcher.dispatch(intent("thing.do", json!({})));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(ack.produced.unwrap()[0].version, 1);
+}
+
+#[test]
+fn handler_rejection_becomes_a_rejected_ack() {
+    let projector = Arc::new(Projector::new());
+    let store = Arc::new(TunnelStore::new());
+    let dispatcher = Dispatcher::new(projector, Arc::new(TunnelHandler { store }));
+    let ack = dispatcher.dispatch(intent("tunnel.start", json!({}))); // no id
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "bad_payload");
+}
+
+// ── Envelope serde shapes (must mirror the TypeScript types) ─────────────────
+
+#[test]
+fn intent_serialises_with_camelcase_keys() {
+    let v = serde_json::to_value(intent("tunnel.start", json!({ "id": "t2" }))).unwrap();
+    assert_eq!(v["intentId"], json!("01J-tunnel.start"));
+    assert_eq!(v["kind"], json!("tunnel.start"));
+    assert_eq!(v["clientId"], json!("A"));
+    assert_eq!(v["payload"], json!({ "id": "t2" }));
+}
+
+#[test]
+fn ack_omits_absent_fields() {
+    let accepted = serde_json::to_value(IntentAck::accepted("i1", vec![])).unwrap();
+    assert_eq!(accepted["status"], json!("accepted"));
+    assert!(accepted.get("error").is_none());
+    assert_eq!(accepted["produced"], json!([]));
+
+    let rejected = serde_json::to_value(IntentAck::rejected("i1", "code", "msg")).unwrap();
+    assert_eq!(rejected["status"], json!("rejected"));
+    assert_eq!(
+        rejected["error"],
+        json!({ "code": "code", "message": "msg" })
+    );
+    assert!(rejected.get("produced").is_none());
+}
+
+#[test]
+fn projection_frame_is_tagged_by_kind() {
+    let snap = ProjectionFrame::Snapshot(SnapshotFrame {
+        region: "tunnels".into(),
+        version: 41,
+        view: json!({ "tunnels": [] }),
+    });
+    let v = serde_json::to_value(&snap).unwrap();
+    assert_eq!(v["kind"], json!("snapshot"));
+    assert_eq!(v["region"], json!("tunnels"));
+    assert_eq!(v["version"], json!(41));
+
+    let diff = ProjectionFrame::Diff(DiffFrame {
+        region: "tunnels".into(),
+        base_version: 41,
+        version: 42,
+        ops: vec![DiffOp::Replace {
+            path: "/tunnels/1/status".into(),
+            value: json!("connecting"),
+        }],
+    });
+    let v = serde_json::to_value(&diff).unwrap();
+    assert_eq!(v["kind"], json!("diff"));
+    assert_eq!(v["baseVersion"], json!(41));
+    assert_eq!(
+        v["ops"][0],
+        json!({ "op": "replace", "path": "/tunnels/1/status", "value": "connecting" })
+    );
+
+    // Round-trips back to the same frame.
+    assert_eq!(serde_json::from_value::<ProjectionFrame>(v).unwrap(), diff);
+}

--- a/src/services/transport/ProjectionClient.test.ts
+++ b/src/services/transport/ProjectionClient.test.ts
@@ -1,0 +1,180 @@
+import { compare } from "fast-json-patch";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { ProjectionClient, type ProjectionCacheState } from "./ProjectionClient";
+import type { FrameHandler, Subscription, Transport } from "./Transport";
+import type { DiffFrame, DiffOp, IntentAck, ProjectionFrame, SnapshotFrame } from "./types";
+
+const clone = <T>(v: T): T => JSON.parse(JSON.stringify(v)) as T;
+
+/**
+ * In-memory transport backed by a single-region "server" that mirrors the Rust
+ * `Projector`: subscribe returns a snapshot, `publish` computes a diff and
+ * streams it, and `resync` returns the current snapshot (or `null` when the
+ * caller is already current). Frame drops and raw frame injection are exposed
+ * so tests can force gaps and exercise the semantic-op path.
+ */
+class FakeTransport implements Transport {
+  version = 0;
+  view: unknown;
+  resyncHaves: Array<number | undefined> = [];
+  dropNext = 0;
+  private handler?: FrameHandler;
+
+  constructor(
+    initial: unknown,
+    private readonly region = "tunnels"
+  ) {
+    this.view = initial;
+  }
+
+  async dispatch(): Promise<IntentAck> {
+    throw new Error("dispatch not exercised in these tests");
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handler = onFrame;
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handler = undefined;
+      },
+    };
+  }
+
+  async resync(region: string, have?: number): Promise<SnapshotFrame | null> {
+    this.resyncHaves.push(have);
+    if (have === this.version) return null;
+    return this.snapshot(region);
+  }
+
+  /** Mutate authoritative state and stream one diff (unless dropped). */
+  publish(newView: unknown): void {
+    const ops = compare(this.view as object, newView as object) as DiffOp[];
+    if (ops.length === 0) return;
+    const baseVersion = this.version;
+    const version = baseVersion + 1;
+    const frame: DiffFrame = { region: this.region, kind: "diff", baseVersion, version, ops };
+    this.view = newView;
+    this.version = version;
+    if (this.dropNext > 0) {
+      this.dropNext -= 1;
+      return; // simulate a dropped frame
+    }
+    this.handler?.(frame);
+  }
+
+  /** Push an arbitrary frame to the subscriber (raw injection). */
+  emit(frame: ProjectionFrame): void {
+    this.handler?.(frame);
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { region, kind: "snapshot", version: this.version, view: clone(this.view) };
+  }
+}
+
+const tunnelsView = () => ({
+  tunnels: [
+    { id: "t1", status: "connected" },
+    { id: "t2", status: "stopped" },
+  ],
+});
+
+describe("ProjectionClient", () => {
+  let transport: FakeTransport;
+  let client: ProjectionClient;
+  let states: ProjectionCacheState[];
+
+  beforeEach(async () => {
+    transport = new FakeTransport(tunnelsView());
+    client = new ProjectionClient(transport, "tunnels");
+    states = [];
+    client.onChange((s) => states.push(clone(s)));
+    await client.start();
+  });
+
+  it("adopts the snapshot as its baseline on subscribe", () => {
+    expect(client.state.version).toBe(0);
+    expect(client.state.view).toEqual(tunnelsView());
+    expect(states).toHaveLength(1);
+  });
+
+  it("applies an ordered diff and advances the version by one", () => {
+    const next = clone(tunnelsView());
+    next.tunnels[1].status = "connecting";
+    transport.publish(next);
+
+    expect(client.state.version).toBe(1);
+    expect(client.state.view).toEqual(next);
+    expect(states[states.length - 1]).toEqual({ version: 1, view: next });
+  });
+
+  it("stays in step across several ordered diffs", () => {
+    const a = clone(tunnelsView());
+    a.tunnels[1].status = "connecting";
+    transport.publish(a);
+    const b = clone(a);
+    b.tunnels[1].status = "connected";
+    transport.publish(b);
+    const c = clone(b);
+    c.tunnels[0].status = "stopped";
+    transport.publish(c);
+
+    expect(client.state.version).toBe(3);
+    expect(client.state.view).toEqual(transport.view);
+  });
+
+  it("detects a gap from a dropped frame and re-baselines via resync", async () => {
+    // Drop the next emitted frame: backend advances to v1 but the client never
+    // sees it, so it stays at v0.
+    transport.dropNext = 1;
+    const dropped = clone(tunnelsView());
+    dropped.tunnels[1].status = "connecting";
+    transport.publish(dropped);
+    expect(client.state.version).toBe(0);
+
+    // The following diff has baseVersion 1, which no longer fits the client's
+    // v0 — a gap. The client discards it and resyncs.
+    const next = clone(dropped);
+    next.tunnels[0].status = "stopped";
+    transport.publish(next);
+    await Promise.resolve(); // let the async resync settle
+
+    expect(transport.resyncHaves).toContain(0);
+    expect(client.state.version).toBe(transport.version);
+    expect(client.state.view).toEqual(transport.view);
+  });
+
+  it("resyncs instead of applying an un-interpretable semantic op", async () => {
+    transport.emit({
+      region: "tunnels",
+      kind: "diff",
+      baseVersion: 0,
+      version: 1,
+      ops: [{ op: "semantic", name: "tunnelStatusChanged", data: { id: "t2" } }],
+    });
+    await Promise.resolve();
+
+    expect(transport.resyncHaves).toContain(0);
+    // Backend was still at v0, so resync returns null and the cache is unchanged.
+    expect(client.state.version).toBe(0);
+    expect(client.state.view).toEqual(tunnelsView());
+  });
+
+  it("resync is a no-op when the cache is already current", async () => {
+    await client.resync();
+    expect(transport.resyncHaves).toEqual([0]);
+    expect(client.state.version).toBe(0);
+    expect(states).toHaveLength(1); // no extra change emitted
+  });
+
+  it("stops applying frames after stop()", () => {
+    client.stop();
+    const next = clone(tunnelsView());
+    next.tunnels[1].status = "connecting";
+    transport.publish(next);
+    expect(client.state.version).toBe(0);
+    expect(states).toHaveLength(1);
+  });
+});

--- a/src/services/transport/ProjectionClient.ts
+++ b/src/services/transport/ProjectionClient.ts
@@ -1,0 +1,127 @@
+/**
+ * Per-region cache adapter for the projection substrate (#2149).
+ *
+ * Holds `{ version, view }` for one region, applies ordered diffs, detects
+ * gaps (`baseVersion !== version`) and re-baselines via `resync`, and notifies
+ * listeners on every change. It computes and decides nothing about the view —
+ * the backend is the single authoritative writer; this is a dumb cache.
+ *
+ * Diffs are applied with the maintained `fast-json-patch` package (RFC 6902),
+ * the mirror of the Rust reference applier `projection::apply_ops`.
+ */
+
+import { applyPatch, type Operation } from "fast-json-patch";
+
+import type { FrameHandler, Subscription, Transport } from "./Transport";
+import type { DiffFrame, ProjectionFrame, SnapshotFrame } from "./types";
+
+/** The cache's public state for one region. */
+export interface ProjectionCacheState {
+  /** `-1` until the first snapshot is adopted. */
+  version: number;
+  view: unknown;
+}
+
+/** Notified with the new cache state on every change. */
+export type CacheListener = (state: ProjectionCacheState) => void;
+
+export class ProjectionClient {
+  private version = -1;
+  private view: unknown = undefined;
+  private subscription?: Subscription;
+  private readonly listeners = new Set<CacheListener>();
+  private closed = false;
+  private resyncing = false;
+
+  constructor(
+    private readonly transport: Transport,
+    public readonly region: string
+  ) {}
+
+  /** Current cached `{ version, view }`. */
+  get state(): ProjectionCacheState {
+    return { version: this.version, view: this.view };
+  }
+
+  /** Subscribe a listener; returns an unsubscribe function. */
+  onChange(listener: CacheListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  /** Attach to the region and adopt its snapshot as the baseline. */
+  async start(): Promise<void> {
+    this.closed = false;
+    const onFrame: FrameHandler = (frame) => this.onFrame(frame);
+    this.subscription = await this.transport.subscribe(this.region, onFrame);
+    this.adoptSnapshot(this.subscription.snapshot);
+  }
+
+  /** Detach and stop applying frames. Idempotent. */
+  stop(): void {
+    this.closed = true;
+    this.subscription?.unsubscribe();
+    this.subscription = undefined;
+  }
+
+  private onFrame(frame: ProjectionFrame): void {
+    if (this.closed) return;
+    if (frame.kind === "snapshot") {
+      this.adoptSnapshot(frame);
+      return;
+    }
+    this.applyDiff(frame);
+  }
+
+  private adoptSnapshot(snapshot: SnapshotFrame): void {
+    this.version = snapshot.version;
+    this.view = snapshot.view;
+    this.emit();
+  }
+
+  private applyDiff(diff: DiffFrame): void {
+    // Gap: a frame was dropped, reordered, or the stream reconnected. Discard
+    // and re-baseline rather than apply out of order.
+    if (diff.baseVersion !== this.version) {
+      void this.resync();
+      return;
+    }
+    // The semantic-op escape hatch has no RFC 6902 apply path (unused in Phase
+    // 1); fall back to a resync rather than apply a frame we cannot interpret.
+    if (diff.ops.some((op) => op.op === "semantic")) {
+      void this.resync();
+      return;
+    }
+    const result = applyPatch(this.view, diff.ops as Operation[], false, false);
+    this.view = result.newDocument;
+    this.version = diff.version;
+    this.emit();
+  }
+
+  /**
+   * Re-baseline the region from the backend. A `null` response means the cache
+   * is already current (nothing to adopt). Guarded against concurrent runs.
+   */
+  async resync(): Promise<void> {
+    if (this.closed || this.resyncing) return;
+    this.resyncing = true;
+    try {
+      const have = this.version >= 0 ? this.version : undefined;
+      const snapshot = await this.transport.resync(this.region, have);
+      if (snapshot && !this.closed) {
+        this.adoptSnapshot(snapshot);
+      }
+    } finally {
+      this.resyncing = false;
+    }
+  }
+
+  private emit(): void {
+    const state = this.state;
+    for (const listener of this.listeners) {
+      listener(state);
+    }
+  }
+}

--- a/src/services/transport/TauriTransport.ts
+++ b/src/services/transport/TauriTransport.ts
@@ -1,0 +1,54 @@
+/**
+ * Desktop transport: rides Tauri IPC.
+ *
+ * `dispatch` wraps the `intent_dispatch` command; `subscribe` opens a
+ * per-region `tauri::ipc::Channel` (efficient per-region push) and returns the
+ * snapshot from `projection_subscribe`. See
+ * `src-tauri/src/commands/projection.rs`.
+ */
+
+import { Channel, invoke } from "@tauri-apps/api/core";
+
+import { newClientId } from "./ids";
+import type { FrameHandler, Subscription, Transport } from "./Transport";
+import type { Intent, IntentAck, ProjectionFrame, SnapshotFrame } from "./types";
+
+export class TauriTransport implements Transport {
+  private subCounter = 0;
+
+  constructor(private readonly clientId: string = newClientId()) {}
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    return invoke<IntentAck>("intent_dispatch", { intent });
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    const subscriptionId = `${this.clientId}:${region}:${this.subCounter++}`;
+    const channel = new Channel<ProjectionFrame>();
+    channel.onmessage = onFrame;
+
+    const snapshot = await invoke<SnapshotFrame>("projection_subscribe", {
+      region,
+      subscriptionId,
+      clientId: this.clientId,
+      channel,
+    });
+
+    let active = true;
+    return {
+      snapshot,
+      unsubscribe: () => {
+        if (!active) return;
+        active = false;
+        void invoke("projection_unsubscribe", { region, subscriptionId });
+      },
+    };
+  }
+
+  async resync(region: string, have?: number): Promise<SnapshotFrame | null> {
+    return invoke<SnapshotFrame | null>("projection_resync", {
+      region,
+      have: have ?? null,
+    });
+  }
+}

--- a/src/services/transport/Transport.ts
+++ b/src/services/transport/Transport.ts
@@ -1,0 +1,53 @@
+/**
+ * The transport abstraction shared with remote-client mode.
+ *
+ * A `Transport` carries the substrate's two generic channels over whichever
+ * link is selected — Tauri IPC on desktop ({@link TauriTransport}) or JSON-RPC
+ * over WebSocket in remote-client mode ({@link WebSocketTransport}). It owns
+ * *where the bytes travel*; the {@link ProjectionClient} owns *what state-shaped
+ * messages travel over it*.
+ */
+
+import type { Intent, IntentAck, ProjectionFrame, SnapshotFrame } from "./types";
+
+/** A live subscription to a region's diff stream. */
+export interface Subscription {
+  /** The snapshot returned at attach time; the cache's initial baseline. */
+  readonly snapshot: SnapshotFrame;
+  /** Detach from the region. Idempotent. */
+  unsubscribe(): void;
+}
+
+/** Callback invoked for every frame pushed on a subscribed region. */
+export type FrameHandler = (frame: ProjectionFrame) => void;
+
+/**
+ * Transport-neutral access to the projection substrate.
+ *
+ * Implementations must preserve per-region ordering of pushed frames; there is
+ * no cross-region ordering guarantee.
+ */
+export interface Transport {
+  /**
+   * Channel 1 — dispatch a user intent; resolves with the ack receipt. The
+   * result of an accepted intent arrives separately as a projection diff on
+   * the affected region(s).
+   */
+  dispatch(intent: Intent): Promise<IntentAck>;
+
+  /**
+   * Channel 2 — attach to a region. Resolves once the initial snapshot has
+   * arrived; every subsequent frame for the region is delivered to `onFrame`
+   * in order. Snapshot and stream-start are atomic backend-side, so no diff
+   * can slip between the snapshot's version and the first streamed diff.
+   */
+  subscribe(region: string, onFrame: FrameHandler): Promise<Subscription>;
+
+  /**
+   * Recover a region after a detected gap or a reconnect. `have` lets the
+   * backend skip work if the client is already current: it resolves to `null`
+   * when `have` already matches the region's current version, otherwise to a
+   * fresh snapshot to re-baseline from.
+   */
+  resync(region: string, have?: number): Promise<SnapshotFrame | null>;
+}

--- a/src/services/transport/WebSocketTransport.ts
+++ b/src/services/transport/WebSocketTransport.ts
@@ -1,0 +1,85 @@
+/**
+ * Remote-client transport: rides JSON-RPC over a WebSocket.
+ *
+ * The substrate's envelopes become additional JSON-RPC methods
+ * (`intent.dispatch`, `projection.subscribe`, `projection.unsubscribe`,
+ * `projection.resync`) and a `projection.frame` server→client notification,
+ * carried by whichever transport remote-client mode selects — no second
+ * transport layer.
+ *
+ * The concrete WebSocket server is remote-client mode's Phase 2 and does not
+ * exist yet; this transport depends only on a minimal {@link JsonRpcSocket}
+ * abstraction so it is fully unit-testable with a fake socket today and drops
+ * onto the real socket unchanged once it lands.
+ */
+
+import { newClientId } from "./ids";
+import type { FrameHandler, Subscription, Transport } from "./Transport";
+import type { Intent, IntentAck, ProjectionFrame, SnapshotFrame } from "./types";
+
+/** The minimal JSON-RPC surface the transport needs from a socket. */
+export interface JsonRpcSocket {
+  /** Send a request and await its result. */
+  request<T>(method: string, params: unknown): Promise<T>;
+  /**
+   * Register a handler for a server→client notification method. Returns a
+   * function that removes the handler.
+   */
+  onNotification(method: string, handler: (params: unknown) => void): () => void;
+}
+
+export class WebSocketTransport implements Transport {
+  private readonly handlers = new Map<string, FrameHandler>();
+  private notificationHandle?: () => void;
+  private subCounter = 0;
+
+  constructor(
+    private readonly socket: JsonRpcSocket,
+    private readonly clientId: string = newClientId()
+  ) {}
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    return this.socket.request<IntentAck>("intent.dispatch", { intent });
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.ensureListener();
+    const subscriptionId = `${this.clientId}:${region}:${this.subCounter++}`;
+    this.handlers.set(region, onFrame);
+
+    const snapshot = await this.socket.request<SnapshotFrame>("projection.subscribe", {
+      region,
+      subscriptionId,
+      clientId: this.clientId,
+    });
+
+    let active = true;
+    return {
+      snapshot,
+      unsubscribe: () => {
+        if (!active) return;
+        active = false;
+        this.handlers.delete(region);
+        void this.socket
+          .request("projection.unsubscribe", { region, subscriptionId })
+          .catch(() => {});
+      },
+    };
+  }
+
+  async resync(region: string, have?: number): Promise<SnapshotFrame | null> {
+    return this.socket.request<SnapshotFrame | null>("projection.resync", {
+      region,
+      have: have ?? null,
+    });
+  }
+
+  /** Route the single `projection.frame` notification stream by region. */
+  private ensureListener(): void {
+    if (this.notificationHandle) return;
+    this.notificationHandle = this.socket.onNotification("projection.frame", (params) => {
+      const frame = params as ProjectionFrame;
+      this.handlers.get(frame.region)?.(frame);
+    });
+  }
+}

--- a/src/services/transport/ids.ts
+++ b/src/services/transport/ids.ts
@@ -1,0 +1,23 @@
+/**
+ * Client-generated identifiers for the projection substrate (#2149).
+ *
+ * Intent ids are ULIDs — lexicographically sortable, time-ordered, and
+ * collision-resistant — per the design concept. Backed by the maintained
+ * `ulid` package rather than a hand-rolled generator.
+ */
+
+import { ulid } from "ulid";
+
+/** A fresh ULID for an {@link import("./types").Intent}'s `intentId`. */
+export function newIntentId(): string {
+  return ulid();
+}
+
+/**
+ * A stable per-client identity for a transport instance. Used as the `clientId`
+ * on intents and subscriptions (fan-out / audit identity, and the key for
+ * client-scoped regions like `layout@<clientId>`).
+ */
+export function newClientId(): string {
+  return `client-${ulid()}`;
+}

--- a/src/services/transport/index.ts
+++ b/src/services/transport/index.ts
@@ -1,0 +1,52 @@
+/**
+ * Projection substrate transport (#2149) — public surface.
+ *
+ * The transport abstraction is shared with remote-client mode: on desktop it
+ * rides Tauri IPC ({@link TauriTransport}); in a browser it rides JSON-RPC over
+ * WebSocket ({@link WebSocketTransport}). {@link ProjectionClient} is the dumb
+ * per-region cache that sits on top of whichever transport is selected.
+ */
+
+import { TauriTransport } from "./TauriTransport";
+import type { Transport } from "./Transport";
+import { WebSocketTransport, type JsonRpcSocket } from "./WebSocketTransport";
+
+export type {
+  DiffFrame,
+  DiffOp,
+  Intent,
+  IntentAck,
+  IntentError,
+  ProducedRegion,
+  ProjectionFrame,
+  SnapshotFrame,
+} from "./types";
+export type { FrameHandler, Subscription, Transport } from "./Transport";
+export { TauriTransport } from "./TauriTransport";
+export { WebSocketTransport, type JsonRpcSocket } from "./WebSocketTransport";
+export {
+  ProjectionClient,
+  type CacheListener,
+  type ProjectionCacheState,
+} from "./ProjectionClient";
+export { newClientId, newIntentId } from "./ids";
+
+/** True when running inside the Tauri desktop shell. */
+export function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI__" in window;
+}
+
+/**
+ * Select the transport for the current environment: {@link TauriTransport} in
+ * the desktop shell, otherwise a {@link WebSocketTransport} over the provided
+ * JSON-RPC socket (remote-client mode). Throws in a non-Tauri environment when
+ * no socket is supplied, since the WebSocket server is remote-client mode's
+ * Phase 2 and not yet wired.
+ */
+export function createTransport(opts?: { socket?: JsonRpcSocket }): Transport {
+  if (isTauri()) return new TauriTransport();
+  if (opts?.socket) return new WebSocketTransport(opts.socket);
+  throw new Error(
+    "non-Tauri environment requires a JSON-RPC socket (remote-client mode transport)"
+  );
+}

--- a/src/services/transport/transport.test.ts
+++ b/src/services/transport/transport.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createTransport, isTauri } from "./index";
+import { WebSocketTransport, type JsonRpcSocket } from "./WebSocketTransport";
+import type { DiffFrame, IntentAck, SnapshotFrame } from "./types";
+
+class FakeSocket implements JsonRpcSocket {
+  requests: Array<{ method: string; params: unknown }> = [];
+  responses = new Map<string, unknown>();
+  private notifHandlers = new Map<string, (p: unknown) => void>();
+
+  async request<T>(method: string, params: unknown): Promise<T> {
+    this.requests.push({ method, params });
+    return this.responses.get(method) as T;
+  }
+
+  onNotification(method: string, handler: (p: unknown) => void): () => void {
+    this.notifHandlers.set(method, handler);
+    return () => this.notifHandlers.delete(method);
+  }
+
+  emitNotification(method: string, params: unknown): void {
+    this.notifHandlers.get(method)?.(params);
+  }
+}
+
+const snapshot: SnapshotFrame = {
+  region: "tunnels",
+  kind: "snapshot",
+  version: 41,
+  view: { tunnels: [] },
+};
+
+describe("WebSocketTransport", () => {
+  it("dispatches an intent as a JSON-RPC request", async () => {
+    const socket = new FakeSocket();
+    const ack: IntentAck = { intentId: "i1", status: "accepted", produced: [] };
+    socket.responses.set("intent.dispatch", ack);
+    const transport = new WebSocketTransport(socket, "client-1");
+
+    const intent = {
+      intentId: "i1",
+      kind: "tunnel.start",
+      payload: { id: "t2" },
+      clientId: "client-1",
+    };
+    const result = await transport.dispatch(intent);
+
+    expect(result).toEqual(ack);
+    expect(socket.requests).toEqual([{ method: "intent.dispatch", params: { intent } }]);
+  });
+
+  it("routes projection.frame notifications to the subscribing region only", async () => {
+    const socket = new FakeSocket();
+    socket.responses.set("projection.subscribe", snapshot);
+    const transport = new WebSocketTransport(socket, "client-1");
+
+    const frames: DiffFrame[] = [];
+    const sub = await transport.subscribe("tunnels", (f) => frames.push(f as DiffFrame));
+    expect(sub.snapshot).toEqual(snapshot);
+
+    const diff: DiffFrame = {
+      region: "tunnels",
+      kind: "diff",
+      baseVersion: 41,
+      version: 42,
+      ops: [{ op: "replace", path: "/tunnels/0/status", value: "connecting" }],
+    };
+    socket.emitNotification("projection.frame", diff);
+    socket.emitNotification("projection.frame", { ...diff, region: "servers" });
+    expect(frames).toEqual([diff]);
+
+    // Unsubscribe stops delivery and tells the server.
+    sub.unsubscribe();
+    expect(socket.requests[socket.requests.length - 1]?.method).toBe("projection.unsubscribe");
+    socket.emitNotification("projection.frame", diff);
+    expect(frames).toHaveLength(1);
+  });
+
+  it("passes the held version to resync", async () => {
+    const socket = new FakeSocket();
+    socket.responses.set("projection.resync", snapshot);
+    const transport = new WebSocketTransport(socket, "client-1");
+
+    const result = await transport.resync("tunnels", 40);
+    expect(result).toEqual(snapshot);
+    expect(socket.requests).toEqual([
+      { method: "projection.resync", params: { region: "tunnels", have: 40 } },
+    ]);
+  });
+});
+
+describe("createTransport selector", () => {
+  it("reports a non-Tauri environment under jsdom", () => {
+    expect(isTauri()).toBe(false);
+  });
+
+  it("throws without a socket when not in Tauri", () => {
+    expect(() => createTransport()).toThrow(/socket/i);
+  });
+
+  it("builds a WebSocketTransport over a supplied socket", () => {
+    const socket = new FakeSocket();
+    expect(createTransport({ socket })).toBeInstanceOf(WebSocketTransport);
+  });
+
+  it("selects TauriTransport when the Tauri global is present", () => {
+    vi.stubGlobal("window", { __TAURI__: {} });
+    try {
+      expect(isTauri()).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/src/services/transport/types.ts
+++ b/src/services/transport/types.ts
@@ -1,0 +1,99 @@
+/**
+ * Wire envelopes for the stateless-UI projection substrate (#2149).
+ *
+ * These types are the twin of the Rust `serde` structs in
+ * `src-tauri/src/projection/frame.rs`. They are transport-neutral: identical
+ * whether they ride Tauri IPC (desktop) or JSON-RPC over WebSocket
+ * (remote-client mode). See the design concept
+ * `docs/concepts/future/stateless-ui-projection-substrate.html`.
+ *
+ * The substrate carries two new generic channels:
+ * - channel 1 `dispatch(intent)` (UI → backend): one {@link Intent}, answered
+ *   by an {@link IntentAck} receipt.
+ * - channel 2 `subscribe(region)` (backend → UI): an initial
+ *   {@link SnapshotFrame} then an ordered stream of {@link DiffFrame}s.
+ *
+ * The terminal `terminal-output` byte stream is channel 3 and is wholly
+ * independent of this module.
+ */
+
+/** A user intent dispatched by a client (channel 1, UI → backend). */
+export interface Intent<P = unknown> {
+  /** Client-generated ULID; correlates the ack (and any optimistic echo). */
+  intentId: string;
+  /** Dotted `<domain>.<action>`, e.g. `"tunnel.start"`, `"layout.moveTab"`. */
+  kind: string;
+  /** Kind-specific, serialisable payload; validated backend-side. */
+  payload: P;
+  /** Which attached client dispatched it (fan-out / audit identity). */
+  clientId: string;
+}
+
+/** Error detail attached to a rejected {@link IntentAck}. */
+export interface IntentError {
+  code: string;
+  message: string;
+}
+
+/** A region advanced by an intent, so a client can await the confirming diff. */
+export interface ProducedRegion {
+  region: string;
+  version: number;
+}
+
+/**
+ * Receipt for a dispatched {@link Intent} (channel 1 reply).
+ *
+ * The ack is a receipt, not the result: the result of an intent is always a
+ * projection diff on the affected region(s), never data returned inline.
+ */
+export interface IntentAck {
+  /** Echoes the request's `intentId`. */
+  intentId: string;
+  status: "accepted" | "rejected";
+  /** Present iff `status === "rejected"`. */
+  error?: IntentError;
+  /** Regions this intent advanced. Empty/absent for no-op / query intents. */
+  produced?: ProducedRegion[];
+}
+
+/** A projection frame pushed to a subscriber (channel 2, backend → UI). */
+export type ProjectionFrame = SnapshotFrame | DiffFrame;
+
+/**
+ * The complete, render-ready view model for a region at a baseline version.
+ * Emitted on attach and on resync only; steady state is {@link DiffFrame}s.
+ */
+export interface SnapshotFrame {
+  region: string;
+  kind: "snapshot";
+  /** `u64` monotonic; the cache adopts this as its baseline. */
+  version: number;
+  /** The complete, render-ready view model for the region. */
+  view: unknown;
+}
+
+/** An ordered mutation of a region's cached view model. */
+export interface DiffFrame {
+  region: string;
+  kind: "diff";
+  /** MUST equal the cache's current version, else it is a gap. */
+  baseVersion: number;
+  /** `=== baseVersion + 1`. */
+  version: number;
+  /** Ordered mutations to apply to the cached view model. */
+  ops: DiffOp[];
+}
+
+/**
+ * A single diff operation.
+ *
+ * The default shape is an RFC 6902 JSON-Patch subset (`add` / `remove` /
+ * `replace`). The `semantic` variant is the per-domain compact-op escape hatch
+ * reserved by the design; it is unused in Phase 1.
+ */
+export type DiffOp =
+  | { op: "replace"; path: string; value: unknown }
+  | { op: "add"; path: string; value: unknown }
+  | { op: "remove"; path: string }
+  | { op: "semantic"; name: string; data: unknown };

--- a/src/store/projectionCache.ts
+++ b/src/store/projectionCache.ts
@@ -1,0 +1,63 @@
+/**
+ * Dumb projection-cache store for the stateless-UI substrate (#2149).
+ *
+ * Holds the last backend-pushed view model per region and notifies React; it
+ * computes and decides nothing (the backend is the single authoritative
+ * writer). A {@link ProjectionClient} drives one region into this store via
+ * {@link connectRegion}.
+ *
+ * Phase-1 note: this lives adjacent to the 8k-line `appStore.ts` rather than
+ * inside it. Phase 1 migrates no real domain, so there is no slice to convert
+ * yet; when a domain migrates (Phase 2+), its `appStore` slice becomes a dumb
+ * cache fed the same way. Keeping the generic cache separate keeps the Phase-1
+ * change additive and low-blast-radius.
+ */
+
+import { create } from "zustand";
+
+import { ProjectionClient } from "@/services/transport/ProjectionClient";
+import type { Transport } from "@/services/transport/Transport";
+
+/** Cached `{ version, view }` for a single region. */
+export interface RegionCache {
+  version: number;
+  view: unknown;
+}
+
+interface ProjectionCacheStore {
+  /** region id → last pushed view model + version. */
+  regions: Record<string, RegionCache>;
+  /** Replace a region's cached state (called by a {@link ProjectionClient}). */
+  setRegion: (region: string, cache: RegionCache) => void;
+  /** Drop a region from the cache (e.g. on unsubscribe). */
+  clearRegion: (region: string) => void;
+}
+
+export const useProjectionCache = create<ProjectionCacheStore>((set) => ({
+  regions: {},
+  setRegion: (region, cache) =>
+    set((state) => ({ regions: { ...state.regions, [region]: cache } })),
+  clearRegion: (region) =>
+    set((state) => {
+      const regions = { ...state.regions };
+      delete regions[region];
+      return { regions };
+    }),
+}));
+
+/**
+ * Attach a region to the dumb projection cache: create a
+ * {@link ProjectionClient}, pipe its changes into the store, and start it.
+ * Resolves with the started client so the caller can `stop()` it on unmount.
+ */
+export async function connectRegion(
+  transport: Transport,
+  region: string
+): Promise<ProjectionClient> {
+  const client = new ProjectionClient(transport, region);
+  client.onChange((state) => {
+    useProjectionCache.getState().setRegion(region, state);
+  });
+  await client.start();
+  return client;
+}


### PR DESCRIPTION
## What & why

Phase 1 of the stateless-UI / agent-centric port (#2139): builds the **projection substrate** — the two generic channels the whole port rides on — implemented exactly to the settled design in `docs/concepts/future/stateless-ui-projection-substrate.html`.

**Mechanism only. No domain is migrated** (tunnels/tabs/etc. are Phase 2, #2150). The substrate lands *beside* the existing ~206 typed commands and ~36 events (strangler); the terminal `terminal-output` byte stream is a separate, untouched channel.

## What the substrate delivers

**Rust (`src-tauri/src/projection/`, `commands/projection.rs`)**
- **Envelopes** (`frame.rs`) — `Intent` / `IntentAck` (explicit receipt with `produced` versions), `ProjectionFrame` = `SnapshotFrame` | `DiffFrame`, and `DiffOp` as an RFC 6902 subset (`add`/`remove`/`replace`) with a reserved-but-unused `semantic` escape hatch. Serde-mirror of the TS types.
- **Projector** — subscription registry (`region → subscribers`), monotonic `u64` per-region versions, snapshot-on-attach captured under the same lock as subscriber insertion, `publish` computes **one** diff and fans it to every subscriber (`baseVersion=V, version=V+1`), dead-sink reaping, and `resync` (returns `None` when already current). Supports both shared (`<domain>`) and client-scoped (`<domain>@<client>`) regions generically.
- **Single-writer dispatch** — `Dispatcher` serialises intents; `HandlerRegistry` routes by kind (Phase 1 registers none → `unknown_intent`).
- **Tauri commands** — `intent_dispatch`, `projection_subscribe` (opens a per-region `tauri::ipc::Channel`), `projection_unsubscribe`, `projection_resync`; wired into `lib.rs` managed state.
- **Diff/apply** are library-backed (`json-patch`, RFC 6902) per the repo's prefer-libraries rule, not hand-rolled.

**TypeScript (`src/services/transport/`, `src/store/projectionCache.ts`)**
- Mirrored envelope types; a `Transport` abstraction shared with remote-client mode (`TauriTransport` + `WebSocketTransport` over JSON-RPC, selected by environment).
- `ProjectionClient` — dumb per-region cache: applies diffs via `fast-json-patch`, **detects gaps** (`baseVersion !== version`) and re-baselines via `resync`.
- `projectionCache` Zustand store + `connectRegion` adapter (the "dumb projection cache" — additive, adjacent to `appStore.ts`).

## Harness scenarios proven

Rust in-memory harness (`projection/tests.rs`, 15 tests) drives a synthetic SSH-tunnels region end-to-end: **subscribe → identical snapshot for 2 subscribers**, **dispatch(intent) → one diff fanned out to both**, both caches converging on authority, then **a forced version gap → `resync` → re-baseline** (no stale diff applied), plus dead-sink reaping, no-op publish, version invariants, semantic-op rejection, and envelope serde shapes. TS side (`ProjectionClient.test.ts` + `transport.test.ts`, 14 tests) proves the client loop and WebSocket frame routing.

## Design points interpreted
- **Carried defaults** from #2149 followed: explicit `IntentAck`, pessimistic-by-default (no optimistic echo built), JSON-Patch diffs with an unused semantic escape hatch, and shared-vs-client-scoped left generic (both supported, neither decided).
- **Dumb cache placement**: added as `src/store/projectionCache.ts` adjacent to the 8k-line `appStore.ts` rather than embedded in it — Phase 1 migrates no slice, so keeping the generic cache separate keeps the change additive and low-blast-radius. A real domain slice folds into `appStore` in Phase 2.
- **`WebSocketTransport`** depends on a minimal `JsonRpcSocket` interface (the WS server is remote-client mode's Phase 2, not yet wired), so it is unit-tested today and drops onto the real socket unchanged.

## Testing
- `cargo test -p termihub --lib projection` — 15 pass; `cargo clippy … -D warnings` clean; `cargo fmt` clean.
- `vitest run src/services/transport` — 14 pass; `tsc --noEmit`, `eslint` clean.

Closes #2149
Part of #2139
