### PR TITLE
fix(backend): carry kind discriminator on projection snapshot frame

### DIFF
--- a/src-tauri/src/projection/frame.rs
+++ b/src-tauri/src/projection/frame.rs
@@ -107,10 +107,18 @@ impl IntentAck {
 
 /// A projection frame pushed to a subscriber (channel 2, backend → UI).
 ///
-/// Internally tagged by `kind`, matching the TypeScript discriminated union
-/// `{ kind: "snapshot" | "diff", ... }`.
+/// A discriminated union on `kind`, matching the TypeScript
+/// `{ kind: "snapshot" | "diff", ... }`. The discriminator lives on each
+/// variant's own struct ([`SnapshotFrame::kind`] / [`DiffFrame::kind`]) rather
+/// than being synthesised by an internal serde `tag`, so a frame returned
+/// **bare** from a command (`projection_subscribe` / `projection_resync` hand
+/// back a lone [`SnapshotFrame`]) carries exactly the same `kind` as the same
+/// frame wrapped in this enum — no missing tag on the bare form, no doubled tag
+/// on the wrapped form (#2170). The enum is therefore `untagged`: it adds
+/// nothing to the wire, and the per-variant literal `kind` markers are what let
+/// deserialisation tell a snapshot from a diff.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(tag = "kind", rename_all = "lowercase")]
+#[serde(untagged)]
 pub enum ProjectionFrame {
     Snapshot(SnapshotFrame),
     Diff(DiffFrame),
@@ -134,12 +142,40 @@ impl ProjectionFrame {
     }
 }
 
+/// The `kind` discriminator of a [`SnapshotFrame`] — always `"snapshot"`.
+///
+/// A dedicated single-variant enum (rather than a bare `String`) so the field
+/// is self-describing and, crucially, so a *diff*'s `kind: "diff"` fails to
+/// deserialise into it — that mismatch is what lets the `untagged`
+/// [`ProjectionFrame`] discriminate the two frames.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum SnapshotKind {
+    #[default]
+    Snapshot,
+}
+
+/// The `kind` discriminator of a [`DiffFrame`] — always `"diff"`. See
+/// [`SnapshotKind`] for why this is a single-variant enum.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum DiffKind {
+    #[default]
+    Diff,
+}
+
 /// The complete, render-ready view model for a region at a baseline version.
 ///
 /// Emitted on attach and on resync only; steady state is [`DiffFrame`]s.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotFrame {
+    /// Discriminator (`"snapshot"`); carried on the struct so the bare
+    /// subscribe/resync return value tags itself, matching the TS
+    /// `SnapshotFrame` type (#2170). `default` keeps a producer that omits it
+    /// deserialisable.
+    #[serde(default)]
+    pub kind: SnapshotKind,
     pub region: String,
     /// `u64` monotonic; the cache adopts this as its baseline.
     pub version: u64,
