### PR TITLE
refactor(test): formalize cross-language golden-vector harness (Closes #2147)

### DIFF
--- a/core/tests/fixtures/golden/README.md
+++ b/core/tests/fixtures/golden/README.md
@@ -8,7 +8,24 @@ vectors and must produce identical output, so any drift between the two
 implementations fails a test.
 
 The panel-tree port (#2143) established this convention; the sibling ports
-(#2144–#2147) reuse it verbatim.
+(#2144–#2146) reuse it verbatim, and #2147 extracted the shared runner they all
+drive (see [Shared runner](#shared-runner) below).
+
+## TypeScript is authoritative
+
+The vectors are **derived from the TypeScript suite, which stays the source of
+truth.** The direction is one-way: expected values are lifted from the util's
+`*.test.ts` cases, and the Rust port is written to reproduce them. So when a
+golden case fails, the default is that **the Rust port is wrong** — fix the Rust
+side (or, if the TS behaviour genuinely changed, update the TS test first, then
+regenerate the affected vectors). Never "fix" a red case by editing `expected`
+to match whatever Rust currently emits; that silently ratifies a divergence,
+which is exactly what these fixtures exist to catch.
+
+(The fixtures are plain JSON so a future `vitest` loader could replay them
+against the TS implementation too — a genuine dual-run. Today only the Rust
+`cargo test` side loads them; the TS side remains the authoring source rather
+than a second reader.)
 
 ## Layout
 
@@ -63,8 +80,9 @@ Nodes use the same shape both languages serialize to:
 
 ## Matcher conventions
 
-The Rust harness (`core/tests/panel_tree_golden.rs`) compares `expected` to the
-serialized actual result structurally, with two deliberate relaxations:
+The shared runner (`core/tests/support/golden.rs`, see below) compares
+`expected` to the serialized actual result structurally, with two deliberate
+relaxations:
 
 1. **`"__GENERATED__"`** as an expected string matches any string in the actual
    output. Use it for freshly generated panel ids (`splitLeaf` wrapping a leaf,
@@ -75,3 +93,60 @@ serialized actual result structurally, with two deliberate relaxations:
 
 Object key sets must match exactly — so omit optional fields (`sizes`,
 `lastActiveLeafId`) from `expected` whenever the function does not set them.
+
+## Shared runner
+
+The loader, the structural matcher above, and the driver loop live **once** in
+`core/tests/support/golden.rs` — a test-only support module (not a `cargo test`
+target of its own; it sits in a subdirectory). It exposes three items:
+
+- `run_golden_suite(util, min_cases, run_case)` — loads every `*.json` under
+  `golden/<util>/`, and for each `{operation, cases}` envelope calls
+  `run_case(operation, case)` per case and asserts the result matches. The
+  `min_cases` floor fails the suite if fewer than that many cases ran (guards a
+  fixture dir that silently loads nothing).
+- `from::<T>(value)` — deserialize a fixture JSON value into a port argument
+  type, panicking with a clear message on a shape mismatch.
+- `json_matches(expected, actual)` / `fixture_dir(util)` — the matcher and path
+  helper, exposed for direct use if ever needed (the driver uses them itself).
+
+A per-util `*_golden.rs` file therefore contains **only** its `run_case`
+mapping plus a one-line `#[test]`. See `core/tests/panel_tree_golden.rs` for the
+worked example.
+
+## Adding a new port's golden vectors
+
+1. **Extract the vectors from the TS suite.** For the util's `src/utils/<util>.test.ts`,
+   capture each interesting case as `{name, input, args?, expected}` and group
+   the cases per exported function into `golden/<util>/<function>.json` with the
+   `{operation, cases}` envelope above. `operation` is the exported (camelCase)
+   TS function name; `expected` is its result serialized to JSON.
+2. **Add the runner.** Create `core/tests/<util>_golden.rs`:
+
+   ```rust
+   mod support;
+   use serde_json::Value;
+   use support::golden::{from, run_golden_suite};
+   // + the port's public items from termihub_core
+
+   fn run_case(operation: &str, case: &Value) -> Value {
+       let input = &case["input"];
+       let args = &case["args"];
+       match operation {
+           "yourFunction" => serde_json::to_value(
+               termihub_core::your_module::your_function(&from(input)),
+           )
+           .expect("serialize"),
+           other => panic!("unknown golden operation: {other}"),
+       }
+   }
+
+   #[test]
+   fn golden_vectors_match_typescript() {
+       run_golden_suite("<util>", <min_cases>, run_case);
+   }
+   ```
+
+3. **Run it:** `cargo test -p termihub-core --test <util>_golden`. Every TS case
+   must reproduce exactly; a mismatch means the Rust port diverges (fix the port,
+   per [TypeScript is authoritative](#typescript-is-authoritative)).

--- a/core/tests/panel_tree_golden.rs
+++ b/core/tests/panel_tree_golden.rs
@@ -9,49 +9,20 @@
 //!
 //! Fixture format and the shared-convention rationale live in
 //! `tests/fixtures/golden/README.md`. This is the first Phase-0 port; the
-//! sibling util ports (#2144–#2147) reuse the same directory layout, envelope,
-//! and matcher.
+//! sibling util ports (#2144–#2146) reuse the same directory layout, envelope,
+//! and matcher, all now driven by the shared runner in `support::golden`
+//! (#2147). This suite supplies only the panel-tree `run_case` mapping.
+
+mod support;
 
 use serde_json::{json, Value};
-use std::fs;
-use std::path::{Path, PathBuf};
+use support::golden::{from, run_golden_suite};
 use termihub_core::layout::panel_tree::{
     count_tabs_in_tree, edge_to_split, find_adjacent_leaf, find_leaf, find_leaf_by_tab,
     get_all_leaves, get_panel_active_session_id, is_window_empty, mark_active_leaf,
     normalize_sizes, remove_leaf, simplify_tree, split_leaf, Direction, DropEdge, FocusDirection,
     LeafPanel, PanelNode, Position, TabGroup,
 };
-
-fn fixture_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("fixtures")
-        .join("golden")
-        .join("panel_tree")
-}
-
-/// Deep JSON equality with two golden-vector conventions:
-///   * the string `"__GENERATED__"` in `expected` matches any string in
-///     `actual` (freshly generated panel ids are non-deterministic);
-///   * numbers compare within a 1e-9 tolerance (cross-language float rounding).
-fn json_matches(expected: &Value, actual: &Value) -> bool {
-    match (expected, actual) {
-        (Value::String(e), _) if e == "__GENERATED__" => actual.is_string(),
-        (Value::Number(e), Value::Number(a)) => match (e.as_f64(), a.as_f64()) {
-            (Some(x), Some(y)) => (x - y).abs() < 1e-9,
-            _ => e == a,
-        },
-        (Value::Array(e), Value::Array(a)) => {
-            e.len() == a.len() && e.iter().zip(a).all(|(x, y)| json_matches(x, y))
-        }
-        (Value::Object(e), Value::Object(a)) => {
-            e.len() == a.len()
-                && e.iter()
-                    .all(|(k, v)| a.get(k).is_some_and(|av| json_matches(v, av)))
-        }
-        _ => expected == actual,
-    }
-}
 
 fn leaf_opt_to_value(leaf: Option<&LeafPanel>) -> Value {
     match leaf {
@@ -65,10 +36,6 @@ fn node_opt_to_value(node: Option<PanelNode>) -> Value {
         Some(n) => serde_json::to_value(n).expect("serialize node"),
         None => Value::Null,
     }
-}
-
-fn from<T: serde::de::DeserializeOwned>(v: &Value) -> T {
-    serde_json::from_value(v.clone()).expect("deserialize fixture value")
 }
 
 /// Run one case for `operation`, returning the serialized actual result.
@@ -156,45 +123,5 @@ fn run_case(operation: &str, case: &Value) -> Value {
 
 #[test]
 fn golden_vectors_match_typescript() {
-    let dir = fixture_dir();
-    let mut files: Vec<PathBuf> = fs::read_dir(&dir)
-        .unwrap_or_else(|e| panic!("read fixture dir {}: {e}", dir.display()))
-        .filter_map(|e| e.ok().map(|e| e.path()))
-        .filter(|p| p.extension().is_some_and(|x| x == "json"))
-        .collect();
-    files.sort();
-    assert!(
-        !files.is_empty(),
-        "no golden fixtures found in {}",
-        dir.display()
-    );
-
-    let mut total_cases = 0usize;
-    for file in files {
-        let raw = fs::read_to_string(&file).expect("read fixture");
-        let fixture: Value =
-            serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {}: {e}", file.display()));
-        let operation = fixture["operation"]
-            .as_str()
-            .unwrap_or_else(|| panic!("{} missing operation", file.display()));
-        let cases = fixture["cases"]
-            .as_array()
-            .unwrap_or_else(|| panic!("{} missing cases array", file.display()));
-
-        for case in cases {
-            let name = case["name"].as_str().unwrap_or("<unnamed>");
-            let actual = run_case(operation, case);
-            let expected = &case["expected"];
-            assert!(
-                json_matches(expected, &actual),
-                "golden mismatch in {} :: {operation} :: {name}\n  expected: {}\n  actual:   {}",
-                file.display(),
-                serde_json::to_string(expected).unwrap_or_default(),
-                serde_json::to_string(&actual).unwrap_or_default(),
-            );
-            total_cases += 1;
-        }
-    }
-    // Sanity: make sure the harness actually exercised a meaningful body of cases.
-    assert!(total_cases >= 40, "only ran {total_cases} golden cases");
+    run_golden_suite("panel_tree", 40, run_case);
 }

--- a/core/tests/reconnect_backoff_golden.rs
+++ b/core/tests/reconnect_backoff_golden.rs
@@ -9,49 +9,18 @@
 //!
 //! Fixture format and the shared-convention rationale live in
 //! `tests/fixtures/golden/README.md`. This reuses verbatim the directory
-//! layout, envelope, and matcher the panel-tree port (#2143) established. The
-//! injectable RNG is encoded per case as a constant `rand` value in `args`.
+//! layout, envelope, and matcher the panel-tree port (#2143) established, now
+//! driven by the shared runner in `support::golden` (#2147). The injectable RNG
+//! is encoded per case as a constant `rand` value in `args`.
+
+mod support;
 
 use serde_json::{json, Value};
-use std::fs;
-use std::path::{Path, PathBuf};
+use support::golden::{from, run_golden_suite};
 use termihub_core::reconnect_backoff::{
     backoff_delay, is_active_reconnect_phase, next_reconnect_delay, reconnect_reducer,
     should_give_up, BackoffConfig, ReconnectEvent, ReconnectPhase, ReconnectState,
 };
-
-fn fixture_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("fixtures")
-        .join("golden")
-        .join("reconnect_backoff")
-}
-
-/// Deep JSON equality with the golden-vector numeric convention: numbers
-/// compare within a 1e-9 tolerance (cross-language float rounding, and the
-/// integer-valued `f64` results the backoff curve returns).
-fn json_matches(expected: &Value, actual: &Value) -> bool {
-    match (expected, actual) {
-        (Value::Number(e), Value::Number(a)) => match (e.as_f64(), a.as_f64()) {
-            (Some(x), Some(y)) => (x - y).abs() < 1e-9,
-            _ => e == a,
-        },
-        (Value::Array(e), Value::Array(a)) => {
-            e.len() == a.len() && e.iter().zip(a).all(|(x, y)| json_matches(x, y))
-        }
-        (Value::Object(e), Value::Object(a)) => {
-            e.len() == a.len()
-                && e.iter()
-                    .all(|(k, v)| a.get(k).is_some_and(|av| json_matches(v, av)))
-        }
-        _ => expected == actual,
-    }
-}
-
-fn from<T: serde::de::DeserializeOwned>(v: &Value) -> T {
-    serde_json::from_value(v.clone()).expect("deserialize fixture value")
-}
 
 /// The per-case constant RNG (`() => rand`), defaulting to the no-swing 0.5 when
 /// a case omits it (jitter-disabled cases never read it).
@@ -103,45 +72,5 @@ fn run_case(operation: &str, case: &Value) -> Value {
 
 #[test]
 fn golden_vectors_match_typescript() {
-    let dir = fixture_dir();
-    let mut files: Vec<PathBuf> = fs::read_dir(&dir)
-        .unwrap_or_else(|e| panic!("read fixture dir {}: {e}", dir.display()))
-        .filter_map(|e| e.ok().map(|e| e.path()))
-        .filter(|p| p.extension().is_some_and(|x| x == "json"))
-        .collect();
-    files.sort();
-    assert!(
-        !files.is_empty(),
-        "no golden fixtures found in {}",
-        dir.display()
-    );
-
-    let mut total_cases = 0usize;
-    for file in files {
-        let raw = fs::read_to_string(&file).expect("read fixture");
-        let fixture: Value =
-            serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {}: {e}", file.display()));
-        let operation = fixture["operation"]
-            .as_str()
-            .unwrap_or_else(|| panic!("{} missing operation", file.display()));
-        let cases = fixture["cases"]
-            .as_array()
-            .unwrap_or_else(|| panic!("{} missing cases array", file.display()));
-
-        for case in cases {
-            let name = case["name"].as_str().unwrap_or("<unnamed>");
-            let actual = run_case(operation, case);
-            let expected = &case["expected"];
-            assert!(
-                json_matches(expected, &actual),
-                "golden mismatch in {} :: {operation} :: {name}\n  expected: {}\n  actual:   {}",
-                file.display(),
-                serde_json::to_string(expected).unwrap_or_default(),
-                serde_json::to_string(&actual).unwrap_or_default(),
-            );
-            total_cases += 1;
-        }
-    }
-    // Sanity: make sure the harness actually exercised a meaningful body of cases.
-    assert!(total_cases >= 30, "only ran {total_cases} golden cases");
+    run_golden_suite("reconnect_backoff", 30, run_case);
 }

--- a/core/tests/restore_mode_golden.rs
+++ b/core/tests/restore_mode_golden.rs
@@ -8,51 +8,20 @@
 //!
 //! Fixture format and the shared-convention rationale live in
 //! `tests/fixtures/golden/README.md`. This reuses verbatim the directory
-//! layout, envelope, and matcher the panel-tree port (#2143) established. The
-//! optional `connections` list and the flat `selected` index array are carried
-//! per case in `args`.
+//! layout, envelope, and matcher the panel-tree port (#2143) established, now
+//! driven by the shared runner in `support::golden` (#2147). The optional
+//! `connections` list and the flat `selected` index array are carried per case
+//! in `args`.
+
+mod support;
 
 use serde_json::Value;
 use std::collections::HashSet;
-use std::fs;
-use std::path::{Path, PathBuf};
+use support::golden::{from, run_golden_suite};
 use termihub_core::restore_mode::{
     filter_session_by_selection, get_workspace_leaves, resolve_restore_mode,
     summarize_last_session, AppSettings, LastSession, SavedConnection, WorkspaceLayoutNode,
 };
-
-fn fixture_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("fixtures")
-        .join("golden")
-        .join("restore_mode")
-}
-
-/// Deep JSON equality with the golden-vector numeric convention: numbers
-/// compare within a 1e-9 tolerance (cross-language float rounding in the
-/// size-redistribution path). Object key sets must match exactly.
-fn json_matches(expected: &Value, actual: &Value) -> bool {
-    match (expected, actual) {
-        (Value::Number(e), Value::Number(a)) => match (e.as_f64(), a.as_f64()) {
-            (Some(x), Some(y)) => (x - y).abs() < 1e-9,
-            _ => e == a,
-        },
-        (Value::Array(e), Value::Array(a)) => {
-            e.len() == a.len() && e.iter().zip(a).all(|(x, y)| json_matches(x, y))
-        }
-        (Value::Object(e), Value::Object(a)) => {
-            e.len() == a.len()
-                && e.iter()
-                    .all(|(k, v)| a.get(k).is_some_and(|av| json_matches(v, av)))
-        }
-        _ => expected == actual,
-    }
-}
-
-fn from<T: serde::de::DeserializeOwned>(v: &Value) -> T {
-    serde_json::from_value(v.clone()).expect("deserialize fixture value")
-}
 
 /// Run one case for `operation`, returning the serialized actual result.
 fn run_case(operation: &str, case: &Value) -> Value {
@@ -96,45 +65,5 @@ fn run_case(operation: &str, case: &Value) -> Value {
 
 #[test]
 fn golden_vectors_match_typescript() {
-    let dir = fixture_dir();
-    let mut files: Vec<PathBuf> = fs::read_dir(&dir)
-        .unwrap_or_else(|e| panic!("read fixture dir {}: {e}", dir.display()))
-        .filter_map(|e| e.ok().map(|e| e.path()))
-        .filter(|p| p.extension().is_some_and(|x| x == "json"))
-        .collect();
-    files.sort();
-    assert!(
-        !files.is_empty(),
-        "no golden fixtures found in {}",
-        dir.display()
-    );
-
-    let mut total_cases = 0usize;
-    for file in files {
-        let raw = fs::read_to_string(&file).expect("read fixture");
-        let fixture: Value =
-            serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {}: {e}", file.display()));
-        let operation = fixture["operation"]
-            .as_str()
-            .unwrap_or_else(|| panic!("{} missing operation", file.display()));
-        let cases = fixture["cases"]
-            .as_array()
-            .unwrap_or_else(|| panic!("{} missing cases array", file.display()));
-
-        for case in cases {
-            let name = case["name"].as_str().unwrap_or("<unnamed>");
-            let actual = run_case(operation, case);
-            let expected = &case["expected"];
-            assert!(
-                json_matches(expected, &actual),
-                "golden mismatch in {} :: {operation} :: {name}\n  expected: {}\n  actual:   {}",
-                file.display(),
-                serde_json::to_string(expected).unwrap_or_default(),
-                serde_json::to_string(&actual).unwrap_or_default(),
-            );
-            total_cases += 1;
-        }
-    }
-    // Sanity: make sure the harness actually exercised a meaningful body of cases.
-    assert!(total_cases >= 20, "only ran {total_cases} golden cases");
+    run_golden_suite("restore_mode", 20, run_case);
 }

--- a/core/tests/schema_defaults_golden.rs
+++ b/core/tests/schema_defaults_golden.rs
@@ -9,53 +9,18 @@
 //! Fixture format and the shared-convention rationale live in
 //! `tests/fixtures/golden/README.md`. The panel-tree port (#2143) established
 //! the convention; this sibling port reuses the same directory layout, envelope,
-//! and matcher.
+//! and matcher, now driven by the shared runner in `support::golden` (#2147).
+
+mod support;
 
 use serde_json::{json, Map, Value};
-use std::fs;
-use std::path::{Path, PathBuf};
+use support::golden::{from, run_golden_suite};
 use termihub_core::connection::schema::{SettingsField, SettingsSchema};
 use termihub_core::connection::schema_defaults::{
     build_defaults, filter_credential_fields, filter_runtime_options,
     find_key_passphrase_prompt_info, find_password_prompt_info, is_field_visible,
     PasswordPromptInfo,
 };
-
-fn fixture_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("fixtures")
-        .join("golden")
-        .join("schema_defaults")
-}
-
-/// Deep JSON equality with two golden-vector conventions (shared with the
-/// panel-tree harness):
-///   * the string `"__GENERATED__"` in `expected` matches any string in
-///     `actual`;
-///   * numbers compare within a 1e-9 tolerance (cross-language float rounding).
-fn json_matches(expected: &Value, actual: &Value) -> bool {
-    match (expected, actual) {
-        (Value::String(e), _) if e == "__GENERATED__" => actual.is_string(),
-        (Value::Number(e), Value::Number(a)) => match (e.as_f64(), a.as_f64()) {
-            (Some(x), Some(y)) => (x - y).abs() < 1e-9,
-            _ => e == a,
-        },
-        (Value::Array(e), Value::Array(a)) => {
-            e.len() == a.len() && e.iter().zip(a).all(|(x, y)| json_matches(x, y))
-        }
-        (Value::Object(e), Value::Object(a)) => {
-            e.len() == a.len()
-                && e.iter()
-                    .all(|(k, v)| a.get(k).is_some_and(|av| json_matches(v, av)))
-        }
-        _ => expected == actual,
-    }
-}
-
-fn from<T: serde::de::DeserializeOwned>(v: &Value) -> T {
-    serde_json::from_value(v.clone()).expect("deserialize fixture value")
-}
 
 /// Extract the `settings` argument (a JSON object) into a `Map`.
 fn settings(args: &Value) -> Map<String, Value> {
@@ -112,45 +77,5 @@ fn run_case(operation: &str, case: &Value) -> Value {
 
 #[test]
 fn golden_vectors_match_typescript() {
-    let dir = fixture_dir();
-    let mut files: Vec<PathBuf> = fs::read_dir(&dir)
-        .unwrap_or_else(|e| panic!("read fixture dir {}: {e}", dir.display()))
-        .filter_map(|e| e.ok().map(|e| e.path()))
-        .filter(|p| p.extension().is_some_and(|x| x == "json"))
-        .collect();
-    files.sort();
-    assert!(
-        !files.is_empty(),
-        "no golden fixtures found in {}",
-        dir.display()
-    );
-
-    let mut total_cases = 0usize;
-    for file in files {
-        let raw = fs::read_to_string(&file).expect("read fixture");
-        let fixture: Value =
-            serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {}: {e}", file.display()));
-        let operation = fixture["operation"]
-            .as_str()
-            .unwrap_or_else(|| panic!("{} missing operation", file.display()));
-        let cases = fixture["cases"]
-            .as_array()
-            .unwrap_or_else(|| panic!("{} missing cases array", file.display()));
-
-        for case in cases {
-            let name = case["name"].as_str().unwrap_or("<unnamed>");
-            let actual = run_case(operation, case);
-            let expected = &case["expected"];
-            assert!(
-                json_matches(expected, &actual),
-                "golden mismatch in {} :: {operation} :: {name}\n  expected: {}\n  actual:   {}",
-                file.display(),
-                serde_json::to_string(expected).unwrap_or_default(),
-                serde_json::to_string(&actual).unwrap_or_default(),
-            );
-            total_cases += 1;
-        }
-    }
-    // Sanity: make sure the harness actually exercised a meaningful body of cases.
-    assert!(total_cases >= 25, "only ran {total_cases} golden cases");
+    run_golden_suite("schema_defaults", 25, run_case);
 }

--- a/core/tests/support/golden.rs
+++ b/core/tests/support/golden.rs
@@ -1,0 +1,135 @@
+//! Shared cross-language golden-vector test runner (#2147).
+//!
+//! This is the reusable core of every `*_golden.rs` suite. The four Phase-0
+//! util ports (panel-tree #2143, reconnect-backoff #2144, restore-mode #2145,
+//! schema-defaults #2146) each re-implemented an identical fixture loader,
+//! structural matcher, and driver loop; this module extracts them so Phase-1+
+//! ports reuse it instead of copy-pasting.
+//!
+//! ## What a golden suite provides, and what this module provides
+//!
+//! A per-util suite supplies only the util-specific `run_case` closure — the
+//! bit that deserializes a case's `input`/`args`, calls the Rust port, and
+//! serializes the result back to JSON. Everything else (finding the fixture
+//! files, parsing the `{operation, cases}` envelope, structural comparison with
+//! the golden relaxations, and the "enough cases actually ran" sanity floor)
+//! lives here in [`run_golden_suite`].
+//!
+//! The fixture format, directory layout, and the TS-authoritative convention are
+//! documented in `tests/fixtures/golden/README.md`.
+
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Directory holding one util's golden fixtures: `tests/fixtures/golden/<util>`.
+///
+/// `util` is the snake_case util directory name (`panel_tree`,
+/// `reconnect_backoff`, `restore_mode`, `schema_defaults`, …).
+pub fn fixture_dir(util: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("golden")
+        .join(util)
+}
+
+/// Deserialize a fixture JSON value into a typed Rust value, panicking with a
+/// clear message on shape mismatch. The workhorse `run_case` closures use this
+/// to turn a case's `input`/`args` into the port's argument types.
+pub fn from<T: serde::de::DeserializeOwned>(v: &Value) -> T {
+    serde_json::from_value(v.clone()).expect("deserialize fixture value")
+}
+
+/// Deep structural JSON equality with the two golden-vector relaxations shared
+/// across every suite:
+///
+///   * the string `"__GENERATED__"` in `expected` matches **any** string in
+///     `actual` — for freshly generated, non-deterministic ids (e.g. `splitLeaf`
+///     wrapping a leaf, `simplifyTree` collapsing to a new empty leaf);
+///   * numbers compare within a `1e-9` tolerance, absorbing cross-language float
+///     rounding (size redistribution, the backoff curve, …).
+///
+/// Object key sets must match **exactly**, so a fixture must omit optional
+/// fields the function does not set. Suites whose data never contains
+/// `"__GENERATED__"` are unaffected by that arm; keeping one matcher lets every
+/// suite share it.
+pub fn json_matches(expected: &Value, actual: &Value) -> bool {
+    match (expected, actual) {
+        (Value::String(e), _) if e == "__GENERATED__" => actual.is_string(),
+        (Value::Number(e), Value::Number(a)) => match (e.as_f64(), a.as_f64()) {
+            (Some(x), Some(y)) => (x - y).abs() < 1e-9,
+            _ => e == a,
+        },
+        (Value::Array(e), Value::Array(a)) => {
+            e.len() == a.len() && e.iter().zip(a).all(|(x, y)| json_matches(x, y))
+        }
+        (Value::Object(e), Value::Object(a)) => {
+            e.len() == a.len()
+                && e.iter()
+                    .all(|(k, v)| a.get(k).is_some_and(|av| json_matches(v, av)))
+        }
+        _ => expected == actual,
+    }
+}
+
+/// Drive a util's whole golden suite.
+///
+/// Loads every `*.json` fixture under `tests/fixtures/golden/<util>`, and for
+/// each `{operation, cases}` envelope runs `run_case(operation, case)` per case,
+/// asserting the serialized actual result matches the case's `expected` under
+/// [`json_matches`]. `min_cases` is a per-util sanity floor: the total number of
+/// cases run must reach it, guarding against a suite that silently loads nothing.
+///
+/// `run_case` receives the fixture's `operation` string and the whole `case`
+/// object (with its `input`, optional `args`, and `expected`), and returns the
+/// port's result serialized to a [`Value`].
+pub fn run_golden_suite<F>(util: &str, min_cases: usize, run_case: F)
+where
+    F: Fn(&str, &Value) -> Value,
+{
+    let dir = fixture_dir(util);
+    let mut files: Vec<PathBuf> = fs::read_dir(&dir)
+        .unwrap_or_else(|e| panic!("read fixture dir {}: {e}", dir.display()))
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().is_some_and(|x| x == "json"))
+        .collect();
+    files.sort();
+    assert!(
+        !files.is_empty(),
+        "no golden fixtures found in {}",
+        dir.display()
+    );
+
+    let mut total_cases = 0usize;
+    for file in files {
+        let raw = fs::read_to_string(&file).expect("read fixture");
+        let fixture: Value =
+            serde_json::from_str(&raw).unwrap_or_else(|e| panic!("parse {}: {e}", file.display()));
+        let operation = fixture["operation"]
+            .as_str()
+            .unwrap_or_else(|| panic!("{} missing operation", file.display()));
+        let cases = fixture["cases"]
+            .as_array()
+            .unwrap_or_else(|| panic!("{} missing cases array", file.display()));
+
+        for case in cases {
+            let name = case["name"].as_str().unwrap_or("<unnamed>");
+            let actual = run_case(operation, case);
+            let expected = &case["expected"];
+            assert!(
+                json_matches(expected, &actual),
+                "golden mismatch in {} :: {operation} :: {name}\n  expected: {}\n  actual:   {}",
+                file.display(),
+                serde_json::to_string(expected).unwrap_or_default(),
+                serde_json::to_string(&actual).unwrap_or_default(),
+            );
+            total_cases += 1;
+        }
+    }
+    // Sanity: make sure the harness actually exercised a meaningful body of cases.
+    assert!(
+        total_cases >= min_cases,
+        "only ran {total_cases} golden cases for {util} (expected >= {min_cases})"
+    );
+}

--- a/core/tests/support/mod.rs
+++ b/core/tests/support/mod.rs
@@ -1,0 +1,10 @@
+//! Shared support code for `termihub-core` integration tests that is not tied to
+//! the Docker/SSH fixtures in [`crate::common`].
+//!
+//! Currently this hosts the [`golden`] helper: the cross-language golden-vector
+//! runner shared by every `*_golden.rs` suite (#2147). Each integration test is
+//! compiled as its own crate, so a suite that does not use every item here would
+//! otherwise warn — allow dead code at the module root.
+#![allow(dead_code)]
+
+pub mod golden;


### PR DESCRIPTION
## What

Phase 0 of the stateless-UI port (#2139) established a cross-language golden-vector convention: each pure TS util ported to `termihub-core` keeps input→expected fixtures under `core/tests/fixtures/golden/<util>/`, and the Rust port replays them so any drift fails a test. The four Phase-0 ports (#2143 panelTree, #2144 reconnectBackoff, #2145 restoreMode, #2146 schemaDefaults) each **re-implemented an identical** fixture loader, structural matcher, `from()` helper, and driver loop.

This issue formalizes that convention so Phase-1+ ports reuse it instead of copy-pasting.

## Changes

- **New shared runner** `core/tests/support/golden.rs` — one `run_golden_suite(util, min_cases, run_case)` driver plus `from()`, `json_matches()`, and `fixture_dir()`. It is a test-only support module (in a subdirectory, so not a `cargo test` target of its own).
- **Refactored all four `*_golden.rs` runners** to route through it. Each now supplies **only** its util-specific `run_case` mapping plus a one-line `#[test]`. No fixtures and no assertions changed — every pre-existing golden case still passes unchanged.
- **Documented the convention** in `core/tests/fixtures/golden/README.md`: fixture layout, `{operation, cases}` envelope, the shared runner, a step-by-step "adding a new port's golden vectors" guide, and the **TypeScript-authoritative** rule (vectors are derived from the TS suite; a red case means the Rust port is wrong, never edit `expected` to match Rust).

## Verification

- `cargo test -p termihub-core --test panel_tree_golden --test reconnect_backoff_golden --test schema_defaults_golden --test restore_mode_golden` — all green, same case counts as before.
- `cargo clippy` on the four targets (`-D warnings`) and `cargo fmt --check` clean.
- `markdownlint` on the README clean.

Test/docs-only, non-user-facing — no changelog fragment.

Closes #2147
Part of #2139