### PR TITLE
feat(backend): shadow session-lifecycle projection region (Phase 4 step 1)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,6 +34,11 @@ pub mod projection;
 pub mod run_location;
 mod session;
 mod session_history;
+/// Shadow session-lifecycle authority (#2152, Phase 4 step 1 of #2139): the
+/// shared `session-lifecycle` projection region + `session.*` intents, built on
+/// the ported auto-reconnect engine (#2144). Registered and served but not yet
+/// driving the live UI — see [`session_projection`].
+mod session_projection;
 mod spawn;
 mod terminal;
 mod tunnel;
@@ -670,6 +675,18 @@ pub fn run() {
                     &mut registry,
                     app.handle().clone(),
                 );
+                // Shadow SessionLifecycleStore (#2152 step 1): the shared
+                // `session-lifecycle` region + `session.*` intents on the ported
+                // auto-reconnect engine (#2144). Managed authoritative state that
+                // serves intents, but nothing in the live UI subscribes to or
+                // renders the region yet — a pure shadow foundation (later steps
+                // cut the transitions, then rendering, over to it). The shared
+                // region is seeded below once the store is managed.
+                app.manage(Arc::new(session_projection::SessionLifecycleStore::new()));
+                session_projection::projection::register_session_intents(
+                    &mut registry,
+                    app.handle().clone(),
+                );
                 // Test-bridge-only: add the diagnostic region's `diag.*` routes so
                 // the projection-assertion harness (#2164) has a self-contained
                 // region to drive. Never registered in production launches. See
