### PR TITLE
feat(backend): shadow system-monitor projection store and region (Monitors domain)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,6 +40,12 @@ mod session_history;
 /// driving the live UI — see [`session_projection`].
 mod session_projection;
 mod spawn;
+/// Shadow system-monitor authority (#2224, Phase 5 of #2139): the shared
+/// `system-monitors` projection region + `monitor.*` intents, built on the
+/// monitoring types shared with the agent crate (`termihub_core::monitoring`).
+/// Registered and served but not yet driving the live UI — see
+/// [`system_monitor_projection`].
+mod system_monitor_projection;
 mod terminal;
 mod tunnel;
 mod utils;
@@ -687,6 +693,19 @@ pub fn run() {
                     &mut registry,
                     app.handle().clone(),
                 );
+                // Shadow SystemMonitorStore (#2224, Phase 5): the shared
+                // `system-monitors` region + `monitor.*` intents on the
+                // monitoring types shared with the agent crate
+                // (`termihub_core::monitoring`). Managed authoritative state that
+                // serves intents, but nothing in the live UI subscribes to or
+                // renders the region yet — a pure shadow foundation (later steps
+                // cut rendering, then mutations, over to it). The shared region is
+                // seeded below once the store is managed.
+                app.manage(Arc::new(system_monitor_projection::SystemMonitorStore::new()));
+                system_monitor_projection::projection::register_monitor_intents(
+                    &mut registry,
+                    app.handle().clone(),
+                );
                 // Test-bridge-only: add the diagnostic region's `diag.*` routes so
                 // the projection-assertion harness (#2164) has a self-contained
                 // region to drive. Never registered in production launches. See
