### PR TITLE
feat(ui): cut structural layout mutations to the store (Part of #2151)

### DIFF
--- a/src-tauri/src/layout/projection.rs
+++ b/src-tauri/src/layout/projection.rs
@@ -27,6 +27,7 @@
 //! | `layout.merge`              | `{ sourcePanelId, targetPanelId }`       | move all tabs into the target, drop the source |
 //! | `layout.moveTab`            | `{ tabId, targetPanelId, edge }`         | move a tab (center = merge; edge = split)      |
 //! | `layout.closeTabStructure`  | `{ tabId }`                              | remove a tab; drop its leaf if left empty      |
+//! | `layout.replace`            | `{ root, activePanelId }`                | install a whole tree (the bridge's seed path)  |
 //!
 //! # Shadow mode
 //!
@@ -42,6 +43,8 @@ use std::sync::Arc;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use tauri::{AppHandle, Manager};
+
+use termihub_core::layout::panel_tree::PanelNode;
 
 use crate::layout::store::{LayoutError, LayoutStore};
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
@@ -109,7 +112,7 @@ pub fn register_layout_intents(registry: &mut HandlerRegistry, app_handle: AppHa
         Ok(publish_layout(projector, &store, &intent.client_id))
     });
 
-    let handle = app_handle;
+    let handle = app_handle.clone();
     registry.route("layout.closeTabStructure", move |intent, projector| {
         let store = store_of(&handle)?;
         let tab_id = required_str(intent, "tabId")?;
@@ -118,6 +121,30 @@ pub fn register_layout_intents(registry: &mut HandlerRegistry, app_handle: AppHa
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &store, &intent.client_id))
     });
+
+    let handle = app_handle;
+    registry.route("layout.replace", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let (root, active_panel_id) = parse_replace(intent)?;
+        store.replace(&intent.client_id, root, active_panel_id);
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+}
+
+/// Parse a `layout.replace` payload `{ root: PanelNode, activePanelId? }`.
+fn parse_replace(intent: &Intent) -> Result<(PanelNode, Option<String>), (String, String)> {
+    let root_value = intent
+        .payload
+        .get("root")
+        .ok_or_else(|| ("bad_payload".to_string(), "missing 'root'".to_string()))?;
+    let root: PanelNode = serde_json::from_value(root_value.clone())
+        .map_err(|e| ("bad_payload".to_string(), format!("invalid 'root': {e}")))?;
+    let active_panel_id = intent
+        .payload
+        .get("activePanelId")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    Ok((root, active_panel_id))
 }
 
 /// Resolve the managed layout store, or a rejectable error if it is absent.

--- a/src-tauri/src/layout/projection_tests.rs
+++ b/src-tauri/src/layout/projection_tests.rs
@@ -101,11 +101,18 @@ fn registry_for(store: Arc<LayoutStore>) -> HandlerRegistry {
         Ok(publish_layout(projector, &s, &intent.client_id))
     });
 
