### PR TITLE
feat(tunnel): tunnel host field + run-location routing seam (part of #2155)

### DIFF
--- a/docs/changes/dev0/feature/2155-agent-hosted-tunnels.md
+++ b/docs/changes/dev0/feature/2155-agent-hosted-tunnels.md
@@ -1,0 +1,18 @@
+### Added
+
+- SSH tunnels now carry a first-class **Tunnel host** dimension (part of the
+  agent-centric stateless-UI port, #2155 / #2139). Each tunnel records where its
+  SSH client runs — **This computer** (the default, exactly today's behaviour) or
+  a named **Agent** — surfaced as a run-location selector in the tunnel editor and
+  a per-row **host badge** on every tunnel in the Tunnels sidebar and the Open
+  Connections panel (including "this computer", so the vantage point is always
+  legible). The editor names each endpoint by its concrete machine and address
+  ("Listens on agent build-box · 127.0.0.1:5432") instead of a bare
+  "local"/"remote" adjective, and flags the reachability trap — an agent-hosted
+  loopback listener is reachable only from the agent — with a non-blocking warning
+  and a one-click **Widen bind** remediation. SSH semantics are unchanged; only
+  the host machine moves. New tunnels default to This computer, so agent hosting
+  is strictly opt-in. Actually forwarding an agent-hosted tunnel (the agent-side
+  backend) is not wired yet — selecting an agent and starting the tunnel surfaces
+  a clear "not yet supported" error rather than silently forwarding on the
+  desktop; the agent backend lands as a follow-up.

--- a/src-tauri/src/tunnel/config.rs
+++ b/src-tauri/src/tunnel/config.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::run_location::RunLocation;
+
 /// The three SSH tunnel types.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", content = "config", rename_all = "camelCase")]
@@ -62,6 +64,15 @@ pub struct TunnelConfig {
     pub ssh_connection_id: String,
     /// Tunnel type and its specific configuration.
     pub tunnel_type: TunnelType,
+    /// Which machine hosts (runs the SSH client for) this tunnel.
+    ///
+    /// [`RunLocation::ThisComputer`] (the default) is today's behaviour — the
+    /// forward runs on the desktop. [`RunLocation::Agent`] routes hosting to a
+    /// remote agent through the S1 run-location resolver (S3, #2155). Defaulted
+    /// on deserialize so tunnels saved before this field existed load as
+    /// desktop-hosted, and so agent hosting stays opt-in.
+    #[serde(default)]
+    pub host: RunLocation,
     /// Whether to start this tunnel automatically when the app launches.
     #[serde(default)]
     pub auto_start: bool,
@@ -142,6 +153,7 @@ mod tests {
                 remote_host: "db.internal".to_string(),
                 remote_port: 5432,
             }),
+            host: RunLocation::ThisComputer,
             auto_start: true,
             reconnect_on_disconnect: false,
         };
@@ -170,6 +182,7 @@ mod tests {
                 local_host: "127.0.0.1".to_string(),
                 local_port: 3000,
             }),
+            host: RunLocation::ThisComputer,
             auto_start: false,
             reconnect_on_disconnect: true,
         };
@@ -195,6 +208,7 @@ mod tests {
                 local_host: "127.0.0.1".to_string(),
                 local_port: 1080,
             }),
+            host: RunLocation::ThisComputer,
             auto_start: false,
             reconnect_on_disconnect: false,
         };
@@ -221,6 +235,7 @@ mod tests {
                     remote_host: "localhost".to_string(),
                     remote_port: 80,
                 }),
+                host: RunLocation::ThisComputer,
                 auto_start: false,
                 reconnect_on_disconnect: false,
             }],
@@ -298,6 +313,36 @@ mod tests {
         let config: TunnelConfig = serde_json::from_str(json).unwrap();
         assert!(!config.auto_start);
         assert!(!config.reconnect_on_disconnect);
+        // A config saved before the run-location field existed loads as
+        // desktop-hosted, so agent hosting is opt-in (S3, #2155).
+        assert_eq!(config.host, RunLocation::ThisComputer);
+    }
+
+    #[test]
+    fn host_round_trips_and_defaults_to_this_computer() {
+        // Explicit agent host round-trips through the tagged run-location shape.
+        let config = TunnelConfig {
+            id: "tun-agent".to_string(),
+            name: "Agent DB".to_string(),
+            ssh_connection_id: "conn-1".to_string(),
+            tunnel_type: TunnelType::Local(LocalForwardConfig {
+                local_host: "127.0.0.1".to_string(),
+                local_port: 5432,
+                remote_host: "db.internal".to_string(),
+                remote_port: 5432,
+            }),
+            host: RunLocation::Agent("build-box".to_string()),
+            auto_start: false,
+            reconnect_on_disconnect: false,
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["host"]["kind"], "agent");
+        assert_eq!(json["host"]["agentId"], "build-box");
+        let back: TunnelConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(back.host, RunLocation::Agent("build-box".to_string()));
+
+        // The serde default (no field in JSON) is desktop hosting.
+        assert_eq!(RunLocation::default(), RunLocation::ThisComputer);
     }
 
     #[test]
@@ -312,6 +357,7 @@ mod tests {
                 remote_host: "localhost".to_string(),
                 remote_port: 80,
             }),
+            host: RunLocation::ThisComputer,
             auto_start: false,
             reconnect_on_disconnect: false,
         };

--- a/src-tauri/src/tunnel/projection_tests.rs
+++ b/src-tauri/src/tunnel/projection_tests.rs
@@ -41,6 +41,7 @@ fn local_tunnel(id: &str, name: &str) -> TunnelConfig {
             remote_host: "db.internal".to_string(),
             remote_port: 5432,
         }),
+        host: crate::run_location::RunLocation::ThisComputer,
         auto_start: false,
         reconnect_on_disconnect: false,
     }
@@ -55,6 +56,7 @@ fn dynamic_tunnel(id: &str, name: &str) -> TunnelConfig {
             local_host: "127.0.0.1".to_string(),
             local_port: 1080,
         }),
+        host: crate::run_location::RunLocation::ThisComputer,
         auto_start: false,
         reconnect_on_disconnect: false,
     }

