### PR TITLE
test(agent): deterministic waits for windows shell-session flake (Closes #2194)

### DIFF
--- a/agent/src/monitoring/mod.rs
+++ b/agent/src/monitoring/mod.rs
@@ -598,7 +598,7 @@ mod tests {
         };
 
         let first = Box::new(FakeCollector { fail: fail.clone() }) as Box<dyn StatsCollector>;
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let cancel = CancellationToken::new();
 
         let handle = tokio::spawn(monitoring_task(
@@ -611,8 +611,15 @@ mod tests {
             cancel,
         ));
 
-        // Let the first collect(s) succeed → Live, then drop the stream.
-        tokio::time::sleep(Duration::from_millis(60)).await;
+        // Wait for a real sample — proof the loop reached `Live` — before dropping
+        // the stream, rather than a fixed sleep that flakes on a loaded runner
+        // where the first collect can miss a tight window (mirrors
+        // `monitoring_task_reconnects_and_resumes`). Only a genuine Live→Stale
+        // drop exercises the reconnect campaign this test asserts on.
+        let first_sample = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("first live sample before timeout");
+        assert!(first_sample.is_some(), "a live sample must be sent");
         fail.store(true, Ordering::SeqCst);
 
         // The task must terminate on its own (budget exhausted → Offline),

--- a/agent/tests/local_agent_integration.rs
+++ b/agent/tests/local_agent_integration.rs
@@ -685,13 +685,28 @@ impl AgentClient {
         )
     }
 
-    /// Read `connection.output` notifications until one contains `needle` or
-    /// the deadline is exceeded. Uses short per-read timeouts so the loop
-    /// reacts promptly to new data without spinning.
+    /// Read `connection.output` notifications until one contains `needle` or the
+    /// shared readiness budget ([`ready_timeout`]) elapses. Uses short per-read
+    /// timeouts so the loop reacts promptly to new data without spinning.
+    ///
+    /// # Why the ceiling is [`ready_timeout`] and not a per-call fixed budget
+    ///
+    /// A shell's cold start plus the command round-trip (write → PTY echo →
+    /// forwarder → notification channel → TCP) can momentarily exceed a tight
+    /// fixed budget on a loaded **Windows** CI runner. A hardcoded 10s ceiling
+    /// here is what flaked the attach/reattach tests (#2194): the assertion fired
+    /// "no connection.output … received" even though the output was merely late,
+    /// not lost — and the very tests that flaked were exactly the ones using this
+    /// fixed-budget wait, while the reconnect test that instead polls on
+    /// [`ready_timeout`] never did. A fixed budget is a guess; this reuses the
+    /// same generous, env-overridable ([`TERMIHUB_TEST_READY_TIMEOUT_SECS`])
+    /// ceiling as the other readiness waits. Because the loop polls and returns
+    /// the instant `needle` arrives, a higher ceiling never slows the passing
+    /// path — it only widens the window before we give up.
     ///
     /// Returns `true` if `needle` was found in the decoded output.
-    fn wait_for_output(&mut self, needle: &str, timeout: Duration) -> bool {
-        let deadline = Instant::now() + timeout;
+    fn wait_for_output(&mut self, needle: &str) -> bool {
+        let deadline = Instant::now() + ready_timeout();
         self.set_read_timeout(Some(Duration::from_millis(100)));
 
         loop {
@@ -785,7 +800,7 @@ fn shell_session_attach_and_receive_output() {
         "connection.write failed: {write_resp}"
     );
 
-    let got = client.wait_for_output("termihub-output-marker", Duration::from_secs(10));
+    let got = client.wait_for_output("termihub-output-marker");
     assert!(
         got,
         "no connection.output notification containing 'termihub-output-marker' received"
@@ -871,7 +886,7 @@ fn shell_session_reattach_after_reconnect() {
             "write on first connection failed: {write_resp}"
         );
 
-        let got = client.wait_for_output("first-connection", Duration::from_secs(10));
+        let got = client.wait_for_output("first-connection");
         assert!(got, "shell did not respond on first connection");
         // implicit drop → disconnects
     }
@@ -908,7 +923,7 @@ fn shell_session_reattach_after_reconnect() {
         "write after re-attach failed: {write_resp}"
     );
 
-    let got = client2.wait_for_output("second-connection", Duration::from_secs(10));
+    let got = client2.wait_for_output("second-connection");
     assert!(
         got,
         "no output after re-attach — shell may not have survived reconnect"
@@ -1175,7 +1190,7 @@ fn persistent_shell_buffer_replayed_on_same_connection_reattach() {
     let wr = client.write_input(&setup.session_id, &cmd);
     assert!(wr["result"].is_object(), "write failed: {wr}");
     assert!(
-        client.wait_for_output(marker, Duration::from_secs(15)),
+        client.wait_for_output(marker),
         "marker '{marker}' not received on first attach — shell not responding"
     );
 
@@ -1194,7 +1209,7 @@ fn persistent_shell_buffer_replayed_on_same_connection_reattach() {
     assert!(ra["result"].is_object(), "re-attach failed: {ra}");
 
     assert!(
-        client.wait_for_output(marker, Duration::from_secs(10)),
+        client.wait_for_output(marker),
         "buffer replay after re-attach did not contain '{marker}' — \
          persistent session ring buffer not working"
     );
@@ -1234,7 +1249,7 @@ fn persistent_shell_buffer_replayed_after_tcp_reconnect() {
         let wr = client.write_input(&setup.session_id, &cmd);
         assert!(wr["result"].is_object(), "write failed: {wr}");
         assert!(
-            client.wait_for_output(marker, Duration::from_secs(15)),
+            client.wait_for_output(marker),
             "marker not received on first connection"
         );
         // Drop: TCP connection closes → agent calls detach_all() → DaemonClient
@@ -1272,7 +1287,7 @@ fn persistent_shell_buffer_replayed_after_tcp_reconnect() {
         assert!(ar["result"].is_object(), "re-attach failed: {ar}");
 
         assert!(
-            client.wait_for_output(marker, Duration::from_secs(10)),
+            client.wait_for_output(marker),
             "buffer replay after TCP reconnect did not contain '{marker}' — \
              ring buffer may not have survived the disconnect"
         );


### PR DESCRIPTION
## Problem

The Windows `Run Tests (windows-latest)` leg intermittently failed the agent shell-session integration tests, always passing on a plain re-run with an unrelated diff:

- `shell_session_attach_and_receive_output`
- `shell_session_reattach_after_reconnect`
- (also seen) `monitoring_task_stops_when_reconnect_exhausted`

Because the matrix is fail-fast, one flaky Windows leg cancels the other platforms and costs a full re-run.

Closes #2194

## Root cause (reasoned, not repro'd — the flake is Windows-only)

**The correlation is clean:** the tests that flaked were exactly the ones whose output wait used a **hardcoded ceiling** (`wait_for_output(marker, Duration::from_secs(10))`), while `shell_session_persists_across_client_disconnect` — which reconnects but polls on the shared `ready_timeout()` (60s, env-overridable) — never appeared in the flake list.

`wait_for_output` already **polls** (100 ms reads, returns the instant the needle arrives), so the 10 s was purely a give-up deadline. On a loaded Windows runner, a shell's cold start + command round-trip (write → PTY echo → output forwarder → notification channel → TCP) can momentarily exceed a tight fixed budget, so the assertion fires "no connection.output … received" even though the output is merely **late, not lost**. I confirmed it can't be lost: the local shell is in-process and the marker output is produced strictly *after* `subscribe_output()` swaps in the live channel, so it always reaches the forwarder.

`monitoring_task_stops_when_reconnect_exhausted` had a separate fixed-timing assumption: it blindly slept `60 ms` to assume the task had reached `Live` before dropping the stream. On a starved runner the first collect can miss that window, so the intended Live→Stale drop (and the reconnect campaign the test asserts on) may never happen.

## Fix

- Route `wait_for_output`'s ceiling through the existing generous, env-overridable `ready_timeout()` (`TERMIHUB_TEST_READY_TIMEOUT_SECS`) instead of a per-call fixed guess, and remove the fixed `timeout` argument from all 7 call sites so the fixed-budget ceiling **cannot be reintroduced**. Because it polls and returns on first match, the passing path is unchanged — only the give-up window widens.
- `monitoring_task_stops_when_reconnect_exhausted`: wait for a real sample before flipping `fail` (mirrors the sibling passing test `monitoring_task_reconnects_and_resumes`), proving `Live` was reached rather than guessing a window.

**No production code changed** — this is test-hardening only. The tests still fully exercise attach → write → receive-output and the disconnect → reconnect → re-attach → receive-output lifecycle (and, for monitoring, the Live→Stale→exhausted-budget→stop path); they still fail if that behavior regresses. Only the give-up deadline changed, so a real attach/reattach break still fails fast on the assertion, not a timeout.

## Verification

- `cargo test -p termihub-agent --test local_agent_integration shell_session` → 4 passed (macOS)
- `monitoring_task_stops_when_reconnect_exhausted` → passed
- `cargo clippy -p termihub-agent --all-targets --all-features -- -D warnings` → clean
- `cargo fmt --check` → clean

Confidence is **probabilistic**: verification is on macOS and the flake is Windows-only. The fix widens the readiness window on a poll-with-early-return and removes a blind sleep, so it is robust rather than lucky-once, but a couple of extra Windows-leg re-runs before/after merge are worth doing to build confidence.