### PR TITLE
feat(backend): shadow connections-tree projection store and region

### DIFF
--- a/src-tauri/src/connections_projection/mod.rs
+++ b/src-tauri/src/connections_projection/mod.rs
@@ -1,0 +1,40 @@
+//! Shadow connections-tree authority — Phase 5 of the stateless-UI migration
+//! (#2225, part of #2139 and #2153).
+//!
+//! Moves the saved-connection / folder tree the frontend drives in `appStore`
+//! (`folders: ConnectionFolder[]` + `connections: SavedConnection[]`) onto a Rust
+//! authority. The saved-connection config already lives in Rust
+//! ([`crate::connection`]); this store therefore **wraps that existing authority**
+//! — it reuses the flat in-memory types the manager and IPC layer already speak
+//! ([`crate::connection::config::SavedConnection`] and
+//! [`crate::connection::config::ConnectionFolder`]) rather than re-homing them.
+//! It owns a single **shared** `connections` projection region (Open Design
+//! Decision #4) and serves the `connection.*` intents through the projection
+//! substrate ([`crate::projection`]), mirroring the SSH-tunnels pilot
+//! ([`crate::tunnel::projection`]), the session-lifecycle shadow
+//! ([`crate::session_projection`]) and the system-monitor shadow
+//! ([`crate::system_monitor_projection`]).
+//!
+//! # Shared region — Open Design Decision #4
+//!
+//! The saved connections/folders are a single persisted config (the connections
+//! JSON file), identical for every viewing client — like SSH tunnels. So the
+//! inventory (the two flat arrays, including each folder's persisted
+//! `isExpanded`) is modelled here as one **shared** `connections` region. Truly
+//! per-client presentation — tree *selection* / highlight, which lives only in
+//! the `useTreeSelection` React hook and is never persisted — stays a frontend
+//! concern under partial projection and is deliberately kept out of the store.
+//!
+//! # Shadow mode — zero user-facing change
+//!
+//! This step is deliberately **not** authoritative. The store exists, accepts
+//! `connection.*` intents, and projects diffs, but nothing in the live UI
+//! subscribes to or renders the `connections` region, and no frontend code
+//! dispatches `connection.*` intents yet. The existing `appStore` connections
+//! slice and the sidebar rendering are untouched. Later steps cut rendering, then
+//! mutation, over to the region, then remove the `appStore` state.
+
+pub mod projection;
+pub mod store;
+
+pub use store::ConnectionsStore;

