### PR TITLE
feat(ui): enable intent-routed layout mutations by default (Closes #2184)

### DIFF
--- a/src/components/Terminal/ConfirmSessionCloseDialog.test.tsx
+++ b/src/components/Terminal/ConfirmSessionCloseDialog.test.tsx
@@ -3,6 +3,7 @@ import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { getAllLeaves } from "@/utils/panelTree";
+import { setLayoutIntentsEnabled } from "@/store/layoutBridge";
 import { ConfirmSessionCloseDialog } from "./ConfirmSessionCloseDialog";
 
 const toastSuccess = vi.fn();
@@ -26,6 +27,10 @@ const q = (testId: string) => document.querySelector(`[data-testid="${testId}"]`
 describe("ConfirmSessionCloseDialog", () => {
   beforeEach(() => {
     useAppStore.setState(useAppStore.getInitialState());
+    // The panel-kind spec splits synchronously before rendering; pin to the local
+    // reducer (retained resilience fallback) since the mutation cut (#2184) makes
+    // the intent path async by default.
+    setLayoutIntentsEnabled(false);
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -36,6 +41,7 @@ describe("ConfirmSessionCloseDialog", () => {
     act(() => root.unmount());
     container.remove();
     vi.clearAllMocks();
+    setLayoutIntentsEnabled(null);
   });
 
   it("renders nothing when no request is pending", () => {

--- a/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/hooks/useKeyboardShortcuts.test.ts
@@ -60,6 +60,7 @@ import {
 import { matchHotkeyWorkflow } from "@/services/workflowTriggers";
 import { useAppStore } from "@/store/appStore";
 import { getAllLeaves } from "@/utils/panelTree";
+import { setLayoutIntentsEnabled } from "@/store/layoutBridge";
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
 
 const mockProcessKeyEvent = vi.mocked(processKeyEvent);
@@ -92,6 +93,10 @@ describe("useKeyboardShortcuts", () => {
     mockIsShellReservedKey.mockReturnValue(false);
     mockMatchHotkeyWorkflow.mockReturnValue(null);
     useAppStore.setState(useAppStore.getInitialState());
+    // split-right/-down assert the split synchronously; pin to the local reducer
+    // (the retained resilience fallback) since the mutation cut (#2184) makes the
+    // intent path async by default. Intent path covered in appStore.layoutBridge.test.ts.
+    setLayoutIntentsEnabled(false);
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -100,6 +105,7 @@ describe("useKeyboardShortcuts", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    setLayoutIntentsEnabled(null);
   });
 
   describe("lifecycle", () => {

--- a/src/services/contextCommands.test.ts
+++ b/src/services/contextCommands.test.ts
@@ -6,10 +6,11 @@
  * current context, and `run()` acts on that target (and is inert when none
  * applies). The same registry backs both the keyboard handler and the palette.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { CONTEXT_COMMANDS } from "./contextCommands";
 import { useAppStore, getActiveTab } from "@/store/appStore";
 import { getAllLeaves } from "@/utils/panelTree";
+import { setLayoutIntentsEnabled } from "@/store/layoutBridge";
 
 /** Add a tab of the given content type and make it the active tab/panel. */
 function addActiveTab(contentType: "terminal" | "editor" = "terminal"): string {
@@ -30,6 +31,14 @@ function activeLeaf() {
 
 beforeEach(() => {
   useAppStore.setState({ ...useAppStore.getInitialState() });
+  // focus-panel sets up panels via a synchronous splitPanel; pin to the local
+  // reducer (retained resilience fallback) since the mutation cut (#2184) makes
+  // the intent path async by default.
+  setLayoutIntentsEnabled(false);
+});
+
+afterEach(() => {
+  setLayoutIntentsEnabled(null);
 });
 
 describe("CONTEXT_COMMANDS registry", () => {

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 // Mock service modules before importing the store
 vi.mock("@/services/storage", () => ({
@@ -34,6 +34,7 @@ vi.mock("@/services/api", () => ({
 }));
 
 import { useAppStore, _resetConnectionReloadSeq } from "./appStore";
+import { setLayoutIntentsEnabled } from "./layoutBridge";
 import type { LeafPanel } from "@/types/terminal";
 import { findLeaf, getAllLeaves } from "@/utils/panelTree";
 import * as api from "@/services/api";
@@ -51,6 +52,15 @@ describe("appStore", () => {
     useAppStore.setState(useAppStore.getInitialState());
     // Reset the reload sequencer so sequence numbers don't bleed between tests
     _resetConnectionReloadSeq();
+    // These specs assert panel-tree reducer results synchronously. The mutation
+    // cut (#2184) makes split/move async intent round-trips by default; here we
+    // exercise the retained local reducer (the resilience fallback) directly.
+    // The intent-routed path has its own coverage in appStore.layoutBridge.test.ts.
+    setLayoutIntentsEnabled(false);
+  });
+
+  afterEach(() => {
+    setLayoutIntentsEnabled(null);
   });
 
   describe("addTab", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -4552,8 +4552,12 @@ export const useAppStore = create<AppState>((set, get, store) => {
       })),
 
     splitPanel: (direction) => {
-      // Local reducer (the shipped path, and the fallback when the store cut is
-      // enabled). Kept verbatim so the flag-off behaviour is unchanged.
+      // Local reducer. Since #2184 the intent path below is the default, so this
+      // is the retained resilience/rollback fallback: it runs when the flag is
+      // explicitly off (rollback) or an intent dispatch/reconcile fails, so a
+      // backend hiccup can never break layout. Not a duplicate algebra — it
+      // orchestrates the shared `@/utils/panelTree` helpers (the same seam the
+      // Rust store ports), so keeping it costs no drift, only a safety net.
       const applyLocal = () =>
         set((state) => {
           const dir = direction ?? "horizontal";
@@ -4566,9 +4570,10 @@ export const useAppStore = create<AppState>((set, get, store) => {
           return { rootPanel, activePanelId: newLeaf.id };
         });
 
-      // Step-2 cut (#2151): route the structural split through the `layout.split`
-      // intent; the store mutates and the diff is reconciled back. On any failure
-      // fall back to the local reducer so layout never breaks.
+      // Structural split cut (#2151 step 2, default-on since #2184): route
+      // through the `layout.split` intent; the backend LayoutStore mutates and
+      // reconcileNode is the authoritative writer of the reconciled tree. On any
+      // failure fall back to the local reducer so layout never breaks.
       if (!layoutIntentsEnabled()) return applyLocal();
       const { rootPanel, activePanelId } = get();
       if (!activePanelId) return applyLocal();
@@ -4610,7 +4615,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
       }),
 
     splitPanelWithTab: (tabId, fromPanelId, targetPanelId, edge) => {
-      // Local reducer (shipped path + fallback), kept verbatim.
+      // Local reducer. As with splitPanel, since #2184 this is the retained
+      // resilience/rollback fallback (flag off, or an intent failure) rather than
+      // the default path — kept as a safety net over the shared panelTree algebra.
       const applyLocal = () =>
         set((state) => {
           const splitInfo = edgeToSplit(edge);
@@ -4683,11 +4690,12 @@ export const useAppStore = create<AppState>((set, get, store) => {
           return { rootPanel, activePanelId: newLeaf.id };
         });
 
-      // Step-2 cut (#2151): a tab-carrying drop maps to `layout.moveTab`
-      // (center = merge into the target stack, edge = split the target). The
-      // backend collapses an emptied self-drop source but the local reducer
-      // keeps it, so the single-tab self-edge-drop corner stays on the local
-      // path to preserve exact parity; everything else routes through the store.
+      // Tab-carrying drop cut (#2151 step 2, default-on since #2184): maps to
+      // `layout.moveTab` (center = merge into the target stack, edge = split the
+      // target). The backend collapses an emptied self-drop source but the local
+      // reducer keeps it, so the single-tab self-edge-drop corner stays on the
+      // local path to preserve exact parity; everything else routes through the
+      // store, with reconcileNode as the authoritative writer.
       if (!layoutIntentsEnabled()) return applyLocal();
       const { rootPanel, activePanelId } = get();
       const sourceLeaf = findLeaf(rootPanel, fromPanelId);

--- a/src/store/layoutBridge.test.ts
+++ b/src/store/layoutBridge.test.ts
@@ -212,9 +212,9 @@ describe("layoutBridge — feature flags", () => {
     setLayoutRenderFromProjectionEnabled(null);
   });
 
-  it("mutation cut is off by default (async round-trip needs GUI verification)", () => {
+  it("mutation cut is on by default (#2184: GUI-verified parity-clean)", () => {
     setLayoutIntentsEnabled(null);
-    expect(layoutIntentsEnabled()).toBe(false);
+    expect(layoutIntentsEnabled()).toBe(true);
   });
 
   it("render cut is on by default (step 3: parity-safe by construction)", () => {

--- a/src/store/layoutBridge.ts
+++ b/src/store/layoutBridge.ts
@@ -36,10 +36,11 @@
  *
  * # Strangler safety
  *
- * The mutation cut is gated by {@link layoutIntentsEnabled} — **off by default**,
- * so the shipped app keeps running on the untouched local reducers. Even when
- * enabled, any dispatch/reconcile failure falls back to the local mutation, so a
- * backend hiccup can never break layout. The render cut
+ * The mutation cut is gated by {@link layoutIntentsEnabled} — **on by default**
+ * since #2184 (verified parity-clean in a live GUI run). Any dispatch/reconcile
+ * failure falls back to the local mutation, so a backend hiccup can never break
+ * layout, and the flag can be set to `"false"` to restore the pre-cut local
+ * reducers for rollback. The render cut
  * ({@link layoutRenderFromProjectionEnabled}, on by default) is separately safe:
  * it only composes from the projection when the view mirrors `appStore`'s tree,
  * else falls back to that tree verbatim.
@@ -148,16 +149,19 @@ function readFlag(
  * Whether structural layout **mutations** route through `layout.*` intents
  * (step 2) instead of editing `appStore.rootPanel` locally.
  *
- * **Off by default.** This makes the backend `LayoutStore` authoritative for
- * mutations, which turns split/move/merge into asynchronous backend round-trips
- * — a behavioural change that must be verified with a local GUI run before it
- * ships on. It is intentionally decoupled from the render cut
- * ({@link layoutRenderFromProjectionEnabled}), which is parity-safe on its own.
- * Overridable at runtime via `window.__TERMIHUB_LAYOUT_INTENTS__` or
- * `localStorage["termihub.layoutIntents"]`.
+ * **On by default** (#2184). The backend `LayoutStore` is authoritative for
+ * mutations: split/move/merge run as asynchronous backend round-trips, with the
+ * projected diff reconciled back into `appStore` by {@link reconcileNode}. The
+ * behavioural (timing) change was verified parity-clean in a live GUI run before
+ * flipping — split, drag-to-edge, drag-to-center, tab-move across panels, and
+ * merge, with live-terminal scrollback surviving every op. Any dispatch/reconcile
+ * failure still falls back to the local reducer, so a backend hiccup can never
+ * break layout. Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_LAYOUT_INTENTS__` or `localStorage["termihub.layoutIntents"]`
+ * (set `"false"` to restore the pre-cut local-mutation path).
  */
 export function layoutIntentsEnabled(): boolean {
-  return readFlag(flagOverride, "__TERMIHUB_LAYOUT_INTENTS__", "termihub.layoutIntents", false);
+  return readFlag(flagOverride, "__TERMIHUB_LAYOUT_INTENTS__", "termihub.layoutIntents", true);
 }
 
 /**


### PR DESCRIPTION
## What

Flips `layoutIntentsEnabled()` from off to **on by default** (#2184), so structural layout mutations (split, drag-to-edge, drag-to-center, tab-move across panels, merge) route through the backend `layout.*` intents by default. The projected `layout@<clientId>` diff is reconciled back into `appStore` by `reconcileNode`, which is now the authoritative writer of the panel tree for these ops.

Part of #2151 (Phase 3 layout). **#2151 stays OPEN** for the remaining decomposition steps (see "Step 4 scope" below and step 5 multi-window/restore).

## GUI-verification gate (satisfied)

The mutation cut is an async (timing) behaviour change, so #2184 required a live GUI parity run before shipping it on. **The maintainer verified both cuts live:**

- **Pass 1** — render-from-projection parity + live xterm scrollback survival.
- **Pass 2** — `layoutIntentsEnabled` enabled, re-tested split / merge / drag / tab-move — all parity-clean.

Interactive GUI parity was maintainer-verified; it was **not** re-run in this PR. The automated suite below is green.

## Changes

- `src/store/layoutBridge.ts` — `layoutIntentsEnabled()` default `false` → `true`; doc comments updated. The override plumbing (`window.__TERMIHUB_LAYOUT_INTENTS__` / `localStorage["termihub.layoutIntents"]` / `setLayoutIntentsEnabled`) is kept intact for rollback and tests — set `"false"` to restore the pre-cut local-mutation path.
- `src/store/layoutBridge.test.ts` — default-flag assertion flipped to on.
- Panel-tree reducer unit specs that assert results **synchronously** are pinned to the local reducer via `setLayoutIntentsEnabled(false)` (they exercise the retained resilience fallback; the intent path keeps its coverage in `appStore.layoutBridge.test.ts`): `appStore.test.ts` (split / moveTab / setActivePanel-zoom-follow), `useKeyboardShortcuts.test.ts` (split-right), `contextCommands.test.ts` (focus-panel), `ConfirmSessionCloseDialog.test.tsx` (panel-remove).
- `src/store/appStore.ts` — comment clarifications on `splitPanel` / `splitPanelWithTab` documenting the post-#2184 roles (reconcileNode = authoritative writer; `applyLocal` = retained resilience/rollback fallback).

## Resilience

Any dispatch/reconcile failure still falls back to the local reducer, so a backend hiccup cannot break layout. Rollback is one flag flip away.

## Step 4 of #2151 (retire the appStore panel-tree reducers) — scope note

Step 4's literal goal (delete the appStore panel-tree reducers) is **deliberately not completed here**, for two evidence-based reasons:

1. **The reducers double as the rollback path.** #2184 requires the flag to remain a working rollback (flag off → local mutation), and the fixed unit tests depend on it. The `applyLocal` blocks are the *same code* serving both rollback and the resilience fallback — deleting them would break the mandated rollback and remove the safety net, with **no** de-duplication benefit (they orchestrate the shared `@/utils/panelTree` algebra, not a duplicate).
2. **Step 2's structural-mutation cut only partially landed.** Only `layout.split` and `layout.moveTab` are wired from the frontend; `removePanel` / `closeTab` panel-prune / `reorderTabs` / `setActivePanel` / resize have **no wired intent** (the backend `layout.merge` / `layout.closeTabStructure` exist but are unused). Those reducers are still the sole authoritative path and cannot be removed until they are cut over.

Filed **#2188** (Ready2Implement) to complete step 2's remaining structural-mutation cuts — the prerequisite before step 4 can delete the reducers. #2151 remains open.

## Tests

Full frontend suite green (508 files / 4727 tests), `pnpm build` (typecheck) and `pnpm run lint` clean. No Rust changes.

Closes #2184