### PR TITLE
feat: cut session-lifecycle mutations to session.* intents + backend timer driver (Closes #2203)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -722,6 +722,32 @@ pub fn run() {
                         commands::projection_diag::initial_view(),
                     );
                 }
+                // Backend reconnect timer driver (#2203, Phase 4 step 2): moves
+                // the frontend `setTimeout` reconnect loop server-side. Built
+                // here — after the projector exists — so a fired backoff timer
+                // can advance the store and fan the `session-lifecycle` diff out
+                // itself. In shadow mode it stays off-path (nothing dispatches
+                // `session.reconnect` yet); once the frontend `sessionIntents`
+                // flag is on, the store's `Waiting` phases arm it and it drives
+                // the `reconnectAttempt` edge on the ported #2144 backoff schedule.
+                if let Some(store) =
+                    app.handle().try_state::<Arc<session_projection::SessionLifecycleStore>>()
+                {
+                    let store: Arc<session_projection::SessionLifecycleStore> = (*store).clone();
+                    let projector = projection_state.projector.clone();
+                    let store_for_publish = store.clone();
+                    let driver = Arc::new(session_projection::ReconnectTimerDriver::new(
+                        store,
+                        Arc::new(session_projection::TokioReconnectScheduler::new()),
+                        Arc::new(move || {
+                            session_projection::projection::publish_sessions(
+                                &projector,
+                                &store_for_publish,
+                            );
+                        }),
+                    ));
+                    app.manage(driver);
+                }
                 app.manage(projection_state);
             }
 

--- a/src-tauri/src/session_projection/mod.rs
+++ b/src-tauri/src/session_projection/mod.rs
@@ -22,5 +22,7 @@
 
 pub mod projection;
 pub mod store;
+pub mod timer;
 
 pub use store::SessionLifecycleStore;
+pub use timer::{ReconnectTimerDriver, TokioReconnectScheduler};

--- a/src-tauri/src/session_projection/projection.rs
+++ b/src-tauri/src/session_projection/projection.rs
@@ -49,6 +49,7 @@ use tauri::{AppHandle, Manager};
 
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
 use crate::session_projection::store::SessionLifecycleStore;
+use crate::session_projection::timer::ReconnectTimerDriver;
 
 /// The projection region id for the session-lifecycle domain (shared, per Open
 /// Design Decision #4).
