### PR TITLE
refactor(embedded-servers): lift servers onto core Service trait (Part of #2154)

### DIFF
--- a/src-tauri/src/commands/embedded_servers.rs
+++ b/src-tauri/src/commands/embedded_servers.rs
@@ -1,4 +1,5 @@
 use tauri::State;
+use termihub_core::service::ServiceInfo;
 
 use crate::embedded_servers::config::{EmbeddedServerConfig, ServerState};
 use crate::embedded_servers::server_manager::EmbeddedServerManager;
@@ -45,6 +46,18 @@ pub fn list_network_interfaces() -> Vec<NetworkInterface> {
     });
 
     interfaces
+}
+
+/// List the embedded server types available for run-location routing
+/// (HTTP/FTP/TFTP), with their schema and capabilities.
+///
+/// Backs the run-location selector UI (a later S-phase); mirrors
+/// `network_services_list` (#2172).
+#[tauri::command]
+pub fn embedded_servers_services_list(
+    manager: State<'_, EmbeddedServerManager>,
+) -> Vec<ServiceInfo> {
+    manager.available_services()
 }
 
 /// Return all saved embedded server configurations.

--- a/src-tauri/src/embedded_servers/ftp_server.rs
+++ b/src-tauri/src/embedded_servers/ftp_server.rs
@@ -20,7 +20,7 @@ use libunftp::ServerBuilder;
 use unftp_sbe_fs::Filesystem;
 
 use super::config::{AtomicServerStats, EmbeddedServerConfig, FtpAuth};
-use super::server_manager::BindSignal;
+use super::service::BindSignal;
 
 // ─── Public entry point ───────────────────────────────────────────────────────
 

--- a/src-tauri/src/embedded_servers/http_server.rs
+++ b/src-tauri/src/embedded_servers/http_server.rs
@@ -14,7 +14,7 @@ use axum::{middleware, Router};
 use tower_http::services::ServeDir;
 
 use super::config::{AtomicServerStats, EmbeddedServerConfig};
-use super::server_manager::BindSignal;
+use super::service::BindSignal;
 
 /// State shared with middleware for connection tracking.
 #[derive(Clone)]

--- a/src-tauri/src/embedded_servers/mod.rs
+++ b/src-tauri/src/embedded_servers/mod.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod server_manager;
+pub mod service;
 pub mod storage;
 
 mod ftp_server;

--- a/src-tauri/src/embedded_servers/server_manager.rs
+++ b/src-tauri/src/embedded_servers/server_manager.rs
@@ -1,100 +1,58 @@
+//! Desktop host for the embedded HTTP/FTP/TFTP servers.
+//!
+//! Each configured server is an [`EmbeddedServerService`] behind the core
+//! [`Service`](termihub_core::service::Service) trait (#2154, following the
+//! HTTP-monitor pilot #2157/#2172). The manager owns the persisted configs, a
+//! map of live services, a [`ServiceRegistry`] for run-location discovery, and a
+//! [`RunLocationResolver`] deciding where a server runs. Each service emits its
+//! status transitions on a core [`EventChannel`](termihub_core::service::EventChannel);
+//! the manager bridges those to the existing `embedded-server-status-changed`
+//! Tauri event, so the frontend contract is unchanged.
+
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{RecvTimeoutError, SyncSender};
-use std::sync::{Arc, Mutex};
-use std::thread;
-use std::time::Duration;
+use std::sync::Mutex;
 
 use anyhow::{Context, Result};
 use tauri::{AppHandle, Emitter};
+use tokio::sync::broadcast::error::RecvError;
 
 use super::config::{
-    AtomicServerStats, EmbeddedServerConfig, EmbeddedServerStore, ServerState, ServerStats,
-    ServerStatus, ServerType,
+    EmbeddedServerConfig, EmbeddedServerStore, ServerState, ServerStats, ServerStatus, ServerType,
 };
-use super::ftp_server::start_ftp_server;
-use super::http_server::start_http_server;
+use super::service::{
+    auto_start_error_state, service_id_for, EmbeddedServerService, STATUS_EVENT_KIND,
+};
 use super::storage::EmbeddedServerStorage;
-use super::tftp_server::start_tftp_server;
 use crate::connection::recovery::RecoveryWarning;
+use crate::run_location::{ResolvedLocation, RunLocationResolver};
 use crate::utils::errors::TerminalError;
 
-/// How long the manager waits for a server thread to confirm its bind before
-/// treating the start as failed. Binding a local socket is near-instant, so a
-/// generous timeout only guards against a wedged thread (GAP G3, #1145).
-const BIND_CONFIRM_TIMEOUT: Duration = Duration::from_secs(5);
+use termihub_core::service::{Service, ServiceInfo, ServiceRegistry};
 
-/// One-shot handle a server thread uses to report whether its listening socket
-/// bound successfully.
+/// Tauri event forwarded to the frontend for each embedded server status change.
 ///
-/// The manager holds the receiving end and only emits `Running` once
-/// [`BindSignal::confirm`] arrives; a [`BindSignal::fail`] (or a dropped sender)
-/// keeps the server out of the `active` map so it never shows a stuck "Running"
-/// before flipping to `Error` (GAP G3, #1145).
-pub(super) struct BindSignal {
-    tx: SyncSender<Result<(), String>>,
-}
-
-impl BindSignal {
-    /// Report that the listening socket bound successfully.
-    pub(super) fn confirm(&self) {
-        // A full/closed channel means the manager already gave up waiting; the
-        // send failure is harmless because the thread will still shut down.
-        let _ = self.tx.send(Ok(()));
-    }
-
-    /// Report that binding failed, carrying the reason for the UI.
-    pub(super) fn fail(&self, reason: &str) {
-        let _ = self.tx.send(Err(reason.to_string()));
-    }
-}
-
-/// Decision the manager makes from a server thread's bind signal.
-#[derive(Debug)]
-enum BindOutcome {
-    /// The socket bound — keep the `active` entry and emit `Running`.
-    Running,
-    /// The bind failed (explicit error, dropped sender, or timeout) — drop the
-    /// `active` entry and emit `Error` with this reason.
-    Failed(String),
-}
-
-/// Map a server thread's bind signal (received over the confirm channel) to the
-/// manager's next action, so `Running` is only ever produced after a *confirmed*
-/// bind (GAP G3, #1145).
-///
-/// Pure and `AppHandle`-free so the start-flow decision can be unit-tested.
-fn decide_bind_outcome(signal: Result<Result<(), String>, RecvTimeoutError>) -> BindOutcome {
-    match signal {
-        Ok(Ok(())) => BindOutcome::Running,
-        Ok(Err(reason)) => BindOutcome::Failed(reason),
-        Err(RecvTimeoutError::Disconnected) => {
-            BindOutcome::Failed("server exited before confirming it was listening".to_string())
-        }
-        Err(RecvTimeoutError::Timeout) => {
-            BindOutcome::Failed("server did not confirm it was listening in time".to_string())
-        }
-    }
-}
-
-/// A running server instance.
-struct ActiveServer {
-    shutdown: Arc<AtomicBool>,
-    #[allow(dead_code)]
-    thread_handle: thread::JoinHandle<()>,
-    stats: Arc<AtomicServerStats>,
-    started_at: String,
-    /// Shared status updated by the server thread on error.
-    error: Arc<Mutex<Option<String>>>,
-}
+/// A server's [`EmbeddedServerService`] emits the status on its core
+/// [`EventChannel`](termihub_core::service::EventChannel); the manager bridges it
+/// to this Tauri event so the frontend receives the same `ServerState` payload as
+/// before the lift.
+const SERVER_STATUS_EVENT: &str = "embedded-server-status-changed";
 
 /// Central manager for embedded HTTP/FTP/TFTP servers.
 ///
-/// Follows the same pattern as `TunnelManager`.
+/// Follows the same pattern as `NetworkManager` (#2172): holds the services,
+/// registers their types in a [`ServiceRegistry`], and routes each start through
+/// the [`RunLocationResolver`].
 pub struct EmbeddedServerManager {
     configs: Mutex<EmbeddedServerStore>,
     storage: EmbeddedServerStorage,
-    active: Mutex<HashMap<String, ActiveServer>>,
+    /// Live services keyed by config id (running **or** stopped-but-listed).
+    services: Mutex<HashMap<String, EmbeddedServerService>>,
+    /// Registry of run-location-routable server types (discovery, schema,
+    /// capabilities). Backs the run-location selector UI (a later S-phase).
+    service_registry: ServiceRegistry,
+    /// Resolver deciding where a server runs (local vs agent). S1 default is
+    /// always local — the run-location selector UI arrives in a later S-phase.
+    run_location: RunLocationResolver,
     app_handle: AppHandle,
     recovery_warnings: Mutex<Vec<RecoveryWarning>>,
 }