--- a/src-tauri/src/tunnel/tunnel_manager.rs
+++ b/src-tauri/src/tunnel/tunnel_manager.rs
@@ -1316,9 +1316,10 @@ mod tests {
     use super::super::connecting::{ConnectingTracker, FinishOutcome};
     use super::super::local_forward::ForwarderStats;
     use super::{
-        backoff_delay, clear_last_error, last_error_for, record_last_error, resolve_local_tunnel_host,
-        resolve_managed_arc, resting_status, run_reconnect_loop, snapshot_active_stats,
-        wait_forwarder_death, wait_session_death, ActiveTunnel, ReconnectOutcome, TunnelStatsUpdate,
+        backoff_delay, clear_last_error, last_error_for, record_last_error,
+        resolve_local_tunnel_host, resolve_managed_arc, resting_status, run_reconnect_loop,
+        snapshot_active_stats, wait_forwarder_death, wait_session_death, ActiveTunnel,
+        ReconnectOutcome, TunnelStatsUpdate,
     };
     use crate::run_location::RunLocation;
     use crate::tunnel::config::TunnelStatus;
@@ -1543,8 +1544,9 @@ mod tests {
     /// never a silent fall-through to the desktop path.
     #[test]
     fn agent_host_is_not_yet_supported() {
-        let err = resolve_local_tunnel_host(TUNNEL_ID, &RunLocation::Agent("build-box".to_string()))
-            .expect_err("agent-hosted tunnels must not resolve to the local path yet");
+        let err =
+            resolve_local_tunnel_host(TUNNEL_ID, &RunLocation::Agent("build-box".to_string()))
+                .expect_err("agent-hosted tunnels must not resolve to the local path yet");
         assert!(err.contains("not yet supported"), "message: {err}");
         assert!(err.contains("build-box"), "message names the agent: {err}");
         assert!(err.contains(TUNNEL_ID), "message names the tunnel: {err}");

--- a/src-tauri/src/tunnel/tunnel_manager.rs
+++ b/src-tauri/src/tunnel/tunnel_manager.rs
@@ -23,6 +23,7 @@ use super::remote_forward::RemoteForwarder;
 use super::storage::TunnelStorage;
 use crate::connection::manager::ConnectionManager;
 use crate::connection::recovery::RecoveryWarning;
+use crate::run_location::{Locality, ResolvedLocation, RunLocationResolver};
 use crate::utils::errors::TerminalError;
 use crate::utils::ssh_auth::connect_with_registry_cancellable;
 
@@ -140,6 +141,29 @@ fn resting_status(
         (TunnelStatus::Error, Some(error))
     } else {
         (TunnelStatus::Disconnected, None)
+    }
+}
+
+/// Decide whether a tunnel may start on the desktop's local forwarder path, per
+/// its run-location host (S3, #2155).
+///
+/// A tunnel is never desktop-only, so the resolver honours whatever host the
+/// config carries. [`RunLocation::ThisComputer`] resolves to the local path
+/// (`Ok(())`) — today's behaviour. [`RunLocation::Agent`] is recognised but the
+/// agent-side tunnel forwarding backend is not built yet, so it yields a
+/// human-readable error the caller records + emits as the tunnel's resting
+/// `Error` rather than silently forwarding on the desktop. Pure (no locking, no
+/// IO, no `AppHandle`) so the routing decision is unit-testable directly.
+fn resolve_local_tunnel_host(
+    tunnel_id: &str,
+    host: &crate::run_location::RunLocation,
+) -> Result<(), String> {
+    match RunLocationResolver::new().resolve(tunnel_id, Locality::LocalOrAgent, host) {
+        Ok(ResolvedLocation::Local) => Ok(()),
+        Ok(ResolvedLocation::Agent(agent_id)) => Err(format!(
+            "agent-hosted tunnels are not yet supported (tunnel '{tunnel_id}' requested agent '{agent_id}')"
+        )),
+        Err(e) => Err(e.to_string()),
     }
 }
 
@@ -413,6 +437,18 @@ impl TunnelManager {
                     TerminalError::TunnelError(format!("Tunnel not found: {}", tunnel_id))
                 })?
         };