-    let s = store;
+    let s = store.clone();
     registry.route("layout.closeTabStructure", move |intent, projector| {
         let tab_id = required_str(intent, "tabId")?;
         s.close_tab_structure(&intent.client_id, &tab_id)
             .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store;
+    registry.route("layout.replace", move |intent, projector| {
+        let (root, active_panel_id) = parse_replace(intent)?;
+        s.replace(&intent.client_id, root, active_panel_id);
         Ok(publish_layout(projector, &s, &intent.client_id))
     });
 
@@ -281,6 +288,57 @@ fn move_and_close_intents_advance_the_region_monotonically() {
         cache.view,
         store.snapshot("A"),
         "cache converges on authority"
+    );
+}
+
+#[test]
+fn replace_seeds_a_tree_then_a_structural_intent_round_trips() {
+    // The step-2 bridge flow: an empty store is seeded from the frontend tree via
+    // `layout.replace`, then a structural intent mutates that seeded tree and the
+    // cache converges on authority — the round-trip the frontend reconciles.
+    let store = Arc::new(LayoutStore::new());
+    let region = layout_region("A");
+    let projector = Arc::new(Projector::new());
+    // Lazily seeds an empty leaf; the region exists before the first replace.
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(&region, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    // Seed the store with the frontend's authoritative tree.
+    let ack = dispatcher.dispatch(intent(
+        "layout.replace",
+        "A",
+        json!({ "root": two_panel_tree(), "activePanelId": "a" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    // Now a structural intent operates on the seeded tree.
+    let ack = dispatcher.dispatch(intent(
+        "layout.moveTab",
+        "A",
+        json!({ "tabId": "t1", "targetPanelId": "b", "edge": "center" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 2, "one diff for replace, one for the move");
+    for diff in &diffs {
+        cache.apply(diff);
+    }
+    assert_eq!(cache.version, 2);
+    assert_eq!(
+        cache.view,
+        store.snapshot("A"),
+        "cache converges on authority"
+    );
+    // t1 landed in b; a is left with t2 — tab count is conserved across the seed.
+    let root: PanelNode = serde_json::from_value(store.snapshot("A")["root"].clone()).unwrap();
+    assert_eq!(
+        termihub_core::layout::panel_tree::count_tabs_in_tree(&root),
+        3
     );
 }
 

--- a/src-tauri/src/layout/store.rs
+++ b/src-tauri/src/layout/store.rs
@@ -280,9 +280,13 @@ fn single_empty_leaf() -> PanelNode {
     PanelNode::Leaf(create_leaf_panel())
 }
 
-/// A copy of `leaf` with `tab_id` removed; the active tab falls back to the
-/// first remaining tab when the removed tab was active.
+/// A copy of `leaf` with `tab_id` removed; when the removed tab was active, the
+/// active tab falls back **positionally** — the tab that shifts into the removed
+/// slot, or the new last tab. This matches the frontend `removeTabFromLeaf`
+/// reducer (`min(idx, len-1)`) exactly, so cutting a tab-moving mutation over to
+/// the store preserves which tab the source panel focuses (#2151 step 2).
 fn with_tab_removed(leaf: &LeafPanel, tab_id: &str) -> LeafPanel {
+    let removed_idx = leaf.tabs.iter().position(|t| t.id == tab_id);
     let tabs: Vec<Tab> = leaf
         .tabs
         .iter()
@@ -290,7 +294,13 @@ fn with_tab_removed(leaf: &LeafPanel, tab_id: &str) -> LeafPanel {
         .cloned()
         .collect();
     let active_tab_id = if leaf.active_tab_id.as_deref() == Some(tab_id) {
-        tabs.first().map(|t| t.id.clone())
+        match removed_idx {
+            Some(idx) if !tabs.is_empty() => {
+                let new_idx = idx.min(tabs.len() - 1);
+                Some(tabs[new_idx].id.clone())
+            }
+            _ => None,
+        }
     } else {
         leaf.active_tab_id.clone()
     };

--- a/src-tauri/src/layout/store.rs
+++ b/src-tauri/src/layout/store.rs
@@ -230,6 +230,28 @@ impl LayoutStore {
         Ok(())
     }
 
+    /// `layout.replace` — install a complete tree for a client, replacing any
+    /// existing one.
+    ///
+    /// This is the **seed-before-mutate** entry point the step-2 frontend bridge
+    /// uses to keep the store authoritative for structure while tab *creation*
+    /// still lives in `appStore` (partial projection). Because tabs enter the
+    /// app via session creation — not a layout intent — the store would
+    /// otherwise never learn about them; the bridge pushes its current
+    /// structural tree (in the minimal `{ id, sessionId, contentType }` tab
+    /// form) here immediately before dispatching a structural intent, so the
+    /// four transforms operate on the real tree and project a diff the frontend
+    /// can reconcile back. The active panel is repointed at a real leaf when the
+    /// supplied id is absent.
+    pub fn replace(&self, client_id: &str, root: PanelNode, active_panel_id: Option<String>) {
+        let mut state = LayoutState {
+            root,
+            active_panel_id,
+        };
+        fix_active(&mut state);
+        self.lock().insert(client_id.to_string(), state);
+    }
+
     /// Install a specific tree for a client — test-only seeding so intent tests
     /// can start from a populated layout without a tab-creating intent (tabs
     /// enter via session creation in `appStore`, out of this shadow's scope).

--- a/src-tauri/src/layout/store_tests.rs
+++ b/src-tauri/src/layout/store_tests.rs
@@ -104,6 +104,42 @@ fn clients_are_isolated() {
 // ── split ────────────────────────────────────────────────────────────────────
 
 #[test]
+fn replace_installs_a_whole_tree_over_the_seeded_empty_leaf() {
+    let store = LayoutStore::new();
+    // A never-touched client seeds one empty leaf; replace overwrites it with the
+    // frontend's authoritative tree (the step-2 seed-before-mutate path).
+    store.replace("C", two_panel_tree(), Some("a".to_string()));
+
+    let root = root_of(&store, "C");
+    assert_eq!(count_tabs_in_tree(&root), 3, "the whole tree is installed");
+    assert_eq!(get_all_leaves(&root).len(), 2);
+    assert_eq!(active_of(&store, "C").as_deref(), Some("a"));
+
+    // A subsequent structural transform now operates on the installed tree.
+    store
+        .move_tab("C", "t1", "b", DropEdge::Center)
+        .expect("move on the replaced tree");
+    let root = root_of(&store, "C");
+    assert_eq!(
+        count_tabs_in_tree(&root),
+        3,
+        "no tabs lost across replace+move"
+    );
+}
+
+#[test]
+fn replace_with_an_absent_active_panel_repoints_to_a_real_leaf() {
+    let store = LayoutStore::new();
+    store.replace("C", two_panel_tree(), Some("ghost".to_string()));
+    let active = active_of(&store, "C").expect("active repointed");
+    let root = root_of(&store, "C");
+    assert!(
+        find_leaf(&root, &active).is_some(),
+        "active panel points at an existing leaf"
+    );
+}
+
+#[test]
 fn split_inserts_a_new_empty_focused_leaf_and_preserves_tab_count() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));

--- a/src-tauri/src/layout/store_tests.rs
+++ b/src-tauri/src/layout/store_tests.rs
@@ -273,7 +273,8 @@ fn removing_a_middle_active_tab_falls_back_positionally_like_the_frontend() {
     store.seed_for_test("C", root, Some("a".to_string()));
     store.close_tab_structure("C", "t2").unwrap();
 
-    let a = find_leaf(&root_of(&store, "C"), "a").unwrap();
+    let root = root_of(&store, "C");
+    let a = find_leaf(&root, "a").unwrap();
     assert_eq!(
         a.active_tab_id.as_deref(),
         Some("t3"),

--- a/src-tauri/src/layout/store_tests.rs
+++ b/src-tauri/src/layout/store_tests.rs
@@ -260,6 +260,28 @@ fn move_tab_of_unknown_tab_is_rejected() {
 // ── closeTabStructure ────────────────────────────────────────────────────────
 
 #[test]
+fn removing_a_middle_active_tab_falls_back_positionally_like_the_frontend() {
+    // Parity with the frontend `removeTabFromLeaf` (`min(idx, len-1)`): removing
+    // the *middle* active tab focuses the tab that shifts into its slot, not the
+    // first tab. A single leaf `a` = [t1, t2(active), t3].
+    let store = LayoutStore::new();
+    let root = PanelNode::Leaf(LeafPanel {
+        id: "a".to_string(),
+        tabs: vec![tab("t1"), tab("t2"), tab("t3")],
+        active_tab_id: Some("t2".to_string()),
+    });
+    store.seed_for_test("C", root, Some("a".to_string()));
+    store.close_tab_structure("C", "t2").unwrap();
+
+    let a = find_leaf(&root_of(&store, "C"), "a").unwrap();
+    assert_eq!(
+        a.active_tab_id.as_deref(),
+        Some("t3"),
+        "positional fallback picks t3 (the tab now at the removed index), not t1"
+    );
+}
+
+#[test]
 fn close_tab_removes_one_tab_keeping_a_non_empty_leaf() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));

--- a/src/store/appStore.layoutBridge.test.ts
+++ b/src/store/appStore.layoutBridge.test.ts
@@ -1,0 +1,206 @@
+/**
+ * appStore ↔ layout projection bridge wiring (#2151 step 2).
+ *
+ * Drives the `splitPanel` mutation through a simulated backend (a fake transport
+ * that applies the `layout.*` intent with the same panel-tree algebra the Rust
+ * store uses, then pushes the diff to the region client) and asserts the
+ * reconciled tree lands in `appStore.rootPanel` with the rich tabs preserved.
+ * Also pins the strangler guarantees: flag-off keeps the local reducer, and a
+ * rejected intent falls back to it.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import type { PanelNode } from "@/types/terminal";
+import {
+  createLeafPanel,
+  getAllLeaves,
+  findLeaf,
+  simplifyTree,
+  splitLeaf,
+} from "@/utils/panelTree";
+
+interface RegionState {
+  version: number;
+  view: unknown;
+}
+
+const { backend, dispatched } = vi.hoisted(() => ({
+  backend: {
+    version: -1,
+    view: undefined as unknown,
+    listeners: new Set<(s: RegionState) => void>(),
+    reject: false,
+    push(view: unknown) {
+      this.version += 1;
+      this.view = view;
+      const snapshot = { version: this.version, view: this.view };
+      this.listeners.forEach((l) => l(snapshot));
+    },
+    reset() {
+      this.version = -1;
+      this.view = undefined;
+      this.listeners.clear();
+      this.reject = false;
+    },
+  },
+  dispatched: [] as { kind: string; payload: Record<string, unknown> }[],
+}));
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  getSettings: vi.fn(() =>
+    Promise.resolve({ version: "1", externalConnectionFiles: [], powerMonitoringEnabled: true })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn(() => vi.fn()) }));
+
+vi.mock("@/services/transport", () => ({
+  newClientId: () => "client-test",
+  newIntentId: () => "intent-test",
+  createTransport: () => ({
+    async dispatch(intent: { kind: string; payload: Record<string, unknown> }) {
+      dispatched.push({ kind: intent.kind, payload: intent.payload });
+      if (backend.reject) {
+        return { intentId: "intent-test", status: "rejected", error: { code: "x", message: "nope" } };
+      }
+      if (intent.kind === "layout.replace") {
+        backend.push({ root: intent.payload.root, activePanelId: intent.payload.activePanelId });
+      } else if (intent.kind === "layout.split") {
+        const view = backend.view as { root: PanelNode };
+        const newLeaf = createLeafPanel();
+        let root = splitLeaf(
+          view.root,
+          intent.payload.panelId as string,
+          newLeaf,
+          intent.payload.direction as "horizontal" | "vertical",
+          intent.payload.position as "before" | "after"
+        );
+        root = simplifyTree(root);
+        backend.push({ root, activePanelId: newLeaf.id });
+      }
+      return {
+        intentId: "intent-test",
+        status: "accepted",
+        produced: [{ region: "layout@client-test", version: backend.version }],
+      };
+    },
+    subscribe: vi.fn(),
+    resync: vi.fn(),
+  }),
+  ProjectionClient: class {
+    constructor(
+      _transport: unknown,
+      public readonly region: string
+    ) {}
+    get state(): RegionState {
+      return { version: backend.version, view: backend.view };
+    }
+    onChange(listener: (s: RegionState) => void) {
+      backend.listeners.add(listener);
+      return () => backend.listeners.delete(listener);
+    }
+    async start() {
+      backend.push({ root: createLeafPanel(), activePanelId: null });
+    }
+    stop() {}
+  },
+}));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return { ...actual, toast: { loading: vi.fn(), success: vi.fn(), error: vi.fn() } };
+});
+
+import { useAppStore } from "./appStore";
+import { setLayoutIntentsEnabled } from "./layoutBridge";
+import type { TerminalTab } from "@/types/terminal";
+
+function tab(id: string): TerminalTab {
+  return {
+    id,
+    sessionId: `sess-${id}`,
+    title: `Tab ${id}`,
+    connectionType: "local",
+    contentType: "terminal",
+    config: {} as TerminalTab["config"],
+    panelId: "a",
+    isActive: id === "t1",
+  } as TerminalTab;
+}
+
+function seedTree(): PanelNode {
+  return {
+    type: "split",
+    id: "root",
+    direction: "horizontal",
+    children: [
+      { type: "leaf", id: "a", tabs: [tab("t1"), tab("t2")], activeTabId: "t1" },
+      { type: "leaf", id: "b", tabs: [tab("t3")], activeTabId: "t3" },
+    ],
+  };
+}
+
+async function flush() {
+  // Let the fire-and-forget bridge promise chain settle.
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe("appStore layout bridge — splitPanel cut (#2151)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
+    backend.reset();
+    dispatched.length = 0;
+    setLayoutIntentsEnabled(null);
+  });
+
+  it("flag off: splitPanel mutates locally and dispatches nothing", () => {
+    setLayoutIntentsEnabled(false);
+    useAppStore.getState().splitPanel("vertical");
+
+    expect(dispatched).toHaveLength(0);
+    expect(getAllLeaves(useAppStore.getState().rootPanel)).toHaveLength(3);
+  });
+
+  it("flag on: splitPanel seeds then dispatches layout.split and reconciles the diff", async () => {
+    setLayoutIntentsEnabled(true);
+    useAppStore.getState().splitPanel("vertical");
+    await flush();
+
+    // Seed-before-mutate: replace precedes the structural intent.
+    expect(dispatched.map((d) => d.kind)).toEqual(["layout.replace", "layout.split"]);
+    expect(dispatched[1].payload).toMatchObject({
+      panelId: "a",
+      direction: "vertical",
+      position: "after",
+    });
+
+    const root = useAppStore.getState().rootPanel;
+    const leaves = getAllLeaves(root);
+    expect(leaves).toHaveLength(3);
+    // The new empty leaf is focused.
+    const active = findLeaf(root, useAppStore.getState().activePanelId!);
+    expect(active?.tabs).toHaveLength(0);
+    // Existing rich tabs survived the round-trip (re-hydrated by id).
+    const a = findLeaf(root, "a")!;
+    expect(a.tabs.map((t) => t.id)).toEqual(["t1", "t2"]);
+    expect(a.tabs[0].title).toBe("Tab t1");
+    expect(a.tabs[0].sessionId).toBe("sess-t1");
+  });
+
+  it("flag on but intent rejected: falls back to the local reducer", async () => {
+    setLayoutIntentsEnabled(true);
+    backend.reject = true;
+    useAppStore.getState().splitPanel("vertical");
+    await flush();
+
+    // Still ended up split — via the local fallback path.
+    expect(getAllLeaves(useAppStore.getState().rootPanel)).toHaveLength(3);
+  });
+});

--- a/src/store/appStore.layoutBridge.test.ts
+++ b/src/store/appStore.layoutBridge.test.ts
@@ -71,7 +71,11 @@ vi.mock("@/services/transport", () => ({
     async dispatch(intent: { kind: string; payload: Record<string, unknown> }) {
       dispatched.push({ kind: intent.kind, payload: intent.payload });
       if (backend.reject) {
-        return { intentId: "intent-test", status: "rejected", error: { code: "x", message: "nope" } };
+        return {
+          intentId: "intent-test",
+          status: "rejected",
+          error: { code: "x", message: "nope" },
+        };
       }
       if (intent.kind === "layout.replace") {
         backend.push({ root: intent.payload.root, activePanelId: intent.payload.activePanelId });

--- a/src/store/appStore.layoutBridge.test.ts
+++ b/src/store/appStore.layoutBridge.test.ts
@@ -10,13 +10,18 @@
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-import type { PanelNode } from "@/types/terminal";
+import type { LeafPanel, PanelNode } from "@/types/terminal";
 import {
   createLeafPanel,
-  getAllLeaves,
+  edgeToSplit,
   findLeaf,
+  findLeafByTab,
+  generatePanelId,
+  getAllLeaves,
+  removeLeaf,
   simplifyTree,
   splitLeaf,
+  updateLeaf,
 } from "@/utils/panelTree";
 
 interface RegionState {
@@ -82,6 +87,39 @@ vi.mock("@/services/transport", () => ({
         );
         root = simplifyTree(root);
         backend.push({ root, activePanelId: newLeaf.id });
+      } else if (intent.kind === "layout.moveTab") {
+        // Mirrors the Rust store's move_tab: detach (positional active fallback),
+        // place (center = append / edge = split), prune emptied source, simplify.
+        // It does NOT repoint the active panel — the frontend bridge does.
+        const view = backend.view as { root: PanelNode; activePanelId: string | null };
+        const tabId = intent.payload.tabId as string;
+        const target = intent.payload.targetPanelId as string;
+        const src = findLeafByTab(view.root, tabId)!;
+        const theTab = src.tabs.find((t) => t.id === tabId)!;
+        let root = updateLeaf(view.root, src.id, (leaf) => removeTabMinimal(leaf, tabId));
+        const splitInfo = edgeToSplit(intent.payload.edge as never);
+        if (!splitInfo) {
+          root = updateLeaf(root, target, (leaf) => ({
+            ...leaf,
+            tabs: [...leaf.tabs, { ...theTab }],
+            activeTabId: tabId,
+          }));
+        } else {
+          const newLeaf: LeafPanel = {
+            type: "leaf",
+            id: generatePanelId(),
+            tabs: [{ ...theTab }],
+            activeTabId: tabId,
+          };
+          root = splitLeaf(root, target, newLeaf, splitInfo.direction, splitInfo.position);
+        }
+        const src2 = findLeaf(root, src.id);
+        if (src2 && src2.tabs.length === 0) {
+          const removed = removeLeaf(root, src.id);
+          root = removed ?? root;
+        }
+        root = simplifyTree(root);
+        backend.push({ root, activePanelId: view.activePanelId });
       }
       return {
         intentId: "intent-test",
@@ -131,6 +169,33 @@ function tab(id: string): TerminalTab {
     panelId: "a",
     isActive: id === "t1",
   } as TerminalTab;
+}
+
+/** Minimal-view tab removal with the positional active fallback (Rust parity). */
+function removeTabMinimal(leaf: LeafPanel, tabId: string): LeafPanel {
+  const idx = leaf.tabs.findIndex((t) => t.id === tabId);
+  if (idx === -1) return leaf;
+  const tabs = leaf.tabs.filter((t) => t.id !== tabId);
+  let activeTabId = leaf.activeTabId;
+  if (activeTabId === tabId) {
+    activeTabId = tabs.length ? tabs[Math.min(idx, tabs.length - 1)].id : null;
+  }
+  return { ...leaf, tabs, activeTabId };
+}
+
+/**
+ * A structural fingerprint of a tree, ignoring panel ids (which legitimately
+ * differ between the local reducer and the store) but keeping tab id order and
+ * per-leaf active tab — so two trees compare equal iff they place the same tabs
+ * the same way. `activeTabs` records the tab ids of the focused panel.
+ */
+function normalize(root: PanelNode, activePanelId: string | null): unknown {
+  const shape = (n: PanelNode): unknown =>
+    n.type === "leaf"
+      ? { leaf: n.tabs.map((t) => t.id), active: n.activeTabId }
+      : { split: n.direction, children: n.children.map(shape) };
+  const activeLeaf = activePanelId ? findLeaf(root, activePanelId) : null;
+  return { tree: shape(root), activeTabs: activeLeaf?.tabs.map((t) => t.id) ?? null };
 }
 
 function seedTree(): PanelNode {
@@ -202,5 +267,79 @@ describe("appStore layout bridge — splitPanel cut (#2151)", () => {
 
     // Still ended up split — via the local fallback path.
     expect(getAllLeaves(useAppStore.getState().rootPanel)).toHaveLength(3);
+  });
+});
+
+/**
+ * Parity: the store-cut (flag on) path must place tabs identically to the local
+ * reducer (flag off) for every operation cut in step 2. Runs the same operation
+ * both ways from a fresh tree and compares the id-agnostic fingerprint.
+ */
+describe("appStore layout bridge — cut ↔ local parity (#2151)", () => {
+  async function runBothWays(op: () => void): Promise<{ local: unknown; cut: unknown }> {
+    // Local (flag off).
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
+    setLayoutIntentsEnabled(false);
+    op();
+    const s1 = useAppStore.getState();
+    const local = normalize(s1.rootPanel, s1.activePanelId);
+
+    // Cut (flag on) — same starting tree, backend simulated by the panel-tree algebra.
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
+    backend.reset();
+    setLayoutIntentsEnabled(true);
+    op();
+    await flush();
+    const s2 = useAppStore.getState();
+    const cut = normalize(s2.rootPanel, s2.activePanelId);
+    return { local, cut };
+  }
+
+  it("splitPanel produces an identical tree both ways", async () => {
+    const { local, cut } = await runBothWays(() => useAppStore.getState().splitPanel("vertical"));
+    expect(cut).toEqual(local);
+  });
+
+  it("drag-to-center (merge a tab into another panel) matches the local reducer", async () => {
+    const { local, cut } = await runBothWays(() =>
+      useAppStore.getState().splitPanelWithTab("t1", "a", "b", "center")
+    );
+    expect(cut).toEqual(local);
+  });
+
+  it("drag-to-edge (split a panel with a tab) matches the local reducer", async () => {
+    const { local, cut } = await runBothWays(() =>
+      useAppStore.getState().splitPanelWithTab("t3", "b", "a", "right")
+    );
+    expect(cut).toEqual(local);
+  });
+
+  it("dragging a middle active tab out preserves the source's focus both ways", async () => {
+    const threeTab = (): PanelNode => ({
+      type: "split",
+      id: "root",
+      direction: "horizontal",
+      children: [
+        { type: "leaf", id: "a", tabs: [tab("t1"), tab("t2"), tab("t3")], activeTabId: "t2" },
+        { type: "leaf", id: "b", tabs: [tab("t4")], activeTabId: "t4" },
+      ],
+    });
+    // Local.
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ rootPanel: threeTab(), activePanelId: "a" });
+    setLayoutIntentsEnabled(false);
+    useAppStore.getState().splitPanelWithTab("t2", "a", "b", "center");
+    const local = normalize(useAppStore.getState().rootPanel, useAppStore.getState().activePanelId);
+    // Cut.
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ rootPanel: threeTab(), activePanelId: "a" });
+    backend.reset();
+    setLayoutIntentsEnabled(true);
+    useAppStore.getState().splitPanelWithTab("t2", "a", "b", "center");
+    await flush();
+    const cut = normalize(useAppStore.getState().rootPanel, useAppStore.getState().activePanelId);
+    expect(cut).toEqual(local);
   });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -4692,9 +4692,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
       const { rootPanel, activePanelId } = get();
       const sourceLeaf = findLeaf(rootPanel, fromPanelId);
       const selfEdgeSingleTab =
-        edge !== "center" &&
-        fromPanelId === targetPanelId &&
-        (sourceLeaf?.tabs.length ?? 0) <= 1;
+        edge !== "center" && fromPanelId === targetPanelId && (sourceLeaf?.tabs.length ?? 0) <= 1;
       if (!sourceLeaf || selfEdgeSingleTab) return applyLocal();
 
       void runLayoutIntent(

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -269,6 +269,12 @@ import {
   edgeToSplit,
   markActiveLeaf,
 } from "@/utils/panelTree";
+import {
+  layoutIntentsEnabled,
+  logBridgeFallback,
+  moveTabPayload,
+  runLayoutIntent,
+} from "@/store/layoutBridge";
 
 export type SidebarView =
   | "connections"
@@ -4545,17 +4551,39 @@ export const useAppStore = create<AppState>((set, get, store) => {
         }),
       })),
 
-    splitPanel: (direction) =>
-      set((state) => {
-        const dir = direction ?? "horizontal";
-        const targetId = state.activePanelId;
-        if (!targetId) return state;
+    splitPanel: (direction) => {
+      // Local reducer (the shipped path, and the fallback when the store cut is
+      // enabled). Kept verbatim so the flag-off behaviour is unchanged.
+      const applyLocal = () =>
+        set((state) => {
+          const dir = direction ?? "horizontal";
+          const targetId = state.activePanelId;
+          if (!targetId) return state;
 
-        const newLeaf = createLeafPanel();
-        let rootPanel = splitLeaf(state.rootPanel, targetId, newLeaf, dir, "after");
-        rootPanel = simplifyTree(rootPanel);
-        return { rootPanel, activePanelId: newLeaf.id };
-      }),
+          const newLeaf = createLeafPanel();
+          let rootPanel = splitLeaf(state.rootPanel, targetId, newLeaf, dir, "after");
+          rootPanel = simplifyTree(rootPanel);
+          return { rootPanel, activePanelId: newLeaf.id };
+        });
+
+      // Step-2 cut (#2151): route the structural split through the `layout.split`
+      // intent; the store mutates and the diff is reconciled back. On any failure
+      // fall back to the local reducer so layout never breaks.
+      if (!layoutIntentsEnabled()) return applyLocal();
+      const { rootPanel, activePanelId } = get();
+      if (!activePanelId) return applyLocal();
+      void runLayoutIntent(
+        "layout.split",
+        { panelId: activePanelId, direction: direction ?? "horizontal", position: "after" },
+        rootPanel,
+        activePanelId
+      )
+        .then((res) => set(res))
+        .catch((err) => {
+          logBridgeFallback("layout.split", err);
+          applyLocal();
+        });
+    },
 
     removePanel: (panelId) =>
       set((state) => {
@@ -4581,77 +4609,107 @@ export const useAppStore = create<AppState>((set, get, store) => {
         return { activePanelId: panelId, zoomedTabId: newZoomedTabId };
       }),
 
-    splitPanelWithTab: (tabId, fromPanelId, targetPanelId, edge) =>
-      set((state) => {
-        const splitInfo = edgeToSplit(edge);
+    splitPanelWithTab: (tabId, fromPanelId, targetPanelId, edge) => {
+      // Local reducer (shipped path + fallback), kept verbatim.
+      const applyLocal = () =>
+        set((state) => {
+          const splitInfo = edgeToSplit(edge);
 
-        // Center drop: move tab to existing panel
-        if (!splitInfo) {
+          // Center drop: move tab to existing panel
+          if (!splitInfo) {
+            const sourceLeaf = findLeaf(state.rootPanel, fromPanelId);
+            if (!sourceLeaf) return state;
+            const tab = sourceLeaf.tabs.find((t) => t.id === tabId);
+            if (!tab) return state;
+
+            const movedTab: TerminalTab = { ...tab, panelId: targetPanelId, isActive: true };
+
+            let rootPanel = updateLeaf(state.rootPanel, fromPanelId, (leaf) =>
+              removeTabFromLeaf(leaf, tabId)
+            );
+            rootPanel = updateLeaf(rootPanel, targetPanelId, (leaf) => ({
+              ...leaf,
+              tabs: [...leaf.tabs.map((t) => ({ ...t, isActive: false })), movedTab],
+              activeTabId: movedTab.id,
+            }));
+
+            // Clean up empty source
+            const updatedSource = findLeaf(rootPanel, fromPanelId);
+            const allLeaves = getAllLeaves(rootPanel);
+            if (updatedSource && updatedSource.tabs.length === 0 && allLeaves.length > 1) {
+              const removed = removeLeaf(rootPanel, fromPanelId);
+              rootPanel = removed ? simplifyTree(removed) : rootPanel;
+            }
+
+            return { rootPanel, activePanelId: targetPanelId };
+          }
+
+          // Edge drop: create new panel via split
           const sourceLeaf = findLeaf(state.rootPanel, fromPanelId);
           if (!sourceLeaf) return state;
           const tab = sourceLeaf.tabs.find((t) => t.id === tabId);
           if (!tab) return state;
 
-          const movedTab: TerminalTab = { ...tab, panelId: targetPanelId, isActive: true };
+          const newLeaf = createLeafPanel();
+          const movedTab: TerminalTab = { ...tab, panelId: newLeaf.id, isActive: true };
+          newLeaf.tabs = [movedTab];
+          newLeaf.activeTabId = movedTab.id;
 
+          // Remove tab from source
           let rootPanel = updateLeaf(state.rootPanel, fromPanelId, (leaf) =>
             removeTabFromLeaf(leaf, tabId)
           );
-          rootPanel = updateLeaf(rootPanel, targetPanelId, (leaf) => ({
-            ...leaf,
-            tabs: [...leaf.tabs.map((t) => ({ ...t, isActive: false })), movedTab],
-            activeTabId: movedTab.id,
-          }));
 
-          // Clean up empty source
-          const updatedSource = findLeaf(rootPanel, fromPanelId);
-          const allLeaves = getAllLeaves(rootPanel);
-          if (updatedSource && updatedSource.tabs.length === 0 && allLeaves.length > 1) {
-            const removed = removeLeaf(rootPanel, fromPanelId);
-            rootPanel = removed ? simplifyTree(removed) : rootPanel;
+          // Clean up empty source before splitting (unless source IS the target)
+          if (fromPanelId !== targetPanelId) {
+            const updatedSource = findLeaf(rootPanel, fromPanelId);
+            const allLeaves = getAllLeaves(rootPanel);
+            if (updatedSource && updatedSource.tabs.length === 0 && allLeaves.length > 1) {
+              const removed = removeLeaf(rootPanel, fromPanelId);
+              rootPanel = removed ? simplifyTree(removed) : rootPanel;
+            }
           }
 
-          return { rootPanel, activePanelId: targetPanelId };
-        }
+          // Split the target
+          rootPanel = splitLeaf(
+            rootPanel,
+            targetPanelId,
+            newLeaf,
+            splitInfo.direction,
+            splitInfo.position
+          );
+          rootPanel = simplifyTree(rootPanel);
 
-        // Edge drop: create new panel via split
-        const sourceLeaf = findLeaf(state.rootPanel, fromPanelId);
-        if (!sourceLeaf) return state;
-        const tab = sourceLeaf.tabs.find((t) => t.id === tabId);
-        if (!tab) return state;
+          return { rootPanel, activePanelId: newLeaf.id };
+        });
 
-        const newLeaf = createLeafPanel();
-        const movedTab: TerminalTab = { ...tab, panelId: newLeaf.id, isActive: true };
-        newLeaf.tabs = [movedTab];
-        newLeaf.activeTabId = movedTab.id;
+      // Step-2 cut (#2151): a tab-carrying drop maps to `layout.moveTab`
+      // (center = merge into the target stack, edge = split the target). The
+      // backend collapses an emptied self-drop source but the local reducer
+      // keeps it, so the single-tab self-edge-drop corner stays on the local
+      // path to preserve exact parity; everything else routes through the store.
+      if (!layoutIntentsEnabled()) return applyLocal();
+      const { rootPanel, activePanelId } = get();
+      const sourceLeaf = findLeaf(rootPanel, fromPanelId);
+      const selfEdgeSingleTab =
+        edge !== "center" &&
+        fromPanelId === targetPanelId &&
+        (sourceLeaf?.tabs.length ?? 0) <= 1;
+      if (!sourceLeaf || selfEdgeSingleTab) return applyLocal();
 
-        // Remove tab from source
-        let rootPanel = updateLeaf(state.rootPanel, fromPanelId, (leaf) =>
-          removeTabFromLeaf(leaf, tabId)
-        );
-
-        // Clean up empty source before splitting (unless source IS the target)
-        if (fromPanelId !== targetPanelId) {
-          const updatedSource = findLeaf(rootPanel, fromPanelId);
-          const allLeaves = getAllLeaves(rootPanel);
-          if (updatedSource && updatedSource.tabs.length === 0 && allLeaves.length > 1) {
-            const removed = removeLeaf(rootPanel, fromPanelId);
-            rootPanel = removed ? simplifyTree(removed) : rootPanel;
-          }
-        }
-
-        // Split the target
-        rootPanel = splitLeaf(
-          rootPanel,
-          targetPanelId,
-          newLeaf,
-          splitInfo.direction,
-          splitInfo.position
-        );
-        rootPanel = simplifyTree(rootPanel);
-
-        return { rootPanel, activePanelId: newLeaf.id };
-      }),
+      void runLayoutIntent(
+        "layout.moveTab",
+        moveTabPayload(tabId, targetPanelId, edge),
+        rootPanel,
+        activePanelId,
+        tabId
+      )
+        .then((res) => set(res))
+        .catch((err) => {
+          logBridgeFallback("layout.moveTab", err);
+          applyLocal();
+        });
+    },
 
     // Connections — initialized empty, loaded from backend on mount
     folders: [],

--- a/src/store/layoutBridge.test.ts
+++ b/src/store/layoutBridge.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for the layout projection bridge (#2151 step 2): the rich⇄minimal
+ * tree mapping, the reconcile that re-hydrates minimal-tab diffs into rich
+ * `TerminalTab`s by id, and the feature flag. The dispatch/subscribe round-trip
+ * is exercised at the appStore level in `appStore.layoutBridge.test.ts`.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+
+import type { PanelNode, TerminalTab } from "@/types/terminal";
+
+import {
+  collectTabs,
+  layoutIntentsEnabled,
+  reconcileNode,
+  setLayoutIntentsEnabled,
+  toMinimalNode,
+} from "./layoutBridge";
+
+function tab(id: string, extra: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id,
+    sessionId: `sess-${id}`,
+    title: `Tab ${id}`,
+    connectionType: "local",
+    contentType: "terminal",
+    config: {} as TerminalTab["config"],
+    panelId: "orig",
+    isActive: false,
+    ...extra,
+  } as TerminalTab;
+}
+
+/** Two-leaf split: `a` = [t1(active), t2], `b` = [t3]. */
+function tree(): PanelNode {
+  return {
+    type: "split",
+    id: "root",
+    direction: "horizontal",
+    sizes: [50, 50],
+    children: [
+      { type: "leaf", id: "a", tabs: [tab("t1"), tab("t2")], activeTabId: "t1" },
+      { type: "leaf", id: "b", tabs: [tab("t3")], activeTabId: "t3" },
+    ],
+  };
+}
+
+describe("layoutBridge — tree mapping", () => {
+  it("toMinimalNode strips tabs to the projected minimal form", () => {
+    const min = toMinimalNode(tree());
+    expect(min).toEqual({
+      type: "split",
+      id: "root",
+      direction: "horizontal",
+      sizes: [50, 50],
+      children: [
+        {
+          type: "leaf",
+          id: "a",
+          tabs: [
+            { id: "t1", sessionId: "sess-t1", contentType: "terminal" },
+            { id: "t2", sessionId: "sess-t2", contentType: "terminal" },
+          ],
+          activeTabId: "t1",
+        },
+        {
+          type: "leaf",
+          id: "b",
+          tabs: [{ id: "t3", sessionId: "sess-t3", contentType: "terminal" }],
+          activeTabId: "t3",
+        },
+      ],
+    });
+  });
+
+  it("collectTabs indexes every rich tab by id", () => {
+    const map = collectTabs(tree());
+    expect([...map.keys()].sort()).toEqual(["t1", "t2", "t3"]);
+    expect(map.get("t1")?.title).toBe("Tab t1");
+  });
+
+  it("reconcileNode re-hydrates rich tabs and re-derives panelId + isActive", () => {
+    const tabsById = collectTabs(tree());
+    // A projected tree where t1 moved from a into b; b now active on t1.
+    const projected = {
+      type: "split" as const,
+      id: "root",
+      direction: "horizontal" as const,
+      sizes: [50, 50],
+      children: [
+        { type: "leaf" as const, id: "a", tabs: [{ id: "t2", contentType: "terminal" }], activeTabId: "t2" },
+        {
+          type: "leaf" as const,
+          id: "b",
+          tabs: [
+            { id: "t3", contentType: "terminal" },
+            { id: "t1", contentType: "terminal" },
+          ],
+          activeTabId: "t1",
+        },
+      ],
+    };
+    const rich = reconcileNode(projected, tabsById) as Extract<PanelNode, { type: "split" }>;
+
+    const leafB = rich.children[1] as Extract<PanelNode, { type: "leaf" }>;
+    expect(leafB.tabs.map((t) => t.id)).toEqual(["t3", "t1"]);
+    // Rich fields survive; panelId follows the containing leaf; isActive tracks activeTabId.
+    const t1 = leafB.tabs.find((t) => t.id === "t1")!;
+    expect(t1.title).toBe("Tab t1");
+    expect(t1.panelId).toBe("b");
+    expect(t1.isActive).toBe(true);
+    expect(leafB.tabs.find((t) => t.id === "t3")!.isActive).toBe(false);
+    // The split preserves geometry.
+    expect(rich.sizes).toEqual([50, 50]);
+  });
+
+  it("reconcileNode throws on a tab absent from the index (triggers local fallback)", () => {
+    const projected = {
+      type: "leaf" as const,
+      id: "a",
+      tabs: [{ id: "ghost", contentType: "terminal" }],
+      activeTabId: "ghost",
+    };
+    expect(() => reconcileNode(projected, new Map())).toThrow(/unknown tab ghost/);
+  });
+});
+
+describe("layoutBridge — feature flag", () => {
+  afterEach(() => setLayoutIntentsEnabled(null));
+
+  it("is off by default", () => {
+    setLayoutIntentsEnabled(null);
+    expect(layoutIntentsEnabled()).toBe(false);
+  });
+
+  it("honours a programmatic override", () => {
+    setLayoutIntentsEnabled(true);
+    expect(layoutIntentsEnabled()).toBe(true);
+    setLayoutIntentsEnabled(false);
+    expect(layoutIntentsEnabled()).toBe(false);
+  });
+});

--- a/src/store/layoutBridge.test.ts
+++ b/src/store/layoutBridge.test.ts
@@ -87,7 +87,12 @@ describe("layoutBridge — tree mapping", () => {
       direction: "horizontal" as const,
       sizes: [50, 50],
       children: [
-        { type: "leaf" as const, id: "a", tabs: [{ id: "t2", contentType: "terminal" }], activeTabId: "t2" },
+        {
+          type: "leaf" as const,
+          id: "a",
+          tabs: [{ id: "t2", contentType: "terminal" }],
+          activeTabId: "t2",
+        },
         {
           type: "leaf" as const,
           id: "b",

--- a/src/store/layoutBridge.ts
+++ b/src/store/layoutBridge.ts
@@ -328,7 +328,11 @@ export async function runLayoutIntent(
 }
 
 /** Map a {@link DropEdge} to a `layout.moveTab` payload for a split-with-tab drop. */
-export function moveTabPayload(tabId: string, targetPanelId: string, edge: DropEdge): Record<string, unknown> {
+export function moveTabPayload(
+  tabId: string,
+  targetPanelId: string,
+  edge: DropEdge
+): Record<string, unknown> {
   return { tabId, targetPanelId, edge };
 }
 

--- a/src/store/layoutBridge.ts
+++ b/src/store/layoutBridge.ts
@@ -1,0 +1,339 @@
+/**
+ * Layout projection bridge — Phase 3 step 2 of the stateless-UI migration
+ * (#2151, part of #2139).
+ *
+ * Step 1 landed a shadow, backend-authoritative `LayoutStore` served as the
+ * client-scoped `layout@<clientId>` projection region, but nothing in the UI
+ * touched it. Step 2 makes the store authoritative for **panel-tree structure**:
+ * the four structural mutations (split / move-tab / merge-a-tab / split-with-tab)
+ * dispatch `layout.*` intents instead of editing `appStore.rootPanel` locally,
+ * and the resulting projection diff is reconciled back into `appStore`'s
+ * existing panel-tree shape so `SplitView` renders exactly as before (rendering
+ * is cut over in step 3, the reducers removed in step 4).
+ *
+ * # Seed-before-mutate
+ *
+ * Under partial projection the region carries only structure + the minimal tab
+ * model (`{ id, sessionId, contentType }`); tab **creation** still lives in
+ * `appStore` (a session-coupled concern deferred to a later phase). The shadow
+ * store is therefore never told about tabs on its own. So each structural
+ * mutation first **seeds** the store with `appStore`'s current tree (in the
+ * minimal-tab form) via `layout.replace`, then dispatches the transform. The
+ * store thus mutates the real tree and projects a diff; the frontend
+ * {@link reconcileNode reconciles} that minimal-tab diff back into rich
+ * {@link TerminalTab}s by id (the xterm DOM is registered globally by tab id, so
+ * a moved tab keeps its live session + scrollback). Seeding per-op also means
+ * the store never drifts from `appStore` between ops.
+ *
+ * # Strangler safety
+ *
+ * The cut is gated by {@link layoutIntentsEnabled} — **off by default**, so the
+ * shipped app keeps running on the untouched local reducers until step 3 flips
+ * rendering over too. Even when enabled, any dispatch/reconcile failure falls
+ * back to the local mutation, so a backend hiccup can never break layout.
+ */
+
+import {
+  createTransport,
+  newClientId,
+  newIntentId,
+  ProjectionClient,
+  type IntentAck,
+  type Transport,
+} from "@/services/transport";
+import type { DropEdge, LeafPanel, PanelNode, SplitContainer, TerminalTab } from "@/types/terminal";
+import { frontendLog } from "@/utils/frontendLog";
+import { findLeafByTab } from "@/utils/panelTree";
+
+/** The structural result the bridge hands back to `appStore`. */
+export interface LayoutStructuralResult {
+  rootPanel: PanelNode;
+  activePanelId: string | null;
+}
+
+// ── Minimal projected shapes (twins of the Rust `layout` view model) ──────────
+
+interface MinimalTab {
+  id: string;
+  sessionId?: string | null;
+  contentType: string;
+}
+interface MinimalLeaf {
+  type: "leaf";
+  id: string;
+  tabs: MinimalTab[];
+  activeTabId: string | null;
+}
+interface MinimalSplit {
+  type: "split";
+  id: string;
+  direction: "horizontal" | "vertical";
+  children: MinimalNode[];
+  sizes?: number[];
+  lastActiveLeafId?: string;
+}
+type MinimalNode = MinimalLeaf | MinimalSplit;
+
+/** The `layout@<clientId>` region view model: tree + focused panel. */
+interface LayoutView {
+  root: MinimalNode;
+  activePanelId: string | null;
+}
+
+// ── Feature flag (runtime-flippable so a dev build can verify the ON path) ─────
+
+interface LayoutFlagWindow {
+  __TERMIHUB_LAYOUT_INTENTS__?: boolean;
+  localStorage?: Storage;
+}
+
+let flagOverride: boolean | null = null;
+
+/**
+ * Programmatic override for the layout-intents flag (tests, and a runtime
+ * toggle). `null` clears the override and falls back to the window/localStorage
+ * signal, then to the default.
+ */
+export function setLayoutIntentsEnabled(value: boolean | null): void {
+  flagOverride = value;
+}
+
+/**
+ * Whether structural layout mutations route through `layout.*` intents (step 2)
+ * instead of mutating `appStore.rootPanel` locally.
+ *
+ * **Off by default.** Step 2 lands the machinery gated; step 3 (rendering cut)
+ * flips the default on. Overridable at runtime for verification via
+ * `window.__TERMIHUB_LAYOUT_INTENTS__` or `localStorage["termihub.layoutIntents"]`.
+ */
+export function layoutIntentsEnabled(): boolean {
+  if (flagOverride !== null) return flagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as LayoutFlagWindow;
+      if (typeof w.__TERMIHUB_LAYOUT_INTENTS__ === "boolean") {
+        return w.__TERMIHUB_LAYOUT_INTENTS__;
+      }
+      const ls = w.localStorage?.getItem("termihub.layoutIntents");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return false;
+}
+
+// ── Transport + region client (lazy, mirrors the tunnel slice) ─────────────────
+
+// A stable per-session client identity. The client-scoped region is
+// `layout@<clientId>`, and dispatched intents carry the same id, so this
+// checkout mutates and subscribes to its own layout region.
+const clientId = newClientId();
+const region = `layout@${clientId}`;
+
+let transportInstance: Transport | null = null;
+let regionClient: ProjectionClient | null = null;
+let startPromise: Promise<ProjectionClient> | null = null;
+
+function transport(): Transport {
+  if (!transportInstance) {
+    transportInstance = createTransport();
+  }
+  return transportInstance;
+}
+
+/**
+ * Ensure the `layout@<clientId>` region client is subscribed, so intent diffs
+ * are received. Idempotent and de-duplicated across concurrent callers.
+ */
+function ensureSubscribed(): Promise<ProjectionClient> {
+  if (regionClient) return Promise.resolve(regionClient);
+  if (!startPromise) {
+    const client = new ProjectionClient(transport(), region);
+    startPromise = client
+      .start()
+      .then(() => {
+        regionClient = client;
+        return client;
+      })
+      .catch((err) => {
+        startPromise = null;
+        throw err;
+      });
+  }
+  return startPromise;
+}
+
+async function dispatch(kind: string, payload: unknown): Promise<IntentAck> {
+  return transport().dispatch({ intentId: newIntentId(), kind, payload, clientId });
+}
+
+function throwIfRejected(ack: IntentAck, what: string): void {
+  if (ack.status === "rejected") {
+    throw new Error(ack.error?.message ?? `layout intent ${what} rejected`);
+  }
+}
+
+// ── Tree mapping: rich ⇄ minimal, and reconcile ──────────────────────────────
+
+/** Strip a rich panel tree down to the minimal projected form for seeding. */
+export function toMinimalNode(node: PanelNode): MinimalNode {
+  if (node.type === "leaf") {
+    return {
+      type: "leaf",
+      id: node.id,
+      tabs: node.tabs.map((t) => ({
+        id: t.id,
+        sessionId: t.sessionId ?? null,
+        contentType: t.contentType,
+      })),
+      activeTabId: node.activeTabId,
+    };
+  }
+  const split: MinimalSplit = {
+    type: "split",
+    id: node.id,
+    direction: node.direction,
+    children: node.children.map(toMinimalNode),
+  };
+  if (node.sizes) split.sizes = node.sizes;
+  if (node.lastActiveLeafId) split.lastActiveLeafId = node.lastActiveLeafId;
+  return split;
+}
+
+/** Index every rich tab in a tree by id, for reconcile lookups. */
+export function collectTabs(node: PanelNode): Map<string, TerminalTab> {
+  const map = new Map<string, TerminalTab>();
+  const walk = (n: PanelNode): void => {
+    if (n.type === "leaf") {
+      for (const t of n.tabs) map.set(t.id, t);
+    } else {
+      n.children.forEach(walk);
+    }
+  };
+  walk(node);
+  return map;
+}
+
+/**
+ * Rebuild a rich {@link PanelNode} from a projected minimal tree, re-attaching
+ * each tab's rich fields by id from `tabsById` (partial projection: the region
+ * carries only structure + minimal tab identity). Per-leaf, `panelId` and
+ * `isActive` are re-derived from the projected structure — exactly what the old
+ * local reducers set — so `SplitView`'s selectors see an identical shape.
+ *
+ * Throws if the projection references a tab absent from `tabsById`; the caller
+ * treats that as a bridge failure and falls back to the local mutation.
+ */
+export function reconcileNode(node: MinimalNode, tabsById: Map<string, TerminalTab>): PanelNode {
+  if (node.type === "leaf") {
+    const tabs: TerminalTab[] = node.tabs.map((mt) => {
+      const rich = tabsById.get(mt.id);
+      if (!rich) {
+        throw new Error(`layout reconcile: unknown tab ${mt.id}`);
+      }
+      return { ...rich, panelId: node.id, isActive: mt.id === node.activeTabId };
+    });
+    const leaf: LeafPanel = {
+      type: "leaf",
+      id: node.id,
+      tabs,
+      activeTabId: node.activeTabId,
+    };
+    return leaf;
+  }
+  const split: SplitContainer = {
+    type: "split",
+    id: node.id,
+    direction: node.direction,
+    children: node.children.map((c) => reconcileNode(c, tabsById)),
+  };
+  if (node.sizes) split.sizes = node.sizes;
+  if (node.lastActiveLeafId) split.lastActiveLeafId = node.lastActiveLeafId;
+  return split;
+}
+
+// ── Await a region version, then read the reconciled tree ─────────────────────
+
+/** Resolve once the region client has caught up to (at least) `version`. */
+function awaitVersion(client: ProjectionClient, version: number, timeoutMs = 4000): Promise<void> {
+  if (client.state.version >= version) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      unsubscribe();
+      reject(new Error(`layout region did not reach version ${version} in time`));
+    }, timeoutMs);
+    const unsubscribe = client.onChange((state) => {
+      if (state.version >= version) {
+        clearTimeout(timer);
+        unsubscribe();
+        resolve();
+      }
+    });
+  });
+}
+
+/**
+ * Run a structural layout mutation through the store: seed the store with the
+ * current tree, dispatch `kind`, await the resulting diff, and reconcile it back
+ * into `appStore`'s rich panel-tree shape.
+ *
+ * The backend `move_tab` transform does not repoint the focused panel, but the
+ * old local move/split-with-tab reducers all focus the tab's destination. So
+ * when `focusTabId` is given, the reconciled `activePanelId` is re-derived as
+ * the panel that now holds that tab — reproducing the old focus behaviour.
+ *
+ * @param kind        the `layout.*` intent kind
+ * @param payload     the intent payload
+ * @param root        `appStore`'s current `rootPanel` (authoritative structure)
+ * @param active      `appStore`'s current `activePanelId`
+ * @param focusTabId  when set, focus the panel this tab landed in
+ * @returns the reconciled `{ rootPanel, activePanelId }` to apply to `appStore`
+ * @throws  on a rejected/failed intent or an unreconcilable diff (caller falls
+ *          back to the local mutation)
+ */
+export async function runLayoutIntent(
+  kind: string,
+  payload: Record<string, unknown>,
+  root: PanelNode,
+  active: string | null,
+  focusTabId?: string
+): Promise<LayoutStructuralResult> {
+  const client = await ensureSubscribed();
+  const tabsById = collectTabs(root);
+
+  // Seed the store with appStore's authoritative tree, then transform it.
+  throwIfRejected(
+    await dispatch("layout.replace", { root: toMinimalNode(root), activePanelId: active }),
+    "replace"
+  );
+  const ack = await dispatch(kind, payload);
+  throwIfRejected(ack, kind);
+
+  const produced = ack.produced?.find((p) => p.region === region);
+  if (produced) {
+    await awaitVersion(client, produced.version);
+  }
+
+  const view = client.state.view as LayoutView | undefined;
+  if (!view || !view.root) {
+    throw new Error("layout region has no view after intent");
+  }
+  const rootPanel = reconcileNode(view.root, tabsById);
+  const activePanelId = focusTabId
+    ? (findLeafByTab(rootPanel, focusTabId)?.id ?? view.activePanelId)
+    : view.activePanelId;
+  return { rootPanel, activePanelId };
+}
+
+/** Map a {@link DropEdge} to a `layout.moveTab` payload for a split-with-tab drop. */
+export function moveTabPayload(tabId: string, targetPanelId: string, edge: DropEdge): Record<string, unknown> {
+  return { tabId, targetPanelId, edge };
+}
+
+/** Log a bridge fallback so the local-path recovery is visible in the LogViewer. */
+export function logBridgeFallback(kind: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  frontendLog("layout_bridge", `${kind} fell back to local mutation: ${message}`);
+}


### PR DESCRIPTION
## Phase 3 step 2 — cut structural layout mutations over to the store

`Part of #2151` (the umbrella stays open for steps 3–5).

Step 1 (PR #2174) landed the shadow, backend-authoritative `LayoutStore` +
client-scoped `layout@<clientId>` region + `layout.*` intents, but nothing in
the UI touched it. Step 2 starts making the store authoritative for
**panel-tree structure**: structural mutations dispatch `layout.*` intents and
the resulting projection diff is reconciled back into `appStore`'s existing
panel-tree shape, so `SplitView` renders exactly as before (rendering is cut in
step 3, the reducers removed in step 4).

### What this does

- **Backend — `layout.replace` seed intent.** The shadow store is never fed tabs
  (tab *creation* stays in `appStore` under partial projection), so the four
  structural intents can't operate on the real tree. `layout.replace` installs a
  client's whole tree (minimal-tab form). Also aligns the store's
  `with_tab_removed` to the frontend's **positional** active-tab fallback
  (`min(idx, len-1)`), so a source panel focuses the same tab after a move.
- **Frontend — the projection bridge (`src/store/layoutBridge.ts`).** For each cut
  mutation it *seeds* the store with `appStore`'s current tree, dispatches the
  intent, awaits the diff, and **reconciles** the minimal-tab view back into rich
  `TerminalTab`s by id. Because the xterm DOM is registered globally by tab id
  (`TerminalRegistry`) and `TerminalSlot` reparents it, a moved tab keeps its
  **live session + scrollback**. Seeding per-op means the store never drifts from
  `appStore` between ops.
- **Cut so far:** `splitPanel` → `layout.split`; `splitPanelWithTab` (drag to
  panel center = merge a tab into the stack, drag to edge = split) →
  `layout.moveTab`. The single-tab **self-edge-drop** corner (where the store
  collapses the emptied source but the local reducer keeps it) stays on the local
  path to preserve exact parity.

### Strangler safety

Gated by `layoutIntentsEnabled()` — **off by default**, so the shipped app keeps
running on the untouched local reducers; even when enabled, any
dispatch/reconcile failure falls back to the local mutation. Rendering and the
`appStore` reducers are unchanged (steps 3–4). The flag is runtime-flippable
(`localStorage["termihub.layoutIntents"]` / `window.__TERMIHUB_LAYOUT_INTENTS__`)
so step 3 can flip the default after a GUI verification pass.

### Left for follow-ups (filed, `Part of #2151`)

- `moveTab` (tab-bar drop at an index) needs an **indexed** `layout.moveTab`
  payload the backend intent doesn't yet carry.
- `closeTab` structural half — session/side-map coupling warrants a focused,
  atomic cut.
- `reorderTabs` intra-panel reorder.

### Tests

- Rust: `layout.replace` store + projection round-trip; positional
  active-tab-removal parity. (25 layout tests green.)
- Frontend: bridge unit tests (rich⇄minimal map, reconcile re-hydration by id,
  unknown-tab throw, flag) + `appStore` round-trip (seed→intent→diff→appStore,
  flag-off, rejection-fallback) + **cut↔local parity comparisons** running
  `splitPanel`, drag-center, drag-edge, and a middle-active-tab move both ways and
  asserting identical trees.

### Verification note

The interactive GUI drag-drop pass (mouse drags + visual scrollback check) was
**not** performed here; it is substituted by the automated cut↔local parity tests
above, and the flag ships **off** so there is zero user-facing change. Recommend a
manual `./scripts/dev.sh` pass with the flag on before step 3 flips the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
