### PR TITLE
refactor(workspace): wire core restore_mode into the restore path (Closes #2200)

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod portable;
 pub mod projection;
 pub mod projection_diag;
 pub mod remote_desktop;
+pub mod restore_mode;
 pub mod session;
 pub mod session_history;
 pub mod shell_integration;

--- a/src-tauri/src/commands/restore_mode.rs
+++ b/src-tauri/src/commands/restore_mode.rs
@@ -1,0 +1,114 @@
+//! Tauri command surface for the startup session-restore decision logic (#2200).
+//!
+//! Wires the previously-dormant `termihub_core::restore_mode` port (#2145) into
+//! the frontend restore path. Each command is a thin, **stateless** wrapper over
+//! one of the core's pure decision functions; the frontend's
+//! `src/utils/restoreMode.ts` now delegates its logic here so there is a single
+//! source of truth (the Rust port), proven equivalent to the retired TypeScript
+//! logic by the #2145 golden vectors (`core/tests/restore_mode_golden.rs`).
+//!
+//! ## The async-probe seam
+//!
+//! [`restore_summarize_last_session`] does the **pure** work: it flattens a
+//! stored session into per-tab descriptors, each carrying the connection
+//! `target` its reachability check would probe. It never performs the probe.
+//! The asynchronous reachability probe stays entirely client-side
+//! (`src/utils/restoreReachability.ts` + `probeRestorePromptReachability`),
+//! consuming the `target`s this command produced and patching `reachability`
+//! onto the prompt afterwards. That decoupling — pure decision here, async I/O
+//! probe on the client — is why the lift is partial rather than whole.
+
+use std::collections::HashSet;
+
+use termihub_core::restore_mode::{
+    filter_session_by_selection, resolve_restore_mode, summarize_last_session, AppSettings,
+    LastSession, RestoreLastSessionMode, RestorePrompt, SavedConnection,
+};
+
+/// Resolve the effective restore mode from settings, migrating the legacy
+/// `restoreLastSessionOnStartup` boolean when the explicit mode is unset.
+#[tauri::command]
+pub fn restore_resolve_mode(settings: AppSettings) -> RestoreLastSessionMode {
+    resolve_restore_mode(&settings)
+}
+
+/// Flatten a stored last session into the per-tab restore-dialog summary. Each
+/// tab carries the `target` the client-side reachability probe then consumes.
+#[tauri::command]
+pub fn restore_summarize_last_session(
+    session: LastSession,
+    connections: Vec<SavedConnection>,
+) -> RestorePrompt {
+    summarize_last_session(&session, &connections)
+}
+
+/// Prune a stored last session down to the flat tab indices the user selected
+/// (same order [`restore_summarize_last_session`] produced).
+#[tauri::command]
+pub fn restore_filter_session_by_selection(
+    session: LastSession,
+    selected: Vec<i64>,
+) -> LastSession {
+    let selected: HashSet<i64> = selected.into_iter().collect();
+    filter_session_by_selection(&session, &selected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // These assert the command wrappers pass their arguments straight through to
+    // the core functions unchanged; the behaviour of the functions themselves is
+    // proven equivalent to the retired TS logic by `restore_mode_golden.rs`.
+
+    #[test]
+    fn resolve_mode_delegates_to_core() {
+        let settings: AppSettings =
+            serde_json::from_value(json!({ "restoreLastSessionMode": "always" })).unwrap();
+        assert_eq!(
+            restore_resolve_mode(settings.clone()),
+            resolve_restore_mode(&settings)
+        );
+    }
+
+    #[test]
+    fn summarize_delegates_to_core() {
+        let session: LastSession = serde_json::from_value(json!({
+            "version": "1",
+            "activeGroupIndex": 0,
+            "tabGroups": [{
+                "name": "g",
+                "layout": { "type": "leaf", "tabs": [
+                    { "title": "shell", "inlineConfig": { "type": "local", "config": {} } }
+                ] }
+            }]
+        }))
+        .unwrap();
+        assert_eq!(
+            restore_summarize_last_session(session.clone(), Vec::new()),
+            summarize_last_session(&session, &[])
+        );
+    }
+
+    #[test]
+    fn filter_collects_selection_into_set() {
+        let session: LastSession = serde_json::from_value(json!({
+            "version": "1",
+            "activeGroupIndex": 0,
+            "tabGroups": [{
+                "name": "g",
+                "layout": { "type": "leaf", "tabs": [
+                    { "title": "a", "inlineConfig": { "type": "local", "config": {} } },
+                    { "title": "b", "inlineConfig": { "type": "local", "config": {} } }
+                ] }
+            }]
+        }))
+        .unwrap();
+        let expected = filter_session_by_selection(&session, &HashSet::from([0]));
+        assert_eq!(
+            restore_filter_session_by_selection(session, vec![0]),
+            expected
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1182,6 +1182,10 @@ pub fn run() {
             commands::workspace::save_last_session,
             commands::workspace::load_last_session,
             commands::workspace::clear_last_session,
+            // Startup session-restore decision logic, wired to core (#2200)
+            commands::restore_mode::restore_resolve_mode,
+            commands::restore_mode::restore_summarize_last_session,
+            commands::restore_mode::restore_filter_session_by_selection,
             // Multi-window foundation (#1900)
             commands::window::open_window,
             commands::window::claim_session,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -153,7 +153,7 @@ function App() {
       }
 
       const store = useAppStore.getState();
-      const restoreMode = resolveRestoreMode(store.settings);
+      const restoreMode = await resolveRestoreMode(store.settings);
       if (restoreMode === "never") {
         // Never restore: drop any stale stored session from a previous run.
         await store.clearLastSession();

--- a/src/components/Settings/GeneralSettings.tsx
+++ b/src/components/Settings/GeneralSettings.tsx
@@ -4,7 +4,7 @@ import { ShellType } from "@/types/terminal";
 import { detectAvailableShells } from "@/utils/shell-detection";
 import { getWslDistroName } from "@/utils/shell-detection";
 import { useAppStore } from "@/store/appStore";
-import { resolveRestoreMode } from "@/utils/restoreMode";
+import { resolveRestoreMode, type RestoreLastSessionMode } from "@/utils/restoreMode";
 import { isWindows } from "@/utils/platform";
 import { shouldOfferGitBashSetup } from "@/utils/gitBashSetup";
 import { Button, NumberInput, Select, SelectItem, Toggle, toast } from "@/components/ui";
@@ -52,6 +52,24 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
   const platformDefaultShell = useAppStore((s) => s.defaultShell);
   const historyCount = useAppStore((s) => s.sessionHistory.length);
   const clearSessionHistory = useAppStore((s) => s.clearSessionHistory);
+
+  // The restore-mode decision now lives in `core::restore_mode` (#2200), so the
+  // dropdown value is resolved asynchronously via the `restore_resolve_mode`
+  // command. Seed with the explicit mode when set (the common case, no flicker);
+  // the effect below then authoritatively resolves the legacy-boolean migration.
+  const explicitMode = settings.restoreLastSessionMode;
+  const [restoreMode, setRestoreMode] = useState<RestoreLastSessionMode>(
+    explicitMode === "never" || explicitMode === "always" ? explicitMode : "ask"
+  );
+  useEffect(() => {
+    let active = true;
+    void resolveRestoreMode(settings).then((mode) => {
+      if (active) setRestoreMode(mode);
+    });
+    return () => {
+      active = false;
+    };
+  }, [settings]);
 
   const refreshShells = useCallback(() => {
     detectAvailableShells().then(setAvailableShells);
@@ -235,7 +253,7 @@ export function GeneralSettings({ settings, onChange, visibleFields }: GeneralSe
             hint="Choose how the tabs and panel layout from your previous session are handled when the app starts. Never starts fresh; Ask offers a restore dialog; Always restores silently. Sessions that can no longer reconnect are shown in a disconnected state."
           >
             <Select
-              value={resolveRestoreMode(settings)}
+              value={restoreMode}
               onChange={(value) =>
                 onChange({
                   ...settings,

--- a/src/store/appStore.lastSession.test.ts
+++ b/src/store/appStore.lastSession.test.ts
@@ -48,6 +48,24 @@ vi.mock("@/services/lastSessionApi", () => ({
   clearLastSession: vi.fn(() => Promise.resolve()),
 }));
 
+// The restore-mode decision logic now lives in `core::restore_mode`, reached
+// over IPC (#2200) and thus unavailable in this JS test. Mock the async decision
+// boundary; `resolveRestoreMode` mirrors the core guard so the mode-driven
+// save/skip branches stay input-driven. Parity with the retired TS logic is
+// proven by the Rust golden vectors (`core/tests/restore_mode_golden.rs`).
+vi.mock("@/utils/restoreMode", () => ({
+  resolveRestoreMode: vi.fn(
+    async (s: { restoreLastSessionMode?: string; restoreLastSessionOnStartup?: boolean }) => {
+      const m = s.restoreLastSessionMode;
+      if (m === "never" || m === "ask" || m === "always") return m;
+      if (s.restoreLastSessionOnStartup === false) return "never";
+      return "ask";
+    }
+  ),
+  summarizeLastSession: vi.fn(async () => ({ tabCount: 0, tabs: [] })),
+  filterSessionBySelection: vi.fn(async (session: unknown) => session),
+}));
+
 // Spy on the shared toast hub so restore-failure feedback (G3, #1146) is observable.
 vi.mock("@/components/ui", () => ({
   toast: {

--- a/src/store/appStore.restoreMode.test.ts
+++ b/src/store/appStore.restoreMode.test.ts
@@ -30,6 +30,25 @@ vi.mock("@/services/lastSessionApi", () => ({
   clearLastSession: vi.fn(() => Promise.resolve()),
 }));
 
+// The restore-mode decision logic now lives in `core::restore_mode` and is
+// reached over IPC (#2200), so it is unavailable in this JS test environment.
+// These are store-orchestration tests; mock the (async) decision boundary with
+// deterministic outputs — the logic's correctness is proven by the Rust golden
+// vectors (`core/tests/restore_mode_golden.rs`). The `resolveRestoreMode` mock
+// mirrors the core guard so mode-driven branches stay input-driven.
+vi.mock("@/utils/restoreMode", () => ({
+  resolveRestoreMode: vi.fn(
+    async (s: { restoreLastSessionMode?: string; restoreLastSessionOnStartup?: boolean }) => {
+      const m = s.restoreLastSessionMode;
+      if (m === "never" || m === "ask" || m === "always") return m;
+      if (s.restoreLastSessionOnStartup === false) return "never";
+      return "ask";
+    }
+  ),
+  summarizeLastSession: vi.fn(async () => ({ tabCount: 0, tabs: [] })),
+  filterSessionBySelection: vi.fn(async (session: unknown) => session),
+}));
+
 vi.mock("@/components/ui", () => ({
   toast: {
     success: vi.fn(),
@@ -44,7 +63,10 @@ vi.mock("@/components/ui", () => ({
 import { useAppStore } from "./appStore";
 import { saveLastSession, loadLastSession, clearLastSession } from "@/services/lastSessionApi";
 import { saveSettings } from "@/services/storage";
+import { summarizeLastSession } from "@/utils/restoreMode";
 import type { LastSession } from "@/types/lastSession";
+
+const mockSummarize = vi.mocked(summarizeLastSession);
 
 const mockSave = vi.mocked(saveLastSession);
 const mockLoad = vi.mocked(loadLastSession);
@@ -112,6 +134,10 @@ describe("startup restore mode", () => {
   describe("promptRestore", () => {
     it("raises the prompt when a session with tabs is stored", async () => {
       mockLoad.mockResolvedValue(storedSession);
+      mockSummarize.mockResolvedValueOnce({
+        tabCount: 1,
+        tabs: [{ title: "Shell A", typeLabel: "Local", target: { kind: "local" } }],
+      });
 
       await useAppStore.getState().promptRestore();
 

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -8295,7 +8295,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
       const state = get();
       // Respect the setting at save time so toggling it takes effect immediately.
       // "never" means the user does not want a session kept, so skip the write.
-      if (resolveRestoreMode(state.settings) === "never") return;
+      if ((await resolveRestoreMode(state.settings)) === "never") return;
       const ownGroups = captureAllTabGroups(
         state.tabGroups,
         state.activeTabGroupId,
@@ -8363,7 +8363,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
         // Partial restore (#1931): prune the stored session to the tabs the user
         // checked before building anything. An empty selection restores nothing.
         const session = selectedIndices
-          ? filterSessionBySelection(loaded, new Set(selectedIndices))
+          ? await filterSessionBySelection(loaded, new Set(selectedIndices))
           : loaded;
         if (session.tabGroups.length === 0) return false;
         const state = get();
@@ -8467,7 +8467,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
         // Pass loaded connections so `connectionRef` tabs resolve a host/serial
         // target for the reachability probe (connections are loaded before this
         // runs at startup).
-        const summary = summarizeLastSession(session, get().connections);
+        const summary = await summarizeLastSession(session, get().connections);
         // Nothing launchable → treat as "no session" and stay silent.
         if (summary.tabCount === 0) return;
         set({ restorePrompt: summary });

--- a/src/utils/restoreMode.test.ts
+++ b/src/utils/restoreMode.test.ts
@@ -1,42 +1,38 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
 import { filterSessionBySelection, resolveRestoreMode, summarizeLastSession } from "./restoreMode";
 import type { AppSettings, SavedConnection } from "@/types/connection";
 import type { LastSession } from "@/types/lastSession";
-import { countWorkspaceTabs, getWorkspaceLeaves } from "@/utils/workspaceLayout";
+
+// The restore-mode decision logic now lives in `core::restore_mode` (Rust) and
+// is reached over IPC (#2200). These wrappers are thin delegations; the pure
+// behaviour (label derivation, target derivation, session pruning, legacy-mode
+// migration) is proven equivalent to the retired TypeScript logic by the golden
+// vectors in `core/tests/restore_mode_golden.rs`, extracted from this suite's
+// original cases. Here we only assert the frontend delegates correctly: the
+// right command, the right argument shape, and the command's result returned
+// verbatim.
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+const mockInvoke = vi.mocked(invoke);
 
 function settings(partial: Partial<AppSettings>): AppSettings {
   return { version: "1", externalConnectionFiles: [], ...partial } as AppSettings;
 }
 
+beforeEach(() => {
+  mockInvoke.mockReset();
+});
+
 describe("resolveRestoreMode", () => {
-  it("returns the explicit mode when set", () => {
-    expect(resolveRestoreMode(settings({ restoreLastSessionMode: "never" }))).toBe("never");
-    expect(resolveRestoreMode(settings({ restoreLastSessionMode: "ask" }))).toBe("ask");
-    expect(resolveRestoreMode(settings({ restoreLastSessionMode: "always" }))).toBe("always");
-  });
-
-  it("prefers the explicit mode over the legacy boolean", () => {
-    expect(
-      resolveRestoreMode(
-        settings({ restoreLastSessionMode: "always", restoreLastSessionOnStartup: false })
-      )
-    ).toBe("always");
-  });
-
-  it("migrates the legacy boolean false to never", () => {
-    expect(resolveRestoreMode(settings({ restoreLastSessionOnStartup: false }))).toBe("never");
-  });
-
-  it("defaults to ask when nothing is set", () => {
-    expect(resolveRestoreMode(settings({}))).toBe("ask");
-  });
-
-  it("defaults to ask when the legacy boolean is true", () => {
-    expect(resolveRestoreMode(settings({ restoreLastSessionOnStartup: true }))).toBe("ask");
-  });
-
-  it("falls through to ask for an out-of-range mode value", () => {
-    expect(resolveRestoreMode(settings({ restoreLastSessionMode: "bogus" as "ask" }))).toBe("ask");
+  it("delegates to restore_resolve_mode and returns its result", async () => {
+    mockInvoke.mockResolvedValueOnce("always");
+    const s = settings({ restoreLastSessionMode: "always" });
+    await expect(resolveRestoreMode(s)).resolves.toBe("always");
+    expect(mockInvoke).toHaveBeenCalledWith("restore_resolve_mode", { settings: s });
   });
 });
 
@@ -48,205 +44,49 @@ describe("summarizeLastSession", () => {
       {
         name: "Group",
         layout: {
-          type: "split",
-          direction: "horizontal",
-          children: [
-            {
-              type: "leaf",
-              tabs: [
-                { title: "prod-db", inlineConfig: { type: "ssh", config: { host: "prod-db" } } },
-                { inlineConfig: { type: "serial", config: { device: "/dev/ttyUSB0" } } },
-              ],
-            },
-            {
-              type: "leaf",
-              tabs: [{ inlineConfig: { type: "local", config: { shell: "bash" } } }],
-            },
-          ],
+          type: "leaf",
+          tabs: [{ title: "prod-db", inlineConfig: { type: "ssh", config: { host: "prod-db" } } }],
         },
       },
     ],
   };
 
-  it("counts every tab across nested leaves", () => {
-    expect(summarizeLastSession(session).tabCount).toBe(3);
-  });
-
-  it("uses the title override and derives type labels", () => {
-    const { tabs } = summarizeLastSession(session);
-    expect(tabs[0]).toMatchObject({ title: "prod-db", typeLabel: "SSH" });
-    // No title: falls back to the device path, Serial type badge.
-    expect(tabs[1]).toMatchObject({ title: "/dev/ttyUSB0", typeLabel: "Serial" });
-    expect(tabs[2]).toMatchObject({ title: "Local", typeLabel: "Local" });
-  });
-
-  it("derives a probe target per tab", () => {
-    const { tabs } = summarizeLastSession(session);
-    expect(tabs[0].target).toEqual({ kind: "host", host: "prod-db", port: 22 });
-    expect(tabs[1].target).toEqual({ kind: "serial", device: "/dev/ttyUSB0" });
-    expect(tabs[2].target).toEqual({ kind: "local" });
-  });
-
-  it("uses the telnet default port when unspecified", () => {
-    const telnet: LastSession = {
-      version: "1",
-      activeGroupIndex: 0,
-      tabGroups: [
-        {
-          name: "G",
-          layout: {
-            type: "leaf",
-            tabs: [{ inlineConfig: { type: "telnet", config: { host: "switch" } } }],
-          },
-        },
-      ],
-    };
-    expect(summarizeLastSession(telnet).tabs[0].target).toEqual({
-      kind: "host",
-      host: "switch",
-      port: 23,
+  it("delegates to restore_summarize_last_session with session and connections", async () => {
+    const prompt = { tabCount: 1, tabs: [{ title: "prod-db", typeLabel: "SSH" }] };
+    mockInvoke.mockResolvedValueOnce(prompt);
+    const connections: SavedConnection[] = [];
+    await expect(summarizeLastSession(session, connections)).resolves.toBe(prompt);
+    expect(mockInvoke).toHaveBeenCalledWith("restore_summarize_last_session", {
+      session,
+      connections,
     });
   });
 
-  it("honours an explicit host port", () => {
-    const ssh: LastSession = {
-      version: "1",
-      activeGroupIndex: 0,
-      tabGroups: [
-        {
-          name: "G",
-          layout: {
-            type: "leaf",
-            tabs: [{ inlineConfig: { type: "ssh", config: { host: "h", port: 2222 } } }],
-          },
-        },
-      ],
-    };
-    expect(summarizeLastSession(ssh).tabs[0].target).toEqual({
-      kind: "host",
-      host: "h",
-      port: 2222,
+  it("defaults connections to an empty array when omitted", async () => {
+    mockInvoke.mockResolvedValueOnce({ tabCount: 0, tabs: [] });
+    await summarizeLastSession(session);
+    expect(mockInvoke).toHaveBeenCalledWith("restore_summarize_last_session", {
+      session,
+      connections: [],
     });
-  });
-
-  it("resolves a connectionRef target from the supplied connections", () => {
-    const connections: SavedConnection[] = [
-      {
-        id: "c1",
-        name: "prod",
-        folderId: null,
-        config: { type: "ssh", config: { host: "10.0.0.5", port: 22 } },
-      } as SavedConnection,
-    ];
-    const refSession: LastSession = {
-      version: "1",
-      activeGroupIndex: 0,
-      tabGroups: [
-        { name: "G", layout: { type: "leaf", tabs: [{ connectionRef: "c1", title: "prod" }] } },
-      ],
-    };
-    expect(summarizeLastSession(refSession, connections).tabs[0].target).toEqual({
-      kind: "host",
-      host: "10.0.0.5",
-      port: 22,
-    });
-    // Without the connections it cannot resolve the ref → not network-probed.
-    expect(summarizeLastSession(refSession).tabs[0].target).toEqual({ kind: "local" });
-  });
-
-  it("derives an agent target from an agentRef tab", () => {
-    const agentSession: LastSession = {
-      version: "1",
-      activeGroupIndex: 0,
-      tabGroups: [
-        {
-          name: "G",
-          layout: {
-            type: "leaf",
-            tabs: [{ agentRef: { agentId: "a1", definitionId: "d1" } }],
-          },
-        },
-      ],
-    };
-    expect(summarizeLastSession(agentSession).tabs[0].target).toEqual({
-      kind: "agent",
-      agentId: "a1",
-    });
-  });
-
-  it("reports zero tabs for an empty session", () => {
-    const empty: LastSession = {
-      version: "1",
-      activeGroupIndex: 0,
-      tabGroups: [{ name: "Empty", layout: { type: "leaf", tabs: [] } }],
-    };
-    expect(summarizeLastSession(empty)).toEqual({ tabCount: 0, tabs: [] });
   });
 });
 
 describe("filterSessionBySelection", () => {
-  // Flat tab order (matching summarizeLastSession): 0 ssh, 1 serial, 2 local.
   const session: LastSession = {
     version: "1",
     activeGroupIndex: 0,
     tabGroups: [
-      {
-        name: "Group",
-        layout: {
-          type: "split",
-          direction: "horizontal",
-          sizes: [60, 40],
-          children: [
-            {
-              type: "leaf",
-              tabs: [
-                { title: "ssh", inlineConfig: { type: "ssh", config: { host: "h" } } },
-                { title: "serial", inlineConfig: { type: "serial", config: { device: "/dev/x" } } },
-              ],
-            },
-            {
-              type: "leaf",
-              tabs: [{ title: "local", inlineConfig: { type: "local", config: {} } }],
-            },
-          ],
-        },
-      },
+      { name: "Group", layout: { type: "leaf", tabs: [{ title: "a" }, { title: "b" }] } },
     ],
   };
 
-  it("keeps only the selected tabs", () => {
-    const filtered = filterSessionBySelection(session, new Set([0, 2]));
-    const titles = filtered.tabGroups.flatMap((g) =>
-      getWorkspaceLeaves(g.layout).flatMap((l) => l.tabs.map((t) => t.title))
-    );
-    expect(titles).toEqual(["ssh", "local"]);
-  });
-
-  it("collapses a split whose sibling leaf empties out", () => {
-    // Deselect the local tab (index 2) → the second leaf empties, the split
-    // collapses to the first leaf.
-    const filtered = filterSessionBySelection(session, new Set([0, 1]));
-    const layout = filtered.tabGroups[0].layout;
-    expect(layout.type).toBe("leaf");
-    expect(countWorkspaceTabs(layout)).toBe(2);
-  });
-
-  it("drops a group whose every tab was deselected", () => {
-    const twoGroups: LastSession = {
-      version: "1",
-      activeGroupIndex: 1,
-      tabGroups: [
-        { name: "A", layout: { type: "leaf", tabs: [{ title: "a" }] } },
-        { name: "B", layout: { type: "leaf", tabs: [{ title: "b" }] } },
-      ],
-    };
-    // Keep only tab 0 (group A) → group B is removed, active remaps to A.
-    const filtered = filterSessionBySelection(twoGroups, new Set([0]));
-    expect(filtered.tabGroups.map((g) => g.name)).toEqual(["A"]);
-    expect(filtered.activeGroupIndex).toBe(0);
-  });
-
-  it("yields no groups when nothing is selected", () => {
-    expect(filterSessionBySelection(session, new Set()).tabGroups).toEqual([]);
+  it("delegates to restore_filter_session_by_selection with the selection as an array", async () => {
+    mockInvoke.mockResolvedValueOnce(session);
+    await expect(filterSessionBySelection(session, new Set([0, 2]))).resolves.toBe(session);
+    expect(mockInvoke).toHaveBeenCalledWith("restore_filter_session_by_selection", {
+      session,
+      selected: [0, 2],
+    });
   });
 });

--- a/src/utils/restoreMode.ts
+++ b/src/utils/restoreMode.ts
@@ -7,10 +7,10 @@
  * - `"always"` — restore the previous session silently.
  */
 
+import { invoke } from "@tauri-apps/api/core";
+
 import type { AppSettings, SavedConnection } from "@/types/connection";
 import type { LastSession } from "@/types/lastSession";
-import type { WorkspaceLayoutNode, WorkspaceTabDef, WorkspaceTabGroupDef } from "@/types/workspace";
-import { getWorkspaceLeaves } from "@/utils/workspaceLayout";
 
 /** The three restore modes. */
 export type RestoreLastSessionMode = "never" | "ask" | "always";
@@ -77,8 +77,6 @@ export interface RestorePrompt {
   tabs: RestoreTabInfo[];
 }
 
-const VALID_MODES: readonly RestoreLastSessionMode[] = ["never", "ask", "always"];
-
 /**
  * Resolve the effective restore mode from settings, migrating the legacy
  * boolean `restoreLastSessionOnStartup` when the explicit mode is unset.
@@ -86,101 +84,12 @@ const VALID_MODES: readonly RestoreLastSessionMode[] = ["never", "ask", "always"
  * - explicit {@link AppSettings.restoreLastSessionMode} wins when valid;
  * - otherwise the legacy boolean `=== false` maps to `"never"`;
  * - otherwise the default is `"ask"` (the concept default).
+ *
+ * The decision logic lives in `core::restore_mode` (Rust); this delegates to the
+ * `restore_resolve_mode` command so there is a single source of truth (#2200).
  */
-export function resolveRestoreMode(settings: AppSettings): RestoreLastSessionMode {
-  const explicit = settings.restoreLastSessionMode;
-  if (explicit && VALID_MODES.includes(explicit)) return explicit;
-  if (settings.restoreLastSessionOnStartup === false) return "never";
-  return "ask";
-}
-
-/** Map a stored tab definition's connection type to a short display label. */
-function tabTypeLabel(tab: WorkspaceTabDef): string {
-  if (tab.agentRef) return "Agent";
-  const type = tab.inlineConfig?.type;
-  switch (type) {
-    case "ssh":
-      return "SSH";
-    case "serial":
-      return "Serial";
-    case "telnet":
-      return "Telnet";
-    case "docker":
-      return "Docker";
-    case "wsl":
-      return "WSL";
-    case "local":
-      return "Local";
-    default:
-      return type ? type.charAt(0).toUpperCase() + type.slice(1) : "Terminal";
-  }
-}
-
-/** Best-effort title for a stored tab when no explicit title was captured. */
-function tabFallbackTitle(tab: WorkspaceTabDef): string {
-  const cfg = tab.inlineConfig?.config as Record<string, unknown> | undefined;
-  const host = typeof cfg?.host === "string" ? cfg.host : undefined;
-  const user = typeof cfg?.username === "string" ? cfg.username : undefined;
-  if (host) return user ? `${user}@${host}` : host;
-  const device = typeof cfg?.device === "string" ? cfg.device : undefined;
-  if (device) return device;
-  return tabTypeLabel(tab);
-}
-
-/** Default TCP ports for host-based connection types, used when unspecified. */
-const DEFAULT_HOST_PORTS: Record<string, number> = { ssh: 22, telnet: 23 };
-
-/**
- * Resolve a stored tab's effective connection type and config, following a
- * `connectionRef` into the supplied saved connections when present. Returns
- * `undefined` when neither an inline config nor a resolvable reference exists.
- */
-function resolveTabConfig(
-  tab: WorkspaceTabDef,
-  connections: SavedConnection[]
-): { type: string; config: Record<string, unknown> } | undefined {
-  if (tab.inlineConfig) return tab.inlineConfig;
-  if (tab.connectionRef) {
-    const saved = connections.find((c) => c.id === tab.connectionRef);
-    if (saved) {
-      return { type: saved.config.type, config: saved.config.config as Record<string, unknown> };
-    }
-  }
-  return undefined;
-}
-
-/**
- * Derive the reachability {@link RestoreTabTarget} for a stored tab. Host-based
- * types (SSH/telnet) yield a `host` target; serial yields a `serial` target;
- * agent references yield an `agent` target; everything else (local, docker,
- * WSL, unresolved refs) is `local` and is not network-probed.
- */
-function deriveTabTarget(tab: WorkspaceTabDef, connections: SavedConnection[]): RestoreTabTarget {
-  if (tab.agentRef) return { kind: "agent", agentId: tab.agentRef.agentId };
-
-  const resolved = resolveTabConfig(tab, connections);
-  const type = resolved?.type;
-  const config = resolved?.config ?? {};
-
-  if (type === "ssh" || type === "telnet") {
-    const host = typeof config.host === "string" ? config.host : undefined;
-    if (host) {
-      const port = typeof config.port === "number" ? config.port : DEFAULT_HOST_PORTS[type];
-      return { kind: "host", host, port };
-    }
-  }
-
-  if (type === "serial") {
-    const device =
-      typeof config.device === "string"
-        ? config.device
-        : typeof config.port === "string"
-          ? config.port
-          : undefined;
-    if (device) return { kind: "serial", device };
-  }
-
-  return { kind: "local" };
+export async function resolveRestoreMode(settings: AppSettings): Promise<RestoreLastSessionMode> {
+  return await invoke<RestoreLastSessionMode>("restore_resolve_mode", { settings });
 }
 
 /**
@@ -190,24 +99,18 @@ function deriveTabTarget(tab: WorkspaceTabDef, connections: SavedConnection[]): 
  *
  * `connections` (optional) lets `connectionRef` tabs resolve their host/serial
  * target for the reachability probe; pass the loaded connections when available.
+ *
+ * The summarisation is pure and runs in `core::restore_mode` (#2200): each tab
+ * carries the {@link RestoreTabTarget} the probe needs, but the **asynchronous
+ * reachability probe itself stays client-side** ({@link RestoreTabInfo.reachability}
+ * is populated afterwards by `probeRestoreTargets`). That is the async-probe
+ * seam — pure decision server-side, network I/O on the client.
  */
-export function summarizeLastSession(
+export async function summarizeLastSession(
   session: LastSession,
   connections: SavedConnection[] = []
-): RestorePrompt {
-  const tabs: RestoreTabInfo[] = [];
-  for (const group of session.tabGroups) {
-    for (const leaf of getWorkspaceLeaves(group.layout)) {
-      for (const tab of leaf.tabs) {
-        tabs.push({
-          title: tab.title?.trim() || tabFallbackTitle(tab),
-          typeLabel: tabTypeLabel(tab),
-          target: deriveTabTarget(tab, connections),
-        });
-      }
-    }
-  }
-  return { tabCount: tabs.length, tabs };
+): Promise<RestorePrompt> {
+  return await invoke<RestorePrompt>("restore_summarize_last_session", { session, connections });
 }
 
 /**
@@ -219,63 +122,15 @@ export function summarizeLastSession(
  * groups whose layout empties out are removed. `activeGroupIndex` is remapped to
  * the surviving group nearest the original active one; `windows` are preserved
  * untouched (an emptied window still round-trips, per #1902).
+ *
+ * Delegates to the `restore_filter_session_by_selection` core command (#2200).
  */
-export function filterSessionBySelection(
+export async function filterSessionBySelection(
   session: LastSession,
   selected: ReadonlySet<number>
-): LastSession {
-  let flatIndex = 0;
-
-  const filterNode = (node: WorkspaceLayoutNode): WorkspaceLayoutNode | null => {
-    if (node.type === "leaf") {
-      const tabs = node.tabs.filter(() => selected.has(flatIndex++));
-      return tabs.length > 0 ? { ...node, tabs } : null;
-    }
-
-    const keptChildren: WorkspaceLayoutNode[] = [];
-    const keptOriginalIndices: number[] = [];
-    node.children.forEach((child, i) => {
-      const filtered = filterNode(child);
-      if (filtered) {
-        keptChildren.push(filtered);
-        keptOriginalIndices.push(i);
-      }
-    });
-
-    if (keptChildren.length === 0) return null;
-    if (keptChildren.length === 1) return keptChildren[0];
-
-    let sizes = node.sizes;
-    if (sizes) {
-      const chosen = keptOriginalIndices.map((i) => sizes?.[i] ?? 0);
-      const total = chosen.reduce((a, b) => a + b, 0);
-      sizes = total > 0 ? chosen.map((s) => (s / total) * 100) : undefined;
-    }
-    return { ...node, children: keptChildren, ...(sizes ? { sizes } : {}) };
-  };
-
-  const groups: WorkspaceTabGroupDef[] = [];
-  const keptGroupIndices: number[] = [];
-  session.tabGroups.forEach((group, i) => {
-    const layout = filterNode(group.layout);
-    if (layout) {
-      groups.push({ ...group, layout });
-      keptGroupIndices.push(i);
-    }
+): Promise<LastSession> {
+  return await invoke<LastSession>("restore_filter_session_by_selection", {
+    session,
+    selected: [...selected],
   });
-
-  // Remap the active group to a surviving one: the same group if it survived,
-  // otherwise the nearest surviving group at or after it, else the first.
-  let activeGroupIndex = 0;
-  if (keptGroupIndices.length > 0) {
-    const exact = keptGroupIndices.indexOf(session.activeGroupIndex);
-    if (exact >= 0) {
-      activeGroupIndex = exact;
-    } else {
-      const after = keptGroupIndices.findIndex((i) => i >= session.activeGroupIndex);
-      activeGroupIndex = after >= 0 ? after : keptGroupIndices.length - 1;
-    }
-  }
-
-  return { ...session, tabGroups: groups, activeGroupIndex };
 }


### PR DESCRIPTION
## What & why

Follow-up to #2145 / #2151 (Phase 3). #2145 ported the startup session-restore decision logic to `core/src/restore_mode.rs` as a proven-equivalent Rust twin, but that port was **dormant** — no command called it and the frontend still ran its own `src/utils/restoreMode.ts` logic. This wires the core port into the live restore path and retires the TypeScript duplicates.

Closes #2200.

## Changes

- **New stateless Tauri command surface** (`src-tauri/src/commands/restore_mode.rs`), thin wrappers over the core functions:
  - `restore_resolve_mode(settings)`
  - `restore_summarize_last_session(session, connections)`
  - `restore_filter_session_by_selection(session, selected)`
- **`src/utils/restoreMode.ts` logic retired** — the three exported functions now delegate to those commands (and are `async`). All **types are kept** (`RestoreLastSessionMode`, `RestoreReachability`, `RestoreTabTarget`, `RestoreTabInfo`, `RestorePrompt`), so `SessionRestoreDialog`, `restoreReachability.ts`, and the store keep their type imports unchanged. The private helpers (`deriveTabTarget`, `tabTypeLabel`, `tabFallbackTitle`, `resolveTabConfig`, `VALID_MODES`, `DEFAULT_HOST_PORTS`) are gone — that logic now lives only in Rust.
- **Callers updated to await**: `App.tsx` (startup), `appStore.ts` (`saveLastSession`, `restoreLastSession`, `promptRestore`), and `GeneralSettings.tsx` (settings dropdown resolves the mode via a `useEffect`, seeded synchronously from the explicit mode to avoid flicker).

## The async-probe seam (partial lift, as #2200 anticipated)

`summarizeLastSession` is **pure** and moves fully to core: it produces each tab's `RestoreTabTarget`. The **asynchronous reachability probe stays client-side** (`restoreReachability.ts` + `probeRestorePromptReachability`), consuming those targets and patching `reachability`/`unreachableReason` onto the prompt afterwards. The two were already decoupled through the `target` field, so the seam is clean — pure decision server-side, network I/O on the client. This is documented in the command module and in `restoreMode.ts`.

## Parity / tests

- Behavioural parity with the retired TS logic is guaranteed by the existing **#2145 golden vectors** (`core/tests/restore_mode_golden.rs`, extracted from the original `restoreMode.test.ts` cases) — the core functions the commands call still pass them unchanged.
- Rust: added delegation tests in the command module (args pass straight through to core).
- Frontend: `restoreMode.test.ts` rewritten to verify the wrappers delegate to the right command with the right argument shape (the behavioural cases now belong to the Rust golden vectors).
- Green locally: `cargo test`/`clippy -D warnings`/`fmt`, frontend `tsc --noEmit`, ESLint, Prettier, and the affected Vitest suites.

## Notes

Non-user-facing refactor (behaviour unchanged), so no changelog fragment.