### PR TITLE
feat(ui): route remaining panel-tree mutations through layout intents (Closes #2188)

### DIFF
--- a/docs/changes/dev1/feature/2188-wire-remaining-layout-intents.md
+++ b/docs/changes/dev1/feature/2188-wire-remaining-layout-intents.md
@@ -1,0 +1,5 @@
+### Changed
+
+- Split-pane sizes now persist when you drag a resize handle, so a custom split
+  ratio survives panel remounts and workspace save/restore instead of snapping
+  back to an even split. (#2188)

--- a/src-tauri/src/layout/projection.rs
+++ b/src-tauri/src/layout/projection.rs
@@ -27,6 +27,10 @@
 //! | `layout.merge`              | `{ sourcePanelId, targetPanelId }`       | move all tabs into the target, drop the source |
 //! | `layout.moveTab`            | `{ tabId, targetPanelId, edge }`         | move a tab (center = merge; edge = split)      |
 //! | `layout.closeTabStructure`  | `{ tabId }`                              | remove a tab; drop its leaf if left empty      |
+//! | `layout.removePanel`        | `{ panelId }`                            | drop a whole leaf panel, then simplify         |
+//! | `layout.reorderTabs`        | `{ panelId, oldIndex, newIndex }`        | reorder a tab within its leaf                   |
+//! | `layout.setActivePanel`     | `{ panelId }`                            | repoint the focused panel                       |
+//! | `layout.resize`             | `{ splitId, sizes }`                     | persist a split's child percentage sizes        |
 //! | `layout.replace`            | `{ root, activePanelId }`                | install a whole tree (the bridge's seed path)  |
 //!
 //! # Shadow mode
@@ -69,7 +73,7 @@ pub fn publish_layout(
     }
 }
 
-/// Register the four `layout.*` intents on a handler registry.
+/// Register the `layout.*` intents on a handler registry.
 ///
 /// Each route resolves the managed [`LayoutStore`] lazily (so it rejects
 /// gracefully rather than panicking if the store is somehow absent), mutates the
@@ -118,6 +122,49 @@ pub fn register_layout_intents(registry: &mut HandlerRegistry, app_handle: AppHa
         let tab_id = required_str(intent, "tabId")?;
         store
             .close_tab_structure(&intent.client_id, &tab_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.removePanel", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let panel_id = required_str(intent, "panelId")?;
+        store
+            .remove_panel(&intent.client_id, &panel_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.reorderTabs", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let panel_id = required_str(intent, "panelId")?;
+        let old_index = required_usize(intent, "oldIndex")?;
+        let new_index = required_usize(intent, "newIndex")?;
+        store
+            .reorder_tabs(&intent.client_id, &panel_id, old_index, new_index)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.setActivePanel", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let panel_id = required_str(intent, "panelId")?;
+        store
+            .set_active_panel(&intent.client_id, &panel_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.resize", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let split_id = required_str(intent, "splitId")?;
+        let sizes = required_sizes(intent, "sizes")?;
+        store
+            .resize(&intent.client_id, &split_id, sizes)
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &store, &intent.client_id))
     });
@@ -173,6 +220,32 @@ fn required_str(intent: &Intent, key: &str) -> Result<String, (String, String)> 
         .and_then(Value::as_str)
         .map(str::to_string)
         .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// Extract a required non-negative integer field (e.g. a tab index).
+fn required_usize(intent: &Intent, key: &str) -> Result<usize, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_u64)
+        .map(|n| n as usize)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// Extract a required array of finite numbers (e.g. split `sizes`).
+fn required_sizes(intent: &Intent, key: &str) -> Result<Vec<f64>, (String, String)> {
+    let arr = intent
+        .payload
+        .get(key)
+        .and_then(Value::as_array)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))?;
+    arr.iter()
+        .map(|v| {
+            v.as_f64()
+                .filter(|n| n.is_finite())
+                .ok_or_else(|| ("bad_payload".to_string(), format!("invalid '{key}' entry")))
+        })
+        .collect()
 }
 
 /// Extract and deserialize a required enum field (e.g. `direction`, `edge`).

--- a/src-tauri/src/layout/projection_tests.rs
+++ b/src-tauri/src/layout/projection_tests.rs
@@ -109,6 +109,41 @@ fn registry_for(store: Arc<LayoutStore>) -> HandlerRegistry {
         Ok(publish_layout(projector, &s, &intent.client_id))
     });
 