@@ -110,10 +68,18 @@ impl EmbeddedServerManager {
         Ok(Self {
             configs: Mutex::new(result.data),
             storage,
-            active: Mutex::new(HashMap::new()),
+            services: Mutex::new(HashMap::new()),
+            service_registry: build_service_registry(),
+            run_location: RunLocationResolver::new(),
             app_handle: app_handle.clone(),
             recovery_warnings: Mutex::new(result.warnings),
         })
+    }
+
+    /// The server types registered for run-location routing (HTTP/FTP/TFTP).
+    /// Backs discovery and the run-location selector UI.
+    pub fn available_services(&self) -> Vec<ServiceInfo> {
+        self.service_registry.available_services()
     }
 
     /// Drain and return any recovery warnings collected during initialisation.
@@ -126,19 +92,13 @@ impl EmbeddedServerManager {
 
     /// Return all saved server configurations.
     pub fn get_configs(&self) -> Result<Vec<EmbeddedServerConfig>, TerminalError> {
-        let store = self
-            .configs
-            .lock()
-            .map_err(|e| TerminalError::EmbeddedServerError(format!("Lock error: {e}")))?;
+        let store = self.lock_configs()?;
         Ok(store.servers.clone())
     }
 
     /// Add or update a server configuration.
     pub fn save_config(&self, config: EmbeddedServerConfig) -> Result<(), TerminalError> {
-        let mut store = self
-            .configs
-            .lock()
-            .map_err(|e| TerminalError::EmbeddedServerError(format!("Lock error: {e}")))?;
+        let mut store = self.lock_configs()?;
         if let Some(existing) = store.servers.iter_mut().find(|s| s.id == config.id) {
             *existing = config;
         } else {
@@ -153,10 +113,10 @@ impl EmbeddedServerManager {
     /// Delete a configuration. Stops the server first if it is running.
     pub fn delete_config(&self, server_id: &str) -> Result<(), TerminalError> {
         self.stop_server(server_id)?;
-        let mut store = self
-            .configs
-            .lock()
-            .map_err(|e| TerminalError::EmbeddedServerError(format!("Lock error: {e}")))?;
+        if let Ok(mut services) = self.services.lock() {
+            services.remove(server_id);
+        }
+        let mut store = self.lock_configs()?;
         store.servers.retain(|s| s.id != server_id);
         self.storage
             .save(&store)
@@ -166,55 +126,48 @@ impl EmbeddedServerManager {
 
     /// Return the current runtime state of every configured server.
     pub fn get_states(&self) -> Result<Vec<ServerState>, TerminalError> {
-        let store = self
-            .configs
-            .lock()
-            .map_err(|e| TerminalError::EmbeddedServerError(format!("Lock error: {e}")))?;
-        let active = self
-            .active
-            .lock()
-            .map_err(|e| TerminalError::EmbeddedServerError(format!("Lock error: {e}")))?;
-
+        let store = self.lock_configs()?;
+        let services = self.lock_services()?;
         let states = store
             .servers
             .iter()
             .map(|cfg| {
-                if let Some(srv) = active.get(&cfg.id) {
-                    let error = srv.error.lock().ok().and_then(|e| e.clone());
-                    let status = if error.is_some() {
-                        ServerStatus::Error
-                    } else {
-                        ServerStatus::Running
-                    };
-                    ServerState {
-                        server_id: cfg.id.clone(),
-                        status,
-                        error,
-                        stats: srv.stats.snapshot(),
-                        started_at: Some(srv.started_at.clone()),
-                    }
-                } else {
-                    ServerState {
+                services
+                    .get(&cfg.id)
+                    .and_then(|svc| svc.state())
+                    .unwrap_or_else(|| ServerState {
                         server_id: cfg.id.clone(),
                         status: ServerStatus::Stopped,
                         error: None,
                         stats: ServerStats::default(),
                         started_at: None,
-                    }
-                }
+                    })
             })
             .collect();
-
         Ok(states)
     }
 
     /// Start a server by ID.
+    ///
+    /// The run-location is resolved through the [`RunLocationResolver`] (S1
+    /// default: always local; an agent request is rejected until agent hosting
+    /// lands). The server's status transitions are emitted on its core
+    /// [`EventChannel`](termihub_core::service::EventChannel) and bridged to the
+    /// [`SERVER_STATUS_EVENT`] Tauri event.
     pub fn start_server(&self, server_id: &str) -> Result<(), TerminalError> {
+        match self.run_location.resolve_default() {
+            ResolvedLocation::Local => {}
+            ResolvedLocation::Agent(agent) => {
+                // The run-location selector UI (which could request an agent) is a
+                // later S-phase; today the resolver always returns local.
+                return Err(TerminalError::EmbeddedServerError(format!(
+                    "agent-hosted embedded servers are not yet supported (requested '{agent}')"
+                )));
+            }
+        }
+
         let config = {
-            let store = self
-                .configs
-                .lock()
-                .map_err(|e| TerminalError::EmbeddedServerError(format!("Lock error: {e}")))?;
+            let store = self.lock_configs()?;
             store
                 .servers
                 .iter()
@@ -225,148 +178,40 @@ impl EmbeddedServerManager {
                 })?
         };
 
-        {
-            let mut active = self
-                .active
-                .lock()
-                .map_err(|e| TerminalError::EmbeddedServerError(format!("Lock error: {e}")))?;
-            match active.get(server_id) {
-                // A live server (no runtime error recorded) genuinely blocks a
-                // second start.
-                Some(srv) if active_entry_is_live(&srv.error) => {
-                    return Err(TerminalError::EmbeddedServerError(format!(
-                        "Server {server_id} is already running"
-                    )));
-                }
-                // GAP G2/G9: a server that failed at runtime leaves a dead husk
-                // in `active`. Drop it so `Error → Stopped` is real and this
-                // start acts as a Retry instead of being rejected as "already
-                // running". Its thread has already exited (it emitted `Error`).
-                Some(_) => {
-                    if let Some(dead) = active.remove(server_id) {
-                        dead.shutdown.store(true, Ordering::Relaxed);
-                    }
-                }
-                None => {}
-            }
+        let mut services = self.lock_services()?;
+        // Reuse an existing (stopped) service so its event channel + bridge task
+        // persist across restarts; create + bridge a fresh one otherwise.
+        if !services.contains_key(server_id) {
+            let service = EmbeddedServerService::new(config.server_type.clone());
+            // Subscribe before starting so the bridge cannot miss the first
+            // Starting transition.
+            spawn_event_bridge(self.app_handle.clone(), service.subscribe_events());
+            services.insert(server_id.to_string(), service);
         }
-
-        // Pre-flight bind check so we can return an error immediately for the
-        // common "port already in use" case.
-        self.check_port(&config)?;
-
-        self.emit_status(server_id, ServerStatus::Starting, None);
-
-        let shutdown = Arc::new(AtomicBool::new(false));
-        let stats = AtomicServerStats::new();
-        let error_slot: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-
-        // One-slot channel the server thread uses to confirm (or reject) its
-        // real bind. `Running` is only emitted after this confirmation, so a
-        // late bind failure never leaves the item stuck green (GAP G3, #1145).
-        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel::<Result<(), String>>(1);
-
-        let cfg = config.clone();
-        let shutdown_clone = Arc::clone(&shutdown);
-        let stats_clone = Arc::clone(&stats);
-        let error_clone = Arc::clone(&error_slot);
-        let handle_clone = self.app_handle.clone();
-        let id = server_id.to_string();
-
-        let thread_handle = thread::spawn(move || {
-            let ready = BindSignal { tx: ready_tx };
-            let result = match cfg.server_type {
-                ServerType::Http => start_http_server(&cfg, shutdown_clone, stats_clone, ready),
-                ServerType::Ftp => start_ftp_server(&cfg, shutdown_clone, stats_clone, ready),
-                ServerType::Tftp => start_tftp_server(&cfg, shutdown_clone, stats_clone, ready),
-            };
-
-            if let Err(e) = result {
-                let msg = e.to_string();
-                tracing::error!(%id, "Embedded server error: {msg}");
-                if let Ok(mut slot) = error_clone.lock() {
-                    *slot = Some(msg.clone());
-                }
-                let state = ServerState {
-                    server_id: id.clone(),
-                    status: ServerStatus::Error,
-                    error: Some(msg),
-                    stats: ServerStats::default(),
-                    started_at: None,
-                };
-                let _ = handle_clone.emit("embedded-server-status-changed", &state);
-            }
-        });
-
-        // Wait for the thread to confirm its bind before declaring Running.
-        match decide_bind_outcome(ready_rx.recv_timeout(BIND_CONFIRM_TIMEOUT)) {
-            BindOutcome::Running => {
-                let started_at = chrono::Utc::now().to_rfc3339();
-                {
-                    let mut active = self.active.lock().map_err(|e| {
-                        TerminalError::EmbeddedServerError(format!("Lock error: {e}"))
-                    })?;
-                    active.insert(
-                        server_id.to_string(),
-                        ActiveServer {
-                            shutdown,
-                            thread_handle,
-                            stats,
-                            started_at,
-                            error: error_slot,
-                        },
-                    );
-                }
-
-                self.emit_status(server_id, ServerStatus::Running, None);
-                tracing::info!(%server_id, "Embedded server started");
-                Ok(())
-            }
-            BindOutcome::Failed(reason) => {
-                // Bind never confirmed. Signal the thread to unwind (in case it
-                // did bind but timed out) and leave nothing in `active`, so the
-                // server is reported as Error rather than a stuck Running.
-                shutdown.store(true, Ordering::Relaxed);
-                tracing::warn!(%server_id, "Embedded server failed to start: {reason}");
-                self.emit_status(server_id, ServerStatus::Error, Some(reason.clone()));
-                Err(TerminalError::EmbeddedServerError(reason))
-            }
-        }
+        let service = services
+            .get_mut(server_id)
+            .expect("service was just inserted");
+        service.start_with(config)
     }
 
-    /// Stop a running server by ID.
+    /// Stop a running server by ID (kept listed as `Stopped`).
     pub fn stop_server(&self, server_id: &str) -> Result<(), TerminalError> {
-        let server = {
-            let mut active = self
-                .active
-                .lock()
-                .map_err(|e| TerminalError::EmbeddedServerError(format!("Lock error: {e}")))?;
-            active.remove(server_id)
-        };
-
-        if let Some(srv) = server {
-            srv.shutdown.store(true, Ordering::Relaxed);
-            // Do not join — the server thread will exit on its own after the
-            // next poll cycle.  This avoids blocking the main thread.
-            self.emit_status(server_id, ServerStatus::Stopped, None);
-            tracing::info!(%server_id, "Embedded server stopped");
+        let mut services = self.lock_services()?;
+        if let Some(service) = services.get_mut(server_id) {
+            service.shutdown();
         }
-
         Ok(())
     }
 
     /// Stop all running servers (called on app shutdown).
     pub fn stop_all(&self) {
-        let ids: Vec<String> = self
-            .active
-            .lock()
-            .map(|a| a.keys().cloned().collect())
-            .unwrap_or_default();
-
-        for id in ids {
-            if let Err(e) = self.stop_server(&id) {
-                tracing::error!(%id, "Failed to stop embedded server: {e}");
-            }
+        let Ok(mut services) = self.services.lock() else {
+            tracing::error!("embedded server services lock poisoned during stop_all");
+            return;
+        };
+        for (id, service) in services.iter_mut() {
+            service.shutdown();
+            tracing::debug!(%id, "Stopped embedded server during teardown");
         }
     }
 
@@ -384,13 +229,13 @@ impl EmbeddedServerManager {
                 if let Err(e) = self.start_server(&cfg.id) {
                     // Surface the failure (e.g. port busy at boot) as an Error
                     // state so the sidebar shows the server red with a reason,
-                    // instead of silently leaving it stopped (GAP G7, #1145).
+                    // instead of silently leaving it stopped (GAP G7, #1145). A
+                    // pre-flight failure returns before the service emits, so the
+                    // manager emits the Error state here.
                     let msg = e.to_string();
                     tracing::warn!(id = %cfg.id, "Failed to auto-start embedded server: {msg}");
                     let state = auto_start_error_state(&cfg.id, &msg);
-                    let _ = self
-                        .app_handle
-                        .emit("embedded-server-status-changed", &state);
+                    let _ = self.app_handle.emit(SERVER_STATUS_EVENT, &state);
                 }
             }
         }
@@ -398,326 +243,107 @@ impl EmbeddedServerManager {
 
     // ─── Private helpers ──────────────────────────────────────────────────────
 
-    /// Attempt a quick bind to check whether the port is available.
-    fn check_port(&self, config: &EmbeddedServerConfig) -> Result<(), TerminalError> {
-        Self::check_port_config(config)
+    fn lock_configs(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, EmbeddedServerStore>, TerminalError> {
+        self.configs
+            .lock()
+            .map_err(|e| TerminalError::EmbeddedServerError(format!("Lock error: {e}")))
     }
 
-    /// Attempt a quick bind to check whether a config's port is available.
-    ///
-    /// Static so the pre-flight check can be exercised without a live manager
-    /// (and its [`AppHandle`]).
-    fn check_port_config(config: &EmbeddedServerConfig) -> Result<(), TerminalError> {
-        let addr = format!("{}:{}", config.bind_host, config.port);
-        match config.server_type {
-            ServerType::Tftp => {
-                let socket = std::net::UdpSocket::bind(&addr).map_err(|e| {
-                    TerminalError::EmbeddedServerError(format!(
-                        "Port {} is already in use: {e}",
-                        config.port
-                    ))
-                })?;
-                drop(socket);
-            }
-            _ => {
-                let listener = std::net::TcpListener::bind(&addr).map_err(|e| {
-                    TerminalError::EmbeddedServerError(format!(
-                        "Port {} is already in use: {e}",
-                        config.port
-                    ))
-                })?;
-                drop(listener);
+    fn lock_services(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, HashMap<String, EmbeddedServerService>>, TerminalError>
+    {
+        self.services
+            .lock()
+            .map_err(|e| TerminalError::EmbeddedServerError(format!("Lock error: {e}")))
+    }
+}
+
+/// Build the [`ServiceRegistry`] with the run-location-routable server types.
+fn build_service_registry() -> ServiceRegistry {
+    let mut registry = ServiceRegistry::new();
+    for (ty, icon) in [
+        (ServerType::Http, "globe"),
+        (ServerType::Ftp, "folder"),
+        (ServerType::Tftp, "download"),
+    ] {
+        let id = service_id_for(&ty);
+        let display = super::service::display_name_for(&ty);
+        let ty_for_factory = ty.clone();
+        registry.register(
+            id,
+            display,
+            icon,
+            Box::new(move || Box::new(EmbeddedServerService::new(ty_for_factory.clone()))),
+        );
+    }
+    registry
+}
+
+/// Bridge a server's core [`EventChannel`](termihub_core::service::EventChannel)
+/// to the desktop's Tauri emitter.
+///
+/// Forwards each `status` [`ServiceEvent`](termihub_core::service::ServiceEvent)
+/// as a [`SERVER_STATUS_EVENT`] Tauri event so the frontend receives the same
+/// `ServerState` payload as before the lift. The task ends when the service is
+/// dropped (channel closed).
+fn spawn_event_bridge(app: AppHandle, mut events: termihub_core::service::ServiceEventReceiver) {
+    tauri::async_runtime::spawn(async move {
+        loop {
+            match events.recv().await {
+                Ok(event) if event.kind == STATUS_EVENT_KIND => {
+                    let _ = app.emit(SERVER_STATUS_EVENT, event.payload);
+                }
+                Ok(_) => {}
+                // Advisory events: a lagging bridge drops the oldest and keeps going.
+                Err(RecvError::Lagged(_)) => continue,
+                // All senders dropped (service removed) — nothing more to forward.
+                Err(RecvError::Closed) => break,
             }
         }
-        Ok(())
-    }
-
-    fn emit_status(&self, server_id: &str, status: ServerStatus, error: Option<String>) {
-        // Snapshot the *real* live stats and start time from the active entry (as
-        // `get_states` does) instead of shipping zeroed defaults, so the sidebar
-        // traffic line and uptime reflect reality (GAP G6, #1145). If the server
-        // is no longer active (e.g. a `Stopped` transition), fall back to the
-        // zeroed defaults, which is correct for a server with no live traffic.
-        let (stats, started_at) = self
-            .active
-            .lock()
-            .ok()
-            .and_then(|active| {
-                active
-                    .get(server_id)
-                    .map(|srv| (srv.stats.snapshot(), Some(srv.started_at.clone())))
-            })
-            .unwrap_or_default();
-
-        let state = build_status_state(server_id, status, error, stats, started_at);
-        let _ = self
-            .app_handle
-            .emit("embedded-server-status-changed", &state);
-    }
-}
-
-/// Assemble the [`ServerState`] broadcast on `embedded-server-status-changed`.
-///
-/// Kept as a free function so the payload contract (real stats + `started_at`
-/// carried through, not zeroed — GAP G6, #1145) can be unit-tested without a
-/// live [`AppHandle`].
-fn build_status_state(
-    server_id: &str,
-    status: ServerStatus,
-    error: Option<String>,
-    stats: ServerStats,
-    started_at: Option<String>,
-) -> ServerState {
-    ServerState {
-        server_id: server_id.to_string(),
-        status,
-        error,
-        stats,
-        started_at,
-    }
-}
-
-/// Decide whether an `active` map entry represents a *live* server (as opposed
-/// to a dead husk left behind by a runtime failure).
-///
-/// The server thread records the failure reason into its shared `error` slot and
-/// then exits, but the manager keeps the map entry so `get_states` can keep
-/// surfacing the error. A live entry (empty error slot) must block a second
-/// concurrent start; a failed entry (error slot set) must NOT, so a subsequent
-/// `start_server` acts as a Retry rather than being rejected as "already
-/// running" — making `Error → Stopped` a real, escapable transition
-/// (GAP G2/G9, #1145).
-fn active_entry_is_live(error: &Arc<Mutex<Option<String>>>) -> bool {
-    // If the lock is poisoned we cannot prove the server is healthy, so treat it
-    // as not-live and allow a fresh start to recover.
-    error.lock().map(|slot| slot.is_none()).unwrap_or(false)
-}
-
-/// Build the `Error` [`ServerState`] surfaced when a server marked `auto_start`
-/// fails to start at launch (e.g. its port is already in use).
-///
-/// Keeps the failure visible in the sidebar (red, with a reason) instead of
-/// silently leaving the server stopped (GAP G7, #1145).
-fn auto_start_error_state(server_id: &str, error: &str) -> ServerState {
-    ServerState {
-        server_id: server_id.to_string(),
-        status: ServerStatus::Error,
-        error: Some(error.to_string()),
-        stats: ServerStats::default(),
-        started_at: None,
-    }
+    });
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::mpsc;
 
-    /// A successful bind signal must produce a `Running` outcome so the manager
-    /// keeps the `active` entry and emits `Running` (GAP G3, #1145).
     #[test]
-    fn bind_success_signal_yields_running() {
-        let outcome = decide_bind_outcome(Ok(Ok(())));
-        assert!(
-            matches!(outcome, BindOutcome::Running),
-            "Ok(Ok(())) should map to Running, got {outcome:?}"
-        );
+    fn registry_exposes_the_three_server_types() {
+        let registry = build_service_registry();
+        let ids: Vec<String> = registry
+            .available_services()
+            .into_iter()
+            .map(|s| s.service_id)
+            .collect();
+        assert!(ids.contains(&service_id_for(&ServerType::Http).to_string()));
+        assert!(ids.contains(&service_id_for(&ServerType::Ftp).to_string()));
+        assert!(ids.contains(&service_id_for(&ServerType::Tftp).to_string()));
     }
 
-    /// A late bind failure reported by the server thread must yield `Failed`
-    /// carrying the reason, so the manager emits `Error` and drops the `active`
-    /// entry instead of leaving the item stuck green (GAP G3, #1145).
     #[test]
-    fn bind_failure_signal_yields_failed_with_reason() {
-        let outcome = decide_bind_outcome(Ok(Err("Port 8080 is already in use".to_string())));
-        match outcome {
-            BindOutcome::Failed(reason) => assert!(
-                reason.contains("already in use"),
-                "failure reason must be preserved, got: {reason}"
-            ),
-            other => panic!("expected Failed, got {other:?}"),
+    fn registered_server_types_are_not_desktop_only() {
+        // Serving files may run on an agent — the run-location selector must be
+        // allowed to offer an agent for these.
+        let registry = build_service_registry();
+        for svc in registry.available_services() {
+            assert!(svc.capabilities.emits_events);
+            assert!(
+                !svc.capabilities.desktop_only,
+                "{} must not be desktop-only",
+                svc.service_id
+            );
         }
     }
 
-    /// If the thread dies (panics / returns) before signalling, the sender is
-    /// dropped and `recv` reports `Disconnected` — this is a start failure, so
-    /// it must be `Failed`, never `Running` (GAP G3, #1145).
     #[test]
-    fn bind_disconnected_signal_yields_failed() {
-        let outcome = decide_bind_outcome(Err(mpsc::RecvTimeoutError::Disconnected));
-        assert!(
-            matches!(outcome, BindOutcome::Failed(_)),
-            "a disconnected channel means the bind never confirmed, got {outcome:?}"
-        );
-    }
-
-    /// A bind that never confirms within the timeout must also be `Failed`, so
-    /// `Running` is only ever emitted after a *confirmed* bind (GAP G3, #1145).
-    #[test]
-    fn bind_timeout_signal_yields_failed() {
-        let outcome = decide_bind_outcome(Err(mpsc::RecvTimeoutError::Timeout));
-        assert!(
-            matches!(outcome, BindOutcome::Failed(_)),
-            "a timed-out bind is not a confirmed bind, got {outcome:?}"
-        );
-    }
-
-    /// End-to-end over the real channel: a thread that binds then signals success
-    /// must result in `Running`, while a thread that reports a bind error must
-    /// not — so no live `active` entry lingers on failure (GAP G3, #1145).
-    #[test]
-    fn real_channel_success_and_failure_paths() {
-        // Success path: sender reports Ok before the (simulated) serve loop.
-        let (tx, rx) = mpsc::sync_channel::<Result<(), String>>(1);
-        std::thread::spawn(move || {
-            let _ = tx.send(Ok(()));
-        });
-        let outcome = decide_bind_outcome(rx.recv_timeout(BIND_CONFIRM_TIMEOUT));
-        assert!(matches!(outcome, BindOutcome::Running));
-
-        // Failure path: sender reports a bind error and the manager must not
-        // treat it as running.
-        let (tx, rx) = mpsc::sync_channel::<Result<(), String>>(1);
-        std::thread::spawn(move || {
-            let _ = tx.send(Err("bind failed".to_string()));
-        });
-        let outcome = decide_bind_outcome(rx.recv_timeout(BIND_CONFIRM_TIMEOUT));
-        assert!(matches!(outcome, BindOutcome::Failed(_)));
-    }
-
-    /// A freshly-spawned server whose error slot is still empty is live and must
-    /// block a second, concurrent start with "already running".
-    #[test]
-    fn active_entry_without_error_is_live() {
-        let error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-        assert!(
-            active_entry_is_live(&error),
-            "a running server (no error recorded) must count as live"
-        );
-    }
-
-    /// GAP G2/G9: once a server thread has failed at runtime its `active` entry is
-    /// a dead husk — `active_entry_is_live` must report `false` so `start_server`
-    /// no longer rejects a retry with "already running". This makes `Error →
-    /// Stopped` real and Start/Retry work again, while `get_states` still surfaces
-    /// the recorded error until the retry happens.
-    #[test]
-    fn errored_active_entry_is_not_live_so_start_is_allowed() {
-        let error: Arc<Mutex<Option<String>>> =
-            Arc::new(Mutex::new(Some("Port 8080 is already in use".to_string())));
-        assert!(
-            !active_entry_is_live(&error),
-            "a server whose error slot is set must NOT count as live, so a retry \
-             (start_server) is allowed instead of being blocked as 'already running'"
-        );
-    }
-
-    /// GAP G6, #1145: the status payload broadcast on
-    /// `embedded-server-status-changed` must carry the *real* live stats and
-    /// `started_at` snapshotted from the active entry, not zeroed defaults —
-    /// otherwise the sidebar traffic line and uptime always read zero.
-    #[test]
-    fn status_state_carries_real_stats_and_started_at() {
-        let stats = ServerStats {
-            active_connections: 2,
-            total_connections: 7,
-            bytes_sent: 4096,
-            bytes_received: 512,
-        };
-        let started_at = "2024-01-01T00:00:00+00:00".to_string();
-
-        let state = build_status_state(
-            "srv-1",
-            ServerStatus::Running,
-            None,
-            stats.clone(),
-            Some(started_at.clone()),
-        );
-
-        assert_eq!(state.server_id, "srv-1");
-        assert_eq!(state.status, ServerStatus::Running);
-        assert_eq!(
-            state.stats.total_connections, 7,
-            "live total_connections must be preserved, not reset to 0"
-        );
-        assert_eq!(
-            state.stats.active_connections, 2,
-            "live active_connections must be preserved"
-        );
-        assert_eq!(state.stats.bytes_sent, 4096, "bytes_sent must be preserved");
-        assert_eq!(
-            state.stats.bytes_received, 512,
-            "bytes_received must be preserved"
-        );
-        assert_eq!(
-            state.started_at,
-            Some(started_at),
-            "started_at must be carried through so uptime can render (GAP G6)"
-        );
-    }
-
-    /// When no active entry exists (e.g. a `Stopped` transition after the entry
-    /// was removed), the status payload falls back to zeroed stats / no start
-    /// time — which is correct, since a stopped server has no live traffic.
-    #[test]
-    fn status_state_defaults_when_no_active_entry() {
-        let state = build_status_state(
-            "srv-1",
-            ServerStatus::Stopped,
-            None,
-            ServerStats::default(),
-            None,
-        );
-        assert_eq!(state.status, ServerStatus::Stopped);
-        assert_eq!(state.stats.total_connections, 0);
-        assert!(state.started_at.is_none());
-    }
-
-    /// A port bound at boot must not cause a silent no-op: the auto-start
-    /// failure has to surface as an `Error` state carrying the reason so the
-    /// sidebar can show the server red at launch (GAP G7, #1145).
-    #[test]
-    fn auto_start_failure_surfaces_error_state_with_message() {
-        // Bind a TCP port so the pre-flight bind check fails deterministically.
-        let listener = std::net::TcpListener::bind("127.0.0.1:0")
-            .expect("should bind an ephemeral port for the test");
-        let busy_port = listener
-            .local_addr()
-            .expect("bound listener should expose its address")
-            .port();
-
-        let config = EmbeddedServerConfig {
-            id: "auto-http".to_string(),
-            name: "Auto HTTP".to_string(),
-            server_type: ServerType::Http,
-            root_directory: ".".to_string(),
-            bind_host: "127.0.0.1".to_string(),
-            port: busy_port,
-            auto_start: true,
-            read_only: true,
-            directory_listing: None,
-            ftp_auth: None,
-        };
-
-        // Reproduce the auto-start pre-flight failure: the port is taken.
-        let err = EmbeddedServerManager::check_port_config(&config)
-            .expect_err("binding an already-bound port must fail");
-        let msg = err.to_string();
-        assert!(
-            msg.contains("already in use"),
-            "error should explain the port is busy, got: {msg}"
-        );
-
-        // The failure must be turned into a visible Error state, not swallowed.
-        let state = auto_start_error_state(&config.id, &msg);
-        assert_eq!(state.server_id, "auto-http");
-        assert_eq!(state.status, ServerStatus::Error);
-        assert_eq!(state.error.as_deref(), Some(msg.as_str()));
-        assert!(
-            state.error.is_some_and(|e| e.contains("already in use")),
-            "surfaced error must carry the reason"
-        );
-
-        drop(listener);
+    fn registry_create_yields_a_stopped_service() {
+        let registry = build_service_registry();
+        let svc = registry
+            .create(service_id_for(&ServerType::Ftp))
+            .expect("ftp server type is registered");
+        assert_eq!(svc.service_id(), service_id_for(&ServerType::Ftp));
     }
 }

--- a/src-tauri/src/embedded_servers/service.rs
+++ b/src-tauri/src/embedded_servers/service.rs
@@ -1,0 +1,855 @@
+//! Embedded server lifted onto the core [`Service`] trait.
+//!
+//! # S2 lift — embedded servers behind the core `Service` trait (#2154)
+//!
+//! Following the HTTP-monitor pilot (#2157/#2172), each embedded HTTP/FTP/TFTP
+//! server is an [`EmbeddedServerService`] implementing
+//! [`termihub_core::service::Service`] (the S1 substrate from #2148). A server's
+//! lifecycle — spawn its listener thread, confirm the bind, track live stats,
+//! stop — is owned by the service, which emits status transitions as
+//! [`ServiceEvent`]s on the core-owned [`EventChannel`] instead of pushing them
+//! through Tauri's [`Emitter`](tauri::Emitter). The desktop host
+//! ([`EmbeddedServerManager`](super::server_manager::EmbeddedServerManager))
+//! bridges that channel to the existing `embedded-server-status-changed` Tauri
+//! event, so the frontend contract is byte-for-byte unchanged.
+//!
+//! Decoupling the servers from `AppHandle` is what lets the *same* service run
+//! on the desktop **or** a remote agent (concept #2139, Phase S2). Physically
+//! relocating the server implementations into `core/src/embedded_servers/` and
+//! registering them on the agent is a follow-up (it requires moving the `axum`
+//! / `libunftp` dependency stack into the core + agent crates); this lift lands
+//! the trait, the event channel, run-location routing, and discovery.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{RecvTimeoutError, SyncSender};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use termihub_core::connection::schema::{FieldType, SettingsField, SettingsGroup};
+use termihub_core::connection::SettingsSchema;
+use termihub_core::service::{
+    EventChannel, Service, ServiceCapabilities, ServiceError, ServiceEvent, ServiceEventReceiver,
+    ServiceStatus,
+};
+
+use super::config::{
+    AtomicServerStats, EmbeddedServerConfig, ServerState, ServerStats, ServerStatus, ServerType,
+};
+use super::ftp_server::start_ftp_server;
+use super::http_server::start_http_server;
+use super::tftp_server::start_tftp_server;
+use crate::utils::errors::TerminalError;
+
+/// Machine-readable service id for the embedded HTTP server.
+pub const SERVICE_ID_HTTP: &str = "http_server";
+/// Machine-readable service id for the embedded FTP server.
+pub const SERVICE_ID_FTP: &str = "ftp_server";
+/// Machine-readable service id for the embedded TFTP server.
+pub const SERVICE_ID_TFTP: &str = "tftp_server";
+
+/// Event kind emitted on the [`EventChannel`] for each status transition.
+///
+/// The payload is a [`ServerState`], matching the `embedded-server-status-changed`
+/// Tauri event the desktop host bridges it to.
+pub const STATUS_EVENT_KIND: &str = "status";
+
+/// How long the service waits for a server thread to confirm its bind before
+/// treating the start as failed. Binding a local socket is near-instant, so a
+/// generous timeout only guards against a wedged thread (GAP G3, #1145).
+const BIND_CONFIRM_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// The core [`service_id`](Service::service_id) for a [`ServerType`].
+pub fn service_id_for(server_type: &ServerType) -> &'static str {
+    match server_type {
+        ServerType::Http => SERVICE_ID_HTTP,
+        ServerType::Ftp => SERVICE_ID_FTP,
+        ServerType::Tftp => SERVICE_ID_TFTP,
+    }
+}
+
+/// Human-readable [`display_name`](Service::display_name) for a [`ServerType`].
+pub fn display_name_for(server_type: &ServerType) -> &'static str {
+    match server_type {
+        ServerType::Http => "HTTP Server",
+        ServerType::Ftp => "FTP Server",
+        ServerType::Tftp => "TFTP Server",
+    }
+}
+
+/// One-shot handle a server thread uses to report whether its listening socket
+/// bound successfully.
+///
+/// The service holds the receiving end and only reports `Running` once
+/// [`BindSignal::confirm`] arrives; a [`BindSignal::fail`] (or a dropped sender)
+/// keeps the server out of the active slot so it never shows a stuck "Running"
+/// before flipping to `Error` (GAP G3, #1145).
+pub struct BindSignal {
+    tx: SyncSender<Result<(), String>>,
+}
+
+impl BindSignal {
+    /// Report that the listening socket bound successfully.
+    pub fn confirm(&self) {
+        // A full/closed channel means the service already gave up waiting; the
+        // send failure is harmless because the thread will still shut down.
+        let _ = self.tx.send(Ok(()));
+    }
+
+    /// Report that binding failed, carrying the reason for the UI.
+    pub fn fail(&self, reason: &str) {
+        let _ = self.tx.send(Err(reason.to_string()));
+    }
+}
+
+/// Decision the service makes from a server thread's bind signal.
+#[derive(Debug)]
+enum BindOutcome {
+    /// The socket bound — keep the active entry and report `Running`.
+    Running,
+    /// The bind failed (explicit error, dropped sender, or timeout) — drop the
+    /// active entry and report `Error` with this reason.
+    Failed(String),
+}
+
+/// Map a server thread's bind signal (received over the confirm channel) to the
+/// service's next action, so `Running` is only ever produced after a *confirmed*
+/// bind (GAP G3, #1145).
+///
+/// Pure and `AppHandle`-free so the start-flow decision can be unit-tested.
+fn decide_bind_outcome(signal: Result<Result<(), String>, RecvTimeoutError>) -> BindOutcome {
+    match signal {
+        Ok(Ok(())) => BindOutcome::Running,
+        Ok(Err(reason)) => BindOutcome::Failed(reason),
+        Err(RecvTimeoutError::Disconnected) => {
+            BindOutcome::Failed("server exited before confirming it was listening".to_string())
+        }
+        Err(RecvTimeoutError::Timeout) => {
+            BindOutcome::Failed("server did not confirm it was listening in time".to_string())
+        }
+    }
+}
+
+/// A running server instance.
+struct ActiveServer {
+    shutdown: Arc<AtomicBool>,
+    #[allow(dead_code)]
+    thread_handle: thread::JoinHandle<()>,
+    stats: Arc<AtomicServerStats>,
+    started_at: String,
+    /// Shared status updated by the server thread on error.
+    error: Arc<Mutex<Option<String>>>,
+}
+
+/// A single embedded HTTP/FTP/TFTP server lifted onto the core [`Service`] trait.
+///
+/// Created stopped for a given [`ServerType`]; a call to
+/// [`start_with`](Self::start_with) (or the trait's async
+/// [`start`](Service::start)) spawns the listener thread and, once the bind is
+/// confirmed, emits a [`ServiceStatus::Running`] transition on the
+/// [`EventChannel`]. The server implementations themselves
+/// ([`start_http_server`] etc.) are unchanged and fully `AppHandle`-free.
+pub struct EmbeddedServerService {
+    /// Which protocol this service hosts.
+    server_type: ServerType,
+    /// Config, set once the service is started. `None` before the first start.
+    config: Option<EmbeddedServerConfig>,
+    /// The live listener thread + its shared state, when running.
+    active: Option<ActiveServer>,
+    /// Current lifecycle status.
+    status: ServiceStatus,
+    /// Core event channel status transitions are emitted through.
+    events: EventChannel,
+}
+
+impl EmbeddedServerService {
+    /// Create a new, stopped embedded server service for `server_type`.
+    pub fn new(server_type: ServerType) -> Self {
+        Self {
+            server_type,
+            config: None,
+            active: None,
+            status: ServiceStatus::Stopped,
+            events: EventChannel::new(),
+        }
+    }
+
+    /// Emit a [`ServerState`] on the event channel as a `status` [`ServiceEvent`].
+    fn emit_state(&self, state: ServerState) {
+        self.events
+            .emit(ServiceEvent::new(STATUS_EVENT_KIND, state));
+    }
+
+    /// Attempt a quick bind to check whether a config's port is available.
+    ///
+    /// Static so the pre-flight check can be exercised without a live service.
+    pub fn check_port_config(config: &EmbeddedServerConfig) -> Result<(), TerminalError> {
+        let addr = format!("{}:{}", config.bind_host, config.port);
+        match config.server_type {
+            ServerType::Tftp => {
+                let socket = std::net::UdpSocket::bind(&addr).map_err(|e| {
+                    TerminalError::EmbeddedServerError(format!(
+                        "Port {} is already in use: {e}",
+                        config.port
+                    ))
+                })?;
+                drop(socket);
+            }
+            _ => {
+                let listener = std::net::TcpListener::bind(&addr).map_err(|e| {
+                    TerminalError::EmbeddedServerError(format!(
+                        "Port {} is already in use: {e}",
+                        config.port
+                    ))
+                })?;
+                drop(listener);
+            }
+        }
+        Ok(())
+    }
+
+    /// Start the server for `config` synchronously.
+    ///
+    /// Spawns the listener thread, waits for its bind to confirm, and emits the
+    /// `Starting` → `Running` (or `Error`) transitions on the [`EventChannel`].
+    /// The desktop host calls this directly from a synchronous Tauri command; the
+    /// trait's async [`start`](Service::start) parses a JSON config and delegates
+    /// here.
+    pub fn start_with(&mut self, config: EmbeddedServerConfig) -> Result<(), TerminalError> {
+        // A live server genuinely blocks a second start; a dead husk from a prior
+        // runtime failure does not (so a start acts as a Retry — GAP G2/G9).
+        if self.is_live() {
+            return Err(TerminalError::EmbeddedServerError(format!(
+                "Server {} is already running",
+                config.id
+            )));
+        }
+        self.active = None;
+
+        // Pre-flight bind check so we can return immediately for the common
+        // "port already in use" case.
+        Self::check_port_config(&config)?;
+
+        self.status = ServiceStatus::Starting;
+        self.config = Some(config.clone());
+        self.emit_state(build_status_state(
+            &config.id,
+            ServerStatus::Starting,
+            None,
+            ServerStats::default(),
+            None,
+        ));
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let stats = AtomicServerStats::new();
+        let error_slot: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
+        // One-slot channel the server thread uses to confirm (or reject) its real
+        // bind. `Running` is only emitted after this confirmation, so a late bind
+        // failure never leaves the item stuck green (GAP G3, #1145).
+        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel::<Result<(), String>>(1);
+
+        let cfg = config.clone();
+        let shutdown_clone = Arc::clone(&shutdown);
+        let stats_clone = Arc::clone(&stats);
+        let error_clone = Arc::clone(&error_slot);
+        let events = self.events.clone();
+        let id = config.id.clone();
+
+        let thread_handle = thread::spawn(move || {
+            let ready = BindSignal { tx: ready_tx };
+            let result = match cfg.server_type {
+                ServerType::Http => start_http_server(&cfg, shutdown_clone, stats_clone, ready),
+                ServerType::Ftp => start_ftp_server(&cfg, shutdown_clone, stats_clone, ready),
+                ServerType::Tftp => start_tftp_server(&cfg, shutdown_clone, stats_clone, ready),
+            };
+
+            if let Err(e) = result {
+                let msg = e.to_string();
+                tracing::error!(%id, "Embedded server error: {msg}");
+                if let Ok(mut slot) = error_clone.lock() {
+                    *slot = Some(msg.clone());
+                }
+                events.emit(ServiceEvent::new(
+                    STATUS_EVENT_KIND,
+                    build_status_state(
+                        &id,
+                        ServerStatus::Error,
+                        Some(msg),
+                        ServerStats::default(),
+                        None,
+                    ),
+                ));
+            }
+        });
+
+        // Wait for the thread to confirm its bind before declaring Running.
+        match decide_bind_outcome(ready_rx.recv_timeout(BIND_CONFIRM_TIMEOUT)) {
+            BindOutcome::Running => {
+                let started_at = chrono::Utc::now().to_rfc3339();
+                let snapshot = stats.snapshot();
+                self.active = Some(ActiveServer {
+                    shutdown,
+                    thread_handle,
+                    stats,
+                    started_at: started_at.clone(),
+                    error: error_slot,
+                });
+                self.status = ServiceStatus::Running;
+                self.emit_state(build_status_state(
+                    &config.id,
+                    ServerStatus::Running,
+                    None,
+                    snapshot,
+                    Some(started_at),
+                ));
+                tracing::info!(server_id = %config.id, "Embedded server started");
+                Ok(())
+            }
+            BindOutcome::Failed(reason) => {
+                // Bind never confirmed. Signal the thread to unwind (in case it
+                // did bind but timed out) and leave nothing active, so the server
+                // is reported as Error rather than a stuck Running.
+                shutdown.store(true, Ordering::Relaxed);
+                self.status = ServiceStatus::Failed(reason.clone());
+                tracing::warn!(server_id = %config.id, "Embedded server failed to start: {reason}");
+                self.emit_state(build_status_state(
+                    &config.id,
+                    ServerStatus::Error,
+                    Some(reason.clone()),
+                    ServerStats::default(),
+                    None,
+                ));
+                Err(TerminalError::EmbeddedServerError(reason))
+            }
+        }
+    }
+
+    /// Stop the running server, emitting a `Stopped` transition.
+    ///
+    /// The server thread exits on its own after its next poll cycle (we do not
+    /// join, to avoid blocking the caller). Synchronous counterpart of the
+    /// trait's async [`stop`](Service::stop).
+    pub fn shutdown(&mut self) {
+        if let Some(active) = self.active.take() {
+            active.shutdown.store(true, Ordering::Relaxed);
+            if let Some(config) = &self.config {
+                self.status = ServiceStatus::Stopped;
+                self.events.emit(ServiceEvent::new(
+                    STATUS_EVENT_KIND,
+                    build_status_state(
+                        &config.id,
+                        ServerStatus::Stopped,
+                        None,
+                        ServerStats::default(),
+                        None,
+                    ),
+                ));
+                tracing::info!(server_id = %config.id, "Embedded server stopped");
+            }
+        }
+        self.status = ServiceStatus::Stopped;
+    }
+
+    /// Whether the server is currently live (running, with no recorded runtime
+    /// error). A dead husk left by a runtime failure is not live, so a fresh
+    /// start acts as a Retry (GAP G2/G9, #1145).
+    pub fn is_live(&self) -> bool {
+        self.active
+            .as_ref()
+            .map(|a| active_entry_is_live(&a.error))
+            .unwrap_or(false)
+    }
+
+    /// Snapshot this server's runtime [`ServerState`] for listing.
+    ///
+    /// Returns `None` for a service that was never started (no config).
+    pub fn state(&self) -> Option<ServerState> {
+        let config = self.config.as_ref()?;
+        Some(match &self.active {
+            Some(active) => {
+                let error = active.error.lock().ok().and_then(|e| e.clone());
+                let status = if error.is_some() {
+                    ServerStatus::Error
+                } else {
+                    ServerStatus::Running
+                };
+                ServerState {
+                    server_id: config.id.clone(),
+                    status,
+                    error,
+                    stats: active.stats.snapshot(),
+                    started_at: Some(active.started_at.clone()),
+                }
+            }
+            None => ServerState {
+                server_id: config.id.clone(),
+                status: ServerStatus::Stopped,
+                error: None,
+                stats: ServerStats::default(),
+                started_at: None,
+            },
+        })
+    }
+
+    /// The settings schema for a server type (keys match [`EmbeddedServerConfig`]'s
+    /// camelCase fields). Backs the run-location / server-config discovery UI.
+    fn schema_for(server_type: &ServerType) -> SettingsSchema {
+        let mut fields = vec![
+            field("name", "Name", FieldType::Text, true, None),
+            field(
+                "rootDirectory",
+                "Root directory",
+                FieldType::Text,
+                true,
+                None,
+            ),
+            field(
+                "bindHost",
+                "Bind host",
+                FieldType::Text,
+                true,
+                Some(Value::from("127.0.0.1")),
+            ),
+            field(
+                "port",
+                "Port",
+                FieldType::Number {
+                    min: Some(1.0),
+                    max: Some(65_535.0),
+                },
+                true,
+                None,
+            ),
+            field(
+                "autoStart",
+                "Start on launch",
+                FieldType::Boolean,
+                false,
+                Some(Value::Bool(false)),
+            ),
+            field(
+                "readOnly",
+                "Read-only",
+                FieldType::Boolean,
+                false,
+                Some(Value::Bool(false)),
+            ),
+        ];
+        if *server_type == ServerType::Http {
+            fields.push(field(
+                "directoryListing",
+                "Directory listing",
+                FieldType::Boolean,
+                false,
+                Some(Value::Bool(true)),
+            ));
+        }
+        SettingsSchema {
+            groups: vec![SettingsGroup {
+                key: "server".to_string(),
+                label: display_name_for(server_type).to_string(),
+                fields,
+            }],
+        }
+    }
+
+    /// Test-only: construct a service in the `Running` state with `config` but
+    /// **without** spawning a real listener thread, so host-level bookkeeping
+    /// tests need no real socket.
+    #[cfg(test)]
+    pub(crate) fn test_running(config: EmbeddedServerConfig) -> Self {
+        let mut svc = Self::new(config.server_type.clone());
+        svc.active = Some(ActiveServer {
+            shutdown: Arc::new(AtomicBool::new(false)),
+            thread_handle: thread::spawn(|| {}),
+            stats: AtomicServerStats::new(),
+            started_at: chrono::Utc::now().to_rfc3339(),
+            error: Arc::new(Mutex::new(None)),
+        });
+        svc.status = ServiceStatus::Running;
+        svc.config = Some(config);
+        svc
+    }
+}
+
+#[async_trait]
+impl Service for EmbeddedServerService {
+    fn service_id(&self) -> &str {
+        service_id_for(&self.server_type)
+    }
+
+    fn display_name(&self) -> &str {
+        display_name_for(&self.server_type)
+    }
+
+    fn settings_schema(&self) -> SettingsSchema {
+        Self::schema_for(&self.server_type)
+    }
+
+    fn capabilities(&self) -> ServiceCapabilities {
+        ServiceCapabilities {
+            configurable: true,
+            emits_events: true,
+            // Serving files from a remote vantage point is a natural agent
+            // run-location; embedded servers are not in the permanent
+            // desktop-only set (credentials, spawn rendezvous, file watch,
+            // OS-window management).
+            desktop_only: false,
+        }
+    }
+
+    async fn start(&mut self, config: Value) -> Result<(), ServiceError> {
+        let config: EmbeddedServerConfig = serde_json::from_value(config)
+            .map_err(|e| ServiceError::InvalidConfig(e.to_string()))?;
+        if config.server_type != self.server_type {
+            return Err(ServiceError::InvalidConfig(format!(
+                "config is for a {:?} server but this service hosts {:?}",
+                config.server_type, self.server_type
+            )));
+        }
+        self.start_with(config)
+            .map_err(|e| ServiceError::StartFailed(e.to_string()))
+    }
+
+    async fn stop(&mut self) -> Result<(), ServiceError> {
+        self.shutdown();
+        Ok(())
+    }
+
+    fn status(&self) -> ServiceStatus {
+        self.status.clone()
+    }
+
+    fn subscribe_events(&self) -> ServiceEventReceiver {
+        self.events.subscribe()
+    }
+}
+
+/// Build a settings field with sensible defaults for the parts we don't use.
+fn field(
+    key: &str,
+    label: &str,
+    field_type: FieldType,
+    required: bool,
+    default: Option<Value>,
+) -> SettingsField {
+    SettingsField {
+        key: key.to_string(),
+        label: label.to_string(),
+        description: None,
+        help_text: None,
+        field_type,
+        required,
+        default,
+        placeholder: None,
+        supports_env_expansion: false,
+        supports_tilde_expansion: false,
+        visible_when: None,
+    }
+}
+
+/// Assemble the [`ServerState`] broadcast on `embedded-server-status-changed`.
+///
+/// Kept as a free function so the payload contract (real stats + `started_at`
+/// carried through, not zeroed — GAP G6, #1145) can be unit-tested.
+pub(super) fn build_status_state(
+    server_id: &str,
+    status: ServerStatus,
+    error: Option<String>,
+    stats: ServerStats,
+    started_at: Option<String>,
+) -> ServerState {
+    ServerState {
+        server_id: server_id.to_string(),
+        status,
+        error,
+        stats,
+        started_at,
+    }
+}
+
+/// Decide whether an active entry represents a *live* server (as opposed to a
+/// dead husk left behind by a runtime failure).
+///
+/// A live entry (empty error slot) must block a second concurrent start; a
+/// failed entry (error slot set) must NOT, so a subsequent start acts as a Retry
+/// rather than being rejected as "already running" (GAP G2/G9, #1145).
+fn active_entry_is_live(error: &Arc<Mutex<Option<String>>>) -> bool {
+    // If the lock is poisoned we cannot prove the server is healthy, so treat it
+    // as not-live and allow a fresh start to recover.
+    error.lock().map(|slot| slot.is_none()).unwrap_or(false)
+}
+
+/// Build the `Error` [`ServerState`] surfaced when a server marked `auto_start`
+/// fails to start at launch (e.g. its port is already in use) (GAP G7, #1145).
+pub(super) fn auto_start_error_state(server_id: &str, error: &str) -> ServerState {
+    ServerState {
+        server_id: server_id.to_string(),
+        status: ServerStatus::Error,
+        error: Some(error.to_string()),
+        stats: ServerStats::default(),
+        started_at: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+    use termihub_core::service::ServiceEventReceiver;
+
+    fn http_config(port: u16) -> EmbeddedServerConfig {
+        EmbeddedServerConfig {
+            id: "srv-http".to_string(),
+            name: "Test HTTP".to_string(),
+            server_type: ServerType::Http,
+            root_directory: ".".to_string(),
+            bind_host: "127.0.0.1".to_string(),
+            port,
+            auto_start: false,
+            read_only: true,
+            directory_listing: Some(true),
+            ftp_auth: None,
+        }
+    }
+
+    async fn recv_state(rx: &mut ServiceEventReceiver) -> ServerState {
+        let event = rx
+            .recv()
+            .await
+            .expect("a status event must arrive on the channel");
+        assert_eq!(event.kind, STATUS_EVENT_KIND);
+        serde_json::from_value(event.payload).expect("payload is a ServerState")
+    }
+
+    // ── bind-outcome decision (GAP G3, #1145) ─────────────────────────────────
+
+    #[test]
+    fn bind_success_signal_yields_running() {
+        assert!(matches!(
+            decide_bind_outcome(Ok(Ok(()))),
+            BindOutcome::Running
+        ));
+    }
+
+    #[test]
+    fn bind_failure_signal_yields_failed_with_reason() {
+        match decide_bind_outcome(Ok(Err("Port 8080 is already in use".to_string()))) {
+            BindOutcome::Failed(reason) => assert!(reason.contains("already in use")),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bind_disconnected_signal_yields_failed() {
+        assert!(matches!(
+            decide_bind_outcome(Err(mpsc::RecvTimeoutError::Disconnected)),
+            BindOutcome::Failed(_)
+        ));
+    }
+
+    #[test]
+    fn bind_timeout_signal_yields_failed() {
+        assert!(matches!(
+            decide_bind_outcome(Err(mpsc::RecvTimeoutError::Timeout)),
+            BindOutcome::Failed(_)
+        ));
+    }
+
+    // ── liveness (GAP G2/G9) ──────────────────────────────────────────────────
+
+    #[test]
+    fn active_entry_without_error_is_live() {
+        let error: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        assert!(active_entry_is_live(&error));
+    }
+
+    #[test]
+    fn errored_active_entry_is_not_live_so_start_is_allowed() {
+        let error: Arc<Mutex<Option<String>>> =
+            Arc::new(Mutex::new(Some("Port 8080 is already in use".to_string())));
+        assert!(!active_entry_is_live(&error));
+    }
+
+    // ── status payload contract (GAP G6) ──────────────────────────────────────
+
+    #[test]
+    fn status_state_carries_real_stats_and_started_at() {
+        let stats = ServerStats {
+            active_connections: 2,
+            total_connections: 7,
+            bytes_sent: 4096,
+            bytes_received: 512,
+        };
+        let started_at = "2024-01-01T00:00:00+00:00".to_string();
+        let state = build_status_state(
+            "srv-1",
+            ServerStatus::Running,
+            None,
+            stats,
+            Some(started_at.clone()),
+        );
+        assert_eq!(state.stats.total_connections, 7);
+        assert_eq!(state.stats.active_connections, 2);
+        assert_eq!(state.stats.bytes_sent, 4096);
+        assert_eq!(state.stats.bytes_received, 512);
+        assert_eq!(state.started_at, Some(started_at));
+    }
+
+    #[test]
+    fn status_state_defaults_when_no_active_entry() {
+        let state = build_status_state(
+            "srv-1",
+            ServerStatus::Stopped,
+            None,
+            ServerStats::default(),
+            None,
+        );
+        assert_eq!(state.status, ServerStatus::Stopped);
+        assert_eq!(state.stats.total_connections, 0);
+        assert!(state.started_at.is_none());
+    }
+
+    // ── Service metadata / schema ─────────────────────────────────────────────
+
+    #[test]
+    fn service_metadata_and_capabilities() {
+        for (ty, id) in [
+            (ServerType::Http, SERVICE_ID_HTTP),
+            (ServerType::Ftp, SERVICE_ID_FTP),
+            (ServerType::Tftp, SERVICE_ID_TFTP),
+        ] {
+            let svc = EmbeddedServerService::new(ty);
+            assert_eq!(svc.service_id(), id);
+            let caps = svc.capabilities();
+            assert!(caps.configurable);
+            assert!(caps.emits_events);
+            // Serving files may run on an agent — not desktop-only.
+            assert!(!caps.desktop_only);
+            // The schema exposes the core config fields.
+            let keys: Vec<String> = svc
+                .settings_schema()
+                .groups
+                .iter()
+                .flat_map(|g| g.fields.iter().map(|f| f.key.clone()))
+                .collect();
+            for expected in ["name", "rootDirectory", "bindHost", "port"] {
+                assert!(keys.contains(&expected.to_string()), "missing {expected}");
+            }
+        }
+    }
+
+    #[test]
+    fn http_schema_has_directory_listing_but_tftp_does_not() {
+        let http_keys: Vec<String> = EmbeddedServerService::new(ServerType::Http)
+            .settings_schema()
+            .groups
+            .iter()
+            .flat_map(|g| g.fields.iter().map(|f| f.key.clone()))
+            .collect();
+        assert!(http_keys.contains(&"directoryListing".to_string()));
+
+        let tftp_keys: Vec<String> = EmbeddedServerService::new(ServerType::Tftp)
+            .settings_schema()
+            .groups
+            .iter()
+            .flat_map(|g| g.fields.iter().map(|f| f.key.clone()))
+            .collect();
+        assert!(!tftp_keys.contains(&"directoryListing".to_string()));
+    }
+
+    #[test]
+    fn new_service_is_stopped_with_no_state() {
+        let svc = EmbeddedServerService::new(ServerType::Http);
+        assert_eq!(svc.status(), ServiceStatus::Stopped);
+        assert!(!svc.is_live());
+        assert!(svc.state().is_none());
+    }
+
+    #[test]
+    fn test_running_service_reports_live_running_state() {
+        // A service constructed in the Running state (no real socket) lists as a
+        // live, running server — the shape the host uses for bookkeeping.
+        let svc = EmbeddedServerService::test_running(http_config(0));
+        assert_eq!(svc.status(), ServiceStatus::Running);
+        assert!(svc.is_live());
+        let state = svc.state().expect("a started service has a state");
+        assert_eq!(state.status, ServerStatus::Running);
+        assert_eq!(state.server_id, "srv-http");
+    }
+
+    // ── real lifecycle over a live socket ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn start_runs_and_emits_status_through_event_channel() {
+        // An ephemeral port the HTTP server can bind.
+        let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
+        let port = probe.local_addr().unwrap().port();
+        drop(probe);
+
+        let mut svc = EmbeddedServerService::new(ServerType::Http);
+        let mut rx = svc.subscribe_events();
+        let cfg = http_config(port);
+        svc.start(serde_json::to_value(&cfg).unwrap())
+            .await
+            .expect("start should succeed");
+
+        assert_eq!(svc.status(), ServiceStatus::Running);
+        assert!(svc.is_live());
+
+        // Starting → Running transitions arrive on the core EventChannel (not a
+        // Tauri emitter).
+        let starting = recv_state(&mut rx).await;
+        assert_eq!(starting.status, ServerStatus::Starting);
+        let running = recv_state(&mut rx).await;
+        assert_eq!(running.status, ServerStatus::Running);
+        assert_eq!(running.server_id, cfg.id);
+
+        svc.stop().await.expect("stop");
+        assert_eq!(svc.status(), ServiceStatus::Stopped);
+        assert!(!svc.is_live());
+        let stopped = recv_state(&mut rx).await;
+        assert_eq!(stopped.status, ServerStatus::Stopped);
+    }
+
+    #[tokio::test]
+    async fn start_rejects_invalid_config() {
+        let mut svc = EmbeddedServerService::new(ServerType::Http);
+        let err = svc.start(serde_json::json!({ "id": "x" })).await;
+        assert!(matches!(err, Err(ServiceError::InvalidConfig(_))));
+        assert_eq!(svc.status(), ServiceStatus::Stopped);
+    }
+
+    #[tokio::test]
+    async fn start_rejects_mismatched_server_type() {
+        // An FTP config handed to an HTTP service is a config error, not a start.
+        let mut svc = EmbeddedServerService::new(ServerType::Http);
+        let mut cfg = http_config(0);
+        cfg.server_type = ServerType::Ftp;
+        let err = svc.start(serde_json::to_value(&cfg).unwrap()).await;
+        assert!(matches!(err, Err(ServiceError::InvalidConfig(_))));
+    }
+
+    #[test]
+    fn start_with_rejects_busy_port() {
+        // Hold a port, then a start against it must fail the pre-flight bind check
+        // and return an error (matching the original manager: the interactive
+        // caller surfaces the returned error; no listener is left running).
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let busy = listener.local_addr().unwrap().port();
+
+        let mut svc = EmbeddedServerService::new(ServerType::Http);
+        let err = svc
+            .start_with(http_config(busy))
+            .expect_err("busy port must fail the pre-flight bind");
+        assert!(err.to_string().contains("already in use"));
+        assert!(
+            !svc.is_live(),
+            "a failed start must not leave a live server"
+        );
+        drop(listener);
+    }
+}

--- a/src-tauri/src/embedded_servers/tftp_server.rs
+++ b/src-tauri/src/embedded_servers/tftp_server.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 
 use super::config::{AtomicServerStats, EmbeddedServerConfig};
-use super::server_manager::BindSignal;
+use super::service::BindSignal;
 
 // ─── TFTP opcodes (RFC 1350 §5) ──────────────────────────────────────────────
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1187,6 +1187,7 @@ pub fn run() {
             commands::network::network_http_monitor_list,
             commands::network::network_services_list,
             // Embedded servers
+            commands::embedded_servers::embedded_servers_services_list,
             commands::embedded_servers::list_embedded_servers,
             commands::embedded_servers::save_embedded_server,
             commands::embedded_servers::delete_embedded_server,


### PR DESCRIPTION
## Summary

First bounded slice of **#2154** (the S2 remainder of the stateless-UI port, #2139): lift the embedded **HTTP/FTP/TFTP servers** onto `termihub_core::service::Service` and decouple them from Tauri's `AppHandle`/`Emitter`, exactly mirroring the HTTP-monitor pilot (#2157/#2172). This is a **lift, not a redesign** — no user-facing behaviour changes.

`Part of #2154` — the issue stays **open**; the remaining acceptance bullets are filed as follow-ups (below).

## What changed

- **`EmbeddedServerService` implements the core `Service` trait** (`start`/`stop`/`status`/`subscribe_events` + `settings_schema` + `capabilities`), one instance per configured server. It owns a server's lifecycle — spawn the listener thread, confirm the bind (GAP G3, #1145), track live stats, stop — and emits each status transition as a `status` `ServiceEvent` on the core-owned `EventChannel` instead of pushing through `AppHandle::emit`. The server implementations themselves (`start_http_server` etc.) are unchanged and were already `AppHandle`-free.
- **`EmbeddedServerManager` is now a thin desktop host**: it holds the `EmbeddedServerService` instances, registers the three server types in a `ServiceRegistry` (discovery/schema/capabilities), routes each start through the `RunLocationResolver` (S1 default: always local; an agent request is explicitly rejected until agent hosting lands), and bridges each service's `EventChannel` to the existing `embedded-server-status-changed` Tauri event.
- **Frontend contract unchanged** — same event name, same `ServerState` payload. All the manager's persistence / auto-start / stop-all / states semantics are preserved, and every GAP-#1145 regression test moved with the logic it covers.
- **`capabilities.desktop_only = false`** for all three: serving files from a remote vantage point is a natural agent run-location, not part of the permanent desktop-only set.
- Added `embedded_servers_services_list` command backing run-location discovery (mirrors `network_services_list`, #2172).

## How events flow now

Before: manager → `app.emit("embedded-server-status-changed", state)`.
After: service status transition → `EventChannel::emit(ServiceEvent{kind:"status", payload: ServerState})` → desktop bridge task → `app.emit("embedded-server-status-changed", payload)`.

## Why the servers aren't physically in `core/` yet

Moving the server code into `core/src/embedded_servers/` means moving the `axum`/`tower-http`/`libunftp`/`unftp-sbe-fs` dependency stack into `core` (and enabling it for `agent`) — a multi-crate dependency change with cross-platform build risk, out of scope for a bounded PR. This slice lands the trait, the event channel, run-location routing, and discovery; the relocation + agent hosting is a follow-up (see #2192).

## Verification

- New unit test starts a **real HTTP server on an ephemeral port** and asserts the `Starting`→`Running`→`Stopped` transitions arrive on the core `EventChannel` (proving events no longer depend on a Tauri emitter), plus busy-port pre-flight rejection, invalid/mismatched-config rejection, schema/capabilities, and the relocated GAP-#1145 helper tests. `cargo test -p termihub embedded_servers` — 45 tests green.
- `cargo clippy -p termihub --all-targets -D warnings` and `cargo fmt --all -- --check` green.

## Follow-ups (keeping #2154 open)

- #2190 — route network tools (ping/traceroute/port-scan/DNS/WoL) to the agent via the resolver.
- #2191 — the run-location selector UI in Network Tools & Servers.
- #2192 — relocate the servers into `core/src/embedded_servers/` + host them on the agent.

Part of #2154
Part of #2139