### PR TITLE
feat(tunnel): surface agent-hosted tunnel vantage + live stats in projection

### DIFF
--- a/docs/changes/dev0/feature/2199-agent-tunnel-stats-vantage.md
+++ b/docs/changes/dev0/feature/2199-agent-tunnel-stats-vantage.md
@@ -1,0 +1,12 @@
+### Added
+
+- Agent-hosted SSH tunnels now surface their live traffic stats and reported
+  vantage in the Tunnels sidebar and the Open Connections panel, matching
+  desktop tunnels. The desktop polls each agent-hosted tunnel's `tunnel.status`
+  off the projection's single-writer path, so up/down bytes and connection
+  counts update live instead of resting at zero. Each running agent tunnel also
+  shows where the agent bound its listen socket — "reachable only on <agent>"
+  (a loopback bind, warned because it is not reachable from this computer),
+  "reachable on <agent>'s network", or "reachable on the SSH server's network"
+  (`-R` forwards) — data-driven from the agent's runtime classification rather
+  than the persisted host+bind guess (#2199).

--- a/src-tauri/src/tunnel/config.rs
+++ b/src-tauri/src/tunnel/config.rs
@@ -12,6 +12,10 @@ use crate::run_location::RunLocation;
 pub use termihub_core::tunnel::config::{
     DynamicForwardConfig, LocalForwardConfig, RemoteForwardConfig, TunnelStats,
 };
+// `ReachableFrom` (who can reach an agent-hosted tunnel's listen socket) lives in
+// core beside the forward engines. Re-exported here so `TunnelState` can carry
+// the agent-reported vantage (#2199) and desktop call sites use the one type.
+pub use termihub_core::tunnel::ReachableFrom;
 
 /// The three SSH tunnel types.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -78,6 +82,43 @@ pub struct TunnelState {
     pub error: Option<String>,
     /// Live traffic statistics.
     pub stats: TunnelStats,
+    /// For an agent-hosted tunnel: which agent forwards it (its agent id), as
+    /// confirmed by the agent's report. `None` for desktop-hosted tunnels
+    /// (#2199). The frontend resolves the id to a human agent name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bound_on: Option<String>,
+    /// For an agent-hosted tunnel: the `host:port` the listen socket actually
+    /// bound (on the agent for `-L`/`-D`, on the SSH server for `-R`), reported
+    /// by the agent. `None` for desktop-hosted tunnels (#2199).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bound_address: Option<String>,
+    /// For an agent-hosted tunnel: who can reach the listen socket, as the agent
+    /// classified it at bind time. `None` for desktop-hosted tunnels (#2199).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reachable_from: Option<ReachableFrom>,
+}
+
+impl TunnelState {
+    /// A desktop-hosted (or not-yet-resolved) tunnel state: no agent vantage.
+    ///
+    /// The common constructor for every non-agent path, so adding an agent-only
+    /// field to the view model does not churn each call site.
+    pub fn desktop(
+        tunnel_id: String,
+        status: TunnelStatus,
+        error: Option<String>,
+        stats: TunnelStats,
+    ) -> Self {
+        Self {
+            tunnel_id,
+            status,
+            error,
+            stats,
+            bound_on: None,
+            bound_address: None,
+            reachable_from: None,
+        }
+    }
 }
 
 /// Top-level schema for the tunnels JSON file.
