### PR TITLE
feat(network): route network tools to the agent via the run-location resolver (Closes #2190)

### DIFF
--- a/docs/changes/dev1/feature/2190-network-tool-run-location.md
+++ b/docs/changes/dev1/feature/2190-network-tool-run-location.md
@@ -1,0 +1,13 @@
+### Added
+
+- Network diagnostic tools (**ping**, **traceroute**, **port scan**, **DNS
+  lookup**, **Wake-on-LAN**) can now run on a **remote agent** instead of the
+  desktop, so a probe reflects the agent's network vantage rather than the
+  desktop's (part of the agent-centric stateless-UI port, #2154 / #2139). Where a
+  tool runs is a per-tool desktop-side preference (`set_network_tool_run_location`);
+  when it resolves to an agent, the desktop proxies the call to the agent's
+  existing `network.*` methods and surfaces the results through the **same events**
+  as a local run. Every tool still defaults to **This computer**, so this is
+  strictly opt-in with no behaviour change until the run-location selector UI
+  (#2191) records a non-default choice. The **HTTP monitor** stays desktop-only —
+  the agent has no HTTP-monitor method, so it is never offered an agent.

--- a/src-tauri/src/commands/network.rs
+++ b/src-tauri/src/commands/network.rs
@@ -4,6 +4,8 @@
 //! background tasks and stream results back via Tauri events. One-shot
 //! operations (DNS, WoL, open ports) return immediately.
 
+use std::sync::Arc;
+
 use tauri::{AppHandle, Emitter, State};
 
 use termihub_core::network::{
@@ -13,8 +15,42 @@ use termihub_core::network::{
 use termihub_core::service::ServiceInfo;
 
 use crate::network::http_monitor::{HttpMonitorConfig, HttpMonitorState};
-use crate::network::NetworkManager;
+use crate::network::{agent_tools, NetworkManager};
+use crate::run_location::{ResolvedLocation, RunLocation};
+use crate::terminal::agent_manager::AgentRpcClient;
 use crate::utils::errors::TerminalError;
+
+/// Fetch the agent RPC client when a tool's run-location resolves to an agent
+/// (#2190). `Ok(None)` for a local run; an error when an agent is requested but
+/// no agent client is available.
+fn agent_client_for(
+    manager: &NetworkManager,
+    location: &ResolvedLocation,
+) -> Result<Option<Arc<dyn AgentRpcClient>>, TerminalError> {
+    match location {
+        ResolvedLocation::Local => Ok(None),
+        ResolvedLocation::Agent(_) => manager
+            .agent_rpc_client()
+            .map(Some)
+            .ok_or_else(|| TerminalError::NetworkError("agent manager is not available".into())),
+    }
+}
+
+/// Set (or clear) the run-location preference for a network tool (#2190).
+///
+/// Recording an agent routes that tool's next invocation to the agent's
+/// `network.*` methods; [`RunLocation::ThisComputer`] clears the preference
+/// (back to running on the desktop). The desktop-only HTTP monitor refuses an
+/// agent location. Backs the run-location selector UI (#2191) and is the hook
+/// for exercising agent-routed tools meanwhile.
+#[tauri::command]
+pub fn set_network_tool_run_location(
+    tool: String,
+    run_location: RunLocation,
+    manager: State<'_, NetworkManager>,
+) -> Result<(), TerminalError> {
+    manager.set_run_location(&tool, run_location)
+}
 
 // ── Port Scanner ─────────────────────────────────────────────────────────────
 
@@ -40,6 +76,12 @@ pub async fn network_port_scan(
     let targets = port_scan::parse_target_spec(&host)
         .map_err(|e| TerminalError::NetworkError(e.to_string()))?;
 
+    // Route by run-location (#2190). A tool with no recorded preference resolves
+    // local and takes the existing desktop path; an agent preference proxies the
+    // scan to that agent's `network.port_scan` and re-emits the same events.
+    let location = manager.resolve_tool_location(agent_tools::tool::PORT_SCAN)?;
+    let agent_client = agent_client_for(&manager, &location)?;
+
     let (task_id, cancel) = manager.register_task();
 
     let app_clone = app.clone();
@@ -50,45 +92,58 @@ pub async fn network_port_scan(
         let app = app_clone;
         let tid = task_id_clone.clone();
 
-        let on_result = {
-            let app = app.clone();
-            let tid = tid.clone();
-            move |result: PortScanResult| {
-                let _ = app.emit(
-                    "network-scan-result",
-                    serde_json::json!({
-                        "taskId": tid,
-                        "host": result.host,
-                        "port": result.port,
-                        "state": result.state,
-                        "latencyMs": result.latency_ms,
-                    }),
-                );
+        match location {
+            ResolvedLocation::Agent(agent_id) => {
+                let params = agent_tools::port_scan_params(&host, &ports, timeout_ms, concurrency);
+                let client = agent_client.expect("agent client present for agent location");
+                let (app2, tid2) = (app.clone(), tid.clone());
+                let _ = tokio::task::spawn_blocking(move || {
+                    agent_tools::dispatch_port_scan(&client, &agent_id, &app2, &tid2, params);
+                })
+                .await;
             }
-        };
+            ResolvedLocation::Local => {
+                let on_result = {
+                    let app = app.clone();
+                    let tid = tid.clone();
+                    move |result: PortScanResult| {
+                        let _ = app.emit(
+                            "network-scan-result",
+                            serde_json::json!({
+                                "taskId": tid,
+                                "host": result.host,
+                                "port": result.port,
+                                "state": result.state,
+                                "latencyMs": result.latency_ms,
+                            }),
+                        );
+                    }
+                };
 
-        let summary = port_scan::scan_targets(
-            &targets,
-            &port_list,
-            timeout_ms.unwrap_or(2000),
-            concurrency.unwrap_or(100),
-            on_result,
-            cancel,
-        )
-        .await;
+                let summary = port_scan::scan_targets(
+                    &targets,
+                    &port_list,
+                    timeout_ms.unwrap_or(2000),
+                    concurrency.unwrap_or(100),
+                    on_result,
+                    cancel,
+                )
+                .await;
 
-        match summary {
-            Ok(s) => {
-                let _ = app.emit(
-                    "network-scan-complete",
-                    serde_json::json!({ "taskId": &tid, "summary": s }),
-                );
-            }
-            Err(e) => {
-                let _ = app.emit(
-                    "network-scan-error",
-                    serde_json::json!({ "taskId": &tid, "error": e.to_string() }),
-                );
+                match summary {
+                    Ok(s) => {
+                        let _ = app.emit(
+                            "network-scan-complete",
+                            serde_json::json!({ "taskId": &tid, "summary": s }),
+                        );
+                    }
+                    Err(e) => {
+                        let _ = app.emit(
+                            "network-scan-error",
+                            serde_json::json!({ "taskId": &tid, "error": e.to_string() }),
+                        );
+                    }
+                }
             }
         }
 
@@ -151,6 +206,12 @@ pub async fn network_ping_start(
     manager: State<'_, NetworkManager>,
     app: AppHandle,
 ) -> Result<String, TerminalError> {
+    // Route by run-location (#2190): a recorded agent preference proxies the ping
+    // to that agent's `network.ping` (a bounded, collect-and-return batch) and
+    // re-emits the same events; no preference keeps the existing desktop path.
+    let location = manager.resolve_tool_location(agent_tools::tool::PING)?;
+    let agent_client = agent_client_for(&manager, &location)?;
+
     let (task_id, cancel) = manager.register_task();
 
     let app_clone = app.clone();
@@ -162,35 +223,50 @@ pub async fn network_ping_start(
         let app = app_clone;
         let tid = task_id_clone.clone();
 
-        let on_result = {
-            let app = app.clone();
-            let tid = tid.clone();
-            move |result| {
-                let _ = app.emit(
-                    "network-ping-result",
-                    serde_json::json!({ "taskId": &tid, "result": result }),
-                );
+        match location {
+            ResolvedLocation::Agent(agent_id) => {
+                let params = agent_tools::ping_params(&host, interval_ms, count);
+                let client = agent_client.expect("agent client present for agent location");
+                let (app2, tid2) = (app.clone(), tid.clone());
+                let _ = tokio::task::spawn_blocking(move || {
+                    agent_tools::dispatch_ping(&client, &agent_id, &app2, &tid2, params);
+                })
+                .await;
             }
-        };
+            ResolvedLocation::Local => {
+                let on_result = {
+                    let app = app.clone();
+                    let tid = tid.clone();
+                    move |result| {
+                        let _ = app.emit(
+                            "network-ping-result",
+                            serde_json::json!({ "taskId": &tid, "result": result }),
+                        );
+                    }
+                };
 
-        let result =
-            ping::ping_stream(&host, interval_ms.unwrap_or(1000), count, on_result, cancel).await;
-        // Check cancellation *after* the stream ends so Stop is reported as
-        // canceled rather than completed (the token is set while it runs).
-        let canceled = cancel_clone.is_cancelled();
+                let result =
+                    ping::ping_stream(&host, interval_ms.unwrap_or(1000), count, on_result, cancel)
+                        .await;
+                // Check cancellation *after* the stream ends so Stop is reported
+                // as canceled rather than completed (the token is set while it
+                // runs).
+                let canceled = cancel_clone.is_cancelled();
 
-        match result {
-            Ok(stats) => {
-                let _ = app.emit(
-                    "network-ping-complete",
-                    serde_json::json!({ "taskId": &tid, "stats": stats, "canceled": canceled }),
-                );
-            }
-            Err(e) => {
-                let _ = app.emit(
-                    "network-ping-error",
-                    serde_json::json!({ "taskId": &tid, "error": e.to_string() }),
-                );
+                match result {
+                    Ok(stats) => {
+                        let _ = app.emit(
+                            "network-ping-complete",
+                            serde_json::json!({ "taskId": &tid, "stats": stats, "canceled": canceled }),
+                        );
+                    }
+                    Err(e) => {
+                        let _ = app.emit(
+                            "network-ping-error",
+                            serde_json::json!({ "taskId": &tid, "error": e.to_string() }),
+                        );
+                    }
+                }
             }
         }
 
@@ -364,17 +440,40 @@ mod tests {
 }
 
 /// Perform a DNS lookup and return the records immediately.
+///
+/// Routes by run-location (#2190): an agent preference proxies to the agent's
+/// `network.dns_lookup` (returning the same `DnsResult` shape); no preference
+/// resolves on the desktop as before.
 #[tauri::command]
 pub async fn network_dns_lookup(
     hostname: String,
     record_type: String,
     server: Option<String>,
+    manager: State<'_, NetworkManager>,
 ) -> Result<serde_json::Value, TerminalError> {
+    // Validate the record type locally so the error is identical regardless of
+    // where the lookup runs.
     let rtype = parse_record_type(&record_type)?;
-    let result = dns::dns_lookup(&hostname, rtype, server.as_deref())
-        .await
-        .map_err(|e| TerminalError::NetworkError(e.to_string()))?;
-    serde_json::to_value(result).map_err(|e| TerminalError::NetworkError(e.to_string()))
+
+    match manager.resolve_tool_location(agent_tools::tool::DNS)? {
+        ResolvedLocation::Agent(agent_id) => {
+            let client = manager.agent_rpc_client().ok_or_else(|| {
+                TerminalError::NetworkError("agent manager is not available".into())
+            })?;
+            let params = agent_tools::dns_params(&hostname, &record_type, server.as_deref());
+            tokio::task::spawn_blocking(move || {
+                client.send_request(&agent_id, "network.dns_lookup", params)
+            })
+            .await
+            .map_err(|e| TerminalError::NetworkError(e.to_string()))?
+        }
+        ResolvedLocation::Local => {
+            let result = dns::dns_lookup(&hostname, rtype, server.as_deref())
+                .await
+                .map_err(|e| TerminalError::NetworkError(e.to_string()))?;
+            serde_json::to_value(result).map_err(|e| TerminalError::NetworkError(e.to_string()))
+        }
+    }
 }
 
 // ── Open Ports ───────────────────────────────────────────────────────────────
@@ -401,6 +500,13 @@ pub async fn network_traceroute(
     manager: State<'_, NetworkManager>,
     app: AppHandle,
 ) -> Result<String, TerminalError> {
+    // Route by run-location (#2190): a recorded agent preference proxies the
+    // traceroute to that agent's `network.traceroute` (showing the agent's path
+    // to the target) and re-emits the same hop events; no preference keeps the
+    // existing desktop path.
+    let location = manager.resolve_tool_location(agent_tools::tool::TRACEROUTE)?;
+    let agent_client = agent_client_for(&manager, &location)?;
+
     let (task_id, cancel) = manager.register_task();
 
     let app_clone = app.clone();
@@ -411,31 +517,45 @@ pub async fn network_traceroute(
         let app = app_clone;
         let tid = task_id_clone.clone();
 
-        let on_hop = {
-            let app = app.clone();
-            let tid = tid.clone();
-            move |hop| {
-                let _ = app.emit(
-                    "network-traceroute-hop",
-                    serde_json::json!({ "taskId": &tid, "hop": hop }),
-                );
+        match location {
+            ResolvedLocation::Agent(agent_id) => {
+                let params = agent_tools::traceroute_params(&host, max_hops);
+                let client = agent_client.expect("agent client present for agent location");
+                let (app2, tid2) = (app.clone(), tid.clone());
+                let _ = tokio::task::spawn_blocking(move || {
+                    agent_tools::dispatch_traceroute(&client, &agent_id, &app2, &tid2, params);
+                })
+                .await;
             }
-        };
+            ResolvedLocation::Local => {
+                let on_hop = {
+                    let app = app.clone();
+                    let tid = tid.clone();
+                    move |hop| {
+                        let _ = app.emit(
+                            "network-traceroute-hop",
+                            serde_json::json!({ "taskId": &tid, "hop": hop }),
+                        );
+                    }
+                };
 
-        let result = traceroute::traceroute(&host, max_hops.unwrap_or(30), on_hop, cancel).await;
+                let result =
+                    traceroute::traceroute(&host, max_hops.unwrap_or(30), on_hop, cancel).await;
 
-        match result {
-            Ok(()) => {
-                let _ = app.emit(
-                    "network-traceroute-complete",
-                    serde_json::json!({ "taskId": &tid }),
-                );
-            }
-            Err(e) => {
-                let _ = app.emit(
-                    "network-traceroute-error",
-                    serde_json::json!({ "taskId": &tid, "error": e.to_string() }),
-                );
+                match result {
+                    Ok(()) => {
+                        let _ = app.emit(
+                            "network-traceroute-complete",
+                            serde_json::json!({ "taskId": &tid }),
+                        );
+                    }
+                    Err(e) => {
+                        let _ = app.emit(
+                            "network-traceroute-error",
+                            serde_json::json!({ "taskId": &tid, "error": e.to_string() }),
+                        );
+                    }
+                }
             }
         }
 
@@ -458,10 +578,30 @@ pub fn network_traceroute_cancel(
 // ── Wake-on-LAN ──────────────────────────────────────────────────────────────
 
 /// Send a Wake-on-LAN magic packet.
+///
+/// Routes by run-location (#2190): an agent preference sends the magic packet
+/// from the agent's LAN via `network.wol`; no preference sends it from the
+/// desktop as before.
 #[tauri::command]
-pub fn network_wol_send(mac: String, broadcast: String, port: u16) -> Result<(), TerminalError> {
-    wol::send_magic_packet(&mac, &broadcast, port)
-        .map_err(|e| TerminalError::NetworkError(e.to_string()))
+pub fn network_wol_send(
+    mac: String,
+    broadcast: String,
+    port: u16,
+    manager: State<'_, NetworkManager>,
+) -> Result<(), TerminalError> {
+    match manager.resolve_tool_location(agent_tools::tool::WOL)? {
+        ResolvedLocation::Agent(agent_id) => {
+            let client = manager.agent_rpc_client().ok_or_else(|| {
+                TerminalError::NetworkError("agent manager is not available".into())
+            })?;
+            let params = agent_tools::wol_params(&mac, &broadcast, port);
+            client
+                .send_request(&agent_id, "network.wol", params)
+                .map(|_| ())
+        }
+        ResolvedLocation::Local => wol::send_magic_packet(&mac, &broadcast, port)
+            .map_err(|e| TerminalError::NetworkError(e.to_string())),
+    }
 }
 
 /// List saved WoL devices.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1240,6 +1240,7 @@ pub fn run() {
             commands::network::network_http_monitor_stop_all,
             commands::network::network_http_monitor_list,
             commands::network::network_services_list,
+            commands::network::set_network_tool_run_location,
             // Embedded servers
             commands::embedded_servers::embedded_servers_services_list,
             commands::embedded_servers::list_embedded_servers,

--- a/src-tauri/src/network/agent_tools.rs
+++ b/src-tauri/src/network/agent_tools.rs
@@ -1,0 +1,309 @@
+//! Route desktop network-tool invocations to a remote agent (#2190).
+//!
+//! Part of the stateless-UI / agent-empowerment S-track (S2, part of #2154).
+//! When a network tool's run-location resolves to an agent — via the S1
+//! [`RunLocationResolver`](crate::run_location::RunLocationResolver) — the desktop
+//! does **not** run the local `termihub_core::network` path. It proxies the call
+//! to the agent's existing `network.*` JSON-RPC methods and re-emits the results
+//! as the *same* Tauri events the local path emits, so the frontend cannot tell
+//! where a tool ran. This mirrors the embedded-server (#2214) and tunnel (#2187)
+//! run-location wiring.
+//!
+//! The agent's `network.*` methods are **collect-and-return** — they gather every
+//! result before replying — so a streaming desktop tool (port scan, ping,
+//! traceroute) fans the agent's one batched reply back out as per-item events
+//! followed by the completion event. The result surface is identical to the
+//! local path because both sides serialize the same `termihub_core::network`
+//! types (camelCase).
+//!
+//! Run-location is a **desktop-side preference**: nothing here is baked into the
+//! payload sent to the agent — the agent is simply asked to run a network probe
+//! from its own vantage.
+
+use std::sync::Arc;
+
+use serde::de::DeserializeOwned;
+use serde_json::{json, Value};
+use tauri::{AppHandle, Emitter};
+
+use termihub_core::network::{PingResult, PortScanResult, TracerouteHop};
+
+use crate::run_location::Locality;
+use crate::terminal::agent_manager::AgentRpcClient;
+
+/// Run-location preference keys for the built-in network tools (#2190).
+///
+/// Each key identifies a tool **type** (not an instance) in the desktop-side
+/// per-tool run-location preference map on [`NetworkManager`](super::NetworkManager).
+pub mod tool {
+    /// Ping session — agent-routable (`network.ping`).
+    pub const PING: &str = "ping";
+    /// Traceroute — agent-routable (`network.traceroute`).
+    pub const TRACEROUTE: &str = "traceroute";
+    /// TCP port scan — agent-routable (`network.port_scan`).
+    pub const PORT_SCAN: &str = "port_scan";
+    /// DNS lookup — agent-routable (`network.dns_lookup`).
+    pub const DNS: &str = "dns";
+    /// Wake-on-LAN — agent-routable (`network.wol`).
+    pub const WOL: &str = "wol";
+    /// HTTP monitor — **desktop-only**: the agent deliberately excludes HTTP
+    /// monitoring, so it is never offered an agent (Open Design Decision #4).
+    pub const HTTP_MONITOR: &str = "http_monitor";
+}
+
+/// The [`Locality`] of a network tool (#2190).
+///
+/// Everything the agent exposes over `network.*` is [`Locality::LocalOrAgent`];
+/// the HTTP monitor is [`Locality::DesktopOnly`] because the agent has no
+/// HTTP-monitor method, so the resolver must never offer it an agent.
+pub fn locality_for(tool: &str) -> Locality {
+    match tool {
+        tool::HTTP_MONITOR => Locality::DesktopOnly,
+        _ => Locality::LocalOrAgent,
+    }
+}
+
+/// Fallback count for an agent-routed ping given no explicit count (#2190).
+///
+/// The agent's `network.ping` collects every echo before replying, so an
+/// unbounded (`count: None`) request would never return over a single blocking
+/// RPC. Bound it to the conventional `ping -c 4` default when the caller gave no
+/// count; an explicit count is always honoured.
+pub const AGENT_PING_DEFAULT_COUNT: u32 = 4;
+
+// ── Param builders (pure; snake_case, as the agent's serde structs parse) ─────
+
+/// Build `network.port_scan` params.
+pub fn port_scan_params(
+    host: &str,
+    ports: &str,
+    timeout_ms: Option<u64>,
+    concurrency: Option<usize>,
+) -> Value {
+    json!({
+        "host": host,
+        "ports": ports,
+        "timeout_ms": timeout_ms,
+        "concurrency": concurrency,
+    })
+}
+
+/// Build `network.ping` params, bounding an absent count (see
+/// [`AGENT_PING_DEFAULT_COUNT`]).
+pub fn ping_params(host: &str, interval_ms: Option<u64>, count: Option<u32>) -> Value {
+    json!({
+        "host": host,
+        "interval_ms": interval_ms,
+        "count": count.unwrap_or(AGENT_PING_DEFAULT_COUNT),
+    })
+}
+
+/// Build `network.traceroute` params.
+pub fn traceroute_params(host: &str, max_hops: Option<u8>) -> Value {
+    json!({ "host": host, "max_hops": max_hops })
+}
+
+/// Build `network.dns_lookup` params.
+pub fn dns_params(hostname: &str, record_type: &str, server: Option<&str>) -> Value {
+    json!({ "hostname": hostname, "record_type": record_type, "server": server })
+}
+
+/// Build `network.wol` params.
+pub fn wol_params(mac: &str, broadcast: &str, port: u16) -> Value {
+    json!({ "mac": mac, "broadcast": broadcast, "port": port })
+}
+
+// ── Dispatchers (blocking RPC + event re-emission) ────────────────────────────
+//
+// `AgentRpcClient::send_request` is blocking, so callers run these on a blocking
+// thread (`spawn_blocking`). Emission is via the same event names/shapes the
+// local desktop path uses, so results surface identically.
+
+/// Proxy a port scan to the agent and fan its batched reply out as the same
+/// `network-scan-*` events the local path emits.
+pub fn dispatch_port_scan(
+    client: &Arc<dyn AgentRpcClient>,
+    agent_id: &str,
+    app: &AppHandle,
+    task_id: &str,
+    params: Value,
+) {
+    match client.send_request(agent_id, "network.port_scan", params) {
+        Ok(reply) => {
+            for r in parse_list::<PortScanResult>(&reply, "results") {
+                let _ = app.emit(
+                    "network-scan-result",
+                    json!({
+                        "taskId": task_id,
+                        "host": r.host,
+                        "port": r.port,
+                        "state": r.state,
+                        "latencyMs": r.latency_ms,
+                    }),
+                );
+            }
+            let _ = app.emit(
+                "network-scan-complete",
+                json!({ "taskId": task_id, "summary": field(&reply, "summary") }),
+            );
+        }
+        Err(e) => emit_error(app, "network-scan-error", task_id, &e.to_string()),
+    }
+}
+
+/// Proxy a ping session to the agent and fan its batched reply out as the same
+/// `network-ping-*` events the local path emits.
+pub fn dispatch_ping(
+    client: &Arc<dyn AgentRpcClient>,
+    agent_id: &str,
+    app: &AppHandle,
+    task_id: &str,
+    params: Value,
+) {
+    match client.send_request(agent_id, "network.ping", params) {
+        Ok(reply) => {
+            for r in parse_list::<PingResult>(&reply, "results") {
+                let _ = app.emit(
+                    "network-ping-result",
+                    json!({ "taskId": task_id, "result": r }),
+                );
+            }
+            let _ = app.emit(
+                "network-ping-complete",
+                // An agent ping is a fixed-count batch, so it always runs to
+                // completion (never "canceled").
+                json!({ "taskId": task_id, "stats": field(&reply, "stats"), "canceled": false }),
+            );
+        }
+        Err(e) => emit_error(app, "network-ping-error", task_id, &e.to_string()),
+    }
+}
+
+/// Proxy a traceroute to the agent and fan its batched reply out as the same
+/// `network-traceroute-*` events the local path emits.
+pub fn dispatch_traceroute(
+    client: &Arc<dyn AgentRpcClient>,
+    agent_id: &str,
+    app: &AppHandle,
+    task_id: &str,
+    params: Value,
+) {
+    match client.send_request(agent_id, "network.traceroute", params) {
+        Ok(reply) => {
+            for hop in parse_list::<TracerouteHop>(&reply, "hops") {
+                let _ = app.emit(
+                    "network-traceroute-hop",
+                    json!({ "taskId": task_id, "hop": hop }),
+                );
+            }
+            let _ = app.emit("network-traceroute-complete", json!({ "taskId": task_id }));
+        }
+        Err(e) => emit_error(app, "network-traceroute-error", task_id, &e.to_string()),
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Deserialize `reply[key]` into a `Vec<T>`, defaulting to empty on any
+/// missing/unparseable field so a malformed reply degrades to "no results"
+/// rather than a panic.
+fn parse_list<T: DeserializeOwned>(reply: &Value, key: &str) -> Vec<T> {
+    reply
+        .get(key)
+        .and_then(|v| serde_json::from_value::<Vec<T>>(v.clone()).ok())
+        .unwrap_or_default()
+}
+
+/// Extract `reply[key]` as an owned [`Value`], or `null` when absent.
+fn field(reply: &Value, key: &str) -> Value {
+    reply.get(key).cloned().unwrap_or(Value::Null)
+}
+
+fn emit_error(app: &AppHandle, event: &str, task_id: &str, error: &str) {
+    let _ = app.emit(event, json!({ "taskId": task_id, "error": error }));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http_monitor_is_desktop_only_every_other_tool_is_routable() {
+        assert_eq!(locality_for(tool::HTTP_MONITOR), Locality::DesktopOnly);
+        for t in [
+            tool::PING,
+            tool::TRACEROUTE,
+            tool::PORT_SCAN,
+            tool::DNS,
+            tool::WOL,
+        ] {
+            assert_eq!(
+                locality_for(t),
+                Locality::LocalOrAgent,
+                "{t} must be routable"
+            );
+        }
+    }
+
+    #[test]
+    fn port_scan_params_are_snake_case() {
+        let p = port_scan_params("host.example", "1-1024", Some(2000), Some(100));
+        assert_eq!(p["host"], "host.example");
+        assert_eq!(p["ports"], "1-1024");
+        assert_eq!(p["timeout_ms"], 2000);
+        assert_eq!(p["concurrency"], 100);
+    }
+
+    #[test]
+    fn ping_params_bound_an_absent_count() {
+        // No count → the agent gets the bounded default, so its collect-and-return
+        // ping cannot run forever.
+        let p = ping_params("host.example", Some(1000), None);
+        assert_eq!(p["count"], AGENT_PING_DEFAULT_COUNT);
+        assert_eq!(p["interval_ms"], 1000);
+        // An explicit count is honoured verbatim.
+        let p = ping_params("host.example", None, Some(10));
+        assert_eq!(p["count"], 10);
+    }
+
+    #[test]
+    fn traceroute_and_dns_and_wol_params_shape() {
+        let t = traceroute_params("host.example", Some(20));
+        assert_eq!(t["host"], "host.example");
+        assert_eq!(t["max_hops"], 20);
+
+        let d = dns_params("example.com", "A", Some("1.1.1.1"));
+        assert_eq!(d["hostname"], "example.com");
+        assert_eq!(d["record_type"], "A");
+        assert_eq!(d["server"], "1.1.1.1");
+
+        let w = wol_params("aa:bb:cc:dd:ee:ff", "255.255.255.255", 9);
+        assert_eq!(w["mac"], "aa:bb:cc:dd:ee:ff");
+        assert_eq!(w["broadcast"], "255.255.255.255");
+        assert_eq!(w["port"], 9);
+    }
+
+    #[test]
+    fn parse_list_tolerates_missing_and_bad_fields() {
+        // Missing key → empty (no panic).
+        let empty: Vec<PortScanResult> = parse_list(&json!({}), "results");
+        assert!(empty.is_empty());
+
+        // Well-formed agent reply (camelCase, as the shared core type serializes)
+        // → parsed into the typed results the local path also emits.
+        let reply = json!({
+            "results": [
+                { "host": "10.0.0.1", "port": 22, "state": "open", "latencyMs": 3 }
+            ],
+            "summary": { "total": 1, "open": 1, "closed": 0, "filtered": 0, "elapsedMs": 5 }
+        });
+        let parsed: Vec<PortScanResult> = parse_list(&reply, "results");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].host, "10.0.0.1");
+        assert_eq!(parsed[0].port, 22);
+        assert_eq!(parsed[0].latency_ms, Some(3));
+        // `field` lifts the summary object out for the completion event.
+        assert_eq!(field(&reply, "summary")["open"], 1);
+        assert_eq!(field(&reply, "missing"), Value::Null);
+    }
+}

--- a/src-tauri/src/network/mod.rs
+++ b/src-tauri/src/network/mod.rs
@@ -4,6 +4,7 @@
 //! Manages running task lifetimes (port scans, ping sessions, traceroutes) and
 //! the persistent HTTP monitors.
 
+pub mod agent_tools;
 pub mod http_monitor;
 pub mod http_monitor_storage;
 pub mod wol_storage;
@@ -22,7 +23,8 @@ use http_monitor::{HttpMonitorConfig, HttpMonitorService, HttpMonitorState};
 use termihub_core::network::WolDevice;
 use termihub_core::service::{Service, ServiceInfo, ServiceRegistry};
 
-use crate::run_location::{ResolvedLocation, RunLocationResolver};
+use crate::run_location::{ResolvedLocation, RunLocation, RunLocationResolver};
+use crate::terminal::agent_manager::AgentRpcClient;
 use crate::utils::errors::TerminalError;
 
 /// Tauri event forwarded to the frontend for each HTTP monitor check.
@@ -45,9 +47,16 @@ pub struct NetworkManager {
     /// Desktop-side registry of run-location-routable services. The HTTP monitor
     /// is registered here (discovery, schema, capabilities) as the S2 pilot.
     service_registry: ServiceRegistry,
-    /// Resolver deciding where a service runs (local vs agent). S1 default is
-    /// always local — the run-location selector UI arrives in a later S-phase.
+    /// Resolver deciding where a tool/service runs (local vs agent). Honours the
+    /// per-tool preference in `run_locations`; a tool with no recorded preference
+    /// resolves local, so users see no behaviour change (#2190).
     run_location: RunLocationResolver,
+    /// Per-tool run-location preference — which machine each network tool runs on
+    /// (#2190). Keyed by the tool-type keys in [`agent_tools::tool`]. In-memory
+    /// today; the selector UI that records a non-default choice is a later
+    /// S-phase (#2191). An absent entry means [`RunLocation::ThisComputer`], the
+    /// desktop default and today's behaviour.
+    run_locations: Mutex<HashMap<String, RunLocation>>,
     /// Saved Wake-on-LAN devices (persisted to disk).
     wol_devices: Mutex<Vec<WolDevice>>,
     /// App config directory for persistence.
@@ -64,6 +73,7 @@ impl NetworkManager {
             http_monitors: Mutex::new(HashMap::new()),
             service_registry: build_service_registry(),
             run_location: RunLocationResolver::new(),
+            run_locations: Mutex::new(HashMap::new()),
             wol_devices: Mutex::new(Vec::new()),
             config_dir: PathBuf::new(),
             app_handle: Arc::new(Mutex::new(None)),
@@ -74,6 +84,74 @@ impl NetworkManager {
     /// HTTP monitor). Backs future discovery / the run-location selector UI.
     pub fn available_services(&self) -> Vec<ServiceInfo> {
         self.service_registry.available_services()
+    }
+
+    // ── Run-location routing (#2190) ─────────────────────────────────────────
+
+    /// Set (or clear) the run-location preference for a network tool (#2190).
+    ///
+    /// [`RunLocation::ThisComputer`] clears the entry (back to the desktop
+    /// default); a [`RunLocation::Agent`] records which agent should run the tool
+    /// on its next invocation. This is the desktop-side preference the S1
+    /// resolver was designed around; the selector UI that calls it lands in a
+    /// later S-phase (#2191), and it is the test hook for the agent-routed path
+    /// meanwhile.
+    ///
+    /// A [`Locality::DesktopOnly`] tool (the HTTP monitor) refuses an agent
+    /// location up front, so a forbidden choice never reaches the resolver.
+    pub fn set_run_location(&self, tool: &str, location: RunLocation) -> Result<(), TerminalError> {
+        // Validate desktop-only tools reject an agent request immediately.
+        self.run_location
+            .resolve(tool, agent_tools::locality_for(tool), &location)
+            .map_err(|e| TerminalError::NetworkError(e.to_string()))?;
+
+        let mut map = self
+            .run_locations
+            .lock()
+            .map_err(|_| TerminalError::InternalError("run-location lock poisoned".into()))?;
+        match location {
+            RunLocation::ThisComputer => {
+                map.remove(tool);
+            }
+            agent @ RunLocation::Agent(_) => {
+                map.insert(tool.to_string(), agent);
+            }
+        }
+        Ok(())
+    }
+
+    /// Read a tool's recorded run-location preference, defaulting to
+    /// [`RunLocation::ThisComputer`] when none is set (#2190).
+    fn requested_run_location(&self, tool: &str) -> RunLocation {
+        self.run_locations
+            .lock()
+            .ok()
+            .and_then(|map| map.get(tool).cloned())
+            .unwrap_or_default()
+    }
+
+    /// Resolve where a network tool should run from its recorded preference
+    /// (#2190). Defaults to [`ResolvedLocation::Local`] (no preference), and
+    /// refuses an agent for a [`Locality::DesktopOnly`] tool.
+    pub fn resolve_tool_location(&self, tool: &str) -> Result<ResolvedLocation, TerminalError> {
+        self.run_location
+            .resolve(
+                tool,
+                agent_tools::locality_for(tool),
+                &self.requested_run_location(tool),
+            )
+            .map_err(|e| TerminalError::NetworkError(e.to_string()))
+    }
+
+    /// The agent RPC client from Tauri managed state, if available (#2190).
+    ///
+    /// `None` before the app is fully set up (e.g. in unit tests without a live
+    /// Tauri app); the agent-routed path treats that as "agent unavailable".
+    pub fn agent_rpc_client(&self) -> Option<Arc<dyn AgentRpcClient>> {
+        use tauri::Manager;
+        let app = self.app_handle()?;
+        app.try_state::<Arc<dyn AgentRpcClient>>()
+            .map(|state| (*state).clone())
     }
 
     /// Initialise the manager with the app config directory and app handle.
@@ -169,13 +247,14 @@ impl NetworkManager {
     /// forwards them to the [`HTTP_MONITOR_CHECK_EVENT`] Tauri event so the
     /// frontend contract is unchanged.
     fn spawn_http_monitor(&self, config: HttpMonitorConfig) -> Result<String, TerminalError> {
-        match self.run_location.resolve_default() {
+        // The HTTP monitor is desktop-only (Open Design Decision #4): the agent
+        // has no HTTP-monitor method, so the resolver refuses an agent location
+        // for it and it always runs locally (#2190).
+        match self.resolve_tool_location(agent_tools::tool::HTTP_MONITOR)? {
             ResolvedLocation::Local => {}
             ResolvedLocation::Agent(agent) => {
-                // The run-location selector UI (which could request an agent) is
-                // a later S-phase; today the resolver always returns local.
                 return Err(TerminalError::InternalError(format!(
-                    "agent-hosted HTTP monitors are not yet supported (requested '{agent}')"
+                    "HTTP monitors are desktop-only and cannot run on an agent (requested '{agent}')"
                 )));
             }
         }
@@ -497,6 +576,81 @@ mod tests {
         assert!(monitor.capabilities.emits_events);
         // A network probe may run on an agent — not desktop-only.
         assert!(!monitor.capabilities.desktop_only);
+    }
+
+    // ── Run-location routing (#2190) ─────────────────────────────────────────
+
+    #[test]
+    fn tools_default_to_local_with_no_preference() {
+        let mgr = NetworkManager::new();
+        for t in [
+            agent_tools::tool::PING,
+            agent_tools::tool::TRACEROUTE,
+            agent_tools::tool::PORT_SCAN,
+            agent_tools::tool::DNS,
+            agent_tools::tool::WOL,
+            agent_tools::tool::HTTP_MONITOR,
+        ] {
+            assert_eq!(
+                mgr.resolve_tool_location(t).expect("resolve"),
+                ResolvedLocation::Local,
+                "{t} must default to local"
+            );
+        }
+    }
+
+    #[test]
+    fn recording_an_agent_routes_a_routable_tool_to_it() {
+        let mgr = NetworkManager::new();
+        mgr.set_run_location(
+            agent_tools::tool::PING,
+            RunLocation::Agent("build-box".into()),
+        )
+        .expect("set agent");
+        assert_eq!(
+            mgr.resolve_tool_location(agent_tools::tool::PING).unwrap(),
+            ResolvedLocation::Agent("build-box".into())
+        );
+        // Other tools are unaffected — the preference is per-tool.
+        assert_eq!(
+            mgr.resolve_tool_location(agent_tools::tool::DNS).unwrap(),
+            ResolvedLocation::Local
+        );
+    }
+
+    #[test]
+    fn this_computer_clears_a_recorded_preference() {
+        let mgr = NetworkManager::new();
+        mgr.set_run_location(
+            agent_tools::tool::TRACEROUTE,
+            RunLocation::Agent("a1".into()),
+        )
+        .expect("set agent");
+        mgr.set_run_location(agent_tools::tool::TRACEROUTE, RunLocation::ThisComputer)
+            .expect("clear");
+        assert_eq!(
+            mgr.resolve_tool_location(agent_tools::tool::TRACEROUTE)
+                .unwrap(),
+            ResolvedLocation::Local
+        );
+    }
+
+    #[test]
+    fn http_monitor_refuses_an_agent_location() {
+        let mgr = NetworkManager::new();
+        // Setting an agent location on the desktop-only HTTP monitor is rejected
+        // up front, so nothing that must stay local is ever offered an agent.
+        let err = mgr.set_run_location(
+            agent_tools::tool::HTTP_MONITOR,
+            RunLocation::Agent("a1".into()),
+        );
+        assert!(err.is_err(), "http monitor must refuse an agent location");
+        // And it still resolves local.
+        assert_eq!(
+            mgr.resolve_tool_location(agent_tools::tool::HTTP_MONITOR)
+                .unwrap(),
+            ResolvedLocation::Local
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Wires the desktop network diagnostic tools — **ping, traceroute, port scan, DNS lookup, Wake-on-LAN** — through the S1 `RunLocationResolver` so each can execute on a **remote agent** instead of the desktop, reflecting the agent's network vantage. This is the S2 network-tool remainder of the stateless-UI port; it mirrors the embedded-server (#2214) and tunnel (#2187) run-location wiring.

Closes #2190
Part of #2154

## How it routes

- Run-location is a **per-tool desktop-side preference** (`set_network_tool_run_location(tool, run_location)` on `NetworkManager`), keyed by tool type — never baked into the agent payload. Absent preference ⇒ `ThisComputer`, so **behaviour is unchanged** until the selector UI (#2191) records a non-default choice.
- Each tool command resolves via `NetworkManager::resolve_tool_location`. On `Agent(id)` it proxies to the agent's existing `network.*` JSON-RPC method (the agent already exposes these) and **re-emits the same Tauri events / returns the same shapes** as a local run, so the frontend cannot tell where a tool ran. The agent's methods are collect-and-return, so a streaming tool (port scan/ping/traceroute) fans the batched reply back out as per-item events + the completion event.
- The **HTTP monitor is marked desktop-only** (`Locality::DesktopOnly`) — the agent has no HTTP-monitor method — so the resolver refuses it an agent and `set_network_tool_run_location` rejects an agent choice up front (Open Design Decision #4).
- An agent-routed ping with no explicit count is bounded to `ping -c 4` so the agent's collect-and-return `network.ping` cannot block forever.

## New code

- `src-tauri/src/network/agent_tools.rs` — tool keys, `locality_for`, pure param builders, and the blocking-RPC dispatchers that re-emit events.
- `NetworkManager` gains the per-tool preference map + `set_run_location` / `resolve_tool_location` / `agent_rpc_client`.
- Command routing in `commands/network.rs` + the new `set_network_tool_run_location` command (registered in `lib.rs`).

## Tests

- Unit tests for routing decisions (default-local, agent routing, clear, HTTP-monitor refusal), locality, param snake-casing, ping count-bounding, and reply parsing.
- **Local verification**: drove the agent binary (`--stdio`) directly through `network.dns_lookup` (real `example.com` A records) and `network.ping` (3-echo batch + stats) — both returned the exact camelCase shapes the desktop dispatcher deserializes and re-emits. `network.traceroute` is reachable but needs raw-socket privileges an unprivileged local agent lacks (it errors cleanly through the error path); a privileged container run exercises the full hop path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)