@@ -154,6 +190,11 @@ pub struct SnapshotFrame {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct DiffFrame {
+    /// Discriminator (`"diff"`); carried on the struct so this frame tags
+    /// itself identically whether bare or wrapped in [`ProjectionFrame`]
+    /// (#2170). `default` keeps a producer that omits it deserialisable.
+    #[serde(default)]
+    pub kind: DiffKind,
     pub region: String,
     /// MUST equal the cache's current version, else it is a gap.
     pub base_version: u64,

--- a/src-tauri/src/projection/mod.rs
+++ b/src-tauri/src/projection/mod.rs
@@ -23,8 +23,8 @@ mod frame;
 mod region;
 
 pub use frame::{
-    DiffFrame, DiffOp, Intent, IntentAck, IntentErrorInfo, IntentStatus, ProducedRegion,
-    ProjectionFrame, SnapshotFrame,
+    DiffFrame, DiffKind, DiffOp, Intent, IntentAck, IntentErrorInfo, IntentStatus, ProducedRegion,
+    ProjectionFrame, SnapshotFrame, SnapshotKind,
 };
 pub use region::ProjectedStore;
 
@@ -144,6 +144,7 @@ impl RegionState {
 
     fn snapshot(&self, region: &str) -> SnapshotFrame {
         SnapshotFrame {
+            kind: SnapshotKind::Snapshot,
             region: region.to_string(),
             version: self.version,
             view: self.view.clone(),
@@ -252,6 +253,7 @@ impl Projector {
         state.view = new_view;
 
         let frame = ProjectionFrame::Diff(DiffFrame {
+            kind: DiffKind::Diff,
             region: region.to_string(),
             base_version,
             version,

--- a/src-tauri/src/projection/tests.rs
+++ b/src-tauri/src/projection/tests.rs
@@ -448,6 +448,7 @@ fn ack_omits_absent_fields() {
 #[test]
 fn projection_frame_is_tagged_by_kind() {
     let snap = ProjectionFrame::Snapshot(SnapshotFrame {
+        kind: SnapshotKind::Snapshot,
         region: "tunnels".into(),
         version: 41,
         view: json!({ "tunnels": [] }),
@@ -458,6 +459,7 @@ fn projection_frame_is_tagged_by_kind() {
     assert_eq!(v["version"], json!(41));
 
     let diff = ProjectionFrame::Diff(DiffFrame {
+        kind: DiffKind::Diff,
         region: "tunnels".into(),
         base_version: 41,
         version: 42,

--- a/src-tauri/src/projection/tests.rs
+++ b/src-tauri/src/projection/tests.rs
@@ -477,3 +477,57 @@ fn projection_frame_is_tagged_by_kind() {
     // Round-trips back to the same frame.
     assert_eq!(serde_json::from_value::<ProjectionFrame>(v).unwrap(), diff);
 }
+
+/// #2170 — a snapshot must carry exactly one `kind: "snapshot"` discriminator in
+/// *both* wire forms: the bare [`SnapshotFrame`] returned by
+/// `projection_subscribe` / `projection_resync`, and the enum-wrapped
+/// [`ProjectionFrame::Snapshot`] pushed over the diff channel. The original bug
+/// was a *missing* tag on the bare form; the fix must not introduce a *doubled*
+/// tag on the wrapped form.
+#[test]
+fn snapshot_frame_carries_single_kind_discriminator_in_both_forms() {
+    // Build a snapshot the way the wire delivers one (no explicit kind).
+    let bare: SnapshotFrame = serde_json::from_value(json!({
+        "region": "tunnels",
+        "version": 7,
+        "view": { "tunnels": [] },
+    }))
+    .expect("snapshot deserializes without an explicit kind");
+
+    // Standalone form — the subscribe/resync return value.
+    let standalone = serde_json::to_string(&bare).unwrap();
+    assert_eq!(
+        standalone.matches("\"kind\"").count(),
+        1,
+        "standalone snapshot must carry exactly one kind: {standalone}",
+    );
+    let standalone_v = serde_json::to_value(&bare).unwrap();
+    assert_eq!(standalone_v["kind"], json!("snapshot"));
+    assert_eq!(standalone_v["region"], json!("tunnels"));
+    assert_eq!(standalone_v["version"], json!(7));
+    assert_eq!(standalone_v["view"], json!({ "tunnels": [] }));
+
+    // Enum-wrapped form — the channel-pushed `ProjectionFrame::Snapshot`.
+    let wrapped = ProjectionFrame::Snapshot(bare.clone());
+    let wrapped_s = serde_json::to_string(&wrapped).unwrap();
+    assert_eq!(
+        wrapped_s.matches("\"kind\"").count(),
+        1,
+        "enum-wrapped snapshot must carry exactly one kind (no double tag): {wrapped_s}",
+    );
+    let wrapped_v = serde_json::to_value(&wrapped).unwrap();
+    assert_eq!(wrapped_v["kind"], json!("snapshot"));
+    assert_eq!(wrapped_v["region"], json!("tunnels"));
+    assert_eq!(wrapped_v["version"], json!(7));
+    assert_eq!(wrapped_v["view"], json!({ "tunnels": [] }));
+
+    // Both forms round-trip back to the same value.
+    assert_eq!(
+        serde_json::from_value::<SnapshotFrame>(standalone_v).unwrap(),
+        bare,
+    );
+    assert_eq!(
+        serde_json::from_value::<ProjectionFrame>(wrapped_v).unwrap(),
+        wrapped,
+    );
+}

--- a/tests/system/termihub_harness/projection.py
+++ b/tests/system/termihub_harness/projection.py
@@ -141,16 +141,14 @@ class ProjectionHarness(HarnessMixin):
     def assert_snapshot(
         snapshot: dict[str, Any], *, version: int, view: Any = None
     ) -> None:
-        """Assert a snapshot's ``version`` (and ``view`` if given).
+        """Assert a snapshot's ``kind`` discriminator, ``version`` (and ``view``).
 
-        The snapshot returned by ``projection_subscribe`` / ``projection_resync`` is
-        a bare ``SnapshotFrame`` on the wire — ``{region, version, view}`` with **no**
-        ``kind`` discriminator (only the channel-pushed ``ProjectionFrame`` enum
-        carries the ``kind`` tag). So ``kind`` is asserted only when present, and the
-        substantive check is on ``version`` (and ``view``). See #2170.
+        Every snapshot on the wire — the bare ``SnapshotFrame`` returned by
+        ``projection_subscribe`` / ``projection_resync`` *and* a channel-pushed
+        ``ProjectionFrame`` snapshot — carries ``kind: "snapshot"``, matching the TS
+        ``SnapshotFrame`` type. That is now required, not merely tolerated (#2170).
         """
-        if "kind" in snapshot:
-            assert snapshot["kind"] == "snapshot", f"not a snapshot frame: {snapshot}"
+        assert snapshot.get("kind") == "snapshot", f"not a snapshot frame: {snapshot}"
         assert (
             snapshot["version"] == version
         ), f"snapshot version {snapshot['version']} != {version}"


### PR DESCRIPTION
## Problem

The TS `ProjectionFrame` is a discriminated union on `kind`, but the Rust `SnapshotFrame` struct had no `kind` field — the discriminator was synthesised only by the `#[serde(tag = "kind")]` on the `ProjectionFrame` enum. So a snapshot returned **bare** from `projection_subscribe` / `projection_resync` serialized as `{region, version, view}` with **no `kind`**, inconsistent with the enum-wrapped form and mismatching its declared TS `SnapshotFrame` type.

## Fix

- Moved the discriminator onto each frame struct: `SnapshotFrame.kind: SnapshotKind` (always `"snapshot"`) and `DiffFrame.kind: DiffKind` (always `"diff"`), each a single-variant marker enum.
- Made `ProjectionFrame` `#[serde(untagged)]` — it now adds nothing to the wire, and the per-variant literal `kind` markers are what disambiguate on deserialize (a diff's `kind: "diff"` cannot deserialize into `SnapshotKind`, so the untagged enum still tells the two frames apart).
- Result: **exactly one** `kind: "snapshot"` in both forms — the bare command return value and the channel-pushed `ProjectionFrame::Snapshot` — with no doubled tag.
- `#[serde(default)]` on both `kind` fields keeps a producer that omits it deserializable.

## Tests

- Added a serde round-trip test pinning the snapshot JSON shape in both forms (standalone and enum-wrapped): asserts exactly one `kind: "snapshot"` (counted in the serialized string, so a doubled tag would fail) plus `{region, version, view}`, and round-trips both. Committed test-first (red before the fix).
- Tightened `assert_snapshot` in the projection Python harness to **require** `kind == "snapshot"` (it had been loosened to tolerate the missing field).

The TS `SnapshotFrame` type already declares `kind`, so no frontend change was needed.

Closes #2170