### PR TITLE
feat(ui): cut layout rendering to the projected render-list (Part of #2151)

### DIFF
--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -33,6 +33,7 @@ import {
   X,
 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useLayoutRenderTree } from "@/store/useLayoutRenderTree";
 import { PanelNode, LeafPanel, TerminalTab, DropEdge } from "@/types/terminal";
 import { getAllLeaves, findLeafByTab, isWindowEmpty } from "@/utils/panelTree";
 import { broadcastPanelClass } from "@/utils/broadcastPanel";
@@ -67,7 +68,10 @@ import { PanelErrorBoundary } from "./PanelErrorBoundary";
 import "./SplitView.css";
 
 export function SplitView() {
-  const rootPanel = useAppStore((s) => s.rootPanel);
+  // Structure from the projected layout render-list (#2151 step 3); content is
+  // overlaid per-tab from appStore. Flag-off / desync falls back to appStore's
+  // tree verbatim, so rendering is byte-for-byte unchanged.
+  const rootPanel = useLayoutRenderTree();
   const tabGroups = useAppStore((s) => s.tabGroups);
   const activeTabGroupId = useAppStore((s) => s.activeTabGroupId);
   const setActivePanel = useAppStore((s) => s.setActivePanel);

--- a/src/store/layoutBridge.test.ts
+++ b/src/store/layoutBridge.test.ts
@@ -10,10 +10,17 @@ import type { PanelNode, TerminalTab } from "@/types/terminal";
 
 import {
   collectTabs,
+  composeRenderTree,
+  type LayoutView,
   layoutIntentsEnabled,
+  layoutRenderFromProjectionEnabled,
+  minimalNodesEqual,
   reconcileNode,
   setLayoutIntentsEnabled,
+  setLayoutRenderFromProjectionEnabled,
   toMinimalNode,
+  treeSignature,
+  viewMatchesTree,
 } from "./layoutBridge";
 
 function tab(id: string, extra: Partial<TerminalTab> = {}): TerminalTab {
@@ -129,18 +136,108 @@ describe("layoutBridge — tree mapping", () => {
   });
 });
 
-describe("layoutBridge — feature flag", () => {
-  afterEach(() => setLayoutIntentsEnabled(null));
+describe("layoutBridge — render-from-projection helpers (#2151 step 3)", () => {
+  /** The projected (minimal) view of `tree()`, focused on panel `a`. */
+  function view(): LayoutView {
+    return { root: toMinimalNode(tree()), activePanelId: "a" };
+  }
 
-  it("is off by default", () => {
+  it("minimalNodesEqual: a tree equals its own minimal projection", () => {
+    expect(minimalNodesEqual(toMinimalNode(tree()), view().root)).toBe(true);
+  });
+
+  it("minimalNodesEqual: sensitive to tab order, active tab, sizes, and direction", () => {
+    const base = toMinimalNode(tree());
+    const reordered = toMinimalNode({
+      type: "split",
+      id: "root",
+      direction: "horizontal",
+      sizes: [50, 50],
+      children: [
+        { type: "leaf", id: "a", tabs: [tab("t2"), tab("t1")], activeTabId: "t1" },
+        { type: "leaf", id: "b", tabs: [tab("t3")], activeTabId: "t3" },
+      ],
+    });
+    expect(minimalNodesEqual(base, reordered)).toBe(false);
+
+    const otherActive = toMinimalNode({
+      type: "split",
+      id: "root",
+      direction: "horizontal",
+      sizes: [50, 50],
+      children: [
+        { type: "leaf", id: "a", tabs: [tab("t1"), tab("t2")], activeTabId: "t2" },
+        { type: "leaf", id: "b", tabs: [tab("t3")], activeTabId: "t3" },
+      ],
+    });
+    expect(minimalNodesEqual(base, otherActive)).toBe(false);
+  });
+
+  it("viewMatchesTree: true only when structure AND active panel align", () => {
+    expect(viewMatchesTree(view(), tree(), "a")).toBe(true);
+    // Active panel differs.
+    expect(viewMatchesTree(view(), tree(), "b")).toBe(false);
+    // A view missing a tab appStore still has (local add not yet in the region).
+    const stale: LayoutView = {
+      root: toMinimalNode({
+        type: "split",
+        id: "root",
+        direction: "horizontal",
+        sizes: [50, 50],
+        children: [
+          { type: "leaf", id: "a", tabs: [tab("t1")], activeTabId: "t1" },
+          { type: "leaf", id: "b", tabs: [tab("t3")], activeTabId: "t3" },
+        ],
+      }),
+      activePanelId: "a",
+    };
+    expect(viewMatchesTree(stale, tree(), "a")).toBe(false);
+    expect(viewMatchesTree(null, tree(), "a")).toBe(false);
+  });
+
+  it("composeRenderTree: structure from the view, rich content from appStore by id", () => {
+    const rich = composeRenderTree(view(), tree()) as Extract<PanelNode, { type: "split" }>;
+    const leafA = rich.children[0] as Extract<PanelNode, { type: "leaf" }>;
+    // Same structure as the source tree, with rich fields re-hydrated.
+    expect(leafA.tabs.map((t) => t.id)).toEqual(["t1", "t2"]);
+    expect(leafA.tabs[0].title).toBe("Tab t1");
+    expect(leafA.tabs[0].isActive).toBe(true);
+    expect(leafA.tabs[0].panelId).toBe("a");
+    expect(rich.sizes).toEqual([50, 50]);
+  });
+
+  it("treeSignature: stable for an unchanged tree, changes when structure changes", () => {
+    const a = treeSignature(tree(), "a");
+    expect(treeSignature(tree(), "a")).toBe(a);
+    expect(treeSignature(tree(), "b")).not.toBe(a);
+  });
+});
+
+describe("layoutBridge — feature flags", () => {
+  afterEach(() => {
+    setLayoutIntentsEnabled(null);
+    setLayoutRenderFromProjectionEnabled(null);
+  });
+
+  it("mutation cut is off by default (async round-trip needs GUI verification)", () => {
     setLayoutIntentsEnabled(null);
     expect(layoutIntentsEnabled()).toBe(false);
   });
 
-  it("honours a programmatic override", () => {
+  it("render cut is on by default (step 3: parity-safe by construction)", () => {
+    setLayoutRenderFromProjectionEnabled(null);
+    expect(layoutRenderFromProjectionEnabled()).toBe(true);
+  });
+
+  it("honours programmatic overrides on each flag independently", () => {
     setLayoutIntentsEnabled(true);
     expect(layoutIntentsEnabled()).toBe(true);
     setLayoutIntentsEnabled(false);
     expect(layoutIntentsEnabled()).toBe(false);
+
+    setLayoutRenderFromProjectionEnabled(false);
+    expect(layoutRenderFromProjectionEnabled()).toBe(false);
+    setLayoutRenderFromProjectionEnabled(true);
+    expect(layoutRenderFromProjectionEnabled()).toBe(true);
   });
 });

--- a/src/store/layoutBridge.test.ts
+++ b/src/store/layoutBridge.test.ts
@@ -19,7 +19,6 @@ import {
   setLayoutIntentsEnabled,
   setLayoutRenderFromProjectionEnabled,
   toMinimalNode,
-  treeSignature,
   viewMatchesTree,
 } from "./layoutBridge";
 
@@ -204,12 +203,6 @@ describe("layoutBridge — render-from-projection helpers (#2151 step 3)", () =>
     expect(leafA.tabs[0].isActive).toBe(true);
     expect(leafA.tabs[0].panelId).toBe("a");
     expect(rich.sizes).toEqual([50, 50]);
-  });
-
-  it("treeSignature: stable for an unchanged tree, changes when structure changes", () => {
-    const a = treeSignature(tree(), "a");
-    expect(treeSignature(tree(), "a")).toBe(a);
-    expect(treeSignature(tree(), "b")).not.toBe(a);
   });
 });
 

--- a/src/store/layoutBridge.ts
+++ b/src/store/layoutBridge.ts
@@ -172,7 +172,8 @@ export function layoutIntentsEnabled(): boolean {
  * identical to the pre-cut renderer, and live xterm DOM is reparented (never
  * remounted) because tab/panel ids are preserved. Independent of the mutation
  * cut: the region is seeded from `appStore` whether mutations are local or
- * intent-routed. Overridable for an instant rollback / A-B check via
+ * intent-routed. Overridable for rollback / an A-B check (the renderer reads it
+ * at mount, so a flip takes effect on reload) via
  * `window.__TERMIHUB_LAYOUT_RENDER__` or `localStorage["termihub.layoutRender"]`.
  */
 export function layoutRenderFromProjectionEnabled(): boolean {
@@ -503,16 +504,6 @@ export async function seedLayoutRegion(
     await dispatch("layout.replace", { root: toMinimalNode(root), activePanelId }),
     "replace"
   );
-}
-
-/** The `layout@<clientId>` region id (diagnostics/tests). */
-export function layoutRegionId(): string {
-  return region;
-}
-
-/** A stable structural signature of a tree + focus, for de-duping region seeds. */
-export function treeSignature(root: PanelNode, activePanelId: string | null): string {
-  return `${JSON.stringify(toMinimalNode(root))}|${activePanelId ?? ""}`;
 }
 
 /** Log a render-path fallback so the projection-cut recovery is visible. */

--- a/src/store/layoutBridge.ts
+++ b/src/store/layoutBridge.ts
@@ -1,5 +1,5 @@
 /**
- * Layout projection bridge — Phase 3 step 2 of the stateless-UI migration
+ * Layout projection bridge — Phase 3 steps 2–3 of the stateless-UI migration
  * (#2151, part of #2139).
  *
  * Step 1 landed a shadow, backend-authoritative `LayoutStore` served as the
@@ -8,8 +8,17 @@
  * the four structural mutations (split / move-tab / merge-a-tab / split-with-tab)
  * dispatch `layout.*` intents instead of editing `appStore.rootPanel` locally,
  * and the resulting projection diff is reconciled back into `appStore`'s
- * existing panel-tree shape so `SplitView` renders exactly as before (rendering
- * is cut over in step 3, the reducers removed in step 4).
+ * existing panel-tree shape so `SplitView` renders exactly as before.
+ *
+ * Step 3 cuts **rendering** over: the render helpers below
+ * ({@link viewMatchesTree}, {@link composeRenderTree}, {@link seedLayoutRegion})
+ * let {@link import("./useLayoutRenderTree").useLayoutRenderTree} source the
+ * renderer's panel/tab structure from the projected render-list (content still
+ * overlaid from `appStore` — partial projection). The two cuts are gated
+ * independently ({@link layoutIntentsEnabled} for mutations, off by default;
+ * {@link layoutRenderFromProjectionEnabled} for rendering, on by default) so the
+ * parity-safe render cut can ship live without the async mutation flip. The
+ * appStore panel-tree reducers are removed in step 4.
  *
  * # Seed-before-mutate
  *
@@ -27,10 +36,13 @@
  *
  * # Strangler safety
  *
- * The cut is gated by {@link layoutIntentsEnabled} — **off by default**, so the
- * shipped app keeps running on the untouched local reducers until step 3 flips
- * rendering over too. Even when enabled, any dispatch/reconcile failure falls
- * back to the local mutation, so a backend hiccup can never break layout.
+ * The mutation cut is gated by {@link layoutIntentsEnabled} — **off by default**,
+ * so the shipped app keeps running on the untouched local reducers. Even when
+ * enabled, any dispatch/reconcile failure falls back to the local mutation, so a
+ * backend hiccup can never break layout. The render cut
+ * ({@link layoutRenderFromProjectionEnabled}, on by default) is separately safe:
+ * it only composes from the projection when the view mirrors `appStore`'s tree,
+ * else falls back to that tree verbatim.
  */
 
 import {
@@ -72,10 +84,10 @@ interface MinimalSplit {
   sizes?: number[];
   lastActiveLeafId?: string;
 }
-type MinimalNode = MinimalLeaf | MinimalSplit;
+export type MinimalNode = MinimalLeaf | MinimalSplit;
 
 /** The `layout@<clientId>` region view model: tree + focused panel. */
-interface LayoutView {
+export interface LayoutView {
   root: MinimalNode;
   activePanelId: string | null;
 }
@@ -84,44 +96,87 @@ interface LayoutView {
 
 interface LayoutFlagWindow {
   __TERMIHUB_LAYOUT_INTENTS__?: boolean;
+  __TERMIHUB_LAYOUT_RENDER__?: boolean;
   localStorage?: Storage;
 }
 
 let flagOverride: boolean | null = null;
+let renderFlagOverride: boolean | null = null;
 
 /**
- * Programmatic override for the layout-intents flag (tests, and a runtime
- * toggle). `null` clears the override and falls back to the window/localStorage
- * signal, then to the default.
+ * Programmatic override for the layout-intents (mutation) flag (tests, and a
+ * runtime toggle). `null` clears the override and falls back to the
+ * window/localStorage signal, then to the default.
  */
 export function setLayoutIntentsEnabled(value: boolean | null): void {
   flagOverride = value;
 }
 
 /**
- * Whether structural layout mutations route through `layout.*` intents (step 2)
- * instead of mutating `appStore.rootPanel` locally.
- *
- * **Off by default.** Step 2 lands the machinery gated; step 3 (rendering cut)
- * flips the default on. Overridable at runtime for verification via
- * `window.__TERMIHUB_LAYOUT_INTENTS__` or `localStorage["termihub.layoutIntents"]`.
+ * Programmatic override for the render-from-projection flag (tests, runtime
+ * toggle). `null` clears it and falls back to the window/localStorage signal,
+ * then to the default.
  */
-export function layoutIntentsEnabled(): boolean {
-  if (flagOverride !== null) return flagOverride;
+export function setLayoutRenderFromProjectionEnabled(value: boolean | null): void {
+  renderFlagOverride = value;
+}
+
+/** Read a boolean feature signal from `window`/`localStorage`, else `dflt`. */
+function readFlag(
+  override: boolean | null,
+  windowKey: keyof LayoutFlagWindow,
+  storageKey: string,
+  dflt: boolean
+): boolean {
+  if (override !== null) return override;
   try {
     if (typeof window !== "undefined") {
       const w = window as unknown as LayoutFlagWindow;
-      if (typeof w.__TERMIHUB_LAYOUT_INTENTS__ === "boolean") {
-        return w.__TERMIHUB_LAYOUT_INTENTS__;
-      }
-      const ls = w.localStorage?.getItem("termihub.layoutIntents");
+      const wv = w[windowKey];
+      if (typeof wv === "boolean") return wv;
+      const ls = w.localStorage?.getItem(storageKey);
       if (ls === "true") return true;
       if (ls === "false") return false;
     }
   } catch {
     // A missing/blocked window or storage just means "use the default".
   }
-  return false;
+  return dflt;
+}
+
+/**
+ * Whether structural layout **mutations** route through `layout.*` intents
+ * (step 2) instead of editing `appStore.rootPanel` locally.
+ *
+ * **Off by default.** This makes the backend `LayoutStore` authoritative for
+ * mutations, which turns split/move/merge into asynchronous backend round-trips
+ * — a behavioural change that must be verified with a local GUI run before it
+ * ships on. It is intentionally decoupled from the render cut
+ * ({@link layoutRenderFromProjectionEnabled}), which is parity-safe on its own.
+ * Overridable at runtime via `window.__TERMIHUB_LAYOUT_INTENTS__` or
+ * `localStorage["termihub.layoutIntents"]`.
+ */
+export function layoutIntentsEnabled(): boolean {
+  return readFlag(flagOverride, "__TERMIHUB_LAYOUT_INTENTS__", "termihub.layoutIntents", false);
+}
+
+/**
+ * Whether the **renderer** sources its panel/tab structure from the projected
+ * `layout@<clientId>` render-list (step 3,
+ * {@link import("./useLayoutRenderTree").useLayoutRenderTree}) rather than from
+ * `appStore.rootPanel` directly.
+ *
+ * **On by default.** Parity-safe by construction: the renderer composes from the
+ * projection only when its view structurally mirrors `appStore`'s tree, and
+ * otherwise falls back to that tree verbatim — so the rendered output is always
+ * identical to the pre-cut renderer, and live xterm DOM is reparented (never
+ * remounted) because tab/panel ids are preserved. Independent of the mutation
+ * cut: the region is seeded from `appStore` whether mutations are local or
+ * intent-routed. Overridable for an instant rollback / A-B check via
+ * `window.__TERMIHUB_LAYOUT_RENDER__` or `localStorage["termihub.layoutRender"]`.
+ */
+export function layoutRenderFromProjectionEnabled(): boolean {
+  return readFlag(renderFlagOverride, "__TERMIHUB_LAYOUT_RENDER__", "termihub.layoutRender", true);
 }
 
 // ── Transport + region client (lazy, mirrors the tunnel slice) ─────────────────
@@ -340,4 +395,128 @@ export function moveTabPayload(
 export function logBridgeFallback(kind: string, err: unknown): void {
   const message = err instanceof Error ? err.message : String(err);
   frontendLog("layout_bridge", `${kind} fell back to local mutation: ${message}`);
+}
+
+// ── Render-from-projection (step 3): compose structure ⊕ content, gate, seed ──
+//
+// Step 2 made `LayoutStore` authoritative for structural mutations and mirrored
+// the reconciled tree back into `appStore.rootPanel`. Step 3 cuts the renderer
+// itself over: `SplitView` sources its panel/tab **structure** from the
+// projected `layout@<clientId>` render-list and overlays per-tab **content**
+// (title, colour, session status, broadcast, zoom) from `appStore` — the
+// partial-projection seam (Decision #2). The composition reuses the tested
+// {@link reconcileNode}: the projection supplies the tree shape (leaf/split
+// nodes, tab order, active tab, split sizes, panel ids); `appStore`'s current
+// rich tabs supply the content, re-attached by id. Because the composed tree
+// carries the same `tab.id`/`panel.id`s, the live xterm DOM (registered by tab
+// id, adopted by the id-keyed `TerminalSlot`) is reparented, never remounted.
+//
+// **Strangler safety.** The renderer only composes from the projection when the
+// projected view is a *faithful structural mirror* of `appStore`'s tree
+// ({@link viewMatchesTree}); otherwise it falls back to `appStore.rootPanel`
+// verbatim. Tab create/close/reorder/activate are not yet layout intents
+// (deferred), so those edit `appStore` locally and momentarily desync the
+// region — the gate makes the renderer fall back rather than show a stale tree,
+// and {@link seedLayoutRegion} catches the region back up so composing resumes.
+// The gate guarantees the composed tree is structurally identical to
+// `appStore.rootPanel`, so rendering can never diverge from the pre-cut output.
+
+/** Deep structural equality over two minimal projected trees (order-independent
+ * on object keys; array order is significant, as it is user-visible tab/panel
+ * order). */
+export function minimalNodesEqual(a: MinimalNode, b: MinimalNode): boolean {
+  if (a.type !== b.type) return false;
+  if (a.id !== b.id) return false;
+  if (a.type === "leaf" && b.type === "leaf") {
+    if (a.activeTabId !== b.activeTabId) return false;
+    if (a.tabs.length !== b.tabs.length) return false;
+    return a.tabs.every((t, i) => {
+      const o = b.tabs[i];
+      return (
+        t.id === o.id &&
+        (t.sessionId ?? null) === (o.sessionId ?? null) &&
+        t.contentType === o.contentType
+      );
+    });
+  }
+  if (a.type === "split" && b.type === "split") {
+    if (a.direction !== b.direction) return false;
+    if ((a.lastActiveLeafId ?? null) !== (b.lastActiveLeafId ?? null)) return false;
+    if (!sizesEqual(a.sizes, b.sizes)) return false;
+    if (a.children.length !== b.children.length) return false;
+    return a.children.every((c, i) => minimalNodesEqual(c, b.children[i]));
+  }
+  return false;
+}
+
+/** Compare two optional split-size arrays exactly. */
+function sizesEqual(a: number[] | undefined, b: number[] | undefined): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  return a.length === b.length && a.every((n, i) => n === b[i]);
+}
+
+/**
+ * Whether a projected `view` is a faithful structural mirror of `root` +
+ * `activePanelId` — the gate that decides if the renderer may source structure
+ * from the projection (true) or must fall back to `appStore` (false).
+ */
+export function viewMatchesTree(
+  view: LayoutView | null | undefined,
+  root: PanelNode,
+  activePanelId: string | null
+): boolean {
+  if (!view || !view.root) return false;
+  if ((view.activePanelId ?? null) !== (activePanelId ?? null)) return false;
+  return minimalNodesEqual(toMinimalNode(root), view.root);
+}
+
+/**
+ * Compose the rich render tree from a projected view: **structure** from
+ * `view.root`, **content** re-attached by tab id from `contentRoot`'s rich tabs.
+ * Throws (via {@link reconcileNode}) if the view references a tab absent from
+ * `contentRoot`; callers gate with {@link viewMatchesTree} first so this never
+ * throws on the happy path.
+ */
+export function composeRenderTree(view: LayoutView, contentRoot: PanelNode): PanelNode {
+  return reconcileNode(view.root, collectTabs(contentRoot));
+}
+
+/** Ensure the layout region client is subscribed; the renderer's entry point.
+ * `async` so a synchronous transport-construction failure (e.g. non-Tauri, no
+ * socket) surfaces as a rejection the caller can catch and fall back on. */
+export async function ensureLayoutRegionClient(): Promise<ProjectionClient> {
+  return ensureSubscribed();
+}
+
+/**
+ * Seed the layout region with a whole tree so the projection tracks
+ * `appStore`'s current structure (the render-side counterpart to the mutation
+ * bridge's seed-before-mutate). Idempotent server-side: replacing with the same
+ * tree yields no diff.
+ */
+export async function seedLayoutRegion(
+  root: PanelNode,
+  activePanelId: string | null
+): Promise<void> {
+  throwIfRejected(
+    await dispatch("layout.replace", { root: toMinimalNode(root), activePanelId }),
+    "replace"
+  );
+}
+
+/** The `layout@<clientId>` region id (diagnostics/tests). */
+export function layoutRegionId(): string {
+  return region;
+}
+
+/** A stable structural signature of a tree + focus, for de-duping region seeds. */
+export function treeSignature(root: PanelNode, activePanelId: string | null): string {
+  return `${JSON.stringify(toMinimalNode(root))}|${activePanelId ?? ""}`;
+}
+
+/** Log a render-path fallback so the projection-cut recovery is visible. */
+export function logRenderFallback(err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  frontendLog("layout_bridge", `render fell back to appStore tree: ${message}`);
 }

--- a/src/store/useLayoutRenderTree.test.tsx
+++ b/src/store/useLayoutRenderTree.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * `useLayoutRenderTree` — the renderer's cut to the projected layout render-list
+ * (#2151 step 3). Drives the hook against a simulated `layout@<clientId>` region
+ * and asserts: flag-off returns the appStore tree untouched and dispatches
+ * nothing; flag-on seeds the region and then composes the render tree from the
+ * projection (structure) + appStore (content), structurally identical to the
+ * appStore tree; and a region that has not caught up falls back to the appStore
+ * tree rather than render a stale structure.
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import type { LeafPanel, PanelNode, TerminalTab } from "@/types/terminal";
+
+interface RegionState {
+  version: number;
+  view: unknown;
+}
+
+const { backend, dispatched } = vi.hoisted(() => ({
+  backend: {
+    version: -1,
+    view: undefined as unknown,
+    listeners: new Set<(s: RegionState) => void>(),
+    /** When false, `layout.replace` is accepted but does NOT advance the region
+     * (simulates a region that has not caught up to appStore). */
+    applyReplace: true,
+    push(view: unknown) {
+      this.version += 1;
+      this.view = view;
+      const snapshot = { version: this.version, view: this.view };
+      this.listeners.forEach((l) => l(snapshot));
+    },
+    reset() {
+      this.version = -1;
+      this.view = undefined;
+      this.listeners.clear();
+      this.applyReplace = true;
+    },
+  },
+  dispatched: [] as { kind: string; payload: Record<string, unknown> }[],
+}));
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  getSettings: vi.fn(() =>
+    Promise.resolve({ version: "1", externalConnectionFiles: [], powerMonitoringEnabled: true })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn(() => vi.fn()) }));
+
+vi.mock("@/services/transport", () => ({
+  newClientId: () => "client-test",
+  newIntentId: () => "intent-test",
+  createTransport: () => ({
+    async dispatch(intent: { kind: string; payload: Record<string, unknown> }) {
+      dispatched.push({ kind: intent.kind, payload: intent.payload });
+      if (intent.kind === "layout.replace" && backend.applyReplace) {
+        backend.push({ root: intent.payload.root, activePanelId: intent.payload.activePanelId });
+      }
+      return {
+        intentId: "intent-test",
+        status: "accepted",
+        produced: [{ region: "layout@client-test", version: backend.version }],
+      };
+    },
+    subscribe: vi.fn(),
+    resync: vi.fn(),
+  }),
+  ProjectionClient: class {
+    constructor(
+      _transport: unknown,
+      public readonly region: string
+    ) {}
+    get state(): RegionState {
+      return { version: backend.version, view: backend.view };
+    }
+    onChange(listener: (s: RegionState) => void) {
+      backend.listeners.add(listener);
+      return () => backend.listeners.delete(listener);
+    }
+    async start() {
+      // The store seeds an unknown client's region to a single empty leaf.
+      backend.push({
+        root: { type: "leaf", id: "seed", tabs: [], activeTabId: null },
+        activePanelId: "seed",
+      });
+    }
+    stop() {}
+  },
+}));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return { ...actual, toast: { loading: vi.fn(), success: vi.fn(), error: vi.fn() } };
+});
+
+import { useAppStore } from "./appStore";
+import { setLayoutRenderFromProjectionEnabled, toMinimalNode } from "./layoutBridge";
+import { useLayoutRenderTree } from "./useLayoutRenderTree";
+
+function tab(id: string): TerminalTab {
+  return {
+    id,
+    sessionId: `sess-${id}`,
+    title: `Tab ${id}`,
+    connectionType: "local",
+    contentType: "terminal",
+    config: {} as TerminalTab["config"],
+    panelId: "a",
+    isActive: id === "t1",
+  } as TerminalTab;
+}
+
+function seedTree(): PanelNode {
+  return {
+    type: "split",
+    id: "root",
+    direction: "horizontal",
+    sizes: [50, 50],
+    children: [
+      { type: "leaf", id: "a", tabs: [tab("t1"), tab("t2")], activeTabId: "t1" },
+      { type: "leaf", id: "b", tabs: [tab("t3")], activeTabId: "t3" },
+    ] as LeafPanel[],
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let latest: PanelNode | null = null;
+
+function Probe() {
+  latest = useLayoutRenderTree();
+  return null;
+}
+
+async function mount() {
+  await act(async () => {
+    root.render(<Probe />);
+  });
+  // Let the async subscribe + seed + onChange settle.
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+describe("useLayoutRenderTree (#2151 step 3)", () => {
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
+    backend.reset();
+    dispatched.length = 0;
+    latest = null;
+    setLayoutRenderFromProjectionEnabled(null);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    setLayoutRenderFromProjectionEnabled(null);
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("flag off: returns the appStore tree verbatim and dispatches nothing", async () => {
+    setLayoutRenderFromProjectionEnabled(false);
+    await mount();
+    expect(dispatched).toHaveLength(0);
+    expect(latest).toBe(useAppStore.getState().rootPanel);
+  });
+
+  it("flag on: seeds the region, then composes structure⊕content matching appStore", async () => {
+    setLayoutRenderFromProjectionEnabled(true);
+    await mount();
+
+    // The initial snapshot was a single empty leaf (not a mirror) → the hook
+    // seeded the region with appStore's tree.
+    expect(dispatched.map((d) => d.kind)).toContain("layout.replace");
+
+    // Composed from the projection: structurally identical to appStore's tree.
+    const store = useAppStore.getState().rootPanel;
+    expect(latest).not.toBeNull();
+    expect(toMinimalNode(latest!)).toEqual(toMinimalNode(store));
+
+    const split = latest as Extract<PanelNode, { type: "split" }>;
+    const leafA = split.children[0] as LeafPanel;
+    // Rich content re-hydrated by id.
+    expect(leafA.tabs.map((t) => t.id)).toEqual(["t1", "t2"]);
+    expect(leafA.tabs[0].title).toBe("Tab t1");
+    expect(leafA.tabs[0].sessionId).toBe("sess-t1");
+  });
+
+  it("flag on but region never catches up: falls back to the appStore tree", async () => {
+    setLayoutRenderFromProjectionEnabled(true);
+    backend.applyReplace = false; // region stays on the initial single-leaf snapshot
+    await mount();
+
+    // Seed was attempted, but the region did not advance to a mirror.
+    expect(dispatched.map((d) => d.kind)).toContain("layout.replace");
+    // Renderer fell back to appStore's tree rather than showing the stale leaf.
+    expect(latest).toBe(useAppStore.getState().rootPanel);
+  });
+});

--- a/src/store/useLayoutRenderTree.ts
+++ b/src/store/useLayoutRenderTree.ts
@@ -39,8 +39,10 @@ import {
   type LayoutView,
   layoutRenderFromProjectionEnabled,
   logRenderFallback,
+  type MinimalNode,
+  minimalNodesEqual,
   seedLayoutRegion,
-  treeSignature,
+  toMinimalNode,
   viewMatchesTree,
 } from "@/store/layoutBridge";
 import type { ProjectionCacheState, ProjectionClient } from "@/services/transport";
@@ -62,7 +64,7 @@ export function useLayoutRenderTree(): PanelNode {
 
   const [regionState, setRegionState] = useState<ProjectionCacheState | null>(null);
   const clientRef = useRef<ProjectionClient | null>(null);
-  const lastSeededSig = useRef<string | null>(null);
+  const lastSeeded = useRef<{ root: MinimalNode; activePanelId: string | null } | null>(null);
 
   // Subscribe to the layout region while enabled; a transport that cannot
   // subscribe (non-Tauri without a socket) just leaves the renderer on the
@@ -91,13 +93,20 @@ export function useLayoutRenderTree(): PanelNode {
 
   // Keep the region a faithful mirror of appStore's structure. When the view is
   // not a mirror (initial single-leaf snapshot, or a local non-intent edit),
-  // seed it with the current tree so composing can resume. De-duped by
-  // signature so a settled tree is not reseeded on every render.
+  // seed it with the current tree so composing can resume. De-duped so a settled
+  // tree is not reseeded on every render.
   useEffect(() => {
     if (!enabled || !clientRef.current || matches) return;
-    const sig = treeSignature(storeRoot, storeActivePanelId);
-    if (sig === lastSeededSig.current) return;
-    lastSeededSig.current = sig;
+    const minimal = toMinimalNode(storeRoot);
+    const prev = lastSeeded.current;
+    if (
+      prev &&
+      prev.activePanelId === storeActivePanelId &&
+      minimalNodesEqual(prev.root, minimal)
+    ) {
+      return;
+    }
+    lastSeeded.current = { root: minimal, activePanelId: storeActivePanelId };
     seedLayoutRegion(storeRoot, storeActivePanelId).catch((err) => logRenderFallback(err));
     // `regionState` is a dep so the seed re-evaluates once the region snapshot
     // first arrives (which sets `clientRef` but may leave `matches` false).

--- a/src/store/useLayoutRenderTree.ts
+++ b/src/store/useLayoutRenderTree.ts
@@ -18,8 +18,9 @@
  *
  * # Safety (strangler)
  *
- * - **Gated** by {@link layoutIntentsEnabled}. Flag off → the hook returns
- *   `appStore.rootPanel` verbatim, so the renderer is byte-for-byte unchanged.
+ * - **Gated** by {@link layoutRenderFromProjectionEnabled}. Flag off → the hook
+ *   returns `appStore.rootPanel` verbatim, so the renderer is byte-for-byte
+ *   unchanged.
  * - **Faithful-mirror gate.** The projection drives the render only when its
  *   view is a structural mirror of `appStore`'s tree ({@link viewMatchesTree}).
  *   Tab create/close/reorder/activate are not yet layout intents, so they edit

--- a/src/store/useLayoutRenderTree.ts
+++ b/src/store/useLayoutRenderTree.ts
@@ -1,0 +1,119 @@
+/**
+ * `useLayoutRenderTree` — the renderer's cut to the projected layout render-list
+ * (#2151 step 3, part of #2139).
+ *
+ * `SplitView` renders the active tab group's panel tree. Through step 2 that
+ * tree came straight from `appStore.rootPanel` (a mirror the mutation bridge
+ * reconciled from the `layout@<clientId>` projection). Step 3 makes the
+ * **renderer** source its structure from the projection directly and overlay
+ * per-tab content from `appStore` — the partial-projection seam (Decision #2:
+ * the layout region carries only panel structure + minimal tab identity; title,
+ * colour, session status, broadcast and zoom stay in `appStore`).
+ *
+ * The hook returns a rich {@link PanelNode} — structure from the projection,
+ * content re-attached by tab id from `appStore`'s current tree — so `SplitView`
+ * consumes it exactly where it used to read `appStore.rootPanel` (one call
+ * site). Because the composed tree preserves every `tab.id`/`panel.id`, the live
+ * xterm DOM is reparented, never remounted (see {@link composeRenderTree}).
+ *
+ * # Safety (strangler)
+ *
+ * - **Gated** by {@link layoutIntentsEnabled}. Flag off → the hook returns
+ *   `appStore.rootPanel` verbatim, so the renderer is byte-for-byte unchanged.
+ * - **Faithful-mirror gate.** The projection drives the render only when its
+ *   view is a structural mirror of `appStore`'s tree ({@link viewMatchesTree}).
+ *   Tab create/close/reorder/activate are not yet layout intents, so they edit
+ *   `appStore` locally and momentarily desync the region; while desynced the
+ *   hook falls back to `appStore.rootPanel` (never a stale tree) and
+ *   {@link seedLayoutRegion} catches the region up so composing resumes. The
+ *   gate guarantees the composed tree is structurally identical to
+ *   `appStore.rootPanel`, so rendering can never diverge from the pre-cut output.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { useAppStore } from "@/store/appStore";
+import {
+  composeRenderTree,
+  ensureLayoutRegionClient,
+  type LayoutView,
+  layoutRenderFromProjectionEnabled,
+  logRenderFallback,
+  seedLayoutRegion,
+  treeSignature,
+  viewMatchesTree,
+} from "@/store/layoutBridge";
+import type { ProjectionCacheState, ProjectionClient } from "@/services/transport";
+import type { PanelNode } from "@/types/terminal";
+
+/**
+ * The active tab group's panel tree for rendering: structure sourced from the
+ * projected layout region when it faithfully mirrors `appStore`, otherwise
+ * `appStore.rootPanel` verbatim (flag off, region not yet caught up, or a
+ * transport that cannot subscribe).
+ */
+export function useLayoutRenderTree(): PanelNode {
+  const storeRoot = useAppStore((s) => s.rootPanel);
+  const storeActivePanelId = useAppStore((s) => s.activePanelId);
+
+  // Read the flag once at mount: it flips only via dev tooling, and the
+  // subscription lifecycle is keyed off it below.
+  const [enabled] = useState(() => layoutRenderFromProjectionEnabled());
+
+  const [regionState, setRegionState] = useState<ProjectionCacheState | null>(null);
+  const clientRef = useRef<ProjectionClient | null>(null);
+  const lastSeededSig = useRef<string | null>(null);
+
+  // Subscribe to the layout region while enabled; a transport that cannot
+  // subscribe (non-Tauri without a socket) just leaves the renderer on the
+  // appStore fallback.
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    let unsubscribe = (): void => {};
+    ensureLayoutRegionClient()
+      .then((client) => {
+        if (cancelled) return;
+        clientRef.current = client;
+        setRegionState(client.state);
+        unsubscribe = client.onChange((state) => setRegionState(state));
+      })
+      .catch((err) => logRenderFallback(err));
+    return () => {
+      cancelled = true;
+      unsubscribe();
+      clientRef.current = null;
+    };
+  }, [enabled]);
+
+  const view = regionState?.view as LayoutView | undefined;
+  const matches = enabled && viewMatchesTree(view, storeRoot, storeActivePanelId);
+
+  // Keep the region a faithful mirror of appStore's structure. When the view is
+  // not a mirror (initial single-leaf snapshot, or a local non-intent edit),
+  // seed it with the current tree so composing can resume. De-duped by
+  // signature so a settled tree is not reseeded on every render.
+  useEffect(() => {
+    if (!enabled || !clientRef.current || matches) return;
+    const sig = treeSignature(storeRoot, storeActivePanelId);
+    if (sig === lastSeededSig.current) return;
+    lastSeededSig.current = sig;
+    seedLayoutRegion(storeRoot, storeActivePanelId).catch((err) => logRenderFallback(err));
+    // `regionState` is a dep so the seed re-evaluates once the region snapshot
+    // first arrives (which sets `clientRef` but may leave `matches` false).
+  }, [enabled, matches, storeRoot, storeActivePanelId, regionState]);
+
+  return useMemo(() => {
+    if (matches && view) {
+      try {
+        return composeRenderTree(view, storeRoot);
+      } catch (err) {
+        // A tab referenced by the view but absent from appStore — treat as a
+        // desync and fall back rather than throw in render.
+        logRenderFallback(err);
+        return storeRoot;
+      }
+    }
+    return storeRoot;
+  }, [matches, view, storeRoot]);
+}


### PR DESCRIPTION
## Phase 3 · step 3 — cut layout **rendering** to the projected render-list

Part of #2151 (part of #2139). Steps 1 (shadow `LayoutStore`, PR #2174) and 2 (mutation cut, PR #2177) merged; this is **step 3 of 5**. The umbrella issue stays open for steps 4–5.

### What changes

`SplitView` now sources its panel/tab **structure** from the projected `layout@<clientId>` render-list and overlays per-tab **content** (title, colour, session status, broadcast, zoom) from `appStore` — the partial-projection seam (Decision #2). The composition reuses the step-2 `reconcileNode`: the projection supplies the tree shape (leaf/split nodes, tab order, active tab, split sizes, panel ids); `appStore`'s rich tabs supply the content, re-attached by id.

The new `useLayoutRenderTree()` hook (`src/store/useLayoutRenderTree.ts`) subscribes to the layout region, seeds it from `appStore`'s tree when they diverge, and composes the render tree. `SplitView` consumes it at the **single call site** that used to read `appStore.rootPanel` (line 70) — the whole tree flows down from there as props, so no other renderer change is needed.

### Live xterm survival (the parity-critical point)

The `<Terminal>` DOM elements are a stable pool keyed by `tab.id` (in `TerminalHost`); `TerminalSlot` adopts them by `tab.id` via `appendChild` and parks them on unmount. Because the composed render tree **preserves every `tab.id`/`panel.id`**, a re-render from the projection reparents the live xterm element — it never remounts — so scrollback, PTY session, and view-mode all survive every layout change. `reconcileNode` re-attaches the same rich `TerminalTab` objects by id and re-derives `panelId`/`isActive` exactly as the old reducers did.

### Strangler safety — parity by construction

The render cut is gated by a **new, separate** flag `layoutRenderFromProjectionEnabled` (**on by default**), decoupled from step 2's `layoutIntentsEnabled` (**still off by default**):

- The renderer composes from the projection **only when the projected view is a faithful structural mirror** of `appStore`'s tree (`viewMatchesTree`: same tree shape, tab order, active tab, sizes, panel ids, and active panel). Otherwise it returns `appStore.rootPanel` **verbatim**. So the rendered output is *always* structurally identical to the pre-cut renderer — there is no input under which rendering diverges.
- Tab create/close/reorder/activate are not yet layout intents; they edit `appStore` locally and briefly desync the region. While desynced the hook falls back to the store tree, and `seedLayoutRegion` catches the region up so composing resumes.

**Why the flags are decoupled:** flipping the *mutation* cut on makes split/move/merge asynchronous backend round-trips — a behavioural change that needs a local GUI run before shipping (it also breaks a handful of synchronous-assertion unit tests). The *render* cut is parity-safe on its own and independent of where mutations run (the region is seeded from `appStore` either way), so it ships live now; the mutation flip stays available at runtime for a GUI-verified flip later. Both flags are runtime-flippable (`window.__TERMIHUB_LAYOUT_RENDER__` / `localStorage["termihub.layoutRender"]`, read at mount → effective on reload) for rollback / A-B.

`appStore`'s panel-tree reducers are **untouched** (removed in step 4).

### Tests

- `src/store/layoutBridge.test.ts` — new bridge helpers (`minimalNodesEqual`, `viewMatchesTree`, `composeRenderTree`) and both decoupled flag defaults/overrides.
- `src/store/useLayoutRenderTree.test.tsx` — drives the hook against a simulated region: flag-off returns the store tree untouched and dispatches nothing; flag-on seeds the region then composes a tree structurally identical to the store tree with rich content re-hydrated by id; a region that never catches up falls back to the store tree.
- Full frontend suite green (4721). `cargo fmt`/`clippy -D warnings` clean (no Rust changed). Production `pnpm build` green.

### Verification note

Automated verification only: unit tests + typecheck + lint + clippy/fmt + production build. Parity is guaranteed **by construction** (identical composed tree, else verbatim fallback) and live-terminal survival follows from id-preservation, so the render cut is safe to default on. Interactive GUI drag-drop parity was **not** exercised in this automated environment — manual steps below for the reviewer's own check before (optionally) flipping the mutation cut on too.

#### Manual test steps (reviewer)

Run `./scripts/dev.sh`. With the render cut on by default: split a panel, drag a tab to an edge (split) and to center (merge), move a tab across panels, close tabs, change focus, zoom. Confirm pixel/behaviour parity with `develop`. Open a shell, produce scrollback, then split/move its panel — scrollback and the live session must survive. To A-B: set `localStorage["termihub.layoutRender"]="false"` and reload to compare against the pre-cut renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Follow-ups

- #2184 — verify + enable the mutation cut (`layoutIntentsEnabled`) by default (deferred here pending a GUI parity run).