@@ -74,87 +75,118 @@ pub fn publish_sessions(
 ///
 /// Each route resolves the managed [`SessionLifecycleStore`] lazily (so it
 /// rejects gracefully rather than panicking if the store is somehow absent),
-/// applies the transition, and publishes the shared region. All transitions are
-/// pure/fast map edits, so they run inline on the dispatcher's single writer.
+/// applies the transition, publishes the shared region, and then reconciles the
+/// backend reconnect timer for that session ([`sync_timer`]). All transitions
+/// are pure/fast map edits, so they run inline on the dispatcher's single writer.
 pub fn register_session_intents(registry: &mut HandlerRegistry, app_handle: AppHandle) {
     let handle = app_handle.clone();
     registry.route("session.connect", move |intent, projector| {
         let store = store_of(&handle)?;
-        store.connect(&required_str(intent, "sessionId")?);
-        Ok(publish_sessions(projector, &store))
+        let id = required_str(intent, "sessionId")?;
+        store.connect(&id);
+        let produced = publish_sessions(projector, &store);
+        sync_timer(&handle, &id);
+        Ok(produced)
     });
 
     let handle = app_handle.clone();
     registry.route("session.connected", move |intent, projector| {
         let store = store_of(&handle)?;
-        store.connected(&required_str(intent, "sessionId")?);
-        Ok(publish_sessions(projector, &store))
+        let id = required_str(intent, "sessionId")?;
+        store.connected(&id);
+        let produced = publish_sessions(projector, &store);
+        sync_timer(&handle, &id);
+        Ok(produced)
     });
 
     let handle = app_handle.clone();
     registry.route("session.connectFailed", move |intent, projector| {
         let store = store_of(&handle)?;
-        store.connect_failed(
-            &required_str(intent, "sessionId")?,
-            optional_str(intent, "error"),
-        );
-        Ok(publish_sessions(projector, &store))
+        let id = required_str(intent, "sessionId")?;
+        store.connect_failed(&id, optional_str(intent, "error"));
+        let produced = publish_sessions(projector, &store);
+        sync_timer(&handle, &id);
+        Ok(produced)
     });
 
     let handle = app_handle.clone();
     registry.route("session.disconnect", move |intent, projector| {
         let store = store_of(&handle)?;
-        store.disconnect(&required_str(intent, "sessionId")?);
-        Ok(publish_sessions(projector, &store))
+        let id = required_str(intent, "sessionId")?;
+        store.disconnect(&id);
+        let produced = publish_sessions(projector, &store);
+        sync_timer(&handle, &id);
+        Ok(produced)
     });
 
     let handle = app_handle.clone();
     registry.route("session.dropped", move |intent, projector| {
         let store = store_of(&handle)?;
-        store.dropped(
-            &required_str(intent, "sessionId")?,
-            optional_str(intent, "error"),
-        );
-        Ok(publish_sessions(projector, &store))
+        let id = required_str(intent, "sessionId")?;
+        store.dropped(&id, optional_str(intent, "error"));
+        let produced = publish_sessions(projector, &store);
+        sync_timer(&handle, &id);
+        Ok(produced)
     });
 
     let handle = app_handle.clone();
     registry.route("session.reconnect", move |intent, projector| {
         let store = store_of(&handle)?;
-        store.reconnect(&required_str(intent, "sessionId")?);
-        Ok(publish_sessions(projector, &store))
+        let id = required_str(intent, "sessionId")?;
+        store.reconnect(&id);
+        let produced = publish_sessions(projector, &store);
+        sync_timer(&handle, &id);
+        Ok(produced)
     });
 
     let handle = app_handle.clone();
     registry.route("session.reconnectAttempt", move |intent, projector| {
         let store = store_of(&handle)?;
-        store.reconnect_attempt(&required_str(intent, "sessionId")?);
-        Ok(publish_sessions(projector, &store))
+        let id = required_str(intent, "sessionId")?;
+        store.reconnect_attempt(&id);
+        let produced = publish_sessions(projector, &store);
+        sync_timer(&handle, &id);
+        Ok(produced)
     });
 
     let handle = app_handle.clone();
     registry.route("session.reconnectFailed", move |intent, projector| {
         let store = store_of(&handle)?;
-        store.reconnect_failed(
-            &required_str(intent, "sessionId")?,
-            optional_str(intent, "error"),
-        );
-        Ok(publish_sessions(projector, &store))
+        let id = required_str(intent, "sessionId")?;
+        store.reconnect_failed(&id, optional_str(intent, "error"));
+        let produced = publish_sessions(projector, &store);
+        sync_timer(&handle, &id);
+        Ok(produced)
     });
 
     let handle = app_handle.clone();
     registry.route("session.cancelReconnect", move |intent, projector| {
         let store = store_of(&handle)?;
-        store.cancel_reconnect(&required_str(intent, "sessionId")?);
-        Ok(publish_sessions(projector, &store))
+        let id = required_str(intent, "sessionId")?;
+        store.cancel_reconnect(&id);
+        let produced = publish_sessions(projector, &store);
+        sync_timer(&handle, &id);
+        Ok(produced)
     });
 
     let handle = app_handle;
     registry.route("session.remove", move |intent, projector| {
         let store = store_of(&handle)?;
-        store.remove(&required_str(intent, "sessionId")?);
-        Ok(publish_sessions(projector, &store))
+        let id = required_str(intent, "sessionId")?;
+        store.remove(&id);
+        let produced = publish_sessions(projector, &store);
+        sync_timer(&handle, &id);
+        Ok(produced)
     });
+}
+
+/// Reconcile the backend reconnect timer for a session after a transition, when
+/// the timer driver is present. Off-path (a silent no-op) if the driver is not
+/// managed yet — e.g. the shadow-only setup where nothing arms the loop.
+fn sync_timer(app_handle: &AppHandle, session_id: &str) {
+    if let Some(driver) = app_handle.try_state::<Arc<ReconnectTimerDriver>>() {
+        (*driver).sync(session_id);
+    }
 }
 
 /// Resolve the managed session-lifecycle store, or a rejectable error if absent.

--- a/src-tauri/src/session_projection/store.rs
+++ b/src-tauri/src/session_projection/store.rs
@@ -334,6 +334,14 @@ impl SessionLifecycleStore {
         self.lock().sessions.get(session_id).cloned()
     }
 
+    /// The current auto-reconnect loop state for a session, or `None` if the
+    /// session is unknown. Read by the backend timer driver ([`crate::session_projection::timer`],
+    /// #2203) to decide whether to arm a backoff timer (a `Waiting` phase) and
+    /// for how long (`delay_ms`).
+    pub fn reconnect_state(&self, session_id: &str) -> Option<ReconnectState> {
+        self.lock().sessions.get(session_id).map(|s| s.reconnect)
+    }
+
     /// Replace the jitter source — test-only, for a deterministic backoff
     /// schedule.
     #[cfg(test)]

--- a/src-tauri/src/session_projection/timer.rs
+++ b/src-tauri/src/session_projection/timer.rs
@@ -1,0 +1,176 @@
+//! Backend reconnect timer driver — Phase 4 step 2 of the stateless-UI migration
+//! (#2203, part of #2152 / #2139).
+//!
+//! The auto-reconnect backoff loop used to time itself in the frontend: a
+//! `setTimeout` in `appStore.autoReconnectTimers` fired the `Waiting → Connecting`
+//! edge after each backoff window. Once the shadow [`SessionLifecycleStore`] is
+//! authoritative for session status (step 2), the *timing* has to move
+//! server-side too — otherwise a client that never re-dispatches would strand a
+//! session in `Waiting` forever. This module is that one genuinely new mechanism:
+//! a cancellable, per-session one-shot timer that fires the store's
+//! `session.reconnectAttempt` transition itself, on the ported #2144 backoff
+//! schedule.
+//!
+//! # How it drives the loop
+//!
+//! The store's reconnect sub-machine reports a `Waiting` phase whenever it is
+//! counting down a backoff window, with the concrete jittered `delay_ms` to wait.
+//! After every `session.*` transition the intent routes call
+//! [`ReconnectTimerDriver::sync`], which reconciles the timer with that phase:
+//!
+//! - **`Waiting`** → arm (replacing any prior) a one-shot for `delay_ms`. When it
+//!   elapses [`ReconnectTimerDriver::fire`] advances the store
+//!   (`Waiting → Connecting`, attempt++) and fans the diff out. The frontend,
+//!   reconciling the `Connecting` diff, redrives the actual connection; its
+//!   success (`session.connected`) or failure (`session.reconnectFailed`) then
+//!   drives the next transition — a failure re-enters `Waiting` and re-arms here.
+//! - **anything else** (`Connecting`, `Idle`, `Gaveup`, connected, disconnected,
+//!   removed) → cancel any pending timer. So a success, a user cancel, a
+//!   give-up, or a tab close all stop the loop.
+//!
+//! The backend only times the `Waiting → Attempt` edge; the attempt's outcome
+//! still comes from the client (which owns the transport). This keeps the retry
+//! *count* and *schedule* authoritative server-side while the connection redrive
+//! stays where the sockets live.
+//!
+//! # Deterministic timing (testability)
+//!
+//! The wall-clock is behind the [`ReconnectScheduler`] trait so tests are not
+//! flaky: production uses [`TokioReconnectScheduler`] (a real
+//! `tokio::time::sleep`), while unit tests inject a `ManualScheduler` that
+//! records armed delays and fires on command, so a full reconnect sequence runs
+//! synchronously with exact, injected-jitter delays.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
+
+use termihub_core::reconnect_backoff::ReconnectPhase;
+
+use crate::session_projection::store::SessionLifecycleStore;
+
+/// The action a fired timer runs: advance the store and fan the diff out.
+type FireTask = Box<dyn FnOnce() + Send>;
+
+/// A cancellable, per-key one-shot timer — the wall-clock behind the reconnect
+/// loop, abstracted so tests inject a deterministic double.
+///
+/// `schedule` arms (replacing any existing timer for `key`) a one-shot that runs
+/// `task` after `delay_ms`; `cancel` drops a pending timer. Both are idempotent
+/// per key.
+pub trait ReconnectScheduler: Send + Sync {
+    /// Arm a one-shot for `key`, replacing any pending timer for the same key,
+    /// to run `task` after `delay_ms` milliseconds.
+    fn schedule(&self, key: String, delay_ms: u64, task: FireTask);
+    /// Cancel any pending timer for `key`. A no-op if none is armed.
+    fn cancel(&self, key: &str);
+}
+
+/// Production [`ReconnectScheduler`] backed by `tokio::time::sleep`. Each armed
+/// timer is a spawned task; cancelling aborts it. Requires a Tokio runtime
+/// (always present in the Tauri app).
+pub struct TokioReconnectScheduler {
+    handles: Mutex<HashMap<String, tokio::task::JoinHandle<()>>>,
+}
+
+impl TokioReconnectScheduler {
+    pub fn new() -> Self {
+        Self {
+            handles: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, tokio::task::JoinHandle<()>>> {
+        self.handles.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl Default for TokioReconnectScheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ReconnectScheduler for TokioReconnectScheduler {
+    fn schedule(&self, key: String, delay_ms: u64, task: FireTask) {
+        // Replace any prior timer for this key so a re-arm never leaves two live.
+        self.cancel(&key);
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            task();
+        });
+        self.lock().insert(key, handle);
+    }
+
+    fn cancel(&self, key: &str) {
+        if let Some(handle) = self.lock().remove(key) {
+            handle.abort();
+        }
+    }
+}
+
+/// Drives the reconnect backoff loop's timing for the shadow
+/// [`SessionLifecycleStore`]. Holds the store, the injectable scheduler, and a
+/// publish hook (in production: fan the `session-lifecycle` region out via the
+/// projector). Managed as Tauri state and resolved by the `session.*` intent
+/// routes, which call [`Self::sync`] after each transition.
+pub struct ReconnectTimerDriver {
+    store: Arc<SessionLifecycleStore>,
+    scheduler: Arc<dyn ReconnectScheduler>,
+    /// Fan the advanced region out after a fired timer mutates the store. In
+    /// production this republishes the shared `session-lifecycle` region.
+    publish: Arc<dyn Fn() + Send + Sync>,
+}
+
+impl ReconnectTimerDriver {
+    /// Build a driver over a store, a scheduler, and a publish hook.
+    pub fn new(
+        store: Arc<SessionLifecycleStore>,
+        scheduler: Arc<dyn ReconnectScheduler>,
+        publish: Arc<dyn Fn() + Send + Sync>,
+    ) -> Self {
+        Self {
+            store,
+            scheduler,
+            publish,
+        }
+    }
+
+    /// Reconcile the timer for `session_id` with the store's current reconnect
+    /// phase: arm a one-shot for a `Waiting` phase's `delay_ms`, else cancel any
+    /// pending timer. Idempotent and cheap, so the routes call it after every
+    /// `session.*` transition regardless of kind.
+    pub fn sync(self: &Arc<Self>, session_id: &str) {
+        match self.store.reconnect_state(session_id) {
+            Some(state) if state.phase == ReconnectPhase::Waiting => {
+                let delay = state.delay_ms.max(0) as u64;
+                let this = Arc::clone(self);
+                let id = session_id.to_string();
+                self.scheduler.schedule(
+                    session_id.to_string(),
+                    delay,
+                    Box::new(move || this.fire(&id)),
+                );
+            }
+            _ => self.scheduler.cancel(session_id),
+        }
+    }
+
+    /// The backoff timer for `session_id` elapsed: advance the store's reconnect
+    /// sub-machine one attempt (`Waiting → Connecting`, attempt++) and fan the
+    /// diff out. The frontend, reconciling the `Connecting` status, performs the
+    /// real connection redrive; its outcome drives the next transition.
+    ///
+    /// The store transition is itself atomic (guarded by the store's own mutex),
+    /// so this runs correctly off the dispatcher's write path without corrupting
+    /// state — a fired timer and a concurrent intent each publish a consistent,
+    /// monotonically-versioned diff.
+    fn fire(&self, session_id: &str) {
+        self.store.reconnect_attempt(session_id);
+        (self.publish)();
+    }
+}
+
+#[cfg(test)]
+#[path = "timer_tests.rs"]
+mod tests;

--- a/src-tauri/src/session_projection/timer_tests.rs
+++ b/src-tauri/src/session_projection/timer_tests.rs
@@ -16,11 +16,14 @@ use crate::projection::Projector;
 use crate::session_projection::projection::{publish_sessions, SESSION_LIFECYCLE_REGION};
 use crate::session_projection::store::{SessionLifecycleStore, SessionStatus};
 
+/// The armed one-shots a [`ManualScheduler`] records: `key → (delay, task)`.
+type ArmedTasks = std::collections::HashMap<String, (u64, Box<dyn FnOnce() + Send>)>;
+
 /// A test scheduler that records the armed one-shots instead of sleeping, so a
 /// test can inspect the armed delay and fire the timer synchronously.
 #[derive(Default)]
 struct ManualScheduler {
-    tasks: Mutex<std::collections::HashMap<String, (u64, Box<dyn FnOnce() + Send>)>>,
+    tasks: Mutex<ArmedTasks>,
 }
 
 impl ManualScheduler {
@@ -30,11 +33,7 @@ impl ManualScheduler {
 
     /// The delay a key is currently armed for, or `None` if nothing is armed.
     fn armed_delay(&self, key: &str) -> Option<u64> {
-        self.tasks
-            .lock()
-            .unwrap()
-            .get(key)
-            .map(|(delay, _)| *delay)
+        self.tasks.lock().unwrap().get(key).map(|(delay, _)| *delay)
     }
 
     /// Run and consume the armed task for `key` (the timer "elapsed").
@@ -56,16 +55,19 @@ impl ReconnectScheduler for ManualScheduler {
     }
 }
 
-/// A store (zero jitter), projector-registered region, a manual scheduler, and a
-/// driver whose publish hook fans the region out. Returns them all so a test can
-/// both drive intents and inspect the timer.
-fn harness() -> (
+/// The test harness bundle: store, projector, scheduler, driver, publish counter.
+type Harness = (
     Arc<SessionLifecycleStore>,
     Arc<Projector>,
     Arc<ManualScheduler>,
     Arc<ReconnectTimerDriver>,
     Arc<AtomicUsize>,
-) {
+);
+
+/// A store (zero jitter), projector-registered region, a manual scheduler, and a
+/// driver whose publish hook fans the region out. Returns them all so a test can
+/// both drive intents and inspect the timer.
+fn harness() -> Harness {
     let store = Arc::new(SessionLifecycleStore::new());
     store.set_rand_for_test(Box::new(|| 0.5));
     let projector = Arc::new(Projector::new());
@@ -96,19 +98,31 @@ fn a_waiting_phase_arms_the_backoff_delay_and_a_success_cancels_it() {
     store.connected("s1");
     store.dropped("s1", Some("reset".into()));
     driver.sync("s1");
-    assert_eq!(scheduler.armed_delay("s1"), None, "a plain drop does not retry");
+    assert_eq!(
+        scheduler.armed_delay("s1"),
+        None,
+        "a plain drop does not retry"
+    );
 
     store.reconnect("s1");
     driver.sync("s1");
     assert_eq!(store.get("s1").unwrap().status, SessionStatus::Reconnecting);
-    assert_eq!(scheduler.armed_delay("s1"), Some(1000), "attempt-1 backoff armed");
+    assert_eq!(
+        scheduler.armed_delay("s1"),
+        Some(1000),
+        "attempt-1 backoff armed"
+    );
 
     // The timer fires: the store advances Waiting → Connecting (attempt++).
     scheduler.fire("s1");
     let s = store.get("s1").unwrap();
     assert_eq!(s.reconnect.phase, ReconnectPhase::Connecting);
     assert_eq!(s.reconnect.attempt, 1);
-    assert_eq!(scheduler.armed_delay("s1"), None, "no timer while connecting");
+    assert_eq!(
+        scheduler.armed_delay("s1"),
+        None,
+        "no timer while connecting"
+    );
 
     // The attempt succeeds → the loop settles and any timer is cancelled.
     store.connected("s1");
@@ -127,7 +141,9 @@ fn the_timer_drives_the_expected_backoff_attempt_sequence_until_giveup() {
 
     // Expected uncapped backoff schedule (base 1000, factor 2, cap 30000):
     // attempt 1..=10 → 1000, 2000, 4000, 8000, 16000, then capped at 30000.
-    let expected = [1000u64, 2000, 4000, 8000, 16000, 30000, 30000, 30000, 30000, 30000];
+    let expected = [
+        1000u64, 2000, 4000, 8000, 16000, 30000, 30000, 30000, 30000, 30000,
+    ];
     for (i, want) in expected.iter().enumerate() {
         assert_eq!(
             scheduler.armed_delay("s1"),
@@ -149,7 +165,11 @@ fn the_timer_drives_the_expected_backoff_attempt_sequence_until_giveup() {
     let s = store.get("s1").unwrap();
     assert_eq!(s.status, SessionStatus::Failed);
     assert_eq!(s.reconnect.phase, ReconnectPhase::Gaveup);
-    assert_eq!(scheduler.armed_delay("s1"), None, "give-up cancels the timer");
+    assert_eq!(
+        scheduler.armed_delay("s1"),
+        None,
+        "give-up cancels the timer"
+    );
 }
 
 #[test]
@@ -166,7 +186,10 @@ fn a_fired_timer_publishes_the_advanced_region_as_a_diff() {
     let after = projector.region_version(SESSION_LIFECYCLE_REGION).unwrap();
     assert_eq!(after, before + 1, "the fired attempt fanned out one diff");
     let snap = projector.snapshot(SESSION_LIFECYCLE_REGION);
-    assert_eq!(snap.view["sessions"]["s1"]["reconnect"]["phase"], json!("connecting"));
+    assert_eq!(
+        snap.view["sessions"]["s1"]["reconnect"]["phase"],
+        json!("connecting")
+    );
 }
 
 #[test]
@@ -179,7 +202,11 @@ fn cancel_reconnect_stops_the_timer() {
 
     store.cancel_reconnect("s1");
     driver.sync("s1");
-    assert_eq!(scheduler.armed_delay("s1"), None, "user cancel disarms the loop");
+    assert_eq!(
+        scheduler.armed_delay("s1"),
+        None,
+        "user cancel disarms the loop"
+    );
     assert_eq!(store.get("s1").unwrap().status, SessionStatus::Disconnected);
 }
 
@@ -193,5 +220,9 @@ fn remove_disarms_any_pending_timer() {
 
     store.remove("s1");
     driver.sync("s1");
-    assert_eq!(scheduler.armed_delay("s1"), None, "a removed session has no timer");
+    assert_eq!(
+        scheduler.armed_delay("s1"),
+        None,
+        "a removed session has no timer"
+    );
 }

--- a/src-tauri/src/session_projection/timer_tests.rs
+++ b/src-tauri/src/session_projection/timer_tests.rs
@@ -1,0 +1,197 @@
+//! Deterministic tests for the backend reconnect timer driver (#2203).
+//!
+//! A `ManualScheduler` records armed delays and fires on command, so a full
+//! reconnect sequence runs synchronously with exact delays (the store's jitter
+//! source is pinned to 0.5 → zero swing, so attempt N's delay is its uncapped
+//! base: 1000, 2000, 4000, … ms). No wall-clock, no `tokio`, no flake.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::json;
+use termihub_core::reconnect_backoff::ReconnectPhase;
+
+use super::{ReconnectScheduler, ReconnectTimerDriver};
+use crate::projection::Projector;
+use crate::session_projection::projection::{publish_sessions, SESSION_LIFECYCLE_REGION};
+use crate::session_projection::store::{SessionLifecycleStore, SessionStatus};
+
+/// A test scheduler that records the armed one-shots instead of sleeping, so a
+/// test can inspect the armed delay and fire the timer synchronously.
+#[derive(Default)]
+struct ManualScheduler {
+    tasks: Mutex<std::collections::HashMap<String, (u64, Box<dyn FnOnce() + Send>)>>,
+}
+
+impl ManualScheduler {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    /// The delay a key is currently armed for, or `None` if nothing is armed.
+    fn armed_delay(&self, key: &str) -> Option<u64> {
+        self.tasks
+            .lock()
+            .unwrap()
+            .get(key)
+            .map(|(delay, _)| *delay)
+    }
+
+    /// Run and consume the armed task for `key` (the timer "elapsed").
+    fn fire(&self, key: &str) {
+        let task = self.tasks.lock().unwrap().remove(key);
+        if let Some((_, task)) = task {
+            task();
+        }
+    }
+}
+
+impl ReconnectScheduler for ManualScheduler {
+    fn schedule(&self, key: String, delay_ms: u64, task: Box<dyn FnOnce() + Send>) {
+        self.tasks.lock().unwrap().insert(key, (delay_ms, task));
+    }
+
+    fn cancel(&self, key: &str) {
+        self.tasks.lock().unwrap().remove(key);
+    }
+}
+
+/// A store (zero jitter), projector-registered region, a manual scheduler, and a
+/// driver whose publish hook fans the region out. Returns them all so a test can
+/// both drive intents and inspect the timer.
+fn harness() -> (
+    Arc<SessionLifecycleStore>,
+    Arc<Projector>,
+    Arc<ManualScheduler>,
+    Arc<ReconnectTimerDriver>,
+    Arc<AtomicUsize>,
+) {
+    let store = Arc::new(SessionLifecycleStore::new());
+    store.set_rand_for_test(Box::new(|| 0.5));
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let scheduler = Arc::new(ManualScheduler::new());
+
+    let publishes = Arc::new(AtomicUsize::new(0));
+    let store_for_publish = store.clone();
+    let projector_for_publish = projector.clone();
+    let publishes_for_hook = publishes.clone();
+    let driver = Arc::new(ReconnectTimerDriver::new(
+        store.clone(),
+        scheduler.clone(),
+        Arc::new(move || {
+            publishes_for_hook.fetch_add(1, Ordering::SeqCst);
+            publish_sessions(&projector_for_publish, &store_for_publish);
+        }),
+    ));
+    (store, projector, scheduler, driver, publishes)
+}
+
+#[test]
+fn a_waiting_phase_arms_the_backoff_delay_and_a_success_cancels_it() {
+    let (store, _projector, scheduler, driver, _pub) = harness();
+
+    // Drop → reconnect enters Waiting with the attempt-1 delay (1000 ms).
+    store.connect("s1");
+    store.connected("s1");
+    store.dropped("s1", Some("reset".into()));
+    driver.sync("s1");
+    assert_eq!(scheduler.armed_delay("s1"), None, "a plain drop does not retry");
+
+    store.reconnect("s1");
+    driver.sync("s1");
+    assert_eq!(store.get("s1").unwrap().status, SessionStatus::Reconnecting);
+    assert_eq!(scheduler.armed_delay("s1"), Some(1000), "attempt-1 backoff armed");
+
+    // The timer fires: the store advances Waiting → Connecting (attempt++).
+    scheduler.fire("s1");
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.reconnect.phase, ReconnectPhase::Connecting);
+    assert_eq!(s.reconnect.attempt, 1);
+    assert_eq!(scheduler.armed_delay("s1"), None, "no timer while connecting");
+
+    // The attempt succeeds → the loop settles and any timer is cancelled.
+    store.connected("s1");
+    driver.sync("s1");
+    assert_eq!(store.get("s1").unwrap().status, SessionStatus::Connected);
+    assert_eq!(scheduler.armed_delay("s1"), None);
+}
+
+#[test]
+fn the_timer_drives_the_expected_backoff_attempt_sequence_until_giveup() {
+    let (store, _projector, scheduler, driver, _pub) = harness();
+    store.connect("s1");
+    store.connected("s1");
+    store.reconnect("s1"); // Drop → Waiting (attempt 0, delay for attempt 1)
+    driver.sync("s1");
+
+    // Expected uncapped backoff schedule (base 1000, factor 2, cap 30000):
+    // attempt 1..=10 → 1000, 2000, 4000, 8000, 16000, then capped at 30000.
+    let expected = [1000u64, 2000, 4000, 8000, 16000, 30000, 30000, 30000, 30000, 30000];
+    for (i, want) in expected.iter().enumerate() {
+        assert_eq!(
+            scheduler.armed_delay("s1"),
+            Some(*want),
+            "attempt {} backoff delay",
+            i + 1
+        );
+        // Timer fires → an attempt starts (Waiting → Connecting).
+        scheduler.fire("s1");
+        let s = store.get("s1").unwrap();
+        assert_eq!(s.reconnect.phase, ReconnectPhase::Connecting);
+        assert_eq!(s.reconnect.attempt, (i as i64) + 1);
+        // The frontend would redrive; here we play its role and fail the attempt.
+        store.reconnect_failed("s1", Some("still down".into()));
+        driver.sync("s1");
+    }
+
+    // The 10th failure exhausts max_attempts (DEFAULT_BACKOFF = 10): terminal.
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.status, SessionStatus::Failed);
+    assert_eq!(s.reconnect.phase, ReconnectPhase::Gaveup);
+    assert_eq!(scheduler.armed_delay("s1"), None, "give-up cancels the timer");
+}
+
+#[test]
+fn a_fired_timer_publishes_the_advanced_region_as_a_diff() {
+    let (store, projector, scheduler, driver, publishes) = harness();
+    store.connect("s1");
+    store.reconnect("s1");
+    driver.sync("s1");
+    let before = projector.region_version(SESSION_LIFECYCLE_REGION).unwrap();
+
+    scheduler.fire("s1");
+
+    assert_eq!(publishes.load(Ordering::SeqCst), 1, "fire published once");
+    let after = projector.region_version(SESSION_LIFECYCLE_REGION).unwrap();
+    assert_eq!(after, before + 1, "the fired attempt fanned out one diff");
+    let snap = projector.snapshot(SESSION_LIFECYCLE_REGION);
+    assert_eq!(snap.view["sessions"]["s1"]["reconnect"]["phase"], json!("connecting"));
+}
+
+#[test]
+fn cancel_reconnect_stops_the_timer() {
+    let (store, _projector, scheduler, driver, _pub) = harness();
+    store.connect("s1");
+    store.reconnect("s1");
+    driver.sync("s1");
+    assert!(scheduler.armed_delay("s1").is_some());
+
+    store.cancel_reconnect("s1");
+    driver.sync("s1");
+    assert_eq!(scheduler.armed_delay("s1"), None, "user cancel disarms the loop");
+    assert_eq!(store.get("s1").unwrap().status, SessionStatus::Disconnected);
+}
+
+#[test]
+fn remove_disarms_any_pending_timer() {
+    let (store, _projector, scheduler, driver, _pub) = harness();
+    store.connect("s1");
+    store.reconnect("s1");
+    driver.sync("s1");
+    assert!(scheduler.armed_delay("s1").is_some());
+
+    store.remove("s1");
+    driver.sync("s1");
+    assert_eq!(scheduler.armed_delay("s1"), None, "a removed session has no timer");
+}

--- a/src/store/appStore.sessionBridge.test.ts
+++ b/src/store/appStore.sessionBridge.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Same lightweight service mocks the auto-reconnect suite uses: the loop never
+// calls the backend directly, so these only satisfy module import.
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  persistAgent: vi.fn(() => Promise.resolve()),
+  removeAgent: vi.fn(() => Promise.resolve()),
+  reorderAgents: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve()),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  startPersistentSession: vi.fn(() => Promise.resolve("sid")),
+  stopPersistentSession: vi.fn(() => Promise.resolve()),
+  attachPersistentTab: vi.fn(() => Promise.resolve(1)),
+  connectAgent: vi.fn(() => Promise.resolve({ capabilities: {} })),
+  disconnectAgent: vi.fn(),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  listAgentConnections: vi.fn(() => Promise.resolve({ connections: [], folders: [] })),
+  saveAgentDefinition: vi.fn(),
+  updateAgentDefinition: vi.fn(),
+  deleteAgentDefinition: vi.fn(() => Promise.resolve()),
+  createAgentFolder: vi.fn(),
+  updateAgentFolder: vi.fn(() => Promise.resolve({})),
+  deleteAgentFolder: vi.fn(() => Promise.resolve()),
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  removeCredential: vi.fn(() => Promise.resolve()),
+  getConnectionTypes: vi.fn(() => Promise.resolve([])),
+  sessionGetCapabilities: vi.fn(() => Promise.resolve({})),
+}));
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+
+import { useAppStore } from "./appStore";
+import {
+  SESSION_LIFECYCLE_REGION,
+  setSessionIntentsEnabled,
+  setSessionTransportForTest,
+  stopSessionSubscription,
+  type ProjectedSessionLifecycle,
+} from "./sessionBridge";
+
+/** A substrate double that applies `session.reconnect` (→ waiting) and fans a
+ * fresh snapshot to every subscriber, so the appStore cut's mirror + reconcile
+ * round-trip runs end to end. */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  private sessions: Record<string, ProjectedSessionLifecycle> = {};
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    const id = (intent.payload as { sessionId: string }).sessionId;
+    if (intent.kind === "session.reconnect") {
+      this.sessions[id] = {
+        status: "reconnecting",
+        reconnect: { phase: "waiting", attempt: 0, delayMs: 1000 },
+      };
+      this.version += 1;
+      this.fan();
+    }
+    return { intentId: intent.intentId, status: "accepted", produced: [] };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  /** Simulate the backend timer firing the Waiting→Connecting edge. */
+  fireAttempt(id: string, attempt: number): void {
+    this.sessions[id] = {
+      status: "reconnecting",
+      reconnect: { phase: "connecting", attempt, delayMs: 0 },
+    };
+    this.version += 1;
+    this.fan();
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return {
+      kind: "snapshot",
+      region,
+      version: this.version,
+      view: structuredClone({ sessions: this.sessions }),
+    };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(SESSION_LIFECYCLE_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+const auto = (tabId: string) => useAppStore.getState().terminalAutoReconnect[tabId];
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+function makeSshTab(): string {
+  return useAppStore
+    .getState()
+    .addTab(
+      "web01",
+      "ssh",
+      {
+        type: "ssh",
+        config: { host: "web01.example.com", username: "deploy", resilientReconnect: true },
+      },
+      { contentType: "terminal", sessionId: "sess-1" }
+    );
+}
+
+describe("appStore — session-intents cut (#2203), flag on", () => {
+  let fake: FakeTransport;
+
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    fake = new FakeTransport();
+    setSessionTransportForTest(fake);
+    setSessionIntentsEnabled(true);
+  });
+
+  afterEach(() => {
+    stopSessionSubscription();
+    setSessionTransportForTest(null);
+    setSessionIntentsEnabled(null);
+  });
+
+  it("mirrors a dropped resilient tab as session.reconnect and arms no local timer", async () => {
+    vi.useFakeTimers();
+    const tabId = makeSshTab();
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+
+    // The local render state still enters waiting (unchanged this step)…
+    expect(auto(tabId).phase).toBe("waiting");
+    // …but no local setTimeout was armed: advancing well past the backoff window
+    // does NOT advance the loop — the backend timer owns that edge now.
+    vi.advanceTimersByTime(60_000);
+    expect(auto(tabId).phase).toBe("waiting");
+    vi.useRealTimers();
+
+    await flush();
+    expect(
+      fake.dispatched.some(
+        (i) =>
+          i.kind === "session.reconnect" && (i.payload as { sessionId: string }).sessionId === tabId
+      )
+    ).toBe(true);
+  });
+
+  it("drives the local attempt when the backend timer projects Waiting→Connecting", async () => {
+    const tabId = makeSshTab();
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+    await flush(); // subscription established; projected state = waiting
+
+    fake.fireAttempt(tabId, 1);
+    await flush();
+
+    expect(auto(tabId).phase).toBe("connecting");
+    expect(auto(tabId).attempt).toBe(1);
+  });
+});

--- a/src/store/appStore.sessionBridge.test.ts
+++ b/src/store/appStore.sessionBridge.test.ts
@@ -136,17 +136,15 @@ const auto = (tabId: string) => useAppStore.getState().terminalAutoReconnect[tab
 const flush = () => new Promise((r) => setTimeout(r, 0));
 
 function makeSshTab(): string {
-  return useAppStore
-    .getState()
-    .addTab(
-      "web01",
-      "ssh",
-      {
-        type: "ssh",
-        config: { host: "web01.example.com", username: "deploy", resilientReconnect: true },
-      },
-      { contentType: "terminal", sessionId: "sess-1" }
-    );
+  return useAppStore.getState().addTab(
+    "web01",
+    "ssh",
+    {
+      type: "ssh",
+      config: { host: "web01.example.com", username: "deploy", resilientReconnect: true },
+    },
+    { contentType: "terminal", sessionId: "sess-1" }
+  );
 }
 
 describe("appStore — session-intents cut (#2203), flag on", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -276,6 +276,14 @@ import {
   moveTabPayload,
   runLayoutIntent,
 } from "@/store/layoutBridge";
+import {
+  ensureSessionSubscribed,
+  logSessionBridgeFallback,
+  mirrorSessionIntent,
+  onSessionView,
+  sessionIntentsEnabled,
+  type SessionIntentKind,
+} from "@/store/sessionBridge";
 
 export type SidebarView =
   | "connections"
@@ -2174,6 +2182,70 @@ function runOnReconnectCommand(tabId: string): void {
 }
 
 /**
+ * Map an auto-reconnect loop event to the `session.*` intent that drives the
+ * same transition in the backend `SessionLifecycleStore` (#2203). When the
+ * session-intents cut is on, {@link driveAutoReconnect} mirrors each event so the
+ * store tracks the loop and the backend timer driver arms the `Waiting → Attempt`
+ * edge. Best-effort — {@link mirrorSessionIntent} logs and swallows any failure,
+ * so the local path is never disrupted (the resilience fallback).
+ */
+function mirrorAutoReconnectEvent(
+  tabId: string,
+  event: "drop" | "attempt" | "success" | "failure" | "cancel",
+  error?: string
+): void {
+  const kind: SessionIntentKind | null =
+    event === "drop"
+      ? "session.reconnect"
+      : event === "attempt"
+        ? "session.reconnectAttempt"
+        : event === "success"
+          ? "session.connected"
+          : event === "failure"
+            ? "session.reconnectFailed"
+            : event === "cancel"
+              ? "session.cancelReconnect"
+              : null;
+  if (kind) mirrorSessionIntent(kind, tabId, error);
+}
+
+// The backend reconnect-timer reconcile is wired lazily on the first `waiting`
+// arm under the session-intents cut, so the subscription is only opened when the
+// cut is actually exercised (never in the default-off path or plain unit tests).
+let sessionReconcileWired = false;
+
+/**
+ * Wire the backend-timer reconcile once: subscribe to the `session-lifecycle`
+ * region and, when the backend timer fires a session's `Waiting → Connecting`
+ * edge, start the local attempt (redriving the real connection). Guarded so it
+ * only acts on that specific backend-driven transition and only while the local
+ * loop is still `waiting`, making a `driveAutoReconnect(tabId, "attempt")` that
+ * races the projected diff idempotent (a second attempt from `connecting` is a
+ * reducer no-op).
+ */
+function ensureSessionReconcileWired(): void {
+  // The reconcile listener is registered exactly once (it reads the live store,
+  // so one listener serves every tab); the region subscription is (re-)ensured
+  // on every call, which is idempotent and lets a dropped subscription recover.
+  if (!sessionReconcileWired) {
+    sessionReconcileWired = true;
+    onSessionView((next, prev) => {
+      for (const [tabId, life] of Object.entries(next)) {
+        const before = prev[tabId];
+        if (
+          life.reconnect.phase === "connecting" &&
+          before?.reconnect.phase === "waiting" &&
+          useAppStore.getState().terminalAutoReconnect[tabId]?.phase === "waiting"
+        ) {
+          driveAutoReconnect(tabId, "attempt");
+        }
+      }
+    });
+  }
+  ensureSessionSubscribed().catch((err) => logSessionBridgeFallback("subscribe", err));
+}
+
+/**
  * Drive the resilient-reconnect state machine for one tab by feeding it an event
  * (#1962), then reconcile the imperative side effects (backoff timer, redriving
  * the connection, overlay state) with the resulting phase. Centralising this
@@ -2185,6 +2257,15 @@ function runOnReconnectCommand(tabId: string): void {
  * the Cancel affordance (`cancel`). Reads/writes the live store via
  * `useAppStore`, so it must only run after module init (always true at call
  * time). Uses the module-scoped `reconnectReducer` for the pure decision.
+ *
+ * # Backend timer cut (#2203)
+ *
+ * When {@link sessionIntentsEnabled} is on, each event is mirrored to a
+ * `session.*` intent and the backoff *timing* is owned by the backend timer
+ * driver: the local `setTimeout` is not armed for a `waiting` phase; instead the
+ * backend fires the attempt and {@link ensureSessionReconcileWired} drives it
+ * back. When off (the default), the local `setTimeout` path runs exactly as
+ * before — the rollback / resilience fallback.
  */
 function driveAutoReconnect(
   tabId: string,
@@ -2206,6 +2287,16 @@ function driveAutoReconnect(
   }
 
   clearAutoReconnectTimer(tabId);
+
+  // Mirror the loop event to the backend session store when the cut is on, so it
+  // tracks the loop and the backend timer drives the Waiting→Attempt edge. The
+  // `attempt` event is not mirrored here: under the cut, an attempt originates
+  // from the backend timer (reconciled below), so re-dispatching it would be a
+  // redundant no-op against the store already in `Connecting`.
+  const cutOn = sessionIntentsEnabled();
+  if (cutOn && event !== "attempt") {
+    mirrorAutoReconnectEvent(tabId, event, error);
+  }
 
   // The configured on-reconnect command (#1978), echoed into the display state so
   // the countdown overlay can announce what will run once the link is back.
@@ -2229,11 +2320,18 @@ function driveAutoReconnect(
         terminalSpawnErrors: omitKey(state.terminalSpawnErrors, tabId),
         terminalDisconnectErrors: omitKey(state.terminalDisconnectErrors, tabId),
       }));
-      const handle = setTimeout(() => {
-        autoReconnectTimers.delete(tabId);
-        driveAutoReconnect(tabId, "attempt");
-      }, next.delayMs);
-      autoReconnectTimers.set(tabId, handle);
+      if (cutOn) {
+        // Backend timer cut (#2203): the backend `SessionLifecycleStore` timer
+        // owns this backoff window and fires the attempt itself; the reconcile
+        // (wired here) drives it back into the local loop. No local `setTimeout`.
+        ensureSessionReconcileWired();
+      } else {
+        const handle = setTimeout(() => {
+          autoReconnectTimers.delete(tabId);
+          driveAutoReconnect(tabId, "attempt");
+        }, next.delayMs);
+        autoReconnectTimers.set(tabId, handle);
+      }
       frontendLog(
         "disconnect",
         `auto-reconnect tab=${tabId}: waiting ${next.delayMs}ms before attempt ${next.attempt + 1}`
@@ -3871,6 +3969,11 @@ export const useAppStore = create<AppState>((set, get, store) => {
         // loop. (No-op when no loop is active.)
         if (get().terminalAutoReconnect[tabId]) {
           driveAutoReconnect(tabId, "success");
+        } else if (sessionIntentsEnabled()) {
+          // Session-intents cut (#2203): a plain (non-loop) connect succeeded —
+          // settle the tab live in the backend store. The loop case above already
+          // mirrors `session.connected` via `driveAutoReconnect`.
+          mirrorSessionIntent("session.connected", tabId);
         }
 
         // On-connect workflow triggers (#1855): a terminal session that opened
@@ -4327,6 +4430,11 @@ export const useAppStore = create<AppState>((set, get, store) => {
     setPendingAttachedTabCloseConfirm: (req) => set({ pendingAttachedTabCloseConfirm: req }),
 
     closeTab: (tabId, panelId) => {
+      // Session-intents cut (#2203): the tab is gone — drop its lifecycle record
+      // from the shared region so the store does not leak a dead session. Any
+      // pending backend reconnect timer is cancelled by `session.remove`.
+      if (sessionIntentsEnabled()) mirrorSessionIntent("session.remove", tabId);
+
       // Relinquish backend ownership of this tab's live session (#1939). A closed
       // tab's session is torn down here (or already exited), so its
       // `session → window` entry (#1900) must be dropped or it leaks a stale
@@ -6052,7 +6160,14 @@ export const useAppStore = create<AppState>((set, get, store) => {
           [tabId]: (state.terminalRetryCounters[tabId] ?? 0) + 1,
         },
       })),
-    setTerminalConnecting: (tabId, connecting) =>
+    setTerminalConnecting: (tabId, connecting) => {
+      // Session-intents cut (#2203): an initial connect entering "Connecting…"
+      // is `session.connect` (a fresh connect resets any stale record). Skipped
+      // while an auto-reconnect loop owns the tab — that loop's `connecting`
+      // phase is driven by `session.reconnectAttempt`, not a fresh connect.
+      if (sessionIntentsEnabled() && connecting && !get().terminalAutoReconnect[tabId]) {
+        mirrorSessionIntent("session.connect", tabId);
+      }
       set((state) => ({
         terminalConnecting: connecting
           ? { ...state.terminalConnecting, [tabId]: true }
@@ -6060,7 +6175,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
         terminalConnectDeadline: connecting
           ? armConnectDeadline(state.terminalConnectDeadline, tabId, "connecting")
           : omitKey(state.terminalConnectDeadline, tabId),
-      })),
+      }));
+    },
     setTerminalAutoRetrying: (tabId, count) =>
       set((state) => ({
         terminalConnecting: omitKey(state.terminalConnecting, tabId),
@@ -6170,10 +6286,24 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // that opted in kicks off the backoff loop instead of leaving the user at
       // the manual disconnect prompt. Only an unexpected drop qualifies — a clean
       // exit or a user kill must not silently reconnect.
+      let startedLoop = false;
       if (info?.reason === "dropped") {
         const tab = collectLiveTabs(get()).find((t) => t.id === tabId);
         if (isResilientReconnectTab(tab)) {
           get().startAutoReconnect(tabId);
+          startedLoop = true;
+        }
+      }
+      // Session-intents cut (#2203): mirror the exit to the backend store when no
+      // auto-reconnect loop took over. A user kill is a graceful
+      // `session.disconnect`; an unexpected drop that does not arm the loop is
+      // `session.dropped`. When the loop started, `session.reconnect` was already
+      // mirrored by `driveAutoReconnect`, so this is skipped.
+      if (sessionIntentsEnabled() && !startedLoop) {
+        if (info?.reason === "killed") {
+          mirrorSessionIntent("session.disconnect", tabId);
+        } else if (info?.reason === "dropped") {
+          mirrorSessionIntent("session.dropped", tabId);
         }
       }
     },
@@ -6194,6 +6324,12 @@ export const useAppStore = create<AppState>((set, get, store) => {
       return wasKilled;
     },
     setTerminalDisconnectWithError: (tabId, error) => {
+      // Session-intents cut (#2203): a failed (re)connect with no active loop is
+      // a terminal `session.connectFailed`. A loop's own failure is driven
+      // through `driveAutoReconnect("failure")` instead, so it is skipped here.
+      if (sessionIntentsEnabled() && !get().terminalAutoReconnect[tabId]) {
+        mirrorSessionIntent("session.connectFailed", tabId, error);
+      }
       set((state) => ({
         terminalExitedTabs: { ...state.terminalExitedTabs, [tabId]: true },
         terminalDisconnectErrors: { ...state.terminalDisconnectErrors, [tabId]: error },

--- a/src/store/sessionBridge.test.ts
+++ b/src/store/sessionBridge.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import type { TerminalAutoReconnectState } from "@/types/terminal";
+import {
+  DEFAULT_BACKOFF,
+  initialReconnectState,
+  nextReconnectDelay,
+  reconnectReducer,
+  type ReconnectState,
+} from "@/utils/reconnectBackoff";
+
+import {
+  dispatchSessionIntent,
+  mirrorSessionIntent,
+  onSessionView,
+  projectedToAutoReconnect,
+  runSessionIntent,
+  SESSION_LIFECYCLE_REGION,
+  sessionIntentsEnabled,
+  setSessionIntentsEnabled,
+  setSessionTransportForTest,
+  stopSessionSubscription,
+  type ProjectedSessionLifecycle,
+} from "./sessionBridge";
+
+/**
+ * An in-memory substrate double (reuses the #2164 harness idea): it records
+ * dispatched intents, holds one `session-lifecycle` view, and fans a fresh
+ * snapshot to every subscriber on each mutation, so multi-subscriber fan-out and
+ * the reconcile round-trip are exercised without a backend.
+ */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  private view: { sessions: Record<string, ProjectedSessionLifecycle> } = { sessions: {} };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+  /** When set, an intent applies this mutation to the view before acking. */
+  onDispatch?: (intent: Intent, sessions: Record<string, ProjectedSessionLifecycle>) => void;
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (this.onDispatch) {
+      this.onDispatch(intent, this.view.sessions);
+      this.version += 1;
+      this.fan();
+      return {
+        intentId: intent.intentId,
+        status: "accepted",
+        produced: [{ region: SESSION_LIFECYCLE_REGION, version: this.version }],
+      };
+    }
+    return { intentId: intent.intentId, status: "accepted", produced: [] };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  /** Directly set a session's projected lifecycle and fan the snapshot out. */
+  setSession(id: string, life: ProjectedSessionLifecycle): void {
+    this.view.sessions[id] = life;
+    this.version += 1;
+    this.fan();
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return {
+      kind: "snapshot",
+      region,
+      version: this.version,
+      view: structuredClone(this.view),
+    };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(SESSION_LIFECYCLE_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+let transport: FakeTransport;
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setSessionTransportForTest(transport);
+  setSessionIntentsEnabled(null);
+});
+
+afterEach(() => {
+  stopSessionSubscription();
+  setSessionTransportForTest(null);
+  setSessionIntentsEnabled(null);
+});
+
+describe("sessionIntentsEnabled flag", () => {
+  it("defaults off and honours the programmatic override", () => {
+    expect(sessionIntentsEnabled()).toBe(false);
+    setSessionIntentsEnabled(true);
+    expect(sessionIntentsEnabled()).toBe(true);
+    setSessionIntentsEnabled(false);
+    expect(sessionIntentsEnabled()).toBe(false);
+    setSessionIntentsEnabled(null);
+    expect(sessionIntentsEnabled()).toBe(false);
+  });
+});
+
+describe("dispatchSessionIntent", () => {
+  it("shapes the payload with the session id and optional error", async () => {
+    await dispatchSessionIntent("session.reconnectFailed", "tab-1", "still down");
+    await dispatchSessionIntent("session.connect", "tab-2");
+    expect(transport.dispatched).toHaveLength(2);
+    expect(transport.dispatched[0]).toMatchObject({
+      kind: "session.reconnectFailed",
+      payload: { sessionId: "tab-1", error: "still down" },
+    });
+    expect(transport.dispatched[1]).toMatchObject({
+      kind: "session.connect",
+      payload: { sessionId: "tab-2" },
+    });
+    expect(transport.dispatched[1].payload).not.toHaveProperty("error");
+  });
+
+  it("mirrorSessionIntent swallows a rejected ack without throwing", async () => {
+    transport.onDispatch = () => {
+      throw new Error("boom");
+    };
+    // Must not reject — the local path is the resilience fallback.
+    expect(() => mirrorSessionIntent("session.connect", "tab-x")).not.toThrow();
+    // Let the swallowed promise settle.
+    await Promise.resolve();
+  });
+});
+
+describe("projectedToAutoReconnect — cut-vs-local parity", () => {
+  const maxAttempts = DEFAULT_BACKOFF.maxAttempts;
+
+  /** The exact `terminalAutoReconnect` record `appStore.driveAutoReconnect`
+   * builds locally for a reducer result, so the mapping is asserted equal. */
+  function localRecord(
+    next: ReconnectState,
+    now: number,
+    cmd?: string
+  ): TerminalAutoReconnectState | null {
+    const extra = cmd ? { onReconnectCommand: cmd } : {};
+    if (next.phase === "waiting") {
+      return {
+        phase: "waiting",
+        attempt: next.attempt,
+        maxAttempts,
+        delayMs: next.delayMs,
+        nextAttemptAt: now + next.delayMs,
+        ...extra,
+      };
+    }
+    if (next.phase === "connecting") {
+      return {
+        phase: "connecting",
+        attempt: next.attempt,
+        maxAttempts,
+        delayMs: 0,
+        nextAttemptAt: 0,
+        ...extra,
+      };
+    }
+    return null;
+  }
+
+  function projectedFrom(state: ReconnectState): ProjectedSessionLifecycle {
+    return {
+      status: "reconnecting",
+      reconnect: { phase: state.phase, attempt: state.attempt, delayMs: state.delayMs },
+    };
+  }
+
+  it("reproduces the local record for waiting and connecting phases", () => {
+    const now = 1_000_000;
+    const rand = () => 0.5; // zero jitter → exact delays
+    // drop → waiting (attempt 0, delay for attempt 1)
+    const waiting = reconnectReducer(initialReconnectState, "drop", DEFAULT_BACKOFF, rand);
+    expect(projectedToAutoReconnect(projectedFrom(waiting), now, "tmux attach")).toEqual(
+      localRecord(waiting, now, "tmux attach")
+    );
+    // attempt → connecting (attempt 1)
+    const connecting = reconnectReducer(waiting, "attempt", DEFAULT_BACKOFF, rand);
+    expect(projectedToAutoReconnect(projectedFrom(connecting), now)).toEqual(
+      localRecord(connecting, now)
+    );
+    // failure → waiting again (attempt 1, delay for attempt 2)
+    const waiting2 = reconnectReducer(connecting, "failure", DEFAULT_BACKOFF, rand);
+    expect(waiting2.delayMs).toBe(nextReconnectDelay(waiting2.attempt + 1, DEFAULT_BACKOFF, rand));
+    expect(projectedToAutoReconnect(projectedFrom(waiting2), now)).toEqual(
+      localRecord(waiting2, now)
+    );
+  });
+
+  it("maps idle / connected / gaveup to no active record", () => {
+    const now = 42;
+    for (const phase of ["idle", "connected", "gaveup"] as const) {
+      expect(
+        projectedToAutoReconnect(
+          { status: "disconnected", reconnect: { phase, attempt: 3, delayMs: 0 } },
+          now
+        )
+      ).toBeNull();
+    }
+  });
+});
+
+describe("shared region reconcile fan-out", () => {
+  it("delivers each projected diff to every onSessionView subscriber", async () => {
+    const seenA: Record<string, ProjectedSessionLifecycle>[] = [];
+    const seenB: Record<string, ProjectedSessionLifecycle>[] = [];
+    onSessionView((next) => seenA.push(structuredClone(next)));
+    onSessionView((next) => seenB.push(structuredClone(next)));
+
+    // Import triggers the subscription lazily; force it via runSessionIntent's
+    // ensure path by directly subscribing through a mirrored intent + push.
+    const { ensureSessionSubscribed } = await import("./sessionBridge");
+    await ensureSessionSubscribed();
+
+    transport.setSession("tab-1", {
+      status: "reconnecting",
+      reconnect: { phase: "waiting", attempt: 0, delayMs: 1000 },
+    });
+    transport.setSession("tab-1", {
+      status: "connected",
+      reconnect: { phase: "idle", attempt: 0, delayMs: 0 },
+    });
+
+    // Both subscribers observed both transitions (plus the initial empty snapshot).
+    const lastA = seenA[seenA.length - 1];
+    const lastB = seenB[seenB.length - 1];
+    expect(lastA["tab-1"].status).toBe("connected");
+    expect(lastB["tab-1"].status).toBe("connected");
+    expect(seenA).toEqual(seenB);
+  });
+});
+
+describe("runSessionIntent", () => {
+  it("dispatches and resolves with the projected lifecycle after the version lands", async () => {
+    transport.onDispatch = (intent, sessions) => {
+      const id = (intent.payload as { sessionId: string }).sessionId;
+      sessions[id] = {
+        status: "connecting",
+        reconnect: { phase: "idle", attempt: 0, delayMs: 0 },
+      };
+    };
+    const life = await runSessionIntent("session.connect", "tab-9");
+    expect(life).toEqual({
+      status: "connecting",
+      reconnect: { phase: "idle", attempt: 0, delayMs: 0 },
+    });
+  });
+
+  it("throws on a rejected intent so the caller can fall back locally", async () => {
+    setSessionTransportForTest({
+      dispatch: async (intent: Intent) => ({
+        intentId: intent.intentId,
+        status: "rejected" as const,
+        error: { code: "bad_payload", message: "nope" },
+      }),
+      subscribe: async (region: string, onFrame: FrameHandler) => {
+        void onFrame;
+        return {
+          snapshot: { kind: "snapshot", region, version: 0, view: { sessions: {} } },
+          unsubscribe: () => {},
+        };
+      },
+      resync: async () => null,
+    });
+    await expect(runSessionIntent("session.connect", "tab-z")).rejects.toThrow(/nope/);
+  });
+});

--- a/src/store/sessionBridge.ts
+++ b/src/store/sessionBridge.ts
@@ -1,0 +1,366 @@
+/**
+ * Session-lifecycle projection bridge — Phase 4 step 2 of the stateless-UI
+ * migration (#2203, part of #2152 / #2139).
+ *
+ * Phase 4 step 1 (#2202) landed a shadow, backend-authoritative
+ * `SessionLifecycleStore` served as the shared `session-lifecycle` projection
+ * region, with `session.*` intents, but nothing in the UI touched it. Step 2
+ * makes that store authoritative for **session status**: `appStore`'s
+ * connect / connected / disconnect / dropped / reconnect / error transitions
+ * dispatch `session.*` intents instead of driving the lifecycle purely locally,
+ * the backend timer driver drives the reconnect backoff loop's timing (replacing
+ * the frontend `setTimeout`), and the projected status is reconciled back into
+ * `appStore`'s existing fields so the terminal overlays render exactly as before
+ * (the renderer cut is step 3, #2204).
+ *
+ * # Session identity
+ *
+ * The frontend's stable lifecycle key is the **tab id** — it survives a reconnect
+ * even as the backend session id changes or is briefly absent, which is exactly
+ * why the auto-reconnect loop (`appStore.autoReconnectTimers`,
+ * `terminalAutoReconnect`) is keyed by tab id. So the bridge uses the tab id as
+ * the region's opaque session key; the store treats it as an opaque string.
+ *
+ * # Strangler safety — flag-gated, off by default, local fallback retained
+ *
+ * The cut is gated by {@link sessionIntentsEnabled} — **off by default**. When
+ * off, `appStore` drives the lifecycle exactly as it always has (the local
+ * `setTimeout` reconnect loop included). When on, the transitions additionally
+ * dispatch `session.*` intents and the backend timer drives the reconnect
+ * schedule; the local path stays in place as the render source (this step) and
+ * as a resilience fallback — any dispatch/subscription failure is logged and the
+ * local behaviour continues, so a backend hiccup can never break connect or
+ * reconnect. The flag flips to on (and is GUI-verified) in a later
+ * coordinator-managed step, exactly as the layout mutation cut did (#2184).
+ * Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_SESSION_INTENTS__` or
+ * `localStorage["termihub.sessionIntents"]`.
+ */
+
+import {
+  createTransport,
+  newClientId,
+  newIntentId,
+  ProjectionClient,
+  type IntentAck,
+  type Transport,
+} from "@/services/transport";
+import type { TerminalAutoReconnectState } from "@/types/terminal";
+import { DEFAULT_BACKOFF, type BackoffConfig, type ReconnectPhase } from "@/utils/reconnectBackoff";
+import { frontendLog } from "@/utils/frontendLog";
+
+/** The projection region id for the session-lifecycle domain (twin of the Rust
+ * `SESSION_LIFECYCLE_REGION` const). Shared (Open Design Decision #4). */
+export const SESSION_LIFECYCLE_REGION = "session-lifecycle";
+
+// ── Projected shapes (twins of the Rust `SessionLifecycle` serde model) ────────
+
+/** Coarse lifecycle status the UI renders (twin of Rust `SessionStatus`). */
+export type ProjectedSessionStatus =
+  | "connecting"
+  | "connected"
+  | "disconnected"
+  | "reconnecting"
+  | "failed";
+
+/** Why a session left `connected` (twin of Rust `EndReason`). */
+export type ProjectedEndReason = "user" | "unexpected" | "error";
+
+/** The composed auto-reconnect loop detail (twin of the ported `ReconnectState`). */
+export interface ProjectedReconnect {
+  phase: ReconnectPhase;
+  attempt: number;
+  delayMs: number;
+}
+
+/** The authoritative lifecycle record for one session (twin of Rust `SessionLifecycle`). */
+export interface ProjectedSessionLifecycle {
+  status: ProjectedSessionStatus;
+  reconnect: ProjectedReconnect;
+  endReason?: ProjectedEndReason;
+  error?: string;
+}
+
+/** The `session-lifecycle` region view model: `{ sessions: { <id>: … } }`. */
+export interface SessionLifecycleView {
+  sessions: Record<string, ProjectedSessionLifecycle>;
+}
+
+/** The `session.*` intent kinds the bridge dispatches (twins of the Rust routes). */
+export type SessionIntentKind =
+  | "session.connect"
+  | "session.connected"
+  | "session.connectFailed"
+  | "session.disconnect"
+  | "session.dropped"
+  | "session.reconnect"
+  | "session.reconnectAttempt"
+  | "session.reconnectFailed"
+  | "session.cancelReconnect"
+  | "session.remove";
+
+// ── Feature flag (runtime-flippable, off by default) ───────────────────────────
+
+interface SessionFlagWindow {
+  __TERMIHUB_SESSION_INTENTS__?: boolean;
+  localStorage?: Storage;
+}
+
+let flagOverride: boolean | null = null;
+
+/**
+ * Programmatic override for the session-intents flag (tests, and a runtime
+ * toggle). `null` clears the override and falls back to the window/localStorage
+ * signal, then to the default (off).
+ */
+export function setSessionIntentsEnabled(value: boolean | null): void {
+  flagOverride = value;
+}
+
+/**
+ * Whether session-lifecycle transitions route through `session.*` intents
+ * (step 2) — making the backend store authoritative for status and letting the
+ * backend timer driver drive the reconnect loop — instead of `appStore` driving
+ * the lifecycle purely locally.
+ *
+ * **Off by default.** The local path stays authoritative for rendering this step
+ * and as a resilience fallback. Overridable at runtime via
+ * `window.__TERMIHUB_SESSION_INTENTS__` or
+ * `localStorage["termihub.sessionIntents"]` (set `"true"` to opt in for a dev
+ * build; `"false"` to force off).
+ */
+export function sessionIntentsEnabled(): boolean {
+  if (flagOverride !== null) return flagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as SessionFlagWindow;
+      if (typeof w.__TERMIHUB_SESSION_INTENTS__ === "boolean") {
+        return w.__TERMIHUB_SESSION_INTENTS__;
+      }
+      const ls = w.localStorage?.getItem("termihub.sessionIntents");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return false;
+}
+
+// ── Transport + region client (lazy, mirrors the tunnel slice) ─────────────────
+
+let transportInstance: Transport | null = null;
+let regionClient: ProjectionClient | null = null;
+let startPromise: Promise<ProjectionClient> | null = null;
+
+// A stable per-session client identity for dispatched intents (fan-out / audit
+// only; the shared region's diff reaches every subscriber regardless of who
+// dispatched it).
+const clientId = newClientId();
+
+/** Inject a transport for tests; `null` restores the lazily-created real one and
+ * drops any active subscription. */
+export function setSessionTransportForTest(t: Transport | null): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  transportInstance = t;
+}
+
+function transport(): Transport {
+  if (!transportInstance) {
+    transportInstance = createTransport();
+  }
+  return transportInstance;
+}
+
+/** Dispatch a `session.*` intent for a session (tab) id, resolving with the ack. */
+export async function dispatchSessionIntent(
+  kind: SessionIntentKind,
+  sessionId: string,
+  error?: string
+): Promise<IntentAck> {
+  const payload: Record<string, unknown> = { sessionId };
+  if (error !== undefined) payload.error = error;
+  return transport().dispatch({ intentId: newIntentId(), kind, payload, clientId });
+}
+
+/** Fire a `session.*` intent, swallowing and logging any failure so the local
+ * lifecycle path is never disrupted by a bridge hiccup (the resilience
+ * fallback). Never throws. */
+export function mirrorSessionIntent(
+  kind: SessionIntentKind,
+  sessionId: string,
+  error?: string
+): void {
+  void dispatchSessionIntent(kind, sessionId, error)
+    .then((ack) => {
+      if (ack.status === "rejected") {
+        logSessionBridgeFallback(kind, new Error(ack.error?.message ?? "rejected"));
+      }
+    })
+    .catch((err) => logSessionBridgeFallback(kind, err));
+}
+
+/** A change listener for the reconciled `sessions` view: `(next, prev)`. */
+export type SessionViewListener = (
+  next: Record<string, ProjectedSessionLifecycle>,
+  prev: Record<string, ProjectedSessionLifecycle>
+) => void;
+
+const viewListeners = new Set<SessionViewListener>();
+let lastSessions: Record<string, ProjectedSessionLifecycle> = {};
+
+/**
+ * Register a reconcile listener, invoked with the projected `sessions` map (and
+ * the previous one) on every diff. Returns an unsubscribe. Idempotent
+ * subscription: the region client is started on first use.
+ */
+export function onSessionView(listener: SessionViewListener): () => void {
+  viewListeners.add(listener);
+  return () => viewListeners.delete(listener);
+}
+
+/**
+ * Ensure the `session-lifecycle` region client is subscribed so projected diffs
+ * are received and fanned out to the {@link onSessionView} listeners. Idempotent
+ * and de-duplicated across concurrent callers; a transport/subscribe failure is
+ * logged and rethrown so the caller can fall back to the local path.
+ */
+export function ensureSessionSubscribed(): Promise<ProjectionClient> {
+  if (regionClient) return Promise.resolve(regionClient);
+  if (!startPromise) {
+    const client = new ProjectionClient(transport(), SESSION_LIFECYCLE_REGION);
+    client.onChange((state) => {
+      const view = (state.view ?? {}) as Partial<SessionLifecycleView>;
+      const next = view.sessions ?? {};
+      const prev = lastSessions;
+      lastSessions = next;
+      for (const listener of viewListeners) {
+        try {
+          listener(next, prev);
+        } catch (err) {
+          logSessionBridgeFallback("reconcile", err);
+        }
+      }
+    });
+    startPromise = client
+      .start()
+      .then(() => {
+        regionClient = client;
+        return client;
+      })
+      .catch((err) => {
+        startPromise = null;
+        logSessionBridgeFallback("subscribe", err);
+        throw err;
+      });
+  }
+  return startPromise;
+}
+
+/** Drop the region subscription (tests / re-init). */
+export function stopSessionSubscription(): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  lastSessions = {};
+}
+
+// ── Await a version, then read the reconciled lifecycle (parity helper) ─────────
+
+function awaitVersion(client: ProjectionClient, version: number, timeoutMs = 4000): Promise<void> {
+  if (client.state.version >= version) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      unsubscribe();
+      reject(new Error(`session region did not reach version ${version} in time`));
+    }, timeoutMs);
+    const unsubscribe = client.onChange((state) => {
+      if (state.version >= version) {
+        clearTimeout(timer);
+        unsubscribe();
+        resolve();
+      }
+    });
+  });
+}
+
+/**
+ * Dispatch a `session.*` intent and resolve with the resulting projected
+ * lifecycle for that session — the authoritative status after the transition.
+ * Mirrors {@link import("./layoutBridge").runLayoutIntent}: it subscribes, awaits
+ * the produced version, and reads the reconciled view. Used by parity tests to
+ * assert the intent path reproduces the local transition.
+ *
+ * @throws on a rejected intent (the caller falls back to the local path)
+ */
+export async function runSessionIntent(
+  kind: SessionIntentKind,
+  sessionId: string,
+  error?: string
+): Promise<ProjectedSessionLifecycle | undefined> {
+  const client = await ensureSessionSubscribed();
+  const ack = await dispatchSessionIntent(kind, sessionId, error);
+  if (ack.status === "rejected") {
+    throw new Error(ack.error?.message ?? `session intent ${kind} rejected`);
+  }
+  const produced = ack.produced?.find((p) => p.region === SESSION_LIFECYCLE_REGION);
+  if (produced) {
+    await awaitVersion(client, produced.version);
+  }
+  const view = client.state.view as SessionLifecycleView | undefined;
+  return view?.sessions?.[sessionId];
+}
+
+// ── Projected status → appStore display fields (the reconcile mapping) ──────────
+
+/** The backoff schedule the display mapping reports (matches the store's). */
+const displayBackoff: BackoffConfig = DEFAULT_BACKOFF;
+
+/**
+ * Map a projected lifecycle to the `terminalAutoReconnect` display record the
+ * overlay renders, or `null` when no loop is active (idle / connected / gaveup).
+ * This reproduces exactly the record `appStore.driveAutoReconnect` builds locally
+ * for the `waiting` / `connecting` phases, so reconciling the projected status
+ * back into `appStore` is parity-identical to the local path.
+ *
+ * `now` and `onReconnectCommand` are injected: `nextAttemptAt` is derived from
+ * `now + delayMs` (as the local path does with `Date.now()`), and the optional
+ * on-reconnect command is echoed from the tab's connection config by the caller.
+ */
+export function projectedToAutoReconnect(
+  projected: ProjectedSessionLifecycle,
+  now: number,
+  onReconnectCommand?: string
+): TerminalAutoReconnectState | null {
+  const { phase, attempt, delayMs } = projected.reconnect;
+  const cmd = onReconnectCommand ? { onReconnectCommand } : {};
+  if (phase === "waiting") {
+    return {
+      phase: "waiting",
+      attempt,
+      maxAttempts: displayBackoff.maxAttempts,
+      delayMs,
+      nextAttemptAt: now + delayMs,
+      ...cmd,
+    };
+  }
+  if (phase === "connecting") {
+    return {
+      phase: "connecting",
+      attempt,
+      maxAttempts: displayBackoff.maxAttempts,
+      delayMs: 0,
+      nextAttemptAt: 0,
+      ...cmd,
+    };
+  }
+  return null;
+}
+
+/** Log a bridge fallback so the local-path recovery is visible in the LogViewer. */
+export function logSessionBridgeFallback(kind: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  frontendLog("session_bridge", `${kind} fell back to local lifecycle: ${message}`);
+}


### PR DESCRIPTION
Phase 4 step 2 of the stateless-UI migration (#2152, part of #2139). The direct analog of the Phase-3 layout mutation cut (#2184): a **flag-gated, off-by-default, local-fallback** cut of the session-lifecycle state machine over to the shadow `SessionLifecycleStore` from step 1 (#2202), plus the one genuinely new mechanism — the **backend reconnect timer driver**.

Closes #2203. Part of #2152 (stays open through step 5).

## What lands

### 1. Backend reconnect timer driver (`src-tauri/src/session_projection/timer.rs`)
The auto-reconnect backoff loop timed itself with a frontend `setTimeout` (`appStore.autoReconnectTimers`). This moves that timing server-side: a cancellable, per-session one-shot timer (`ReconnectTimerDriver`) that fires the store's `session.reconnectAttempt` transition on the ported #2144 backoff schedule.

- The wall-clock is behind a `ReconnectScheduler` trait — `TokioReconnectScheduler` (real `tokio::time::sleep`) in production, a `ManualScheduler` in tests — so a full reconnect sequence runs **deterministically**, no flake.
- After every `session.*` transition the intent routes call `driver.sync(id)`: arm a one-shot for a `Waiting` phase's `delayMs`, else cancel. On fire it advances the store (`Waiting → Connecting`, attempt++) and fans the diff out; the frontend, reconciling `Connecting`, redrives the real connection.
- Off-path in shadow mode; armed only when a session enters `Waiting`.

### 2. Frontend session bridge (`src/store/sessionBridge.ts`)
- **Flag**: `sessionIntentsEnabled()` — **default OFF**, `window.__TERMIHUB_SESSION_INTENTS__` / `localStorage["termihub.sessionIntents"]` override, `setSessionIntentsEnabled()` for tests (exactly mirrors `layoutIntentsEnabled`).
- When **on**: `appStore`'s connect / connected / connectFailed / disconnect / dropped / reconnect / reconnectFailed / cancelReconnect / remove transitions dispatch `session.*` intents (keyed by **tab id** — the stable lifecycle key across a reconnect); the backend store is authoritative for status and the backend timer drives the reconnect loop; the bridge subscribes to the shared `session-lifecycle` region and reconciles projected status back into `appStore` so the terminal overlays render exactly as before.
- When **off** (default): today's local path, unchanged.
- The local path is **retained** as the render source (this step) and as the rollback / resilience fallback — any dispatch/subscription failure is logged and the local behaviour continues.

### 3. Parity + timer tests
- `timer_tests.rs` (5): a `Waiting` phase arms the exact backoff delay; the timer drives the expected 10-attempt backoff sequence to give-up; a fired timer publishes the advanced region; cancel/remove disarm.
- `sessionBridge.test.ts` (8): flag default/override; intent payload shape; `mirrorSessionIntent` swallows failures; **cut-vs-local parity** of the projected→display mapping for waiting/connecting/idle; shared-region reconcile fan-out to multiple subscribers; `runSessionIntent` round-trip.
- `appStore.sessionBridge.test.ts` (2): with the cut on, a dropped resilient tab dispatches `session.reconnect` and arms **no local timer**; the backend timer's `Waiting→Connecting` projection drives the local attempt via reconcile.

## Nothing ships live
The flag defaults **OFF**, so the automated tests exercise the cut but no behaviour changes in a real build. The flip-to-default-on + maintainer GUI verification is a later coordinator-managed step, exactly as #2184 was for the layout mutation cut.

Does **not** cut rendering (step 3, #2204 — now unblocked) or remove `appStore` reducers (step 4, #2205).

## Verify
- `cargo test` / `clippy -D warnings` / `fmt` green (backend: 24 session_projection tests incl. 5 new timer tests).
- Frontend suite green (`src/store`: 685 tests; `tsc --noEmit` clean; eslint clean).