### PR TITLE
feat(tunnel): failure-toast parity for tunnel start/reconnect (Closes #2169)

### DIFF
--- a/docs/changes/dev1/fix/2169-tunnel-failure-toast-parity.md
+++ b/docs/changes/dev1/fix/2169-tunnel-failure-toast-parity.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- SSH tunnels: restored the transient failure toast on a first-connect
+  `Start`/`Reconnect` error, lost when those became fire-and-forget in the
+  tunnels projection migration. The toast is now driven from the projected
+  status transition (the tunnel reaching `error` shortly after the client's own
+  start/reconnect) and is scoped to the initiating client, so a mid-session
+  tunnel death or another client's start still surfaces only as the Error status
+  badge. The success/validation toasts and the Error badge/tooltip are unchanged.

--- a/src/store/slices/tunnelSlice.ts
+++ b/src/store/slices/tunnelSlice.ts
@@ -36,6 +36,21 @@ interface TunnelsView {
 const _tunnelStartInFlight = new Set<string>();
 const _tunnelStopInFlight = new Set<string>();
 
+// First-connect failure-toast tracking (#2169). After the projection migration
+// (#2150) `tunnel.start` / `tunnel.reconnect` are fire-and-forget: the ack only
+// confirms the start was *accepted*, and a failure during the SSH handshake now
+// arrives as a projected `error` status rather than the old synchronous red
+// toast. To restore that immediate failure feedback for parity — without
+// re-serialising the blocking handshake onto the dispatcher — we remember each
+// tunnel THIS client just dispatched a start/reconnect for, and raise a transient
+// failure toast when its projected state *transitions into* `error`.
+//
+// Keyed by tunnel id → the verb for the message ("start" | "reconnect"). The map
+// is intentionally per-client (module-local), so only the initiating client sees
+// the toast — a mid-session death or another client's start (which this client
+// never dispatched) surfaces only as the Error status badge, never a toast here.
+const _awaitingFirstConnect = new Map<string, "start" | "reconnect">();
+
 // The projection transport + `tunnels` region client, shared across the slice.
 // Both are created lazily on first use (`loadTunnels` / the first intent) so the
 // slice imports cleanly in a non-Tauri context (e.g. unit tests), where
@@ -70,6 +85,41 @@ function errMessage(err: unknown): string {
 }
 
 /**
+ * Raise the first-connect failure toast (#2169) for any tunnel THIS client
+ * dispatched a start/reconnect for whose projected status just transitioned into
+ * `error`, then stop tracking it.
+ *
+ * Driven purely from the projected status diff (never from re-serialising the
+ * handshake): we compare the previously cached states against the freshly pushed
+ * ones and only fire on a genuine `→ error` transition, so a repeated/coalesced
+ * diff that still shows `error` cannot re-toast, and a stale pre-dispatch `error`
+ * (from an earlier failed attempt) is not mistaken for the new outcome. A tunnel
+ * that instead reaches `connected` is a success — its "Started/Reconnected …"
+ * toast already fired on the ack — so we simply stop tracking it, leaving a
+ * later mid-session death to surface only as the Error badge.
+ */
+function raiseFirstConnectFailureToasts(
+  prevStates: Record<string, TunnelState>,
+  nextStates: Record<string, TunnelState>,
+  tunnels: TunnelConfig[]
+): void {
+  if (_awaitingFirstConnect.size === 0) return;
+  for (const [id, verb] of _awaitingFirstConnect) {
+    const nextStatus = nextStates[id]?.status;
+    if (nextStatus === "error" && prevStates[id]?.status !== "error") {
+      const name = tunnels.find((t) => t.id === id)?.name ?? "tunnel";
+      const detail = nextStates[id]?.error ?? "connection failed";
+      toast.error(`Failed to ${verb} ${name}: ${detail}`);
+      _awaitingFirstConnect.delete(id);
+    } else if (nextStatus === "connected") {
+      // Resolved successfully — the ack already toasted success. Stop watching so
+      // a later mid-session drop to `error` is a badge, not a first-connect toast.
+      _awaitingFirstConnect.delete(id);
+    }
+  }
+}
+
+/**
  * SSH tunnel domain slice — migrated onto the stateless-UI projection substrate
  * (#2150, the Phase-2 pilot of #2139).
  *
@@ -99,12 +149,19 @@ export const createTunnelSlice: StateCreator<AppState, [], [], TunnelSlice> = (s
 
   loadTunnels: async () => {
     try {
-      // Re-subscribing (e.g. a re-init) drops the previous region client first.
+      // Re-subscribing (e.g. a re-init) drops the previous region client first,
+      // and any pending first-connect watches with it (they belong to the old
+      // session's dispatches).
       _client?.stop();
+      _awaitingFirstConnect.clear();
       const client = new ProjectionClient(transport(), TUNNELS_REGION);
       client.onChange((state) => {
         const view = (state.view ?? {}) as Partial<TunnelsView>;
-        set({ tunnels: view.tunnels ?? [], tunnelStates: view.states ?? {} });
+        const nextStates = view.states ?? {};
+        // Detect first-connect failures against the previously cached states
+        // BEFORE overwriting them (#2169).
+        raiseFirstConnectFailureToasts(get().tunnelStates, nextStates, view.tunnels ?? []);
+        set({ tunnels: view.tunnels ?? [], tunnelStates: nextStates });
       });
       await client.start();
       _client = client;
@@ -153,6 +210,9 @@ export const createTunnelSlice: StateCreator<AppState, [], [], TunnelSlice> = (s
       const ack = await dispatchTunnelIntent("tunnel.start", { id: tunnelId });
       throwIfRejected(ack, "start tunnel");
       toast.success(`Started ${name}`, { id: toastId });
+      // Accepted — now watch for a handshake failure arriving as a projected
+      // `error` transition and re-raise the failure toast then (#2169).
+      _awaitingFirstConnect.set(tunnelId, "start");
     } catch (err) {
       frontendLog("app_store", `Failed to start tunnel: ${errMessage(err)}`);
       toast.error(`Failed to start ${name}: ${errMessage(err)}`, { id: toastId });
@@ -196,6 +256,9 @@ export const createTunnelSlice: StateCreator<AppState, [], [], TunnelSlice> = (s
       const ack = await dispatchTunnelIntent("tunnel.reconnect", { id: tunnelId });
       throwIfRejected(ack, "reconnect tunnel");
       toast.success(`Reconnected ${name}`, { id: toastId });
+      // Accepted — watch for the stop→start sequence failing during its
+      // handshake, arriving as a projected `error` transition (#2169).
+      _awaitingFirstConnect.set(tunnelId, "reconnect");
     } catch (err) {
       frontendLog("app_store", `Failed to reconnect tunnel: ${errMessage(err)}`);
       toast.error(`Failed to reconnect ${name}: ${errMessage(err)}`, { id: toastId });

--- a/src/store/tunnelSlice.failureToast.test.ts
+++ b/src/store/tunnelSlice.failureToast.test.ts
@@ -1,0 +1,201 @@
+/**
+ * First-connect failure-toast parity for the tunnel slice (#2169).
+ *
+ * After the projection migration (#2150) `tunnel.start` / `tunnel.reconnect` are
+ * fire-and-forget: the ack only confirms the start was *accepted*, so a failure
+ * during the SSH handshake arrives as a projected `error` status rather than the
+ * old synchronous red toast. These tests pin that the slice re-raises the failure
+ * toast — driven purely from the projected status transition — and only for a
+ * start/reconnect THIS client dispatched (never a mid-session death or another
+ * client's start, which surface only as the Error status badge).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import type { IntentAck, ProjectionCacheState } from "@/services/transport";
+import type { TunnelConfig, TunnelState } from "@/types/tunnel";
+
+const { clientHooks, dispatchMock, toastMock } = vi.hoisted(() => ({
+  clientHooks: {
+    listener: null as null | ((state: ProjectionCacheState) => void),
+  },
+  dispatchMock: vi.fn(),
+  toastMock: { loading: vi.fn(() => "toast-id"), success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/transport", () => ({
+  createTransport: () => ({ dispatch: dispatchMock, subscribe: vi.fn(), resync: vi.fn() }),
+  newClientId: () => "client-test",
+  newIntentId: () => "intent-test",
+  ProjectionClient: class {
+    onChange(listener: (state: ProjectionCacheState) => void) {
+      clientHooks.listener = listener;
+      return () => {
+        clientHooks.listener = null;
+      };
+    }
+    async start() {}
+    stop() {}
+  },
+}));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return { ...actual, toast: toastMock };
+});
+
+import { useAppStore } from "./appStore";
+
+function makeTunnel(id: string, name: string): TunnelConfig {
+  return {
+    id,
+    name,
+    sshConnectionId: "conn-1",
+    tunnelType: {
+      type: "local",
+      config: { localHost: "127.0.0.1", localPort: 8080, remoteHost: "127.0.0.1", remotePort: 80 },
+    },
+    autoStart: false,
+    reconnectOnDisconnect: false,
+  };
+}
+
+function makeState(id: string, status: TunnelState["status"], error?: string): TunnelState {
+  return {
+    tunnelId: id,
+    status,
+    error,
+    stats: { bytesSent: 0, bytesReceived: 0, activeConnections: 0, totalConnections: 0 },
+  };
+}
+
+/** Push a projected `tunnels` view through the region client's onChange listener. */
+function pushView(states: Record<string, TunnelState>, tunnels: TunnelConfig[]): void {
+  clientHooks.listener?.({ version: 1, view: { tunnels, states } });
+}
+
+const accepted: IntentAck = { intentId: "intent-test", status: "accepted", produced: [] };
+
+describe("tunnelSlice — first-connect failure toast (#2169)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    clientHooks.listener = null;
+    vi.clearAllMocks();
+    dispatchMock.mockResolvedValue(accepted);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("re-raises a failure toast when a client-started tunnel transitions to error", async () => {
+    const t1 = makeTunnel("t1", "db");
+    await useAppStore.getState().loadTunnels();
+    pushView({ t1: makeState("t1", "disconnected") }, [t1]);
+
+    await useAppStore.getState().startTunnel("t1");
+    toastMock.error.mockClear(); // ignore any ack-path toast; assert on the projected one
+
+    // Handshake in progress, then fails during the connect.
+    pushView({ t1: makeState("t1", "connecting") }, [t1]);
+    expect(toastMock.error).not.toHaveBeenCalled();
+
+    pushView({ t1: makeState("t1", "error", "connection refused") }, [t1]);
+    expect(toastMock.error).toHaveBeenCalledTimes(1);
+    expect(toastMock.error.mock.calls[0][0]).toContain("Failed to start db");
+    expect(toastMock.error.mock.calls[0][0]).toContain("connection refused");
+  });
+
+  it("does not re-toast on a repeated/coalesced diff that still shows error", async () => {
+    const t1 = makeTunnel("t1", "db");
+    await useAppStore.getState().loadTunnels();
+    pushView({ t1: makeState("t1", "disconnected") }, [t1]);
+    await useAppStore.getState().startTunnel("t1");
+    toastMock.error.mockClear();
+
+    pushView({ t1: makeState("t1", "connecting") }, [t1]);
+    pushView({ t1: makeState("t1", "error", "connection refused") }, [t1]);
+    pushView({ t1: makeState("t1", "error", "connection refused") }, [t1]); // repeat
+    expect(toastMock.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not toast for a tunnel this client never started (mid-session death / other client)", async () => {
+    const t1 = makeTunnel("t1", "db");
+    await useAppStore.getState().loadTunnels();
+    // No startTunnel dispatched here — the tunnel was already connected and dies.
+    pushView({ t1: makeState("t1", "connected") }, [t1]);
+    pushView({ t1: makeState("t1", "error", "pipe broke") }, [t1]);
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  it("does not toast on a later mid-session death after a successful first connect", async () => {
+    const t1 = makeTunnel("t1", "db");
+    await useAppStore.getState().loadTunnels();
+    pushView({ t1: makeState("t1", "disconnected") }, [t1]);
+    await useAppStore.getState().startTunnel("t1");
+    toastMock.error.mockClear();
+
+    // Connects successfully — the watch resolves.
+    pushView({ t1: makeState("t1", "connecting") }, [t1]);
+    pushView({ t1: makeState("t1", "connected") }, [t1]);
+    // Later the tunnel dies mid-session: badge only, no first-connect toast.
+    pushView({ t1: makeState("t1", "error", "pipe broke") }, [t1]);
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  it("labels a failed reconnect as 'Failed to reconnect'", async () => {
+    const t1 = makeTunnel("t1", "db");
+    await useAppStore.getState().loadTunnels();
+    pushView({ t1: makeState("t1", "connected") }, [t1]);
+
+    await useAppStore.getState().reconnectTunnel("t1");
+    toastMock.error.mockClear();
+
+    // Reconnect tears down then fails on the fresh handshake.
+    pushView({ t1: makeState("t1", "disconnected") }, [t1]);
+    pushView({ t1: makeState("t1", "connecting") }, [t1]);
+    pushView({ t1: makeState("t1", "error", "auth failed") }, [t1]);
+    expect(toastMock.error).toHaveBeenCalledTimes(1);
+    expect(toastMock.error.mock.calls[0][0]).toContain("Failed to reconnect db");
+  });
+
+  it("scopes the watch to the current session — a re-subscribe clears pending watches", async () => {
+    const t1 = makeTunnel("t1", "db");
+    await useAppStore.getState().loadTunnels();
+    pushView({ t1: makeState("t1", "disconnected") }, [t1]);
+    await useAppStore.getState().startTunnel("t1");
+    toastMock.error.mockClear();
+
+    // Re-init (e.g. a store re-subscribe) drops the pending watch with the client.
+    await useAppStore.getState().loadTunnels();
+    pushView({ t1: makeState("t1", "connecting") }, [t1]);
+    pushView({ t1: makeState("t1", "error", "connection refused") }, [t1]);
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

Follow-up to #2150 (PR #2167). After the tunnels projection migration, `tunnel.start` / `tunnel.reconnect` are fire-and-forget: the intent ack only confirms the start was *accepted*, so a failure during the SSH handshake surfaced only as an **Error status badge** on the tunnel row — the transient red "Failed to start …" toast the old synchronous path produced was lost.

This restores that failure toast for parity, **driven from the projected status transition** — not by re-serialising the blocking handshake back onto the single-writer dispatcher (which would violate the substrate's "results are diffs" contract).

## How

- The tunnel slice now remembers each tunnel **this client** just dispatched a `start`/`reconnect` for (a module-local `Map<id, "start" | "reconnect">`, populated only after the ack is *accepted*).
- The `tunnels` region `onChange` handler compares the previously cached states against the freshly pushed ones and raises `toast.error("Failed to start/reconnect <name>: <detail>")` only on a genuine **`→ error` transition** for a watched tunnel, then stops watching it. Reaching `connected` resolves the watch silently (the ack already toasted success).
- Because the watch map is **per-client** and only holds ids this client dispatched, the toast fires **only for the initiating client**: a mid-session tunnel death, or another client's start in a multi-client world, is never in this client's map and so surfaces only as the Error badge.
- Transition-based detection (not a bare "is error" check) means a repeated/coalesced diff that still shows `error` cannot re-toast, and a stale pre-dispatch `error` from an earlier attempt is not mistaken for the new outcome.
- The success/validation toasts and the Error status badge/tooltip are unchanged. No backend change — the projection already streams `connecting → error` as diffs.

## Tests

New `src/store/tunnelSlice.failureToast.test.ts`:
- client-started tunnel `connecting → error` raises a failure toast with the error detail;
- no re-toast on a repeated/coalesced `error` diff;
- a tunnel this client never started (mid-session death / other client) does **not** toast;
- no toast on a later mid-session death after a successful first connect;
- a failed `reconnect` is labelled "Failed to reconnect";
- a re-subscribe clears pending watches (session scoping).

Verified red→green (3 assertions fail without the slice change). Full `vitest` (505 files), `eslint`, `prettier`, `tsc` build: green.

Closes #2169