+
+        // Route by run-location (S3, #2155). Desktop-hosted tunnels (the default)
+        // take the existing local forwarder path below; agent-hosted tunnels are
+        // recognised here but their forwarding backend is not built yet, so
+        // surface a clear, durable `Error` rather than silently running the
+        // forward on the desktop. Mirrors the analogous stub in
+        // `NetworkManager::spawn_http_monitor` (S1, #2148).
+        if let Err(message) = resolve_local_tunnel_host(tunnel_id, &config.host) {
+            record_last_error(&self.last_errors, tunnel_id, message.clone());
+            self.emit_status(tunnel_id, TunnelStatus::Error, Some(message.clone()));
+            return Err(TerminalError::TunnelError(message));
+        }
 
         // Check if already active
         {
@@ -1280,10 +1316,11 @@ mod tests {
     use super::super::connecting::{ConnectingTracker, FinishOutcome};
     use super::super::local_forward::ForwarderStats;
     use super::{
-        backoff_delay, clear_last_error, last_error_for, record_last_error, resolve_managed_arc,
-        resting_status, run_reconnect_loop, snapshot_active_stats, wait_forwarder_death,
-        wait_session_death, ActiveTunnel, ReconnectOutcome, TunnelStatsUpdate,
+        backoff_delay, clear_last_error, last_error_for, record_last_error, resolve_local_tunnel_host,
+        resolve_managed_arc, resting_status, run_reconnect_loop, snapshot_active_stats,
+        wait_forwarder_death, wait_session_death, ActiveTunnel, ReconnectOutcome, TunnelStatsUpdate,
     };
+    use crate::run_location::RunLocation;
     use crate::tunnel::config::TunnelStatus;
     use tauri::Manager;
     use termihub_core::backends::ssh::session_pool::{PooledRef, RefPool};
@@ -1493,6 +1530,24 @@ mod tests {
         );
         assert_eq!(status, TunnelStatus::Error);
         assert_eq!(error.as_deref(), Some("connect refused"));
+    }
+
+    /// S3 (#2155): a desktop-hosted tunnel routes to the local forwarder path.
+    #[test]
+    fn this_computer_host_routes_local() {
+        assert!(resolve_local_tunnel_host(TUNNEL_ID, &RunLocation::ThisComputer).is_ok());
+    }
+
+    /// S3 (#2155): an agent-hosted tunnel is recognised but not yet forwardable,
+    /// so it yields a clear error naming the tunnel and the requested agent —
+    /// never a silent fall-through to the desktop path.
+    #[test]
+    fn agent_host_is_not_yet_supported() {
+        let err = resolve_local_tunnel_host(TUNNEL_ID, &RunLocation::Agent("build-box".to_string()))
+            .expect_err("agent-hosted tunnels must not resolve to the local path yet");
+        assert!(err.contains("not yet supported"), "message: {err}");
+        assert!(err.contains("build-box"), "message names the agent: {err}");
+        assert!(err.contains(TUNNEL_ID), "message names the tunnel: {err}");
     }
 
     /// GAP 3: "never started" (no map entry) stays `Disconnected` — distinct

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -26,6 +26,7 @@ import {
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Modal, Button, Tooltip, Progress, ConfirmDialog, toast } from "@/components/ui";
 import { formatBytes } from "@/utils/formatters";
+import { resolveTunnelHost, isAgentHost, tunnelHostBadge } from "@/utils/tunnelHost";
 import type { TransferState } from "@/types/connection";
 import type { MonitoringEntry } from "@/types/monitoring";
 import { MONITORING_INTERVAL_OPTIONS, DEFAULT_MONITORING_INTERVAL_MS } from "@/types/monitoring";
@@ -841,12 +842,23 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
               // the "connecting" badge, error surfaces its persisted message.
               const badge: BadgeVariant =
                 status === "connected" ? "connected" : status === "error" ? "error" : "connecting";
+              // Vantage badge: always state where the tunnel is hosted (S3, #2155),
+              // then append any error message.
+              const tunnelHost = resolveTunnelHost(t);
+              const hostAgentName = isAgentHost(tunnelHost)
+                ? (remoteAgents.find((a) => a.id === tunnelHost.agentId)?.name ??
+                  tunnelHost.agentId)
+                : undefined;
+              const hostBadge = tunnelHostBadge(tunnelHost, hostAgentName);
+              const hostText = hostBadge.onAgent ? `agent ${hostBadge.label}` : "this computer";
+              const detail =
+                status === "error" && state?.error ? `${hostText} · ${state.error}` : hostText;
               return (
                 <ConnectionRow
                   key={t.id}
                   icon={<ArrowLeftRight size={14} />}
                   title={t.name}
-                  detail={status === "error" ? state?.error : undefined}
+                  detail={detail}
                   badge={badge}
                   onKill={() => handleKillTunnel(t.id)}
                   killLabel="Stop"

--- a/src/components/TunnelEditor/TunnelEditor.css
+++ b/src/components/TunnelEditor/TunnelEditor.css
@@ -122,3 +122,70 @@
   padding-top: 8px;
   border-top: 1px solid var(--border-primary);
 }
+
+/* Named endpoint lines — surface the vantage point (S3, #2155). */
+.tunnel-editor__endpoints {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  background: var(--bg-secondary);
+  font-size: 12.5px;
+  line-height: 1.6;
+}
+
+.tunnel-editor__endpoints-host {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+
+.tunnel-editor__endpoint-line code {
+  font-family: var(--font-mono, monospace);
+  color: var(--text-primary);
+}
+
+.tunnel-editor__endpoint-note {
+  color: var(--text-secondary);
+}
+
+/* Non-blocking reachability warning for an agent-hosted loopback listen. */
+.tunnel-editor__reachability {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-warning);
+  border-radius: var(--radius-md);
+  background: var(--bg-warning);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+
+.tunnel-editor__reachability-icon {
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: var(--color-warning);
+}
+
+.tunnel-editor__reachability-text {
+  color: var(--text-primary);
+}
+
+.tunnel-editor__reachability-action {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent-color);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.tunnel-editor__reachability-action:hover {
+  color: var(--text-primary);
+}

--- a/src/components/TunnelEditor/TunnelEditor.host.test.tsx
+++ b/src/components/TunnelEditor/TunnelEditor.host.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Tunnel host (run-location) tests for the TunnelEditor (S3, #2155): the
+ * "Tunnel host" field, named endpoint lines naming the concrete machine, the
+ * non-blocking reachability warning for an agent-hosted loopback listen, and its
+ * "Widen bind" remediation.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TunnelEditor } from "./TunnelEditor";
+import { TooltipProvider } from "@/components/ui";
+import type { SavedConnection } from "@/types/connection";
+import type { TunnelConfig } from "@/types/tunnel";
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+const TAB_ID = "tab-tun-host";
+const PANEL_ID = "panel-tun-host";
+
+const SSH_CONN: SavedConnection = {
+  id: "ssh-1",
+  name: "bastion",
+  config: { type: "ssh", config: { host: "h", username: "u" } },
+  folderId: null,
+};
+
+// The editor only reads id + name off a remote agent.
+const AGENT = { id: "agent-1", name: "build-box" };
+
+const AGENT_TUNNEL: TunnelConfig = {
+  id: "tun-agent",
+  name: "db",
+  sshConnectionId: "ssh-1",
+  tunnelType: {
+    type: "local",
+    config: {
+      localHost: "127.0.0.1",
+      localPort: 5432,
+      remoteHost: "db.internal",
+      remotePort: 5432,
+    },
+  },
+  host: { kind: "agent", agentId: "agent-1" },
+  autoStart: false,
+  reconnectOnDisconnect: false,
+};
+
+const ROOT_PANEL = {
+  type: "leaf",
+  id: PANEL_ID,
+  tabs: [{ id: TAB_ID }],
+  activeTabId: TAB_ID,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+let saveTunnel: ReturnType<typeof vi.fn>;
+
+function render(tunnelId: string | null) {
+  act(() => {
+    root.render(
+      <TooltipProvider>
+        <TunnelEditor tabId={TAB_ID} meta={{ tunnelId }} isVisible={true} />
+      </TooltipProvider>
+    );
+  });
+}
+
+function q(testid: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+}
+
+describe("TunnelEditor — tunnel host (S3, #2155)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    saveTunnel = vi.fn(() => Promise.resolve());
+    useAppStore.setState({
+      ...useAppStore.getInitialState(),
+      connections: [SSH_CONN],
+      tunnels: [AGENT_TUNNEL],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      remoteAgents: [AGENT as any],
+      saveTunnel,
+      startTunnel: vi.fn(() => Promise.resolve()),
+      closeTab: vi.fn(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      rootPanel: ROOT_PANEL as any,
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("exposes a Tunnel host field", () => {
+    render(null);
+    expect(q("tunnel-editor-host")).not.toBeNull();
+  });
+
+  it("names the concrete machine in the endpoint lines for a new (desktop) tunnel", () => {
+    render(null);
+    const endpoints = q("tunnel-editor-endpoints");
+    expect(endpoints?.textContent).toContain("this computer");
+    expect(endpoints?.textContent).toContain("Listens on");
+    // No reachability warning for a desktop-hosted tunnel.
+    expect(q("tunnel-editor-reachability")).toBeNull();
+  });
+
+  it("names the agent and warns for an agent-hosted loopback listen", () => {
+    render("tun-agent");
+    const endpoints = q("tunnel-editor-endpoints");
+    expect(endpoints?.textContent).toContain("agent build-box");
+    const warning = q("tunnel-editor-reachability");
+    expect(warning).not.toBeNull();
+    expect(warning?.textContent).toContain("build-box");
+  });
+
+  it("Widen bind rewrites the loopback listen to 0.0.0.0 and clears the warning", () => {
+    render("tun-agent");
+    const widen = q("tunnel-editor-widen-bind") as HTMLButtonElement;
+    expect(widen).not.toBeNull();
+    act(() => widen.click());
+    // The warning is gone (bind is no longer loopback) and the endpoint line
+    // reflects the widened address.
+    expect(q("tunnel-editor-reachability")).toBeNull();
+    expect(q("tunnel-editor-endpoints")?.textContent).toContain("0.0.0.0:5432");
+  });
+
+  it("persists the agent host through Save", async () => {
+    render("tun-agent");
+    const save = q("tunnel-editor-save") as HTMLButtonElement;
+    await act(async () => {
+      save.click();
+    });
+    expect(saveTunnel).toHaveBeenCalledTimes(1);
+    const saved = saveTunnel.mock.calls[0][0] as TunnelConfig;
+    expect(saved.host).toEqual({ kind: "agent", agentId: "agent-1" });
+  });
+});

--- a/src/components/TunnelEditor/TunnelEditor.host.test.tsx
+++ b/src/components/TunnelEditor/TunnelEditor.host.test.tsx
@@ -58,7 +58,7 @@ const ROOT_PANEL = {
 
 let container: HTMLDivElement;
 let root: Root;
-let saveTunnel: ReturnType<typeof vi.fn>;
+let saveTunnel: (config: TunnelConfig) => Promise<void>;
 
 function render(tunnelId: string | null) {
   act(() => {
@@ -140,8 +140,8 @@ describe("TunnelEditor — tunnel host (S3, #2155)", () => {
     await act(async () => {
       save.click();
     });
-    expect(saveTunnel).toHaveBeenCalledTimes(1);
-    const saved = saveTunnel.mock.calls[0][0] as TunnelConfig;
+    expect(vi.mocked(saveTunnel)).toHaveBeenCalledTimes(1);
+    const saved = vi.mocked(saveTunnel).mock.calls[0][0];
     expect(saved.host).toEqual({ kind: "agent", agentId: "agent-1" });
   });
 });

--- a/src/components/TunnelEditor/TunnelEditor.tsx
+++ b/src/components/TunnelEditor/TunnelEditor.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect } from "react";
+import { Monitor, Server, AlertTriangle } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import {
   TunnelConfig,
@@ -6,15 +7,34 @@ import {
   LocalForwardConfig,
   RemoteForwardConfig,
   DynamicForwardConfig,
+  RunLocation,
+  THIS_COMPUTER,
 } from "@/types/tunnel";
 import { TunnelEditorMeta } from "@/types/terminal";
 import { Button, Input, NumberInput, Select, Field, Toggle, toast } from "@/components/ui";
 import { useEditorKeyboard } from "@/hooks/useEditorKeyboard";
 import { useAutofocusSelect } from "@/hooks/useAutofocusSelect";
 import { frontendLog } from "@/utils/frontendLog";
+import {
+  isAgentHost,
+  tunnelEndpointLines,
+  tunnelReachabilityWarning,
+  WIDE_BIND_HOST,
+} from "@/utils/tunnelHost";
 import { TunnelDiagram } from "./TunnelDiagram";
 import { validateTunnelType } from "./tunnelValidation";
 import "./TunnelEditor.css";
+
+/** Encode a run-location as a `Select` option value, and decode it back. */
+const HOST_THIS = "this";
+function encodeHost(host: RunLocation): string {
+  return isAgentHost(host) ? `agent:${host.agentId}` : HOST_THIS;
+}
+function decodeHost(value: string): RunLocation {
+  return value.startsWith("agent:")
+    ? { kind: "agent", agentId: value.slice("agent:".length) }
+    : THIS_COMPUTER;
+}
 
 interface TunnelEditorProps {
   tabId: string;
@@ -55,6 +75,7 @@ function defaultTunnelType(type: "local" | "remote" | "dynamic"): TunnelType {
 export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
   const tunnels = useAppStore((s) => s.tunnels);
   const connections = useAppStore((s) => s.connections);
+  const remoteAgents = useAppStore((s) => s.remoteAgents);
   const saveTunnel = useAppStore((s) => s.saveTunnel);
   const startTunnel = useAppStore((s) => s.startTunnel);
   const closeTab = useAppStore((s) => s.closeTab);
@@ -73,6 +94,9 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
   const [tunnelType, setTunnelType] = useState<TunnelType>(
     existingTunnel?.tunnelType ?? defaultTunnelType("local")
   );
+  // Which machine hosts this tunnel (S3, #2155). New tunnels default to This
+  // computer — agent hosting is opt-in.
+  const [host, setHost] = useState<RunLocation>(existingTunnel?.host ?? THIS_COMPUTER);
   const [autoStart, setAutoStart] = useState(existingTunnel?.autoStart ?? false);
   const [reconnect, setReconnect] = useState(existingTunnel?.reconnectOnDisconnect ?? false);
 
@@ -82,6 +106,7 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
       setName(existingTunnel.name);
       setSshConnectionId(existingTunnel.sshConnectionId);
       setTunnelType(existingTunnel.tunnelType);
+      setHost(existingTunnel.host ?? THIS_COMPUTER);
       setAutoStart(existingTunnel.autoStart);
       setReconnect(existingTunnel.reconnectOnDisconnect);
     }
@@ -122,6 +147,7 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
         name: name || "Untitled Tunnel",
         sshConnectionId,
         tunnelType,
+        host,
         autoStart,
         reconnectOnDisconnect: reconnect,
       };
@@ -150,6 +176,7 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
       name,
       sshConnectionId,
       tunnelType,
+      host,
       autoStart,
       reconnect,
       saveTunnel,
@@ -169,6 +196,26 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
   }, [rootPanel, tabId, closeTab]);
 
   const sshOptions = sshConnections.map((c) => ({ value: c.id, label: c.name }));
+
+  // Tunnel host (run-location) selector: This computer + every remote agent.
+  const hostOptions = [
+    { value: HOST_THIS, label: "This computer" },
+    ...remoteAgents.map((a) => ({ value: `agent:${a.id}`, label: `Agent · ${a.name}` })),
+  ];
+  const hostAgentName = isAgentHost(host)
+    ? (remoteAgents.find((a) => a.id === host.agentId)?.name ?? host.agentId)
+    : undefined;
+  const sshLabel = sshConnections.find((c) => c.id === sshConnectionId)?.name;
+  const endpointLines = tunnelEndpointLines(tunnelType, host, {
+    agentName: hostAgentName,
+    sshLabel,
+  });
+  const reachability = tunnelReachabilityWarning(tunnelType, host, hostAgentName);
+
+  /** Widen an agent-hosted loopback bind to 0.0.0.0 so this computer can reach it. */
+  const handleWidenBind = useCallback(() => {
+    updateConfig("localHost", WIDE_BIND_HOST);
+  }, [updateConfig]);
 
   const nameRef = useAutofocusSelect<HTMLInputElement>();
 
@@ -215,6 +262,16 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
           />
         </Field>
 
+        <Field label="Tunnel host" htmlFor={`tunnel-host-${tabId}`}>
+          <Select
+            value={encodeHost(host)}
+            onChange={(v) => setHost(decodeHost(v))}
+            options={hostOptions}
+            aria-label="Tunnel host"
+            data-testid="tunnel-editor-host"
+          />
+        </Field>
+
         <div className="tunnel-editor__field">
           <label className="tunnel-editor__label">Tunnel Type</label>
           <div className="tunnel-editor__type-selector" data-testid="tunnel-editor-type-selector">
@@ -246,6 +303,41 @@ export function TunnelEditor({ tabId, meta, isVisible }: TunnelEditorProps) {
         </div>
 
         <TunnelDiagram tunnelType={tunnelType} />
+
+        <div className="tunnel-editor__endpoints" data-testid="tunnel-editor-endpoints">
+          <div className="tunnel-editor__endpoints-host">
+            {isAgentHost(host) ? <Server size={13} /> : <Monitor size={13} />}
+            <span>
+              Host:{" "}
+              <strong>{isAgentHost(host) ? `agent ${hostAgentName}` : "this computer"}</strong>
+            </span>
+          </div>
+          {endpointLines.map((line, i) => (
+            <div className="tunnel-editor__endpoint-line" key={i}>
+              <strong>{line.label}</strong> {line.machine && <span>{line.machine}</span>}
+              {line.machine && line.address ? " · " : ""}
+              {line.address && <code>{line.address}</code>}
+              {line.note && <span className="tunnel-editor__endpoint-note"> ({line.note})</span>}
+            </div>
+          ))}
+        </div>
+
+        {reachability && (
+          <div className="tunnel-editor__reachability" data-testid="tunnel-editor-reachability">
+            <AlertTriangle size={14} className="tunnel-editor__reachability-icon" />
+            <span className="tunnel-editor__reachability-text">
+              {reachability.message}{" "}
+              <button
+                type="button"
+                className="tunnel-editor__reachability-action"
+                onClick={handleWidenBind}
+                data-testid="tunnel-editor-widen-bind"
+              >
+                Widen bind
+              </button>
+            </span>
+          </div>
+        )}
 
         {tunnelType.type === "local" && (
           <>

--- a/src/components/TunnelSidebar/TunnelListItem.host.test.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.host.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Vantage host-badge tests for the tunnel list item (S3, #2155): every row shows
+ * where the tunnel is hosted — "this computer" for desktop tunnels, the agent
+ * name for agent-hosted ones.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TunnelListItem } from "./TunnelListItem";
+import { withTooltip } from "@/test/tooltip";
+import type { TunnelConfig, TunnelState } from "@/types/tunnel";
+import type { SavedConnection } from "@/types/connection";
+
+const noop = () => {};
+
+const BASE: Omit<TunnelConfig, "host"> = {
+  id: "tun-1",
+  name: "My Tunnel",
+  sshConnectionId: "ssh-1",
+  autoStart: false,
+  reconnectOnDisconnect: false,
+  tunnelType: {
+    type: "local",
+    config: { localHost: "127.0.0.1", localPort: 8080, remoteHost: "example.com", remotePort: 80 },
+  },
+};
+
+const STATE: TunnelState = {
+  tunnelId: "tun-1",
+  status: "connected",
+  stats: { bytesSent: 0, bytesReceived: 0, activeConnections: 0, totalConnections: 0 },
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderItem(tunnel: TunnelConfig): void {
+  act(() => {
+    root.render(
+      withTooltip(
+        <TunnelListItem
+          tunnel={tunnel}
+          state={STATE}
+          connections={[] as SavedConnection[]}
+          onStart={noop}
+          onStop={noop}
+          onReconnect={noop}
+          onEdit={noop}
+          onDuplicate={noop}
+          onDelete={noop}
+        />
+      )
+    );
+  });
+}
+
+function badge(): HTMLElement | null {
+  return container.querySelector<HTMLElement>('[data-testid="tunnel-host-tun-1"]');
+}
+
+describe("TunnelListItem — vantage host badge (S3, #2155)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState({
+      ...useAppStore.getInitialState(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      remoteAgents: [{ id: "agent-1", name: "build-box" } as any],
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("reads 'this computer' for a desktop-hosted tunnel (default)", () => {
+    renderItem({ ...BASE, host: { kind: "thisComputer" } });
+    expect(badge()?.textContent).toContain("this computer");
+    expect(badge()?.getAttribute("data-on-agent")).toBe("false");
+  });
+
+  it("reads 'this computer' when the host field is absent (legacy config)", () => {
+    renderItem({ ...BASE } as TunnelConfig);
+    expect(badge()?.textContent).toContain("this computer");
+  });
+
+  it("names the agent for an agent-hosted tunnel", () => {
+    renderItem({ ...BASE, host: { kind: "agent", agentId: "agent-1" } });
+    expect(badge()?.textContent).toContain("build-box");
+    expect(badge()?.getAttribute("data-on-agent")).toBe("true");
+  });
+});

--- a/src/components/TunnelSidebar/TunnelListItem.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.tsx
@@ -1,11 +1,24 @@
 import type React from "react";
-import { Play, Square, Pencil, Copy, Trash2, RotateCw, Info, AlertTriangle } from "lucide-react";
+import {
+  Play,
+  Square,
+  Pencil,
+  Copy,
+  Trash2,
+  RotateCw,
+  Info,
+  AlertTriangle,
+  Monitor,
+  Server,
+} from "lucide-react";
 import { Button, Tooltip, toast } from "@/components/ui";
 import { SidebarListItem, SidebarStatusDot } from "@/components/SidebarListItem";
 import type { SidebarStatusTone } from "@/components/SidebarListItem";
 import { TunnelConfig, TunnelState, TunnelStatus } from "@/types/tunnel";
 import { SavedConnection } from "@/types/connection";
 import { formatBytes } from "@/utils/formatters";
+import { useAppStore } from "@/store/appStore";
+import { resolveTunnelHost, isAgentHost, tunnelHostBadge } from "@/utils/tunnelHost";
 
 interface TunnelListItemProps {
   tunnel: TunnelConfig;
@@ -77,12 +90,21 @@ export function TunnelListItem({
   rowRef,
   rowProps,
 }: TunnelListItemProps) {
+  const remoteAgents = useAppStore((s) => s.remoteAgents);
   const status = state?.status ?? "disconnected";
   const isActive = status === "connected" || status === "connecting" || status === "reconnecting";
   const isError = status === "error";
   const lastError = state?.error;
   const sshConn = connections.find((c) => c.id === tunnel.sshConnectionId);
   const sshLabel = sshConn?.name ?? "Unknown";
+
+  // Vantage badge: which machine hosts this tunnel (S3, #2155). Always shown,
+  // including "this computer" for desktop tunnels.
+  const tunnelHost = resolveTunnelHost(tunnel);
+  const hostAgentName = isAgentHost(tunnelHost)
+    ? (remoteAgents.find((a) => a.id === tunnelHost.agentId)?.name ?? tunnelHost.agentId)
+    : undefined;
+  const hostBadge = tunnelHostBadge(tunnelHost, hostAgentName);
   const typeLabel =
     tunnel.tunnelType.type.charAt(0).toUpperCase() + tunnel.tunnelType.type.slice(1);
 
@@ -241,6 +263,21 @@ export function TunnelListItem({
         <>
           <span>{getPortMapping(tunnel)}</span>
           <span>via {sshLabel}</span>
+          <span
+            className="tunnel-item__host"
+            data-testid={`tunnel-host-${tunnel.id}`}
+            data-on-agent={hostBadge.onAgent}
+            title={
+              hostBadge.onAgent ? `Hosted on agent ${hostBadge.label}` : "Hosted on this computer"
+            }
+          >
+            {hostBadge.onAgent ? (
+              <Server size={11} className="tunnel-item__host-icon" />
+            ) : (
+              <Monitor size={11} className="tunnel-item__host-icon" />
+            )}
+            <span className="tunnel-item__host-label">{hostBadge.label}</span>
+          </span>
           {isActive && state?.stats && (
             <div className="tunnel-item__stats">
               <span>↑ {formatBytes(state.stats.bytesSent)}</span>

--- a/src/components/TunnelSidebar/TunnelSidebar.css
+++ b/src/components/TunnelSidebar/TunnelSidebar.css
@@ -83,3 +83,19 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* Vantage host badge on a tunnel row (S3, #2155). */
+.tunnel-item__host {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--text-secondary);
+}
+
+.tunnel-item__host[data-on-agent="true"] {
+  color: var(--accent-color);
+}
+
+.tunnel-item__host-icon {
+  flex-shrink: 0;
+}

--- a/src/types/tunnel.ts
+++ b/src/types/tunnel.ts
@@ -34,12 +34,29 @@ export type TunnelType =
   | { type: "remote"; config: RemoteForwardConfig }
   | { type: "dynamic"; config: DynamicForwardConfig };
 
+/**
+ * Where a capability (here: a tunnel's SSH client) runs — the S1 run-location
+ * (#2148). Mirrors the Rust `RunLocation` enum's tagged serde shape
+ * (`{ kind: "thisComputer" }` | `{ kind: "agent", agentId }`).
+ */
+export type RunLocation = { kind: "thisComputer" } | { kind: "agent"; agentId: string };
+
+/** The desktop-host run-location — the default for a tunnel. */
+export const THIS_COMPUTER: RunLocation = { kind: "thisComputer" };
+
 /** A saved tunnel configuration. */
 export interface TunnelConfig {
   id: string;
   name: string;
   sshConnectionId: string;
   tunnelType: TunnelType;
+  /**
+   * Which machine hosts (runs the SSH client for) this tunnel (S3, #2155).
+   * Optional for backward compatibility: a config persisted before this field
+   * existed, or a hand-built fixture, is treated as {@link THIS_COMPUTER}. The
+   * Rust side defaults the field on load, so the projection always sends it.
+   */
+  host?: RunLocation;
   autoStart: boolean;
   reconnectOnDisconnect: boolean;
 }

--- a/src/utils/tunnelHost.test.ts
+++ b/src/utils/tunnelHost.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import type { RunLocation, TunnelType } from "@/types/tunnel";
+import {
+  resolveTunnelHost,
+  isAgentHost,
+  isLoopbackBind,
+  tunnelHostBadge,
+  tunnelEndpointLines,
+  tunnelReachabilityWarning,
+} from "./tunnelHost";
+
+const AGENT: RunLocation = { kind: "agent", agentId: "agent-1" };
+const THIS: RunLocation = { kind: "thisComputer" };
+
+const local = (localHost = "127.0.0.1"): TunnelType => ({
+  type: "local",
+  config: { localHost, localPort: 5432, remoteHost: "db.internal", remotePort: 5432 },
+});
+const remote = (): TunnelType => ({
+  type: "remote",
+  config: { remoteHost: "0.0.0.0", remotePort: 8080, localHost: "127.0.0.1", localPort: 3000 },
+});
+const dynamic = (localHost = "127.0.0.1"): TunnelType => ({
+  type: "dynamic",
+  config: { localHost, localPort: 1080 },
+});
+
+describe("resolveTunnelHost", () => {
+  it("defaults a missing host to This computer", () => {
+    expect(resolveTunnelHost({ host: undefined })).toEqual({ kind: "thisComputer" });
+  });
+  it("returns an explicit host unchanged", () => {
+    expect(resolveTunnelHost({ host: AGENT })).toEqual(AGENT);
+  });
+});
+
+describe("isAgentHost / isLoopbackBind", () => {
+  it("narrows the agent variant", () => {
+    expect(isAgentHost(AGENT)).toBe(true);
+    expect(isAgentHost(THIS)).toBe(false);
+  });
+  it("recognises loopback binds but not widened ones", () => {
+    expect(isLoopbackBind("127.0.0.1")).toBe(true);
+    expect(isLoopbackBind("localhost")).toBe(true);
+    expect(isLoopbackBind("::1")).toBe(true);
+    expect(isLoopbackBind("0.0.0.0")).toBe(false);
+    expect(isLoopbackBind("10.0.0.5")).toBe(false);
+  });
+});
+
+describe("tunnelHostBadge", () => {
+  it("reads 'this computer' for the desktop host", () => {
+    expect(tunnelHostBadge(THIS)).toEqual({ label: "this computer", onAgent: false });
+  });
+  it("names the agent, preferring the resolved name over the id", () => {
+    expect(tunnelHostBadge(AGENT, "build-box")).toEqual({ label: "build-box", onAgent: true });
+    expect(tunnelHostBadge(AGENT)).toEqual({ label: "agent-1", onAgent: true });
+  });
+});
+
+describe("tunnelEndpointLines", () => {
+  it("names the concrete machine on an agent-hosted local forward", () => {
+    const lines = tunnelEndpointLines(local(), AGENT, {
+      agentName: "build-box",
+      sshLabel: "bastion",
+    });
+    expect(lines[0].label).toBe("Listens on");
+    expect(lines[0].machine).toBe("agent build-box");
+    expect(lines[0].address).toBe("127.0.0.1:5432");
+    expect(lines[0].note).toContain("only from processes on build-box");
+    expect(lines[1].machine).toContain("SSH server bastion");
+    expect(lines[2].label).toBe("Forwards to");
+    expect(lines[2].note).toContain("resolved from the SSH server");
+  });
+
+  it("keeps the desktop-hosted local forward reading 'this computer'", () => {
+    const lines = tunnelEndpointLines(local(), THIS, { sshLabel: "bastion" });
+    expect(lines[0].machine).toBe("this computer");
+    expect(lines[0].note).toContain("apps on this computer");
+  });
+
+  it("puts the listen side on the SSH server for a remote forward", () => {
+    const lines = tunnelEndpointLines(remote(), AGENT, { agentName: "build-box" });
+    expect(lines[0].machine).toContain("SSH server");
+    expect(lines[1].label).toBe("Forwards to");
+    expect(lines[1].machine).toBe("agent build-box");
+  });
+
+  it("labels the dynamic proxy on the tunnel host", () => {
+    const lines = tunnelEndpointLines(dynamic(), THIS);
+    expect(lines[0].label).toBe("SOCKS5 proxy on");
+    expect(lines[0].machine).toBe("this computer");
+  });
+});
+
+describe("tunnelReachabilityWarning", () => {
+  it("fires for an agent-hosted loopback local forward", () => {
+    const w = tunnelReachabilityWarning(local("127.0.0.1"), AGENT, "build-box");
+    expect(w).not.toBeNull();
+    expect(w?.message).toContain("build-box");
+    expect(w?.bindHost).toBe("127.0.0.1");
+  });
+
+  it("fires for an agent-hosted loopback dynamic proxy", () => {
+    expect(tunnelReachabilityWarning(dynamic("localhost"), AGENT)).not.toBeNull();
+  });
+
+  it("does not fire when the agent bind is widened", () => {
+    expect(tunnelReachabilityWarning(local("0.0.0.0"), AGENT)).toBeNull();
+  });
+
+  it("does not fire for desktop-hosted tunnels", () => {
+    expect(tunnelReachabilityWarning(local("127.0.0.1"), THIS)).toBeNull();
+  });
+
+  it("does not fire for a remote forward (listen is on the SSH server)", () => {
+    expect(tunnelReachabilityWarning(remote(), AGENT)).toBeNull();
+  });
+});

--- a/src/utils/tunnelHost.ts
+++ b/src/utils/tunnelHost.ts
@@ -1,0 +1,173 @@
+/**
+ * Tunnel run-location (host) helpers — the view-model + labelling layer for
+ * agent-hosted tunnels (S3, #2155).
+ *
+ * SSH semantics are invariant; only the host machine moves. "Local"/"remote"
+ * keep their exact SSH meaning relative to the *tunnel host*. These pure helpers
+ * turn a tunnel's {@link RunLocation} host plus its {@link TunnelType} into the
+ * named endpoint copy, the per-row host badge, and the non-blocking reachability
+ * warning the UI renders. They are pure (no store, no React) so they unit-test
+ * directly and the components stay thin renderers.
+ */
+
+import type { PortValue, RunLocation, TunnelConfig, TunnelType } from "@/types/tunnel";
+import { THIS_COMPUTER } from "@/types/tunnel";
+
+/** A tunnel's effective host, defaulting a missing field to This computer. */
+export function resolveTunnelHost(config: Pick<TunnelConfig, "host">): RunLocation {
+  return config.host ?? THIS_COMPUTER;
+}
+
+/** Narrow a run-location to the agent variant. */
+export function isAgentHost(host: RunLocation): host is { kind: "agent"; agentId: string } {
+  return host.kind === "agent";
+}
+
+/**
+ * The badge shown on every tunnel row (sidebar + Open Connections). Desktop
+ * tunnels read "this computer"; agent tunnels name the agent. `agentName` is the
+ * resolved human name for the host agent, falling back to the raw id.
+ */
+export function tunnelHostBadge(
+  host: RunLocation,
+  agentName?: string
+): { label: string; onAgent: boolean } {
+  if (isAgentHost(host)) {
+    return { label: agentName || host.agentId, onAgent: true };
+  }
+  return { label: "this computer", onAgent: false };
+}
+
+/** The concrete machine name used inside endpoint copy ("agent build-box"). */
+function hostMachine(host: RunLocation, agentName?: string): string {
+  return isAgentHost(host) ? `agent ${agentName || host.agentId}` : "this computer";
+}
+
+/** Loopback listen addresses — reachable only from the host machine itself. */
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+
+/** Whether a bind address is loopback (as opposed to a widened / any address). */
+export function isLoopbackBind(hostAddr: string): boolean {
+  return LOOPBACK_HOSTS.has(hostAddr.trim().toLowerCase());
+}
+
+/** A widened bind that exposes the port beyond the host machine itself. */
+export const WIDE_BIND_HOST = "0.0.0.0";
+
+function addr(host: string, port: PortValue): string {
+  return `${host}:${port === "" ? "?" : port}`;
+}
+
+/** A single named endpoint line for the tunnel editor. */
+export interface TunnelEndpointLine {
+  /** Leading bold label, e.g. "Listens on" / "Via" / "Forwards to". */
+  label: string;
+  /** The concrete machine for this endpoint (e.g. "agent build-box"), if any. */
+  machine?: string;
+  /** The address (host:port) for this endpoint, if any. */
+  address?: string;
+  /** A parenthetical note (reachability / resolution vantage), if any. */
+  note?: string;
+}
+
+/** The "who can reach this" note for a listen socket on the tunnel host. */
+function listenReach(host: RunLocation, bindHost: string, agentName?: string): string {
+  const loopback = isLoopbackBind(bindHost);
+  if (isAgentHost(host)) {
+    const name = agentName || host.agentId;
+    return loopback
+      ? `reachable only from processes on ${name} — not this computer`
+      : `reachable on ${name}'s network`;
+  }
+  return loopback ? "reachable from apps on this computer" : "reachable on this computer's network";
+}
+
+/**
+ * The named endpoint lines for a tunnel, naming the concrete machine + address
+ * on each side (never a bare "local"/"remote" adjective) per the endpoint
+ * semantics sub-concept. `sshLabel` is the SSH connection's display name.
+ */
+export function tunnelEndpointLines(
+  tunnelType: TunnelType,
+  host: RunLocation,
+  opts: { agentName?: string; sshLabel?: string } = {}
+): TunnelEndpointLine[] {
+  const { agentName, sshLabel = "SSH connection" } = opts;
+  const machine = hostMachine(host, agentName);
+
+  switch (tunnelType.type) {
+    case "local": {
+      const c = tunnelType.config;
+      return [
+        {
+          label: "Listens on",
+          machine,
+          address: addr(c.localHost, c.localPort),
+          note: listenReach(host, c.localHost, agentName),
+        },
+        { label: "Via", machine: `SSH server ${sshLabel}` },
+        {
+          label: "Forwards to",
+          address: addr(c.remoteHost, c.remotePort),
+          note: "resolved from the SSH server",
+        },
+      ];
+    }
+    case "remote": {
+      const c = tunnelType.config;
+      return [
+        {
+          label: "Listens on",
+          machine: `SSH server ${sshLabel}`,
+          address: addr(c.remoteHost, c.remotePort),
+          note: "reachable on the SSH server's network",
+        },
+        {
+          label: "Forwards to",
+          machine,
+          address: addr(c.localHost, c.localPort),
+          note: `resolved from ${machine}`,
+        },
+      ];
+    }
+    case "dynamic": {
+      const c = tunnelType.config;
+      return [
+        {
+          label: "SOCKS5 proxy on",
+          machine,
+          address: addr(c.localHost, c.localPort),
+          note: listenReach(host, c.localHost, agentName),
+        },
+        { label: "Targets reached from", machine: `SSH server ${sshLabel}` },
+      ];
+    }
+  }
+}
+
+/**
+ * The non-blocking reachability warning for the tunnel editor, or `null` when
+ * none applies. It fires only for an agent-hosted local/dynamic forward bound to
+ * loopback — the one dangerous case where the listen port sits on the agent's
+ * `127.0.0.1` and this computer cannot reach it. Never a hard block: the user
+ * may widen the bind or dismiss it (loopback-on-agent is legitimate when the
+ * consumer is another agent-hosted service).
+ */
+export function tunnelReachabilityWarning(
+  tunnelType: TunnelType,
+  host: RunLocation,
+  agentName?: string
+): { message: string; bindHost: string } | null {
+  if (!isAgentHost(host)) return null;
+  if (tunnelType.type === "remote") return null;
+  const bindHost = tunnelType.config.localHost;
+  if (!isLoopbackBind(bindHost)) return null;
+  const name = agentName || host.agentId;
+  const port = tunnelType.config.localPort;
+  return {
+    message:
+      `This port opens on ${name}, not your computer. ` +
+      `localhost:${port === "" ? "?" : port} here will not reach it.`,
+    bindHost,
+  };
+}


### PR DESCRIPTION
Part of #2155 (S3 of the stateless-UI agent-centric port, #2139). This is the **highest-value coherent slice**: the persisted run-location host field, the routing seam through the S1 resolver, and the full vantage-surfacing UI. Actually forwarding an agent-hosted tunnel (the agent-side backend) is a large greenfield build filed as a follow-up, so **#2155 stays open**.

The endpoint-semantics sub-concept (PR #2173, \`docs/concepts/future/stateless-ui-agent-tunnel-endpoints.html\`) is authoritative here: **SSH semantics are invariant; only the host machine moves.** This slice is the "overwhelmingly a view-model + labelling change" the concept describes.

## What landed
- **Data model.** \`TunnelConfig\` gains a \`host\` run-location (\`RunLocation::ThisComputer\` | \`Agent(id)\`), \`#[serde(default)]\` so tunnels saved before the field load as desktop-hosted. Agent hosting is opt-in.
- **Routing seam.** \`TunnelManager::start_tunnel\` resolves the host through the S1 \`RunLocationResolver\`. Desktop-hosted tunnels take the existing local-forwarder path **unchanged**; agent-hosted tunnels are recognised but their forwarding backend is not built yet, so they surface a clear, durable \`Error\` (mirrors the \`NetworkManager\` HTTP-monitor stub) rather than silently forwarding on the desktop.
- **Tunnel host UI.** A **Tunnel host** selector (This computer | Agent «name») in the editor, defaulting to This computer; **named endpoint lines** naming the concrete machine + address (never a bare "local"/"remote"); a non-blocking **reachability warning** for an agent-hosted loopback listen with a **Widen bind** remediation.
- **Vantage badges.** Every tunnel row in the sidebar and the Open Connections panel shows its host (icon + machine name), including "this computer" for desktop tunnels.

## What is deferred (follow-ups filed, #2155 stays open)
- **#2185** — the agent-side tunnel forwarding backend (service.* RPC + in-agent forwarder + desktop proxy) so agent-hosted tunnels actually forward. This is what needs the local-container verification in #2155's acceptance criteria.
- **#2186** — "Chain a hop to this computer" auto-chaining remediation (the sub-concept's deferred product-defining decision; only "Widen bind" ships here).

## Testing
- Rust: \`TunnelConfig\` host serde default + round-trip; the pure \`resolve_local_tunnel_host\` routing decision (desktop → local, agent → clear error naming tunnel + agent).
- Frontend: \`tunnelHost\` helper unit tests (badge, endpoint lines, reachability); editor host field / endpoints / warning / Widen bind / host-persists-through-save; sidebar host badge.
- \`cargo test\` (tunnel), \`cargo clippy -D warnings\`, \`cargo fmt\`, \`pnpm build\`, ESLint, Prettier all green.

**Not verified via a live container run** on purpose: this slice does not add or change any forwarding — the desktop forward path is untouched and the agent forward path is stubbed — so there is nothing new to forward yet. Agent-hosted forwarding and its container verification live in #2185.