### PR TITLE
feat(network): run-location selector UI for network tools and servers (Closes #2191)

### DIFF
--- a/docs/changes/dev1/feature/2191-run-location-selector-ui.md
+++ b/docs/changes/dev1/feature/2191-run-location-selector-ui.md
@@ -1,0 +1,14 @@
+### Added
+
+- Network Tools and embedded servers now carry a per-item **"Run on"**
+  run-location selector (This computer / an agent), the S2 capstone UI (#2191).
+  Each network-tool panel gains a "Run on" control at its top, and each
+  embedded-server row gains one in its details; both default to **This
+  computer** and opt into an agent only when you pick one. Desktop-only items
+  never offer an agent — the HTTP monitor, ping sweep and open-ports show only
+  "This computer" (Open Design Decision #4). The selection is recorded on the
+  desktop backend (`set_network_tool_run_location` /
+  `set_embedded_server_run_location`), which routes the tool's next invocation
+  or the server's next start to the chosen host. A new shared
+  `RunLocationSelect` control, composed from the `Select` primitive and reusing
+  the tunnel host control's run-location model, backs both surfaces.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3174,3 +3174,36 @@ app. The fix portals these into the dialog's own content node (via the shared
 2. Reorder, edit, and delete steps as normal to confirm the fix changed nothing
    else about the editor's behavior.
 3. Save the workflow and confirm it persists with the steps you added.
+
+### Run-location "Run on" selector — Network Tools & Servers (#2191)
+
+The selector, its desktop-only gating, and the backend wiring are covered by
+component tests (`RunLocationSelect.test.tsx`, `NetworkToolRunLocation.test.tsx`,
+`EmbeddedServerRunLocation.test.tsx`, `runLocation.test.ts`,
+`runLocationStore.test.ts`). This manual pass confirms an agent choice actually
+routes execution end-to-end, which per-PR CI cannot (it needs a live agent).
+
+**Prerequisites.** A configured remote agent that connects successfully (see
+"Parallel test isolation" for a dev agent, or any reachable agent).
+
+**Network tool runs on the agent.**
+
+1. Open a Network Tool (e.g. **Ping**). Confirm a **"Run on"** control appears at
+   the top of the panel, defaulting to **This computer**.
+2. Open it → confirm **This computer** plus one **Agent · «name»** entry per
+   connected agent. Pick the agent.
+3. Run the tool against a host reachable from the agent's network → confirm the
+   result reflects the **agent's** vantage (e.g. a host only the agent can reach
+   resolves/pings), and the control keeps showing the agent.
+4. Open the **HTTP monitor**, **Ping sweep**, and **Open ports** tools → confirm
+   the "Run on" control is present but offers **only This computer** (desktop-only,
+   Open Design Decision #4).
+
+**Embedded server hosted on the agent.**
+
+1. In the **Services** sidebar, confirm each server row shows a **"Run on"**
+   control in its details, defaulting to **This computer**.
+2. Pick an agent, then **Start** the server → confirm it comes up hosted on the
+   agent (reachable on the agent's network / port bound there), not the desktop.
+3. Switch back to **This computer** and restart → confirm it is hosted locally
+   again.

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerItem.tsx
@@ -6,6 +6,9 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { Button, toast, Tooltip } from "@/components/ui";
 import { SidebarListItem, SidebarStatusDot } from "@/components/SidebarListItem";
 import type { SidebarStatusTone } from "@/components/SidebarListItem";
+import { RunLocationSelect } from "@/components/RunLocationSelect";
+import type { RemoteAgentDefinition } from "@/types/connection";
+import { THIS_COMPUTER, type RunLocation } from "@/utils/runLocation";
 import {
   EmbeddedServerConfig,
   ServerState,
@@ -17,6 +20,12 @@ import {
 interface Props {
   config: EmbeddedServerConfig;
   state: ServerState | undefined;
+  /** Agents offered as run targets for this server's "Run on" selector. */
+  agents?: RemoteAgentDefinition[];
+  /** The server's current run-location (This computer or an agent). */
+  runLocation?: RunLocation;
+  /** Called when the user picks a new run-location for this server. */
+  onRunLocationChange?: (location: RunLocation) => void;
   onStart: (id: string) => void | Promise<void>;
   onStop: (id: string) => void | Promise<void>;
   onEdit: (id: string) => void;
@@ -66,6 +75,9 @@ function isActive(status: ServerStatus | undefined): boolean {
 export function EmbeddedServerItem({
   config,
   state,
+  agents = [],
+  runLocation = THIS_COMPUTER,
+  onRunLocationChange,
   onStart,
   onStop,
   onEdit,
@@ -218,6 +230,22 @@ export function EmbeddedServerItem({
               {status === "error" && state?.error && (
                 <span className="sidebar-list-item__error">{state.error}</span>
               )}
+              {/* Run-location selector (#2191). Stop click/double-click from
+                  bubbling to the row's edit/context handlers. */}
+              <span
+                className="server-item__runon"
+                onClick={(e) => e.stopPropagation()}
+                onDoubleClick={(e) => e.stopPropagation()}
+              >
+                <span className="server-item__runon-label">Run on</span>
+                <RunLocationSelect
+                  value={runLocation}
+                  agents={agents}
+                  onChange={onRunLocationChange ?? (() => {})}
+                  aria-label={`Run ${config.name} on`}
+                  data-testid={`server-runloc-${config.id}`}
+                />
+              </span>
             </>
           }
         />

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerRunLocation.test.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerRunLocation.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Wiring tests for the per-server "Run on" run-location selector (#2191):
+ * picking an agent records the preference on the desktop backend and mirrors it
+ * in the run-location store, and a backend rejection rolls the mirror back.
+ *
+ * The Radix-backed selector is replaced with a trivial harness so the wiring is
+ * tested without driving Radix's portal/pointer machinery in jsdom.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import type { EmbeddedServerConfig } from "@/types/embeddedServer";
+import { setEmbeddedServerRunLocation } from "@/services/embeddedServerApi";
+import { useRunLocationStore } from "@/store/runLocationStore";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+import { EmbeddedServerSidebar } from "./EmbeddedServerSidebar";
+
+const toastError = vi.fn();
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return {
+    ...actual,
+    toast: {
+      success: vi.fn(),
+      error: (...args: unknown[]) => toastError(...args),
+      info: vi.fn(),
+      loading: vi.fn(),
+      dismiss: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/components/RunLocationSelect", () => ({
+  RunLocationSelect: ({
+    value,
+    onChange,
+    ...rest
+  }: {
+    value: { kind: string; agentId?: string };
+    onChange: (loc: { kind: string; agentId?: string }) => void;
+    "data-testid"?: string;
+  }) => (
+    <div
+      data-testid={rest["data-testid"]}
+      data-value={value.kind === "agent" ? `agent:${value.agentId}` : "this"}
+    >
+      <button data-testid="pick-agent" onClick={() => onChange({ kind: "agent", agentId: "a1" })}>
+        agent
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/services/embeddedServerApi", () => ({
+  setEmbeddedServerRunLocation: vi.fn(() => Promise.resolve()),
+  listNetworkInterfaces: vi.fn(() => Promise.resolve([{ name: "Loopback", addr: "127.0.0.1" }])),
+}));
+
+vi.mock("@/store/appStore", () => {
+  const state: Record<string, unknown> = {};
+  const useAppStore = (selector: (s: Record<string, unknown>) => unknown) => selector(state);
+  useAppStore.setState = (patch: Record<string, unknown>) => Object.assign(state, patch);
+  return { useAppStore };
+});
+
+function makeServer(id: string, name: string): EmbeddedServerConfig {
+  return {
+    id,
+    name,
+    serverType: "http",
+    rootDirectory: "/tmp",
+    bindHost: "127.0.0.1",
+    port: 8080,
+    autoStart: false,
+    readOnly: false,
+    directoryListing: true,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function seedStore() {
+  (useAppStore as unknown as { setState: (p: Record<string, unknown>) => void }).setState({
+    embeddedServers: [makeServer("srv-1", "Docs")],
+    embeddedServerStates: {},
+    remoteAgents: [
+      {
+        id: "a1",
+        name: "build-server",
+        config: {},
+        agentSettings: {},
+        isExpanded: false,
+        connectionState: "connected",
+      },
+    ],
+    saveEmbeddedServer: vi.fn(() => Promise.resolve()),
+    deleteEmbeddedServer: vi.fn(() => Promise.resolve()),
+    startEmbeddedServer: vi.fn(() => Promise.resolve()),
+    stopEmbeddedServer: vi.fn(() => Promise.resolve()),
+  });
+}
+
+describe("EmbeddedServer run-location wiring", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    seedStore();
+    useRunLocationStore.setState({ networkToolLocations: {}, serverLocations: {} });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("records an agent choice on the backend and mirrors it in the store", async () => {
+    act(() =>
+      root.render(
+        <TooltipProvider>
+          <EmbeddedServerSidebar />
+        </TooltipProvider>
+      )
+    );
+    act(() => {
+      (document.querySelector('[data-testid="pick-agent"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(setEmbeddedServerRunLocation).toHaveBeenCalledWith("srv-1", {
+      kind: "agent",
+      agentId: "a1",
+    });
+    expect(useRunLocationStore.getState().serverLocations["srv-1"]).toEqual({
+      kind: "agent",
+      agentId: "a1",
+    });
+  });
+
+  it("rolls back the mirrored choice when the backend rejects it", async () => {
+    (setEmbeddedServerRunLocation as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("agent unavailable")
+    );
+    act(() =>
+      root.render(
+        <TooltipProvider>
+          <EmbeddedServerSidebar />
+        </TooltipProvider>
+      )
+    );
+    act(() => {
+      (document.querySelector('[data-testid="pick-agent"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(useRunLocationStore.getState().serverLocations["srv-1"]).toEqual({
+      kind: "thisComputer",
+    });
+    expect(toastError).toHaveBeenCalled();
+  });
+});

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.css
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.css
@@ -133,3 +133,16 @@
   gap: 8px;
   padding-left: 20px;
 }
+
+/* Per-server "Run on" run-location control (#2191), in the item's details. */
+.server-item__runon {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  margin-top: var(--spacing-xs);
+}
+
+.server-item__runon-label {
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}

--- a/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.tsx
+++ b/src/components/EmbeddedServerSidebar/EmbeddedServerSidebar.tsx
@@ -1,8 +1,11 @@
 import { useCallback, useMemo, useState } from "react";
 import { Plus } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useRunLocationStore } from "@/store/runLocationStore";
 import { Button, ConfirmDialog, toast } from "@/components/ui";
 import { EmbeddedServerConfig } from "@/types/embeddedServer";
+import { setEmbeddedServerRunLocation } from "@/services/embeddedServerApi";
+import { THIS_COMPUTER, type RunLocation } from "@/utils/runLocation";
 import { EmbeddedServerItem } from "./EmbeddedServerItem";
 import { EmbeddedServerDialog } from "./EmbeddedServerDialog";
 import "./EmbeddedServerSidebar.css";
@@ -13,10 +16,30 @@ import "./EmbeddedServerSidebar.css";
 export function EmbeddedServerSidebar() {
   const servers = useAppStore((s) => s.embeddedServers);
   const serverStates = useAppStore((s) => s.embeddedServerStates);
+  const agents = useAppStore((s) => s.remoteAgents);
   const saveEmbeddedServer = useAppStore((s) => s.saveEmbeddedServer);
   const deleteEmbeddedServer = useAppStore((s) => s.deleteEmbeddedServer);
   const startEmbeddedServer = useAppStore((s) => s.startEmbeddedServer);
   const stopEmbeddedServer = useAppStore((s) => s.stopEmbeddedServer);
+  const serverLocations = useRunLocationStore((s) => s.serverLocations);
+  const setServerLocation = useRunLocationStore((s) => s.setServerLocation);
+
+  // Record a server's run-location: mirror it UI-side (optimistic) and persist
+  // it on the desktop backend, which routes the server's next start. Roll back
+  // and surface a toast if the backend rejects the choice.
+  const handleRunLocationChange = useCallback(
+    (serverId: string, location: RunLocation) => {
+      const previous = serverLocations[serverId] ?? THIS_COMPUTER;
+      setServerLocation(serverId, location);
+      setEmbeddedServerRunLocation(serverId, location).catch((err: unknown) => {
+        setServerLocation(serverId, previous);
+        toast.error("Couldn't change run location", {
+          description: err instanceof Error ? err.message : String(err),
+        });
+      });
+    },
+    [serverLocations, setServerLocation]
+  );
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingConfig, setEditingConfig] = useState<EmbeddedServerConfig | null>(null);
@@ -142,6 +165,9 @@ export function EmbeddedServerSidebar() {
               key={cfg.id}
               config={cfg}
               state={serverStates[cfg.id]}
+              agents={agents}
+              runLocation={serverLocations[cfg.id] ?? THIS_COMPUTER}
+              onRunLocationChange={(location) => handleRunLocationChange(cfg.id, location)}
               onStart={startEmbeddedServer}
               onStop={stopEmbeddedServer}
               onEdit={handleEdit}

--- a/src/components/NetworkTools/NetworkDiagnosticPanel.tsx
+++ b/src/components/NetworkTools/NetworkDiagnosticPanel.tsx
@@ -8,18 +8,15 @@ import { HttpMonitorPanel } from "./HttpMonitorPanel";
 import { TraceroutePanel } from "./TraceroutePanel";
 import { WolPanel } from "./WolPanel";
 import { OpenPortsPanel } from "./OpenPortsPanel";
+import { NetworkToolRunLocation } from "./NetworkToolRunLocation";
 
 interface NetworkDiagnosticPanelProps {
   meta: NetworkDiagnosticMeta;
   isVisible: boolean;
 }
 
-/**
- * Router component: renders the correct diagnostic panel based on `meta.tool`.
- */
-export function NetworkDiagnosticPanel({ meta, isVisible }: NetworkDiagnosticPanelProps) {
-  if (!isVisible) return null;
-
+/** Render the tool panel for a diagnostic tab. */
+function renderTool(meta: NetworkDiagnosticMeta) {
   switch (meta.tool) {
     case "port-scanner":
       return <PortScannerPanel prefillHost={meta.prefillHost} />;
@@ -44,4 +41,21 @@ export function NetworkDiagnosticPanel({ meta, isVisible }: NetworkDiagnosticPan
         </div>
       );
   }
+}
+
+/**
+ * Router component: renders the correct diagnostic panel based on `meta.tool`,
+ * topped by the per-tool "Run on" selector (#2191).
+ */
+export function NetworkDiagnosticPanel({ meta, isVisible }: NetworkDiagnosticPanelProps) {
+  if (!isVisible) return null;
+
+  return (
+    <div className="network-diagnostic" data-testid={`network-diagnostic-${meta.tool}`}>
+      <div className="network-diagnostic__runbar">
+        <NetworkToolRunLocation tool={meta.tool} />
+      </div>
+      {renderTool(meta)}
+    </div>
+  );
 }

--- a/src/components/NetworkTools/NetworkToolRunLocation.test.tsx
+++ b/src/components/NetworkTools/NetworkToolRunLocation.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import type { RemoteAgentDefinition } from "@/types/connection";
+import { setNetworkToolRunLocation } from "@/services/networkApi";
+import { useAppStore } from "@/store/appStore";
+import { useRunLocationStore } from "@/store/runLocationStore";
+import { NetworkToolRunLocation } from "./NetworkToolRunLocation";
+
+// Replace the Radix-backed selector with a trivial harness so the wiring
+// (backend call + optimistic store update + desktop-only gating) can be tested
+// without driving Radix's portal/pointer machinery in jsdom.
+vi.mock("@/components/RunLocationSelect", () => ({
+  RunLocationSelect: ({
+    value,
+    agentAllowed,
+    onChange,
+    ...rest
+  }: {
+    value: { kind: string; agentId?: string };
+    agentAllowed?: boolean;
+    onChange: (loc: { kind: string; agentId?: string }) => void;
+    "data-testid"?: string;
+  }) => (
+    <div
+      data-testid={rest["data-testid"]}
+      data-agent-allowed={String(agentAllowed !== false)}
+      data-value={value.kind === "agent" ? `agent:${value.agentId}` : "this"}
+    >
+      <button data-testid="pick-agent" onClick={() => onChange({ kind: "agent", agentId: "a1" })}>
+        agent
+      </button>
+      <button data-testid="pick-this" onClick={() => onChange({ kind: "thisComputer" })}>
+        this
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/services/networkApi", () => ({
+  setNetworkToolRunLocation: vi.fn(() => Promise.resolve()),
+}));
+
+function agent(id: string, name: string): RemoteAgentDefinition {
+  return {
+    id,
+    name,
+    config: {} as RemoteAgentDefinition["config"],
+    agentSettings: {} as RemoteAgentDefinition["agentSettings"],
+    isExpanded: false,
+    connectionState: "connected",
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => root.render(ui));
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("NetworkToolRunLocation", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState({ remoteAgents: [agent("a1", "build-server")] });
+    useRunLocationStore.setState({ networkToolLocations: {}, serverLocations: {} });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("routes a network tool to an agent and mirrors the choice (persistence)", async () => {
+    render(<NetworkToolRunLocation tool="ping" />);
+    const control = document.querySelector('[data-testid="network-runloc-ping"]') as HTMLElement;
+    expect(control.getAttribute("data-agent-allowed")).toBe("true");
+    expect(control.getAttribute("data-value")).toBe("this");
+
+    act(() => {
+      (document.querySelector('[data-testid="pick-agent"]') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    // Persisted on the backend under the tool's backend key…
+    expect(setNetworkToolRunLocation).toHaveBeenCalledWith("ping", {
+      kind: "agent",
+      agentId: "a1",
+    });
+    // …and mirrored in the store, so the selector keeps showing the agent.
+    expect(useRunLocationStore.getState().networkToolLocations.ping).toEqual({
+      kind: "agent",
+      agentId: "a1",
+    });
+    expect(
+      (document.querySelector('[data-testid="network-runloc-ping"]') as HTMLElement).getAttribute(
+        "data-value"
+      )
+    ).toBe("agent:a1");
+  });
+
+  it("maps the port scanner to its backend key", async () => {
+    render(<NetworkToolRunLocation tool="port-scanner" />);
+    act(() => {
+      (document.querySelector('[data-testid="pick-agent"]') as HTMLButtonElement).click();
+    });
+    await flush();
+    expect(setNetworkToolRunLocation).toHaveBeenCalledWith("port_scan", {
+      kind: "agent",
+      agentId: "a1",
+    });
+  });
+
+  it("gates the agent option for the desktop-only HTTP monitor", () => {
+    render(<NetworkToolRunLocation tool="http-monitor" />);
+    const control = document.querySelector(
+      '[data-testid="network-runloc-http-monitor"]'
+    ) as HTMLElement;
+    expect(control.getAttribute("data-agent-allowed")).toBe("false");
+  });
+
+  it("rolls back the mirrored choice when the backend rejects it", async () => {
+    (setNetworkToolRunLocation as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("agent unavailable")
+    );
+    render(<NetworkToolRunLocation tool="ping" />);
+    act(() => {
+      (document.querySelector('[data-testid="pick-agent"]') as HTMLButtonElement).click();
+    });
+    await flush();
+    // The optimistic update is reverted to the This-computer default.
+    expect(useRunLocationStore.getState().networkToolLocations.ping).toEqual({
+      kind: "thisComputer",
+    });
+  });
+});

--- a/src/components/NetworkTools/NetworkToolRunLocation.tsx
+++ b/src/components/NetworkTools/NetworkToolRunLocation.tsx
@@ -1,0 +1,65 @@
+import { useCallback } from "react";
+import { toast } from "@/components/ui";
+import { RunLocationSelect } from "@/components/RunLocationSelect";
+import { useAppStore } from "@/store/appStore";
+import { useRunLocationStore } from "@/store/runLocationStore";
+import { setNetworkToolRunLocation } from "@/services/networkApi";
+import { THIS_COMPUTER, type RunLocation } from "@/utils/runLocation";
+import type { NetworkTool } from "@/types/terminal";
+import { NETWORK_TOOL_LOCATION } from "./networkToolLocation";
+
+interface NetworkToolRunLocationProps {
+  tool: NetworkTool;
+}
+
+/**
+ * The "Run on" control for a network-tool panel (#2191): choose whether the
+ * tool runs on this computer or a connected agent. Defaults to This computer;
+ * a desktop-only tool (the HTTP monitor, ping sweep, open-ports) offers only
+ * This computer, per Open Design Decision #4.
+ *
+ * The choice is recorded on the desktop backend (which routes the tool's next
+ * invocation) and mirrored in {@link useRunLocationStore} so the selector keeps
+ * showing the chosen vantage. The update is optimistic and rolls back on a
+ * backend failure.
+ */
+export function NetworkToolRunLocation({ tool }: NetworkToolRunLocationProps) {
+  const info = NETWORK_TOOL_LOCATION[tool];
+  const agents = useAppStore((s) => s.remoteAgents);
+  const value = useRunLocationStore((s) => s.networkToolLocations[tool]) ?? THIS_COMPUTER;
+  const setLocation = useRunLocationStore((s) => s.setNetworkToolLocation);
+
+  const handleChange = useCallback(
+    (location: RunLocation) => {
+      const key = info?.backendKey;
+      // Desktop-only / non-routable tools have nothing to persist (they only
+      // ever offer This computer).
+      if (!key) return;
+      const previous = value;
+      setLocation(tool, location); // optimistic
+      setNetworkToolRunLocation(key, location).catch((err: unknown) => {
+        setLocation(tool, previous); // roll back on failure
+        toast.error("Couldn't change run location", {
+          description: err instanceof Error ? err.message : String(err),
+        });
+      });
+    },
+    [info?.backendKey, tool, value, setLocation]
+  );
+
+  if (!info) return null;
+
+  return (
+    <div className="network-panel__runon">
+      <span className="network-panel__runon-label">Run on</span>
+      <RunLocationSelect
+        value={value}
+        agents={agents}
+        onChange={handleChange}
+        agentAllowed={info.agentAllowed}
+        aria-label={`Run ${tool} on`}
+        data-testid={`network-runloc-${tool}`}
+      />
+    </div>
+  );
+}

--- a/src/components/NetworkTools/NetworkTools.css
+++ b/src/components/NetworkTools/NetworkTools.css
@@ -2,6 +2,44 @@
    Network Tools — shared panel styles
    =================================================================== */
 
+/* Diagnostic tab shell: the "Run on" run-location bar (#2191) above the tool
+   panel, which fills the remaining height. */
+.network-diagnostic {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.network-diagnostic > .network-panel {
+  /* Override the standalone panel's `height: 100%` so it flexes below the
+     run-location bar instead of overflowing it. */
+  flex: 1 1 auto;
+  min-height: 0;
+  height: auto;
+}
+
+.network-diagnostic__runbar {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-bottom: 1px solid var(--border-secondary);
+}
+
+/* "Run on" run-location control (label + Select). */
+.network-panel__runon {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.network-panel__runon-label {
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
+}
+
 /* Panel container */
 .network-panel {
   display: flex;

--- a/src/components/NetworkTools/networkToolLocation.ts
+++ b/src/components/NetworkTools/networkToolLocation.ts
@@ -1,0 +1,36 @@
+import type { NetworkTool } from "@/types/terminal";
+
+/** Run-location metadata for a network tool. */
+export interface NetworkToolLocationInfo {
+  /**
+   * The backend tool key passed to `set_network_tool_run_location`, or `null`
+   * for a tool with no agent-routable backend (it always runs on this
+   * computer). The keys mirror `agent_tools::tool` in the Rust backend.
+   */
+  backendKey: string | null;
+  /**
+   * Whether an agent may run this tool. `false` for a desktop-only tool (Open
+   * Design Decision #4) — the "Run on" selector then offers only "This
+   * computer".
+   */
+  agentAllowed: boolean;
+}
+
+/**
+ * Maps each frontend {@link NetworkTool} to its run-location behaviour (#2191).
+ *
+ * The five tools the agent exposes over `network.*` — ping, traceroute, port
+ * scan, DNS, Wake-on-LAN — are agent-routable. The HTTP monitor is
+ * desktop-only (the agent has no HTTP-monitor method). Ping sweep and
+ * open-ports have no agent backend today, so they run on this computer only.
+ */
+export const NETWORK_TOOL_LOCATION: Record<NetworkTool, NetworkToolLocationInfo> = {
+  ping: { backendKey: "ping", agentAllowed: true },
+  traceroute: { backendKey: "traceroute", agentAllowed: true },
+  "port-scanner": { backendKey: "port_scan", agentAllowed: true },
+  "dns-lookup": { backendKey: "dns", agentAllowed: true },
+  wol: { backendKey: "wol", agentAllowed: true },
+  "http-monitor": { backendKey: "http_monitor", agentAllowed: false },
+  "ping-sweep": { backendKey: null, agentAllowed: false },
+  "open-ports": { backendKey: null, agentAllowed: false },
+};

--- a/src/components/RunLocationSelect/RunLocationSelect.test.tsx
+++ b/src/components/RunLocationSelect/RunLocationSelect.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import type { RemoteAgentDefinition } from "@/types/connection";
+import { THIS_COMPUTER } from "@/types/tunnel";
+import { RunLocationSelect } from "./RunLocationSelect";
+
+function agent(id: string, name: string): RemoteAgentDefinition {
+  return {
+    id,
+    name,
+    config: {} as RemoteAgentDefinition["config"],
+    agentSettings: {} as RemoteAgentDefinition["agentSettings"],
+    isExpanded: false,
+    connectionState: "connected",
+  };
+}
+
+const AGENTS = [agent("a1", "build-server")];
+
+let container: HTMLDivElement;
+let root: Root;
+
+function render(ui: React.ReactElement) {
+  act(() => root.render(ui));
+}
+
+describe("RunLocationSelect", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("shows This computer as the selected vantage by default", () => {
+    render(
+      <RunLocationSelect
+        value={THIS_COMPUTER}
+        agents={AGENTS}
+        onChange={() => {}}
+        data-testid="rl"
+      />
+    );
+    const trigger = document.querySelector('[data-testid="rl"]') as HTMLButtonElement;
+    expect(trigger).toBeTruthy();
+    expect(trigger.textContent).toContain("This computer");
+    // With an agent on offer the control is interactive.
+    expect(trigger.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("names the agent when the item runs on one", () => {
+    render(
+      <RunLocationSelect
+        value={{ kind: "agent", agentId: "a1" }}
+        agents={AGENTS}
+        onChange={() => {}}
+        data-testid="rl"
+      />
+    );
+    const trigger = document.querySelector('[data-testid="rl"]') as HTMLButtonElement;
+    expect(trigger.textContent).toContain("build-server");
+  });
+
+  it("disables the control for a desktop-only item (no agent option)", () => {
+    render(
+      <RunLocationSelect
+        value={THIS_COMPUTER}
+        agents={AGENTS}
+        agentAllowed={false}
+        onChange={() => {}}
+        data-testid="rl"
+      />
+    );
+    const trigger = document.querySelector('[data-testid="rl"]') as HTMLButtonElement;
+    expect(trigger.hasAttribute("disabled")).toBe(true);
+    expect(trigger.textContent).toContain("This computer");
+  });
+
+  it("disables the control when there is no agent to offer", () => {
+    render(
+      <RunLocationSelect value={THIS_COMPUTER} agents={[]} onChange={() => {}} data-testid="rl" />
+    );
+    const trigger = document.querySelector('[data-testid="rl"]') as HTMLButtonElement;
+    expect(trigger.hasAttribute("disabled")).toBe(true);
+  });
+});

--- a/src/components/RunLocationSelect/RunLocationSelect.tsx
+++ b/src/components/RunLocationSelect/RunLocationSelect.tsx
@@ -1,0 +1,66 @@
+import { Select } from "@/components/ui";
+import type { RemoteAgentDefinition } from "@/types/connection";
+import {
+  RunLocation,
+  decodeRunLocation,
+  encodeRunLocation,
+  runLocationOptions,
+} from "@/utils/runLocation";
+
+/** Props for the shared {@link RunLocationSelect} control. */
+export interface RunLocationSelectProps {
+  /** The item's current run-location. */
+  value: RunLocation;
+  /** Agents offered as run targets ("This computer" is always offered). */
+  agents: RemoteAgentDefinition[];
+  /** Called with the newly chosen run-location. */
+  onChange: (location: RunLocation) => void;
+  /**
+   * Whether an agent may host this item. `false` for a desktop-only item (Open
+   * Design Decision #4) — the control then offers only "This computer".
+   * Defaults to `true`.
+   */
+  agentAllowed?: boolean;
+  /** Force-disable the control. */
+  disabled?: boolean;
+  /** Accessible label for the trigger. Defaults to "Run on". */
+  "aria-label"?: string;
+  /** Test hook forwarded to the trigger. */
+  "data-testid"?: string;
+}
+
+/**
+ * The shared "Run on" selector — a thin, token-styled wrapper over the `Select`
+ * primitive that both the tunnel host control and the network-tool /
+ * embedded-server run-location selectors compose from (#2191). It renders
+ * "This computer" plus one option per agent, defaulting to the desktop; a
+ * desktop-only item (`agentAllowed={false}`) offers only "This computer".
+ *
+ * The control has no state of its own — the caller owns the value and persists
+ * the choice — so the selector stays a pure renderer over the run-location
+ * model.
+ */
+export function RunLocationSelect({
+  value,
+  agents,
+  onChange,
+  agentAllowed = true,
+  disabled,
+  ...rest
+}: RunLocationSelectProps) {
+  const options = runLocationOptions(agents, agentAllowed);
+  // With no agent to offer, "This computer" is the only choice — disable the
+  // control so it reads as a fixed vantage rather than an interactive no-op.
+  const singleChoice = options.length === 1;
+
+  return (
+    <Select
+      value={encodeRunLocation(value)}
+      onChange={(v) => onChange(decodeRunLocation(v))}
+      options={options}
+      disabled={disabled || singleChoice}
+      aria-label={rest["aria-label"] ?? "Run on"}
+      data-testid={rest["data-testid"]}
+    />
+  );
+}

--- a/src/components/RunLocationSelect/index.ts
+++ b/src/components/RunLocationSelect/index.ts
@@ -1,0 +1,2 @@
+export { RunLocationSelect } from "./RunLocationSelect";
+export type { RunLocationSelectProps } from "./RunLocationSelect";

--- a/src/services/embeddedServerApi.ts
+++ b/src/services/embeddedServerApi.ts
@@ -4,10 +4,24 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { EmbeddedServerConfig, NetworkInterface, ServerState } from "@/types/embeddedServer";
+import type { RunLocation } from "@/types/tunnel";
 
 /** Return all saved embedded server configurations. */
 export async function listEmbeddedServers(): Promise<EmbeddedServerConfig[]> {
   return await invoke<EmbeddedServerConfig[]>("list_embedded_servers");
+}
+
+/**
+ * Set (or clear) which machine hosts a server — "This computer" or a named
+ * agent (#2214). `RunLocation.ThisComputer` clears the preference (back to
+ * desktop hosting); an agent value routes the server's next start to that
+ * agent. Takes effect on the server's next start.
+ */
+export async function setEmbeddedServerRunLocation(
+  serverId: string,
+  runLocation: RunLocation
+): Promise<void> {
+  await invoke("set_embedded_server_run_location", { serverId, runLocation });
 }
 
 /** Add or update an embedded server configuration. */

--- a/src/services/networkApi.ts
+++ b/src/services/networkApi.ts
@@ -24,6 +24,22 @@ import type {
   PingSweepSummary,
   TracerouteHop,
 } from "@/types/network";
+import type { RunLocation } from "@/types/tunnel";
+
+// ── Run location (#2190/#2191) ───────────────────────────────────────────────
+
+/**
+ * Set (or clear) which machine a network tool runs on — "This computer" or a
+ * named agent. `tool` is the backend tool key (e.g. `ping`, `port_scan`).
+ * `RunLocation.ThisComputer` clears the preference (back to the desktop
+ * default); a desktop-only tool (the HTTP monitor) rejects an agent location.
+ */
+export async function setNetworkToolRunLocation(
+  tool: string,
+  runLocation: RunLocation
+): Promise<void> {
+  await invoke("set_network_tool_run_location", { tool, runLocation });
+}
 
 // ── Port Scanner ─────────────────────────────────────────────────────────────
 

--- a/src/store/runLocationStore.test.ts
+++ b/src/store/runLocationStore.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { THIS_COMPUTER } from "@/types/tunnel";
+import { useRunLocationStore } from "./runLocationStore";
+
+describe("runLocationStore", () => {
+  beforeEach(() => {
+    useRunLocationStore.setState({ networkToolLocations: {}, serverLocations: {} });
+  });
+
+  it("records and updates a network tool's run-location", () => {
+    const { setNetworkToolLocation } = useRunLocationStore.getState();
+    expect(useRunLocationStore.getState().networkToolLocations.ping).toBeUndefined();
+
+    setNetworkToolLocation("ping", { kind: "agent", agentId: "a1" });
+    expect(useRunLocationStore.getState().networkToolLocations.ping).toEqual({
+      kind: "agent",
+      agentId: "a1",
+    });
+
+    setNetworkToolLocation("ping", THIS_COMPUTER);
+    expect(useRunLocationStore.getState().networkToolLocations.ping).toEqual(THIS_COMPUTER);
+  });
+
+  it("records a server's run-location independently of tools", () => {
+    const { setServerLocation, setNetworkToolLocation } = useRunLocationStore.getState();
+    setServerLocation("srv-1", { kind: "agent", agentId: "a2" });
+    setNetworkToolLocation("dns", { kind: "agent", agentId: "a1" });
+
+    expect(useRunLocationStore.getState().serverLocations["srv-1"]).toEqual({
+      kind: "agent",
+      agentId: "a2",
+    });
+    expect(useRunLocationStore.getState().networkToolLocations.dns).toEqual({
+      kind: "agent",
+      agentId: "a1",
+    });
+  });
+});

--- a/src/store/runLocationStore.ts
+++ b/src/store/runLocationStore.ts
@@ -1,0 +1,34 @@
+/**
+ * Session store for per-item run-location selections (#2191).
+ *
+ * The desktop backend records each item's run-location preference in memory
+ * (`set_network_tool_run_location` / `set_embedded_server_run_location`) and
+ * exposes no getter — an item with no recorded preference runs on This
+ * computer, the default. This store mirrors the chosen value UI-side so the
+ * selector reflects the current vantage across tab open/close and re-renders
+ * within a session. It is deliberately not persisted to disk: like the backend
+ * map, it resets to the This-computer default on relaunch.
+ */
+
+import { create } from "zustand";
+import type { RunLocation } from "@/types/tunnel";
+
+interface RunLocationState {
+  /** Per-network-tool run-location, keyed by the frontend `NetworkTool` id. */
+  networkToolLocations: Record<string, RunLocation>;
+  /** Per-embedded-server run-location, keyed by server id. */
+  serverLocations: Record<string, RunLocation>;
+  /** Record a network tool's chosen run-location. */
+  setNetworkToolLocation: (tool: string, location: RunLocation) => void;
+  /** Record an embedded server's chosen run-location. */
+  setServerLocation: (serverId: string, location: RunLocation) => void;
+}
+
+export const useRunLocationStore = create<RunLocationState>((set) => ({
+  networkToolLocations: {},
+  serverLocations: {},
+  setNetworkToolLocation: (tool, location) =>
+    set((s) => ({ networkToolLocations: { ...s.networkToolLocations, [tool]: location } })),
+  setServerLocation: (serverId, location) =>
+    set((s) => ({ serverLocations: { ...s.serverLocations, [serverId]: location } })),
+}));

--- a/src/utils/runLocation.test.ts
+++ b/src/utils/runLocation.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import type { RemoteAgentDefinition } from "@/types/connection";
+import { THIS_COMPUTER } from "@/types/tunnel";
+import {
+  RUN_LOCATION_THIS,
+  decodeRunLocation,
+  encodeRunLocation,
+  runLocationLabel,
+  runLocationOptions,
+} from "./runLocation";
+
+function agent(id: string, name: string): RemoteAgentDefinition {
+  return {
+    id,
+    name,
+    config: {} as RemoteAgentDefinition["config"],
+    agentSettings: {} as RemoteAgentDefinition["agentSettings"],
+    isExpanded: false,
+    connectionState: "connected",
+  };
+}
+
+const AGENTS = [agent("a1", "build-server"), agent("a2", "lab-box")];
+
+describe("runLocation helpers", () => {
+  it("encodes This computer and an agent as distinct Select values", () => {
+    expect(encodeRunLocation(THIS_COMPUTER)).toBe(RUN_LOCATION_THIS);
+    expect(encodeRunLocation({ kind: "agent", agentId: "a1" })).toBe("agent:a1");
+  });
+
+  it("round-trips through encode/decode", () => {
+    expect(decodeRunLocation(encodeRunLocation(THIS_COMPUTER))).toEqual(THIS_COMPUTER);
+    const loc = { kind: "agent", agentId: "a1" } as const;
+    expect(decodeRunLocation(encodeRunLocation(loc))).toEqual(loc);
+  });
+
+  it("decodes an unknown value as This computer", () => {
+    expect(decodeRunLocation("nonsense")).toEqual(THIS_COMPUTER);
+  });
+
+  it("offers This computer plus every agent when agents are allowed", () => {
+    const options = runLocationOptions(AGENTS, true);
+    expect(options).toEqual([
+      { value: RUN_LOCATION_THIS, label: "This computer" },
+      { value: "agent:a1", label: "Agent · build-server" },
+      { value: "agent:a2", label: "Agent · lab-box" },
+    ]);
+  });
+
+  it("offers only This computer for a desktop-only item", () => {
+    const options = runLocationOptions(AGENTS, false);
+    expect(options).toEqual([{ value: RUN_LOCATION_THIS, label: "This computer" }]);
+  });
+
+  it("labels a run-location, naming a known agent and falling back to its id", () => {
+    expect(runLocationLabel(THIS_COMPUTER, AGENTS)).toBe("This computer");
+    expect(runLocationLabel({ kind: "agent", agentId: "a1" }, AGENTS)).toBe("Agent · build-server");
+    expect(runLocationLabel({ kind: "agent", agentId: "gone" }, AGENTS)).toBe("Agent · gone");
+  });
+});

--- a/src/utils/runLocation.ts
+++ b/src/utils/runLocation.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared "Run on" (run-location) helpers — the view-model layer behind the
+ * per-item run-location selector (#2191).
+ *
+ * A {@link RunLocation} says which machine an item (tunnel, network tool, or
+ * embedded server) executes on: this computer (the desktop) or a named agent.
+ * The type and its `THIS_COMPUTER` constant are defined once in `@/types/tunnel`
+ * (the first subsystem to grow a run-location) and re-exported here so the
+ * network-tool and embedded-server call sites need not import from a
+ * tunnel-named module. These helpers turn a {@link RunLocation} into the
+ * `Select` option list / encoded value both the tunnel host control and the new
+ * selector share, so there is one encoding, not three.
+ */
+
+import type { SelectOption } from "@/components/ui";
+import type { RemoteAgentDefinition } from "@/types/connection";
+import { RunLocation, THIS_COMPUTER } from "@/types/tunnel";
+import { isAgentHost } from "@/utils/tunnelHost";
+
+export { THIS_COMPUTER, isAgentHost };
+export type { RunLocation };
+
+/** `Select` value for the "This computer" (desktop) option. */
+export const RUN_LOCATION_THIS = "this";
+
+/** Prefix for an agent option's `Select` value (`agent:<id>`). */
+const AGENT_PREFIX = "agent:";
+
+/** Encode a run-location as a `Select` option value. */
+export function encodeRunLocation(location: RunLocation): string {
+  return isAgentHost(location) ? `${AGENT_PREFIX}${location.agentId}` : RUN_LOCATION_THIS;
+}
+
+/** Decode a `Select` option value back into a run-location. */
+export function decodeRunLocation(value: string): RunLocation {
+  return value.startsWith(AGENT_PREFIX)
+    ? { kind: "agent", agentId: value.slice(AGENT_PREFIX.length) }
+    : THIS_COMPUTER;
+}
+
+/**
+ * The "Run on" option list: "This computer" first, then one option per agent.
+ *
+ * When `agentAllowed` is `false` — a desktop-only item, per Open Design
+ * Decision #4 — only "This computer" is offered, so the agent option can never
+ * be picked for an item the agent cannot host.
+ */
+export function runLocationOptions(
+  agents: RemoteAgentDefinition[],
+  agentAllowed: boolean
+): SelectOption[] {
+  const options: SelectOption[] = [{ value: RUN_LOCATION_THIS, label: "This computer" }];
+  if (agentAllowed) {
+    for (const agent of agents) {
+      options.push({ value: `${AGENT_PREFIX}${agent.id}`, label: `Agent · ${agent.name}` });
+    }
+  }
+  return options;
+}
+
+/**
+ * The human label for a run-location, naming the agent when it is known —
+ * "This computer" or "Agent · «name»" — for a badge / where-it-runs indicator.
+ */
+export function runLocationLabel(location: RunLocation, agents: RemoteAgentDefinition[]): string {
+  if (!isAgentHost(location)) return "This computer";
+  const name = agents.find((a) => a.id === location.agentId)?.name ?? location.agentId;
+  return `Agent · ${name}`;
+}


### PR DESCRIPTION
## Summary

The S2 capstone UI: a per-item **"Run on"** run-location selector (This
computer / an agent) for the **Network Tools** and **Embedded Servers**
surfaces, wired to the run-location backends already in place (tunnels #2187,
embedded servers #2214, network tools #2190).

- **Shared control.** New `RunLocationSelect` (`src/components/RunLocationSelect/`)
  composed from the `Select` primitive, backed by shared `src/utils/runLocation.ts`
  helpers (encode/decode/options/label) that reuse the tunnel host control's
  run-location model — one encoding, not three. Tokens only; no bespoke dropdown.
- **Network Tools.** A "Run on" bar tops each diagnostic panel
  (`NetworkDiagnosticPanel` → `NetworkToolRunLocation`). Ping, traceroute, port
  scanner, DNS and Wake-on-LAN are agent-routable; the **HTTP monitor, ping
  sweep and open-ports are desktop-only** and offer only "This computer" (Open
  Design Decision #4).
- **Embedded Servers.** Each server row gains a "Run on" control in its details;
  all server types are agent-hostable.
- **Wiring.** Choosing a location is optimistic, mirrored in a small session
  store (`runLocationStore`), and persisted on the desktop backend
  (`set_network_tool_run_location` / `set_embedded_server_run_location`), which
  routes the tool's next invocation / server's next start. A backend rejection
  rolls the mirror back with a toast. Defaults stay **This computer**.

Frontend-only: both backend commands already exist and are registered; no Rust
changes.

## Testing

- `RunLocationSelect.test.tsx`, `NetworkToolRunLocation.test.tsx`,
  `EmbeddedServerRunLocation.test.tsx`, `runLocation.test.ts`,
  `runLocationStore.test.ts` — default, desktop-only agent gating, backend key
  mapping, optimistic persistence + rollback.
- `tsc`, ESLint, Prettier, markdownlint green; existing NetworkTools /
  EmbeddedServer suites (211 tests) still pass.
- **Interactive local-run (agent routing) not performed in this headless
  environment** — manual steps added to `docs/testing.md` (agent-routed tool +
  agent-hosted server) for a follow-up manual pass. Per-PR CI does not run
  integration tests, so agent routing is a manual/local check by design.

Part of #2154

Closes #2191

🤖 Generated with [Claude Code](https://claude.com/claude-code)