+    let s = store.clone();
+    registry.route("layout.removePanel", move |intent, projector| {
+        let panel_id = required_str(intent, "panelId")?;
+        s.remove_panel(&intent.client_id, &panel_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("layout.reorderTabs", move |intent, projector| {
+        let panel_id = required_str(intent, "panelId")?;
+        let old_index = required_usize(intent, "oldIndex")?;
+        let new_index = required_usize(intent, "newIndex")?;
+        s.reorder_tabs(&intent.client_id, &panel_id, old_index, new_index)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("layout.setActivePanel", move |intent, projector| {
+        let panel_id = required_str(intent, "panelId")?;
+        s.set_active_panel(&intent.client_id, &panel_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("layout.resize", move |intent, projector| {
+        let split_id = required_str(intent, "splitId")?;
+        let sizes = required_sizes(intent, "sizes")?;
+        s.resize(&intent.client_id, &split_id, sizes)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
     let s = store;
     registry.route("layout.replace", move |intent, projector| {
         let (root, active_panel_id) = parse_replace(intent)?;
@@ -340,6 +375,108 @@ fn replace_seeds_a_tree_then_a_structural_intent_round_trips() {
         termihub_core::layout::panel_tree::count_tabs_in_tree(&root),
         3
     );
+}
+
+#[test]
+fn the_step2b_intents_round_trip_and_converge_on_authority() {
+    // The four step-2b cuts (#2188): removePanel, reorderTabs, setActivePanel,
+    // resize each accept and fan a single diff, and the client cache converges on
+    // the store's authoritative view after each.
+    let store = Arc::new(LayoutStore::new());
+    // A three-leaf tree so removePanel/resize have structure to work on.
+    let tree = PanelNode::Split(SplitContainer {
+        id: "root".to_string(),
+        direction: Direction::Horizontal,
+        children: vec![
+            PanelNode::Leaf(leaf("a", &["t1", "t2"])),
+            PanelNode::Leaf(leaf("b", &["t3"])),
+            PanelNode::Leaf(leaf("c", &["t4"])),
+        ],
+        sizes: None,
+        last_active_leaf_id: None,
+    });
+    store.seed_for_test("A", tree, Some("a".to_string()));
+    let region = layout_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(&region, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    let ack = dispatcher.dispatch(intent(
+        "layout.reorderTabs",
+        "A",
+        json!({ "panelId": "a", "oldIndex": 0, "newIndex": 1 }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    let ack = dispatcher.dispatch(intent(
+        "layout.resize",
+        "A",
+        json!({ "splitId": "root", "sizes": [50.0, 25.0, 25.0] }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    let ack = dispatcher.dispatch(intent(
+        "layout.setActivePanel",
+        "A",
+        json!({ "panelId": "c" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    let ack = dispatcher.dispatch(intent("layout.removePanel", "A", json!({ "panelId": "b" })));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 4, "one diff per accepted intent");
+    for diff in &diffs {
+        cache.apply(diff);
+    }
+    assert_eq!(cache.version, 4);
+    assert_eq!(
+        cache.view,
+        store.snapshot("A"),
+        "cache converges on authority"
+    );
+
+    // Final assertions on the authoritative tree.
+    let root: PanelNode = serde_json::from_value(store.snapshot("A")["root"].clone()).unwrap();
+    let a = termihub_core::layout::panel_tree::find_leaf(&root, "a").unwrap();
+    assert_eq!(
+        a.tabs.iter().map(|t| t.id.as_str()).collect::<Vec<_>>(),
+        vec!["t2", "t1"],
+        "reorder landed"
+    );
+    assert!(
+        termihub_core::layout::panel_tree::find_leaf(&root, "b").is_none(),
+        "removePanel dropped b"
+    );
+    assert_eq!(
+        store.snapshot("A")["activePanelId"],
+        json!("c"),
+        "focus folded into the projection"
+    );
+}
+
+#[test]
+fn a_bad_reorder_index_is_rejected_without_advancing() {
+    let store = seeded_store("A");
+    let region = layout_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(&region, "sub", "A", sink.clone());
+
+    // b holds a single tab → index 5 is out of range.
+    let ack = dispatcher.dispatch(intent(
+        "layout.reorderTabs",
+        "A",
+        json!({ "panelId": "b", "oldIndex": 5, "newIndex": 0 }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "bad_payload");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(&region), Some(0));
 }
 
 #[test]

--- a/src-tauri/src/layout/store.rs
+++ b/src-tauri/src/layout/store.rs
@@ -16,8 +16,8 @@ use serde_json::{json, Value};
 
 use termihub_core::layout::panel_tree::{
     create_leaf_panel, edge_to_split, find_leaf, find_leaf_by_tab, generate_panel_id,
-    get_all_leaves, remove_leaf, simplify_tree, split_leaf, update_leaf, Direction, DropEdge,
-    LeafPanel, PanelNode, Position, Tab,
+    get_all_leaves, normalize_sizes, remove_leaf, simplify_tree, split_leaf, update_leaf,
+    Direction, DropEdge, LeafPanel, PanelNode, Position, SplitContainer, Tab,
 };
 
 /// A rejectable layout-intent failure. Maps to an intent ack `(code, message)`
@@ -37,6 +37,13 @@ pub enum LayoutError {
     /// `merge` was asked to merge a panel into itself.
     #[error("source and target panels are the same")]
     SamePanel,
+    /// A `reorderTabs` index fell outside the target leaf's tab range.
+    #[error("tab index out of range")]
+    IndexOutOfRange,
+    /// A `resize` supplied a size array whose length did not match the split's
+    /// child count.
+    #[error("size count does not match the split's children")]
+    SizeMismatch,
 }
 
 impl LayoutError {
@@ -45,7 +52,10 @@ impl LayoutError {
         match self {
             LayoutError::PanelNotFound(_) => "panel_not_found",
             LayoutError::TabNotFound(_) => "tab_not_found",
-            LayoutError::BadEdge | LayoutError::SamePanel => "bad_payload",
+            LayoutError::BadEdge
+            | LayoutError::SamePanel
+            | LayoutError::IndexOutOfRange
+            | LayoutError::SizeMismatch => "bad_payload",
         }
     }
 }
@@ -230,6 +240,102 @@ impl LayoutStore {
         Ok(())
     }
 
+    /// `layout.removePanel` — drop a whole leaf panel (and every tab it holds)
+    /// from the tree, then simplify and repoint focus. The structural half of the
+    /// close-panel action.
+    ///
+    /// Neither [`merge`](Self::merge) (which *preserves* the tabs by moving them
+    /// into a target) nor [`close_tab_structure`](Self::close_tab_structure)
+    /// (which removes a single tab) matches "discard the entire panel", so this is
+    /// its own transform over the shared `remove_leaf` algebra. Removing the sole
+    /// remaining leaf is a no-op — the app always keeps at least one panel —
+    /// mirroring the frontend `removePanel` reducer's `allLeaves.length <= 1`
+    /// guard, so the two paths stay parity-identical.
+    pub fn remove_panel(&self, client_id: &str, panel_id: &str) -> Result<(), LayoutError> {
+        let mut clients = self.lock();
+        let state = clients
+            .entry(client_id.to_string())
+            .or_insert_with(LayoutState::seeded);
+        if find_leaf(&state.root, panel_id).is_none() {
+            return Err(LayoutError::PanelNotFound(panel_id.to_string()));
+        }
+        if get_all_leaves(&state.root).len() <= 1 {
+            // Sole leaf: the frontend leaves the tree untouched; match it.
+            return Ok(());
+        }
+        let removed = remove_leaf(&state.root, panel_id).unwrap_or_else(single_empty_leaf);
+        state.root = simplify_tree(&removed);
+        // `fix_active` repoints focus onto the first surviving leaf when the
+        // removed panel held it — exactly the frontend `newLeaves[0]` fallback.
+        fix_active(state);
+        Ok(())
+    }
+
+    /// `layout.reorderTabs` — move a tab within a single leaf from `old_index` to
+    /// `new_index`, leaving the active tab and every other panel untouched (a
+    /// same-panel drag-reorder). Mirrors the frontend `reorderTabs` reducer.
+    pub fn reorder_tabs(
+        &self,
+        client_id: &str,
+        panel_id: &str,
+        old_index: usize,
+        new_index: usize,
+    ) -> Result<(), LayoutError> {
+        let mut clients = self.lock();
+        let state = clients
+            .entry(client_id.to_string())
+            .or_insert_with(LayoutState::seeded);
+        let leaf = find_leaf(&state.root, panel_id)
+            .ok_or_else(|| LayoutError::PanelNotFound(panel_id.to_string()))?;
+        let len = leaf.tabs.len();
+        if old_index >= len || new_index >= len {
+            return Err(LayoutError::IndexOutOfRange);
+        }
+        state.root = update_leaf(&state.root, panel_id, |leaf| {
+            with_tabs_reordered(leaf, old_index, new_index)
+        });
+        Ok(())
+    }
+
+    /// `layout.setActivePanel` — repoint the focused panel. Focus lives in the
+    /// projected view (`activePanelId`), so this makes the store authoritative for
+    /// it; zoom-follow stays a frontend concern under partial projection.
+    pub fn set_active_panel(&self, client_id: &str, panel_id: &str) -> Result<(), LayoutError> {
+        let mut clients = self.lock();
+        let state = clients
+            .entry(client_id.to_string())
+            .or_insert_with(LayoutState::seeded);
+        if find_leaf(&state.root, panel_id).is_none() {
+            return Err(LayoutError::PanelNotFound(panel_id.to_string()));
+        }
+        state.active_panel_id = Some(panel_id.to_string());
+        Ok(())
+    }
+
+    /// `layout.resize` — persist the child percentage `sizes` of the split
+    /// container `split_id` (normalized to sum to 100), so a user's drag of a
+    /// resize handle survives remounts and workspace save/restore. Rejects a size
+    /// array whose length does not match the split's child count.
+    pub fn resize(
+        &self,
+        client_id: &str,
+        split_id: &str,
+        sizes: Vec<f64>,
+    ) -> Result<(), LayoutError> {
+        let mut clients = self.lock();
+        let state = clients
+            .entry(client_id.to_string())
+            .or_insert_with(LayoutState::seeded);
+        let split = find_split(&state.root, split_id)
+            .ok_or_else(|| LayoutError::PanelNotFound(split_id.to_string()))?;
+        if sizes.len() != split.children.len() {
+            return Err(LayoutError::SizeMismatch);
+        }
+        let normalized = normalize_sizes(&sizes);
+        state.root = set_split_sizes(&state.root, split_id, &normalized);
+        Ok(())
+    }
+
     /// `layout.replace` — install a complete tree for a client, replacing any
     /// existing one.
     ///
@@ -336,6 +442,60 @@ fn with_tabs_appended(leaf: &LeafPanel, extra: &[Tab]) -> LeafPanel {
         id: leaf.id.clone(),
         tabs,
         active_tab_id,
+    }
+}
+
+/// A copy of `leaf` with the tab at `old_index` moved to `new_index`, preserving
+/// the active tab. Mirrors the frontend `reorderTabs` splice-out-then-splice-in;
+/// callers validate the indices against the tab count first.
+fn with_tabs_reordered(leaf: &LeafPanel, old_index: usize, new_index: usize) -> LeafPanel {
+    let mut tabs = leaf.tabs.clone();
+    let moved = tabs.remove(old_index);
+    tabs.insert(new_index.min(tabs.len()), moved);
+    LeafPanel {
+        id: leaf.id.clone(),
+        tabs,
+        active_tab_id: leaf.active_tab_id.clone(),
+    }
+}
+
+/// Find a split container by id anywhere in the tree.
+fn find_split<'a>(root: &'a PanelNode, split_id: &str) -> Option<&'a SplitContainer> {
+    match root {
+        PanelNode::Leaf(_) => None,
+        PanelNode::Split(split) => {
+            if split.id == split_id {
+                return Some(split);
+            }
+            split.children.iter().find_map(|c| find_split(c, split_id))
+        }
+    }
+}
+
+/// Return a copy of the tree with `split_id`'s `sizes` set to `sizes`. A no-op
+/// structural clone when the id is absent (callers validate existence first).
+fn set_split_sizes(root: &PanelNode, split_id: &str, sizes: &[f64]) -> PanelNode {
+    match root {
+        PanelNode::Leaf(leaf) => PanelNode::Leaf(leaf.clone()),
+        PanelNode::Split(split) => {
+            let children = split
+                .children
+                .iter()
+                .map(|c| set_split_sizes(c, split_id, sizes))
+                .collect();
+            let new_sizes = if split.id == split_id {
+                Some(sizes.to_vec())
+            } else {
+                split.sizes.clone()
+            };
+            PanelNode::Split(SplitContainer {
+                id: split.id.clone(),
+                direction: split.direction,
+                children,
+                sizes: new_sizes,
+                last_active_leaf_id: split.last_active_leaf_id.clone(),
+            })
+        }
     }
 }
 

--- a/src-tauri/src/layout/store_tests.rs
+++ b/src-tauri/src/layout/store_tests.rs
@@ -322,6 +322,169 @@ fn close_of_unknown_tab_is_rejected() {
     );
 }
 
+// ── removePanel ──────────────────────────────────────────────────────────────
+
+#[test]
+fn remove_panel_drops_the_whole_leaf_and_simplifies() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    store.remove_panel("C", "a").unwrap();
+
+    let root = root_of(&store, "C");
+    // a (and its two tabs) is gone; the split simplifies to the single leaf b.
+    let leaves = get_all_leaves(&root);
+    assert_eq!(leaves.len(), 1, "removed panel dropped, split simplified");
+    assert_eq!(leaves[0].id, "b");
+    assert_eq!(count_tabs_in_tree(&root), 1, "only b's tab survives");
+    // Focus was on the removed panel → repointed onto the survivor.
+    assert_eq!(active_of(&store, "C").as_deref(), Some("b"));
+}
+
+#[test]
+fn remove_panel_keeps_focus_when_a_different_panel_is_removed() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    store.remove_panel("C", "b").unwrap();
+    // a was focused and survives → focus unchanged (frontend parity).
+    assert_eq!(active_of(&store, "C").as_deref(), Some("a"));
+}
+
+#[test]
+fn remove_panel_on_the_sole_leaf_is_a_no_op() {
+    let store = LayoutStore::new();
+    let root = PanelNode::Leaf(leaf("only", &["t1"]));
+    store.seed_for_test("C", root, Some("only".to_string()));
+    store.remove_panel("C", "only").unwrap();
+
+    let root = root_of(&store, "C");
+    // The app always keeps one panel; the sole leaf is untouched.
+    assert_eq!(get_all_leaves(&root).len(), 1);
+    assert_eq!(count_tabs_in_tree(&root), 1);
+    assert_eq!(active_of(&store, "C").as_deref(), Some("only"));
+}
+
+#[test]
+fn remove_panel_of_unknown_panel_is_rejected() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    assert_eq!(
+        store.remove_panel("C", "ghost").unwrap_err(),
+        LayoutError::PanelNotFound("ghost".to_string()),
+    );
+}
+
+// ── reorderTabs ──────────────────────────────────────────────────────────────
+
+#[test]
+fn reorder_tabs_moves_a_tab_within_its_leaf_keeping_active() {
+    let store = LayoutStore::new();
+    let root = PanelNode::Leaf(LeafPanel {
+        id: "a".to_string(),
+        tabs: vec![tab("t1"), tab("t2"), tab("t3")],
+        active_tab_id: Some("t1".to_string()),
+    });
+    store.seed_for_test("C", root, Some("a".to_string()));
+    // Move t1 (index 0) to index 2.
+    store.reorder_tabs("C", "a", 0, 2).unwrap();
+
+    let root = root_of(&store, "C");
+    let a = find_leaf(&root, "a").unwrap();
+    let ids: Vec<&str> = a.tabs.iter().map(|t| t.id.as_str()).collect();
+    assert_eq!(ids, vec!["t2", "t3", "t1"], "tab reordered");
+    assert_eq!(
+        a.active_tab_id.as_deref(),
+        Some("t1"),
+        "active tab preserved"
+    );
+}
+
+#[test]
+fn reorder_tabs_rejects_an_out_of_range_index() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    // b holds one tab → index 1 is out of range.
+    assert_eq!(
+        store.reorder_tabs("C", "b", 1, 0).unwrap_err(),
+        LayoutError::IndexOutOfRange,
+    );
+    assert_eq!(LayoutError::IndexOutOfRange.code(), "bad_payload");
+}
+
+#[test]
+fn reorder_tabs_of_unknown_panel_is_rejected() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    assert_eq!(
+        store.reorder_tabs("C", "ghost", 0, 0).unwrap_err(),
+        LayoutError::PanelNotFound("ghost".to_string()),
+    );
+}
+
+// ── setActivePanel ───────────────────────────────────────────────────────────
+
+#[test]
+fn set_active_panel_repoints_focus_without_touching_the_tree() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    let before = root_of(&store, "C");
+    store.set_active_panel("C", "b").unwrap();
+
+    assert_eq!(active_of(&store, "C").as_deref(), Some("b"), "focus moved");
+    assert_eq!(root_of(&store, "C"), before, "tree unchanged");
+}
+
+#[test]
+fn set_active_panel_of_unknown_panel_is_rejected() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    assert_eq!(
+        store.set_active_panel("C", "ghost").unwrap_err(),
+        LayoutError::PanelNotFound("ghost".to_string()),
+    );
+}
+
+// ── resize ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn resize_persists_normalized_sizes_on_the_split() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    // Supply sizes that do not sum to 100 → stored normalized.
+    store.resize("C", "root", vec![30.0, 10.0]).unwrap();
+
+    let root = root_of(&store, "C");
+    match root {
+        PanelNode::Split(split) => {
+            let sizes = split.sizes.expect("sizes persisted");
+            assert_eq!(sizes.len(), 2);
+            assert!((sizes[0] - 75.0).abs() < 1e-9, "normalized to sum 100");
+            assert!((sizes[1] - 25.0).abs() < 1e-9);
+        }
+        _ => panic!("expected a split at the root"),
+    }
+}
+
+#[test]
+fn resize_rejects_a_mismatched_size_count() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    assert_eq!(
+        store.resize("C", "root", vec![100.0]).unwrap_err(),
+        LayoutError::SizeMismatch,
+    );
+    assert_eq!(LayoutError::SizeMismatch.code(), "bad_payload");
+}
+
+#[test]
+fn resize_of_unknown_split_is_rejected() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    assert_eq!(
+        store.resize("C", "ghost", vec![50.0, 50.0]).unwrap_err(),
+        LayoutError::PanelNotFound("ghost".to_string()),
+    );
+}
+
 // ── Property tests over the transforms ───────────────────────────────────────
 
 /// After every applied transform: at least one leaf survives, leaf ids stay

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -35,7 +35,7 @@ import {
 import { useAppStore } from "@/store/appStore";
 import { useLayoutRenderTree } from "@/store/useLayoutRenderTree";
 import { PanelNode, LeafPanel, TerminalTab, DropEdge } from "@/types/terminal";
-import { getAllLeaves, findLeafByTab, isWindowEmpty } from "@/utils/panelTree";
+import { getAllLeaves, findLeafByTab, isWindowEmpty, normalizeSizes } from "@/utils/panelTree";
 import { broadcastPanelClass } from "@/utils/broadcastPanel";
 import { getEditorTabDisplayTitle } from "@/utils/editorTabTitle";
 import { isWindows, isMac } from "@/utils/platform";
@@ -538,6 +538,10 @@ interface PanelNodeRendererProps {
 }
 
 function PanelNodeRenderer({ node, setActivePanel, activeDragTab }: PanelNodeRendererProps) {
+  // Hook is read unconditionally (before the leaf/split branch) so a node that
+  // flips between leaf and split across renders keeps a stable hook order.
+  const setPanelSizes = useAppStore((s) => s.setPanelSizes);
+
   if (node.type === "leaf") {
     // Per-panel boundary (#2069): a render throw in one leaf is caught here and
     // shown as a localized fallback, so it cannot propagate to the app-wide
@@ -549,12 +553,28 @@ function PanelNodeRenderer({ node, setActivePanel, activeDragTab }: PanelNodeRen
     );
   }
 
-  const orientation = node.direction === "horizontal" ? "horizontal" : "vertical";
+  const split = node;
+  const orientation = split.direction === "horizontal" ? "horizontal" : "vertical";
+
+  // Persist a resize-handle drag (#2188). `onLayoutChanged` reports the settled
+  // layout as an id→percentage map; map it back to child order and route through
+  // `setPanelSizes` (→ `layout.resize` intent, with a local fallback). Skip when
+  // the layout is unchanged from what is already stored (the initial equal split,
+  // or a re-fire with the same sizes) so mounts do not churn the tree/backend.
+  const handleLayoutChanged = (layout: Record<string, number>): void => {
+    const next = split.children.map((c) => layout[c.id]);
+    if (!next.every((n) => typeof n === "number" && Number.isFinite(n))) return;
+    const prev = split.sizes ?? split.children.map(() => 100 / split.children.length);
+    const normPrev = normalizeSizes(prev);
+    const normNext = normalizeSizes(next);
+    if (normNext.every((n, i) => Math.abs(n - normPrev[i]) < 0.5)) return;
+    setPanelSizes(split.id, next);
+  };
 
   return (
-    <Group orientation={orientation} className="split-view">
-      {node.children.map((child, index) => (
-        <SplitChild key={child.id} index={index} defaultSize={node.sizes?.[index]}>
+    <Group orientation={orientation} className="split-view" onLayoutChanged={handleLayoutChanged}>
+      {split.children.map((child, index) => (
+        <SplitChild key={child.id} id={child.id} index={index} defaultSize={split.sizes?.[index]}>
           <PanelNodeRenderer
             node={child}
             setActivePanel={setActivePanel}
@@ -567,10 +587,12 @@ function PanelNodeRenderer({ node, setActivePanel, activeDragTab }: PanelNodeRen
 }
 
 function SplitChild({
+  id,
   index,
   defaultSize,
   children,
 }: {
+  id: string;
   index: number;
   defaultSize?: number;
   children: React.ReactNode;
@@ -580,7 +602,7 @@ function SplitChild({
       {index > 0 && (
         <Separator className="split-view__resize-handle" data-testid="split-view-resize-handle" />
       )}
-      <Panel minSize={10} defaultSize={defaultSize}>
+      <Panel id={id} minSize={10} defaultSize={defaultSize}>
         {children}
       </Panel>
     </>

--- a/src/store/appStore.layoutBridge.test.ts
+++ b/src/store/appStore.layoutBridge.test.ts
@@ -18,6 +18,7 @@ import {
   findLeafByTab,
   generatePanelId,
   getAllLeaves,
+  normalizeSizes,
   removeLeaf,
   simplifyTree,
   splitLeaf,
@@ -124,6 +125,47 @@ vi.mock("@/services/transport", () => ({
         }
         root = simplifyTree(root);
         backend.push({ root, activePanelId: view.activePanelId });
+      } else if (intent.kind === "layout.removePanel") {
+        // Mirrors the Rust store's remove_panel: drop the whole leaf, simplify,
+        // repoint focus onto the first survivor when the removed panel held it.
+        const view = backend.view as { root: PanelNode; activePanelId: string | null };
+        const panelId = intent.payload.panelId as string;
+        const removed = removeLeaf(view.root, panelId);
+        const root = removed ? simplifyTree(removed) : view.root;
+        let active = view.activePanelId;
+        if (!active || !findLeaf(root, active)) {
+          active = getAllLeaves(root)[0]?.id ?? null;
+        }
+        backend.push({ root, activePanelId: active });
+      } else if (intent.kind === "layout.reorderTabs") {
+        // Mirrors the Rust store's reorder_tabs: move a tab within its leaf,
+        // leaving focus untouched.
+        const view = backend.view as { root: PanelNode; activePanelId: string | null };
+        const panelId = intent.payload.panelId as string;
+        const oldIndex = intent.payload.oldIndex as number;
+        const newIndex = intent.payload.newIndex as number;
+        const root = updateLeaf(view.root, panelId, (leaf) => {
+          const tabs = [...leaf.tabs];
+          const [moved] = tabs.splice(oldIndex, 1);
+          tabs.splice(newIndex, 0, moved);
+          return { ...leaf, tabs };
+        });
+        backend.push({ root, activePanelId: view.activePanelId });
+      } else if (intent.kind === "layout.setActivePanel") {
+        // Mirrors the Rust store's set_active_panel: repoint focus, tree unchanged.
+        const view = backend.view as { root: PanelNode };
+        backend.push({ root: view.root, activePanelId: intent.payload.panelId as string });
+      } else if (intent.kind === "layout.resize") {
+        // Mirrors the Rust store's resize: set the split's normalized sizes.
+        const view = backend.view as { root: PanelNode; activePanelId: string | null };
+        const splitId = intent.payload.splitId as string;
+        const sizes = normalizeSizes(intent.payload.sizes as number[]);
+        const setSizes = (n: PanelNode): PanelNode => {
+          if (n.type === "leaf") return n;
+          const children = n.children.map(setSizes);
+          return n.id === splitId ? { ...n, children, sizes } : { ...n, children };
+        };
+        backend.push({ root: setSizes(view.root), activePanelId: view.activePanelId });
       }
       return {
         intentId: "intent-test",
@@ -318,6 +360,91 @@ describe("appStore layout bridge — cut ↔ local parity (#2151)", () => {
       useAppStore.getState().splitPanelWithTab("t3", "b", "a", "right")
     );
     expect(cut).toEqual(local);
+  });
+
+  it("removePanel drops the panel identically both ways (#2188)", async () => {
+    const { local, cut } = await runBothWays(() => useAppStore.getState().removePanel("a"));
+    expect(cut).toEqual(local);
+  });
+
+  it("removePanel keeps focus on a surviving panel identically both ways (#2188)", async () => {
+    // Focus starts on "a"; removing "b" must leave "a" focused on both paths.
+    const run = async (flag: boolean): Promise<unknown> => {
+      useAppStore.setState(useAppStore.getInitialState());
+      useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
+      backend.reset();
+      setLayoutIntentsEnabled(flag);
+      useAppStore.getState().removePanel("b");
+      await flush();
+      const s = useAppStore.getState();
+      return normalize(s.rootPanel, s.activePanelId);
+    };
+    expect(await run(true)).toEqual(await run(false));
+    expect(useAppStore.getState().activePanelId).toBe("a");
+  });
+
+  it("reorderTabs reorders within a leaf identically both ways (#2188)", async () => {
+    const { local, cut } = await runBothWays(() =>
+      useAppStore.getState().reorderTabs("a", 0, 1)
+    );
+    expect(cut).toEqual(local);
+  });
+
+  it("setActivePanel folds focus into the projection while applying locally (#2188)", async () => {
+    // Flag off (rollback): pure-local focus change, nothing dispatched.
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
+    backend.reset();
+    dispatched.length = 0;
+    setLayoutIntentsEnabled(false);
+    useAppStore.getState().setActivePanel("b");
+    expect(useAppStore.getState().activePanelId).toBe("b");
+    expect(dispatched).toHaveLength(0);
+
+    // Flag on: focus applies synchronously (instant UX) AND folds into the region.
+    useAppStore.setState(useAppStore.getInitialState());
+    useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
+    backend.reset();
+    dispatched.length = 0;
+    setLayoutIntentsEnabled(true);
+    useAppStore.getState().setActivePanel("b");
+    expect(useAppStore.getState().activePanelId).toBe("b");
+    await flush();
+    expect(dispatched.map((d) => d.kind)).toEqual(["layout.replace", "layout.setActivePanel"]);
+    // The projection now tracks the folded focus.
+    expect((backend.view as { activePanelId: string }).activePanelId).toBe("b");
+  });
+
+  it("setActivePanel preserves zoom-follow both ways (#2188)", async () => {
+    const run = async (flag: boolean): Promise<string | null> => {
+      useAppStore.setState(useAppStore.getInitialState());
+      useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a", zoomedTabId: "t1" });
+      backend.reset();
+      setLayoutIntentsEnabled(flag);
+      // Switching focus to b, while zoomed, follows to b's active tab (t3).
+      useAppStore.getState().setActivePanel("b");
+      await flush();
+      return useAppStore.getState().zoomedTabId;
+    };
+    expect(await run(true)).toBe("t3");
+    expect(await run(false)).toBe("t3");
+  });
+
+  it("setPanelSizes persists identical split sizes both ways (#2188)", async () => {
+    const sizesOf = async (flag: boolean): Promise<number[] | undefined> => {
+      useAppStore.setState(useAppStore.getInitialState());
+      useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
+      backend.reset();
+      setLayoutIntentsEnabled(flag);
+      useAppStore.getState().setPanelSizes("root", [70, 30]);
+      await flush();
+      const root = useAppStore.getState().rootPanel;
+      return root.type === "split" ? root.sizes : undefined;
+    };
+    const cut = await sizesOf(true);
+    const local = await sizesOf(false);
+    expect(cut).toEqual(local);
+    expect(cut).toEqual([70, 30]);
   });
 
   it("dragging a middle active tab out preserves the source's focus both ways", async () => {

--- a/src/store/appStore.layoutBridge.test.ts
+++ b/src/store/appStore.layoutBridge.test.ts
@@ -384,9 +384,7 @@ describe("appStore layout bridge — cut ↔ local parity (#2151)", () => {
   });
 
   it("reorderTabs reorders within a leaf identically both ways (#2188)", async () => {
-    const { local, cut } = await runBothWays(() =>
-      useAppStore.getState().reorderTabs("a", 0, 1)
-    );
+    const { local, cut } = await runBothWays(() => useAppStore.getState().reorderTabs("a", 0, 1));
     expect(cut).toEqual(local);
   });
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -268,6 +268,7 @@ import {
   simplifyTree,
   edgeToSplit,
   markActiveLeaf,
+  normalizeSizes,
 } from "@/utils/panelTree";
 import {
   layoutIntentsEnabled,
@@ -711,6 +712,7 @@ export interface AppState extends TunnelSlice, EmbeddedServersSlice, MacrosSlice
   splitPanel: (direction?: "horizontal" | "vertical") => void;
   removePanel: (panelId: string) => void;
   setActivePanel: (panelId: string) => void;
+  setPanelSizes: (splitId: string, sizes: number[]) => void;
   splitPanelWithTab: (
     tabId: string,
     fromPanelId: string,
@@ -2652,6 +2654,21 @@ function removeTabFromLeaf(leaf: LeafPanel, tabId: string): LeafPanel {
   return { ...leaf, tabs, activeTabId: null };
 }
 
+/**
+ * Return a copy of `root` with the split container `splitId`'s child `sizes`
+ * replaced (normalized to sum to 100). A structural no-op when the id is absent.
+ * The local twin of the Rust store's `set_split_sizes`, so the resize cut's
+ * fallback path stays parity-identical.
+ */
+function setSplitSizesInTree(root: PanelNode, splitId: string, sizes: number[]): PanelNode {
+  if (root.type === "leaf") return root;
+  const children = root.children.map((c) => setSplitSizesInTree(c, splitId, sizes));
+  if (root.id === splitId) {
+    return { ...root, children, sizes: normalizeSizes(sizes) };
+  }
+  return { ...root, children };
+}
+
 let groupCounter = 0;
 
 /** Generate a unique tab group ID. */
@@ -4541,15 +4558,37 @@ export const useAppStore = create<AppState>((set, get, store) => {
         return { rootPanel, activePanelId: toPanelId };
       }),
 
-    reorderTabs: (panelId, oldIndex, newIndex) =>
-      set((state) => ({
-        rootPanel: updateLeaf(state.rootPanel, panelId, (leaf) => {
-          const tabs = [...leaf.tabs];
-          const [moved] = tabs.splice(oldIndex, 1);
-          tabs.splice(newIndex, 0, moved);
-          return { ...leaf, tabs };
-        }),
-      })),
+    reorderTabs: (panelId, oldIndex, newIndex) => {
+      // Local reducer — the retained rollback/resilience fallback (see
+      // `splitPanel`). Reorders a tab within its leaf, leaving focus untouched.
+      const applyLocal = () =>
+        set((state) => ({
+          rootPanel: updateLeaf(state.rootPanel, panelId, (leaf) => {
+            const tabs = [...leaf.tabs];
+            const [moved] = tabs.splice(oldIndex, 1);
+            tabs.splice(newIndex, 0, moved);
+            return { ...leaf, tabs };
+          }),
+        }));
+
+      // Structural reorder cut (#2188): route through `layout.reorderTabs`; the
+      // backend LayoutStore reorders and reconcileNode writes the reconciled
+      // tree. Focus is unchanged, so only `rootPanel` is applied. Any failure
+      // falls back to the local reducer.
+      if (!layoutIntentsEnabled()) return applyLocal();
+      const { rootPanel, activePanelId } = get();
+      void runLayoutIntent(
+        "layout.reorderTabs",
+        { panelId, oldIndex, newIndex },
+        rootPanel,
+        activePanelId
+      )
+        .then((res) => set({ rootPanel: res.rootPanel }))
+        .catch((err) => {
+          logBridgeFallback("layout.reorderTabs", err);
+          applyLocal();
+        });
+    },
 
     splitPanel: (direction) => {
       // Local reducer. Since #2184 the intent path below is the default, so this
@@ -4590,29 +4629,88 @@ export const useAppStore = create<AppState>((set, get, store) => {
         });
     },
 
-    removePanel: (panelId) =>
-      set((state) => {
-        const allLeaves = getAllLeaves(state.rootPanel);
-        if (allLeaves.length <= 1) return state;
+    removePanel: (panelId) => {
+      // Local reducer — the retained rollback/resilience fallback. Drops a whole
+      // leaf panel and simplifies; repoints focus onto the first survivor when
+      // the removed panel held it.
+      const applyLocal = () =>
+        set((state) => {
+          const allLeaves = getAllLeaves(state.rootPanel);
+          if (allLeaves.length <= 1) return state;
 
-        const removed = removeLeaf(state.rootPanel, panelId);
-        if (!removed) return state;
-        const rootPanel = simplifyTree(removed);
-        const newLeaves = getAllLeaves(rootPanel);
-        const activePanelId =
-          state.activePanelId === panelId ? (newLeaves[0]?.id ?? null) : state.activePanelId;
-        return { rootPanel, activePanelId };
-      }),
+          const removed = removeLeaf(state.rootPanel, panelId);
+          if (!removed) return state;
+          const rootPanel = simplifyTree(removed);
+          const newLeaves = getAllLeaves(rootPanel);
+          const activePanelId =
+            state.activePanelId === panelId ? (newLeaves[0]?.id ?? null) : state.activePanelId;
+          return { rootPanel, activePanelId };
+        });
 
-    setActivePanel: (panelId) =>
-      set((state) => {
-        let newZoomedTabId = state.zoomedTabId;
-        if (state.zoomedTabId !== null) {
-          const newPanel = findLeaf(state.rootPanel, panelId);
-          newZoomedTabId = newPanel?.activeTabId ?? null;
-        }
-        return { activePanelId: panelId, zoomedTabId: newZoomedTabId };
-      }),
+      // Structural remove cut (#2188): route through `layout.removePanel` — a
+      // dedicated transform, since `merge` preserves the tabs and
+      // `closeTabStructure` is per-tab, so neither models "discard the whole
+      // panel". The sole-leaf case is a no-op both here and in the store. Any
+      // failure falls back to the local reducer.
+      if (!layoutIntentsEnabled()) return applyLocal();
+      const { rootPanel, activePanelId } = get();
+      if (getAllLeaves(rootPanel).length <= 1) return;
+      void runLayoutIntent("layout.removePanel", { panelId }, rootPanel, activePanelId)
+        .then((res) => set(res))
+        .catch((err) => {
+          logBridgeFallback("layout.removePanel", err);
+          applyLocal();
+        });
+    },
+
+    setActivePanel: (panelId) => {
+      // Local reducer — applied synchronously in every mode so focus stays
+      // instant (this is a hot path: every panel click and keyboard-nav step).
+      // Zoom-follow: when the zoom overlay shows a tab from the newly-focused
+      // panel, follow the switch to that panel's active tab.
+      const applyLocal = () =>
+        set((state) => {
+          let newZoomedTabId = state.zoomedTabId;
+          if (state.zoomedTabId !== null) {
+            const newPanel = findLeaf(state.rootPanel, panelId);
+            newZoomedTabId = newPanel?.activeTabId ?? null;
+          }
+          return { activePanelId: panelId, zoomedTabId: newZoomedTabId };
+        });
+
+      // Focus is projection state (`activePanelId`), so fold it into the layout
+      // region (#2188): apply locally for instant UX, then best-effort push the
+      // focus through `layout.setActivePanel` so the backend stays authoritative
+      // and the render-from-projection mirror keeps matching. The reconciled
+      // result is ignored — the local set already landed — and a failure is just
+      // logged (the projection catches up on the next seed).
+      applyLocal();
+      if (!layoutIntentsEnabled()) return;
+      const { rootPanel, activePanelId } = get();
+      void runLayoutIntent("layout.setActivePanel", { panelId }, rootPanel, activePanelId).catch(
+        (err) => logBridgeFallback("layout.setActivePanel", err)
+      );
+    },
+
+    setPanelSizes: (splitId, sizes) => {
+      // Local reducer — the retained rollback/resilience fallback. Persists a
+      // split's child percentage sizes so a resize-handle drag survives remounts
+      // and workspace save/restore.
+      const applyLocal = () =>
+        set((state) => ({ rootPanel: setSplitSizesInTree(state.rootPanel, splitId, sizes) }));
+
+      // Resize cut (#2188): route through `layout.resize`; the backend persists
+      // the normalized sizes and reconcileNode writes the reconciled tree. Only
+      // `rootPanel` changes. Any failure falls back to the local reducer.
+      if (!layoutIntentsEnabled()) return applyLocal();
+      const { rootPanel, activePanelId } = get();
+      void runLayoutIntent("layout.resize", { splitId, sizes }, rootPanel, activePanelId)
+        .then((res) => set({ rootPanel: res.rootPanel }))
+        .catch((err) => {
+          logBridgeFallback("layout.resize", err);
+          applyLocal();
+        });
+    },
 
     splitPanelWithTab: (tabId, fromPanelId, targetPanelId, edge) => {
       // Local reducer. As with splitPanel, since #2184 this is the retained


### PR DESCRIPTION
## Summary

Completes #2151 step 2's structural-mutation cut: routes **every remaining** structural panel-tree mutation through backend-authoritative `layout.*` intents, so the `appStore` panel-tree reducers become pure fallback/rollback. This unblocks #2151 **step 4** (deleting those reducers).

Before this, only `splitPanel` (→`layout.split`) and `splitPanelWithTab` (→`layout.moveTab`) routed through the backend. Now the rest do too, each with the same **seed-before-mutate + reconcile** bridge, **flag-gated** (`layoutIntentsEnabled`, on by default since #2184), with the **local `applyLocal` reducer retained** as both the #2184 rollback path and the resilience fallback on intent failure.

## Ops wired

| appStore op | intent | notes |
| --- | --- | --- |
| `removePanel` | **`layout.removePanel`** (new) | Drops a whole leaf + simplifies. `merge` *preserves* tabs and `closeTabStructure` is per-tab, so neither models "discard the whole panel" — hence a dedicated transform over the shared `remove_leaf` algebra. Sole-leaf is a no-op on both paths. |
| `reorderTabs` | **`layout.reorderTabs`** (new) | Moves a tab within its leaf, focus untouched. |
| `setActivePanel` | **`layout.setActivePanel`** (new) | **Folded** into the projection focus (the issue's stated alternative): applied locally for instant UX (focus is a hot per-click/keyboard-nav path), then pushed to the region so the backend stays authoritative. Zoom-follow preserved. Kept synchronous to avoid regressing focus latency and the many synchronous callers/tests. |
| resize / split-size persistence | **`layout.resize`** (new) | New `setPanelSizes` action + `SplitView` `onLayoutChanged` wiring; the backend persists the split's normalized child sizes. Split sizes now survive remounts and workspace save/restore (previously not persisted at all). |

## Tests

- **Rust**: `store_tests.rs` unit tests for each new store method (happy path + rejection/edge cases); `projection_tests.rs` round-trip test (`removePanel`/`reorderTabs`/`setActivePanel`/`resize` each fan one diff, cache converges on authority) + a bad-index rejection test.
- **Frontend cut-vs-local parity** (`appStore.layoutBridge.test.ts`): each newly-cut op asserts the intent path produces a tree structurally identical to the local reducer; `setActivePanel` asserts the fold (local + dispatched intent, projection tracks focus) and zoom-follow; resize asserts identical persisted sizes both ways. These are the safety net since the flag is on by default.

## Verification

Full frontend suite (4756) + `cargo test` layout module + `clippy -D warnings` + `fmt` all green locally. **The interactive GUI was not driven** — GUI parity for close-panel / reorder / focus-activate / resize (with live-terminal scrollback surviving) is **pending a maintainer spot-check**, as #2184 did for the earlier cut; the automated cut-vs-local parity tests above are thorough to compensate.

## Scope

The `appStore` reducers are **retained** (they remain the fallback/rollback — deleting them is #2151 step 4). No multi-window/restore work (step 5). **#2151 stays open.** `closeTab`'s panel-pruning is session-coupled and left for a later phase (not in this issue's checklist).

Closes #2188
Part of #2151