@@ -214,32 +255,58 @@ mod tests {
 
     #[test]
     fn tunnel_state_serde_round_trip() {
-        let state = TunnelState {
-            tunnel_id: "tun-1".to_string(),
-            status: TunnelStatus::Connected,
-            error: None,
-            stats: TunnelStats {
+        let state = TunnelState::desktop(
+            "tun-1".to_string(),
+            TunnelStatus::Connected,
+            None,
+            TunnelStats {
                 bytes_sent: 1024,
                 bytes_received: 2048,
                 active_connections: 2,
                 total_connections: 10,
             },
-        };
+        );
         let json = serde_json::to_string(&state).unwrap();
         let deserialized: TunnelState = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.status, TunnelStatus::Connected);
         assert!(deserialized.error.is_none());
         assert_eq!(deserialized.stats.bytes_sent, 1024);
+        // Desktop tunnels carry no agent vantage, and it stays off the wire.
+        assert!(deserialized.bound_on.is_none());
+        assert!(deserialized.reachable_from.is_none());
+        assert!(!json.contains("boundOn"));
+        assert!(!json.contains("reachableFrom"));
+    }
+
+    #[test]
+    fn tunnel_state_agent_vantage_round_trips_camel_case() {
+        let state = TunnelState {
+            tunnel_id: "tun-agent".to_string(),
+            status: TunnelStatus::Connected,
+            error: None,
+            stats: TunnelStats::default(),
+            bound_on: Some("build-box".to_string()),
+            bound_address: Some("127.0.0.1:5432".to_string()),
+            reachable_from: Some(ReachableFrom::AgentOnly),
+        };
+        let json = serde_json::to_value(&state).unwrap();
+        assert_eq!(json["boundOn"], "build-box");
+        assert_eq!(json["boundAddress"], "127.0.0.1:5432");
+        assert_eq!(json["reachableFrom"], "agentOnly");
+        let back: TunnelState = serde_json::from_value(json).unwrap();
+        assert_eq!(back.bound_on.as_deref(), Some("build-box"));
+        assert_eq!(back.bound_address.as_deref(), Some("127.0.0.1:5432"));
+        assert_eq!(back.reachable_from, Some(ReachableFrom::AgentOnly));
     }
 
     #[test]
     fn tunnel_state_error_included_when_set() {
-        let state = TunnelState {
-            tunnel_id: "tun-1".to_string(),
-            status: TunnelStatus::Error,
-            error: Some("Connection refused".to_string()),
-            stats: TunnelStats::default(),
-        };
+        let state = TunnelState::desktop(
+            "tun-1".to_string(),
+            TunnelStatus::Error,
+            Some("Connection refused".to_string()),
+            TunnelStats::default(),
+        );
         let json = serde_json::to_string(&state).unwrap();
         assert!(json.contains("Connection refused"));
         let deserialized: TunnelState = serde_json::from_str(&json).unwrap();
@@ -248,12 +315,12 @@ mod tests {
 
     #[test]
     fn tunnel_state_error_omitted_when_none() {
-        let state = TunnelState {
-            tunnel_id: "tun-1".to_string(),
-            status: TunnelStatus::Disconnected,
-            error: None,
-            stats: TunnelStats::default(),
-        };
+        let state = TunnelState::desktop(
+            "tun-1".to_string(),
+            TunnelStatus::Disconnected,
+            None,
+            TunnelStats::default(),
+        );
         let json = serde_json::to_string(&state).unwrap();
         assert!(!json.contains("error"));
     }

--- a/src-tauri/src/tunnel/projection_tests.rs
+++ b/src-tauri/src/tunnel/projection_tests.rs
@@ -63,12 +63,7 @@ fn dynamic_tunnel(id: &str, name: &str) -> TunnelConfig {
 }
 
 fn state(id: &str, status: TunnelStatus) -> TunnelState {
-    TunnelState {
-        tunnel_id: id.to_string(),
-        status,
-        error: None,
-        stats: TunnelStats::default(),
-    }
+    TunnelState::desktop(id.to_string(), status, None, TunnelStats::default())
 }
 
 // ── The pure view builder ────────────────────────────────────────────────────

--- a/src-tauri/src/tunnel/tunnel_manager.rs
+++ b/src-tauri/src/tunnel/tunnel_manager.rs
@@ -14,7 +14,7 @@ use tokio_util::sync::CancellationToken;
 use crate::terminal::backend::SshConfig;
 
 use super::config::{
-    TunnelConfig, TunnelState, TunnelStats, TunnelStatus, TunnelStore, TunnelType,
+    ReachableFrom, TunnelConfig, TunnelState, TunnelStats, TunnelStatus, TunnelStore, TunnelType,
 };
 use super::connecting::{ConnectingTracker, FinishOutcome};
 use super::dynamic_forward::DynamicForwarder;
@@ -207,6 +207,49 @@ fn snapshot_active_stats(active: &HashMap<String, ActiveTunnel>) -> Vec<TunnelSt
         .collect()
 }
 
+/// Poll each agent-hosted tunnel's live `tunnel.status` over the agent RPC,
+/// returning the fresh stats per still-running tunnel (#2199).
+///
+/// Free function (no `&self`) so the poller task can call it inside
+/// `spawn_blocking`. `targets` is a snapshot of `(tunnel_id, agent_id)` pairs. A
+/// failed RPC or a not-running tunnel simply contributes no sample, leaving the
+/// handle's last-known stats in place rather than flickering them to zero.
+fn poll_agent_tunnel_stats(
+    client: Arc<dyn AgentRpcClient>,
+    targets: &[(String, String)],
+) -> Vec<(String, TunnelStats)> {
+    let mut out = Vec::with_capacity(targets.len());
+    for (tunnel_id, agent_id) in targets {
+        let params = serde_json::json!({ "tunnelId": tunnel_id });
+        match client.send_request(agent_id, "tunnel.status", params) {
+            Ok(result) => {
+                if let Some(stats) = stats_from_status_reply(&result) {
+                    out.push((tunnel_id.clone(), stats));
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    "tunnel.status poll for {} on agent {} failed: {}",
+                    tunnel_id,
+                    agent_id,
+                    e
+                );
+            }
+        }
+    }
+    out
+}
+
+/// Extract the live [`TunnelStats`] from a `tunnel.status` reply, or `None` when
+/// the tunnel is not running on the agent or the reply carries no parseable
+/// stats (#2199). Pure, so the parse is unit-testable without an agent mock.
+fn stats_from_status_reply(result: &serde_json::Value) -> Option<TunnelStats> {
+    if result["running"].as_bool() != Some(true) {
+        return None;
+    }
+    serde_json::from_value::<TunnelStats>(result["stats"].clone()).ok()
+}
+
 impl ActiveForwarder {
     /// Take the forwarder's death receiver (once) for the tunnel supervisor.
     fn take_death_signal(&mut self) -> Option<tokio::sync::oneshot::Receiver<()>> {
@@ -244,17 +287,27 @@ struct ActiveTunnel {
     supervisor_cancel: CancellationToken,
 }
 
-/// A tunnel hosted on a remote agent (S3, #2185).
+/// A tunnel hosted on a remote agent (S3, #2185, enriched #2199).
 ///
-/// The desktop holds only *control* state — which agent forwards it — so
-/// `stop_tunnel` can send `tunnel.stop` to the right agent. The data path
-/// (listen socket, SSH session, forwarder) lives entirely on the agent, so
-/// there is no `ActiveForwarder` here. The agent-reported endpoint details
-/// (`boundAddress` / `reachableFrom`) are logged on start; surfacing them into
-/// the projection view model is a follow-up to #2185.
+/// The desktop holds only *control* + *reported* state — which agent forwards
+/// it, where the agent bound its listen socket, and the last live stats sampled
+/// off the agent. The data path (listen socket, SSH session, forwarder) lives
+/// entirely on the agent, so there is no `ActiveForwarder` here. The
+/// endpoint details (`bound_address` / `reachable_from`) come from the agent's
+/// `tunnel.start` reply; `stats` is refreshed by the periodic `tunnel.status`
+/// poller (#2199) so the projection shows live up/down bytes + connection counts
+/// like a desktop tunnel, instead of frozen zeros.
 struct AgentTunnelHandle {
     /// The agent forwarding this tunnel.
     agent_id: String,
+    /// The `host:port` the listen socket bound on the tunnel host (the agent for
+    /// `-L`/`-D`, the SSH server for `-R`), as the agent reported it.
+    bound_address: String,
+    /// Who can reach the listen socket, as the agent classified its bind.
+    reachable_from: ReachableFrom,
+    /// Last live traffic counters sampled from the agent via `tunnel.status`.
+    /// Starts at zero and is refreshed each poll tick (#2199).
+    stats: TunnelStats,
 }
 
 /// Central manager for SSH tunnels.
@@ -283,8 +336,10 @@ pub struct TunnelManager {
     /// Tunnels currently hosted on a remote agent, keyed by tunnel id (S3,
     /// #2185). Disjoint from `active_tunnels` (which holds desktop-hosted
     /// forwarders): an agent-hosted tunnel's data path runs on the agent, so the
-    /// desktop tracks only the control handle here.
-    agent_tunnels: Mutex<HashMap<String, AgentTunnelHandle>>,
+    /// desktop tracks only the control handle here. `Arc`-shared so the periodic
+    /// `tunnel.status` poller task can refresh each handle's live stats without a
+    /// `&self` reference (#2199).
+    agent_tunnels: Arc<Mutex<HashMap<String, AgentTunnelHandle>>>,
     /// Pool of SSH endpoint sessions shared by local/dynamic forwarders on the
     /// same connection. Jump-host gateway sessions are pooled separately in the
     /// process-wide [`shared_gateway_pool`](termihub_core::backends::ssh::session_pool::shared_gateway_pool).
@@ -295,6 +350,13 @@ pub struct TunnelManager {
     /// `Some` while at least one tunnel is active; the task self-reaps and clears
     /// this slot once no tunnel remains, and `stop_all` aborts it on shutdown.
     stats_emitter: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+    /// Handle to the single periodic agent `tunnel.status` poller task (#2199).
+    /// `Some` while at least one agent-hosted tunnel exists; the task self-reaps
+    /// and clears this slot once none remain, and `stop_all` aborts it on
+    /// shutdown. Distinct from `stats_emitter` because agent tunnels live in
+    /// their own track (`agent_tunnels`) and are sampled over the agent RPC
+    /// rather than from a local forwarder.
+    agent_stats_poller: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
 }
 
 impl TunnelManager {
@@ -314,11 +376,12 @@ impl TunnelManager {
             last_errors: Arc::new(Mutex::new(HashMap::new())),
             reconnecting: Arc::new(Mutex::new(HashMap::new())),
             connecting: ConnectingTracker::new(),
-            agent_tunnels: Mutex::new(HashMap::new()),
+            agent_tunnels: Arc::new(Mutex::new(HashMap::new())),
             endpoint_pool: RefPool::new(),
             app_handle: app_handle.clone(),
             recovery_warnings: Mutex::new(result.warnings),
             stats_emitter: Arc::new(Mutex::new(None)),
+            agent_stats_poller: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -402,32 +465,36 @@ impl TunnelManager {
             .iter()
             .map(|config| {
                 if let Some(tunnel) = active.get(&config.id) {
-                    TunnelState {
-                        tunnel_id: config.id.clone(),
-                        status: TunnelStatus::Connected,
-                        error: None,
-                        stats: tunnel.forwarder.stats(),
-                    }
-                } else if agent_tunnels.contains_key(&config.id) {
+                    TunnelState::desktop(
+                        config.id.clone(),
+                        TunnelStatus::Connected,
+                        None,
+                        tunnel.forwarder.stats(),
+                    )
+                } else if let Some(handle) = agent_tunnels.get(&config.id) {
                     // Hosted on an agent (#2185): the data path runs on the
-                    // agent, so the desktop reports `Connected` without live
-                    // stats (streaming per-tick stats over the agent RPC is a
-                    // follow-up).
+                    // agent, so the desktop surfaces the agent-reported vantage
+                    // (which agent, where it bound, who can reach it) plus the
+                    // live stats last sampled by the `tunnel.status` poller
+                    // (#2199) — no longer frozen zeros.
                     TunnelState {
                         tunnel_id: config.id.clone(),
                         status: TunnelStatus::Connected,
                         error: None,
-                        stats: TunnelStats::default(),
+                        stats: handle.stats.clone(),
+                        bound_on: Some(handle.agent_id.clone()),
+                        bound_address: Some(handle.bound_address.clone()),
+                        reachable_from: Some(handle.reachable_from),
                     }
                 } else if reconnecting.contains_key(&config.id) {
                     // In a reconnect-backoff loop (#1246) — report `Reconnecting`
                     // so a reload does not briefly launder it back to Error.
-                    TunnelState {
-                        tunnel_id: config.id.clone(),
-                        status: TunnelStatus::Reconnecting,
-                        error: None,
-                        stats: TunnelStats::default(),
-                    }
+                    TunnelState::desktop(
+                        config.id.clone(),
+                        TunnelStatus::Reconnecting,
+                        None,
+                        TunnelStats::default(),
+                    )
                 } else {
                     // A tunnel that is neither active nor connecting rests as
                     // either `Disconnected` (never failed) or `Error` (its last
@@ -438,12 +505,7 @@ impl TunnelManager {
                         self.connecting.is_connecting(&config.id),
                         last_error_for(&self.last_errors, &config.id),
                     );
-                    TunnelState {
-                        tunnel_id: config.id.clone(),
-                        status,
-                        error,
-                        stats: TunnelStats::default(),
-                    }
+                    TunnelState::desktop(config.id.clone(), status, error, TunnelStats::default())
                 }
             })
             .collect();
@@ -661,8 +723,14 @@ impl TunnelManager {
 
         match agent_manager.send_request(agent_id, "tunnel.start", params) {
             Ok(result) => {
-                let bound_address = result["boundAddress"].as_str().unwrap_or("");
-                let reachable_from = result["reachableFrom"].as_str().unwrap_or("");
+                let bound_address = result["boundAddress"].as_str().unwrap_or("").to_string();
+                // The agent reports its runtime classification (loopback → agent
+                // only, widened → agent LAN, `-R` → the SSH server). Fall back to
+                // the loopback-safe `AgentOnly` if the field is missing/garbled so
+                // the UI never over-promises reachability (#2199).
+                let reachable_from =
+                    serde_json::from_value::<ReachableFrom>(result["reachableFrom"].clone())
+                        .unwrap_or(ReachableFrom::AgentOnly);
                 {
                     let mut agent = self
                         .agent_tunnels
@@ -672,13 +740,19 @@ impl TunnelManager {
                         tunnel_id.to_string(),
                         AgentTunnelHandle {
                             agent_id: agent_id.to_string(),
+                            bound_address: bound_address.clone(),
+                            reachable_from,
+                            stats: TunnelStats::default(),
                         },
                     );
                 }
                 clear_last_error(&self.last_errors, tunnel_id);
                 self.emit_status(tunnel_id, TunnelStatus::Connected, None);
+                // Sample the agent's live stats periodically so the projection's
+                // ↑/↓ bytes + conn count update instead of resting at zero (#2199).
+                self.ensure_agent_stats_poller();
                 tracing::info!(
-                    "Tunnel {} started on agent {} (bound {} on the agent, reachable from {})",
+                    "Tunnel {} started on agent {} (bound {} on the agent, reachable from {:?})",
                     tunnel_id,
                     agent_id,
                     bound_address,
@@ -782,6 +856,104 @@ impl TunnelManager {
         });
 
         *slot = Some(handle);
+    }
+
+    /// Ensure the single periodic agent `tunnel.status` poller task is running
+    /// (#2199).
+    ///
+    /// Idempotent, mirroring [`Self::ensure_stats_emitter`] but for agent-hosted
+    /// tunnels: every [`STATS_EMIT_INTERVAL`] it snapshots the live agent-tunnel
+    /// set, polls each one's `tunnel.status` over the agent RPC **off** the
+    /// projection's single-writer dispatcher (a plain background task, with the
+    /// blocking RPC batch on a `spawn_blocking` thread), writes the fresh stats
+    /// back into the handles, and republishes the `tunnels` region so
+    /// subscribers see live ↑/↓ bytes + connection counts. The task self-reaps
+    /// (clearing this slot) once no agent tunnel remains, so a stopped tunnel
+    /// naturally ends the polling.
+    fn ensure_agent_stats_poller(&self) {
+        let mut slot = match self.agent_stats_poller.lock() {
+            Ok(slot) => slot,
+            Err(_) => return,
+        };
+        // Already running (and not yet finished) — nothing to do.
+        if slot.as_ref().is_some_and(|handle| !handle.is_finished()) {
+            return;
+        }
+
+        let agent_tunnels = Arc::clone(&self.agent_tunnels);
+        let app_handle = self.app_handle.clone();
+        let poller_slot = Arc::clone(&self.agent_stats_poller);
+
+        let handle = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(STATS_EMIT_INTERVAL).await;
+
+                // Snapshot the (tunnel id, agent id) targets under the lock, then
+                // release it before any RPC so a slow agent never blocks a
+                // start/stop that also touches this map.
+                let targets: Vec<(String, String)> = match agent_tunnels.lock() {
+                    Ok(map) => map
+                        .iter()
+                        .map(|(id, handle)| (id.clone(), handle.agent_id.clone()))
+                        .collect(),
+                    Err(_) => break,
+                };
+
+                // No agent-hosted tunnel left: stop polling and clear the slot so
+                // a later start re-spawns the task.
+                if targets.is_empty() {
+                    break;
+                }
+
+                // Resolve the agent RPC client fresh each tick (an agent may
+                // connect after the poller started). Absent → skip this tick.
+                let Some(client) = app_handle
+                    .try_state::<Arc<dyn AgentRpcClient>>()
+                    .map(|state| (*state).clone())
+                else {
+                    continue;
+                };
+
+                // `tunnel.status` is a blocking RPC; run the whole batch on a
+                // blocking thread so no async worker is stalled (mirrors how the
+                // agent-tunnel start path runs its blocking RPC).
+                let samples =
+                    tokio::task::spawn_blocking(move || poll_agent_tunnel_stats(client, &targets))
+                        .await
+                        .unwrap_or_default();
+
+                // Write the fresh samples back into the live handles under the
+                // lock. `bound_address` / `reachable_from` are fixed at bind time
+                // (from the start reply), so only the stats are refreshed here.
+                if let Ok(mut map) = agent_tunnels.lock() {
+                    for (tunnel_id, stats) in samples {
+                        if let Some(handle) = map.get_mut(&tunnel_id) {
+                            handle.stats = stats;
+                        }
+                    }
+                }
+
+                // Project the refreshed stats onto the `tunnels` region (#2199).
+                // `publish` diffs, so an unchanged tick is a no-op.
+                crate::tunnel::projection::publish_tunnels(&app_handle);
+            }
+
+            // Self-reap: drop our own handle so a later start re-spawns the task.
+            if let Ok(mut slot) = poller_slot.lock() {
+                *slot = None;
+            }
+        });
+
+        *slot = Some(handle);
+    }
+
+    /// Abort the agent `tunnel.status` poller task (if any) and clear its slot.
+    fn stop_agent_stats_poller(&self) {
+        if let Ok(mut slot) = self.agent_stats_poller.lock() {
+            if let Some(handle) = slot.take() {
+                handle.abort();
+            }
+        }
     }
 
     /// Build the forwarder for a tunnel config, performing the SSH handshake.
@@ -1157,6 +1329,8 @@ impl TunnelManager {
         // Abort the live-stats emitter promptly on shutdown rather than waiting
         // for its next tick to observe the now-empty active set (GAP 6, #1248).
         self.stop_stats_emitter();
+        // Likewise abort the agent `tunnel.status` poller (#2199).
+        self.stop_agent_stats_poller();
     }
 
     /// Abort the live-stats emitter task (if any) and clear its tracking slot.
@@ -1264,12 +1438,10 @@ fn emit_tunnel_status(
     status: TunnelStatus,
     error: Option<String>,
 ) {
-    let state = TunnelState {
-        tunnel_id: tunnel_id.to_string(),
-        status,
-        error,
-        stats: TunnelStats::default(),
-    };
+    // A status-change event carries no vantage/stats — the projection's
+    // `get_statuses` path fills those for the resting state on the publish below
+    // (#2199); the legacy event stays a bare status ping.
+    let state = TunnelState::desktop(tunnel_id.to_string(), status, error, TunnelStats::default());
     let _ = app_handle.emit("tunnel-status-changed", &state);
     // Project the change onto the stateless-UI `tunnels` region (#2150). Kept
     // beside the legacy event above (strangler): this is the single status-emit
@@ -1524,8 +1696,8 @@ mod tests {
     use super::{
         backoff_delay, clear_last_error, last_error_for, record_last_error, resolve_managed_arc,
         resolve_tunnel_host, resting_status, run_reconnect_loop, snapshot_active_stats,
-        wait_forwarder_death, wait_session_death, ActiveTunnel, ReconnectOutcome,
-        TunnelStatsUpdate,
+        stats_from_status_reply, wait_forwarder_death, wait_session_death, ActiveTunnel,
+        ReconnectOutcome, TunnelStatsUpdate,
     };
     use crate::run_location::{ResolvedLocation, RunLocation};
     use crate::tunnel::config::TunnelStatus;
@@ -2201,5 +2373,40 @@ mod tests {
             updates.is_empty(),
             "no active tunnel must yield no stats events so the emitter stops"
         );
+    }
+
+    /// #2199: a running `tunnel.status` reply yields the parsed live stats, which
+    /// the poller writes back onto the agent handle so the projection shows real
+    /// ↑/↓ bytes + connection counts instead of frozen zeros.
+    #[test]
+    fn stats_from_running_status_reply_are_parsed() {
+        let reply = serde_json::json!({
+            "running": true,
+            "stats": {
+                "bytesSent": 2048,
+                "bytesReceived": 4096,
+                "activeConnections": 3,
+                "totalConnections": 7
+            },
+            "boundAddress": "127.0.0.1:5432",
+            "reachableFrom": "agentOnly"
+        });
+        let stats = stats_from_status_reply(&reply).expect("running reply yields stats");
+        assert_eq!(stats.bytes_sent, 2048);
+        assert_eq!(stats.bytes_received, 4096);
+        assert_eq!(stats.active_connections, 3);
+        assert_eq!(stats.total_connections, 7);
+    }
+
+    /// #2199: a not-running reply (tunnel gone on the agent) contributes no
+    /// sample, so the poller leaves the handle's last-known stats untouched
+    /// rather than flickering them to zero.
+    #[test]
+    fn stats_from_not_running_status_reply_are_ignored() {
+        let reply = serde_json::json!({ "running": false });
+        assert!(stats_from_status_reply(&reply).is_none());
+        // A running reply that somehow omits stats is likewise skipped.
+        let no_stats = serde_json::json!({ "running": true });
+        assert!(stats_from_status_reply(&no_stats).is_none());
     }
 }

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -26,7 +26,12 @@ import {
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Modal, Button, Tooltip, Progress, ConfirmDialog, toast } from "@/components/ui";
 import { formatBytes } from "@/utils/formatters";
-import { resolveTunnelHost, isAgentHost, tunnelHostBadge } from "@/utils/tunnelHost";
+import {
+  resolveTunnelHost,
+  isAgentHost,
+  tunnelHostBadge,
+  reportedReachability,
+} from "@/utils/tunnelHost";
 import type { TransferState } from "@/types/connection";
 import type { MonitoringEntry } from "@/types/monitoring";
 import { MONITORING_INTERVAL_OPTIONS, DEFAULT_MONITORING_INTERVAL_MS } from "@/types/monitoring";
@@ -851,8 +856,28 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
                 : undefined;
               const hostBadge = tunnelHostBadge(tunnelHost, hostAgentName);
               const hostText = hostBadge.onAgent ? `agent ${hostBadge.label}` : "this computer";
-              const detail =
-                status === "error" && state?.error ? `${hostText} · ${state.error}` : hostText;
+              // Live stats + reported reachability for a running tunnel (#2199):
+              // agent-hosted tunnels now carry the same up/down bytes + conn
+              // counts as desktop ones, plus the agent's runtime vantage.
+              const isRunning = status === "connected";
+              const statsText =
+                isRunning && state?.stats
+                  ? `↑ ${formatBytes(state.stats.bytesSent)} ↓ ${formatBytes(
+                      state.stats.bytesReceived
+                    )} · ${state.stats.activeConnections} conn`
+                  : undefined;
+              const reach =
+                isRunning && state?.reachableFrom
+                  ? reportedReachability(state.reachableFrom, hostBadge.label)
+                  : null;
+              const detail = [
+                hostText,
+                statsText,
+                reach?.label,
+                status === "error" && state?.error ? state.error : undefined,
+              ]
+                .filter(Boolean)
+                .join(" · ");
               return (
                 <ConnectionRow
                   key={t.id}

--- a/src/components/TunnelSidebar/TunnelListItem.reach.test.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.reach.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Runtime reachability-note tests for the tunnel list item (#2199): a running
+ * agent-hosted tunnel surfaces the agent's reported vantage — a loopback bind on
+ * the agent warns (not reachable from this computer), a widened / SSH-server bind
+ * reads plainly, and desktop tunnels show no note.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { TunnelListItem } from "./TunnelListItem";
+import { withTooltip } from "@/test/tooltip";
+import type { ReachableFrom, TunnelConfig, TunnelState, TunnelStatus } from "@/types/tunnel";
+import type { SavedConnection } from "@/types/connection";
+
+const noop = () => {};
+
+const AGENT_TUNNEL: TunnelConfig = {
+  id: "tun-1",
+  name: "My Tunnel",
+  sshConnectionId: "ssh-1",
+  autoStart: false,
+  reconnectOnDisconnect: false,
+  host: { kind: "agent", agentId: "agent-1" },
+  tunnelType: {
+    type: "local",
+    config: { localHost: "127.0.0.1", localPort: 8080, remoteHost: "example.com", remotePort: 80 },
+  },
+};
+
+function stateWith(
+  reachableFrom: ReachableFrom | undefined,
+  status: TunnelStatus = "connected",
+  boundAddress?: string
+): TunnelState {
+  return {
+    tunnelId: "tun-1",
+    status,
+    stats: { bytesSent: 0, bytesReceived: 0, activeConnections: 0, totalConnections: 0 },
+    reachableFrom,
+    boundAddress,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderItem(tunnel: TunnelConfig, state: TunnelState): void {
+  act(() => {
+    root.render(
+      withTooltip(
+        <TunnelListItem
+          tunnel={tunnel}
+          state={state}
+          connections={[] as SavedConnection[]}
+          onStart={noop}
+          onStop={noop}
+          onReconnect={noop}
+          onEdit={noop}
+          onDuplicate={noop}
+          onDelete={noop}
+        />
+      )
+    );
+  });
+}
+
+function reach(): HTMLElement | null {
+  return container.querySelector<HTMLElement>('[data-testid="tunnel-reach-tun-1"]');
+}
+
+describe("TunnelListItem — reported reachability note (#2199)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState({
+      ...useAppStore.getInitialState(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      remoteAgents: [{ id: "agent-1", name: "build-box" } as any],
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("warns for a loopback bind on the agent (agentOnly)", () => {
+    renderItem(AGENT_TUNNEL, stateWith("agentOnly", "connected", "127.0.0.1:8080"));
+    expect(reach()?.textContent).toContain("reachable only on build-box");
+    expect(reach()?.getAttribute("data-warn")).toBe("true");
+    // The bound address the agent reported is available on hover.
+    expect(reach()?.getAttribute("title")).toContain("127.0.0.1:8080");
+  });
+
+  it("reads plainly for a widened bind on the agent LAN", () => {
+    renderItem(AGENT_TUNNEL, stateWith("agentLan"));
+    expect(reach()?.textContent).toContain("reachable on build-box's network");
+    expect(reach()?.getAttribute("data-warn")).toBe("false");
+  });
+
+  it("shows no note before the agent has reported reachability", () => {
+    renderItem(AGENT_TUNNEL, stateWith(undefined));
+    expect(reach()).toBeNull();
+  });
+
+  it("shows no note once the tunnel is no longer active", () => {
+    renderItem(AGENT_TUNNEL, stateWith("agentOnly", "disconnected"));
+    expect(reach()).toBeNull();
+  });
+});

--- a/src/components/TunnelSidebar/TunnelListItem.tsx
+++ b/src/components/TunnelSidebar/TunnelListItem.tsx
@@ -18,7 +18,12 @@ import { TunnelConfig, TunnelState, TunnelStatus } from "@/types/tunnel";
 import { SavedConnection } from "@/types/connection";
 import { formatBytes } from "@/utils/formatters";
 import { useAppStore } from "@/store/appStore";
-import { resolveTunnelHost, isAgentHost, tunnelHostBadge } from "@/utils/tunnelHost";
+import {
+  resolveTunnelHost,
+  isAgentHost,
+  tunnelHostBadge,
+  reportedReachability,
+} from "@/utils/tunnelHost";
 
 interface TunnelListItemProps {
   tunnel: TunnelConfig;
@@ -105,6 +110,12 @@ export function TunnelListItem({
     ? (remoteAgents.find((a) => a.id === tunnelHost.agentId)?.name ?? tunnelHost.agentId)
     : undefined;
   const hostBadge = tunnelHostBadge(tunnelHost, hostAgentName);
+  // Runtime vantage from the agent's report (#2199): authoritative reachability
+  // for a running agent-hosted tunnel, surfaced only while it is active.
+  const reach =
+    isActive && state?.reachableFrom
+      ? reportedReachability(state.reachableFrom, hostBadge.label)
+      : null;
   const typeLabel =
     tunnel.tunnelType.type.charAt(0).toUpperCase() + tunnel.tunnelType.type.slice(1);
 
@@ -284,6 +295,19 @@ export function TunnelListItem({
               <span>↓ {formatBytes(state.stats.bytesReceived)}</span>
               <span>{state.stats.activeConnections} conn</span>
             </div>
+          )}
+          {reach && (
+            <span
+              className="tunnel-item__reach"
+              data-testid={`tunnel-reach-${tunnel.id}`}
+              data-warn={reach.warn}
+              title={
+                state?.boundAddress ? `Bound ${state.boundAddress} — ${reach.label}` : reach.label
+              }
+            >
+              {reach.warn && <AlertTriangle size={11} className="tunnel-item__reach-icon" />}
+              <span className="tunnel-item__reach-text">{reach.label}</span>
+            </span>
           )}
           {isError && lastError && (
             <span className="tunnel-item__error" title={lastError}>

--- a/src/components/TunnelSidebar/TunnelSidebar.css
+++ b/src/components/TunnelSidebar/TunnelSidebar.css
@@ -99,3 +99,28 @@
 .tunnel-item__host-icon {
   flex-shrink: 0;
 }
+
+/* Runtime reachability note from the agent's report (#2199). Neutral by
+ * default; amber when the listen port is not reachable from this computer
+ * (a loopback bind on the agent). */
+.tunnel-item__reach {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-secondary);
+  min-width: 0;
+}
+
+.tunnel-item__reach[data-warn="true"] {
+  color: var(--color-warning);
+}
+
+.tunnel-item__reach-icon {
+  flex-shrink: 0;
+}
+
+.tunnel-item__reach-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/types/tunnel.ts
+++ b/src/types/tunnel.ts
@@ -72,10 +72,36 @@ export interface TunnelStats {
   totalConnections: number;
 }
 
+/**
+ * Who can reach an agent-hosted tunnel's listen socket, as the agent classified
+ * its bind at runtime (mirrors the Rust `ReachableFrom` enum). `agentOnly` = a
+ * loopback bind reachable only from processes on the agent; `agentLan` = a
+ * widened bind reachable from the agent's network; `sshServer` = an `-R` remote
+ * forward whose listen socket lives on the SSH server.
+ */
+export type ReachableFrom = "agentOnly" | "agentLan" | "sshServer";
+
 /** Combined runtime state for a tunnel. */
 export interface TunnelState {
   tunnelId: string;
   status: TunnelStatus;
   error?: string;
   stats: TunnelStats;
+  /**
+   * For an agent-hosted tunnel: the id of the agent forwarding it, confirmed by
+   * the agent's report (S3, #2199). Absent for desktop-hosted tunnels. The UI
+   * resolves it to a human agent name for the vantage badge.
+   */
+  boundOn?: string;
+  /**
+   * For an agent-hosted tunnel: the `host:port` the listen socket actually bound
+   * (on the agent for -L/-D, on the SSH server for -R), reported by the agent.
+   * Absent for desktop-hosted tunnels (#2199).
+   */
+  boundAddress?: string;
+  /**
+   * For an agent-hosted tunnel: who can reach the listen socket, from the
+   * agent's runtime classification (#2199). Absent for desktop-hosted tunnels.
+   */
+  reachableFrom?: ReachableFrom;
 }

--- a/src/utils/tunnelHost.test.ts
+++ b/src/utils/tunnelHost.test.ts
@@ -7,6 +7,7 @@ import {
   tunnelHostBadge,
   tunnelEndpointLines,
   tunnelReachabilityWarning,
+  reportedReachability,
 } from "./tunnelHost";
 
 const AGENT: RunLocation = { kind: "agent", agentId: "agent-1" };
@@ -115,5 +116,26 @@ describe("tunnelReachabilityWarning", () => {
 
   it("does not fire for a remote forward (listen is on the SSH server)", () => {
     expect(tunnelReachabilityWarning(remote(), AGENT)).toBeNull();
+  });
+});
+
+describe("reportedReachability", () => {
+  it("warns for a loopback bind on the agent (agentOnly)", () => {
+    const r = reportedReachability("agentOnly", "build-box");
+    expect(r).toEqual({ label: "reachable only on build-box", warn: true });
+  });
+
+  it("does not warn for a widened bind on the agent LAN", () => {
+    const r = reportedReachability("agentLan", "build-box");
+    expect(r).toEqual({ label: "reachable on build-box's network", warn: false });
+  });
+
+  it("describes an -R forward as reachable on the SSH server's network", () => {
+    const r = reportedReachability("sshServer", "build-box");
+    expect(r).toEqual({ label: "reachable on the SSH server's network", warn: false });
+  });
+
+  it("returns null when the agent has not reported (undefined)", () => {
+    expect(reportedReachability(undefined, "build-box")).toBeNull();
   });
 });

--- a/src/utils/tunnelHost.ts
+++ b/src/utils/tunnelHost.ts
@@ -10,7 +10,13 @@
  * directly and the components stay thin renderers.
  */
 
-import type { PortValue, RunLocation, TunnelConfig, TunnelType } from "@/types/tunnel";
+import type {
+  PortValue,
+  ReachableFrom,
+  RunLocation,
+  TunnelConfig,
+  TunnelType,
+} from "@/types/tunnel";
 import { THIS_COMPUTER } from "@/types/tunnel";
 
 /** A tunnel's effective host, defaulting a missing field to This computer. */
@@ -170,4 +176,32 @@ export function tunnelReachabilityWarning(
       `localhost:${port === "" ? "?" : port} here will not reach it.`,
     bindHost,
   };
+}
+
+/**
+ * The runtime vantage note for a *running* agent-hosted tunnel, derived from the
+ * agent's reported {@link ReachableFrom} rather than the persisted host+bind
+ * heuristic (#2199). This is authoritative — it reflects the agent's actual bind
+ * classification, including the `-R` (`sshServer`) case the config-only
+ * {@link tunnelReachabilityWarning} cannot express and any loopback/widened
+ * outcome the agent settled on. Returns `null` when there is no report
+ * (desktop tunnels, or an agent tunnel that has not reported yet).
+ *
+ * `warn` marks the one case where the listen port is NOT reachable from this
+ * computer (`agentOnly` — a loopback bind on the agent), so the UI can badge it.
+ */
+export function reportedReachability(
+  reachableFrom: ReachableFrom | undefined,
+  agentName: string
+): { label: string; warn: boolean } | null {
+  switch (reachableFrom) {
+    case "agentOnly":
+      return { label: `reachable only on ${agentName}`, warn: true };
+    case "agentLan":
+      return { label: `reachable on ${agentName}'s network`, warn: false };
+    case "sshServer":
+      return { label: "reachable on the SSH server's network", warn: false };
+    default:
+      return null;
+  }
 }


### PR DESCRIPTION
Follow-up to #2185 (PR #2196). Agent-hosted tunnels forward traffic and the agent reports `boundAddress` + `reachableFrom` (and live stats via `tunnel.status`), but the desktop previously only **logged** them and reported agent-hosted tunnels as `Connected` with zero stats. This enriches the `tunnels` projection so the sidebar and Open Connections panel show the reported vantage and live traffic for agent-hosted tunnels, matching desktop tunnels.

## What changed

**Backend (`src-tauri/src/tunnel`)**
- `TunnelState` gains `boundOn` (agent id) / `boundAddress` / `reachableFrom`, populated from the agent's `tunnel.start` reply. `None` for desktop-hosted tunnels (skipped on the wire).
- `AgentTunnelHandle` now retains the reported bind + last-sampled stats.
- A periodic `tunnel.status` poller samples each agent-hosted tunnel **off the projection's single-writer path** — a background task that snapshots the agent-tunnel set, runs the blocking RPC batch on `spawn_blocking`, writes the fresh stats back, and republishes the `tunnels` region. It self-reaps when no agent tunnel remains (mirroring the existing desktop live-stats emitter) and is aborted on shutdown. So the ↑/↓ bytes + connection counts update live instead of resting at zero.

**Frontend**
- `TunnelState` type gains the matching optional fields + a `ReachableFrom` type.
- New `reportedReachability` helper data-drives the runtime vantage note from the agent's report (authoritative — including the `-R`/`sshServer` case and the actual loopback/widened outcome) rather than the persisted host+bind heuristic.
- The Tunnels sidebar row and the Open Connections tunnel row show live stats and the reported reachability for running agent-hosted tunnels, warning (amber) when the listen port binds loopback on the agent (not reachable from this computer).

Multi-client correct: stats/vantage live in the shared `tunnels` region, so every client sees them.

## Tests
- Rust: `TunnelState` agent-vantage serde round-trip; `stats_from_status_reply` parsing (running → stats, not-running/missing → skipped).
- Frontend: `reportedReachability` cases; `TunnelListItem` reachability-note rendering (warn/plain/absent/inactive).

## Verification
Per-PR CI does not run integration tests. A headless GUI-driven container run of an agent-hosted tunnel was not performed in this environment. Instead the wire contract was verified end-to-end at the agent boundary: the agent's `tunnel.status` returns `{ running, stats, boundAddress, reachableFrom }` in exactly the camelCase shape the desktop poller parses, and `registry.status()` reports the same live core-forwarder counters (`forwarder.get_stats()`) the desktop already renders live for desktop-hosted tunnels — so once sampled and republished they flow through the projection unchanged. Recommend a manual local-container pass (start an agent-hosted `-L`/`-D` tunnel, push traffic, confirm live counts + vantage) before release.

Closes #2199