--- a/src-tauri/src/connections_projection/projection.rs
+++ b/src-tauri/src/connections_projection/projection.rs
@@ -1,0 +1,191 @@
+//! Connections-tree projection: the shared `connections` region and the
+//! `connection.*` intents (#2225, part of #2139 and #2153).
+//!
+//! Exposes the authoritative [`ConnectionsStore`] as one versioned,
+//! multi-subscriber projection region and turns the tree-mutation transitions the
+//! frontend currently drives into [`Intent`]s — mirroring the SSH-tunnels pilot
+//! ([`crate::tunnel::projection`]), the session-lifecycle shadow
+//! ([`crate::session_projection::projection`]) and the system-monitor shadow
+//! ([`crate::system_monitor_projection::projection`]).
+//!
+//! # The `connections` region
+//!
+//! **Shared** (Open Design Decision #4: the saved-connection config is one
+//! persisted file, identical for every client). The view model:
+//!
+//! ```json
+//! { "folders": [ConnectionFolder, …], "connections": [SavedConnection, …] }
+//! ```
+//!
+//! # Intents
+//!
+//! | kind                        | payload                          | effect                                       |
+//! | --------------------------- | -------------------------------- | -------------------------------------------- |
+//! | `connection.add`            | `{ connection }`                 | append a saved connection                    |
+//! | `connection.update`         | `{ connection }`                 | replace the entry with the same id (edit)    |
+//! | `connection.remove`         | `{ connectionId }`               | drop a connection                            |
+//! | `connection.move`           | `{ connectionId, folderId? }`    | move a connection (absent/null → root)       |
+//! | `connection.addFolder`      | `{ folder }`                     | append a folder                              |
+//! | `connection.removeFolder`   | `{ folderId }`                   | remove a folder, re-homing its children      |
+//! | `connection.toggleFolder`   | `{ folderId }`                   | flip a folder's `isExpanded`                 |
+//!
+//! Ordering is array position, matching the on-disk `children` order; there is no
+//! standalone reorder transition in the `appStore` today, so none is shadowed. If
+//! one is added later it becomes a new `connection.*` intent.
+//!
+//! # Shadow mode
+//!
+//! Registered and fully served, but **not** driving the live UI: no frontend
+//! subscribes to `connections` or dispatches `connection.*` yet, so these intents
+//! mutate only the shadow store and project to a region nobody renders. The
+//! `appStore` connections slice remains authoritative. Per the substrate contract
+//! the result of an intent is never returned inline — it always arrives as a
+//! projection diff on the `connections` region.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+use crate::connection::config::{ConnectionFolder, SavedConnection};
+use crate::connections_projection::store::ConnectionsStore;
+use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
+
+/// The projection region id for the connections-tree domain (shared, per Open
+/// Design Decision #4).
+pub const CONNECTIONS_REGION: &str = "connections";
+
+/// Publish the `connections` region from the store, fanning a diff out to every
+/// subscriber and returning the advanced region for the intent ack (empty when
+/// the view did not change).
+pub fn publish_connections(projector: &Projector, store: &ConnectionsStore) -> Vec<ProducedRegion> {
+    match projector.publish(CONNECTIONS_REGION, store.snapshot()) {
+        Some(version) => vec![ProducedRegion {
+            region: CONNECTIONS_REGION.to_string(),
+            version,
+        }],
+        None => Vec::new(),
+    }
+}
+
+/// Register the `connection.*` intents on a handler registry.
+///
+/// Each route resolves the managed [`ConnectionsStore`] lazily (so it rejects
+/// gracefully rather than panicking if the store is somehow absent), applies the
+/// transition, and publishes the shared region. All transitions are pure/fast
+/// array edits, so they run inline on the dispatcher's single writer.
+pub fn register_connection_intents(registry: &mut HandlerRegistry, app_handle: AppHandle) {
+    let handle = app_handle.clone();
+    registry.route("connection.add", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.add_connection(required_connection(intent)?);
+        Ok(publish_connections(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("connection.update", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.update_connection(required_connection(intent)?);
+        Ok(publish_connections(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("connection.remove", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.remove_connection(&required_str(intent, "connectionId")?);
+        Ok(publish_connections(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("connection.move", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.move_connection(
+            &required_str(intent, "connectionId")?,
+            optional_str(intent, "folderId"),
+        );
+        Ok(publish_connections(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("connection.addFolder", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.add_folder(required_folder(intent)?);
+        Ok(publish_connections(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("connection.removeFolder", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.remove_folder(&required_str(intent, "folderId")?);
+        Ok(publish_connections(projector, &store))
+    });
+
+    let handle = app_handle;
+    registry.route("connection.toggleFolder", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.toggle_folder(&required_str(intent, "folderId")?);
+        Ok(publish_connections(projector, &store))
+    });
+}
+
+/// Resolve the managed connections store, or a rejectable error if absent.
+fn store_of(app_handle: &AppHandle) -> Result<Arc<ConnectionsStore>, (String, String)> {
+    app_handle
+        .try_state::<Arc<ConnectionsStore>>()
+        .map(|state| (*state).clone())
+        .ok_or_else(|| {
+            (
+                "unavailable".to_string(),
+                "connections store is not initialized".to_string(),
+            )
+        })
+}
+
+/// Extract a required string field from an intent payload.
+fn required_str(intent: &Intent, key: &str) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// Extract an optional string field; absent or `null` → `None`.
+fn optional_str(intent: &Intent, key: &str) -> Option<String> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+/// Parse the required `connection` object as a [`SavedConnection`].
+fn required_connection(intent: &Intent) -> Result<SavedConnection, (String, String)> {
+    let value = intent.payload.get("connection").ok_or_else(|| {
+        (
+            "bad_payload".to_string(),
+            "missing 'connection'".to_string(),
+        )
+    })?;
+    serde_json::from_value(value.clone()).map_err(|e| {
+        (
+            "bad_payload".to_string(),
+            format!("invalid connection: {e}"),
+        )
+    })
+}
+
+/// Parse the required `folder` object as a [`ConnectionFolder`].
+fn required_folder(intent: &Intent) -> Result<ConnectionFolder, (String, String)> {
+    let value = intent
+        .payload
+        .get("folder")
+        .ok_or_else(|| ("bad_payload".to_string(), "missing 'folder'".to_string()))?;
+    serde_json::from_value(value.clone())
+        .map_err(|e| ("bad_payload".to_string(), format!("invalid folder: {e}")))
+}
+
+#[cfg(test)]
+#[path = "projection_tests.rs"]
+mod tests;

--- a/src-tauri/src/connections_projection/projection_tests.rs
+++ b/src-tauri/src/connections_projection/projection_tests.rs
@@ -1,0 +1,394 @@
+//! Projection-contract tests for the shared `connections` region (#2225),
+//! reusing the substrate harness (#2164): an in-memory [`ProjectionSink`] and a
+//! client cache that applies diffs. The routes here drive a real
+//! [`ConnectionsStore`] directly (the production `register_connection_intents`
+//! resolves the same store from the Tauri `AppHandle`; that thin wiring is
+//! integration-verified via a local `./scripts/dev.sh` run) through the identical
+//! parse → mutate → publish path.
+//!
+//! Asserted: subscribe → snapshot (identical to every subscriber), an accepted
+//! intent → exactly one coalesced diff fanned to every subscriber with monotonic
+//! versions, rejection paths advance nothing, a no-op intent advances nothing, a
+//! dead subscriber is reaped, and the client cache converges on the store's
+//! authority across a full tree-mutation lifecycle.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::{json, Value};
+
+use crate::connection::config::{ConnectionFolder, SavedConnection};
+use crate::connections_projection::projection::{publish_connections, CONNECTIONS_REGION};
+use crate::connections_projection::store::ConnectionsStore;
+use crate::projection::{
+    apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
+    ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
+};
+use crate::terminal::backend::ConnectionConfig;
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+fn connection(id: &str, name: &str, folder_id: Option<&str>) -> SavedConnection {
+    SavedConnection {
+        id: id.to_string(),
+        name: name.to_string(),
+        config: ConnectionConfig {
+            type_id: "ssh".to_string(),
+            settings: json!({ "host": "example.com", "port": 22 }),
+        },
+        folder_id: folder_id.map(str::to_string),
+        terminal_options: None,
+        source_file: None,
+    }
+}
+
+fn folder(id: &str, name: &str, parent_id: Option<&str>, expanded: bool) -> ConnectionFolder {
+    ConnectionFolder {
+        id: id.to_string(),
+        name: name.to_string(),
+        parent_id: parent_id.map(str::to_string),
+        is_expanded: expanded,
+    }
+}
+
+/// A store with a folder and a connection already present, so a subscriber sees a
+/// populated baseline.
+fn seeded_store() -> Arc<ConnectionsStore> {
+    let store = Arc::new(ConnectionsStore::new());
+    store.add_folder(folder("Work", "Work", None, true));
+    store.add_connection(connection("Work/A", "A", Some("Work")));
+    store
+}
+
+/// The production `connection.*` routes, bound to an injected store instead of
+/// resolving one from an `AppHandle` — the exact parse → mutate → publish path
+/// `register_connection_intents` runs. Each closure mirrors the production route
+/// one-to-one so the test drives real logic, not a stand-in.
+fn registry_for(store: Arc<ConnectionsStore>) -> HandlerRegistry {
+    let mut registry = HandlerRegistry::new();
+
+    let s = store.clone();
+    registry.route("connection.add", move |intent, projector| {
+        s.add_connection(required_connection(intent)?);
+        Ok(publish_connections(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("connection.update", move |intent, projector| {
+        s.update_connection(required_connection(intent)?);
+        Ok(publish_connections(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("connection.remove", move |intent, projector| {
+        s.remove_connection(&required_str(intent, "connectionId")?);
+        Ok(publish_connections(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("connection.move", move |intent, projector| {
+        s.move_connection(
+            &required_str(intent, "connectionId")?,
+            intent
+                .payload
+                .get("folderId")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        );
+        Ok(publish_connections(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("connection.addFolder", move |intent, projector| {
+        s.add_folder(required_folder(intent)?);
+        Ok(publish_connections(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("connection.removeFolder", move |intent, projector| {
+        s.remove_folder(&required_str(intent, "folderId")?);
+        Ok(publish_connections(projector, &s))
+    });
+    let s = store;
+    registry.route("connection.toggleFolder", move |intent, projector| {
+        s.toggle_folder(&required_str(intent, "folderId")?);
+        Ok(publish_connections(projector, &s))
+    });
+
+    registry
+}
+
+fn required_str(intent: &Intent, key: &str) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+fn required_connection(intent: &Intent) -> Result<SavedConnection, (String, String)> {
+    let value = intent.payload.get("connection").ok_or_else(|| {
+        (
+            "bad_payload".to_string(),
+            "missing 'connection'".to_string(),
+        )
+    })?;
+    serde_json::from_value(value.clone()).map_err(|e| {
+        (
+            "bad_payload".to_string(),
+            format!("invalid connection: {e}"),
+        )
+    })
+}
+
+fn required_folder(intent: &Intent) -> Result<ConnectionFolder, (String, String)> {
+    let value = intent
+        .payload
+        .get("folder")
+        .ok_or_else(|| ("bad_payload".to_string(), "missing 'folder'".to_string()))?;
+    serde_json::from_value(value.clone())
+        .map_err(|e| ("bad_payload".to_string(), format!("invalid folder: {e}")))
+}
+
+/// An in-memory sink recording delivered frames; can be killed to simulate a
+/// dead subscriber (mirrors the substrate/tunnel/session/monitor test double).
+struct VecSink {
+    frames: Mutex<Vec<ProjectionFrame>>,
+    alive: AtomicBool,
+}
+
+impl VecSink {
+    fn new() -> Self {
+        Self {
+            frames: Mutex::new(Vec::new()),
+            alive: AtomicBool::new(true),
+        }
+    }
+
+    fn diffs(&self) -> Vec<DiffFrame> {
+        self.frames
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|f| match f {
+                ProjectionFrame::Diff(d) => Some(d.clone()),
+                ProjectionFrame::Snapshot(_) => None,
+            })
+            .collect()
+    }
+}
+
+impl ProjectionSink for VecSink {
+    fn deliver(&self, frame: &ProjectionFrame) -> Result<(), ProjectionError> {
+        if !self.alive.load(Ordering::SeqCst) {
+            return Err(ProjectionError::SinkClosed("killed".into()));
+        }
+        self.frames.lock().unwrap().push(frame.clone());
+        Ok(())
+    }
+}
+
+/// A minimal client cache mirroring the TypeScript `ProjectionClient`.
+struct ClientCache {
+    version: u64,
+    view: Value,
+}
+
+impl ClientCache {
+    fn from_snapshot(s: &SnapshotFrame) -> Self {
+        Self {
+            version: s.version,
+            view: s.view.clone(),
+        }
+    }
+
+    fn apply(&mut self, diff: &DiffFrame) {
+        assert_eq!(diff.base_version, self.version, "diff must fit the cache");
+        apply_ops(&mut self.view, &diff.ops).expect("diff applies cleanly");
+        self.version = diff.version;
+    }
+}
+
+fn intent(kind: &str, payload: Value) -> Intent {
+    Intent {
+        intent_id: format!("01J-{kind}"),
+        kind: kind.to_string(),
+        payload,
+        client_id: "client-1".to_string(),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn subscribe_returns_the_seeded_snapshot_identically_to_every_subscriber() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(CONNECTIONS_REGION, store.snapshot());
+
+    let snap_a = projector.subscribe(CONNECTIONS_REGION, "sub-a", "A", Arc::new(VecSink::new()));
+    let snap_b = projector.subscribe(CONNECTIONS_REGION, "sub-b", "B", Arc::new(VecSink::new()));
+
+    assert_eq!(snap_a.version, 0);
+    assert_eq!(snap_a, snap_b, "a late joiner gets an identical baseline");
+    assert_eq!(snap_a.region, "connections");
+    assert_eq!(snap_a.view["folders"][0]["id"], json!("Work"));
+    assert_eq!(snap_a.view["connections"][0]["id"], json!("Work/A"));
+}
+
+#[test]
+fn a_connection_intent_produces_one_diff_fanned_to_two_subscribers() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(CONNECTIONS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink_a = Arc::new(VecSink::new());
+    let sink_b = Arc::new(VecSink::new());
+    let snap = projector.subscribe(CONNECTIONS_REGION, "sub-a", "A", sink_a.clone());
+    projector.subscribe(CONNECTIONS_REGION, "sub-b", "B", sink_b.clone());
+    let mut cache_a = ClientCache::from_snapshot(&snap);
+
+    let ack = dispatcher.dispatch(intent(
+        "connection.add",
+        json!({ "connection": connection("Work/B", "B", Some("Work")) }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(
+        ack.produced,
+        Some(vec![crate::projection::ProducedRegion {
+            region: CONNECTIONS_REGION.to_string(),
+            version: 1,
+        }])
+    );
+
+    let diffs_a = sink_a.diffs();
+    let diffs_b = sink_b.diffs();
+    assert_eq!(diffs_a.len(), 1, "exactly one diff to A");
+    assert_eq!(diffs_b.len(), 1, "exactly one diff to B");
+    assert_eq!(diffs_a[0], diffs_b[0], "identical diff to every subscriber");
+    assert_eq!(diffs_a[0].base_version, 0);
+    assert_eq!(diffs_a[0].version, 1);
+
+    cache_a.apply(&diffs_a[0]);
+    assert_eq!(
+        cache_a.view,
+        store.snapshot(),
+        "cache converges on authority"
+    );
+    assert_eq!(cache_a.view["connections"][1]["id"], json!("Work/B"));
+}
+
+#[test]
+fn a_full_tree_lifecycle_advances_monotonically_and_converges() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(CONNECTIONS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(CONNECTIONS_REGION, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    // add a nested folder → add a connection in it → move the seeded one into it →
+    // toggle the folder → remove the folder (re-homing children). Each accepted
+    // intent that changes the view = one diff.
+    for (kind, payload) in [
+        (
+            "connection.addFolder",
+            json!({ "folder": folder("Work/Dev", "Dev", Some("Work"), true) }),
+        ),
+        (
+            "connection.add",
+            json!({ "connection": connection("Work/Dev/B", "B", Some("Work/Dev")) }),
+        ),
+        (
+            "connection.move",
+            json!({ "connectionId": "Work/A", "folderId": "Work/Dev" }),
+        ),
+        ("connection.toggleFolder", json!({ "folderId": "Work/Dev" })),
+        ("connection.removeFolder", json!({ "folderId": "Work/Dev" })),
+    ] {
+        let ack = dispatcher.dispatch(intent(kind, payload));
+        assert_eq!(ack.status, IntentStatus::Accepted, "{kind} accepted");
+    }
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 5, "one diff per view-changing intent");
+    for diff in &diffs {
+        cache.apply(diff);
+    }
+    assert_eq!(cache.version, 5);
+    assert_eq!(cache.view, store.snapshot(), "cache converges on authority");
+    // The removed folder is gone and its children were re-homed to root.
+    assert_eq!(
+        cache.view["folders"],
+        json!([folder("Work", "Work", None, true)])
+    );
+    assert_eq!(cache.view["connections"][0]["folderId"], json!(null));
+    assert_eq!(cache.view["connections"][1]["folderId"], json!(null));
+}
+
+#[test]
+fn an_intent_missing_the_connection_is_rejected_without_advancing() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(CONNECTIONS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(CONNECTIONS_REGION, "sub", "A", sink.clone());
+
+    let ack = dispatcher.dispatch(intent("connection.add", json!({ "wrong": "field" })));
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "bad_payload");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(CONNECTIONS_REGION), Some(0));
+}
+
+#[test]
+fn a_no_op_intent_advances_nothing() {
+    // Removing an unknown connection leaves the view unchanged, so the projector
+    // coalesces it to no diff and no version bump.
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(CONNECTIONS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(CONNECTIONS_REGION, "sub", "A", sink.clone());
+
+    let ack = dispatcher.dispatch(intent(
+        "connection.remove",
+        json!({ "connectionId": "ghost" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(ack.produced, Some(vec![]), "no region advanced");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(CONNECTIONS_REGION), Some(0));
+}
+
+#[test]
+fn a_dead_subscriber_is_reaped_on_publish() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(CONNECTIONS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let live = Arc::new(VecSink::new());
+    let dead = Arc::new(VecSink::new());
+    projector.subscribe(CONNECTIONS_REGION, "live", "A", live.clone());
+    projector.subscribe(CONNECTIONS_REGION, "dead", "B", dead.clone());
+    assert_eq!(projector.subscriber_count(CONNECTIONS_REGION), 2);
+
+    dead.alive.store(false, Ordering::SeqCst);
+    dispatcher.dispatch(intent(
+        "connection.toggleFolder",
+        json!({ "folderId": "Work" }),
+    ));
+
+    assert_eq!(
+        live.diffs().len(),
+        1,
+        "the live subscriber still gets the diff"
+    );
+    assert_eq!(
+        projector.subscriber_count(CONNECTIONS_REGION),
+        1,
+        "the dead subscriber was reaped"
+    );
+}

--- a/src-tauri/src/connections_projection/store.rs
+++ b/src-tauri/src/connections_projection/store.rs
@@ -1,0 +1,187 @@
+//! The authoritative, shared connections-tree state behind the shadow
+//! `connections` projection region (#2225, Phase 5 of #2139).
+//!
+//! Models the saved-connection / folder tree the frontend currently drives in
+//! `appStore` (`folders: ConnectionFolder[]` and `connections: SavedConnection[]`):
+//! two flat arrays whose nesting is expressed by parent pointers
+//! (`ConnectionFolder.parentId`, `SavedConnection.folderId`) and whose ordering is
+//! array position. It **wraps the existing Rust authority** — the flat in-memory
+//! types the connection manager already speaks
+//! ([`crate::connection::config::SavedConnection`] and
+//! [`crate::connection::config::ConnectionFolder`], which already carry the exact
+//! camelCase wire shape of the frontend types) — rather than re-homing the config.
+//!
+//! # Shared region — Open Design Decision #4
+//!
+//! The saved connections/folders are one persisted config shared by every client
+//! (like SSH tunnels, [`crate::tunnel::projection`]). The whole inventory — both
+//! arrays, including each folder's persisted `isExpanded` flag (which this codebase
+//! writes to disk via `persistFolder`) — is a single **shared** `connections`
+//! region. The per-client tree *selection* / highlight is presentation: it lives
+//! only in the `useTreeSelection` React hook, is never persisted, and stays a
+//! frontend concern under partial projection — so it is deliberately not modelled
+//! here.
+//!
+//! # Shadow mode — zero user-facing change
+//!
+//! This step is deliberately **not** authoritative. The store exists, accepts
+//! `connection.*` intents, and projects diffs, but nothing in the live UI
+//! subscribes to or renders the `connections` region, and no frontend code
+//! dispatches `connection.*` intents yet. The existing `appStore` connections
+//! slice remains authoritative. Later steps cut rendering, then mutation, over to
+//! the region, then remove the `appStore` state.
+
+use std::sync::{Mutex, MutexGuard};
+
+use serde_json::{json, Value};
+
+use crate::connection::config::{ConnectionFolder, SavedConnection};
+
+/// The private mutable core: the flat folder + connection arrays, mirroring the
+/// `appStore` connections slice one-to-one. One mutex guards it so intents never
+/// interleave — the substrate's single-writer contract also holds within the
+/// store.
+#[derive(Default)]
+struct Inner {
+    folders: Vec<ConnectionFolder>,
+    connections: Vec<SavedConnection>,
+}
+
+/// The shadow connections-tree authority. Owns the flat `folders` and
+/// `connections` arrays keyed by their path-derived ids, mirroring the frontend
+/// `appStore` slice. The single shared `connections` region projects this state.
+#[derive(Default)]
+pub struct ConnectionsStore {
+    inner: Mutex<Inner>,
+}
+
+impl ConnectionsStore {
+    /// A store with an empty tree.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The render-ready view model for the whole region:
+    /// `{ "folders": [ConnectionFolder, …], "connections": [SavedConnection, …] }`.
+    ///
+    /// The key names and element shapes mirror the `appStore` connections slice
+    /// exactly, keeping the eventual render cut a pure parity swap. Pure with
+    /// respect to store state (never mutates), so the projector can safely diff
+    /// two consecutive snapshots.
+    pub fn snapshot(&self) -> Value {
+        let inner = self.lock();
+        json!({
+            "folders": serde_json::to_value(&inner.folders).unwrap_or(Value::Null),
+            "connections": serde_json::to_value(&inner.connections).unwrap_or(Value::Null),
+        })
+    }
+
+    // ── Connection transitions ─────────────────────────────────────────────
+
+    /// `connection.add` — append one saved connection (mirrors `addConnection`,
+    /// which pushes onto the array; ordering is array position).
+    pub fn add_connection(&self, connection: SavedConnection) {
+        self.lock().connections.push(connection);
+    }
+
+    /// `connection.update` — replace the connection whose id matches the incoming
+    /// one (mirrors `updateConnection`'s `map(c => c.id === id ? next : c)`). A
+    /// no-op when no entry carries that id.
+    pub fn update_connection(&self, connection: SavedConnection) {
+        let mut inner = self.lock();
+        if let Some(slot) = inner.connections.iter_mut().find(|c| c.id == connection.id) {
+            *slot = connection;
+        }
+    }
+
+    /// `connection.remove` — drop the connection with this id (mirrors
+    /// `deleteConnection`'s filter). Idempotent.
+    pub fn remove_connection(&self, connection_id: &str) {
+        self.lock().connections.retain(|c| c.id != connection_id);
+    }
+
+    /// `connection.move` — set one connection's `folderId` (mirrors
+    /// `moveConnectionToFolder`; `None` = move to root). A no-op for an unknown id.
+    pub fn move_connection(&self, connection_id: &str, folder_id: Option<String>) {
+        let mut inner = self.lock();
+        if let Some(connection) = inner.connections.iter_mut().find(|c| c.id == connection_id) {
+            connection.folder_id = folder_id;
+        }
+    }
+
+    // ── Folder transitions ─────────────────────────────────────────────────
+
+    /// `connection.addFolder` — append one folder (mirrors `addFolder`).
+    pub fn add_folder(&self, folder: ConnectionFolder) {
+        self.lock().folders.push(folder);
+    }
+
+    /// `connection.removeFolder` — remove a folder and re-home its children, exactly
+    /// as `deleteFolder` does: child folders reparent to the removed folder's own
+    /// parent, and child connections move to root (`folderId = null`). Idempotent.
+    pub fn remove_folder(&self, folder_id: &str) {
+        let mut inner = self.lock();
+        let parent_id = inner
+            .folders
+            .iter()
+            .find(|f| f.id == folder_id)
+            .and_then(|f| f.parent_id.clone());
+        for connection in inner.connections.iter_mut() {
+            if connection.folder_id.as_deref() == Some(folder_id) {
+                connection.folder_id = None;
+            }
+        }
+        for folder in inner.folders.iter_mut() {
+            if folder.parent_id.as_deref() == Some(folder_id) {
+                folder.parent_id = parent_id.clone();
+            }
+        }
+        inner.folders.retain(|f| f.id != folder_id);
+    }
+
+    /// `connection.toggleFolder` — flip one folder's persisted `isExpanded`
+    /// (mirrors `toggleFolder`, which persists via `persistFolder`). A no-op for an
+    /// unknown id.
+    pub fn toggle_folder(&self, folder_id: &str) {
+        let mut inner = self.lock();
+        if let Some(folder) = inner.folders.iter_mut().find(|f| f.id == folder_id) {
+            folder.is_expanded = !folder.is_expanded;
+        }
+    }
+
+    // ── Test / diagnostics helpers ─────────────────────────────────────────
+
+    /// Read one connection entry (test / diagnostics helper).
+    #[cfg(test)]
+    pub fn connection(&self, id: &str) -> Option<SavedConnection> {
+        self.lock().connections.iter().find(|c| c.id == id).cloned()
+    }
+
+    /// Read one folder entry (test / diagnostics helper).
+    #[cfg(test)]
+    pub fn folder(&self, id: &str) -> Option<ConnectionFolder> {
+        self.lock().folders.iter().find(|f| f.id == id).cloned()
+    }
+
+    /// Count of connections currently in the store (test / diagnostics helper).
+    #[cfg(test)]
+    pub fn connection_count(&self) -> usize {
+        self.lock().connections.len()
+    }
+
+    /// Count of folders currently in the store (test / diagnostics helper).
+    #[cfg(test)]
+    pub fn folder_count(&self) -> usize {
+        self.lock().folders.len()
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Inner> {
+        // Short critical sections only; a poisoned lock means another thread
+        // panicked mid-mutation (a bug) — recover rather than cascade.
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod tests;

--- a/src-tauri/src/connections_projection/store_tests.rs
+++ b/src-tauri/src/connections_projection/store_tests.rs
@@ -1,0 +1,242 @@
+//! Unit tests for the shadow [`ConnectionsStore`] transitions (#2225).
+//!
+//! Drives the store directly and asserts on the flat arrays / serialised view
+//! model (the reused config types carry a `serde_json::Value` settings field,
+//! which has no `PartialEq`, so records are compared via their JSON projection or
+//! their scalar fields).
+
+use serde_json::json;
+
+use crate::connection::config::{ConnectionFolder, SavedConnection};
+use crate::terminal::backend::ConnectionConfig;
+
+use super::ConnectionsStore;
+
+/// A deterministic saved connection, optionally inside a folder.
+fn connection(id: &str, name: &str, folder_id: Option<&str>) -> SavedConnection {
+    SavedConnection {
+        id: id.to_string(),
+        name: name.to_string(),
+        config: ConnectionConfig {
+            type_id: "ssh".to_string(),
+            settings: json!({ "host": "example.com", "port": 22 }),
+        },
+        folder_id: folder_id.map(str::to_string),
+        terminal_options: None,
+        source_file: None,
+    }
+}
+
+/// A deterministic folder, optionally nested under a parent.
+fn folder(id: &str, name: &str, parent_id: Option<&str>, expanded: bool) -> ConnectionFolder {
+    ConnectionFolder {
+        id: id.to_string(),
+        name: name.to_string(),
+        parent_id: parent_id.map(str::to_string),
+        is_expanded: expanded,
+    }
+}
+
+#[test]
+fn a_fresh_store_snapshots_empty() {
+    let store = ConnectionsStore::new();
+    assert_eq!(
+        store.snapshot(),
+        json!({ "folders": [], "connections": [] })
+    );
+}
+
+#[test]
+fn add_connection_appends_to_the_array() {
+    let store = ConnectionsStore::new();
+    store.add_connection(connection("Work/A", "A", Some("Work")));
+    store.add_connection(connection("Work/B", "B", Some("Work")));
+
+    assert_eq!(store.connection_count(), 2);
+    assert_eq!(store.connection("Work/A").unwrap().name, "A");
+    // Ordering is array position — the second add lands after the first.
+    let snap = store.snapshot();
+    assert_eq!(snap["connections"][0]["id"], json!("Work/A"));
+    assert_eq!(snap["connections"][1]["id"], json!("Work/B"));
+}
+
+#[test]
+fn update_connection_replaces_the_matching_id_only() {
+    let store = ConnectionsStore::new();
+    store.add_connection(connection("Work/A", "A", Some("Work")));
+    store.add_connection(connection("Work/B", "B", Some("Work")));
+
+    store.update_connection(connection("Work/A", "A renamed", None));
+
+    let updated = store.connection("Work/A").unwrap();
+    assert_eq!(updated.name, "A renamed");
+    assert_eq!(updated.folder_id, None, "the edit moved it to root");
+    assert_eq!(store.connection("Work/B").unwrap().name, "B", "B untouched");
+    assert_eq!(store.connection_count(), 2, "no entry added or dropped");
+}
+
+#[test]
+fn update_connection_is_a_no_op_for_an_unknown_id() {
+    let store = ConnectionsStore::new();
+    store.add_connection(connection("Work/A", "A", None));
+
+    store.update_connection(connection("ghost", "ghost", None));
+
+    assert!(store.connection("ghost").is_none());
+    assert_eq!(store.connection_count(), 1);
+}
+
+#[test]
+fn remove_connection_drops_the_entry() {
+    let store = ConnectionsStore::new();
+    store.add_connection(connection("Work/A", "A", None));
+    store.add_connection(connection("Work/B", "B", None));
+
+    store.remove_connection("Work/A");
+
+    assert!(store.connection("Work/A").is_none());
+    assert!(store.connection("Work/B").is_some());
+    assert_eq!(store.connection_count(), 1);
+}
+
+#[test]
+fn remove_connection_is_idempotent() {
+    let store = ConnectionsStore::new();
+    store.add_connection(connection("Work/A", "A", None));
+    store.remove_connection("Work/A");
+    store.remove_connection("Work/A"); // no panic, no change
+    assert_eq!(store.connection_count(), 0);
+}
+
+#[test]
+fn move_connection_sets_the_folder_id() {
+    let store = ConnectionsStore::new();
+    store.add_connection(connection("Root/A", "A", None));
+
+    store.move_connection("Root/A", Some("Work".to_string()));
+    assert_eq!(
+        store.connection("Root/A").unwrap().folder_id.as_deref(),
+        Some("Work")
+    );
+
+    // Moving to root clears the folder id.
+    store.move_connection("Root/A", None);
+    assert_eq!(store.connection("Root/A").unwrap().folder_id, None);
+}
+
+#[test]
+fn move_connection_is_a_no_op_for_an_unknown_id() {
+    let store = ConnectionsStore::new();
+    store.move_connection("ghost", Some("Work".to_string()));
+    assert_eq!(store.connection_count(), 0);
+}
+
+#[test]
+fn add_folder_appends_to_the_array() {
+    let store = ConnectionsStore::new();
+    store.add_folder(folder("Work", "Work", None, false));
+    store.add_folder(folder("Work/Dev", "Dev", Some("Work"), true));
+
+    assert_eq!(store.folder_count(), 2);
+    assert_eq!(
+        store.folder("Work/Dev").unwrap().parent_id.as_deref(),
+        Some("Work")
+    );
+    assert!(store.folder("Work/Dev").unwrap().is_expanded);
+}
+
+#[test]
+fn toggle_folder_flips_is_expanded() {
+    let store = ConnectionsStore::new();
+    store.add_folder(folder("Work", "Work", None, false));
+
+    store.toggle_folder("Work");
+    assert!(store.folder("Work").unwrap().is_expanded);
+
+    store.toggle_folder("Work");
+    assert!(!store.folder("Work").unwrap().is_expanded);
+}
+
+#[test]
+fn toggle_folder_is_a_no_op_for_an_unknown_id() {
+    let store = ConnectionsStore::new();
+    store.toggle_folder("ghost"); // no panic
+    assert_eq!(store.folder_count(), 0);
+}
+
+#[test]
+fn remove_folder_reparents_child_folders_to_the_removed_parent() {
+    let store = ConnectionsStore::new();
+    // Work > Work/Dev > Work/Dev/Deep
+    store.add_folder(folder("Work", "Work", None, true));
+    store.add_folder(folder("Work/Dev", "Dev", Some("Work"), true));
+    store.add_folder(folder("Work/Dev/Deep", "Deep", Some("Work/Dev"), true));
+
+    store.remove_folder("Work/Dev");
+
+    assert!(store.folder("Work/Dev").is_none(), "the folder is gone");
+    assert_eq!(
+        store.folder("Work/Dev/Deep").unwrap().parent_id.as_deref(),
+        Some("Work"),
+        "the grandchild reparents to the removed folder's parent"
+    );
+}
+
+#[test]
+fn remove_folder_moves_child_connections_to_root() {
+    let store = ConnectionsStore::new();
+    store.add_folder(folder("Work", "Work", None, true));
+    store.add_connection(connection("Work/A", "A", Some("Work")));
+    store.add_connection(connection("Other/B", "B", Some("Other")));
+
+    store.remove_folder("Work");
+
+    assert_eq!(
+        store.connection("Work/A").unwrap().folder_id,
+        None,
+        "a child connection moves to root"
+    );
+    assert_eq!(
+        store.connection("Other/B").unwrap().folder_id.as_deref(),
+        Some("Other"),
+        "an unrelated connection is untouched"
+    );
+    assert!(store.folder("Work").is_none());
+}
+
+#[test]
+fn remove_folder_reparents_children_of_a_root_folder_to_root() {
+    let store = ConnectionsStore::new();
+    // A root folder with a child folder: removing it lifts the child to root
+    // (parent_id becomes the removed folder's own parent, which is None).
+    store.add_folder(folder("Top", "Top", None, true));
+    store.add_folder(folder("Top/Sub", "Sub", Some("Top"), true));
+
+    store.remove_folder("Top");
+
+    assert_eq!(store.folder("Top/Sub").unwrap().parent_id, None);
+}
+
+#[test]
+fn remove_folder_is_idempotent() {
+    let store = ConnectionsStore::new();
+    store.add_folder(folder("Work", "Work", None, true));
+    store.remove_folder("Work");
+    store.remove_folder("Work"); // no panic, no change
+    assert_eq!(store.folder_count(), 0);
+}
+
+#[test]
+fn snapshot_serialises_the_full_view_model() {
+    let store = ConnectionsStore::new();
+    store.add_folder(folder("Work", "Work", None, true));
+    store.add_connection(connection("Work/A", "A", Some("Work")));
+
+    let snap = store.snapshot();
+    assert_eq!(snap["folders"][0]["id"], json!("Work"));
+    assert_eq!(snap["folders"][0]["isExpanded"], json!(true));
+    assert_eq!(snap["folders"][0]["parentId"], json!(null));
+    assert_eq!(snap["connections"][0]["id"], json!("Work/A"));
+    assert_eq!(snap["connections"][0]["folderId"], json!("Work"));
+    assert_eq!(snap["connections"][0]["config"]["type"], json!("ssh"));
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,10 @@
 mod commands;
 mod connection;
+/// Shadow connections-tree authority (#2225, Phase 5 of #2139/#2153): the shared
+/// `connections` projection region + `connection.*` intents, wrapping the
+/// existing saved-connection authority (`crate::connection`). Registered and
+/// served but not yet driving the live UI — see [`connections_projection`].
+mod connections_projection;
 mod credential;
 mod embedded_servers;
 /// File-system access: local FS, SFTP sessions, and the cancellable transfer
@@ -706,6 +711,19 @@ pub fn run() {
                     &mut registry,
                     app.handle().clone(),
                 );
+                // Shadow ConnectionsStore (#2225, Phase 5): the shared
+                // `connections` region + `connection.*` intents, wrapping the
+                // existing saved-connection authority (`crate::connection`).
+                // Managed authoritative state that serves intents, but nothing in
+                // the live UI subscribes to or renders the region yet — a pure
+                // shadow foundation (later steps cut rendering, then mutations,
+                // over to it). The shared region is seeded below once the store is
+                // managed.
+                app.manage(Arc::new(connections_projection::ConnectionsStore::new()));
+                connections_projection::projection::register_connection_intents(
+                    &mut registry,
+                    app.handle().clone(),
+                );
                 // Test-bridge-only: add the diagnostic region's `diag.*` routes so
                 // the projection-assertion harness (#2164) has a self-contained
                 // region to drive. Never registered in production launches. See
@@ -743,6 +761,17 @@ pub fn run() {
                 {
                     projection_state.projector.register_region(
                         system_monitor_projection::projection::SYSTEM_MONITORS_REGION,
+                        store.snapshot(),
+                    );
+                }
+                // Seed the shared `connections` region with the (empty) store
+                // baseline at version 0, so a subscriber attaches to a real region
+                // before the first `connection.*` intent (#2225).
+                if let Some(store) =
+                    app.handle().try_state::<Arc<connections_projection::ConnectionsStore>>()
+                {
+                    projection_state.projector.register_region(
+                        connections_projection::projection::CONNECTIONS_REGION,
                         store.snapshot(),
                     );
                 }


### PR DESCRIPTION
## Summary

Phase 5 shadow foundation for the **Connections tree** domain — the same first step that just landed for Monitors (PR #2230). Adds a backend-only `connections_projection` module and wires it into the app in shadow mode. Zero user-facing change.

Part of #2225 (this PR is **step 1 of 4** — shadow only; the render cut, mutation cut, and reducer removal remain, so #2225 stays open).

## What the shadow models

- A `ConnectionsStore` modelling the appStore saved-connection / folder tree: the two flat arrays (`folders: ConnectionFolder[]`, `connections: SavedConnection[]`), nesting via `parentId`/`folderId` pointers, ordering by array position.
- Exposed as one **shared** `connections` projection region with the view model `{ "folders": [...], "connections": [...] }`, mirroring the appStore slice one-to-one for a clean later render cut.
- `connection.*` intents: `add` / `update` / `remove` / `move` (connection) and `addFolder` / `removeFolder` / `toggleFolder`. `removeFolder` re-homes children exactly as `deleteFolder` does (child folders reparent to the removed folder's parent; child connections move to root).

## Region scope (Open Design Decision #4) — shared

The saved-connection config is a single persisted file, identical for every client (like SSH tunnels), so the whole inventory is one **shared** region. The store **wraps the existing Rust authority** by reusing `connection::config::{SavedConnection, ConnectionFolder}` rather than re-homing the config. Per-client tree **selection / highlight** lives only in the `useTreeSelection` React hook and is never persisted — it is presentation and is deliberately kept out of the store under partial projection. Folder `isExpanded` **is** persisted to disk in this codebase (`persistFolder`), so it is modelled as part of the shared inventory.

There is no standalone reorder transition in the appStore today (ordering is array position), so none is shadowed; if one is added later it becomes a new `connection.*` intent.

## Shadow only — no behavior change

The store is managed and its region seeded at version 0, and intents are registered and served — but nothing subscribes to or renders the region and no frontend dispatches `connection.*` yet. The appStore connections slice remains authoritative. The diff touches only `src-tauri/` (new module + minimal `lib.rs` wiring); no `src/` change.

## Tests

- 16 store unit tests (transitions, no-op/idempotent paths, folder reparenting, snapshot shape).
- 6 projection-contract tests reusing the #2164 substrate harness (subscribe→snapshot fan-out, one coalesced diff per intent with monotonic versions, rejection/no-op advance nothing, dead-subscriber reap, full-lifecycle cache convergence).

`cargo test -p termihub connections_projection` → 22 passed. `cargo clippy --all-targets --all-features -D warnings` and `cargo fmt --check` clean. No frontend files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)