### PR TITLE
refactor(network): lift http monitor onto core Service trait (Closes #2157)

### DIFF
--- a/src-tauri/src/commands/network.rs
+++ b/src-tauri/src/commands/network.rs
@@ -10,6 +10,7 @@ use termihub_core::network::{
     dns, open_ports, ping, ping_sweep, port_scan, traceroute, wol, DnsRecordType, PingSweepResult,
     PortScanResult, WolDevice,
 };
+use termihub_core::service::ServiceInfo;
 
 use crate::network::http_monitor::{HttpMonitorConfig, HttpMonitorState};
 use crate::network::NetworkManager;
@@ -567,6 +568,17 @@ pub fn network_http_monitor_list(
     manager: State<'_, NetworkManager>,
 ) -> Result<Vec<HttpMonitorState>, TerminalError> {
     Ok(manager.list_http_monitors())
+}
+
+/// List the run-location-routable services registered on the desktop.
+///
+/// Backs discovery for the future run-location selector (S-track, #2139). The
+/// HTTP monitor is the S2 pilot (#2157) — the first existing service lifted onto
+/// the core `Service` trait — so it appears here with its schema and
+/// capabilities.
+#[tauri::command]
+pub fn network_services_list(manager: State<'_, NetworkManager>) -> Vec<ServiceInfo> {
+    manager.available_services()
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1153,6 +1153,7 @@ pub fn run() {
             commands::network::network_http_monitor_resume,
             commands::network::network_http_monitor_stop_all,
             commands::network::network_http_monitor_list,
+            commands::network::network_services_list,
             // Embedded servers
             commands::embedded_servers::list_embedded_servers,
             commands::embedded_servers::save_embedded_server,

--- a/src-tauri/src/network/http_monitor.rs
+++ b/src-tauri/src/network/http_monitor.rs
@@ -1,17 +1,48 @@
 //! Periodic HTTP monitor — checks a URL at a fixed interval and emits events.
 //!
 //! This is desktop-only (uses `reqwest`) and is not part of `termihub-core`.
+//!
+//! # S2 pilot — lifted onto the core `Service` trait (#2157)
+//!
+//! The monitor is the first existing service lifted onto
+//! [`termihub_core::service::Service`] (the S1 substrate from #2148). Its poll
+//! loop no longer pushes results through Tauri's [`Emitter`](tauri::Emitter);
+//! instead it emits [`ServiceEvent`]s on the core-owned
+//! [`EventChannel`], and the desktop host bridges that channel to the
+//! `network-http-monitor-check` Tauri event (see
+//! [`crate::network::NetworkManager`]). The service itself is therefore fully
+//! decoupled from `AppHandle` and testable in isolation via
+//! [`Service::subscribe_events`]. Behaviour is unchanged for the user.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Emitter};
+use serde_json::Value;
+use termihub_core::connection::schema::{FieldType, SelectOption, SettingsField, SettingsGroup};
+use termihub_core::connection::SettingsSchema;
+use termihub_core::service::{
+    EventChannel, Service, ServiceCapabilities, ServiceError, ServiceEvent, ServiceEventReceiver,
+    ServiceStatus,
+};
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use uuid::Uuid;
+
+/// Machine-readable service id used in the [`ServiceRegistry`] and run-location
+/// routing.
+///
+/// [`ServiceRegistry`]: termihub_core::service::ServiceRegistry
+pub const SERVICE_ID: &str = "http_monitor";
+
+/// Human-readable service name.
+pub const DISPLAY_NAME: &str = "HTTP Monitor";
+
+/// Event kind emitted on the [`EventChannel`] for each completed check.
+pub const CHECK_EVENT_KIND: &str = "check";
 
 /// Minimum poll interval, in milliseconds.
 ///
@@ -62,15 +93,6 @@ pub struct HttpMonitorState {
     pub last_result: Option<HttpCheckResult>,
 }
 
-/// Handle to a running HTTP monitor background task.
-pub struct HttpMonitorHandle {
-    pub config: HttpMonitorConfig,
-    pub cancel: CancellationToken,
-    /// When set, the poll loop stays alive but skips the HTTP check (Pause).
-    pub paused: Arc<AtomicBool>,
-    pub last_result: std::sync::Arc<std::sync::Mutex<Option<HttpCheckResult>>>,
-}
-
 impl HttpMonitorConfig {
     /// Create a new config with a generated ID.
     ///
@@ -94,40 +116,286 @@ impl HttpMonitorConfig {
     }
 }
 
-/// Spawn a background task that periodically polls a URL.
+/// The HTTP monitor lifted onto the core [`Service`] trait.
 ///
-/// Emits `network-http-monitor-check` events on the app handle.
-/// Returns a [`HttpMonitorHandle`] that can be used to stop the task.
-pub fn start_monitor(config: HttpMonitorConfig, app: AppHandle) -> HttpMonitorHandle {
-    let cancel = CancellationToken::new();
-    let paused = Arc::new(AtomicBool::new(false));
-    let last_result = std::sync::Arc::new(std::sync::Mutex::new(None::<HttpCheckResult>));
+/// One instance drives one URL's poll loop. Created stopped; a call to
+/// [`start`](Service::start) with a JSON [`HttpMonitorConfig`] spawns the loop,
+/// which emits a [`CHECK_EVENT_KIND`] [`ServiceEvent`] (payload:
+/// [`HttpCheckResult`]) on the [`EventChannel`] after every check.
+///
+/// Beyond the trait lifecycle it keeps the monitor-specific
+/// [`pause`](Self::pause) / [`resume`](Self::resume) controls the desktop
+/// manager needs; these are not part of the generic [`Service`] surface.
+pub struct HttpMonitorService {
+    /// Config, set once the service is started. `None` before the first start.
+    config: Option<HttpMonitorConfig>,
+    /// Current lifecycle status.
+    status: ServiceStatus,
+    /// Cancellation token for the running poll loop (fresh on each start).
+    cancel: CancellationToken,
+    /// When set, the poll loop stays alive but skips the HTTP check (Pause).
+    paused: Arc<AtomicBool>,
+    /// Latest check result, shared with the poll loop.
+    last_result: Arc<Mutex<Option<HttpCheckResult>>>,
+    /// Core event channel the poll loop emits `check` events through.
+    events: EventChannel,
+}
 
-    let cancel_clone = cancel.clone();
-    let paused_clone = Arc::clone(&paused);
-    let config_clone = config.clone();
-    let last_result_clone = std::sync::Arc::clone(&last_result);
+impl HttpMonitorService {
+    /// Create a new, stopped HTTP monitor service.
+    pub fn new() -> Self {
+        Self {
+            config: None,
+            status: ServiceStatus::Stopped,
+            cancel: CancellationToken::new(),
+            paused: Arc::new(AtomicBool::new(false)),
+            last_result: Arc::new(Mutex::new(None)),
+            events: EventChannel::new(),
+        }
+    }
 
-    // Spawn on Tauri's managed runtime, not `tokio::spawn`: the
-    // `network_http_monitor_start` command is synchronous, so it runs on a thread
-    // with no Tokio reactor — `tokio::spawn` there panics ("no reactor running").
-    // `tauri::async_runtime::spawn` works from any thread (see #828, #982).
-    tauri::async_runtime::spawn(async move {
-        run_monitor(
-            config_clone,
-            app,
-            cancel_clone,
-            paused_clone,
-            last_result_clone,
-        )
-        .await;
-    });
+    /// The settings schema for the HTTP monitor form (keys match
+    /// [`HttpMonitorConfig`]'s camelCase fields).
+    fn schema() -> SettingsSchema {
+        SettingsSchema {
+            groups: vec![SettingsGroup {
+                key: "monitor".to_string(),
+                label: "HTTP Monitor".to_string(),
+                fields: vec![
+                    field("url", "URL", FieldType::Text, true, None),
+                    field(
+                        "intervalMs",
+                        "Interval (ms)",
+                        FieldType::Number {
+                            min: Some(MIN_INTERVAL_MS as f64),
+                            max: None,
+                        },
+                        true,
+                        Some(Value::from(30_000)),
+                    ),
+                    field(
+                        "method",
+                        "Method",
+                        FieldType::Select {
+                            options: ["GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS"]
+                                .iter()
+                                .map(|m| SelectOption {
+                                    value: (*m).to_string(),
+                                    label: (*m).to_string(),
+                                })
+                                .collect(),
+                        },
+                        true,
+                        Some(Value::from("GET")),
+                    ),
+                    field(
+                        "expectedStatus",
+                        "Expected status",
+                        FieldType::Number {
+                            min: Some(100.0),
+                            max: Some(599.0),
+                        },
+                        true,
+                        Some(Value::from(200)),
+                    ),
+                    field(
+                        "timeoutMs",
+                        "Timeout (ms)",
+                        FieldType::Number {
+                            min: Some(1.0),
+                            max: None,
+                        },
+                        true,
+                        Some(Value::from(5_000)),
+                    ),
+                ],
+            }],
+        }
+    }
 
-    HttpMonitorHandle {
-        config,
-        cancel,
-        paused,
-        last_result,
+    /// Spawn (or re-spawn) the poll loop for `config`, replacing any prior run.
+    ///
+    /// Resets the cancellation token and pause flag, sets status to
+    /// [`ServiceStatus::Running`], and stores the config so [`resume`](Self::resume)
+    /// and [`state`](Self::state) can see it.
+    fn spawn_loop(&mut self, config: HttpMonitorConfig) {
+        // A fresh token so a previous stop's cancellation does not immediately
+        // kill the new loop.
+        self.cancel = CancellationToken::new();
+        self.paused.store(false, Ordering::SeqCst);
+        self.status = ServiceStatus::Running;
+        self.config = Some(config.clone());
+
+        let cancel = self.cancel.clone();
+        let paused = Arc::clone(&self.paused);
+        let last_result = Arc::clone(&self.last_result);
+        let events = self.events.clone();
+
+        // Spawn on Tauri's managed runtime, not `tokio::spawn`: some callers
+        // (synchronous Tauri commands) run on a thread with no Tokio reactor,
+        // where `tokio::spawn` panics ("no reactor running").
+        // `tauri::async_runtime::spawn` works from any thread (see #828, #982).
+        tauri::async_runtime::spawn(async move {
+            run_monitor(config, events, cancel, paused, last_result).await;
+        });
+    }
+
+    /// Start the poll loop for `config` (synchronous).
+    ///
+    /// The trait's async [`start`](Service::start) parses a JSON config and
+    /// delegates here; the desktop manager, running on a synchronous Tauri
+    /// command thread with no reactor, calls this directly.
+    pub fn start_with(&mut self, config: HttpMonitorConfig) {
+        self.spawn_loop(config);
+    }
+
+    /// Stop the poll loop but keep the config so the monitor stays listed and
+    /// can be resumed (synchronous counterpart of the trait's async
+    /// [`stop`](Service::stop)).
+    pub fn shutdown(&mut self) {
+        self.cancel.cancel();
+        self.paused.store(false, Ordering::SeqCst);
+        self.status = ServiceStatus::Stopped;
+    }
+
+    /// Pause the poll loop's body while keeping the loop alive (Resume is
+    /// instant). No-op when the monitor is not running.
+    pub fn pause(&self) {
+        self.paused.store(true, Ordering::SeqCst);
+    }
+
+    /// Resume the monitor.
+    ///
+    /// - A **running** (or paused) monitor simply clears its pause flag.
+    /// - A **stopped** monitor (loop cancelled but still listed) is re-spawned
+    ///   with the same config/id.
+    pub fn resume(&mut self) {
+        if self.is_running() {
+            self.paused.store(false, Ordering::SeqCst);
+        } else if let Some(config) = self.config.clone() {
+            self.spawn_loop(config);
+        }
+    }
+
+    /// Whether the poll loop is currently alive.
+    pub fn is_running(&self) -> bool {
+        self.status == ServiceStatus::Running && !self.cancel.is_cancelled()
+    }
+
+    /// Whether the running loop is currently paused.
+    pub fn is_paused(&self) -> bool {
+        self.paused.load(Ordering::SeqCst)
+    }
+
+    /// The most recent check result, if any.
+    pub fn last_result(&self) -> Option<HttpCheckResult> {
+        self.last_result.lock().ok().and_then(|g| g.clone())
+    }
+
+    /// Test-only: construct a service in the `Running` state with `config` but
+    /// **without** spawning a real poll loop, so manager-level bookkeeping tests
+    /// (stop / remove / pause / list) need no Tokio/Tauri runtime or network.
+    #[cfg(test)]
+    pub(crate) fn test_running(config: HttpMonitorConfig) -> Self {
+        let mut svc = Self::new();
+        svc.config = Some(config);
+        svc.status = ServiceStatus::Running;
+        svc
+    }
+
+    /// Snapshot this monitor as an [`HttpMonitorState`] for listing.
+    ///
+    /// Returns `None` for a service that was never started (no config).
+    pub fn state(&self) -> Option<HttpMonitorState> {
+        let config = self.config.clone()?;
+        let running = self.is_running();
+        Some(HttpMonitorState {
+            config,
+            running,
+            // A stopped loop can't be paused; only report paused while alive.
+            paused: running && self.is_paused(),
+            last_result: self.last_result(),
+        })
+    }
+}
+
+impl Default for HttpMonitorService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Service for HttpMonitorService {
+    fn service_id(&self) -> &str {
+        SERVICE_ID
+    }
+
+    fn display_name(&self) -> &str {
+        DISPLAY_NAME
+    }
+
+    fn settings_schema(&self) -> SettingsSchema {
+        Self::schema()
+    }
+
+    fn capabilities(&self) -> ServiceCapabilities {
+        ServiceCapabilities {
+            configurable: true,
+            emits_events: true,
+            // A network probe is a natural fit for an agent run-location (probe
+            // from a remote vantage point); it is not in the permanent
+            // desktop-only set (credentials, spawn rendezvous, file watch,
+            // OS-window management).
+            desktop_only: false,
+        }
+    }
+
+    async fn start(&mut self, config: Value) -> Result<(), ServiceError> {
+        let config: HttpMonitorConfig = serde_json::from_value(config)
+            .map_err(|e| ServiceError::InvalidConfig(e.to_string()))?;
+        self.spawn_loop(config);
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<(), ServiceError> {
+        // Cancel the poll loop but keep the config so the monitor stays listed
+        // (as `running: false`) and can be resumed. `paused` is cleared so a
+        // later Resume starts clean.
+        self.shutdown();
+        Ok(())
+    }
+
+    fn status(&self) -> ServiceStatus {
+        self.status.clone()
+    }
+
+    fn subscribe_events(&self) -> ServiceEventReceiver {
+        self.events.subscribe()
+    }
+}
+
+/// Build a required/optional settings field with sensible defaults for the
+/// booleans we don't use here.
+fn field(
+    key: &str,
+    label: &str,
+    field_type: FieldType,
+    required: bool,
+    default: Option<Value>,
+) -> SettingsField {
+    SettingsField {
+        key: key.to_string(),
+        label: label.to_string(),
+        description: None,
+        help_text: None,
+        field_type,
+        required,
+        default,
+        placeholder: None,
+        supports_env_expansion: false,
+        supports_tilde_expansion: false,
+        visible_when: None,
     }
 }
 
@@ -174,12 +442,17 @@ fn build_client_outcome(
     }
 }
 
+/// The background poll loop for one monitor.
+///
+/// Emits a [`CHECK_EVENT_KIND`] [`ServiceEvent`] (payload: [`HttpCheckResult`])
+/// on `events` after every check — the host bridges that channel to its own
+/// emitter — and caches the latest result in `last_result`.
 async fn run_monitor(
     config: HttpMonitorConfig,
-    app: AppHandle,
+    events: EventChannel,
     cancel: CancellationToken,
     paused: Arc<AtomicBool>,
-    last_result: std::sync::Arc<std::sync::Mutex<Option<HttpCheckResult>>>,
+    last_result: Arc<Mutex<Option<HttpCheckResult>>>,
 ) {
     let build_result = Client::builder()
         .timeout(Duration::from_millis(config.timeout_ms))
@@ -194,7 +467,7 @@ async fn run_monitor(
                 monitor_id = %config.id,
                 "HTTP monitor: failed to build client — emitting failure result and stopping"
             );
-            let _ = app.emit("network-http-monitor-check", &result);
+            events.emit(ServiceEvent::new(CHECK_EVENT_KIND, &result));
             if let Ok(mut guard) = last_result.lock() {
                 *guard = Some(result);
             }
@@ -221,7 +494,7 @@ async fn run_monitor(
                 "HTTP monitor check complete"
             );
 
-            let _ = app.emit("network-http-monitor-check", &result);
+            events.emit(ServiceEvent::new(CHECK_EVENT_KIND, &result));
 
             if let Ok(mut guard) = last_result.lock() {
                 *guard = Some(result);
@@ -396,5 +669,169 @@ mod tests {
                 panic!("a successful build must map to Ready, not Failed")
             }
         }
+    }
+
+    // ── Service trait impl (#2157) ────────────────────────────────────────────
+
+    fn sample_config() -> HttpMonitorConfig {
+        HttpMonitorConfig::new(
+            "https://example.com".into(),
+            30_000,
+            "GET".into(),
+            200,
+            5_000,
+        )
+    }
+
+    #[test]
+    fn service_metadata_and_capabilities() {
+        let svc = HttpMonitorService::new();
+        assert_eq!(svc.service_id(), SERVICE_ID);
+        assert_eq!(svc.display_name(), DISPLAY_NAME);
+
+        let caps = svc.capabilities();
+        assert!(caps.configurable);
+        assert!(caps.emits_events);
+        // A network probe may run on an agent — it is not desktop-only.
+        assert!(!caps.desktop_only);
+
+        // The schema exposes the config fields (camelCase keys).
+        let schema = svc.settings_schema();
+        let keys: Vec<String> = schema
+            .groups
+            .iter()
+            .flat_map(|g| g.fields.iter().map(|f| f.key.clone()))
+            .collect();
+        for expected in ["url", "intervalMs", "method", "expectedStatus", "timeoutMs"] {
+            assert!(
+                keys.contains(&expected.to_string()),
+                "missing field {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn new_service_is_stopped_with_no_config() {
+        let svc = HttpMonitorService::new();
+        assert_eq!(svc.status(), ServiceStatus::Stopped);
+        assert!(!svc.is_running());
+        // No config yet → nothing to list.
+        assert!(svc.state().is_none());
+    }
+
+    #[tokio::test]
+    async fn start_rejects_invalid_config() {
+        let mut svc = HttpMonitorService::new();
+        // Missing required fields → InvalidConfig, not a panic.
+        let err = svc.start(serde_json::json!({ "url": "x" })).await;
+        assert!(matches!(err, Err(ServiceError::InvalidConfig(_))));
+        assert_eq!(svc.status(), ServiceStatus::Stopped);
+    }
+
+    #[tokio::test]
+    async fn start_runs_and_emits_check_events_through_event_channel() {
+        // Point the monitor at a fast local sink so a real check completes
+        // quickly; assert the result arrives on the core EventChannel (not a
+        // Tauri emitter).
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                if let Ok(mut s) = stream {
+                    use std::io::{Read, Write};
+                    let mut buf = [0u8; 1024];
+                    let _ = s.read(&mut buf);
+                    let _ = s.write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                    );
+                }
+            }
+        });
+
+        let mut cfg = sample_config();
+        cfg.url = format!("http://{addr}/");
+        cfg.interval_ms = MIN_INTERVAL_MS;
+        let cfg_id = cfg.id.clone();
+
+        let mut svc = HttpMonitorService::new();
+        let mut rx = svc.subscribe_events();
+        svc.start(serde_json::to_value(&cfg).unwrap())
+            .await
+            .expect("start");
+        assert_eq!(svc.status(), ServiceStatus::Running);
+        assert!(svc.is_running());
+
+        let event = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("a check event must arrive within 5s")
+            .expect("event channel delivers");
+        assert_eq!(event.kind, CHECK_EVENT_KIND);
+        let result: HttpCheckResult = serde_json::from_value(event.payload).unwrap();
+        assert_eq!(result.monitor_id, cfg_id);
+        assert_eq!(result.status_code, Some(200));
+        assert!(result.ok);
+
+        svc.stop().await.expect("stop");
+        assert_eq!(svc.status(), ServiceStatus::Stopped);
+        assert!(!svc.is_running());
+    }
+
+    #[tokio::test]
+    async fn stop_keeps_config_for_listing_and_resume() {
+        let mut svc = HttpMonitorService::new();
+        let cfg = sample_config();
+        let cfg_id = cfg.id.clone();
+        // Use a non-routable address so no real request completes during the test.
+        let mut cfg2 = cfg.clone();
+        cfg2.url = "http://127.0.0.1:1/".into();
+        svc.start(serde_json::to_value(&cfg2).unwrap())
+            .await
+            .expect("start");
+        svc.stop().await.expect("stop");
+
+        // Stopped keeps the monitor listed (config retained) as running:false.
+        let state = svc.state().expect("state after stop");
+        assert_eq!(state.config.id, cfg_id);
+        assert!(!state.running);
+        assert!(!state.paused);
+    }
+
+    #[tokio::test]
+    async fn pause_and_resume_toggle_the_flag_in_place() {
+        let mut svc = HttpMonitorService::new();
+        let mut cfg = sample_config();
+        cfg.url = "http://127.0.0.1:1/".into();
+        svc.start(serde_json::to_value(&cfg).unwrap())
+            .await
+            .expect("start");
+
+        assert!(!svc.is_paused());
+        svc.pause();
+        assert!(svc.is_paused());
+        assert!(svc.is_running(), "pause keeps the loop alive");
+        assert!(svc.state().unwrap().paused);
+
+        svc.resume();
+        assert!(!svc.is_paused());
+        assert!(svc.is_running());
+    }
+
+    #[tokio::test]
+    async fn resume_restarts_a_stopped_monitor_with_same_config() {
+        let mut svc = HttpMonitorService::new();
+        let mut cfg = sample_config();
+        cfg.url = "http://127.0.0.1:1/".into();
+        let cfg_id = cfg.id.clone();
+        svc.start(serde_json::to_value(&cfg).unwrap())
+            .await
+            .expect("start");
+        svc.stop().await.expect("stop");
+        assert!(!svc.is_running());
+
+        // Resuming a stopped monitor re-spawns the loop, reusing the same id.
+        svc.resume();
+        assert!(svc.is_running());
+        assert_eq!(svc.status(), ServiceStatus::Running);
+        assert_eq!(svc.state().unwrap().config.id, cfg_id);
     }
 }

--- a/src-tauri/src/network/http_monitor.rs
+++ b/src-tauri/src/network/http_monitor.rs
@@ -736,15 +736,13 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
         let addr = listener.local_addr().expect("addr");
         std::thread::spawn(move || {
-            for stream in listener.incoming() {
-                if let Ok(mut s) = stream {
-                    use std::io::{Read, Write};
-                    let mut buf = [0u8; 1024];
-                    let _ = s.read(&mut buf);
-                    let _ = s.write_all(
-                        b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
-                    );
-                }
+            for mut s in listener.incoming().flatten() {
+                use std::io::{Read, Write};
+                let mut buf = [0u8; 1024];
+                let _ = s.read(&mut buf);
+                let _ = s.write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                );
             }
         });
 

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -10,18 +10,28 @@ pub mod wol_storage;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
-use tauri::AppHandle;
+use tauri::{AppHandle, Emitter};
+use tokio::sync::broadcast::error::RecvError;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error};
 use uuid::Uuid;
 
-use http_monitor::{HttpMonitorConfig, HttpMonitorHandle, HttpMonitorState};
+use http_monitor::{HttpMonitorConfig, HttpMonitorService, HttpMonitorState};
 use termihub_core::network::WolDevice;
+use termihub_core::service::{Service, ServiceInfo, ServiceRegistry};
 
+use crate::run_location::{ResolvedLocation, RunLocationResolver};
 use crate::utils::errors::TerminalError;
+
+/// Tauri event forwarded to the frontend for each HTTP monitor check.
+///
+/// The [`HttpMonitorService`] itself emits on the core
+/// [`EventChannel`](termihub_core::service::EventChannel); the desktop host
+/// bridges that channel to this Tauri event so the frontend contract is
+/// unchanged (see [`NetworkManager::spawn_http_monitor`]).
+const HTTP_MONITOR_CHECK_EVENT: &str = "network-http-monitor-check";
 
 /// Central manager for all active network diagnostic tasks.
 ///
@@ -29,8 +39,15 @@ use crate::utils::errors::TerminalError;
 pub struct NetworkManager {
     /// Active scan / ping / traceroute tasks, keyed by task ID.
     active_tasks: Mutex<HashMap<String, CancellationToken>>,
-    /// Running HTTP monitors.
-    http_monitors: Mutex<HashMap<String, HttpMonitorHandle>>,
+    /// Running HTTP monitors, each an [`HttpMonitorService`] behind the core
+    /// [`Service`](termihub_core::service::Service) trait (#2157).
+    http_monitors: Mutex<HashMap<String, HttpMonitorService>>,
+    /// Desktop-side registry of run-location-routable services. The HTTP monitor
+    /// is registered here (discovery, schema, capabilities) as the S2 pilot.
+    service_registry: ServiceRegistry,
+    /// Resolver deciding where a service runs (local vs agent). S1 default is
+    /// always local — the run-location selector UI arrives in a later S-phase.
+    run_location: RunLocationResolver,
     /// Saved Wake-on-LAN devices (persisted to disk).
     wol_devices: Mutex<Vec<WolDevice>>,
     /// App config directory for persistence.
@@ -45,10 +62,18 @@ impl NetworkManager {
         Self {
             active_tasks: Mutex::new(HashMap::new()),
             http_monitors: Mutex::new(HashMap::new()),
+            service_registry: build_service_registry(),
+            run_location: RunLocationResolver::new(),
             wol_devices: Mutex::new(Vec::new()),
             config_dir: PathBuf::new(),
             app_handle: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// The services registered for run-location routing (currently just the
+    /// HTTP monitor). Backs future discovery / the run-location selector UI.
+    pub fn available_services(&self) -> Vec<ServiceInfo> {
+        self.service_registry.available_services()
     }
 
     /// Initialise the manager with the app config directory and app handle.
@@ -133,18 +158,41 @@ impl NetworkManager {
         self.spawn_http_monitor(config)
     }
 
-    /// Spawn the poll loop for a config and track its handle, **without**
+    /// Spawn the poll loop for a config and track its service, **without**
     /// touching disk. Used both by [`start_http_monitor`](Self::start_http_monitor)
     /// (after persisting) and by [`init`](Self::init) when auto-starting the
     /// persisted monitors on launch.
+    ///
+    /// The monitor's run-location is resolved through the [`RunLocationResolver`]
+    /// (S1 default: always local). The service emits check results on its core
+    /// [`EventChannel`](termihub_core::service::EventChannel); a bridge task
+    /// forwards them to the [`HTTP_MONITOR_CHECK_EVENT`] Tauri event so the
+    /// frontend contract is unchanged.
     fn spawn_http_monitor(&self, config: HttpMonitorConfig) -> Result<String, TerminalError> {
+        match self.run_location.resolve_default() {
+            ResolvedLocation::Local => {}
+            ResolvedLocation::Agent(agent) => {
+                // The run-location selector UI (which could request an agent) is
+                // a later S-phase; today the resolver always returns local.
+                return Err(TerminalError::InternalError(format!(
+                    "agent-hosted HTTP monitors are not yet supported (requested '{agent}')"
+                )));
+            }
+        }
+
         let app = self
             .app_handle()
             .ok_or_else(|| TerminalError::InternalError("app handle not available".into()))?;
         let id = config.id.clone();
-        let handle = http_monitor::start_monitor(config, app);
+
+        let mut service = HttpMonitorService::new();
+        // Subscribe before starting so the bridge cannot miss the first check.
+        let events = service.subscribe_events();
+        service.start_with(config);
+        spawn_event_bridge(app, events);
+
         if let Ok(mut monitors) = self.http_monitors.lock() {
-            monitors.insert(id.clone(), handle);
+            monitors.insert(id.clone(), service);
         }
         Ok(id)
     }
@@ -157,17 +205,16 @@ impl NetworkManager {
     /// (or the next launch) can bring it back. Use [`remove_http_monitor`] to
     /// truly delete it.
     pub fn stop_http_monitor(&self, monitor_id: &str) -> Result<(), TerminalError> {
-        let monitors = self
+        let mut monitors = self
             .http_monitors
             .lock()
             .map_err(|_| TerminalError::InternalError("http monitor lock poisoned".into()))?;
-        match monitors.get(monitor_id) {
-            Some(handle) => {
-                // Cancel the poll loop but leave the handle in the map so the
-                // monitor stays listed as `running: false`. `paused` is cleared
-                // so a later Resume starts clean.
-                handle.cancel.cancel();
-                handle.paused.store(false, Ordering::SeqCst);
+        match monitors.get_mut(monitor_id) {
+            Some(service) => {
+                // Cancel the poll loop but leave the service in the map so the
+                // monitor stays listed as `running: false`. Its event channel
+                // stays open, so a later Resume keeps the same bridge task.
+                service.shutdown();
                 Ok(())
             }
             None => Err(TerminalError::NotFound(format!("monitor '{monitor_id}'"))),
@@ -184,8 +231,10 @@ impl NetworkManager {
             .lock()
             .map_err(|_| TerminalError::InternalError("http monitor lock poisoned".into()))?;
         match monitors.remove(monitor_id) {
-            Some(handle) => {
-                handle.cancel.cancel();
+            Some(mut service) => {
+                // Cancel the poll loop; dropping the service also drops its event
+                // channel sender, so the bridge task exits cleanly.
+                service.shutdown();
                 drop(monitors);
                 // Best-effort disk cleanup; a persistence error must not leave
                 // the handle re-inserted.
@@ -206,8 +255,8 @@ impl NetworkManager {
             .lock()
             .map_err(|_| TerminalError::InternalError("http monitor lock poisoned".into()))?;
         match monitors.get(monitor_id) {
-            Some(handle) => {
-                handle.paused.store(true, Ordering::SeqCst);
+            Some(service) => {
+                service.pause();
                 debug!(monitor_id, "Paused HTTP monitor");
                 Ok(())
             }
@@ -221,34 +270,21 @@ impl NetworkManager {
     /// - A **stopped** monitor (loop cancelled, but still listed) is re-spawned
     ///   with a fresh cancellation token, reusing the same config/id.
     pub fn resume_http_monitor(&self, monitor_id: &str) -> Result<(), TerminalError> {
-        // Take the current handle so we can decide whether to un-pause in place
-        // or re-spawn a stopped loop. Clone the config first; drop the lock
-        // before re-spawning (spawn re-locks the map).
-        let stopped_config = {
-            let mut monitors = self
-                .http_monitors
-                .lock()
-                .map_err(|_| TerminalError::InternalError("http monitor lock poisoned".into()))?;
-            match monitors.get(monitor_id) {
-                Some(handle) if !handle.cancel.is_cancelled() => {
-                    // Alive (running or paused): clear the pause flag in place.
-                    handle.paused.store(false, Ordering::SeqCst);
-                    debug!(monitor_id, "Resumed paused HTTP monitor");
-                    None
-                }
-                Some(_) => {
-                    // Stopped: remove the dead handle and re-spawn below.
-                    monitors.remove(monitor_id).map(|h| h.config)
-                }
-                None => return Err(TerminalError::NotFound(format!("monitor '{monitor_id}'"))),
+        let mut monitors = self
+            .http_monitors
+            .lock()
+            .map_err(|_| TerminalError::InternalError("http monitor lock poisoned".into()))?;
+        match monitors.get_mut(monitor_id) {
+            Some(service) => {
+                // The service resumes in place: a paused loop clears its flag; a
+                // stopped loop is re-spawned on the same event channel, so the
+                // existing bridge task keeps forwarding without re-subscribing.
+                service.resume();
+                debug!(monitor_id, "Resumed HTTP monitor");
+                Ok(())
             }
-        };
-
-        if let Some(config) = stopped_config {
-            self.spawn_http_monitor(config)?;
-            debug!(monitor_id, "Restarted stopped HTTP monitor");
+            None => Err(TerminalError::NotFound(format!("monitor '{monitor_id}'"))),
         }
-        Ok(())
     }
 
     // ── HTTP Monitor persistence ────────────────────────────────────────────
@@ -304,8 +340,8 @@ impl NetworkManager {
             error!("http monitor lock poisoned during stop_all");
             return;
         };
-        for (id, handle) in monitors.drain() {
-            handle.cancel.cancel();
+        for (id, mut service) in monitors.drain() {
+            service.shutdown();
             debug!(monitor_id = %id, "Stopped HTTP monitor during teardown");
         }
     }
@@ -315,20 +351,7 @@ impl NetworkManager {
         let Ok(monitors) = self.http_monitors.lock() else {
             return Vec::new();
         };
-        monitors
-            .values()
-            .map(|h| {
-                let last_result = h.last_result.lock().ok().and_then(|g| g.clone());
-                let running = !h.cancel.is_cancelled();
-                HttpMonitorState {
-                    config: h.config.clone(),
-                    running,
-                    // A stopped loop can't be paused; only report paused while alive.
-                    paused: running && h.paused.load(Ordering::SeqCst),
-                    last_result,
-                }
-            })
-            .collect()
+        monitors.values().filter_map(|s| s.state()).collect()
     }
 
     // ── WoL Devices ─────────────────────────────────────────────────────────
@@ -376,17 +399,53 @@ impl Default for NetworkManager {
     }
 }
 
+/// Build the desktop [`ServiceRegistry`] with the run-location-routable services.
+///
+/// The HTTP monitor is the S2 pilot (#2157) — the first existing service lifted
+/// onto the core [`Service`](termihub_core::service::Service) trait.
+fn build_service_registry() -> ServiceRegistry {
+    let mut registry = ServiceRegistry::new();
+    registry.register(
+        http_monitor::SERVICE_ID,
+        http_monitor::DISPLAY_NAME,
+        "activity",
+        Box::new(|| Box::new(HttpMonitorService::new())),
+    );
+    registry
+}
+
+/// Bridge a monitor's core [`EventChannel`](termihub_core::service::EventChannel)
+/// to the desktop's Tauri emitter.
+///
+/// Forwards each `check` [`ServiceEvent`](termihub_core::service::ServiceEvent)
+/// as a [`HTTP_MONITOR_CHECK_EVENT`] Tauri event so the frontend receives the
+/// same `HttpCheckResult` payload as before the lift. The task ends when the
+/// service is dropped (channel closed).
+fn spawn_event_bridge(app: AppHandle, mut events: termihub_core::service::ServiceEventReceiver) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            match events.recv().await {
+                Ok(event) if event.kind == http_monitor::CHECK_EVENT_KIND => {
+                    let _ = app.emit(HTTP_MONITOR_CHECK_EVENT, event.payload);
+                }
+                Ok(_) => {}
+                // Advisory events: a lagging bridge drops the oldest and keeps going.
+                Err(RecvError::Lagged(_)) => continue,
+                // All senders dropped (service removed) — nothing more to forward.
+                Err(RecvError::Closed) => break,
+            }
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use http_monitor::HttpCheckResult;
 
-    use std::sync::atomic::AtomicBool;
-
-    /// Insert a bare monitor handle (no spawned task) so `stop_all_http_monitors`
-    /// can be exercised without a live Tauri `AppHandle`. Returns the id plus the
-    /// handle's cancellation token and `paused` flag so tests can assert on them.
-    fn insert_dummy_monitor(mgr: &NetworkManager) -> (String, CancellationToken, Arc<AtomicBool>) {
+    /// Insert a monitor service in the `Running` state (no real poll loop, so no
+    /// Tauri app or network needed) so manager bookkeeping can be exercised.
+    /// Returns the monitor id.
+    fn insert_dummy_monitor(mgr: &NetworkManager) -> String {
         let config = HttpMonitorConfig::new(
             "https://example.com".into(),
             30_000,
@@ -397,45 +456,47 @@ mod tests {
         insert_dummy_monitor_config(mgr, config)
     }
 
-    /// Insert a dummy handle for a specific config (so persistence + map stay in
-    /// sync in tests that also persist the config).
-    fn insert_dummy_monitor_config(
-        mgr: &NetworkManager,
-        config: HttpMonitorConfig,
-    ) -> (String, CancellationToken, Arc<AtomicBool>) {
+    /// Insert a running monitor service for a specific config (so persistence +
+    /// map stay in sync in tests that also persist the config).
+    fn insert_dummy_monitor_config(mgr: &NetworkManager, config: HttpMonitorConfig) -> String {
         let id = config.id.clone();
-        let cancel = CancellationToken::new();
-        let paused = Arc::new(AtomicBool::new(false));
-        let handle = HttpMonitorHandle {
-            config,
-            cancel: cancel.clone(),
-            paused: Arc::clone(&paused),
-            last_result: Arc::new(Mutex::new(None::<HttpCheckResult>)),
-        };
         mgr.http_monitors
             .lock()
             .expect("http monitor lock")
-            .insert(id.clone(), handle);
-        (id, cancel, paused)
+            .insert(id.clone(), HttpMonitorService::test_running(config));
+        id
     }
 
     #[test]
     fn stop_all_http_monitors_cancels_and_clears() {
         let mgr = NetworkManager::new();
-        let (_id1, token1, _p1) = insert_dummy_monitor(&mgr);
-        let (_id2, token2, _p2) = insert_dummy_monitor(&mgr);
+        let _id1 = insert_dummy_monitor(&mgr);
+        let _id2 = insert_dummy_monitor(&mgr);
 
-        assert_eq!(mgr.list_http_monitors().len(), 2);
-        assert!(!token1.is_cancelled());
-        assert!(!token2.is_cancelled());
+        let listed = mgr.list_http_monitors();
+        assert_eq!(listed.len(), 2);
+        assert!(listed.iter().all(|m| m.running));
 
         mgr.stop_all_http_monitors();
 
-        // Every monitor's cancellation token is fired...
-        assert!(token1.is_cancelled());
-        assert!(token2.is_cancelled());
-        // ...and the map is emptied so nothing lingers.
+        // Every monitor is stopped and drained so nothing lingers.
         assert!(mgr.list_http_monitors().is_empty());
+    }
+
+    #[test]
+    fn http_monitor_registered_in_service_registry() {
+        // The S2 pilot registers the HTTP monitor in the desktop ServiceRegistry
+        // with the run-location-routable capabilities.
+        let mgr = NetworkManager::new();
+        let services = mgr.available_services();
+        let monitor = services
+            .iter()
+            .find(|s| s.service_id == http_monitor::SERVICE_ID)
+            .expect("http_monitor must be registered");
+        assert_eq!(monitor.display_name, http_monitor::DISPLAY_NAME);
+        assert!(monitor.capabilities.emits_events);
+        // A network probe may run on an agent — not desktop-only.
+        assert!(!monitor.capabilities.desktop_only);
     }
 
     #[test]
@@ -537,14 +598,12 @@ mod tests {
             200,
             5_000,
         );
-        let (id, token, _paused) = insert_dummy_monitor_config(&mgr, cfg.clone());
+        let id = insert_dummy_monitor_config(&mgr, cfg.clone());
         mgr.persist_monitor_config(cfg).expect("persist");
 
         mgr.stop_http_monitor(&id).expect("stop");
 
-        // The poll loop is cancelled...
-        assert!(token.is_cancelled());
-        // ...but the monitor stays listed as not running...
+        // The poll loop is cancelled but the monitor stays listed as not running...
         let listed = mgr.list_http_monitors();
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].config.id, id);
@@ -567,12 +626,11 @@ mod tests {
             200,
             5_000,
         );
-        let (id, token, _paused) = insert_dummy_monitor_config(&mgr, cfg.clone());
+        let id = insert_dummy_monitor_config(&mgr, cfg.clone());
         mgr.persist_monitor_config(cfg).expect("persist");
 
         mgr.remove_http_monitor(&id).expect("remove");
 
-        assert!(token.is_cancelled());
         assert!(mgr.list_http_monitors().is_empty());
         assert!(mgr.load_persisted_monitor_configs().is_empty());
     }
@@ -599,18 +657,18 @@ mod tests {
             200,
             5_000,
         );
-        let (id, token, paused) = insert_dummy_monitor_config(&mgr, cfg.clone());
+        let id = insert_dummy_monitor_config(&mgr, cfg.clone());
         mgr.persist_monitor_config(cfg).expect("persist");
 
-        assert!(!paused.load(Ordering::SeqCst));
+        // Initially running, not paused.
+        let listed = mgr.list_http_monitors();
+        assert!(listed[0].running);
+        assert!(!listed[0].paused);
 
         mgr.pause_http_monitor(&id).expect("pause");
 
-        // The poll body is suspended...
-        assert!(paused.load(Ordering::SeqCst));
-        // ...but the loop is not cancelled and the monitor is still listed as
-        // running and paused, with its config kept.
-        assert!(!token.is_cancelled());
+        // The poll body is suspended, but the loop is not cancelled and the
+        // monitor is still listed as running and paused, with its config kept.
         let listed = mgr.list_http_monitors();
         assert_eq!(listed.len(), 1);
         assert!(listed[0].running);
@@ -633,15 +691,14 @@ mod tests {
             5_000,
         );
         let cfg_id = cfg.id.clone();
-        let (id, _token, paused) = insert_dummy_monitor_config(&mgr, cfg.clone());
+        let id = insert_dummy_monitor_config(&mgr, cfg.clone());
         mgr.persist_monitor_config(cfg).expect("persist");
 
         mgr.pause_http_monitor(&id).expect("pause");
-        assert!(paused.load(Ordering::SeqCst));
+        assert!(mgr.list_http_monitors()[0].paused);
 
         mgr.resume_http_monitor(&id).expect("resume");
 
-        assert!(!paused.load(Ordering::SeqCst));
         let listed = mgr.list_http_monitors();
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].config.id, cfg_id);


### PR DESCRIPTION
## Summary

S2 pilot of the stateless-UI / agent-empowerment S-track: lift the **HTTP monitor** (smallest surface) onto `termihub_core::service::Service` and decouple it from Tauri's `Emitter`. This is a **lift, not a redesign** — no user-facing behaviour changes.

Completes the one S1 acceptance bullet deliberately deferred from #2148: *"at least one existing service behind `Service`."*

Closes #2157
Part of #2139

## What changed

- **`HttpMonitorService` implements the core `Service` trait** (`start` / `stop` / `status` / `subscribe_events`, plus `settings_schema` and `capabilities`). Its poll loop now emits a `check` `ServiceEvent` (payload: `HttpCheckResult`) on the core-owned `EventChannel` instead of pushing through `AppHandle::emit`. The service is therefore fully `AppHandle`-free and unit-testable in isolation.
- **`NetworkManager`** stores `HttpMonitorService` instances, registers the monitor in a desktop `ServiceRegistry`, and routes each spawn through the `RunLocationResolver` (S1 default: always local; an agent request is explicitly rejected until the selector UI lands in a later phase).
- **Event bridge** — a per-monitor task forwards `EventChannel` `check` events to the existing `network-http-monitor-check` Tauri event, so the **frontend contract is byte-for-byte unchanged** (same event name, same `HttpCheckResult` payload). The pause/stop/resume/remove/list/persistence semantics are all preserved.
- Added `network_services_list` command backing future run-location discovery.
- `capabilities.desktop_only = false`: an HTTP probe is a natural fit for an agent run-location and is not in the permanent desktop-only set.

## How events flow now

Before: poll loop → `app.emit("network-http-monitor-check", result)`.
After: poll loop → `EventChannel::emit(ServiceEvent{kind:"check", ...})` → desktop bridge task → `app.emit("network-http-monitor-check", payload)`.

## Tests

- Service-level: metadata/capabilities/schema; `InvalidConfig` on bad config; **a real check running against a local TCP sink and arriving on the `EventChannel`** (proves events no longer depend on a Tauri emitter); stop-keeps-config; pause/resume in place; resume re-spawns a stopped monitor.
- Manager-level: registry registration + capabilities; stop/remove/pause/resume/stop-all/list bookkeeping; persistence round-trips (all preserved).
- `cargo test` (network), `clippy --all-targets -D warnings`, `fmt`, and full frontend checks green.

## User-visible behaviour

Unchanged. The HTTP monitor starts, polls, streams results to the UI, pauses/resumes/stops, persists, and auto-restarts on launch exactly as before.