### PR TITLE
feat(terminal): render session status from the projected session-lifecycle region (Closes #2204)

### DIFF
--- a/src/components/Terminal/TerminalDisconnectOverlay.projection.test.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.projection.test.tsx
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { TerminalDisconnectOverlay } from "./TerminalDisconnectOverlay";
+import { withTooltip } from "@/test/tooltip";
+import { useAppStore } from "@/store/appStore";
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import {
+  SESSION_LIFECYCLE_REGION,
+  setSessionIntentsEnabled,
+  setSessionRenderFromProjectionEnabled,
+  setSessionTransportForTest,
+  stopSessionSubscription,
+  type ProjectedSessionLifecycle,
+} from "@/store/sessionBridge";
+import type { TerminalAutoReconnectState } from "@/types/terminal";
+
+// Stub lucide-react icons used in the overlay.
+vi.mock("lucide-react", () => ({
+  WifiOff: () => null,
+  RefreshCw: () => null,
+  X: () => null,
+  AlertTriangle: () => null,
+  Loader2: () => null,
+  CheckCircle2: () => null,
+}));
+
+/**
+ * An in-memory `session-lifecycle` region double: holds one view and fans a fresh
+ * snapshot to every subscriber on each mutation, so the overlay's render can be
+ * driven by projected snapshots without a backend (#2204, reusing the #2164
+ * harness idea from `sessionBridge.test.ts`).
+ */
+class FakeTransport implements Transport {
+  private view: { sessions: Record<string, ProjectedSessionLifecycle> } = { sessions: {} };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+  subscribeCount = 0;
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    return { intentId: intent.intentId, status: "accepted", produced: [] };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.subscribeCount += 1;
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  /** Set a session's projected lifecycle and fan the snapshot out. */
+  setSession(id: string, life: ProjectedSessionLifecycle): void {
+    this.view.sessions[id] = life;
+    this.version += 1;
+    this.fan();
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(SESSION_LIFECYCLE_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+const TAB = "tab-1";
+
+function record(over: Partial<TerminalAutoReconnectState> = {}): TerminalAutoReconnectState {
+  return {
+    phase: "waiting",
+    attempt: 1,
+    maxAttempts: 10,
+    delayMs: 3_000,
+    nextAttemptAt: Date.now() + 3_000,
+    ...over,
+  };
+}
+
+function reconnecting(
+  reconnect: ProjectedSessionLifecycle["reconnect"]
+): ProjectedSessionLifecycle {
+  return { status: "reconnecting", reconnect };
+}
+
+/** Flush the bridge's async subscribe + fan-out so the projected snapshot lands. */
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("TerminalDisconnectOverlay — projected session-lifecycle render cut (#2204)", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  let transport: FakeTransport;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    transport = new FakeTransport();
+    setSessionTransportForTest(transport);
+    setSessionRenderFromProjectionEnabled(true);
+    setSessionIntentsEnabled(true);
+    useAppStore.setState({
+      terminalExitedTabs: { [TAB]: true },
+      terminalDisconnectErrors: {},
+      terminalViewMode: {},
+      terminalReconnectingTabs: {},
+      terminalReconnectTriggerErrors: {},
+      terminalAutoReconnect: {},
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    stopSessionSubscription();
+    setSessionTransportForTest(null);
+    setSessionRenderFromProjectionEnabled(null);
+    setSessionIntentsEnabled(null);
+  });
+
+  it("renders the countdown from a mirroring projected snapshot", async () => {
+    useAppStore.setState({ terminalAutoReconnect: { [TAB]: record({ attempt: 1 }) } });
+    transport.setSession(TAB, reconnecting({ phase: "waiting", attempt: 1, delayMs: 3_000 }));
+
+    act(() => root.render(withTooltip(<TerminalDisconnectOverlay tabId={TAB} />)));
+    await flush();
+
+    // The region was actually subscribed and drove the render.
+    expect(transport.subscribeCount).toBeGreaterThan(0);
+    const countdown = container.querySelector("[data-testid='terminal-auto-reconnect-countdown']");
+    expect(countdown).not.toBeNull();
+    expect(countdown?.textContent).toContain("Attempt 2 of 10");
+  });
+
+  it("keeps the countdown identical to appStore when the projection diverges (mirror-fallback parity)", async () => {
+    // Local record is attempt 1 ("Attempt 2"); the projected snapshot is stale at
+    // a wildly different attempt. The faithful-mirror gate must reject it and the
+    // overlay must stay byte-identical to the local record.
+    useAppStore.setState({ terminalAutoReconnect: { [TAB]: record({ attempt: 1 }) } });
+    transport.setSession(TAB, reconnecting({ phase: "waiting", attempt: 7, delayMs: 99_000 }));
+
+    act(() => root.render(withTooltip(<TerminalDisconnectOverlay tabId={TAB} />)));
+    await flush();
+
+    const countdown = container.querySelector("[data-testid='terminal-auto-reconnect-countdown']");
+    expect(countdown?.textContent).toContain("Attempt 2 of 10");
+    expect(countdown?.textContent).not.toContain("Attempt 8");
+  });
+
+  it("falls back to appStore verbatim when the render cut is off", async () => {
+    setSessionRenderFromProjectionEnabled(false);
+    useAppStore.setState({ terminalAutoReconnect: { [TAB]: record({ attempt: 3 }) } });
+    // A divergent snapshot exists but must be ignored with the flag off.
+    transport.setSession(TAB, reconnecting({ phase: "waiting", attempt: 0, delayMs: 1_000 }));
+
+    act(() => root.render(withTooltip(<TerminalDisconnectOverlay tabId={TAB} />)));
+    await flush();
+
+    const countdown = container.querySelector("[data-testid='terminal-auto-reconnect-countdown']");
+    expect(countdown?.textContent).toContain("Attempt 4 of 10");
+    // With the cut off the hook never subscribes to the region.
+    expect(transport.subscribeCount).toBe(0);
+  });
+
+  it("shows no auto-reconnect overlay when there is no local loop, whatever the region says", async () => {
+    // The region reports a reconnecting session, but appStore has no loop record:
+    // the overlay is seeded from appStore, so nothing spurious renders.
+    transport.setSession(TAB, reconnecting({ phase: "waiting", attempt: 2, delayMs: 5_000 }));
+
+    act(() => root.render(withTooltip(<TerminalDisconnectOverlay tabId={TAB} />)));
+    await flush();
+
+    // The exited (non-view-mode) disconnect overlay shows, but not the reconnect
+    // countdown variant.
+    expect(container.querySelector("[data-testid='terminal-auto-reconnect-countdown']")).toBeNull();
+  });
+});

--- a/src/components/Terminal/TerminalDisconnectOverlay.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { WifiOff, RefreshCw, X, AlertTriangle, Loader2, CheckCircle2 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useSessionAutoReconnect } from "@/store/useSessionLifecycle";
 import { Button, Tooltip } from "@/components/ui";
 import type { TerminalExitInfo } from "@/types/terminal";
 import "./TerminalDisconnectOverlay.css";
@@ -54,7 +55,9 @@ function disconnectCopyFor(info: TerminalExitInfo | undefined): DisconnectCopy {
  * without an agent, and a Cancel affordance that stops the loop.
  */
 function AutoReconnectingOverlay({ tabId }: { tabId: string }) {
-  const auto = useAppStore((s) => s.terminalAutoReconnect[tabId]);
+  // The loop detail is sourced from the projected `session-lifecycle` region when
+  // it faithfully mirrors appStore, else from appStore verbatim (#2204).
+  const auto = useSessionAutoReconnect(tabId);
   const cancelAutoReconnect = useAppStore((s) => s.cancelAutoReconnect);
   // Tick once a second so the countdown stays live.
   const [now, setNow] = useState(() => Date.now());
@@ -138,9 +141,9 @@ export function TerminalDisconnectOverlay({ tabId }: TerminalDisconnectOverlayPr
   const setTerminalExited = useAppStore((s) => s.setTerminalExited);
   const disconnectError = useAppStore((s) => s.terminalDisconnectErrors[tabId]);
   const isReconnecting = useAppStore((s) => s.terminalReconnectingTabs[tabId] ?? false);
-  const autoReconnectWaiting = useAppStore(
-    (s) => s.terminalAutoReconnect[tabId]?.phase === "waiting"
-  );
+  // The auto-reconnect gate reads the same projected-with-fallback loop detail as
+  // the countdown overlay itself, so the region drives which variant shows (#2204).
+  const autoReconnectWaiting = useSessionAutoReconnect(tabId)?.phase === "waiting";
   const reconnectTriggerError = useAppStore((s) => s.terminalReconnectTriggerErrors[tabId]);
   const exitInfo = useAppStore((s) => s.terminalExitInfo[tabId]);
 

--- a/src/store/sessionBridge.test.ts
+++ b/src/store/sessionBridge.test.ts
@@ -20,13 +20,17 @@ import {
 
 import {
   dispatchSessionIntent,
+  effectiveAutoReconnect,
   mirrorSessionIntent,
   onSessionView,
+  projectedReconnectMirrors,
   projectedToAutoReconnect,
   runSessionIntent,
   SESSION_LIFECYCLE_REGION,
   sessionIntentsEnabled,
+  sessionRenderFromProjectionEnabled,
   setSessionIntentsEnabled,
+  setSessionRenderFromProjectionEnabled,
   setSessionTransportForTest,
   stopSessionSubscription,
   type ProjectedSessionLifecycle,
@@ -109,6 +113,7 @@ afterEach(() => {
   stopSessionSubscription();
   setSessionTransportForTest(null);
   setSessionIntentsEnabled(null);
+  setSessionRenderFromProjectionEnabled(null);
 });
 
 describe("sessionIntentsEnabled flag", () => {
@@ -288,5 +293,95 @@ describe("runSessionIntent", () => {
       resync: async () => null,
     });
     await expect(runSessionIntent("session.connect", "tab-z")).rejects.toThrow(/nope/);
+  });
+});
+
+describe("sessionRenderFromProjectionEnabled flag (#2204)", () => {
+  it("defaults on and honours the programmatic override", () => {
+    expect(sessionRenderFromProjectionEnabled()).toBe(true);
+    setSessionRenderFromProjectionEnabled(false);
+    expect(sessionRenderFromProjectionEnabled()).toBe(false);
+    setSessionRenderFromProjectionEnabled(true);
+    expect(sessionRenderFromProjectionEnabled()).toBe(true);
+    setSessionRenderFromProjectionEnabled(null);
+    expect(sessionRenderFromProjectionEnabled()).toBe(true);
+  });
+});
+
+describe("projectedReconnectMirrors — the faithful-mirror gate (#2204)", () => {
+  const record: TerminalAutoReconnectState = {
+    phase: "waiting",
+    attempt: 2,
+    maxAttempts: 10,
+    delayMs: 4_000,
+    nextAttemptAt: 1_004_000,
+  };
+  const projected = (
+    life: Partial<ProjectedSessionLifecycle["reconnect"]>
+  ): ProjectedSessionLifecycle => ({
+    status: "reconnecting",
+    reconnect: { phase: "waiting", attempt: 2, delayMs: 4_000, ...life },
+  });
+
+  it("matches when phase, attempt and delay all agree", () => {
+    expect(projectedReconnectMirrors(projected({}), record)).toBe(true);
+  });
+
+  it("does not match on a phase / attempt / delay divergence", () => {
+    expect(projectedReconnectMirrors(projected({ phase: "connecting" }), record)).toBe(false);
+    expect(projectedReconnectMirrors(projected({ attempt: 3 }), record)).toBe(false);
+    expect(projectedReconnectMirrors(projected({ delayMs: 8_000 }), record)).toBe(false);
+  });
+
+  it("never matches when either side is absent", () => {
+    expect(projectedReconnectMirrors(undefined, record)).toBe(false);
+    expect(projectedReconnectMirrors(projected({}), undefined)).toBe(false);
+    expect(projectedReconnectMirrors(undefined, undefined)).toBe(false);
+  });
+});
+
+describe("effectiveAutoReconnect — render-cut source selection (#2204)", () => {
+  const record: TerminalAutoReconnectState = {
+    phase: "waiting",
+    attempt: 2,
+    maxAttempts: DEFAULT_BACKOFF.maxAttempts,
+    delayMs: 4_000,
+    nextAttemptAt: 1_004_000,
+    onReconnectCommand: "tmux attach",
+  };
+  const mirror: ProjectedSessionLifecycle = {
+    status: "reconnecting",
+    reconnect: { phase: "waiting", attempt: 2, delayMs: 4_000 },
+  };
+
+  it("returns undefined when there is no local loop, whatever the projection says", () => {
+    expect(effectiveAutoReconnect(undefined, mirror)).toBeUndefined();
+    expect(effectiveAutoReconnect(undefined, undefined)).toBeUndefined();
+  });
+
+  it("sources from the projection when it mirrors, byte-identical to the local record", () => {
+    // The gate holds → the record is recomposed from the projected snapshot, and
+    // the re-attached wall-clock anchor + command keep it identical to the local.
+    expect(effectiveAutoReconnect(record, mirror)).toEqual(record);
+  });
+
+  it("falls back to the local record when the projection does not mirror", () => {
+    const stale: ProjectedSessionLifecycle = {
+      status: "reconnecting",
+      reconnect: { phase: "waiting", attempt: 5, delayMs: 30_000 },
+    };
+    // Must be the local record verbatim — never the stale projected numbers.
+    expect(effectiveAutoReconnect(record, stale)).toBe(record);
+    expect(effectiveAutoReconnect(record, undefined)).toBe(record);
+  });
+
+  it("falls back to the local record when the render cut is off", () => {
+    setSessionRenderFromProjectionEnabled(false);
+    expect(effectiveAutoReconnect(record, mirror)).toBe(record);
+  });
+
+  it("preserves the fixed countdown deadline (never re-anchors nextAttemptAt)", () => {
+    const composed = effectiveAutoReconnect(record, mirror);
+    expect(composed?.nextAttemptAt).toBe(record.nextAttemptAt);
   });
 });

--- a/src/store/sessionBridge.ts
+++ b/src/store/sessionBridge.ts
@@ -147,6 +147,57 @@ export function sessionIntentsEnabled(): boolean {
   return false;
 }
 
+// ── Render-cut feature flag (step 3 #2204, on by default) ──────────────────────
+
+let renderFlagOverride: boolean | null = null;
+
+interface SessionRenderFlagWindow {
+  __TERMIHUB_SESSION_RENDER_FROM_PROJECTION__?: boolean;
+  localStorage?: Storage;
+}
+
+/**
+ * Programmatic override for the render-cut flag (tests, and a runtime toggle).
+ * `null` clears the override and falls back to the window/localStorage signal,
+ * then to the default (on).
+ */
+export function setSessionRenderFromProjectionEnabled(value: boolean | null): void {
+  renderFlagOverride = value;
+}
+
+/**
+ * Whether the terminal overlays render their session status from the projected
+ * `session-lifecycle` region (step 3, #2204) instead of reading `appStore`'s
+ * status fields directly.
+ *
+ * **On by default** — the render cut is parity-safe: the overlays render from the
+ * region only when it faithfully mirrors `appStore`'s status
+ * ({@link projectedReconnectMirrors}), and otherwise fall back to `appStore`
+ * verbatim, so the output is byte-identical to the pre-cut path regardless of
+ * {@link sessionIntentsEnabled}. Independent of the mutation flag: the local
+ * reconnect record seeds the effective view, so it is always populated even when
+ * nothing has written the backend region. Overridable at runtime for rollback /
+ * tests via `window.__TERMIHUB_SESSION_RENDER_FROM_PROJECTION__` or
+ * `localStorage["termihub.sessionRenderFromProjection"]`.
+ */
+export function sessionRenderFromProjectionEnabled(): boolean {
+  if (renderFlagOverride !== null) return renderFlagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as SessionRenderFlagWindow;
+      if (typeof w.__TERMIHUB_SESSION_RENDER_FROM_PROJECTION__ === "boolean") {
+        return w.__TERMIHUB_SESSION_RENDER_FROM_PROJECTION__;
+      }
+      const ls = w.localStorage?.getItem("termihub.sessionRenderFromProjection");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return true;
+}
+
 // ── Transport + region client (lazy, mirrors the tunnel slice) ─────────────────
 
 let transportInstance: Transport | null = null;
@@ -357,6 +408,61 @@ export function projectedToAutoReconnect(
     };
   }
   return null;
+}
+
+// ── Render cut: faithful-mirror gate + effective display record (#2204) ─────────
+
+/**
+ * Whether a projected lifecycle's `reconnect` detail faithfully mirrors the
+ * local auto-reconnect display `record` — the gate that decides if the overlay
+ * may render the countdown from the projection (true) or must fall back to
+ * `appStore` (false). Compares the loop's coarse status the region carries
+ * (phase / attempt / backoff delay); the per-client presentation the region does
+ * not carry (the wall-clock anchor, the on-reconnect command) is out of scope
+ * for the gate and re-attached from the local record when composing.
+ *
+ * The twin of the layout render cut's {@link import("./layoutBridge").viewMatchesTree}.
+ */
+export function projectedReconnectMirrors(
+  projected: ProjectedSessionLifecycle | undefined,
+  record: TerminalAutoReconnectState | undefined
+): boolean {
+  if (!projected || !record) return false;
+  const r = projected.reconnect;
+  return r.phase === record.phase && r.attempt === record.attempt && r.delayMs === record.delayMs;
+}
+
+/**
+ * The auto-reconnect display record the disconnect overlay renders, sourced from
+ * the projected `session-lifecycle` region when it faithfully mirrors `appStore`
+ * ({@link projectedReconnectMirrors}), and otherwise the local `record` verbatim
+ * — so the countdown is byte-identical to the pre-cut path.
+ *
+ * When the region mirrors, the loop numbers (phase / attempt / backoff delay /
+ * max attempts) come from the projection via {@link projectedToAutoReconnect},
+ * and the per-client presentation the region does not carry — the wall-clock
+ * `nextAttemptAt` anchor and the on-reconnect command — is re-attached from the
+ * local record (the partial-projection seam, exactly as the layout render cut
+ * re-attaches per-tab content onto the projected structure, #2151). Because the
+ * gate guarantees the loop numbers already agree, the composed record equals the
+ * local one; the projection merely becomes the source of record.
+ *
+ * `undefined` in ⇒ `undefined` out: no active loop, nothing to render.
+ */
+export function effectiveAutoReconnect(
+  record: TerminalAutoReconnectState | undefined,
+  projected: ProjectedSessionLifecycle | undefined
+): TerminalAutoReconnectState | undefined {
+  if (!record) return undefined;
+  if (!sessionRenderFromProjectionEnabled()) return record;
+  if (!projectedReconnectMirrors(projected, record)) return record;
+  // `now0` reproduces the local anchor exactly: with `nextAttemptAt = now0 +
+  // delayMs` and the gate guaranteeing `projected.reconnect.delayMs ===
+  // record.delayMs`, the composed `nextAttemptAt` equals the local record's, so
+  // the live countdown keeps its fixed wall-clock deadline (never re-anchored per
+  // render).
+  const now0 = record.nextAttemptAt - projected!.reconnect.delayMs;
+  return projectedToAutoReconnect(projected!, now0, record.onReconnectCommand) ?? record;
 }
 
 /** Log a bridge fallback so the local-path recovery is visible in the LogViewer. */

--- a/src/store/useSessionLifecycle.ts
+++ b/src/store/useSessionLifecycle.ts
@@ -1,0 +1,90 @@
+/**
+ * `useSessionAutoReconnect` — the terminal overlays' cut to the projected
+ * session-lifecycle status (#2204 step 3, part of #2152 / #2139).
+ *
+ * The agentless auto-reconnect countdown overlay renders the loop's live detail
+ * (phase, attempt, backoff countdown). Through step 2 that detail came straight
+ * from `appStore.terminalAutoReconnect` (the local display record the imperative
+ * backoff timer maintains). Step 3 makes the overlay source that detail from the
+ * shared `session-lifecycle` projection region instead — the direct analog of the
+ * layout render cut ({@link import("./useLayoutRenderTree").useLayoutRenderTree},
+ * #2151 step 3).
+ *
+ * The hook returns the {@link TerminalAutoReconnectState} the overlay renders:
+ * the loop numbers from the projection, the per-client presentation (wall-clock
+ * anchor, on-reconnect command) re-attached from the local record — the
+ * partial-projection seam ({@link effectiveAutoReconnect}).
+ *
+ * # Safety (strangler)
+ *
+ * - **Gated** by {@link sessionRenderFromProjectionEnabled} (on by default). Flag
+ *   off ⇒ the hook returns `appStore`'s record verbatim.
+ * - **Faithful-mirror gate.** The projection sources the render only when its
+ *   `reconnect` detail mirrors the local record ({@link projectedReconnectMirrors});
+ *   otherwise the hook falls back to the local record (never a stale one). The
+ *   local record always seeds the effective view, so it is populated even when
+ *   nothing has written the backend region ({@link sessionIntentsEnabled} off) —
+ *   making the cut parity-safe and independent of the mutation flag.
+ */
+
+import { useEffect, useState } from "react";
+
+import { useAppStore } from "@/store/appStore";
+import {
+  effectiveAutoReconnect,
+  ensureSessionSubscribed,
+  logSessionBridgeFallback,
+  onSessionView,
+  type ProjectedSessionLifecycle,
+  type SessionLifecycleView,
+  sessionRenderFromProjectionEnabled,
+} from "@/store/sessionBridge";
+import type { TerminalAutoReconnectState } from "@/types/terminal";
+
+/**
+ * The auto-reconnect display record for one tab: loop numbers sourced from the
+ * projected `session-lifecycle` region when it faithfully mirrors `appStore`,
+ * otherwise `appStore`'s `terminalAutoReconnect` record verbatim (flag off, region
+ * not yet populated / mirroring, or a transport that cannot subscribe).
+ * `undefined` when no auto-reconnect loop is active for the tab.
+ */
+export function useSessionAutoReconnect(tabId: string): TerminalAutoReconnectState | undefined {
+  const record = useAppStore((s) => s.terminalAutoReconnect[tabId]);
+
+  // Read the flag once at mount: it flips only via dev tooling, and the
+  // subscription lifecycle is keyed off it below.
+  const [enabled] = useState(() => sessionRenderFromProjectionEnabled());
+
+  const [projected, setProjected] = useState<ProjectedSessionLifecycle | undefined>(undefined);
+
+  // Subscribe to the shared session-lifecycle region while enabled; a transport
+  // that cannot subscribe (non-Tauri without a socket) just leaves the overlay on
+  // the appStore fallback.
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const unsubscribe = onSessionView((next) => {
+      if (!cancelled) setProjected(next[tabId]);
+    });
+    // `ensureSessionSubscribed` builds the transport eagerly, so a non-Tauri env
+    // without a socket throws synchronously (not just a rejection) — guard both so
+    // the overlay silently stays on the appStore fallback.
+    try {
+      ensureSessionSubscribed()
+        .then((client) => {
+          if (cancelled) return;
+          const view = client.state.view as SessionLifecycleView | undefined;
+          setProjected(view?.sessions?.[tabId]);
+        })
+        .catch((err) => logSessionBridgeFallback("subscribe", err));
+    } catch (err) {
+      logSessionBridgeFallback("subscribe", err);
+    }
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [enabled, tabId]);
+
+  return effectiveAutoReconnect(record, enabled ? projected : undefined);
+}


### PR DESCRIPTION
## Phase 4 step 3: render session status from the projected session-lifecycle region

Cuts the terminal auto-reconnect overlay's live loop detail to the shared
`session-lifecycle` projection region — the direct analog of Phase 3's render
cut (#2183 / `useLayoutRenderTree`).

### What changed
- **`sessionBridge.ts`**: a render-cut flag `sessionRenderFromProjectionEnabled` (**on by default**, runtime-overridable), a faithful-mirror gate `projectedReconnectMirrors`, and `effectiveAutoReconnect` — the display-record source selector.
- **`useSessionLifecycle.ts`** (new hook, twin of `useLayoutRenderTree`): subscribes to the shared `session-lifecycle` region and returns the tab's `TerminalAutoReconnectState`.
- **`TerminalDisconnectOverlay.tsx`**: the auto-reconnect countdown (`AutoReconnectingOverlay`) and its `autoReconnectWaiting` gate now read the projected-with-fallback loop detail via the hook instead of reading `appStore.terminalAutoReconnect` directly.

### How it renders from the region (mirror-fallback parity)
The overlay renders the loop numbers (phase / attempt / backoff delay / max attempts) from the projected `reconnect` detail via the existing `projectedToAutoReconnect` reconcile helper **only when the region faithfully mirrors appStore's record** (`projectedReconnectMirrors`); otherwise it falls back to the local record verbatim. The per-client presentation the region does not carry — the wall-clock `nextAttemptAt` anchor and the on-reconnect command — is re-attached from the local record (the partial-projection seam, exactly as the layout render cut re-attaches per-tab content onto projected structure). Because the local record always seeds the effective view, the overlay is **always populated and byte-identical to today, independent of `sessionIntentsEnabled`** — the live countdown keeps its fixed deadline and is never re-anchored per render.

### Scope note (partial-projection seam)
The `session-lifecycle` region carries the **coarse** `SessionStatus` + `reconnect` detail. The connect overlay's finer connect sub-phases (reattaching / waiting-for-agent / auto-retry) and the disconnect overlay's exit detail are not carried by the region, so those `appStore` reads intentionally stay — consistent with Phase 3's Decision #2 partial projection. The **appStore status _fields_ are untouched** (removed in step 4, #2205); this PR only moves the reconnect-detail _reads_ off the direct `appStore` path.

### Tests
- Unit: render flag default/override, the faithful-mirror gate, and `effectiveAutoReconnect` source selection (projection-sourced when mirroring, fallback when divergent / flag-off, fixed-deadline preservation).
- Component: the countdown driven end-to-end by projected snapshots through the real hook + bridge subscription, plus the mirror-fallback parity and flag-off fallback.

No user-visible change. Full frontend suite (4787) + `cargo`/clippy/fmt green.

Closes #2204
Part of #2152