@@ -713,6 +732,17 @@ pub fn run() {
                 {
                     projection_state.projector.register_region(
                         session_projection::projection::SESSION_LIFECYCLE_REGION,
+                        store.snapshot(),
+                    );
+                }
+                // Seed the shared `system-monitors` region with the (empty) store
+                // baseline at version 0, so a subscriber attaches to a real region
+                // before the first `monitor.*` intent (#2224).
+                if let Some(store) =
+                    app.handle().try_state::<Arc<system_monitor_projection::SystemMonitorStore>>()
+                {
+                    projection_state.projector.register_region(
+                        system_monitor_projection::projection::SYSTEM_MONITORS_REGION,
                         store.snapshot(),
                     );
                 }

--- a/src-tauri/src/system_monitor_projection/mod.rs
+++ b/src-tauri/src/system_monitor_projection/mod.rs
@@ -1,0 +1,26 @@
+//! Shadow system-monitor authority — Phase 5 of the stateless-UI migration
+//! (#2224, part of #2139).
+//!
+//! Moves the per-host/session monitoring slice the frontend drives in `appStore`
+//! (`monitors: Record<MonitorKey, MonitoringEntry>` + `monitoringStatsCache`) into
+//! a Rust authority built on the monitoring types already shared with the agent
+//! crate (`termihub_core::monitoring`). The store owns a single **shared**
+//! `system-monitors` projection region (Open Design Decision #4: infrastructure
+//! domains are shared) and serves the `monitor.*` intents through the projection
+//! substrate ([`crate::projection`]), mirroring the SSH-tunnels pilot
+//! ([`crate::tunnel::projection`]) and the session-lifecycle shadow
+//! ([`crate::session_projection`]).
+//!
+//! # Shadow mode — zero user-facing change
+//!
+//! This step is deliberately **not** authoritative. The store exists, accepts
+//! intents, and projects diffs, but nothing in the live UI subscribes to or
+//! renders the `system-monitors` region, and no frontend code dispatches
+//! `monitor.*` intents yet. The existing `appStore` monitoring slice and the
+//! status-bar / Open-Connections rendering are untouched. Later steps cut
+//! rendering, then mutation, over to the region, then remove the `appStore` state.
+
+pub mod projection;
+pub mod store;
+
+pub use store::SystemMonitorStore;

--- a/src-tauri/src/system_monitor_projection/projection.rs
+++ b/src-tauri/src/system_monitor_projection/projection.rs
@@ -1,0 +1,224 @@
+//! System-monitor projection: the shared `system-monitors` region and the
+//! `monitor.*` intents (#2224, part of #2139).
+//!
+//! Exposes the authoritative [`SystemMonitorStore`] as one versioned,
+//! multi-subscriber projection region and turns the monitoring transitions the
+//! frontend currently drives into [`Intent`]s — mirroring the SSH-tunnels pilot
+//! ([`crate::tunnel::projection`]) and the session-lifecycle shadow
+//! ([`crate::session_projection::projection`]).
+//!
+//! # The `system-monitors` region
+//!
+//! **Shared** (Open Design Decision #4: infrastructure domains are shared). A
+//! monitor rides a backend session's `MonitoringProvider`; its stats/status are a
+//! property of the session, not of a viewing client, so two clients see the same
+//! monitor. The view model:
+//!
+//! ```json
+//! { "monitors": { "<key>": MonitorEntry, ... }, "statsCache": { "<key>": SystemStats } }
+//! ```
+//!
+//! # Intents
+//!
+//! | kind                   | payload                       | effect                                   |
+//! | ---------------------- | ----------------------------- | ---------------------------------------- |
+//! | `monitor.open`         | `{ key, host?, intervalMs? }` | begin an initial connect (→ connecting)  |
+//! | `monitor.opened`       | `{ key }`                     | provider subscription live (→ live)      |
+//! | `monitor.openFailed`   | `{ key, error? }`             | initial connect errored                  |
+//! | `monitor.stats`        | `{ key, stats }`              | a stats sample arrived                   |
+//! | `monitor.status`       | `{ key, status }`             | collector-loop status update             |
+//! | `monitor.setPaused`    | `{ key, paused }`             | pause/resume collection (#1233)          |
+//! | `monitor.setInterval`  | `{ key, intervalMs }`         | change refresh cadence (#1233)           |
+//! | `monitor.clearError`   | `{ key }`                     | dismiss the error banner                 |
+//! | `monitor.close`        | `{ key }`                     | disconnect and drop the entry            |
+//!
+//! # Shadow mode
+//!
+//! Registered and fully served, but **not** driving the live UI: no frontend
+//! subscribes to `system-monitors` or dispatches `monitor.*` yet, so these
+//! intents mutate only the shadow store and project to a region nobody renders.
+//! The `appStore` monitoring slice remains authoritative. Per the substrate
+//! contract the result of an intent is never returned inline — it always arrives
+//! as a projection diff on the `system-monitors` region.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+use termihub_core::monitoring::{MonitorStatus, SystemStats};
+
+use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
+use crate::system_monitor_projection::store::SystemMonitorStore;
+
+/// The projection region id for the system-monitor domain (shared, per Open
+/// Design Decision #4).
+pub const SYSTEM_MONITORS_REGION: &str = "system-monitors";
+
+/// Publish the `system-monitors` region from the store, fanning a diff out to
+/// every subscriber and returning the advanced region for the intent ack (empty
+/// when the view did not change).
+pub fn publish_monitors(projector: &Projector, store: &SystemMonitorStore) -> Vec<ProducedRegion> {
+    match projector.publish(SYSTEM_MONITORS_REGION, store.snapshot()) {
+        Some(version) => vec![ProducedRegion {
+            region: SYSTEM_MONITORS_REGION.to_string(),
+            version,
+        }],
+        None => Vec::new(),
+    }
+}
+
+/// Register the `monitor.*` intents on a handler registry.
+///
+/// Each route resolves the managed [`SystemMonitorStore`] lazily (so it rejects
+/// gracefully rather than panicking if the store is somehow absent), applies the
+/// transition, and publishes the shared region. All transitions are pure/fast map
+/// edits, so they run inline on the dispatcher's single writer.
+pub fn register_monitor_intents(registry: &mut HandlerRegistry, app_handle: AppHandle) {
+    let handle = app_handle.clone();
+    registry.route("monitor.open", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let key = required_str(intent, "key")?;
+        store.open(&key, optional_str(intent, "host"), optional_u64(intent, "intervalMs"));
+        Ok(publish_monitors(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("monitor.opened", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let key = required_str(intent, "key")?;
+        store.opened(&key);
+        Ok(publish_monitors(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("monitor.openFailed", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let key = required_str(intent, "key")?;
+        store.open_failed(&key, optional_str(intent, "error"));
+        Ok(publish_monitors(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("monitor.stats", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let key = required_str(intent, "key")?;
+        store.stats(&key, required_stats(intent)?);
+        Ok(publish_monitors(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("monitor.status", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let key = required_str(intent, "key")?;
+        store.set_status(&key, required_status(intent)?);
+        Ok(publish_monitors(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("monitor.setPaused", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let key = required_str(intent, "key")?;
+        store.set_paused(&key, required_bool(intent, "paused")?);
+        Ok(publish_monitors(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("monitor.setInterval", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let key = required_str(intent, "key")?;
+        store.set_interval(&key, required_u64(intent, "intervalMs")?);
+        Ok(publish_monitors(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("monitor.clearError", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let key = required_str(intent, "key")?;
+        store.clear_error(&key);
+        Ok(publish_monitors(projector, &store))
+    });
+
+    let handle = app_handle;
+    registry.route("monitor.close", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let key = required_str(intent, "key")?;
+        store.close(&key);
+        Ok(publish_monitors(projector, &store))
+    });
+}
+
+/// Resolve the managed system-monitor store, or a rejectable error if absent.
+fn store_of(app_handle: &AppHandle) -> Result<Arc<SystemMonitorStore>, (String, String)> {
+    app_handle
+        .try_state::<Arc<SystemMonitorStore>>()
+        .map(|state| (*state).clone())
+        .ok_or_else(|| {
+            (
+                "unavailable".to_string(),
+                "system-monitor store is not initialized".to_string(),
+            )
+        })
+}
+
+/// Extract a required string field from an intent payload.
+fn required_str(intent: &Intent, key: &str) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// Extract an optional string field; absent → `None`.
+fn optional_str(intent: &Intent, key: &str) -> Option<String> {
+    intent.payload.get(key).and_then(Value::as_str).map(str::to_string)
+}
+
+/// Extract a required bool field from an intent payload.
+fn required_bool(intent: &Intent, key: &str) -> Result<bool, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_bool)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// Extract a required u64 field from an intent payload.
+fn required_u64(intent: &Intent, key: &str) -> Result<u64, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// Extract an optional u64 field; absent → `None`.
+fn optional_u64(intent: &Intent, key: &str) -> Option<u64> {
+    intent.payload.get(key).and_then(Value::as_u64)
+}
+
+/// Parse the required `stats` object as a [`SystemStats`].
+fn required_stats(intent: &Intent) -> Result<SystemStats, (String, String)> {
+    let value = intent
+        .payload
+        .get("stats")
+        .ok_or_else(|| ("bad_payload".to_string(), "missing 'stats'".to_string()))?;
+    serde_json::from_value(value.clone())
+        .map_err(|e| ("bad_payload".to_string(), format!("invalid stats: {e}")))
+}
+
+/// Parse the required `status` field as a [`MonitorStatus`].
+fn required_status(intent: &Intent) -> Result<MonitorStatus, (String, String)> {
+    let value = intent
+        .payload
+        .get("status")
+        .ok_or_else(|| ("bad_payload".to_string(), "missing 'status'".to_string()))?;
+    serde_json::from_value(value.clone())
+        .map_err(|e| ("bad_payload".to_string(), format!("invalid status: {e}")))
+}
+
+#[cfg(test)]
+#[path = "projection_tests.rs"]
+mod tests;

--- a/src-tauri/src/system_monitor_projection/projection.rs
+++ b/src-tauri/src/system_monitor_projection/projection.rs
@@ -79,7 +79,11 @@ pub fn register_monitor_intents(registry: &mut HandlerRegistry, app_handle: AppH
     registry.route("monitor.open", move |intent, projector| {
         let store = store_of(&handle)?;
         let key = required_str(intent, "key")?;
-        store.open(&key, optional_str(intent, "host"), optional_u64(intent, "intervalMs"));
+        store.open(
+            &key,
+            optional_str(intent, "host"),
+            optional_u64(intent, "intervalMs"),
+        );
         Ok(publish_monitors(projector, &store))
     });
 
@@ -173,7 +177,11 @@ fn required_str(intent: &Intent, key: &str) -> Result<String, (String, String)> 
 
 /// Extract an optional string field; absent → `None`.
 fn optional_str(intent: &Intent, key: &str) -> Option<String> {
-    intent.payload.get(key).and_then(Value::as_str).map(str::to_string)
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
 }
 
 /// Extract a required bool field from an intent payload.

--- a/src-tauri/src/system_monitor_projection/projection_tests.rs
+++ b/src-tauri/src/system_monitor_projection/projection_tests.rs
@@ -1,0 +1,343 @@
+//! Projection-contract tests for the shared `system-monitors` region (#2224),
+//! reusing the substrate harness (#2164): an in-memory [`ProjectionSink`] and a
+//! client cache that applies diffs. The routes here drive a real
+//! [`SystemMonitorStore`] directly (the production `register_monitor_intents`
+//! resolves the same store from the Tauri `AppHandle`; that thin wiring is
+//! integration-verified via a local `./scripts/dev.sh` run) through the identical
+//! parse → mutate → publish path.
+//!
+//! Asserted: subscribe → snapshot (identical to every subscriber), an accepted
+//! intent → exactly one coalesced diff fanned to every subscriber with monotonic
+//! versions, rejection paths advance nothing, a no-op intent advances nothing, a
+//! dead subscriber is reaped, and the client cache converges on the store's
+//! authority across a full monitor lifecycle.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::{json, Value};
+
+use termihub_core::monitoring::SystemStats;
+
+use crate::projection::{
+    apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
+    ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
+};
+use crate::system_monitor_projection::projection::{publish_monitors, SYSTEM_MONITORS_REGION};
+use crate::system_monitor_projection::store::SystemMonitorStore;
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+fn stats(hostname: &str, cpu: f64) -> SystemStats {
+    SystemStats {
+        hostname: hostname.to_string(),
+        uptime_seconds: 100.0,
+        load_average: [0.1, 0.2, 0.3],
+        cpu_usage_percent: cpu,
+        memory_total_kb: 16_000_000,
+        memory_available_kb: 8_000_000,
+        memory_used_percent: 50.0,
+        disk_total_kb: 100_000_000,
+        disk_used_kb: 40_000_000,
+        disk_used_percent: 40.0,
+        os_info: "Linux 6.1".to_string(),
+    }
+}
+
+/// A store with a couple of monitors already in flight, so a subscriber sees a
+/// populated baseline.
+fn seeded_store() -> Arc<SystemMonitorStore> {
+    let store = Arc::new(SystemMonitorStore::new());
+    store.open("s1", Some("host-a".to_string()), None);
+    store.open("s2", Some("host-b".to_string()), None);
+    store.opened("s2");
+    store
+}
+
+/// The production `monitor.*` routes, bound to an injected store instead of
+/// resolving one from an `AppHandle` — the exact parse → mutate → publish path
+/// `register_monitor_intents` runs. Each closure mirrors the production route
+/// one-to-one so the test drives real logic, not a stand-in.
+fn registry_for(store: Arc<SystemMonitorStore>) -> HandlerRegistry {
+    let mut registry = HandlerRegistry::new();
+
+    let s = store.clone();
+    registry.route("monitor.open", move |intent, projector| {
+        s.open(
+            &required_key(intent)?,
+            intent.payload.get("host").and_then(Value::as_str).map(str::to_string),
+            intent.payload.get("intervalMs").and_then(Value::as_u64),
+        );
+        Ok(publish_monitors(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("monitor.opened", move |intent, projector| {
+        s.opened(&required_key(intent)?);
+        Ok(publish_monitors(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("monitor.openFailed", move |intent, projector| {
+        s.open_failed(
+            &required_key(intent)?,
+            intent.payload.get("error").and_then(Value::as_str).map(str::to_string),
+        );
+        Ok(publish_monitors(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("monitor.stats", move |intent, projector| {
+        let key = required_key(intent)?;
+        let value = intent
+            .payload
+            .get("stats")
+            .ok_or_else(|| ("bad_payload".to_string(), "missing 'stats'".to_string()))?;
+        let parsed: SystemStats = serde_json::from_value(value.clone())
+            .map_err(|e| ("bad_payload".to_string(), format!("invalid stats: {e}")))?;
+        s.stats(&key, parsed);
+        Ok(publish_monitors(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("monitor.setPaused", move |intent, projector| {
+        let paused = intent
+            .payload
+            .get("paused")
+            .and_then(Value::as_bool)
+            .ok_or_else(|| ("bad_payload".to_string(), "missing 'paused'".to_string()))?;
+        s.set_paused(&required_key(intent)?, paused);
+        Ok(publish_monitors(projector, &s))
+    });
+    let s = store;
+    registry.route("monitor.close", move |intent, projector| {
+        s.close(&required_key(intent)?);
+        Ok(publish_monitors(projector, &s))
+    });
+
+    registry
+}
+
+/// The route-side `key` parse — the one rejection path shared by every route.
+fn required_key(intent: &Intent) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get("key")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), "missing 'key'".to_string()))
+}
+
+/// An in-memory sink recording delivered frames; can be killed to simulate a
+/// dead subscriber (mirrors the substrate/tunnel/session test double).
+struct VecSink {
+    frames: Mutex<Vec<ProjectionFrame>>,
+    alive: AtomicBool,
+}
+
+impl VecSink {
+    fn new() -> Self {
+        Self {
+            frames: Mutex::new(Vec::new()),
+            alive: AtomicBool::new(true),
+        }
+    }
+
+    fn diffs(&self) -> Vec<DiffFrame> {
+        self.frames
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|f| match f {
+                ProjectionFrame::Diff(d) => Some(d.clone()),
+                ProjectionFrame::Snapshot(_) => None,
+            })
+            .collect()
+    }
+}
+
+impl ProjectionSink for VecSink {
+    fn deliver(&self, frame: &ProjectionFrame) -> Result<(), ProjectionError> {
+        if !self.alive.load(Ordering::SeqCst) {
+            return Err(ProjectionError::SinkClosed("killed".into()));
+        }
+        self.frames.lock().unwrap().push(frame.clone());
+        Ok(())
+    }
+}
+
+/// A minimal client cache mirroring the TypeScript `ProjectionClient`.
+struct ClientCache {
+    version: u64,
+    view: Value,
+}
+
+impl ClientCache {
+    fn from_snapshot(s: &SnapshotFrame) -> Self {
+        Self {
+            version: s.version,
+            view: s.view.clone(),
+        }
+    }
+
+    fn apply(&mut self, diff: &DiffFrame) {
+        assert_eq!(diff.base_version, self.version, "diff must fit the cache");
+        apply_ops(&mut self.view, &diff.ops).expect("diff applies cleanly");
+        self.version = diff.version;
+    }
+}
+
+fn intent(kind: &str, payload: Value) -> Intent {
+    Intent {
+        intent_id: format!("01J-{kind}"),
+        kind: kind.to_string(),
+        payload,
+        client_id: "client-1".to_string(),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn subscribe_returns_the_seeded_snapshot_identically_to_every_subscriber() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SYSTEM_MONITORS_REGION, store.snapshot());
+
+    let snap_a =
+        projector.subscribe(SYSTEM_MONITORS_REGION, "sub-a", "A", Arc::new(VecSink::new()));
+    let snap_b =
+        projector.subscribe(SYSTEM_MONITORS_REGION, "sub-b", "B", Arc::new(VecSink::new()));
+
+    assert_eq!(snap_a.version, 0);
+    assert_eq!(snap_a, snap_b, "a late joiner gets an identical baseline");
+    assert_eq!(snap_a.region, "system-monitors");
+    assert_eq!(snap_a.view["monitors"]["s1"]["status"], json!("connecting"));
+    assert_eq!(snap_a.view["monitors"]["s2"]["status"], json!("live"));
+}
+
+#[test]
+fn a_monitor_intent_produces_one_diff_fanned_to_two_subscribers() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SYSTEM_MONITORS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink_a = Arc::new(VecSink::new());
+    let sink_b = Arc::new(VecSink::new());
+    let snap = projector.subscribe(SYSTEM_MONITORS_REGION, "sub-a", "A", sink_a.clone());
+    projector.subscribe(SYSTEM_MONITORS_REGION, "sub-b", "B", sink_b.clone());
+    let mut cache_a = ClientCache::from_snapshot(&snap);
+
+    let ack = dispatcher.dispatch(intent("monitor.opened", json!({ "key": "s1" })));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(
+        ack.produced,
+        Some(vec![crate::projection::ProducedRegion {
+            region: SYSTEM_MONITORS_REGION.to_string(),
+            version: 1,
+        }])
+    );
+
+    let diffs_a = sink_a.diffs();
+    let diffs_b = sink_b.diffs();
+    assert_eq!(diffs_a.len(), 1, "exactly one diff to A");
+    assert_eq!(diffs_b.len(), 1, "exactly one diff to B");
+    assert_eq!(diffs_a[0], diffs_b[0], "identical diff to every subscriber");
+    assert_eq!(diffs_a[0].base_version, 0);
+    assert_eq!(diffs_a[0].version, 1);
+
+    cache_a.apply(&diffs_a[0]);
+    assert_eq!(cache_a.view, store.snapshot(), "cache converges on authority");
+    assert_eq!(cache_a.view["monitors"]["s1"]["status"], json!("live"));
+}
+
+#[test]
+fn a_full_monitor_lifecycle_advances_monotonically_and_converges() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SYSTEM_MONITORS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(SYSTEM_MONITORS_REGION, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    // s1: connecting → opened → two stats samples → paused → closed. Each accepted
+    // intent that changes the view = one diff.
+    for kind_payload in [
+        ("monitor.opened", json!({ "key": "s1" })),
+        ("monitor.stats", json!({ "key": "s1", "stats": stats("host-a", 12.0) })),
+        ("monitor.stats", json!({ "key": "s1", "stats": stats("host-a", 34.0) })),
+        ("monitor.setPaused", json!({ "key": "s1", "paused": true })),
+        ("monitor.close", json!({ "key": "s1" })),
+    ] {
+        let ack = dispatcher.dispatch(intent(kind_payload.0, kind_payload.1));
+        assert_eq!(ack.status, IntentStatus::Accepted, "{} accepted", kind_payload.0);
+    }
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 5, "one diff per view-changing intent");
+    for diff in &diffs {
+        cache.apply(diff);
+    }
+    assert_eq!(cache.version, 5);
+    assert_eq!(cache.view, store.snapshot(), "cache converges on authority");
+    // s1's entry is gone but its last stats survive in the cache.
+    assert_eq!(cache.view["monitors"].get("s1"), None);
+    assert_eq!(cache.view["statsCache"]["s1"]["cpuUsagePercent"], json!(34.0));
+}
+
+#[test]
+fn an_intent_missing_the_key_is_rejected_without_advancing() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SYSTEM_MONITORS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(SYSTEM_MONITORS_REGION, "sub", "A", sink.clone());
+
+    let ack = dispatcher.dispatch(intent("monitor.open", json!({ "wrong": "field" })));
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "bad_payload");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(SYSTEM_MONITORS_REGION), Some(0));
+}
+
+#[test]
+fn a_no_op_intent_advances_nothing() {
+    // `opened` on an already-live monitor leaves the view unchanged, so the
+    // projector coalesces it to no diff and no version bump.
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SYSTEM_MONITORS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(SYSTEM_MONITORS_REGION, "sub", "A", sink.clone());
+
+    let ack = dispatcher.dispatch(intent("monitor.opened", json!({ "key": "s2" })));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(ack.produced, Some(vec![]), "no region advanced");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(SYSTEM_MONITORS_REGION), Some(0));
+}
+
+#[test]
+fn a_dead_subscriber_is_reaped_on_publish() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SYSTEM_MONITORS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let live = Arc::new(VecSink::new());
+    let dead = Arc::new(VecSink::new());
+    projector.subscribe(SYSTEM_MONITORS_REGION, "live", "A", live.clone());
+    projector.subscribe(SYSTEM_MONITORS_REGION, "dead", "B", dead.clone());
+    assert_eq!(projector.subscriber_count(SYSTEM_MONITORS_REGION), 2);
+
+    dead.alive.store(false, Ordering::SeqCst);
+    dispatcher.dispatch(intent("monitor.opened", json!({ "key": "s1" })));
+
+    assert_eq!(live.diffs().len(), 1, "the live subscriber still gets the diff");
+    assert_eq!(
+        projector.subscriber_count(SYSTEM_MONITORS_REGION),
+        1,
+        "the dead subscriber was reaped"
+    );
+}

--- a/src-tauri/src/system_monitor_projection/projection_tests.rs
+++ b/src-tauri/src/system_monitor_projection/projection_tests.rs
@@ -65,7 +65,11 @@ fn registry_for(store: Arc<SystemMonitorStore>) -> HandlerRegistry {
     registry.route("monitor.open", move |intent, projector| {
         s.open(
             &required_key(intent)?,
-            intent.payload.get("host").and_then(Value::as_str).map(str::to_string),
+            intent
+                .payload
+                .get("host")
+                .and_then(Value::as_str)
+                .map(str::to_string),
             intent.payload.get("intervalMs").and_then(Value::as_u64),
         );
         Ok(publish_monitors(projector, &s))
@@ -79,7 +83,11 @@ fn registry_for(store: Arc<SystemMonitorStore>) -> HandlerRegistry {
     registry.route("monitor.openFailed", move |intent, projector| {
         s.open_failed(
             &required_key(intent)?,
-            intent.payload.get("error").and_then(Value::as_str).map(str::to_string),
+            intent
+                .payload
+                .get("error")
+                .and_then(Value::as_str)
+                .map(str::to_string),
         );
         Ok(publish_monitors(projector, &s))
     });
@@ -200,10 +208,18 @@ fn subscribe_returns_the_seeded_snapshot_identically_to_every_subscriber() {
     let projector = Arc::new(Projector::new());
     projector.register_region(SYSTEM_MONITORS_REGION, store.snapshot());
 
-    let snap_a =
-        projector.subscribe(SYSTEM_MONITORS_REGION, "sub-a", "A", Arc::new(VecSink::new()));
-    let snap_b =
-        projector.subscribe(SYSTEM_MONITORS_REGION, "sub-b", "B", Arc::new(VecSink::new()));
+    let snap_a = projector.subscribe(
+        SYSTEM_MONITORS_REGION,
+        "sub-a",
+        "A",
+        Arc::new(VecSink::new()),
+    );
+    let snap_b = projector.subscribe(
+        SYSTEM_MONITORS_REGION,
+        "sub-b",
+        "B",
+        Arc::new(VecSink::new()),
+    );
 
     assert_eq!(snap_a.version, 0);
     assert_eq!(snap_a, snap_b, "a late joiner gets an identical baseline");
@@ -244,7 +260,11 @@ fn a_monitor_intent_produces_one_diff_fanned_to_two_subscribers() {
     assert_eq!(diffs_a[0].version, 1);
 
     cache_a.apply(&diffs_a[0]);
-    assert_eq!(cache_a.view, store.snapshot(), "cache converges on authority");
+    assert_eq!(
+        cache_a.view,
+        store.snapshot(),
+        "cache converges on authority"
+    );
     assert_eq!(cache_a.view["monitors"]["s1"]["status"], json!("live"));
 }
 
@@ -263,13 +283,24 @@ fn a_full_monitor_lifecycle_advances_monotonically_and_converges() {
     // intent that changes the view = one diff.
     for kind_payload in [
         ("monitor.opened", json!({ "key": "s1" })),
-        ("monitor.stats", json!({ "key": "s1", "stats": stats("host-a", 12.0) })),
-        ("monitor.stats", json!({ "key": "s1", "stats": stats("host-a", 34.0) })),
+        (
+            "monitor.stats",
+            json!({ "key": "s1", "stats": stats("host-a", 12.0) }),
+        ),
+        (
+            "monitor.stats",
+            json!({ "key": "s1", "stats": stats("host-a", 34.0) }),
+        ),
         ("monitor.setPaused", json!({ "key": "s1", "paused": true })),
         ("monitor.close", json!({ "key": "s1" })),
     ] {
         let ack = dispatcher.dispatch(intent(kind_payload.0, kind_payload.1));
-        assert_eq!(ack.status, IntentStatus::Accepted, "{} accepted", kind_payload.0);
+        assert_eq!(
+            ack.status,
+            IntentStatus::Accepted,
+            "{} accepted",
+            kind_payload.0
+        );
     }
 
     let diffs = sink.diffs();
@@ -281,7 +312,10 @@ fn a_full_monitor_lifecycle_advances_monotonically_and_converges() {
     assert_eq!(cache.view, store.snapshot(), "cache converges on authority");
     // s1's entry is gone but its last stats survive in the cache.
     assert_eq!(cache.view["monitors"].get("s1"), None);
-    assert_eq!(cache.view["statsCache"]["s1"]["cpuUsagePercent"], json!(34.0));
+    assert_eq!(
+        cache.view["statsCache"]["s1"]["cpuUsagePercent"],
+        json!(34.0)
+    );
 }
 
 #[test]
@@ -334,7 +368,11 @@ fn a_dead_subscriber_is_reaped_on_publish() {
     dead.alive.store(false, Ordering::SeqCst);
     dispatcher.dispatch(intent("monitor.opened", json!({ "key": "s1" })));
 
-    assert_eq!(live.diffs().len(), 1, "the live subscriber still gets the diff");
+    assert_eq!(
+        live.diffs().len(),
+        1,
+        "the live subscriber still gets the diff"
+    );
     assert_eq!(
         projector.subscriber_count(SYSTEM_MONITORS_REGION),
         1,

--- a/src-tauri/src/system_monitor_projection/store.rs
+++ b/src-tauri/src/system_monitor_projection/store.rs
@@ -1,0 +1,260 @@
+//! The authoritative, shared system-monitor state behind the shadow
+//! `system-monitors` projection region (#2224, Phase 5 of #2139).
+//!
+//! Models the per-host/session monitoring slice the frontend currently drives in
+//! `appStore` (`monitors: Record<MonitorKey, MonitoringEntry>` and the
+//! `monitoringStatsCache`): the connect / live / stale / paused lifecycle of each
+//! monitor plus its last-known [`SystemStats`]. Built on the monitoring types
+//! already shared with the agent crate (`termihub_core::monitoring`), so the view
+//! model matches the frontend `MonitoringEntry` one-to-one.
+//!
+//! # Shared region — Open Design Decision #4
+//!
+//! A monitor subscribes a backend session's `MonitoringProvider` and the provider
+//! pushes stats/status; that lifecycle is a property of the session, not of a
+//! viewing client, so two clients observing the same monitored session see the
+//! same stats (like SSH tunnels, [`crate::tunnel::projection`], and
+//! session-lifecycle, [`crate::session_projection`]). The region is therefore a
+//! single **shared** `system-monitors` region. The per-client choice of which
+//! monitor the status bar renders (the active tab) is layout/presentation and
+//! stays a frontend concern under partial projection.
+//!
+//! # Shadow mode — zero user-facing change
+//!
+//! This step is deliberately **not** authoritative. The store exists, accepts
+//! `monitor.*` intents, and projects diffs, but nothing in the live UI subscribes
+//! to or renders the `system-monitors` region, and no frontend code dispatches
+//! `monitor.*` intents yet. The existing `appStore` monitoring slice remains
+//! authoritative. Later steps cut rendering, then mutation, over to the region,
+//! then remove the `appStore` state.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+
+use termihub_core::monitoring::{MonitorStatus, SystemStats};
+
+/// Default monitoring refresh interval in milliseconds — mirrors the frontend
+/// `DEFAULT_MONITORING_INTERVAL_MS` (#1233).
+pub const DEFAULT_MONITORING_INTERVAL_MS: u64 = 2000;
+
+/// The authoritative record for one monitored host/session — the render-ready
+/// projection of the frontend `MonitoringEntry`. Keyed in the store by the owning
+/// terminal session id (the stable `MonitorKey`).
+///
+/// Every field serialises (no `skip_serializing_if`) so the view model matches
+/// the frontend `MonitoringEntry` shape exactly, keeping the eventual render cut
+/// a pure parity swap.
+// `SystemStats` (a field below) does not derive `PartialEq`, so this record
+// can't either; tests compare via the serialised view model instead.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct MonitorEntry {
+    /// Stable key identifying this monitor (the owning terminal session id).
+    pub key: String,
+    /// Human-readable host label shown in the UI.
+    pub host: Option<String>,
+    /// Backend session id used for the close RPC; equals `key` once the provider
+    /// subscription is live, `None` until established (or after a failed open).
+    pub monitor_session_id: Option<String>,
+    /// Last-known stats for this host, or `None` before the first sample.
+    pub stats: Option<SystemStats>,
+    /// True while the initial connect (or a cache-primed reconnect) is in flight.
+    pub loading: bool,
+    /// Last error message for this host, or `None`.
+    pub error: Option<String>,
+    /// Observable collector-loop status (`live`/`stale`/…), or `None` when idle.
+    pub status: Option<MonitorStatus>,
+    /// Number of stats samples received on this connection (drives CPU priming).
+    pub sample_count: u32,
+    /// True while the user has paused collection (#1233); transport stays open.
+    pub paused: bool,
+    /// Per-entry refresh interval in milliseconds (#1233).
+    pub interval_ms: u64,
+}
+
+impl MonitorEntry {
+    /// A fresh, idle entry for a key (mirrors the frontend `emptyMonitor`).
+    fn empty(key: &str, host: Option<String>) -> Self {
+        Self {
+            key: key.to_string(),
+            host,
+            monitor_session_id: None,
+            stats: None,
+            loading: false,
+            error: None,
+            status: None,
+            sample_count: 0,
+            paused: false,
+            interval_ms: DEFAULT_MONITORING_INTERVAL_MS,
+        }
+    }
+}
+
+/// The private mutable core: the per-monitor map plus the last-known stats cache
+/// (persisted across tab switches for instant display on reconnect). One mutex
+/// guards it so intents never interleave — the substrate's single-writer contract
+/// also holds within the store.
+#[derive(Default)]
+struct Inner {
+    monitors: HashMap<String, MonitorEntry>,
+    stats_cache: HashMap<String, SystemStats>,
+}
+
+/// The shadow system-monitor authority. Owns one [`MonitorEntry`] per monitored
+/// host/session, keyed by `MonitorKey`, plus the last-known stats cache. The
+/// single shared `system-monitors` region projects this state.
+#[derive(Default)]
+pub struct SystemMonitorStore {
+    inner: Mutex<Inner>,
+}
+
+impl SystemMonitorStore {
+    /// A store with no monitors yet.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The render-ready view model for the whole region:
+    /// `{ "monitors": { "<key>": MonitorEntry, ... }, "statsCache": { … } }`.
+    ///
+    /// Pure with respect to monitor state (never mutates), so the projector can
+    /// safely diff two consecutive snapshots.
+    pub fn snapshot(&self) -> Value {
+        let inner = self.lock();
+        let mut monitors = Map::with_capacity(inner.monitors.len());
+        for (key, entry) in &inner.monitors {
+            if let Ok(value) = serde_json::to_value(entry) {
+                monitors.insert(key.clone(), value);
+            }
+        }
+        let mut cache = Map::with_capacity(inner.stats_cache.len());
+        for (key, stats) in &inner.stats_cache {
+            if let Ok(value) = serde_json::to_value(stats) {
+                cache.insert(key.clone(), value);
+            }
+        }
+        json!({ "monitors": Value::Object(monitors), "statsCache": Value::Object(cache) })
+    }
+
+    /// `monitor.open` — begin an initial connect. Upserts a fresh loading entry
+    /// (status `connecting`, `monitorSessionId` still `None`) primed with any
+    /// cached stats for the key, mirroring the frontend `connectMonitoring` start.
+    pub fn open(&self, key: &str, host: Option<String>, interval_ms: Option<u64>) {
+        let mut inner = self.lock();
+        let cached = inner.stats_cache.get(key).cloned();
+        let mut entry = MonitorEntry::empty(key, host);
+        entry.loading = true;
+        entry.status = Some(MonitorStatus::Connecting);
+        entry.stats = cached;
+        entry.interval_ms = interval_ms.unwrap_or(DEFAULT_MONITORING_INTERVAL_MS);
+        inner.monitors.insert(key.to_string(), entry);
+    }
+
+    /// `monitor.opened` — the provider subscription is live. Settles the entry:
+    /// `monitorSessionId = key`, `loading = false`, status `live`.
+    pub fn opened(&self, key: &str) {
+        let mut inner = self.lock();
+        if let Some(entry) = inner.monitors.get_mut(key) {
+            entry.monitor_session_id = Some(key.to_string());
+            entry.loading = false;
+            entry.status = Some(MonitorStatus::Live);
+            entry.error = None;
+        }
+    }
+
+    /// `monitor.openFailed` — the initial connect errored. Clears the loading
+    /// state and records the error (mirrors the failed-open branch that detaches
+    /// listeners and leaves `monitorSessionId` null).
+    pub fn open_failed(&self, key: &str, error: Option<String>) {
+        let mut inner = self.lock();
+        if let Some(entry) = inner.monitors.get_mut(key) {
+            entry.monitor_session_id = None;
+            entry.loading = false;
+            entry.status = None;
+            entry.error = error;
+        }
+    }
+
+    /// `monitor.stats` — a stats sample arrived. Updates the entry's stats,
+    /// increments the sample count, and refreshes the last-known cache so a later
+    /// reconnect shows the value instantly. A no-op for an unknown key.
+    pub fn stats(&self, key: &str, stats: SystemStats) {
+        let mut inner = self.lock();
+        inner.stats_cache.insert(key.to_string(), stats.clone());
+        if let Some(entry) = inner.monitors.get_mut(key) {
+            entry.stats = Some(stats);
+            entry.sample_count = entry.sample_count.saturating_add(1);
+        }
+    }
+
+    /// `monitor.status` — an observable collector-loop status update arrived.
+    pub fn set_status(&self, key: &str, status: MonitorStatus) {
+        let mut inner = self.lock();
+        if let Some(entry) = inner.monitors.get_mut(key) {
+            entry.status = Some(status);
+        }
+    }
+
+    /// `monitor.setPaused` — pause or resume one monitor (#1233). The transport
+    /// stays open; the badge flips to `paused` / `live`.
+    pub fn set_paused(&self, key: &str, paused: bool) {
+        let mut inner = self.lock();
+        if let Some(entry) = inner.monitors.get_mut(key) {
+            entry.paused = paused;
+            entry.status = Some(if paused {
+                MonitorStatus::Paused
+            } else {
+                MonitorStatus::Live
+            });
+        }
+    }
+
+    /// `monitor.setInterval` — change one monitor's refresh interval (#1233).
+    pub fn set_interval(&self, key: &str, interval_ms: u64) {
+        let mut inner = self.lock();
+        if let Some(entry) = inner.monitors.get_mut(key) {
+            entry.interval_ms = interval_ms;
+        }
+    }
+
+    /// `monitor.clearError` — dismiss a monitor's error banner. A no-op when the
+    /// key is unknown or already clear.
+    pub fn clear_error(&self, key: &str) {
+        let mut inner = self.lock();
+        if let Some(entry) = inner.monitors.get_mut(key) {
+            entry.error = None;
+        }
+    }
+
+    /// `monitor.close` — disconnect one monitor and drop its entry. The stats
+    /// cache is retained so a later reconnect can prime instantly (mirrors
+    /// `disconnectMonitoring`, which keeps the cache). Idempotent.
+    pub fn close(&self, key: &str) {
+        self.lock().monitors.remove(key);
+    }
+
+    /// Read one monitor entry (test / diagnostics helper).
+    #[cfg(test)]
+    pub fn get(&self, key: &str) -> Option<MonitorEntry> {
+        self.lock().monitors.get(key).cloned()
+    }
+
+    /// Read the cached last-known stats for a key (test / diagnostics helper).
+    #[cfg(test)]
+    pub fn cached_stats(&self, key: &str) -> Option<SystemStats> {
+        self.lock().stats_cache.get(key).cloned()
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Inner> {
+        // Short critical sections only; a poisoned lock means another thread
+        // panicked mid-mutation (a bug) — recover rather than cascade.
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod tests;

--- a/src-tauri/src/system_monitor_projection/store_tests.rs
+++ b/src-tauri/src/system_monitor_projection/store_tests.rs
@@ -30,7 +30,10 @@ fn sample(hostname: &str, cpu: f64) -> SystemStats {
 #[test]
 fn a_fresh_store_snapshots_empty() {
     let store = SystemMonitorStore::new();
-    assert_eq!(store.snapshot(), json!({ "monitors": {}, "statsCache": {} }));
+    assert_eq!(
+        store.snapshot(),
+        json!({ "monitors": {}, "statsCache": {} })
+    );
 }
 
 #[test]

--- a/src-tauri/src/system_monitor_projection/store_tests.rs
+++ b/src-tauri/src/system_monitor_projection/store_tests.rs
@@ -1,0 +1,178 @@
+//! Unit tests for the shadow [`SystemMonitorStore`] transitions (#2224).
+//!
+//! Drives the store directly and asserts on the serialised view model (the type
+//! carries a `SystemStats` field, which has no `PartialEq`, so records are
+//! compared via their JSON projection).
+
+use serde_json::json;
+
+use termihub_core::monitoring::{MonitorStatus, SystemStats};
+
+use super::{SystemMonitorStore, DEFAULT_MONITORING_INTERVAL_MS};
+
+/// A deterministic sample for a host.
+fn sample(hostname: &str, cpu: f64) -> SystemStats {
+    SystemStats {
+        hostname: hostname.to_string(),
+        uptime_seconds: 100.0,
+        load_average: [0.1, 0.2, 0.3],
+        cpu_usage_percent: cpu,
+        memory_total_kb: 16_000_000,
+        memory_available_kb: 8_000_000,
+        memory_used_percent: 50.0,
+        disk_total_kb: 100_000_000,
+        disk_used_kb: 40_000_000,
+        disk_used_percent: 40.0,
+        os_info: "Linux 6.1".to_string(),
+    }
+}
+
+#[test]
+fn a_fresh_store_snapshots_empty() {
+    let store = SystemMonitorStore::new();
+    assert_eq!(store.snapshot(), json!({ "monitors": {}, "statsCache": {} }));
+}
+
+#[test]
+fn open_creates_a_loading_connecting_entry() {
+    let store = SystemMonitorStore::new();
+    store.open("s1", Some("host-a".to_string()), None);
+
+    let entry = store.get("s1").expect("entry exists");
+    assert_eq!(entry.host.as_deref(), Some("host-a"));
+    assert!(entry.loading);
+    assert_eq!(entry.status, Some(MonitorStatus::Connecting));
+    assert_eq!(entry.monitor_session_id, None);
+    assert_eq!(entry.interval_ms, DEFAULT_MONITORING_INTERVAL_MS);
+}
+
+#[test]
+fn open_honours_a_custom_interval() {
+    let store = SystemMonitorStore::new();
+    store.open("s1", None, Some(5000));
+    assert_eq!(store.get("s1").unwrap().interval_ms, 5000);
+}
+
+#[test]
+fn opened_settles_the_entry_live() {
+    let store = SystemMonitorStore::new();
+    store.open("s1", None, None);
+    store.opened("s1");
+
+    let entry = store.get("s1").unwrap();
+    assert!(!entry.loading);
+    assert_eq!(entry.status, Some(MonitorStatus::Live));
+    assert_eq!(entry.monitor_session_id.as_deref(), Some("s1"));
+}
+
+#[test]
+fn open_failed_clears_loading_and_records_the_error() {
+    let store = SystemMonitorStore::new();
+    store.open("s1", None, None);
+    store.open_failed("s1", Some("connection refused".to_string()));
+
+    let entry = store.get("s1").unwrap();
+    assert!(!entry.loading);
+    assert_eq!(entry.status, None);
+    assert_eq!(entry.monitor_session_id, None);
+    assert_eq!(entry.error.as_deref(), Some("connection refused"));
+}
+
+#[test]
+fn stats_update_entry_and_cache_and_bump_sample_count() {
+    let store = SystemMonitorStore::new();
+    store.open("s1", None, None);
+    store.opened("s1");
+
+    store.stats("s1", sample("host-a", 10.0));
+    store.stats("s1", sample("host-a", 20.0));
+
+    let entry = store.get("s1").unwrap();
+    assert_eq!(entry.sample_count, 2);
+    assert_eq!(entry.stats.as_ref().unwrap().cpu_usage_percent, 20.0);
+    // Cache mirrors the latest sample for instant reconnect priming.
+    assert_eq!(store.cached_stats("s1").unwrap().cpu_usage_percent, 20.0);
+}
+
+#[test]
+fn close_drops_the_entry_but_retains_the_cache() {
+    let store = SystemMonitorStore::new();
+    store.open("s1", None, None);
+    store.opened("s1");
+    store.stats("s1", sample("host-a", 33.0));
+
+    store.close("s1");
+    assert!(store.get("s1").is_none(), "entry dropped");
+    assert!(
+        store.cached_stats("s1").is_some(),
+        "cache retained across close for instant reconnect"
+    );
+}
+
+#[test]
+fn reopen_primes_stats_from_the_retained_cache() {
+    let store = SystemMonitorStore::new();
+    store.open("s1", None, None);
+    store.opened("s1");
+    store.stats("s1", sample("host-a", 55.0));
+    store.close("s1");
+
+    store.open("s1", None, None);
+    let entry = store.get("s1").unwrap();
+    assert_eq!(
+        entry.stats.as_ref().unwrap().cpu_usage_percent,
+        55.0,
+        "a reopened monitor shows the last cached stats immediately"
+    );
+    assert!(entry.loading, "still connecting though");
+}
+
+#[test]
+fn pause_and_resume_flip_status_and_flag() {
+    let store = SystemMonitorStore::new();
+    store.open("s1", None, None);
+    store.opened("s1");
+
+    store.set_paused("s1", true);
+    let entry = store.get("s1").unwrap();
+    assert!(entry.paused);
+    assert_eq!(entry.status, Some(MonitorStatus::Paused));
+
+    store.set_paused("s1", false);
+    let entry = store.get("s1").unwrap();
+    assert!(!entry.paused);
+    assert_eq!(entry.status, Some(MonitorStatus::Live));
+}
+
+#[test]
+fn set_interval_and_status_and_clear_error() {
+    let store = SystemMonitorStore::new();
+    store.open("s1", None, None);
+    store.open_failed("s1", Some("boom".to_string()));
+
+    store.set_interval("s1", 10_000);
+    store.set_status("s1", MonitorStatus::Stale);
+    store.clear_error("s1");
+
+    let entry = store.get("s1").unwrap();
+    assert_eq!(entry.interval_ms, 10_000);
+    assert_eq!(entry.status, Some(MonitorStatus::Stale));
+    assert_eq!(entry.error, None);
+}
+
+#[test]
+fn transitions_on_an_unknown_key_are_no_ops() {
+    let store = SystemMonitorStore::new();
+    // None of these should panic or create an entry.
+    store.opened("ghost");
+    store.stats("ghost", sample("x", 1.0));
+    store.set_status("ghost", MonitorStatus::Live);
+    store.set_paused("ghost", true);
+    store.set_interval("ghost", 1000);
+    store.clear_error("ghost");
+    store.close("ghost");
+    assert!(store.get("ghost").is_none());
+    // `stats` still records the cache even without an entry (matches the
+    // frontend cache write).
+    assert!(store.cached_stats("ghost").is_some());
+}


### PR DESCRIPTION
Part of #2153 (Phase 5 · the long tail) and #2224 (Monitors domain). Part of #2139 (stateless-UI port).

Lands the **shadow foundation** for the first Phase-5 domain — **Monitors** (SSH/session system-monitoring stats). Follows the proven per-domain pattern (Phases 3 & 4): shadow store + projection region first, not authoritative, zero user-facing change.

## What this adds

New backend module `src-tauri/src/system_monitor_projection/`:

- **`SystemMonitorStore`** — the authoritative monitor slice the frontend currently drives in `appStore` (`monitors: Record<MonitorKey, MonitoringEntry>` + `monitoringStatsCache`), built on the monitoring types already shared with the agent crate (`termihub_core::monitoring::{SystemStats, MonitorStatus}`), so the view model matches the frontend `MonitoringEntry` one-to-one.
- **Shared `system-monitors` region** + the `monitor.*` intents (`open`, `opened`, `openFailed`, `stats`, `status`, `setPaused`, `setInterval`, `clearError`, `close`), registered on the projection substrate ([`crate::projection`]) mirroring the SSH-tunnels pilot and the session-lifecycle shadow.
- Store managed and the region seeded at version 0 in `lib.rs`.
- Projection-assertion tests reusing the #2164 harness + store unit tests (17 tests).

## Region scope — shared (Open Design Decision #4)

The monitor rides a backend session's `MonitoringProvider`; its stats/status/paused/interval are a property of the session, not of a viewing client — two clients observing the same monitored session see the same stats (like SSH tunnels and session-lifecycle, both shared infrastructure regions). The per-client choice of *which* monitor the status bar renders (the active tab) is layout/presentation and stays a frontend concern under partial projection.

## Shadow mode — zero user-facing change

Registered and fully served, but **not** driving the live UI: nothing subscribes to or renders the `system-monitors` region, and no frontend code dispatches `monitor.*` yet. The existing `appStore` monitoring slice and the status-bar / Open-Connections rendering are untouched. Diff is backend-only (no `src/` files changed). Later steps (tracked in #2224) cut rendering, then mutation, over to the region, then remove the `appStore` state.

## Tests

- `cargo test -p termihub --lib system_monitor_projection` — 17 pass (11 store unit + 6 projection-contract).
- `cargo clippy -p termihub --lib --all-features -- -D warnings` — clean.
- `cargo fmt --check` — clean.
