### PR TITLE
fix(ui): detect desktop shell via __TAURI_INTERNALS__ (Closes #2166)

### DIFF
--- a/src/services/transport/index.ts
+++ b/src/services/transport/index.ts
@@ -31,9 +31,21 @@ export {
 } from "./ProjectionClient";
 export { newClientId, newIntentId } from "./ids";
 
-/** True when running inside the Tauri desktop shell. */
+/**
+ * True when running inside the Tauri desktop shell.
+ *
+ * Probes `__TAURI_INTERNALS__` — the object `@tauri-apps/api`'s `invoke`/
+ * `Channel` actually use — rather than `__TAURI__`. The desktop app leaves
+ * `app.withGlobalTauri` off (see `src-tauri/tauri.conf.json`), so `__TAURI__`
+ * is absent even though IPC is fully available; keying off it would wrongly
+ * fall through to the remote-client path inside the running app (#2166).
+ * `__TAURI__` is kept as a secondary probe for a globals-enabled build.
+ */
 export function isTauri(): boolean {
-  return typeof window !== "undefined" && "__TAURI__" in window;
+  return (
+    typeof window !== "undefined" &&
+    ("__TAURI_INTERNALS__" in window || "__TAURI__" in window)
+  );
 }
 
 /**

--- a/src/services/transport/index.ts
+++ b/src/services/transport/index.ts
@@ -43,8 +43,7 @@ export { newClientId, newIntentId } from "./ids";
  */
 export function isTauri(): boolean {
   return (
-    typeof window !== "undefined" &&
-    ("__TAURI_INTERNALS__" in window || "__TAURI__" in window)
+    typeof window !== "undefined" && ("__TAURI_INTERNALS__" in window || "__TAURI__" in window)
   );
 }
 

--- a/src/services/transport/transport.test.ts
+++ b/src/services/transport/transport.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createTransport, isTauri } from "./index";
+import { TauriTransport } from "./TauriTransport";
 import { WebSocketTransport, type JsonRpcSocket } from "./WebSocketTransport";
 import type { DiffFrame, IntentAck, SnapshotFrame } from "./types";
 
@@ -108,6 +109,39 @@ describe("createTransport selector", () => {
     vi.stubGlobal("window", { __TAURI__: {} });
     try {
       expect(isTauri()).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  // Regression for #2166: the desktop app runs with `app.withGlobalTauri`
+  // off, so `window.__TAURI__` is absent even though Tauri IPC is fully
+  // available via `window.__TAURI_INTERNALS__` (what `invoke`/`Channel` use).
+  // Detection must key off the internals object, not the optional global.
+  it("detects the desktop shell via __TAURI_INTERNALS__ (withGlobalTauri off)", () => {
+    vi.stubGlobal("window", { __TAURI_INTERNALS__: { invoke: () => {} } });
+    try {
+      expect(isTauri()).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("selects TauriTransport in the desktop shell with withGlobalTauri off", () => {
+    vi.stubGlobal("window", { __TAURI_INTERNALS__: { invoke: () => {} } });
+    try {
+      expect(createTransport()).toBeInstanceOf(TauriTransport);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("falls back to WebSocketTransport in a plain browser (no Tauri internals)", () => {
+    vi.stubGlobal("window", {});
+    try {
+      const socket = new FakeSocket();
+      expect(isTauri()).toBe(false);
+      expect(createTransport({ socket })).toBeInstanceOf(WebSocketTransport);
     } finally {
       vi.unstubAllGlobals();
     }

--- a/src/testbridge/projectionRecorder.ts
+++ b/src/testbridge/projectionRecorder.ts
@@ -25,7 +25,7 @@
  * Installed only in test-bridge mode; it never loads in a production launch.
  */
 
-import { ProjectionClient, TauriTransport, newClientId, newIntentId } from "@/services/transport";
+import { ProjectionClient, createTransport, newClientId, newIntentId } from "@/services/transport";
 import type {
   FrameHandler,
   Intent,
@@ -120,16 +120,14 @@ export class ProjectionRecorder {
   private counter = 0;
 
   /**
-   * `transport` is injectable for unit tests; defaults to a {@link TauriTransport}.
-   *
-   * Constructed directly rather than via `createTransport()`: the recorder only
-   * ever runs inside the desktop app (test-bridge mode), and `createTransport`'s
-   * `isTauri()` probe keys off `window.__TAURI__`, which is absent unless
-   * `withGlobalTauri` is set — so it would wrongly take the remote-client branch
-   * here even though Tauri IPC (`__TAURI_INTERNALS__`) is available.
+   * `transport` is injectable for unit tests; defaults to the production
+   * transport via {@link createTransport}, which resolves to `TauriTransport`
+   * inside the desktop shell. Since #2166 the `isTauri()` probe keys off
+   * `window.__TAURI_INTERNALS__` (what Tauri IPC actually uses), so this
+   * selects the desktop transport correctly even with `withGlobalTauri` off.
    */
   constructor(transport?: Transport) {
-    this.transport = transport ?? new TauriTransport();
+    this.transport = transport ?? createTransport();
   }
 
   /** Attach to `region`; returns the new subscription id and its baseline state. */


### PR DESCRIPTION
## Problem

`createTransport()` selected `TauriTransport` only when `isTauri()` returned true, and `isTauri()` probed `"__TAURI__" in window`. The desktop app leaves `app.withGlobalTauri` **off** in `src-tauri/tauri.conf.json`, so `window.__TAURI__` is absent even though Tauri IPC is fully available via `window.__TAURI_INTERNALS__` (what `@tauri-apps/api`'s `invoke`/`Channel` actually use).

Result: inside the running desktop app, `createTransport()` fell through to the remote-client branch and threw `non-Tauri environment requires a JSON-RPC socket`. `ProjectionRecorder` had to construct `TauriTransport` directly to work around it.

## Fix

- `isTauri()` now probes `"__TAURI_INTERNALS__" in window` — the object `invoke`/`Channel` read, so it is the ground-truth gate for whether `TauriTransport` will work. `"__TAURI__"` is kept as a secondary probe for a globals-enabled build.
- Reverted `ProjectionRecorder` to build its transport via `createTransport()` (scope item 3), which now resolves to `TauriTransport` correctly with `withGlobalTauri` off.

## Tests

Added regression tests in `transport.test.ts`:
- `isTauri()` returns true when only `__TAURI_INTERNALS__` is present (desktop, `withGlobalTauri` off).
- `createTransport()` selects `TauriTransport` in that environment.
- A plain browser (no Tauri internals) still falls back to `WebSocketTransport`.

Test commit precedes the fix commit (red → green).

## Verification

Runtime-environment bug — not caught by per-PR CI. Verified in the real desktop app via the projection bridge harness (`test-system-py.sh -m integration -k projection`), which drives the in-app `ProjectionRecorder` → `createTransport()` → `TauriTransport` end to end. Result recorded in a PR comment.

Closes #2166