@@ -686,6 +703,17 @@ pub fn run() {
                     projection_state.projector.register_region(
                         tunnel::projection::TUNNELS_REGION,
                         tunnel::projection::build_tunnel_view(&manager),
+                    );
+                }
+                // Seed the shared `session-lifecycle` region with the (empty)
+                // store baseline at version 0, so a subscriber attaches to a real
+                // region before the first `session.*` intent (#2152).
+                if let Some(store) =
+                    app.handle().try_state::<Arc<session_projection::SessionLifecycleStore>>()
+                {
+                    projection_state.projector.register_region(
+                        session_projection::projection::SESSION_LIFECYCLE_REGION,
+                        store.snapshot(),
                     );
                 }
                 if diagnostics {

--- a/src-tauri/src/session_projection/mod.rs
+++ b/src-tauri/src/session_projection/mod.rs
@@ -1,0 +1,26 @@
+//! Shadow session-lifecycle authority — Phase 4 step 1 of the stateless-UI
+//! migration (#2152, part of #2139).
+//!
+//! Moves the connect / reconnect / disconnect / error state machine the frontend
+//! drives per session into a Rust authority built on the ported auto-reconnect
+//! engine (`termihub_core::reconnect_backoff`, #2144). The store owns a single
+//! **shared** `session-lifecycle` projection region (Open Design Decision #4:
+//! infrastructure domains are shared) and serves the `session.*` intents through
+//! the projection substrate ([`crate::projection`]), mirroring the SSH-tunnels
+//! pilot ([`crate::tunnel::projection`]).
+//!
+//! # Shadow mode — zero user-facing change
+//!
+//! This step is deliberately **not authoritative**. The store exists, accepts
+//! intents, and projects diffs, but nothing in the live UI subscribes to or
+//! renders the `session-lifecycle` region, and no frontend code dispatches
+//! `session.*` intents yet. The existing `appStore` lifecycle reducers and the
+//! terminal overlays are untouched. Later steps cut the transitions over, then
+//! rendering, then remove the `appStore` state; broadcast/restore-cohort logic
+//! (built on the ported #2145 `restore_mode`) migrates as its own step and keeps
+//! a clean per-domain boundary.
+
+pub mod projection;
+pub mod store;
+
+pub use store::SessionLifecycleStore;

--- a/src-tauri/src/session_projection/projection.rs
+++ b/src-tauri/src/session_projection/projection.rs
@@ -94,7 +94,10 @@ pub fn register_session_intents(registry: &mut HandlerRegistry, app_handle: AppH
     let handle = app_handle.clone();
     registry.route("session.connectFailed", move |intent, projector| {
         let store = store_of(&handle)?;
-        store.connect_failed(&required_str(intent, "sessionId")?, optional_str(intent, "error"));
+        store.connect_failed(
+            &required_str(intent, "sessionId")?,
+            optional_str(intent, "error"),
+        );
         Ok(publish_sessions(projector, &store))
     });
 
@@ -108,7 +111,10 @@ pub fn register_session_intents(registry: &mut HandlerRegistry, app_handle: AppH
     let handle = app_handle.clone();
     registry.route("session.dropped", move |intent, projector| {
         let store = store_of(&handle)?;
-        store.dropped(&required_str(intent, "sessionId")?, optional_str(intent, "error"));
+        store.dropped(
+            &required_str(intent, "sessionId")?,
+            optional_str(intent, "error"),
+        );
         Ok(publish_sessions(projector, &store))
     });
 
@@ -129,7 +135,10 @@ pub fn register_session_intents(registry: &mut HandlerRegistry, app_handle: AppH
     let handle = app_handle.clone();
     registry.route("session.reconnectFailed", move |intent, projector| {
         let store = store_of(&handle)?;
-        store.reconnect_failed(&required_str(intent, "sessionId")?, optional_str(intent, "error"));
+        store.reconnect_failed(
+            &required_str(intent, "sessionId")?,
+            optional_str(intent, "error"),
+        );
         Ok(publish_sessions(projector, &store))
     });
 

--- a/src-tauri/src/session_projection/projection.rs
+++ b/src-tauri/src/session_projection/projection.rs
@@ -1,0 +1,185 @@
+//! Session-lifecycle projection: the shared `session-lifecycle` region and the
+//! `session.*` intents (#2152, part of #2139).
+//!
+//! Exposes the authoritative [`SessionLifecycleStore`] as one versioned,
+//! multi-subscriber projection region and turns the lifecycle transitions the
+//! frontend currently drives into [`Intent`]s — mirroring the SSH-tunnels pilot
+//! ([`crate::tunnel::projection`]), the reference registration pattern for the
+//! substrate ([`crate::projection`]).
+//!
+//! # The `session-lifecycle` region
+//!
+//! **Shared** (Open Design Decision #4: infrastructure domains are shared). The
+//! real sessions live backend-side; their connection/lifecycle status is a
+//! property of the session, not of a viewing client, so two clients see the same
+//! status and a transition projects to both. The view model:
+//!
+//! ```json
+//! { "sessions": { "<sessionId>": SessionLifecycle, ... } }
+//! ```
+//!
+//! # Intents
+//!
+//! | kind                        | payload                     | effect                                        |
+//! | --------------------------- | --------------------------- | --------------------------------------------- |
+//! | `session.connect`           | `{ sessionId }`             | begin an initial connect (→ connecting)        |
+//! | `session.connected`         | `{ sessionId }`             | a connect/reconnect attempt succeeded (→ live) |
+//! | `session.connectFailed`     | `{ sessionId, error? }`     | initial connect errored (→ failed)             |
+//! | `session.disconnect`        | `{ sessionId }`             | user-initiated graceful disconnect             |
+//! | `session.dropped`           | `{ sessionId, error? }`     | unexpected link drop (→ disconnected)          |
+//! | `session.reconnect`         | `{ sessionId }`             | begin/restart the auto-reconnect loop          |
+//! | `session.reconnectAttempt`  | `{ sessionId }`             | backoff timer fired; start an attempt          |
+//! | `session.reconnectFailed`   | `{ sessionId, error? }`     | the attempt failed (back off or give up)       |
+//! | `session.cancelReconnect`   | `{ sessionId }`             | user stopped the retry loop                    |
+//! | `session.remove`            | `{ sessionId }`             | session/tab gone; drop it from the region      |
+//!
+//! # Shadow mode
+//!
+//! Registered and fully served, but **not** driving the live UI: no frontend
+//! subscribes to `session-lifecycle` or dispatches `session.*` yet, so these
+//! intents mutate only the shadow store and project to a region nobody renders.
+//! The `appStore` lifecycle reducers and terminal overlays remain authoritative.
+//! Per the substrate contract the result of an intent is never returned inline —
+//! it always arrives as a projection diff on the `session-lifecycle` region.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
+use crate::session_projection::store::SessionLifecycleStore;
+
+/// The projection region id for the session-lifecycle domain (shared, per Open
+/// Design Decision #4).
+pub const SESSION_LIFECYCLE_REGION: &str = "session-lifecycle";
+
+/// Publish the `session-lifecycle` region from the store, fanning a diff out to
+/// every subscriber and returning the advanced region for the intent ack (empty
+/// when the view did not change).
+pub fn publish_sessions(
+    projector: &Projector,
+    store: &SessionLifecycleStore,
+) -> Vec<ProducedRegion> {
+    match projector.publish(SESSION_LIFECYCLE_REGION, store.snapshot()) {
+        Some(version) => vec![ProducedRegion {
+            region: SESSION_LIFECYCLE_REGION.to_string(),
+            version,
+        }],
+        None => Vec::new(),
+    }
+}
+
+/// Register the `session.*` intents on a handler registry.
+///
+/// Each route resolves the managed [`SessionLifecycleStore`] lazily (so it
+/// rejects gracefully rather than panicking if the store is somehow absent),
+/// applies the transition, and publishes the shared region. All transitions are
+/// pure/fast map edits, so they run inline on the dispatcher's single writer.
+pub fn register_session_intents(registry: &mut HandlerRegistry, app_handle: AppHandle) {
+    let handle = app_handle.clone();
+    registry.route("session.connect", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.connect(&required_str(intent, "sessionId")?);
+        Ok(publish_sessions(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("session.connected", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.connected(&required_str(intent, "sessionId")?);
+        Ok(publish_sessions(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("session.connectFailed", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.connect_failed(&required_str(intent, "sessionId")?, optional_str(intent, "error"));
+        Ok(publish_sessions(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("session.disconnect", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.disconnect(&required_str(intent, "sessionId")?);
+        Ok(publish_sessions(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("session.dropped", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.dropped(&required_str(intent, "sessionId")?, optional_str(intent, "error"));
+        Ok(publish_sessions(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("session.reconnect", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.reconnect(&required_str(intent, "sessionId")?);
+        Ok(publish_sessions(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("session.reconnectAttempt", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.reconnect_attempt(&required_str(intent, "sessionId")?);
+        Ok(publish_sessions(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("session.reconnectFailed", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.reconnect_failed(&required_str(intent, "sessionId")?, optional_str(intent, "error"));
+        Ok(publish_sessions(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("session.cancelReconnect", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.cancel_reconnect(&required_str(intent, "sessionId")?);
+        Ok(publish_sessions(projector, &store))
+    });
+
+    let handle = app_handle;
+    registry.route("session.remove", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.remove(&required_str(intent, "sessionId")?);
+        Ok(publish_sessions(projector, &store))
+    });
+}
+
+/// Resolve the managed session-lifecycle store, or a rejectable error if absent.
+fn store_of(app_handle: &AppHandle) -> Result<Arc<SessionLifecycleStore>, (String, String)> {
+    app_handle
+        .try_state::<Arc<SessionLifecycleStore>>()
+        .map(|state| (*state).clone())
+        .ok_or_else(|| {
+            (
+                "unavailable".to_string(),
+                "session-lifecycle store is not initialized".to_string(),
+            )
+        })
+}
+
+/// Extract a required string field from an intent payload.
+fn required_str(intent: &Intent, key: &str) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// Extract an optional string field (e.g. an error message); absent → `None`.
+fn optional_str(intent: &Intent, key: &str) -> Option<String> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+#[path = "projection_tests.rs"]
+mod tests;

--- a/src-tauri/src/session_projection/projection_tests.rs
+++ b/src-tauri/src/session_projection/projection_tests.rs
@@ -1,0 +1,334 @@
+//! Projection-contract tests for the shared `session-lifecycle` region (#2152),
+//! reusing the substrate harness (#2164): an in-memory [`ProjectionSink`] and a
+//! client cache that applies diffs. The routes here drive a real
+//! [`SessionLifecycleStore`] directly (the production `register_session_intents`
+//! resolves the same store from the Tauri `AppHandle`; that thin wiring is
+//! integration-verified via a local `./scripts/dev.sh` run) through the identical
+//! parse → mutate → publish path.
+//!
+//! Asserted: subscribe → snapshot (identical to every subscriber), an accepted
+//! intent → exactly one coalesced diff fanned to every subscriber with monotonic
+//! versions, rejection paths advance nothing, a dead subscriber is reaped, and
+//! the client cache converges on the store's authority across a full lifecycle.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::{json, Value};
+
+use super::*;
+use crate::projection::{
+    apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
+    ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
+};
+use crate::session_projection::projection::{
+    publish_sessions, register_session_intents, SESSION_LIFECYCLE_REGION,
+};
+use crate::session_projection::store::SessionLifecycleStore;
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+/// A deterministic store (zero jitter) with a couple of sessions already in
+/// flight, so a subscriber sees a populated baseline.
+fn seeded_store() -> Arc<SessionLifecycleStore> {
+    let store = Arc::new(SessionLifecycleStore::new());
+    store.set_rand_for_test(Box::new(|| 0.5));
+    store.connect("s1");
+    store.connect("s2");
+    store.connected("s2");
+    store
+}
+
+/// The production `session.*` routes, bound to an injected store instead of
+/// resolving one from an `AppHandle` — the exact parse → mutate → publish path
+/// `register_session_intents` runs. Each closure mirrors the production route
+/// one-to-one so the test drives real logic, not a stand-in.
+fn registry_for(store: Arc<SessionLifecycleStore>) -> HandlerRegistry {
+    let mut registry = HandlerRegistry::new();
+
+    let s = store.clone();
+    registry.route("session.connect", move |intent, projector| {
+        s.connect(&required_id(intent)?);
+        Ok(publish_sessions(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("session.connected", move |intent, projector| {
+        s.connected(&required_id(intent)?);
+        Ok(publish_sessions(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("session.connectFailed", move |intent, projector| {
+        s.connect_failed(&required_id(intent)?, opt_error(intent));
+        Ok(publish_sessions(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("session.disconnect", move |intent, projector| {
+        s.disconnect(&required_id(intent)?);
+        Ok(publish_sessions(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("session.dropped", move |intent, projector| {
+        s.dropped(&required_id(intent)?, opt_error(intent));
+        Ok(publish_sessions(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("session.reconnect", move |intent, projector| {
+        s.reconnect(&required_id(intent)?);
+        Ok(publish_sessions(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("session.reconnectAttempt", move |intent, projector| {
+        s.reconnect_attempt(&required_id(intent)?);
+        Ok(publish_sessions(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("session.reconnectFailed", move |intent, projector| {
+        s.reconnect_failed(&required_id(intent)?, opt_error(intent));
+        Ok(publish_sessions(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("session.cancelReconnect", move |intent, projector| {
+        s.cancel_reconnect(&required_id(intent)?);
+        Ok(publish_sessions(projector, &s))
+    });
+    let s = store;
+    registry.route("session.remove", move |intent, projector| {
+        s.remove(&required_id(intent)?);
+        Ok(publish_sessions(projector, &s))
+    });
+
+    registry
+}
+
+/// The route-side `sessionId` parse — the one rejection path the routes carry.
+fn required_id(intent: &Intent) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get("sessionId")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), "missing 'sessionId'".to_string()))
+}
+
+fn opt_error(intent: &Intent) -> Option<String> {
+    intent
+        .payload
+        .get("error")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+/// An in-memory sink recording delivered frames; can be killed to simulate a
+/// dead subscriber (mirrors the substrate/tunnel/layout test double).
+struct VecSink {
+    frames: Mutex<Vec<ProjectionFrame>>,
+    alive: AtomicBool,
+}
+
+impl VecSink {
+    fn new() -> Self {
+        Self {
+            frames: Mutex::new(Vec::new()),
+            alive: AtomicBool::new(true),
+        }
+    }
+
+    fn diffs(&self) -> Vec<DiffFrame> {
+        self.frames
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|f| match f {
+                ProjectionFrame::Diff(d) => Some(d.clone()),
+                ProjectionFrame::Snapshot(_) => None,
+            })
+            .collect()
+    }
+}
+
+impl ProjectionSink for VecSink {
+    fn deliver(&self, frame: &ProjectionFrame) -> Result<(), ProjectionError> {
+        if !self.alive.load(Ordering::SeqCst) {
+            return Err(ProjectionError::SinkClosed("killed".into()));
+        }
+        self.frames.lock().unwrap().push(frame.clone());
+        Ok(())
+    }
+}
+
+/// A minimal client cache mirroring the TypeScript `ProjectionClient`.
+struct ClientCache {
+    version: u64,
+    view: Value,
+}
+
+impl ClientCache {
+    fn from_snapshot(s: &SnapshotFrame) -> Self {
+        Self {
+            version: s.version,
+            view: s.view.clone(),
+        }
+    }
+
+    fn apply(&mut self, diff: &DiffFrame) {
+        assert_eq!(diff.base_version, self.version, "diff must fit the cache");
+        apply_ops(&mut self.view, &diff.ops).expect("diff applies cleanly");
+        self.version = diff.version;
+    }
+}
+
+fn intent(kind: &str, payload: Value) -> Intent {
+    Intent {
+        intent_id: format!("01J-{kind}"),
+        kind: kind.to_string(),
+        payload,
+        client_id: "client-1".to_string(),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn subscribe_returns_the_seeded_snapshot_identically_to_every_subscriber() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+
+    let snap_a = projector.subscribe(SESSION_LIFECYCLE_REGION, "sub-a", "A", Arc::new(VecSink::new()));
+    let snap_b = projector.subscribe(SESSION_LIFECYCLE_REGION, "sub-b", "B", Arc::new(VecSink::new()));
+
+    assert_eq!(snap_a.version, 0);
+    assert_eq!(snap_a, snap_b, "a late joiner gets an identical baseline");
+    assert_eq!(snap_a.region, "session-lifecycle");
+    assert_eq!(snap_a.view["sessions"]["s1"]["status"], json!("connecting"));
+    assert_eq!(snap_a.view["sessions"]["s2"]["status"], json!("connected"));
+}
+
+#[test]
+fn a_lifecycle_intent_produces_one_diff_fanned_to_two_subscribers() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink_a = Arc::new(VecSink::new());
+    let sink_b = Arc::new(VecSink::new());
+    let snap = projector.subscribe(SESSION_LIFECYCLE_REGION, "sub-a", "A", sink_a.clone());
+    projector.subscribe(SESSION_LIFECYCLE_REGION, "sub-b", "B", sink_b.clone());
+    let mut cache_a = ClientCache::from_snapshot(&snap);
+
+    let ack = dispatcher.dispatch(intent("session.connected", json!({ "sessionId": "s1" })));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(
+        ack.produced,
+        Some(vec![crate::projection::ProducedRegion {
+            region: SESSION_LIFECYCLE_REGION.to_string(),
+            version: 1,
+        }])
+    );
+
+    let diffs_a = sink_a.diffs();
+    let diffs_b = sink_b.diffs();
+    assert_eq!(diffs_a.len(), 1, "exactly one diff to A");
+    assert_eq!(diffs_b.len(), 1, "exactly one diff to B");
+    assert_eq!(diffs_a[0], diffs_b[0], "identical diff to every subscriber");
+    assert_eq!(diffs_a[0].base_version, 0);
+    assert_eq!(diffs_a[0].version, 1);
+
+    cache_a.apply(&diffs_a[0]);
+    assert_eq!(cache_a.view, store.snapshot(), "cache converges on authority");
+    assert_eq!(cache_a.view["sessions"]["s1"]["status"], json!("connected"));
+}
+
+#[test]
+fn a_full_reconnect_loop_advances_monotonically_and_converges() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(SESSION_LIFECYCLE_REGION, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    // s2 was connected; drive it through drop → reconnect → attempt → fail →
+    // attempt → success. Each accepted intent that changes the view = one diff.
+    for kind_payload in [
+        ("session.dropped", json!({ "sessionId": "s2", "error": "reset" })),
+        ("session.reconnect", json!({ "sessionId": "s2" })),
+        ("session.reconnectAttempt", json!({ "sessionId": "s2" })),
+        ("session.reconnectFailed", json!({ "sessionId": "s2" })),
+        ("session.reconnectAttempt", json!({ "sessionId": "s2" })),
+        ("session.connected", json!({ "sessionId": "s2" })),
+    ] {
+        let ack = dispatcher.dispatch(intent(kind_payload.0, kind_payload.1));
+        assert_eq!(ack.status, IntentStatus::Accepted, "{} accepted", kind_payload.0);
+    }
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 6, "one diff per view-changing intent");
+    for diff in &diffs {
+        cache.apply(diff);
+    }
+    assert_eq!(cache.version, 6);
+    assert_eq!(cache.view, store.snapshot(), "cache converges on authority");
+    assert_eq!(cache.view["sessions"]["s2"]["status"], json!("connected"));
+}
+
+#[test]
+fn an_intent_missing_the_session_id_is_rejected_without_advancing() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(SESSION_LIFECYCLE_REGION, "sub", "A", sink.clone());
+
+    let ack = dispatcher.dispatch(intent("session.connect", json!({ "wrong": "field" })));
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "bad_payload");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(SESSION_LIFECYCLE_REGION), Some(0));
+}
+
+#[test]
+fn a_no_op_intent_advances_nothing() {
+    // `connected` on an already-connected session leaves the view unchanged, so
+    // the projector coalesces it to no diff and no version bump.
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(SESSION_LIFECYCLE_REGION, "sub", "A", sink.clone());
+
+    let ack = dispatcher.dispatch(intent("session.connected", json!({ "sessionId": "s2" })));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(ack.produced, Some(vec![]), "no region advanced");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(SESSION_LIFECYCLE_REGION), Some(0));
+}
+
+#[test]
+fn a_dead_subscriber_is_reaped_on_publish() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let live = Arc::new(VecSink::new());
+    let dead = Arc::new(VecSink::new());
+    projector.subscribe(SESSION_LIFECYCLE_REGION, "live", "A", live.clone());
+    projector.subscribe(SESSION_LIFECYCLE_REGION, "dead", "B", dead.clone());
+    assert_eq!(projector.subscriber_count(SESSION_LIFECYCLE_REGION), 2);
+
+    dead.alive.store(false, Ordering::SeqCst);
+    dispatcher.dispatch(intent("session.connected", json!({ "sessionId": "s1" })));
+
+    assert_eq!(live.diffs().len(), 1, "the live subscriber still gets the diff");
+    assert_eq!(
+        projector.subscriber_count(SESSION_LIFECYCLE_REGION),
+        1,
+        "the dead subscriber was reaped"
+    );
+}

--- a/src-tauri/src/session_projection/projection_tests.rs
+++ b/src-tauri/src/session_projection/projection_tests.rs
@@ -16,14 +16,11 @@ use std::sync::{Arc, Mutex};
 
 use serde_json::{json, Value};
 
-use super::*;
 use crate::projection::{
     apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
     ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
 };
-use crate::session_projection::projection::{
-    publish_sessions, register_session_intents, SESSION_LIFECYCLE_REGION,
-};
+use crate::session_projection::projection::{publish_sessions, SESSION_LIFECYCLE_REGION};
 use crate::session_projection::store::SessionLifecycleStore;
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -194,8 +191,18 @@ fn subscribe_returns_the_seeded_snapshot_identically_to_every_subscriber() {
     let projector = Arc::new(Projector::new());
     projector.register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
 
-    let snap_a = projector.subscribe(SESSION_LIFECYCLE_REGION, "sub-a", "A", Arc::new(VecSink::new()));
-    let snap_b = projector.subscribe(SESSION_LIFECYCLE_REGION, "sub-b", "B", Arc::new(VecSink::new()));
+    let snap_a = projector.subscribe(
+        SESSION_LIFECYCLE_REGION,
+        "sub-a",
+        "A",
+        Arc::new(VecSink::new()),
+    );
+    let snap_b = projector.subscribe(
+        SESSION_LIFECYCLE_REGION,
+        "sub-b",
+        "B",
+        Arc::new(VecSink::new()),
+    );
 
     assert_eq!(snap_a.version, 0);
     assert_eq!(snap_a, snap_b, "a late joiner gets an identical baseline");
@@ -236,7 +243,11 @@ fn a_lifecycle_intent_produces_one_diff_fanned_to_two_subscribers() {
     assert_eq!(diffs_a[0].version, 1);
 
     cache_a.apply(&diffs_a[0]);
-    assert_eq!(cache_a.view, store.snapshot(), "cache converges on authority");
+    assert_eq!(
+        cache_a.view,
+        store.snapshot(),
+        "cache converges on authority"
+    );
     assert_eq!(cache_a.view["sessions"]["s1"]["status"], json!("connected"));
 }
 
@@ -254,7 +265,10 @@ fn a_full_reconnect_loop_advances_monotonically_and_converges() {
     // s2 was connected; drive it through drop → reconnect → attempt → fail →
     // attempt → success. Each accepted intent that changes the view = one diff.
     for kind_payload in [
-        ("session.dropped", json!({ "sessionId": "s2", "error": "reset" })),
+        (
+            "session.dropped",
+            json!({ "sessionId": "s2", "error": "reset" }),
+        ),
         ("session.reconnect", json!({ "sessionId": "s2" })),
         ("session.reconnectAttempt", json!({ "sessionId": "s2" })),
         ("session.reconnectFailed", json!({ "sessionId": "s2" })),
@@ -262,7 +276,12 @@ fn a_full_reconnect_loop_advances_monotonically_and_converges() {
         ("session.connected", json!({ "sessionId": "s2" })),
     ] {
         let ack = dispatcher.dispatch(intent(kind_payload.0, kind_payload.1));
-        assert_eq!(ack.status, IntentStatus::Accepted, "{} accepted", kind_payload.0);
+        assert_eq!(
+            ack.status,
+            IntentStatus::Accepted,
+            "{} accepted",
+            kind_payload.0
+        );
     }
 
     let diffs = sink.diffs();
@@ -325,7 +344,11 @@ fn a_dead_subscriber_is_reaped_on_publish() {
     dead.alive.store(false, Ordering::SeqCst);
     dispatcher.dispatch(intent("session.connected", json!({ "sessionId": "s1" })));
 
-    assert_eq!(live.diffs().len(), 1, "the live subscriber still gets the diff");
+    assert_eq!(
+        live.diffs().len(),
+        1,
+        "the live subscriber still gets the diff"
+    );
     assert_eq!(
         projector.subscriber_count(SESSION_LIFECYCLE_REGION),
         1,

--- a/src-tauri/src/session_projection/store.rs
+++ b/src-tauri/src/session_projection/store.rs
@@ -1,0 +1,367 @@
+//! The authoritative, shared session-lifecycle state machine behind the shadow
+//! `session-lifecycle` projection region (#2152, Phase 4 step 1 of #2139).
+//!
+//! Models the connect / reconnect / disconnect / error state machine the
+//! frontend currently drives per session (`appStore` `terminalConnecting`,
+//! `terminalDisconnects`, `terminalAutoReconnect`, disconnect reasons and
+//! errors), built on the pure, timer-free auto-reconnect engine ported in #2144
+//! (`termihub_core::reconnect_backoff`). This module owns only the lifecycle
+//! **status** per session — not tab content, not layout, not broadcast/restore
+//! cohorts (those migrate in later phases and stay a clean per-domain boundary).
+//!
+//! # Shared region — Open Design Decision #4
+//!
+//! The real sessions already live backend-side and are shared infrastructure
+//! (like SSH tunnels, [`crate::tunnel::projection`]): a session's
+//! connection/lifecycle status is a property of the session itself, not of a
+//! viewing client, so two clients observing the same session see the same
+//! status. The region is therefore a single **shared** `session-lifecycle`
+//! region, mirroring the tunnels pilot. Per-client presentation affordances (a
+//! dismissed disconnect overlay, browsing scrollback in "view mode") are *not*
+//! lifecycle and stay a frontend concern under partial projection.
+//!
+//! # Shadow mode — zero user-facing change
+//!
+//! This step is deliberately **not authoritative**. The store exists, accepts
+//! `session.*` intents, and projects diffs, but nothing in the live UI
+//! subscribes to or renders the `session-lifecycle` region, and no frontend code
+//! dispatches `session.*` intents yet. The existing `appStore` lifecycle
+//! reducers and the terminal overlays remain authoritative. Later steps cut the
+//! transitions over, then rendering, then remove the `appStore` state.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+
+use termihub_core::reconnect_backoff::{
+    reconnect_reducer, BackoffConfig, ReconnectEvent, ReconnectPhase, ReconnectState,
+    DEFAULT_BACKOFF, INITIAL_RECONNECT_STATE,
+};
+
+/// Top-level lifecycle status of a single session — the coarse state the UI
+/// renders (overlay / spinner / live). The fine-grained auto-reconnect detail
+/// (attempt count, backoff delay, waiting-vs-connecting) lives in the composed
+/// [`ReconnectState`], authored by the ported #2144 engine.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionStatus {
+    /// An initial connect attempt is in flight (the "Connecting…" overlay).
+    Connecting,
+    /// A live session.
+    Connected,
+    /// The session ended and is idle (no retry loop running). `end_reason`
+    /// says why; a user disconnect and an unexpected drop both land here.
+    Disconnected,
+    /// An auto-reconnect loop is active; see the composed `reconnect` detail.
+    Reconnecting,
+    /// A terminal failure: the initial connect errored, or the reconnect loop
+    /// exhausted its attempts. `error` carries the message; the user may
+    /// manually reconnect.
+    Failed,
+}
+
+/// Why a session left the `Connected` state — drives the disconnect-overlay
+/// wording the frontend currently derives from `terminalDisconnectReasons`.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum EndReason {
+    /// The user asked to disconnect (graceful).
+    User,
+    /// The link dropped without the user asking (a candidate for reconnect).
+    Unexpected,
+    /// A connect/reconnect attempt errored out.
+    Error,
+}
+
+/// The authoritative lifecycle record for one session.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionLifecycle {
+    pub status: SessionStatus,
+    /// The composed auto-reconnect loop state (ported #2144 engine). `Idle`
+    /// whenever no loop is running.
+    pub reconnect: ReconnectState,
+    /// Set whenever `status` is `Disconnected` (why it ended); `None` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end_reason: Option<EndReason>,
+    /// A human-readable failure message when `status` is `Failed` (or a dropped
+    /// session carried one); `None` otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl SessionLifecycle {
+    /// A session entering its initial connect.
+    fn connecting() -> Self {
+        Self {
+            status: SessionStatus::Connecting,
+            reconnect: INITIAL_RECONNECT_STATE,
+            end_reason: None,
+            error: None,
+        }
+    }
+}
+
+/// The rand source used for backoff jitter. Injectable so tests are
+/// deterministic; production uses `rand`.
+type RandFn = Box<dyn FnMut() -> f64 + Send>;
+
+/// The private mutable core: the per-session map plus the backoff config and the
+/// (injectable) jitter source. One mutex guards it so intents never interleave —
+/// the substrate's single-writer contract also holds within the store.
+struct Inner {
+    sessions: HashMap<String, SessionLifecycle>,
+    config: BackoffConfig,
+    rand: RandFn,
+}
+
+impl Inner {
+    /// Run one reconnect-engine event for a session, returning the next
+    /// [`ReconnectState`]. Reads the session's current reconnect state (Copy) and
+    /// the config before borrowing `rand`, so the field borrows stay disjoint.
+    fn reconnect_event(&mut self, current: ReconnectState, event: ReconnectEvent) -> ReconnectState {
+        let config = self.config;
+        let rand = &mut self.rand;
+        let mut adapter = || (*rand)();
+        reconnect_reducer(&current, event, &config, &mut adapter)
+    }
+}
+
+/// The shadow session-lifecycle authority. Owns one [`SessionLifecycle`] per live
+/// session, keyed by `sessionId`; an unknown session is created lazily on first
+/// touch. The single shared `session-lifecycle` region projects this map.
+pub struct SessionLifecycleStore {
+    inner: Mutex<Inner>,
+}
+
+impl Default for SessionLifecycleStore {
+    fn default() -> Self {
+        Self::with_config(DEFAULT_BACKOFF)
+    }
+}
+
+impl SessionLifecycleStore {
+    /// A store with no sessions yet, using the default backoff schedule and a
+    /// real jitter source.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A store with a specific backoff schedule (production wiring may tune this
+    /// per the persisted reconnect settings later).
+    pub fn with_config(config: BackoffConfig) -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                sessions: HashMap::new(),
+                config,
+                rand: Box::new(|| rand::random::<f64>()),
+            }),
+        }
+    }
+
+    /// The render-ready view model for the whole region:
+    /// `{ "sessions": { "<sessionId>": SessionLifecycle, ... } }`.
+    ///
+    /// Pure with respect to lifecycle state (never mutates), so the projector can
+    /// safely diff two consecutive snapshots.
+    pub fn snapshot(&self) -> Value {
+        let inner = self.lock();
+        let mut map = Map::with_capacity(inner.sessions.len());
+        for (id, lifecycle) in &inner.sessions {
+            if let Ok(value) = serde_json::to_value(lifecycle) {
+                map.insert(id.clone(), value);
+            }
+        }
+        json!({ "sessions": Value::Object(map) })
+    }
+
+    /// `session.connect` — begin an initial connect. Resets any prior state for
+    /// the session id (a fresh connect clears a stale error / reconnect loop).
+    pub fn connect(&self, session_id: &str) {
+        self.lock()
+            .sessions
+            .insert(session_id.to_string(), SessionLifecycle::connecting());
+    }
+
+    /// `session.connected` — a connect or reconnect attempt succeeded. Settles
+    /// the session live and, when a reconnect loop was in flight, feeds the
+    /// engine a `Success` so the attempt counter resets.
+    pub fn connected(&self, session_id: &str) {
+        let mut inner = self.lock();
+        let current = reconnect_of(&inner, session_id);
+        // Only the engine's Connecting sub-phase accepts Success; from a plain
+        // initial connect the loop is Idle and the reducer is a no-op.
+        let reconnect = if current.phase == ReconnectPhase::Connecting {
+            inner.reconnect_event(current, ReconnectEvent::Success)
+        } else {
+            INITIAL_RECONNECT_STATE
+        };
+        let entry = inner
+            .sessions
+            .entry(session_id.to_string())
+            .or_insert_with(SessionLifecycle::connecting);
+        entry.status = SessionStatus::Connected;
+        entry.reconnect = reconnect;
+        entry.end_reason = None;
+        entry.error = None;
+    }
+
+    /// `session.connectFailed` — the initial connect errored. Terminal `Failed`
+    /// with the message; the user may retry.
+    pub fn connect_failed(&self, session_id: &str, error: Option<String>) {
+        let mut inner = self.lock();
+        let entry = inner
+            .sessions
+            .entry(session_id.to_string())
+            .or_insert_with(SessionLifecycle::connecting);
+        entry.status = SessionStatus::Failed;
+        entry.reconnect = INITIAL_RECONNECT_STATE;
+        entry.end_reason = Some(EndReason::Error);
+        entry.error = error;
+    }
+
+    /// `session.disconnect` — a user-initiated graceful disconnect. Stops any
+    /// reconnect loop and lands in idle `Disconnected` with reason `User`.
+    pub fn disconnect(&self, session_id: &str) {
+        let mut inner = self.lock();
+        let entry = inner
+            .sessions
+            .entry(session_id.to_string())
+            .or_insert_with(SessionLifecycle::connecting);
+        entry.status = SessionStatus::Disconnected;
+        entry.reconnect = INITIAL_RECONNECT_STATE;
+        entry.end_reason = Some(EndReason::User);
+        entry.error = None;
+    }
+
+    /// `session.dropped` — the link dropped without the user asking. Lands in
+    /// idle `Disconnected` with reason `Unexpected`; arming an auto-reconnect
+    /// loop is a separate, opt-in `session.reconnect` (mirrors #1962, where the
+    /// disconnect overlay and the resilient-reconnect loop are distinct).
+    pub fn dropped(&self, session_id: &str, error: Option<String>) {
+        let mut inner = self.lock();
+        let entry = inner
+            .sessions
+            .entry(session_id.to_string())
+            .or_insert_with(SessionLifecycle::connecting);
+        entry.status = SessionStatus::Disconnected;
+        entry.reconnect = INITIAL_RECONNECT_STATE;
+        entry.end_reason = Some(EndReason::Unexpected);
+        entry.error = error;
+    }
+
+    /// `session.reconnect` — begin (or restart) the auto-reconnect loop. Feeds
+    /// the engine a `Drop`, arming the first backoff window; `status` becomes
+    /// `Reconnecting`. A `Drop` from a mid-loop `Waiting`/`Connecting` phase is a
+    /// no-op in the engine (the loop is already running).
+    pub fn reconnect(&self, session_id: &str) {
+        let mut inner = self.lock();
+        let current = reconnect_of(&inner, session_id);
+        let reconnect = inner.reconnect_event(current, ReconnectEvent::Drop);
+        let entry = inner
+            .sessions
+            .entry(session_id.to_string())
+            .or_insert_with(SessionLifecycle::connecting);
+        entry.status = SessionStatus::Reconnecting;
+        entry.reconnect = reconnect;
+        entry.end_reason = None;
+    }
+
+    /// `session.reconnectAttempt` — the backoff timer fired; start an attempt.
+    /// Feeds the engine an `Attempt` (Waiting → Connecting, attempt++). A no-op
+    /// outside the `Waiting` phase.
+    pub fn reconnect_attempt(&self, session_id: &str) {
+        let mut inner = self.lock();
+        let current = reconnect_of(&inner, session_id);
+        let reconnect = inner.reconnect_event(current, ReconnectEvent::Attempt);
+        if let Some(entry) = inner.sessions.get_mut(session_id) {
+            entry.reconnect = reconnect;
+            // Attempt keeps the loop active; status stays Reconnecting.
+            if reconnect.phase != ReconnectPhase::Idle {
+                entry.status = SessionStatus::Reconnecting;
+            }
+        }
+    }
+
+    /// `session.reconnectFailed` — the in-flight attempt failed. Feeds the engine
+    /// a `Failure`: it either arms the next backoff window (stay `Reconnecting`)
+    /// or gives up (terminal `Failed` with the message).
+    pub fn reconnect_failed(&self, session_id: &str, error: Option<String>) {
+        let mut inner = self.lock();
+        let current = reconnect_of(&inner, session_id);
+        let reconnect = inner.reconnect_event(current, ReconnectEvent::Failure);
+        if let Some(entry) = inner.sessions.get_mut(session_id) {
+            entry.reconnect = reconnect;
+            if reconnect.phase == ReconnectPhase::Gaveup {
+                entry.status = SessionStatus::Failed;
+                entry.end_reason = Some(EndReason::Error);
+                entry.error = error;
+            } else {
+                entry.status = SessionStatus::Reconnecting;
+            }
+        }
+    }
+
+    /// `session.cancelReconnect` — the user stopped the retry loop. Feeds the
+    /// engine a `Cancel` (→ Gaveup) and drops back to idle `Disconnected` so the
+    /// user can browse scrollback or reconnect manually (mirrors #1962 Cancel).
+    pub fn cancel_reconnect(&self, session_id: &str) {
+        let mut inner = self.lock();
+        let current = reconnect_of(&inner, session_id);
+        let _ = inner.reconnect_event(current, ReconnectEvent::Cancel);
+        if let Some(entry) = inner.sessions.get_mut(session_id) {
+            entry.status = SessionStatus::Disconnected;
+            entry.reconnect = INITIAL_RECONNECT_STATE;
+            entry.end_reason = Some(EndReason::User);
+        }
+    }
+
+    /// `session.remove` — the session/tab is gone; drop it from the region.
+    /// Idempotent: removing an unknown session is a no-op.
+    pub fn remove(&self, session_id: &str) {
+        self.lock().sessions.remove(session_id);
+    }
+
+    /// Read a session's current lifecycle (test / diagnostics helper).
+    #[cfg(test)]
+    pub fn get(&self, session_id: &str) -> Option<SessionLifecycle> {
+        self.lock().sessions.get(session_id).cloned()
+    }
+
+    /// Install a specific lifecycle for a session — test-only seeding so intent
+    /// tests can start from a populated region.
+    #[cfg(test)]
+    pub fn seed_for_test(&self, session_id: &str, lifecycle: SessionLifecycle) {
+        self.lock()
+            .sessions
+            .insert(session_id.to_string(), lifecycle);
+    }
+
+    /// Replace the jitter source — test-only, for a deterministic backoff
+    /// schedule.
+    #[cfg(test)]
+    pub fn set_rand_for_test(&self, rand: RandFn) {
+        self.lock().rand = rand;
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Inner> {
+        // Short critical sections only; a poisoned lock means another thread
+        // panicked mid-mutation (a bug) — recover rather than cascade.
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+/// The current reconnect-engine state for a session, or `Idle` when unknown.
+fn reconnect_of(inner: &Inner, session_id: &str) -> ReconnectState {
+    inner
+        .sessions
+        .get(session_id)
+        .map(|s| s.reconnect)
+        .unwrap_or(INITIAL_RECONNECT_STATE)
+}
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod tests;

--- a/src-tauri/src/session_projection/store.rs
+++ b/src-tauri/src/session_projection/store.rs
@@ -121,7 +121,11 @@ impl Inner {
     /// Run one reconnect-engine event for a session, returning the next
     /// [`ReconnectState`]. Reads the session's current reconnect state (Copy) and
     /// the config before borrowing `rand`, so the field borrows stay disjoint.
-    fn reconnect_event(&mut self, current: ReconnectState, event: ReconnectEvent) -> ReconnectState {
+    fn reconnect_event(
+        &mut self,
+        current: ReconnectState,
+        event: ReconnectEvent,
+    ) -> ReconnectState {
         let config = self.config;
         let rand = &mut self.rand;
         let mut adapter = || (*rand)();
@@ -156,7 +160,7 @@ impl SessionLifecycleStore {
             inner: Mutex::new(Inner {
                 sessions: HashMap::new(),
                 config,
-                rand: Box::new(|| rand::random::<f64>()),
+                rand: Box::new(rand::random::<f64>),
             }),
         }
     }
@@ -328,15 +332,6 @@ impl SessionLifecycleStore {
     #[cfg(test)]
     pub fn get(&self, session_id: &str) -> Option<SessionLifecycle> {
         self.lock().sessions.get(session_id).cloned()
-    }
-
-    /// Install a specific lifecycle for a session — test-only seeding so intent
-    /// tests can start from a populated region.
-    #[cfg(test)]
-    pub fn seed_for_test(&self, session_id: &str, lifecycle: SessionLifecycle) {
-        self.lock()
-            .sessions
-            .insert(session_id.to_string(), lifecycle);
     }
 
     /// Replace the jitter source — test-only, for a deterministic backoff

--- a/src-tauri/src/session_projection/store_tests.rs
+++ b/src-tauri/src/session_projection/store_tests.rs
@@ -1,0 +1,210 @@
+//! State-machine unit tests for the shadow [`SessionLifecycleStore`] (#2152).
+//!
+//! Drives the store directly (no projector) to pin the connect / reconnect /
+//! disconnect / error transitions, including the composed ported #2144 backoff
+//! engine. A deterministic jitter source (`rand() == 0.5` → zero swing) makes the
+//! backoff delays exact: attempt 1 → 1000 ms, attempt 2 → 2000 ms, ….
+
+use super::*;
+use termihub_core::reconnect_backoff::ReconnectPhase;
+
+/// A store whose jitter source always returns 0.5, so the symmetric jitter swing
+/// is exactly 0 and each backoff delay equals its uncapped base.
+fn deterministic_store() -> SessionLifecycleStore {
+    let store = SessionLifecycleStore::new();
+    store.set_rand_for_test(Box::new(|| 0.5));
+    store
+}
+
+#[test]
+fn connect_enters_connecting_with_an_idle_loop() {
+    let store = deterministic_store();
+    store.connect("s1");
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.status, SessionStatus::Connecting);
+    assert_eq!(s.reconnect.phase, ReconnectPhase::Idle);
+    assert_eq!(s.end_reason, None);
+    assert_eq!(s.error, None);
+}
+
+#[test]
+fn connected_settles_live_and_clears_error() {
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connected("s1");
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.status, SessionStatus::Connected);
+    assert_eq!(s.reconnect.phase, ReconnectPhase::Idle);
+    assert_eq!(s.error, None);
+    assert_eq!(s.end_reason, None);
+}
+
+#[test]
+fn connect_failed_is_terminal_with_the_message() {
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connect_failed("s1", Some("auth denied".to_string()));
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.status, SessionStatus::Failed);
+    assert_eq!(s.end_reason, Some(EndReason::Error));
+    assert_eq!(s.error.as_deref(), Some("auth denied"));
+}
+
+#[test]
+fn user_disconnect_lands_idle_with_reason_user() {
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connected("s1");
+    store.disconnect("s1");
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.status, SessionStatus::Disconnected);
+    assert_eq!(s.end_reason, Some(EndReason::User));
+    assert_eq!(s.reconnect.phase, ReconnectPhase::Idle);
+}
+
+#[test]
+fn unexpected_drop_lands_idle_with_reason_unexpected_and_no_loop() {
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connected("s1");
+    store.dropped("s1", Some("connection reset".to_string()));
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.status, SessionStatus::Disconnected);
+    assert_eq!(s.end_reason, Some(EndReason::Unexpected));
+    assert_eq!(s.error.as_deref(), Some("connection reset"));
+    // A drop does not arm the loop on its own — that is an opt-in reconnect.
+    assert_eq!(s.reconnect.phase, ReconnectPhase::Idle);
+}
+
+#[test]
+fn reconnect_arms_the_first_backoff_window() {
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connected("s1");
+    store.reconnect("s1");
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.status, SessionStatus::Reconnecting);
+    assert_eq!(s.reconnect.phase, ReconnectPhase::Waiting);
+    assert_eq!(s.reconnect.attempt, 0, "no attempt started yet");
+    assert_eq!(s.reconnect.delay_ms, 1_000, "first window = base delay");
+}
+
+#[test]
+fn a_successful_reconnect_attempt_settles_live_and_resets_the_loop() {
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connected("s1");
+    store.reconnect("s1"); // waiting, delay 1000
+    store.reconnect_attempt("s1"); // connecting, attempt 1
+    let mid = store.get("s1").unwrap();
+    assert_eq!(mid.status, SessionStatus::Reconnecting);
+    assert_eq!(mid.reconnect.phase, ReconnectPhase::Connecting);
+    assert_eq!(mid.reconnect.attempt, 1);
+
+    store.connected("s1"); // success
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.status, SessionStatus::Connected);
+    assert_eq!(s.reconnect.phase, ReconnectPhase::Connected);
+    assert_eq!(s.reconnect.attempt, 0, "attempt counter reset on success");
+}
+
+#[test]
+fn a_failed_attempt_backs_off_to_the_next_window() {
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connected("s1");
+    store.reconnect("s1"); // waiting, delay 1000
+    store.reconnect_attempt("s1"); // connecting, attempt 1
+    store.reconnect_failed("s1", None); // back off to attempt 2's window
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.status, SessionStatus::Reconnecting);
+    assert_eq!(s.reconnect.phase, ReconnectPhase::Waiting);
+    assert_eq!(s.reconnect.attempt, 1, "one attempt used so far");
+    assert_eq!(s.reconnect.delay_ms, 2_000, "next window doubled");
+}
+
+#[test]
+fn the_loop_gives_up_after_the_attempt_budget_and_lands_failed() {
+    // DEFAULT_BACKOFF.maxAttempts == 10: give up on the 10th failure.
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connected("s1");
+    store.reconnect("s1");
+    for _ in 0..9 {
+        store.reconnect_attempt("s1");
+        store.reconnect_failed("s1", None);
+        assert_eq!(
+            store.get("s1").unwrap().status,
+            SessionStatus::Reconnecting,
+            "still retrying within budget"
+        );
+    }
+    // 10th attempt and failure exhausts the budget.
+    store.reconnect_attempt("s1");
+    store.reconnect_failed("s1", Some("host unreachable".to_string()));
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.status, SessionStatus::Failed);
+    assert_eq!(s.reconnect.phase, ReconnectPhase::Gaveup);
+    assert_eq!(s.reconnect.attempt, 10);
+    assert_eq!(s.end_reason, Some(EndReason::Error));
+    assert_eq!(s.error.as_deref(), Some("host unreachable"));
+}
+
+#[test]
+fn cancel_stops_the_loop_and_returns_to_idle_disconnected() {
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connected("s1");
+    store.reconnect("s1");
+    store.reconnect_attempt("s1");
+    store.cancel_reconnect("s1");
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.status, SessionStatus::Disconnected);
+    assert_eq!(s.end_reason, Some(EndReason::User));
+    assert_eq!(s.reconnect.phase, ReconnectPhase::Idle);
+}
+
+#[test]
+fn remove_drops_the_session_from_the_region() {
+    let store = deterministic_store();
+    store.connect("s1");
+    store.remove("s1");
+    assert_eq!(store.get("s1"), None);
+    // Idempotent: removing an unknown session is fine.
+    store.remove("s1");
+}
+
+#[test]
+fn snapshot_shape_maps_session_ids_to_lifecycles() {
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connect("s2");
+    store.connected("s2");
+    let view = store.snapshot();
+    assert_eq!(view["sessions"]["s1"]["status"], serde_json::json!("connecting"));
+    assert_eq!(view["sessions"]["s2"]["status"], serde_json::json!("connected"));
+    // Reconnect detail is always present; optional fields are omitted when unset.
+    assert_eq!(view["sessions"]["s1"]["reconnect"]["phase"], serde_json::json!("idle"));
+    assert!(view["sessions"]["s1"].get("error").is_none());
+}
+
+#[test]
+fn status_and_reconnect_phase_stay_consistent_through_a_full_loop() {
+    // Invariant: whenever a loop is actively trying, status is Reconnecting; when
+    // it settles or is torn down, the two agree (Connected/Failed/Disconnected).
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connected("s1");
+    store.reconnect("s1");
+    store.reconnect_attempt("s1");
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.status, SessionStatus::Reconnecting);
+    assert!(matches!(
+        s.reconnect.phase,
+        ReconnectPhase::Waiting | ReconnectPhase::Connecting
+    ));
+    store.connected("s1");
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.status, SessionStatus::Connected);
+    assert_eq!(s.reconnect.phase, ReconnectPhase::Connected);
+}

--- a/src-tauri/src/session_projection/store_tests.rs
+++ b/src-tauri/src/session_projection/store_tests.rs
@@ -181,10 +181,19 @@ fn snapshot_shape_maps_session_ids_to_lifecycles() {
     store.connect("s2");
     store.connected("s2");
     let view = store.snapshot();
-    assert_eq!(view["sessions"]["s1"]["status"], serde_json::json!("connecting"));
-    assert_eq!(view["sessions"]["s2"]["status"], serde_json::json!("connected"));
+    assert_eq!(
+        view["sessions"]["s1"]["status"],
+        serde_json::json!("connecting")
+    );
+    assert_eq!(
+        view["sessions"]["s2"]["status"],
+        serde_json::json!("connected")
+    );
     // Reconnect detail is always present; optional fields are omitted when unset.
-    assert_eq!(view["sessions"]["s1"]["reconnect"]["phase"], serde_json::json!("idle"));
+    assert_eq!(
+        view["sessions"]["s1"]["reconnect"]["phase"],
+        serde_json::json!("idle")
+    );
     assert!(view["sessions"]["s1"].get("error").is_none());
 }
 


### PR DESCRIPTION
## What

Phase 4 step 1 of the stateless-UI migration (#2139): a **shadow, backend-authoritative session-lifecycle state machine** exposed as a projection region — the exact mirror of the Phase-3 layout step-1 (#2151) and the SSH-tunnels pilot (#2150).

New module `src-tauri/src/session_projection/`:

- **`SessionLifecycleStore`** — models the connect / reconnect / disconnect / error state machine the frontend currently drives per session (`appStore` `terminalConnecting`, `terminalDisconnects`, `terminalAutoReconnect`, disconnect reasons/errors). Top-level `SessionStatus` (`connecting` · `connected` · `disconnected` · `reconnecting` · `failed`) composes the **ported #2144 auto-reconnect engine** (`termihub_core::reconnect_backoff`) for the retry sub-loop (attempt count, backoff delay, waiting-vs-connecting, give-up) — the port becomes authoritative here, as the issue intends.
- **`session-lifecycle` shared region** (Open Design Decision #4: infrastructure domains are shared). The real sessions live backend-side; a session's connection status is a property of the session, not of a viewing client — like tunnels, two clients see the same status. Per-client presentation (a dismissed disconnect overlay, "view mode" scrollback) is **not** lifecycle and stays a frontend concern, keeping this a clean per-domain region.
- **`session.*` intents** — `connect`, `connected`, `connectFailed`, `disconnect`, `dropped`, `reconnect`, `reconnectAttempt`, `reconnectFailed`, `cancelReconnect`, `remove` — registered and served on the substrate dispatcher.

## Shadow — zero user-facing change

The store is managed state and serves intents, but **nothing in the live UI subscribes to `session-lifecycle` or dispatches `session.*` yet**. The `appStore` lifecycle reducers and terminal overlays remain fully authoritative. Backend-only diff; no frontend file touched.

## Tests

- **State-machine unit tests** (`store_tests.rs`, 13) — every transition incl. the full backoff loop to give-up, with a deterministic jitter source making delays exact (1000 → 2000 → …).
- **Projection-assertion tests** (`projection_tests.rs`, 6, reusing the #2164 harness) — subscribe→snapshot identical to every subscriber, intent→one coalesced diff fanned out with monotonic versions, no-op coalescing, `bad_payload` rejection advances nothing, dead-subscriber reaping, and client-cache convergence across a full reconnect loop.

`cargo test -p termihub --lib session_projection` → 19 passed. `clippy -D warnings` + `fmt` clean.

## Decomposition

The remaining cut-over is decomposed into bounded steps in a comment on the umbrella issue; sub-issues filed `Ready2Implement`.

Part of #2152