### PR TITLE
feat(ui): shadow LayoutStore + client-scoped layout projection region

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7723,6 +7723,7 @@ dependencies = [
  "objc2-foundation",
  "percent-encoding",
  "portable-pty",
+ "proptest",
  "quick-xml",
  "rand 0.8.6",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -205,5 +205,8 @@ keyring = { version = "3", default-features = false, features = [
 ] }
 
 [dev-dependencies]
+# Property tests over the shadow LayoutStore's tree transitions (#2151); the
+# panel-tree algebra it drives is proptest-covered in `termihub-core` (#2143).
+proptest = "1"
 temp-env = "0.3"
 tower = { version = "0.5", features = ["util"] }

--- a/src-tauri/src/layout/mod.rs
+++ b/src-tauri/src/layout/mod.rs
@@ -1,0 +1,28 @@
+//! Shadow `LayoutStore` — Phase 3 step 1 of the stateless-UI migration (#2151,
+//! part of #2139).
+//!
+//! Moves the panel-tree + minimal tab model into a Rust authority built on the
+//! ported panel-tree algebra (`termihub_core::layout::panel_tree`, #2143). The
+//! store owns a **client-scoped** `layout@<clientId>` projection region and
+//! serves the `layout.*` intents (split / merge / move-tab / close-tab-
+//! structure) through the projection substrate ([`crate::projection`]),
+//! mirroring the SSH-tunnels pilot ([`crate::tunnel::projection`]).
+//!
+//! # Shadow mode — zero user-facing change
+//!
+//! This step is deliberately **not authoritative**. The store exists, accepts
+//! intents, and projects diffs, but nothing in the live UI subscribes to or
+//! renders the `layout@<clientId>` region, and no frontend code dispatches
+//! `layout.*` intents yet. The existing `appStore` panel-tree reducers and
+//! `SplitView` rendering are untouched. Later steps (2–5) cut structural
+//! mutations over, then rendering, then remove the `appStore` reducers, then
+//! add multi-window / restore.
+//!
+//! Because layout is per-window/per-client view arrangement, each attached
+//! client gets its own `layout@<clientId>` region (Open Design Decision #1/#6:
+//! multi-client is in scope), seeded and mutated by `intent.client_id`.
+
+pub mod projection;
+pub mod store;
+
+pub use store::LayoutStore;

--- a/src-tauri/src/layout/projection.rs
+++ b/src-tauri/src/layout/projection.rs
@@ -1,0 +1,163 @@
+//! Layout projection: the client-scoped `layout@<clientId>` region and the
+//! `layout.*` intents (#2151, part of #2139).
+//!
+//! Exposes the authoritative [`LayoutStore`] to each attached client as its own
+//! versioned, multi-subscriber projection region and turns the four structural
+//! layout mutations into [`Intent`]s — mirroring the SSH-tunnels pilot
+//! ([`crate::tunnel::projection`]), the reference registration pattern for the
+//! substrate ([`crate::projection`]).
+//!
+//! # The `layout@<clientId>` region
+//!
+//! **Client-scoped** (per Open Design Decision #1/#6: multi-client is in scope,
+//! and layout is per-window view arrangement — moving a tab on one client need
+//! not move it on another). Each client gets its own region, seeded lazily and
+//! mutated via `intent.client_id`. Its render-ready view model is the panel tree
+//! plus the focused panel:
+//!
+//! ```json
+//! { "root": <PanelNode>, "activePanelId": "panel-…" }
+//! ```
+//!
+//! # Intents
+//!
+//! | kind                        | payload                                  | effect                                        |
+//! | --------------------------- | ---------------------------------------- | --------------------------------------------- |
+//! | `layout.split`              | `{ panelId, direction, position }`       | split a leaf, inserting a new empty leaf       |
+//! | `layout.merge`              | `{ sourcePanelId, targetPanelId }`       | move all tabs into the target, drop the source |
+//! | `layout.moveTab`            | `{ tabId, targetPanelId, edge }`         | move a tab (center = merge; edge = split)      |
+//! | `layout.closeTabStructure`  | `{ tabId }`                              | remove a tab; drop its leaf if left empty      |
+//!
+//! # Shadow mode
+//!
+//! Registered and fully served, but **not** driving the live UI: no frontend
+//! subscribes to `layout@<clientId>` or dispatches `layout.*` yet, so these
+//! intents mutate only the shadow store and project to regions nobody renders.
+//! The `appStore` panel-tree reducers and `SplitView` remain authoritative. Per
+//! the substrate contract the result of an intent is never returned inline — it
+//! always arrives as a projection diff on the client's `layout` region.
+
+use std::sync::Arc;
+
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+use crate::layout::store::{LayoutError, LayoutStore};
+use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
+
+/// The projection region id for a client's layout (`layout@<clientId>`).
+pub fn layout_region(client_id: &str) -> String {
+    format!("layout@{client_id}")
+}
+
+/// Publish a client's `layout` region from the store, fanning a diff out to
+/// every subscriber and returning the advanced region for the intent ack (empty
+/// when the view did not change).
+pub fn publish_layout(
+    projector: &Projector,
+    store: &LayoutStore,
+    client_id: &str,
+) -> Vec<ProducedRegion> {
+    let region = layout_region(client_id);
+    match projector.publish(&region, store.snapshot(client_id)) {
+        Some(version) => vec![ProducedRegion { region, version }],
+        None => Vec::new(),
+    }
+}
+
+/// Register the four `layout.*` intents on a handler registry.
+///
+/// Each route resolves the managed [`LayoutStore`] lazily (so it rejects
+/// gracefully rather than panicking if the store is somehow absent), mutates the
+/// dispatching client's tree via [`intent.client_id`](Intent::client_id), and
+/// publishes that client's region. All four transforms are pure/fast tree edits,
+/// so they run inline on the dispatcher's single writer.
+pub fn register_layout_intents(registry: &mut HandlerRegistry, app_handle: AppHandle) {
+    let handle = app_handle.clone();
+    registry.route("layout.split", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let panel_id = required_str(intent, "panelId")?;
+        let direction = required_enum(intent, "direction")?;
+        let position = required_enum(intent, "position")?;
+        store
+            .split(&intent.client_id, &panel_id, direction, position)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.merge", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let source = required_str(intent, "sourcePanelId")?;
+        let target = required_str(intent, "targetPanelId")?;
+        store
+            .merge(&intent.client_id, &source, &target)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.moveTab", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let tab_id = required_str(intent, "tabId")?;
+        let target = required_str(intent, "targetPanelId")?;
+        let edge = required_enum(intent, "edge")?;
+        store
+            .move_tab(&intent.client_id, &tab_id, &target, edge)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle;
+    registry.route("layout.closeTabStructure", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let tab_id = required_str(intent, "tabId")?;
+        store
+            .close_tab_structure(&intent.client_id, &tab_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+}
+
+/// Resolve the managed layout store, or a rejectable error if it is absent.
+fn store_of(app_handle: &AppHandle) -> Result<Arc<LayoutStore>, (String, String)> {
+    app_handle
+        .try_state::<Arc<LayoutStore>>()
+        .map(|state| (*state).clone())
+        .ok_or_else(|| {
+            (
+                "unavailable".to_string(),
+                "layout store is not initialized".to_string(),
+            )
+        })
+}
+
+/// Turn a [`LayoutError`] into an intent-ack `(code, message)` pair.
+fn to_ack_err(err: LayoutError) -> (String, String) {
+    (err.code().to_string(), err.to_string())
+}
+
+/// Extract a required string field from an intent payload.
+fn required_str(intent: &Intent, key: &str) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// Extract and deserialize a required enum field (e.g. `direction`, `edge`).
+fn required_enum<T: DeserializeOwned>(intent: &Intent, key: &str) -> Result<T, (String, String)> {
+    let value = intent
+        .payload
+        .get(key)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))?;
+    serde_json::from_value(value.clone())
+        .map_err(|e| ("bad_payload".to_string(), format!("invalid '{key}': {e}")))
+}
+
+#[cfg(test)]
+#[path = "projection_tests.rs"]
+mod tests;

--- a/src-tauri/src/layout/projection_tests.rs
+++ b/src-tauri/src/layout/projection_tests.rs
@@ -19,8 +19,8 @@ use serde_json::{json, Value};
 
 use super::*;
 use crate::projection::{
-    apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, Projector,
-    ProjectionError, ProjectionFrame, ProjectionSink, SnapshotFrame,
+    apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
+    ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
 };
 use termihub_core::layout::panel_tree::{
     Direction, DropEdge, LeafPanel, PanelNode, Position, SplitContainer, Tab,
@@ -238,7 +238,11 @@ fn split_intent_produces_one_diff_fanned_to_two_subscribers() {
     assert_eq!(diffs_a[0].version, 1);
 
     cache_a.apply(&diffs_a[0]);
-    assert_eq!(cache_a.view, store.snapshot("A"), "cache converges on authority");
+    assert_eq!(
+        cache_a.view,
+        store.snapshot("A"),
+        "cache converges on authority"
+    );
 }
 
 #[test]
@@ -273,7 +277,11 @@ fn move_and_close_intents_advance_the_region_monotonically() {
         cache.apply(diff);
     }
     assert_eq!(cache.version, 2);
-    assert_eq!(cache.view, store.snapshot("A"), "cache converges on authority");
+    assert_eq!(
+        cache.view,
+        store.snapshot("A"),
+        "cache converges on authority"
+    );
 }
 
 #[test]

--- a/src-tauri/src/layout/projection_tests.rs
+++ b/src-tauri/src/layout/projection_tests.rs
@@ -1,0 +1,353 @@
+//! Projection-contract tests for the client-scoped `layout@<clientId>` region
+//! (#2151), reusing the substrate harness patterns established by the Phase-1
+//! tests and the tunnel pilot (an in-memory [`ProjectionSink`] + a client cache
+//! that applies diffs). The routes here drive a real [`LayoutStore`] directly
+//! (the production `register_layout_intents` resolves the same store from the
+//! Tauri `AppHandle`; that thin wiring is integration-verified via a local
+//! `./scripts/dev.sh` run) through the identical parse → mutate → publish path.
+//!
+//! Asserted: subscribe → seeded snapshot (identical to every subscriber), an
+//! accepted intent → exactly one coalesced diff fanned to every subscriber with
+//! monotonic versions, client-scoped isolation (an intent from one client does
+//! not touch another client's region), rejection paths advance nothing, and a
+//! dead subscriber is reaped.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::{json, Value};
+
+use super::*;
+use crate::projection::{
+    apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, Projector,
+    ProjectionError, ProjectionFrame, ProjectionSink, SnapshotFrame,
+};
+use termihub_core::layout::panel_tree::{
+    Direction, DropEdge, LeafPanel, PanelNode, Position, SplitContainer, Tab,
+};
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+fn tab(id: &str) -> Tab {
+    Tab {
+        id: id.to_string(),
+        session_id: None,
+        content_type: "terminal".to_string(),
+    }
+}
+
+fn leaf(id: &str, tab_ids: &[&str]) -> LeafPanel {
+    let tabs: Vec<Tab> = tab_ids.iter().map(|t| tab(t)).collect();
+    let active_tab_id = tabs.first().map(|t| t.id.clone());
+    LeafPanel {
+        id: id.to_string(),
+        tabs,
+        active_tab_id,
+    }
+}
+
+fn two_panel_tree() -> PanelNode {
+    PanelNode::Split(SplitContainer {
+        id: "root".to_string(),
+        direction: Direction::Horizontal,
+        children: vec![
+            PanelNode::Leaf(leaf("a", &["t1", "t2"])),
+            PanelNode::Leaf(leaf("b", &["t3"])),
+        ],
+        sizes: None,
+        last_active_leaf_id: None,
+    })
+}
+
+/// A store seeded with `two_panel_tree` for `client`.
+fn seeded_store(client: &str) -> Arc<LayoutStore> {
+    let store = Arc::new(LayoutStore::new());
+    store.seed_for_test(client, two_panel_tree(), Some("a".to_string()));
+    store
+}
+
+/// The production `layout.*` routes, but bound to an injected store instead of
+/// resolving one from an `AppHandle` — the exact parse → mutate → publish path
+/// `register_layout_intents` runs.
+fn registry_for(store: Arc<LayoutStore>) -> HandlerRegistry {
+    let mut registry = HandlerRegistry::new();
+
+    let s = store.clone();
+    registry.route("layout.split", move |intent, projector| {
+        let panel_id = required_str(intent, "panelId")?;
+        let direction: Direction = required_enum(intent, "direction")?;
+        let position: Position = required_enum(intent, "position")?;
+        s.split(&intent.client_id, &panel_id, direction, position)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("layout.merge", move |intent, projector| {
+        let source = required_str(intent, "sourcePanelId")?;
+        let target = required_str(intent, "targetPanelId")?;
+        s.merge(&intent.client_id, &source, &target)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("layout.moveTab", move |intent, projector| {
+        let tab_id = required_str(intent, "tabId")?;
+        let target = required_str(intent, "targetPanelId")?;
+        let edge: DropEdge = required_enum(intent, "edge")?;
+        s.move_tab(&intent.client_id, &tab_id, &target, edge)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store;
+    registry.route("layout.closeTabStructure", move |intent, projector| {
+        let tab_id = required_str(intent, "tabId")?;
+        s.close_tab_structure(&intent.client_id, &tab_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    registry
+}
+
+/// An in-memory sink recording delivered frames; can be killed to simulate a
+/// dead subscriber (mirrors the substrate/tunnel test double).
+struct VecSink {
+    frames: Mutex<Vec<ProjectionFrame>>,
+    alive: AtomicBool,
+}
+
+impl VecSink {
+    fn new() -> Self {
+        Self {
+            frames: Mutex::new(Vec::new()),
+            alive: AtomicBool::new(true),
+        }
+    }
+
+    fn diffs(&self) -> Vec<DiffFrame> {
+        self.frames
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|f| match f {
+                ProjectionFrame::Diff(d) => Some(d.clone()),
+                ProjectionFrame::Snapshot(_) => None,
+            })
+            .collect()
+    }
+}
+
+impl ProjectionSink for VecSink {
+    fn deliver(&self, frame: &ProjectionFrame) -> Result<(), ProjectionError> {
+        if !self.alive.load(Ordering::SeqCst) {
+            return Err(ProjectionError::SinkClosed("killed".into()));
+        }
+        self.frames.lock().unwrap().push(frame.clone());
+        Ok(())
+    }
+}
+
+/// A minimal client cache mirroring the TypeScript `ProjectionClient`.
+struct ClientCache {
+    version: u64,
+    view: Value,
+}
+
+impl ClientCache {
+    fn from_snapshot(s: &SnapshotFrame) -> Self {
+        Self {
+            version: s.version,
+            view: s.view.clone(),
+        }
+    }
+
+    fn apply(&mut self, diff: &DiffFrame) {
+        assert_eq!(diff.base_version, self.version, "diff must fit the cache");
+        apply_ops(&mut self.view, &diff.ops).expect("diff applies cleanly");
+        self.version = diff.version;
+    }
+}
+
+fn intent(kind: &str, client: &str, payload: Value) -> Intent {
+    Intent {
+        intent_id: format!("01J-{kind}"),
+        kind: kind.to_string(),
+        payload,
+        client_id: client.to_string(),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn subscribe_returns_the_seeded_snapshot_identically_to_every_subscriber() {
+    let store = seeded_store("A");
+    let region = layout_region("A");
+
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+
+    let snap_a = projector.subscribe(&region, "sub-a", "A", Arc::new(VecSink::new()));
+    let snap_b = projector.subscribe(&region, "sub-b", "A", Arc::new(VecSink::new()));
+
+    assert_eq!(snap_a.version, 0);
+    assert_eq!(snap_a, snap_b, "a late joiner gets an identical baseline");
+    assert_eq!(snap_a.region, "layout@A");
+    // The view model is the panel tree + focused panel.
+    assert_eq!(snap_a.view["activePanelId"], json!("a"));
+    assert_eq!(snap_a.view["root"]["type"], json!("split"));
+}
+
+#[test]
+fn split_intent_produces_one_diff_fanned_to_two_subscribers() {
+    let store = seeded_store("A");
+    let region = layout_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink_a = Arc::new(VecSink::new());
+    let sink_b = Arc::new(VecSink::new());
+    let snap = projector.subscribe(&region, "sub-a", "A", sink_a.clone());
+    projector.subscribe(&region, "sub-b", "A", sink_b.clone());
+    let mut cache_a = ClientCache::from_snapshot(&snap);
+
+    let ack = dispatcher.dispatch(intent(
+        "layout.split",
+        "A",
+        json!({ "panelId": "a", "direction": "vertical", "position": "after" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(
+        ack.produced,
+        Some(vec![crate::projection::ProducedRegion {
+            region: region.clone(),
+            version: 1,
+        }])
+    );
+
+    let diffs_a = sink_a.diffs();
+    let diffs_b = sink_b.diffs();
+    assert_eq!(diffs_a.len(), 1, "exactly one diff to A");
+    assert_eq!(diffs_b.len(), 1, "exactly one diff to B");
+    assert_eq!(diffs_a[0], diffs_b[0], "identical diff to every subscriber");
+    assert_eq!(diffs_a[0].base_version, 0);
+    assert_eq!(diffs_a[0].version, 1);
+
+    cache_a.apply(&diffs_a[0]);
+    assert_eq!(cache_a.view, store.snapshot("A"), "cache converges on authority");
+}
+
+#[test]
+fn move_and_close_intents_advance_the_region_monotonically() {
+    let store = seeded_store("A");
+    let region = layout_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(&region, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    let ack = dispatcher.dispatch(intent(
+        "layout.moveTab",
+        "A",
+        json!({ "tabId": "t1", "targetPanelId": "b", "edge": "center" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    let ack = dispatcher.dispatch(intent(
+        "layout.closeTabStructure",
+        "A",
+        json!({ "tabId": "t3" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 2, "one diff per accepted intent");
+    for diff in &diffs {
+        cache.apply(diff);
+    }
+    assert_eq!(cache.version, 2);
+    assert_eq!(cache.view, store.snapshot("A"), "cache converges on authority");
+}
+
+#[test]
+fn intents_are_client_scoped_across_regions() {
+    // One store seeded for two clients; each client subscribes to its own region.
+    let store = Arc::new(LayoutStore::new());
+    store.seed_for_test("A", two_panel_tree(), Some("a".to_string()));
+    store.seed_for_test("B", two_panel_tree(), Some("a".to_string()));
+
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&layout_region("A"), store.snapshot("A"));
+    projector.register_region(&layout_region("B"), store.snapshot("B"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink_a = Arc::new(VecSink::new());
+    let sink_b = Arc::new(VecSink::new());
+    projector.subscribe(&layout_region("A"), "sa", "A", sink_a.clone());
+    projector.subscribe(&layout_region("B"), "sb", "B", sink_b.clone());
+
+    // A splits; only A's region advances.
+    dispatcher.dispatch(intent(
+        "layout.split",
+        "A",
+        json!({ "panelId": "a", "direction": "horizontal", "position": "after" }),
+    ));
+
+    assert_eq!(sink_a.diffs().len(), 1, "A's region got the diff");
+    assert_eq!(sink_b.diffs().len(), 0, "B's region untouched");
+    assert_eq!(projector.region_version(&layout_region("B")), Some(0));
+}
+
+#[test]
+fn a_rejected_intent_advances_nothing() {
+    let store = seeded_store("A");
+    let region = layout_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(&region, "sub", "A", sink.clone());
+
+    // Unknown tab → rejected, no diff, no version bump.
+    let ack = dispatcher.dispatch(intent(
+        "layout.moveTab",
+        "A",
+        json!({ "tabId": "ghost", "targetPanelId": "b", "edge": "center" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "tab_not_found");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(&region), Some(0));
+}
+
+#[test]
+fn a_dead_subscriber_is_reaped_and_others_keep_receiving() {
+    let store = seeded_store("A");
+    let region = layout_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let live = Arc::new(VecSink::new());
+    let dead = Arc::new(VecSink::new());
+    projector.subscribe(&region, "live", "A", live.clone());
+    projector.subscribe(&region, "dead", "A", dead.clone());
+    dead.alive.store(false, Ordering::SeqCst);
+
+    dispatcher.dispatch(intent(
+        "layout.split",
+        "A",
+        json!({ "panelId": "a", "direction": "vertical", "position": "before" }),
+    ));
+
+    assert_eq!(projector.subscriber_count(&region), 1, "dead reaped");
+    assert_eq!(live.diffs().len(), 1, "live subscriber still receives");
+}

--- a/src-tauri/src/layout/store.rs
+++ b/src-tauri/src/layout/store.rs
@@ -1,0 +1,323 @@
+//! The authoritative, client-scoped panel-tree + tab model behind the shadow
+//! `layout@<clientId>` projection region (#2151).
+//!
+//! Every structural transform delegates to the pure panel-tree algebra ported in
+//! #2143 (`termihub_core::layout::panel_tree`) — this module only owns the
+//! per-client authoritative trees and turns the four `layout.*` intents into
+//! algebra calls. It holds **only** the structure + minimal tab model
+//! (`{ id, sessionId, contentType }`, exactly the seam the ported `Tab` models);
+//! session status, tab colours, and broadcast membership stay in `appStore`
+//! under partial projection and migrate in later phases.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard};
+
+use serde_json::{json, Value};
+
+use termihub_core::layout::panel_tree::{
+    create_leaf_panel, edge_to_split, find_leaf, find_leaf_by_tab, generate_panel_id,
+    get_all_leaves, remove_leaf, simplify_tree, split_leaf, update_leaf, Direction, DropEdge,
+    LeafPanel, PanelNode, Position, Tab,
+};
+
+/// A rejectable layout-intent failure. Maps to an intent ack `(code, message)`
+/// in [`super::projection`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum LayoutError {
+    /// A referenced leaf panel id is not present in the client's tree.
+    #[error("panel not found: {0}")]
+    PanelNotFound(String),
+    /// A referenced tab id is not present in the client's tree.
+    #[error("tab not found: {0}")]
+    TabNotFound(String),
+    /// A `moveTab` used the `center` edge where a real split edge was required,
+    /// or vice versa — a malformed payload.
+    #[error("invalid split edge")]
+    BadEdge,
+    /// `merge` was asked to merge a panel into itself.
+    #[error("source and target panels are the same")]
+    SamePanel,
+}
+
+impl LayoutError {
+    /// The stable intent-ack error code for this failure.
+    pub fn code(&self) -> &'static str {
+        match self {
+            LayoutError::PanelNotFound(_) => "panel_not_found",
+            LayoutError::TabNotFound(_) => "tab_not_found",
+            LayoutError::BadEdge | LayoutError::SamePanel => "bad_payload",
+        }
+    }
+}
+
+/// One client's authoritative layout: its panel tree plus the focused panel.
+#[derive(Clone, Debug, PartialEq)]
+struct LayoutState {
+    root: PanelNode,
+    active_panel_id: Option<String>,
+}
+
+impl LayoutState {
+    /// A freshly-seeded layout: a single empty leaf panel, focused.
+    fn seeded() -> Self {
+        let leaf = create_leaf_panel();
+        let id = leaf.id.clone();
+        Self {
+            root: PanelNode::Leaf(leaf),
+            active_panel_id: Some(id),
+        }
+    }
+
+    /// The render-ready view model for this client's region.
+    fn view(&self) -> Value {
+        json!({ "root": self.root, "activePanelId": self.active_panel_id })
+    }
+}
+
+/// The shadow layout authority. Owns one [`LayoutState`] per attached client,
+/// keyed by `clientId`; an unknown client is seeded lazily on first touch.
+#[derive(Default)]
+pub struct LayoutStore {
+    clients: Mutex<HashMap<String, LayoutState>>,
+}
+
+impl LayoutStore {
+    /// A store with no clients yet. Regions are seeded lazily per `clientId`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The current render-ready view model for a client (seeding it if unknown).
+    ///
+    /// Pure with respect to layout structure — it never mutates an existing
+    /// client — so the projector can safely diff two consecutive snapshots.
+    pub fn snapshot(&self, client_id: &str) -> Value {
+        self.lock()
+            .entry(client_id.to_string())
+            .or_insert_with(LayoutState::seeded)
+            .view()
+    }
+
+    /// `layout.split` — split a leaf panel, inserting a new empty leaf beside it
+    /// and focusing the new leaf.
+    pub fn split(
+        &self,
+        client_id: &str,
+        panel_id: &str,
+        direction: Direction,
+        position: Position,
+    ) -> Result<(), LayoutError> {
+        let mut clients = self.lock();
+        let state = clients
+            .entry(client_id.to_string())
+            .or_insert_with(LayoutState::seeded);
+        if find_leaf(&state.root, panel_id).is_none() {
+            return Err(LayoutError::PanelNotFound(panel_id.to_string()));
+        }
+        let new_leaf = create_leaf_panel();
+        let new_id = new_leaf.id.clone();
+        state.root = split_leaf(&state.root, panel_id, &new_leaf, direction, position);
+        state.active_panel_id = Some(new_id);
+        fix_active(state);
+        Ok(())
+    }
+
+    /// `layout.merge` — move every tab of `source_panel_id` into
+    /// `target_panel_id`, drop the now-empty source panel, and simplify.
+    pub fn merge(
+        &self,
+        client_id: &str,
+        source_panel_id: &str,
+        target_panel_id: &str,
+    ) -> Result<(), LayoutError> {
+        if source_panel_id == target_panel_id {
+            return Err(LayoutError::SamePanel);
+        }
+        let mut clients = self.lock();
+        let state = clients
+            .entry(client_id.to_string())
+            .or_insert_with(LayoutState::seeded);
+        let tabs = find_leaf(&state.root, source_panel_id)
+            .ok_or_else(|| LayoutError::PanelNotFound(source_panel_id.to_string()))?
+            .tabs
+            .clone();
+        if find_leaf(&state.root, target_panel_id).is_none() {
+            return Err(LayoutError::PanelNotFound(target_panel_id.to_string()));
+        }
+        let merged = update_leaf(&state.root, target_panel_id, |leaf| {
+            with_tabs_appended(leaf, &tabs)
+        });
+        let pruned =
+            remove_leaf(&merged, source_panel_id).unwrap_or_else(|| single_empty_leaf());
+        state.root = simplify_tree(&pruned);
+        state.active_panel_id = Some(target_panel_id.to_string());
+        fix_active(state);
+        Ok(())
+    }
+
+    /// `layout.moveTab` — move a tab to a target panel. A `center` edge drops it
+    /// into the target's tab stack (a merge); any other edge splits the target
+    /// and places the tab in the new leaf. The source panel is pruned if it is
+    /// left empty.
+    pub fn move_tab(
+        &self,
+        client_id: &str,
+        tab_id: &str,
+        target_panel_id: &str,
+        edge: DropEdge,
+    ) -> Result<(), LayoutError> {
+        let mut clients = self.lock();
+        let state = clients
+            .entry(client_id.to_string())
+            .or_insert_with(LayoutState::seeded);
+        let source_leaf = find_leaf_by_tab(&state.root, tab_id)
+            .ok_or_else(|| LayoutError::TabNotFound(tab_id.to_string()))?;
+        let source_id = source_leaf.id.clone();
+        let tab = source_leaf
+            .tabs
+            .iter()
+            .find(|t| t.id == tab_id)
+            .cloned()
+            .ok_or_else(|| LayoutError::TabNotFound(tab_id.to_string()))?;
+        if find_leaf(&state.root, target_panel_id).is_none() {
+            return Err(LayoutError::PanelNotFound(target_panel_id.to_string()));
+        }
+
+        let detached = update_leaf(&state.root, &source_id, |leaf| with_tab_removed(leaf, tab_id));
+        let placed = match edge {
+            DropEdge::Center => {
+                update_leaf(&detached, target_panel_id, |leaf| with_tab_added(leaf, tab.clone()))
+            }
+            edge => {
+                let spec = edge_to_split(edge).ok_or(LayoutError::BadEdge)?;
+                let new_leaf = LeafPanel {
+                    id: generate_panel_id(),
+                    tabs: vec![tab.clone()],
+                    active_tab_id: Some(tab.id.clone()),
+                };
+                split_leaf(&detached, target_panel_id, &new_leaf, spec.direction, spec.position)
+            }
+        };
+        let pruned = remove_leaf_if_empty(&placed, &source_id);
+        state.root = simplify_tree(&pruned);
+        fix_active(state);
+        Ok(())
+    }
+
+    /// `layout.closeTabStructure` — remove a tab from the tree, dropping its leaf
+    /// if it becomes empty. Only the structural half of closing a tab; session
+    /// teardown stays in `appStore` under partial projection (later phases).
+    pub fn close_tab_structure(&self, client_id: &str, tab_id: &str) -> Result<(), LayoutError> {
+        let mut clients = self.lock();
+        let state = clients
+            .entry(client_id.to_string())
+            .or_insert_with(LayoutState::seeded);
+        let leaf_id = find_leaf_by_tab(&state.root, tab_id)
+            .ok_or_else(|| LayoutError::TabNotFound(tab_id.to_string()))?
+            .id
+            .clone();
+        let detached = update_leaf(&state.root, &leaf_id, |leaf| with_tab_removed(leaf, tab_id));
+        let pruned = remove_leaf_if_empty(&detached, &leaf_id);
+        state.root = simplify_tree(&pruned);
+        fix_active(state);
+        Ok(())
+    }
+
+    /// Install a specific tree for a client — test-only seeding so intent tests
+    /// can start from a populated layout without a tab-creating intent (tabs
+    /// enter via session creation in `appStore`, out of this shadow's scope).
+    #[cfg(test)]
+    pub fn seed_for_test(&self, client_id: &str, root: PanelNode, active_panel_id: Option<String>) {
+        self.lock().insert(
+            client_id.to_string(),
+            LayoutState {
+                root,
+                active_panel_id,
+            },
+        );
+    }
+
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, LayoutState>> {
+        // Short critical sections only; a poisoned lock means another thread
+        // panicked mid-mutation (a bug) — recover rather than cascade.
+        self.clients.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+// ── Pure leaf/tree helpers ───────────────────────────────────────────────────
+
+/// A single empty leaf, the collapse target when a whole tree is emptied.
+fn single_empty_leaf() -> PanelNode {
+    PanelNode::Leaf(create_leaf_panel())
+}
+
+/// A copy of `leaf` with `tab_id` removed; the active tab falls back to the
+/// first remaining tab when the removed tab was active.
+fn with_tab_removed(leaf: &LeafPanel, tab_id: &str) -> LeafPanel {
+    let tabs: Vec<Tab> = leaf.tabs.iter().filter(|t| t.id != tab_id).cloned().collect();
+    let active_tab_id = if leaf.active_tab_id.as_deref() == Some(tab_id) {
+        tabs.first().map(|t| t.id.clone())
+    } else {
+        leaf.active_tab_id.clone()
+    };
+    LeafPanel {
+        id: leaf.id.clone(),
+        tabs,
+        active_tab_id,
+    }
+}
+
+/// A copy of `leaf` with `tab` appended and focused.
+fn with_tab_added(leaf: &LeafPanel, tab: Tab) -> LeafPanel {
+    let mut tabs = leaf.tabs.clone();
+    let active_tab_id = Some(tab.id.clone());
+    tabs.push(tab);
+    LeafPanel {
+        id: leaf.id.clone(),
+        tabs,
+        active_tab_id,
+    }
+}
+
+/// A copy of `leaf` with `extra` appended; focuses the first appended tab only
+/// when the target had no active tab yet.
+fn with_tabs_appended(leaf: &LeafPanel, extra: &[Tab]) -> LeafPanel {
+    let mut tabs = leaf.tabs.clone();
+    tabs.extend(extra.iter().cloned());
+    let active_tab_id = leaf
+        .active_tab_id
+        .clone()
+        .or_else(|| extra.first().map(|t| t.id.clone()));
+    LeafPanel {
+        id: leaf.id.clone(),
+        tabs,
+        active_tab_id,
+    }
+}
+
+/// Remove `leaf_id` from the tree iff it is an empty leaf, collapsing an emptied
+/// tree to a single empty leaf rather than nothing.
+fn remove_leaf_if_empty(root: &PanelNode, leaf_id: &str) -> PanelNode {
+    match find_leaf(root, leaf_id) {
+        Some(leaf) if leaf.tabs.is_empty() => {
+            remove_leaf(root, leaf_id).unwrap_or_else(single_empty_leaf)
+        }
+        _ => root.clone(),
+    }
+}
+
+/// Repoint `active_panel_id` at an existing leaf when the current one is gone.
+fn fix_active(state: &mut LayoutState) {
+    let still_present = state
+        .active_panel_id
+        .as_deref()
+        .map(|id| find_leaf(&state.root, id).is_some())
+        .unwrap_or(false);
+    if !still_present {
+        state.active_panel_id = get_all_leaves(&state.root).first().map(|l| l.id.clone());
+    }
+}
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod tests;

--- a/src-tauri/src/layout/store.rs
+++ b/src-tauri/src/layout/store.rs
@@ -147,8 +147,7 @@ impl LayoutStore {
         let merged = update_leaf(&state.root, target_panel_id, |leaf| {
             with_tabs_appended(leaf, &tabs)
         });
-        let pruned =
-            remove_leaf(&merged, source_panel_id).unwrap_or_else(|| single_empty_leaf());
+        let pruned = remove_leaf(&merged, source_panel_id).unwrap_or_else(single_empty_leaf);
         state.root = simplify_tree(&pruned);
         state.active_panel_id = Some(target_panel_id.to_string());
         fix_active(state);
@@ -183,11 +182,13 @@ impl LayoutStore {
             return Err(LayoutError::PanelNotFound(target_panel_id.to_string()));
         }
 
-        let detached = update_leaf(&state.root, &source_id, |leaf| with_tab_removed(leaf, tab_id));
+        let detached = update_leaf(&state.root, &source_id, |leaf| {
+            with_tab_removed(leaf, tab_id)
+        });
         let placed = match edge {
-            DropEdge::Center => {
-                update_leaf(&detached, target_panel_id, |leaf| with_tab_added(leaf, tab.clone()))
-            }
+            DropEdge::Center => update_leaf(&detached, target_panel_id, |leaf| {
+                with_tab_added(leaf, tab.clone())
+            }),
             edge => {
                 let spec = edge_to_split(edge).ok_or(LayoutError::BadEdge)?;
                 let new_leaf = LeafPanel {
@@ -195,7 +196,13 @@ impl LayoutStore {
                     tabs: vec![tab.clone()],
                     active_tab_id: Some(tab.id.clone()),
                 };
-                split_leaf(&detached, target_panel_id, &new_leaf, spec.direction, spec.position)
+                split_leaf(
+                    &detached,
+                    target_panel_id,
+                    &new_leaf,
+                    spec.direction,
+                    spec.position,
+                )
             }
         };
         let pruned = remove_leaf_if_empty(&placed, &source_id);
@@ -254,7 +261,12 @@ fn single_empty_leaf() -> PanelNode {
 /// A copy of `leaf` with `tab_id` removed; the active tab falls back to the
 /// first remaining tab when the removed tab was active.
 fn with_tab_removed(leaf: &LeafPanel, tab_id: &str) -> LeafPanel {
-    let tabs: Vec<Tab> = leaf.tabs.iter().filter(|t| t.id != tab_id).cloned().collect();
+    let tabs: Vec<Tab> = leaf
+        .tabs
+        .iter()
+        .filter(|t| t.id != tab_id)
+        .cloned()
+        .collect();
     let active_tab_id = if leaf.active_tab_id.as_deref() == Some(tab_id) {
         tabs.first().map(|t| t.id.clone())
     } else {

--- a/src-tauri/src/layout/store_tests.rs
+++ b/src-tauri/src/layout/store_tests.rs
@@ -1,0 +1,339 @@
+//! Unit + property tests for the shadow [`LayoutStore`] (#2151).
+//!
+//! The store is exercised through its public API and asserted on the projected
+//! view model (deserialized back into a [`PanelNode`] so the ported algebra's
+//! own invariants — unique leaf ids, tab-count identity — can be checked). The
+//! property tests drive random sequences of the four `layout.*` transforms and
+//! assert the tree invariants hold after every step.
+
+use proptest::prelude::*;
+use serde_json::Value;
+
+use super::*;
+use termihub_core::layout::panel_tree::{
+    count_tabs_in_tree, find_leaf, get_all_leaves, Direction, DropEdge, LeafPanel, PanelNode,
+    Position, SplitContainer, Tab,
+};
+
+// ── Fixtures / helpers ───────────────────────────────────────────────────────
+
+fn tab(id: &str) -> Tab {
+    Tab {
+        id: id.to_string(),
+        session_id: None,
+        content_type: "terminal".to_string(),
+    }
+}
+
+fn leaf(id: &str, tab_ids: &[&str]) -> LeafPanel {
+    let tabs: Vec<Tab> = tab_ids.iter().map(|t| tab(t)).collect();
+    let active_tab_id = tabs.first().map(|t| t.id.clone());
+    LeafPanel {
+        id: id.to_string(),
+        tabs,
+        active_tab_id,
+    }
+}
+
+/// A two-leaf horizontal split: `a` holds `t1`,`t2`; `b` holds `t3`.
+fn two_panel_tree() -> PanelNode {
+    PanelNode::Split(SplitContainer {
+        id: "root".to_string(),
+        direction: Direction::Horizontal,
+        children: vec![
+            PanelNode::Leaf(leaf("a", &["t1", "t2"])),
+            PanelNode::Leaf(leaf("b", &["t3"])),
+        ],
+        sizes: None,
+        last_active_leaf_id: None,
+    })
+}
+
+fn root_of(store: &LayoutStore, client: &str) -> PanelNode {
+    serde_json::from_value(store.snapshot(client)["root"].clone()).expect("root deserializes")
+}
+
+fn active_of(store: &LayoutStore, client: &str) -> Option<String> {
+    match store.snapshot(client)["activePanelId"].clone() {
+        Value::String(s) => Some(s),
+        _ => None,
+    }
+}
+
+const ALL_EDGES: [DropEdge; 5] = [
+    DropEdge::Left,
+    DropEdge::Right,
+    DropEdge::Top,
+    DropEdge::Bottom,
+    DropEdge::Center,
+];
+
+// ── Seeding ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn unknown_client_is_seeded_with_one_empty_focused_leaf() {
+    let store = LayoutStore::new();
+    let root = root_of(&store, "C");
+    let leaves = get_all_leaves(&root);
+    assert_eq!(leaves.len(), 1, "one leaf");
+    assert!(leaves[0].tabs.is_empty(), "empty");
+    assert_eq!(
+        active_of(&store, "C").as_deref(),
+        Some(leaves[0].id.as_str()),
+        "seeded leaf is focused",
+    );
+}
+
+#[test]
+fn snapshot_does_not_mutate_an_existing_client() {
+    let store = LayoutStore::new();
+    let first = store.snapshot("C");
+    let second = store.snapshot("C");
+    assert_eq!(first, second, "repeated snapshot is stable");
+}
+
+#[test]
+fn clients_are_isolated() {
+    let store = LayoutStore::new();
+    store.seed_for_test("A", two_panel_tree(), Some("a".to_string()));
+    // B is untouched: seeded independently.
+    assert_eq!(count_tabs_in_tree(&root_of(&store, "A")), 3);
+    assert_eq!(count_tabs_in_tree(&root_of(&store, "B")), 0);
+}
+
+// ── split ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn split_inserts_a_new_empty_focused_leaf_and_preserves_tab_count() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    store
+        .split("C", "b", Direction::Vertical, Position::After)
+        .unwrap();
+
+    let root = root_of(&store, "C");
+    assert_eq!(count_tabs_in_tree(&root), 3, "no tabs created");
+    assert_eq!(get_all_leaves(&root).len(), 3, "one more leaf");
+    // The new (empty) leaf is focused.
+    let active = active_of(&store, "C").unwrap();
+    let active_leaf = find_leaf(&root, &active).unwrap();
+    assert!(active_leaf.tabs.is_empty(), "new leaf is empty and focused");
+}
+
+#[test]
+fn split_of_unknown_panel_is_rejected() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    let err = store
+        .split("C", "nope", Direction::Horizontal, Position::After)
+        .unwrap_err();
+    assert_eq!(err, LayoutError::PanelNotFound("nope".to_string()));
+    assert_eq!(err.code(), "panel_not_found");
+}
+
+// ── merge ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn merge_moves_all_tabs_into_target_and_drops_the_source() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    store.merge("C", "a", "b").unwrap();
+
+    let root = root_of(&store, "C");
+    // The tree simplifies to the single surviving leaf `b` holding all 3 tabs.
+    let leaves = get_all_leaves(&root);
+    assert_eq!(leaves.len(), 1, "source dropped, split simplified");
+    assert_eq!(leaves[0].id, "b");
+    assert_eq!(count_tabs_in_tree(&root), 3, "all tabs preserved");
+    let ids: Vec<&str> = leaves[0].tabs.iter().map(|t| t.id.as_str()).collect();
+    assert_eq!(ids, vec!["t3", "t1", "t2"], "target tabs then source tabs");
+    assert_eq!(active_of(&store, "C").as_deref(), Some("b"));
+}
+
+#[test]
+fn merge_into_self_is_rejected() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    assert_eq!(store.merge("C", "a", "a").unwrap_err(), LayoutError::SamePanel);
+}
+
+#[test]
+fn merge_with_unknown_source_is_rejected() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    assert_eq!(
+        store.merge("C", "ghost", "b").unwrap_err(),
+        LayoutError::PanelNotFound("ghost".to_string()),
+    );
+}
+
+// ── moveTab ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn move_tab_center_drops_the_tab_into_the_target_stack() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    store.move_tab("C", "t1", "b", DropEdge::Center).unwrap();
+
+    let root = root_of(&store, "C");
+    assert_eq!(count_tabs_in_tree(&root), 3, "tab count preserved");
+    let b = find_leaf(&root, "b").unwrap();
+    assert!(b.tabs.iter().any(|t| t.id == "t1"), "t1 now in b");
+    assert_eq!(b.active_tab_id.as_deref(), Some("t1"), "moved tab focused");
+    let a = find_leaf(&root, "a").unwrap();
+    assert!(!a.tabs.iter().any(|t| t.id == "t1"), "t1 left a");
+}
+
+#[test]
+fn move_tab_edge_splits_the_target_into_a_new_leaf() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    store.move_tab("C", "t3", "a", DropEdge::Right).unwrap();
+
+    let root = root_of(&store, "C");
+    // b held only t3; moving it out empties and prunes b. t3 lands in a fresh
+    // leaf split to the right of a. Total tabs unchanged.
+    assert_eq!(count_tabs_in_tree(&root), 3);
+    let leaves = get_all_leaves(&root);
+    assert!(
+        leaves.iter().all(|l| l.id != "b"),
+        "emptied source leaf pruned",
+    );
+    let holder = leaves
+        .iter()
+        .find(|l| l.tabs.iter().any(|t| t.id == "t3"))
+        .expect("a leaf holds t3");
+    assert_eq!(holder.tabs.len(), 1, "t3 alone in its new leaf");
+}
+
+#[test]
+fn move_tab_of_unknown_tab_is_rejected() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    assert_eq!(
+        store
+            .move_tab("C", "ghost", "b", DropEdge::Center)
+            .unwrap_err(),
+        LayoutError::TabNotFound("ghost".to_string()),
+    );
+}
+
+// ── closeTabStructure ────────────────────────────────────────────────────────
+
+#[test]
+fn close_tab_removes_one_tab_keeping_a_non_empty_leaf() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    store.close_tab_structure("C", "t1").unwrap();
+
+    let root = root_of(&store, "C");
+    assert_eq!(count_tabs_in_tree(&root), 2, "one tab removed");
+    // a still holds t2, so the leaf survives; active tab falls back to t2.
+    let a = find_leaf(&root, "a").unwrap();
+    assert_eq!(a.tabs.len(), 1);
+    assert_eq!(a.active_tab_id.as_deref(), Some("t2"));
+}
+
+#[test]
+fn close_last_tab_in_a_leaf_prunes_and_simplifies() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("b".to_string()));
+    store.close_tab_structure("C", "t3").unwrap();
+
+    let root = root_of(&store, "C");
+    // b emptied → pruned → split simplified to just a.
+    let leaves = get_all_leaves(&root);
+    assert_eq!(leaves.len(), 1);
+    assert_eq!(leaves[0].id, "a");
+    assert_eq!(count_tabs_in_tree(&root), 2);
+    // Focus repointed off the vanished leaf onto the survivor.
+    assert_eq!(active_of(&store, "C").as_deref(), Some("a"));
+}
+
+#[test]
+fn close_of_unknown_tab_is_rejected() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    assert_eq!(
+        store.close_tab_structure("C", "ghost").unwrap_err(),
+        LayoutError::TabNotFound("ghost".to_string()),
+    );
+}
+
+// ── Property tests over the transforms ───────────────────────────────────────
+
+/// After every applied transform: at least one leaf survives, leaf ids stay
+/// unique, and the focused panel (when set) still exists.
+fn assert_tree_invariants(root: &PanelNode, active: Option<&str>) {
+    let leaves = get_all_leaves(root);
+    assert!(!leaves.is_empty(), "tree never empties to nothing");
+    let mut ids: Vec<&str> = leaves.iter().map(|l| l.id.as_str()).collect();
+    let count = ids.len();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(ids.len(), count, "leaf ids stay unique");
+    if let Some(active) = active {
+        assert!(find_leaf(root, active).is_some(), "focused panel exists");
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(200))]
+
+    /// A random sequence of the four transforms preserves the tree invariants
+    /// after every step, and each transform moves the total tab count exactly as
+    /// specified: only `closeTabStructure` decrements it (by one), split / merge
+    /// / moveTab conserve it.
+    #[test]
+    fn random_transform_sequence_holds_invariants(
+        seq in prop::collection::vec((0u8..4, any::<usize>(), any::<usize>(), 0u8..5), 0..40)
+    ) {
+        let store = LayoutStore::new();
+        let client = "P";
+        store.seed_for_test(client, two_panel_tree(), Some("a".to_string()));
+
+        for (op, i, j, e) in seq {
+            let root = root_of(&store, client);
+            let leaves = get_all_leaves(&root);
+            let leaf_ids: Vec<String> = leaves.iter().map(|l| l.id.clone()).collect();
+            let src = &leaves[i % leaves.len()];
+            let src_id = src.id.clone();
+            let tgt_id = leaf_ids[j % leaf_ids.len()].clone();
+            let before = count_tabs_in_tree(&root);
+
+            match op {
+                0 => {
+                    let direction = if e % 2 == 0 { Direction::Horizontal } else { Direction::Vertical };
+                    let position = if (e / 2) % 2 == 0 { Position::Before } else { Position::After };
+                    store.split(client, &src_id, direction, position).unwrap();
+                    prop_assert_eq!(count_tabs_in_tree(&root_of(&store, client)), before);
+                }
+                1 => {
+                    if src_id != tgt_id {
+                        store.merge(client, &src_id, &tgt_id).unwrap();
+                        prop_assert_eq!(count_tabs_in_tree(&root_of(&store, client)), before);
+                    }
+                }
+                2 => {
+                    if let Some(t) = src.tabs.first() {
+                        let tab_id = t.id.clone();
+                        let edge = ALL_EDGES[e as usize % ALL_EDGES.len()];
+                        store.move_tab(client, &tab_id, &tgt_id, edge).unwrap();
+                        prop_assert_eq!(count_tabs_in_tree(&root_of(&store, client)), before);
+                    }
+                }
+                _ => {
+                    if let Some(t) = src.tabs.first() {
+                        let tab_id = t.id.clone();
+                        store.close_tab_structure(client, &tab_id).unwrap();
+                        prop_assert_eq!(count_tabs_in_tree(&root_of(&store, client)), before - 1);
+                    }
+                }
+            }
+
+            let after = root_of(&store, client);
+            let active = active_of(&store, client);
+            assert_tree_invariants(&after, active.as_deref());
+        }
+    }
+}

--- a/src-tauri/src/layout/store_tests.rs
+++ b/src-tauri/src/layout/store_tests.rs
@@ -154,7 +154,10 @@ fn merge_moves_all_tabs_into_target_and_drops_the_source() {
 fn merge_into_self_is_rejected() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
-    assert_eq!(store.merge("C", "a", "a").unwrap_err(), LayoutError::SamePanel);
+    assert_eq!(
+        store.merge("C", "a", "a").unwrap_err(),
+        LayoutError::SamePanel
+    );
 }
 
 #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,11 @@ mod embedded_servers;
 /// subsystem (public so integration tests can drive `SftpSession` /
 /// `TransferRegistry` directly — issue #1245).
 pub mod files;
+/// Shadow `LayoutStore` (#2151, Phase 3 step 1 of #2139): the client-scoped
+/// `layout@<clientId>` projection region + `layout.*` intents, built on the
+/// ported panel-tree algebra (#2143). Registered and served but not yet driving
+/// the live UI — see [`layout`].
+mod layout;
 /// Native Linux X11 `CLIPBOARD`-selection binding for pasting remote-copied RDP
 /// clipboard files into local apps with delayed rendering (`text/uri-list`) —
 /// the X11 `CLIPBOARD` owner (#1815) plus the native-Wayland `wlr-data-control`
@@ -652,6 +657,19 @@ pub fn run() {
             {
                 let mut registry = crate::projection::HandlerRegistry::new();
                 tunnel::projection::register_tunnel_intents(&mut registry, app.handle().clone());
+                // Shadow LayoutStore (#2151 step 1): client-scoped
+                // `layout@<clientId>` region + `layout.*` intents on the ported
+                // panel-tree algebra (#2143). The store is managed authoritative
+                // state and serves intents, but nothing in the live UI subscribes
+                // to or renders the region yet — a pure shadow foundation (steps
+                // 2+ cut mutations, then rendering, over to it). No client region
+                // is seeded here: layout regions are client-scoped and created
+                // lazily on a client's first `layout.*` intent.
+                app.manage(Arc::new(layout::LayoutStore::new()));
+                layout::projection::register_layout_intents(
+                    &mut registry,
+                    app.handle().clone(),
+                );
                 // Test-bridge-only: add the diagnostic region's `diag.*` routes so
                 // the projection-assertion harness (#2164) has a self-contained
                 // region to drive. Never registered in production launches. See


### PR DESCRIPTION
## What

Step 1 of the Phase 3 layout migration (part of `#2151`): the **shadow `LayoutStore` foundation**. Introduces a Rust `LayoutStore` built on the ported panel-tree algebra (#2143), a client-scoped `layout@<clientId>` projection region, and the four `layout.*` intents — registered on the projection substrate mirroring the SSH-tunnels pilot, but run in **shadow mode** with **zero user-facing change**.

`#2151` was too entangled for a single-PR cutover (see its scoping comment), so it was decomposed into 5 sequenced steps. This is step 1 only; the umbrella issue stays open for steps 2-5.

## Scope (step 1)

- **`src-tauri/src/layout/store.rs`** — `LayoutStore`: per-client authoritative panel tree + minimal tab model (`{ id, sessionId, contentType }` — the seam #2143's `Tab` already models). Every transform delegates to `termihub_core::layout::panel_tree`. Holds **only** structure + minimal tabs under *partial projection*; session status, colours, and broadcast stay in `appStore` for later phases.
- **`src-tauri/src/layout/projection.rs`** — the client-scoped `layout@<clientId>` region (`layout_region`, `publish_layout`) + the four intents: `layout.split`, `layout.merge`, `layout.moveTab` (center = merge into a panel; edge = split), `layout.closeTabStructure`.
- **`src-tauri/src/lib.rs`** — manages the store and registers the intents beside the tunnel pilot. **No client region is seeded at startup** (client-scoped, created lazily on a client's first `layout.*` intent).

## Shadow mode — verified zero-regression

The store exists, accepts intents, and projects diffs, but:
- No frontend code subscribes to `layout@<clientId>` or dispatches `layout.*` (no frontend was touched).
- `appStore`'s panel-tree reducers and `SplitView.tsx` remain authoritative and untouched.

So the store is inert against the running app. Steps 2-5 cut structural mutations, then rendering, over to it, then remove the `appStore` reducers, then add multi-window/restore.

## Tests

- **Projection-contract tests** (reusing the substrate/tunnel harness patterns — in-memory sink + diff-applying client cache): subscribe -> seeded snapshot identical to every subscriber; accepted intent -> exactly one coalesced diff fanned to all subscribers with monotonic versions; **client-scoped isolation** (an intent from client A does not touch client B's region); rejection advances nothing; dead-subscriber reaping.
- **Store unit tests** for each of the four transforms (incl. prune/simplify and focus repointing) and their rejection paths.
- **Property test** driving random sequences of the four transforms, asserting tree invariants (>=1 leaf, unique leaf ids, focused panel exists) and tab-count identity after every step.

21 tests, all green. `cargo fmt --check` and `cargo clippy -D warnings` clean.

Part of `#2151`.