### PR TITLE
feat(agent): shadow agents projection store and region

### DIFF
--- a/src-tauri/src/agents_projection/mod.rs
+++ b/src-tauri/src/agents_projection/mod.rs
@@ -1,0 +1,25 @@
+//! Shadow agents authority — Phase 5 of the stateless-UI migration
+//! (#2226, part of #2139).
+//!
+//! Moves the agents slice the frontend drives in `appStore` (the ordered
+//! `remoteAgents` list plus the per-agent `agentSessions` / `agentDefinitions` /
+//! `agentFolders` maps) into a Rust authority. The store owns a single **shared**
+//! `agents` projection region (Open Design Decision #4: infrastructure domains
+//! are shared) and serves the `agent.*` intents through the projection substrate
+//! ([`crate::projection`]), mirroring the SSH-tunnels pilot
+//! ([`crate::tunnel::projection`]) and the system-monitor shadow
+//! ([`crate::system_monitor_projection`]).
+//!
+//! # Shadow mode — zero user-facing change
+//!
+//! This step is deliberately **not** authoritative. The store exists, accepts
+//! intents, and projects diffs, but nothing in the live UI subscribes to or
+//! renders the `agents` region, and no frontend code dispatches `agent.*` intents
+//! yet. The existing `appStore` agents slice and the agent sidebar / Open
+//! Connections rendering are untouched. Later steps cut rendering, then mutation,
+//! over to the region, then remove the `appStore` state.
+
+pub mod projection;
+pub mod store;
+
+pub use store::AgentsStore;

--- a/src-tauri/src/agents_projection/projection.rs
+++ b/src-tauri/src/agents_projection/projection.rs
@@ -305,8 +305,7 @@ fn required_state(intent: &Intent) -> Result<AgentConnectionState, (String, Stri
         .payload
         .get("state")
         .ok_or_else(|| bad_payload("missing 'state'"))?;
-    serde_json::from_value(value.clone())
-        .map_err(|e| bad_payload(&format!("invalid state: {e}")))
+    serde_json::from_value(value.clone()).map_err(|e| bad_payload(&format!("invalid state: {e}")))
 }
 
 /// Parse the required `definition` object as an [`AgentDefinition`].
@@ -325,8 +324,7 @@ fn required_folder(intent: &Intent) -> Result<AgentFolder, (String, String)> {
         .payload
         .get("folder")
         .ok_or_else(|| bad_payload("missing 'folder'"))?;
-    serde_json::from_value(value.clone())
-        .map_err(|e| bad_payload(&format!("invalid folder: {e}")))
+    serde_json::from_value(value.clone()).map_err(|e| bad_payload(&format!("invalid folder: {e}")))
 }
 
 /// Parse a required array field as a typed list (used for `agent.refresh`'s
@@ -339,8 +337,7 @@ fn required_list<T: serde::de::DeserializeOwned>(
         .payload
         .get(key)
         .ok_or_else(|| bad_payload(&format!("missing '{key}'")))?;
-    serde_json::from_value(value.clone())
-        .map_err(|e| bad_payload(&format!("invalid {key}: {e}")))
+    serde_json::from_value(value.clone()).map_err(|e| bad_payload(&format!("invalid {key}: {e}")))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/agents_projection/projection.rs
+++ b/src-tauri/src/agents_projection/projection.rs
@@ -1,0 +1,348 @@
+//! Agents projection: the shared `agents` region and the `agent.*` intents
+//! (#2226, part of #2139).
+//!
+//! Exposes the authoritative [`AgentsStore`] as one versioned, multi-subscriber
+//! projection region and turns the agent transitions the frontend currently
+//! drives into [`Intent`]s — mirroring the SSH-tunnels pilot
+//! ([`crate::tunnel::projection`]) and the system-monitor shadow
+//! ([`crate::system_monitor_projection::projection`]).
+//!
+//! # The `agents` region
+//!
+//! **Shared** (Open Design Decision #4: infrastructure domains are shared). An
+//! agent's connection/session status is a property of the agent, not of a viewing
+//! client; agent definitions and folders are shared, persisted config. The view
+//! model:
+//!
+//! ```json
+//! {
+//!   "agents": [ AgentEntry, … ],
+//!   "sessions": { "<agentId>": [ AgentSession ] },
+//!   "definitions": { "<agentId>": [ AgentDefinition ] },
+//!   "folders": { "<agentId>": [ AgentFolder ] }
+//! }
+//! ```
+//!
+//! # Intents
+//!
+//! | kind                      | payload                                   | effect                               |
+//! | ------------------------- | ----------------------------------------- | ------------------------------------ |
+//! | `agent.add`               | `{ id, name, config?, agentSettings? }`   | append a fresh disconnected agent    |
+//! | `agent.update`            | `{ id, name, config?, agentSettings? }`   | update persisted fields              |
+//! | `agent.applySettings`     | `{ id, agentSettings }`                    | update just the settings             |
+//! | `agent.remove`            | `{ id }`                                    | drop the agent + its sub-state       |
+//! | `agent.reorder`           | `{ oldIndex, newIndex }`                    | move the agent in the list           |
+//! | `agent.toggleExpanded`    | `{ id }`                                    | flip sidebar expansion               |
+//! | `agent.status`            | `{ id, state, error? }`                     | set connection state (single writer) |
+//! | `agent.setCapabilities`   | `{ id, capabilities }`                      | record negotiated capabilities       |
+//! | `agent.disconnect`        | `{ id }`                                     | force disconnected + clear live      |
+//! | `agent.refresh`           | `{ id, sessions, definitions, folders }`    | replace live/saved sub-state         |
+//! | `agent.clearSessions`     | `{ id }`                                     | empty the live-session list          |
+//! | `agent.saveDefinition`    | `{ id, definition }`                        | upsert a saved definition            |
+//! | `agent.updateDefinition`  | `{ id, definition }`                        | replace a definition by id           |
+//! | `agent.deleteDefinition`  | `{ id, definitionId }`                       | remove a definition                  |
+//! | `agent.createFolder`      | `{ id, folder }`                             | append a folder                      |
+//! | `agent.updateFolder`      | `{ id, folder }`                             | replace a folder by id               |
+//! | `agent.deleteFolder`      | `{ id, folderId }`                           | remove a folder + reparent defs      |
+//!
+//! # Shadow mode
+//!
+//! Registered and fully served, but **not** driving the live UI: no frontend
+//! subscribes to `agents` or dispatches `agent.*` yet, so these intents mutate
+//! only the shadow store and project to a region nobody renders. The `appStore`
+//! agents slice remains authoritative. Per the substrate contract the result of
+//! an intent is never returned inline — it always arrives as a projection diff on
+//! the `agents` region.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+use crate::agents_projection::store::{
+    AgentConnectionState, AgentDefinition, AgentFolder, AgentsStore,
+};
+use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
+
+/// The projection region id for the agents domain (shared, per Open Design
+/// Decision #4).
+pub const AGENTS_REGION: &str = "agents";
+
+/// Publish the `agents` region from the store, fanning a diff out to every
+/// subscriber and returning the advanced region for the intent ack (empty when
+/// the view did not change).
+pub fn publish_agents(projector: &Projector, store: &AgentsStore) -> Vec<ProducedRegion> {
+    match projector.publish(AGENTS_REGION, store.snapshot()) {
+        Some(version) => vec![ProducedRegion {
+            region: AGENTS_REGION.to_string(),
+            version,
+        }],
+        None => Vec::new(),
+    }
+}
+
+/// Register the `agent.*` intents on a handler registry.
+///
+/// Each route resolves the managed [`AgentsStore`] lazily (so it rejects
+/// gracefully rather than panicking if the store is somehow absent), applies the
+/// transition, and publishes the shared region. All transitions are pure/fast
+/// in-memory edits, so they run inline on the dispatcher's single writer.
+pub fn register_agent_intents(registry: &mut HandlerRegistry, app_handle: AppHandle) {
+    let handle = app_handle.clone();
+    registry.route("agent.add", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.add(
+            &required_str(intent, "id")?,
+            &required_str(intent, "name")?,
+            optional_value(intent, "config"),
+            optional_value(intent, "agentSettings"),
+        );
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("agent.update", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.update(
+            &required_str(intent, "id")?,
+            &required_str(intent, "name")?,
+            optional_value(intent, "config"),
+            optional_value(intent, "agentSettings"),
+        );
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("agent.applySettings", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let settings = intent
+            .payload
+            .get("agentSettings")
+            .cloned()
+            .ok_or_else(|| bad_payload("missing 'agentSettings'"))?;
+        store.apply_settings(&required_str(intent, "id")?, settings);
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("agent.remove", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.remove(&required_str(intent, "id")?);
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("agent.reorder", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.reorder(
+            required_usize(intent, "oldIndex")?,
+            required_usize(intent, "newIndex")?,
+        );
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("agent.toggleExpanded", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.toggle_expanded(&required_str(intent, "id")?);
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("agent.status", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.set_status(
+            &required_str(intent, "id")?,
+            required_state(intent)?,
+            optional_str(intent, "error"),
+        );
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("agent.setCapabilities", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let capabilities = intent
+            .payload
+            .get("capabilities")
+            .cloned()
+            .ok_or_else(|| bad_payload("missing 'capabilities'"))?;
+        store.set_capabilities(&required_str(intent, "id")?, capabilities);
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("agent.disconnect", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.disconnect(&required_str(intent, "id")?);
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("agent.refresh", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.refresh(
+            &required_str(intent, "id")?,
+            required_list(intent, "sessions")?,
+            required_list(intent, "definitions")?,
+            required_list(intent, "folders")?,
+        );
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("agent.clearSessions", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.clear_sessions(&required_str(intent, "id")?);
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("agent.saveDefinition", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.save_definition(&required_str(intent, "id")?, required_definition(intent)?);
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("agent.updateDefinition", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.update_definition(&required_str(intent, "id")?, required_definition(intent)?);
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("agent.deleteDefinition", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.delete_definition(
+            &required_str(intent, "id")?,
+            &required_str(intent, "definitionId")?,
+        );
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("agent.createFolder", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.create_folder(&required_str(intent, "id")?, required_folder(intent)?);
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("agent.updateFolder", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.update_folder(&required_str(intent, "id")?, required_folder(intent)?);
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle;
+    registry.route("agent.deleteFolder", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.delete_folder(
+            &required_str(intent, "id")?,
+            &required_str(intent, "folderId")?,
+        );
+        Ok(publish_agents(projector, &store))
+    });
+}
+
+/// Resolve the managed agents store, or a rejectable error if absent.
+fn store_of(app_handle: &AppHandle) -> Result<Arc<AgentsStore>, (String, String)> {
+    app_handle
+        .try_state::<Arc<AgentsStore>>()
+        .map(|state| (*state).clone())
+        .ok_or_else(|| {
+            (
+                "unavailable".to_string(),
+                "agents store is not initialized".to_string(),
+            )
+        })
+}
+
+/// Build a `bad_payload` rejection with a message.
+fn bad_payload(message: &str) -> (String, String) {
+    ("bad_payload".to_string(), message.to_string())
+}
+
+/// Extract a required string field from an intent payload.
+fn required_str(intent: &Intent, key: &str) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| bad_payload(&format!("missing '{key}'")))
+}
+
+/// Extract an optional string field; absent → `None`.
+fn optional_str(intent: &Intent, key: &str) -> Option<String> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+/// Extract an optional JSON field; absent → `Value::Null` (an agent added without
+/// a config carries a null blob, matching an unset frontend field).
+fn optional_value(intent: &Intent, key: &str) -> Value {
+    intent.payload.get(key).cloned().unwrap_or(Value::Null)
+}
+
+/// Extract a required array index (`usize`) field from an intent payload.
+fn required_usize(intent: &Intent, key: &str) -> Result<usize, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_u64)
+        .map(|n| n as usize)
+        .ok_or_else(|| bad_payload(&format!("missing '{key}'")))
+}
+
+/// Parse the required `state` field as an [`AgentConnectionState`].
+fn required_state(intent: &Intent) -> Result<AgentConnectionState, (String, String)> {
+    let value = intent
+        .payload
+        .get("state")
+        .ok_or_else(|| bad_payload("missing 'state'"))?;
+    serde_json::from_value(value.clone())
+        .map_err(|e| bad_payload(&format!("invalid state: {e}")))
+}
+
+/// Parse the required `definition` object as an [`AgentDefinition`].
+fn required_definition(intent: &Intent) -> Result<AgentDefinition, (String, String)> {
+    let value = intent
+        .payload
+        .get("definition")
+        .ok_or_else(|| bad_payload("missing 'definition'"))?;
+    serde_json::from_value(value.clone())
+        .map_err(|e| bad_payload(&format!("invalid definition: {e}")))
+}
+
+/// Parse the required `folder` object as an [`AgentFolder`].
+fn required_folder(intent: &Intent) -> Result<AgentFolder, (String, String)> {
+    let value = intent
+        .payload
+        .get("folder")
+        .ok_or_else(|| bad_payload("missing 'folder'"))?;
+    serde_json::from_value(value.clone())
+        .map_err(|e| bad_payload(&format!("invalid folder: {e}")))
+}
+
+/// Parse a required array field as a typed list (used for `agent.refresh`'s
+/// `sessions` / `definitions` / `folders`).
+fn required_list<T: serde::de::DeserializeOwned>(
+    intent: &Intent,
+    key: &str,
+) -> Result<Vec<T>, (String, String)> {
+    let value = intent
+        .payload
+        .get(key)
+        .ok_or_else(|| bad_payload(&format!("missing '{key}'")))?;
+    serde_json::from_value(value.clone())
+        .map_err(|e| bad_payload(&format!("invalid {key}: {e}")))
+}
+
+#[cfg(test)]
+#[path = "projection_tests.rs"]
+mod tests;

--- a/src-tauri/src/agents_projection/projection_tests.rs
+++ b/src-tauri/src/agents_projection/projection_tests.rs
@@ -17,9 +17,7 @@ use std::sync::{Arc, Mutex};
 use serde_json::{json, Value};
 
 use crate::agents_projection::projection::{publish_agents, AGENTS_REGION};
-use crate::agents_projection::store::{
-    AgentDefinition, AgentFolder, AgentSession, AgentsStore,
-};
+use crate::agents_projection::store::{AgentDefinition, AgentFolder, AgentSession, AgentsStore};
 use crate::projection::{
     apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
     ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
@@ -33,7 +31,11 @@ fn seeded_store() -> Arc<AgentsStore> {
     let store = Arc::new(AgentsStore::new());
     store.add("a1", "Agent One", json!({ "host": "h1" }), json!({}));
     store.add("a2", "Agent Two", json!({ "host": "h2" }), json!({}));
-    store.set_status("a2", crate::agents_projection::store::AgentConnectionState::Connected, None);
+    store.set_status(
+        "a2",
+        crate::agents_projection::store::AgentConnectionState::Connected,
+        None,
+    );
     store
 }
 
@@ -206,8 +208,14 @@ fn subscribe_returns_the_seeded_snapshot_identically_to_every_subscriber() {
     assert_eq!(snap_a, snap_b, "a late joiner gets an identical baseline");
     assert_eq!(snap_a.region, "agents");
     assert_eq!(snap_a.view["agents"][0]["id"], json!("a1"));
-    assert_eq!(snap_a.view["agents"][0]["connectionState"], json!("disconnected"));
-    assert_eq!(snap_a.view["agents"][1]["connectionState"], json!("connected"));
+    assert_eq!(
+        snap_a.view["agents"][0]["connectionState"],
+        json!("disconnected")
+    );
+    assert_eq!(
+        snap_a.view["agents"][1]["connectionState"],
+        json!("connected")
+    );
 }
 
 #[test]
@@ -245,8 +253,15 @@ fn an_agent_intent_produces_one_diff_fanned_to_two_subscribers() {
     assert_eq!(diffs_a[0].version, 1);
 
     cache_a.apply(&diffs_a[0]);
-    assert_eq!(cache_a.view, store.snapshot(), "cache converges on authority");
-    assert_eq!(cache_a.view["agents"][0]["connectionState"], json!("connecting"));
+    assert_eq!(
+        cache_a.view,
+        store.snapshot(),
+        "cache converges on authority"
+    );
+    assert_eq!(
+        cache_a.view["agents"][0]["connectionState"],
+        json!("connecting")
+    );
 }
 
 #[test]
@@ -282,7 +297,12 @@ fn a_full_agent_lifecycle_advances_monotonically_and_converges() {
         ("agent.remove", json!({ "id": "a3" })),
     ] {
         let ack = dispatcher.dispatch(intent(kind_payload.0, kind_payload.1));
-        assert_eq!(ack.status, IntentStatus::Accepted, "{} accepted", kind_payload.0);
+        assert_eq!(
+            ack.status,
+            IntentStatus::Accepted,
+            "{} accepted",
+            kind_payload.0
+        );
     }
 
     let diffs = sink.diffs();
@@ -353,9 +373,16 @@ fn a_dead_subscriber_is_reaped_on_publish() {
     assert_eq!(projector.subscriber_count(AGENTS_REGION), 2);
 
     dead.alive.store(false, Ordering::SeqCst);
-    dispatcher.dispatch(intent("agent.status", json!({ "id": "a1", "state": "connecting" })));
+    dispatcher.dispatch(intent(
+        "agent.status",
+        json!({ "id": "a1", "state": "connecting" }),
+    ));
 
-    assert_eq!(live.diffs().len(), 1, "the live subscriber still gets the diff");
+    assert_eq!(
+        live.diffs().len(),
+        1,
+        "the live subscriber still gets the diff"
+    );
     assert_eq!(
         projector.subscriber_count(AGENTS_REGION),
         1,

--- a/src-tauri/src/agents_projection/projection_tests.rs
+++ b/src-tauri/src/agents_projection/projection_tests.rs
@@ -1,0 +1,364 @@
+//! Projection-contract tests for the shared `agents` region (#2226), reusing the
+//! substrate harness (#2164): an in-memory [`ProjectionSink`] and a client cache
+//! that applies diffs. The routes here drive a real [`AgentsStore`] directly (the
+//! production `register_agent_intents` resolves the same store from the Tauri
+//! `AppHandle`; that thin wiring is integration-verified via a local
+//! `./scripts/dev.sh` run) through the identical parse → mutate → publish path.
+//!
+//! Asserted: subscribe → snapshot (identical to every subscriber), an accepted
+//! intent → exactly one coalesced diff fanned to every subscriber with monotonic
+//! versions, rejection paths advance nothing, a no-op intent advances nothing, a
+//! dead subscriber is reaped, and the client cache converges on the store's
+//! authority across a full agent lifecycle.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::{json, Value};
+
+use crate::agents_projection::projection::{publish_agents, AGENTS_REGION};
+use crate::agents_projection::store::{
+    AgentDefinition, AgentFolder, AgentSession, AgentsStore,
+};
+use crate::projection::{
+    apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
+    ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
+};
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+/// A store with a couple of agents already configured, so a subscriber sees a
+/// populated baseline.
+fn seeded_store() -> Arc<AgentsStore> {
+    let store = Arc::new(AgentsStore::new());
+    store.add("a1", "Agent One", json!({ "host": "h1" }), json!({}));
+    store.add("a2", "Agent Two", json!({ "host": "h2" }), json!({}));
+    store.set_status("a2", crate::agents_projection::store::AgentConnectionState::Connected, None);
+    store
+}
+
+/// The production `agent.*` routes, bound to an injected store instead of
+/// resolving one from an `AppHandle` — the exact parse → mutate → publish path
+/// `register_agent_intents` runs. Each closure mirrors the production route so
+/// the test drives real logic, not a stand-in.
+fn registry_for(store: Arc<AgentsStore>) -> HandlerRegistry {
+    let mut registry = HandlerRegistry::new();
+
+    let s = store.clone();
+    registry.route("agent.add", move |intent, projector| {
+        s.add(
+            &required_str(intent, "id")?,
+            &required_str(intent, "name")?,
+            intent.payload.get("config").cloned().unwrap_or(Value::Null),
+            intent
+                .payload
+                .get("agentSettings")
+                .cloned()
+                .unwrap_or(Value::Null),
+        );
+        Ok(publish_agents(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("agent.status", move |intent, projector| {
+        let state = serde_json::from_value(
+            intent
+                .payload
+                .get("state")
+                .cloned()
+                .ok_or_else(|| ("bad_payload".to_string(), "missing 'state'".to_string()))?,
+        )
+        .map_err(|e| ("bad_payload".to_string(), format!("invalid state: {e}")))?;
+        s.set_status(
+            &required_str(intent, "id")?,
+            state,
+            intent
+                .payload
+                .get("error")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        );
+        Ok(publish_agents(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("agent.refresh", move |intent, projector| {
+        let sessions: Vec<AgentSession> = parse_list(intent, "sessions")?;
+        let definitions: Vec<AgentDefinition> = parse_list(intent, "definitions")?;
+        let folders: Vec<AgentFolder> = parse_list(intent, "folders")?;
+        s.refresh(&required_str(intent, "id")?, sessions, definitions, folders);
+        Ok(publish_agents(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("agent.disconnect", move |intent, projector| {
+        s.disconnect(&required_str(intent, "id")?);
+        Ok(publish_agents(projector, &s))
+    });
+    let s = store;
+    registry.route("agent.remove", move |intent, projector| {
+        s.remove(&required_str(intent, "id")?);
+        Ok(publish_agents(projector, &s))
+    });
+
+    registry
+}
+
+/// The route-side `id` parse — the one rejection path shared by every route.
+fn required_str(intent: &Intent, key: &str) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+fn parse_list<T: serde::de::DeserializeOwned>(
+    intent: &Intent,
+    key: &str,
+) -> Result<Vec<T>, (String, String)> {
+    let value = intent
+        .payload
+        .get(key)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))?;
+    serde_json::from_value(value.clone())
+        .map_err(|e| ("bad_payload".to_string(), format!("invalid {key}: {e}")))
+}
+
+/// An in-memory sink recording delivered frames; can be killed to simulate a
+/// dead subscriber (mirrors the substrate/tunnel/session test double).
+struct VecSink {
+    frames: Mutex<Vec<ProjectionFrame>>,
+    alive: AtomicBool,
+}
+
+impl VecSink {
+    fn new() -> Self {
+        Self {
+            frames: Mutex::new(Vec::new()),
+            alive: AtomicBool::new(true),
+        }
+    }
+
+    fn diffs(&self) -> Vec<DiffFrame> {
+        self.frames
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|f| match f {
+                ProjectionFrame::Diff(d) => Some(d.clone()),
+                ProjectionFrame::Snapshot(_) => None,
+            })
+            .collect()
+    }
+}
+
+impl ProjectionSink for VecSink {
+    fn deliver(&self, frame: &ProjectionFrame) -> Result<(), ProjectionError> {
+        if !self.alive.load(Ordering::SeqCst) {
+            return Err(ProjectionError::SinkClosed("killed".into()));
+        }
+        self.frames.lock().unwrap().push(frame.clone());
+        Ok(())
+    }
+}
+
+/// A minimal client cache mirroring the TypeScript `ProjectionClient`.
+struct ClientCache {
+    version: u64,
+    view: Value,
+}
+
+impl ClientCache {
+    fn from_snapshot(s: &SnapshotFrame) -> Self {
+        Self {
+            version: s.version,
+            view: s.view.clone(),
+        }
+    }
+
+    fn apply(&mut self, diff: &DiffFrame) {
+        assert_eq!(diff.base_version, self.version, "diff must fit the cache");
+        apply_ops(&mut self.view, &diff.ops).expect("diff applies cleanly");
+        self.version = diff.version;
+    }
+}
+
+fn intent(kind: &str, payload: Value) -> Intent {
+    Intent {
+        intent_id: format!("01J-{kind}"),
+        kind: kind.to_string(),
+        payload,
+        client_id: "client-1".to_string(),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn subscribe_returns_the_seeded_snapshot_identically_to_every_subscriber() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(AGENTS_REGION, store.snapshot());
+
+    let snap_a = projector.subscribe(AGENTS_REGION, "sub-a", "A", Arc::new(VecSink::new()));
+    let snap_b = projector.subscribe(AGENTS_REGION, "sub-b", "B", Arc::new(VecSink::new()));
+
+    assert_eq!(snap_a.version, 0);
+    assert_eq!(snap_a, snap_b, "a late joiner gets an identical baseline");
+    assert_eq!(snap_a.region, "agents");
+    assert_eq!(snap_a.view["agents"][0]["id"], json!("a1"));
+    assert_eq!(snap_a.view["agents"][0]["connectionState"], json!("disconnected"));
+    assert_eq!(snap_a.view["agents"][1]["connectionState"], json!("connected"));
+}
+
+#[test]
+fn an_agent_intent_produces_one_diff_fanned_to_two_subscribers() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(AGENTS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink_a = Arc::new(VecSink::new());
+    let sink_b = Arc::new(VecSink::new());
+    let snap = projector.subscribe(AGENTS_REGION, "sub-a", "A", sink_a.clone());
+    projector.subscribe(AGENTS_REGION, "sub-b", "B", sink_b.clone());
+    let mut cache_a = ClientCache::from_snapshot(&snap);
+
+    let ack = dispatcher.dispatch(intent(
+        "agent.status",
+        json!({ "id": "a1", "state": "connecting" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(
+        ack.produced,
+        Some(vec![crate::projection::ProducedRegion {
+            region: AGENTS_REGION.to_string(),
+            version: 1,
+        }])
+    );
+
+    let diffs_a = sink_a.diffs();
+    let diffs_b = sink_b.diffs();
+    assert_eq!(diffs_a.len(), 1, "exactly one diff to A");
+    assert_eq!(diffs_b.len(), 1, "exactly one diff to B");
+    assert_eq!(diffs_a[0], diffs_b[0], "identical diff to every subscriber");
+    assert_eq!(diffs_a[0].base_version, 0);
+    assert_eq!(diffs_a[0].version, 1);
+
+    cache_a.apply(&diffs_a[0]);
+    assert_eq!(cache_a.view, store.snapshot(), "cache converges on authority");
+    assert_eq!(cache_a.view["agents"][0]["connectionState"], json!("connecting"));
+}
+
+#[test]
+fn a_full_agent_lifecycle_advances_monotonically_and_converges() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(AGENTS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(AGENTS_REGION, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    // a3: add → connecting → connected → refresh (sessions/defs/folders) →
+    // disconnect → remove. Each accepted intent that changes the view = one diff.
+    for kind_payload in [
+        (
+            "agent.add",
+            json!({ "id": "a3", "name": "Three", "config": { "host": "h3" }, "agentSettings": {} }),
+        ),
+        ("agent.status", json!({ "id": "a3", "state": "connecting" })),
+        ("agent.status", json!({ "id": "a3", "state": "connected" })),
+        (
+            "agent.refresh",
+            json!({
+                "id": "a3",
+                "sessions": [{ "sessionId": "s1", "title": "t", "type": "shell", "status": "running", "attached": true }],
+                "definitions": [{ "id": "d1", "name": "def", "sessionType": "shell", "config": {}, "persistent": false, "folderId": null }],
+                "folders": [{ "id": "f1", "name": "F", "parentId": null, "isExpanded": true }]
+            }),
+        ),
+        ("agent.disconnect", json!({ "id": "a3" })),
+        ("agent.remove", json!({ "id": "a3" })),
+    ] {
+        let ack = dispatcher.dispatch(intent(kind_payload.0, kind_payload.1));
+        assert_eq!(ack.status, IntentStatus::Accepted, "{} accepted", kind_payload.0);
+    }
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 6, "one diff per view-changing intent");
+    for diff in &diffs {
+        cache.apply(diff);
+    }
+    assert_eq!(cache.version, 6);
+    assert_eq!(cache.view, store.snapshot(), "cache converges on authority");
+    // a3 is gone again; the seeded agents remain.
+    let ids: Vec<&str> = cache.view["agents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|a| a["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids, vec!["a1", "a2"]);
+}
+
+#[test]
+fn an_intent_missing_the_id_is_rejected_without_advancing() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(AGENTS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(AGENTS_REGION, "sub", "A", sink.clone());
+
+    let ack = dispatcher.dispatch(intent("agent.status", json!({ "state": "connected" })));
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "bad_payload");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(AGENTS_REGION), Some(0));
+}
+
+#[test]
+fn a_no_op_intent_advances_nothing() {
+    // `status → connected` on an already-connected agent leaves the view
+    // unchanged, so the projector coalesces it to no diff and no version bump.
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(AGENTS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(AGENTS_REGION, "sub", "A", sink.clone());
+
+    let ack = dispatcher.dispatch(intent(
+        "agent.status",
+        json!({ "id": "a2", "state": "connected" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(ack.produced, Some(vec![]), "no region advanced");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(AGENTS_REGION), Some(0));
+}
+
+#[test]
+fn a_dead_subscriber_is_reaped_on_publish() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(AGENTS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let live = Arc::new(VecSink::new());
+    let dead = Arc::new(VecSink::new());
+    projector.subscribe(AGENTS_REGION, "live", "A", live.clone());
+    projector.subscribe(AGENTS_REGION, "dead", "B", dead.clone());
+    assert_eq!(projector.subscriber_count(AGENTS_REGION), 2);
+
+    dead.alive.store(false, Ordering::SeqCst);
+    dispatcher.dispatch(intent("agent.status", json!({ "id": "a1", "state": "connecting" })));
+
+    assert_eq!(live.diffs().len(), 1, "the live subscriber still gets the diff");
+    assert_eq!(
+        projector.subscriber_count(AGENTS_REGION),
+        1,
+        "the dead subscriber was reaped"
+    );
+}

--- a/src-tauri/src/agents_projection/store.rs
+++ b/src-tauri/src/agents_projection/store.rs
@@ -1,0 +1,448 @@
+//! The authoritative, shared agents state behind the shadow `agents` projection
+//! region (#2226, Phase 5 of #2139).
+//!
+//! Models the agents slice the frontend currently drives in `appStore`: the
+//! ordered `remoteAgents` list (each agent's persisted config/settings plus its
+//! live connection status, capabilities and last error) and the per-agent
+//! `agentSessions` / `agentDefinitions` / `agentFolders` maps. The view model is
+//! shaped to match those frontend structures one-to-one, keeping the eventual
+//! render cut a pure parity swap.
+//!
+//! # Shared region — Open Design Decision #4
+//!
+//! An agent's connection/session status is a property of the agent, not of a
+//! viewing client: two clients observing the same configured agent see the same
+//! `connected`/`reconnecting` state and the same live sessions (like SSH tunnels,
+//! [`crate::tunnel::projection`], and session-lifecycle,
+//! [`crate::session_projection`]). Agent **definitions and folders** are shared,
+//! persisted config. The region is therefore a single **shared** `agents` region.
+//! Any per-client presentation (which agent a client has focused, banner
+//! dismissal) stays a frontend concern under partial projection.
+//!
+//! # Shadow mode — zero user-facing change
+//!
+//! This step is deliberately **not** authoritative. The store exists, accepts
+//! `agent.*` intents, and projects diffs, but nothing in the live UI subscribes
+//! to or renders the `agents` region, and no frontend code dispatches `agent.*`
+//! intents yet. The existing `appStore` agents slice remains authoritative. Later
+//! steps cut rendering, then mutation, over to the region, then remove the
+//! `appStore` state.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// The live connection state of a configured agent — mirrors the frontend
+/// `RemoteAgentDefinition["connectionState"]` union. Written only by the
+/// backend-authoritative `agent.status` transition (the single-writer rule the
+/// frontend documents as G4/#1234).
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum AgentConnectionState {
+    /// Not connected (the default for a freshly added agent).
+    #[default]
+    Disconnected,
+    /// A connect attempt is in flight.
+    Connecting,
+    /// The transport is up and the agent handshake completed.
+    Connected,
+    /// The transport dropped and auto-reconnect is retrying.
+    Reconnecting,
+}
+
+/// The authoritative record for one configured agent — the render-ready
+/// projection of the frontend `RemoteAgentDefinition`. Held in an ordered list so
+/// the sidebar order (`reorderRemoteAgents`) is preserved.
+///
+/// `config`, `agentSettings` and `capabilities` are carried as opaque JSON so the
+/// store owns the agent's identity and status without coupling to the internals
+/// of those blobs (which the connection/agent-setup layers define).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentEntry {
+    /// Stable agent id.
+    pub id: String,
+    /// Human-readable agent name shown in the sidebar.
+    pub name: String,
+    /// The agent's `RemoteAgentConfig` (opaque here).
+    pub config: Value,
+    /// The agent's `AgentSettings` (opaque here).
+    pub agent_settings: Value,
+    /// Sidebar expansion state.
+    pub is_expanded: bool,
+    /// Live connection state (backend-authoritative, single-writer).
+    pub connection_state: AgentConnectionState,
+    /// Negotiated capabilities once connected; absent until then.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<Value>,
+    /// Last terminal error after auto-reconnect exhausted (G3/#1236); absent when
+    /// clear. Surfaced as the Reconnect-button tooltip.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}
+
+impl AgentEntry {
+    /// A freshly added, disconnected, collapsed agent (mirrors the frontend
+    /// `addRemoteAgent` shape for a new definition).
+    fn new(id: &str, name: &str, config: Value, agent_settings: Value) -> Self {
+        Self {
+            id: id.to_string(),
+            name: name.to_string(),
+            config,
+            agent_settings,
+            is_expanded: false,
+            connection_state: AgentConnectionState::Disconnected,
+            capabilities: None,
+            last_error: None,
+        }
+    }
+}
+
+/// A live remote session on an agent — mirrors the frontend `AgentSessionInfo`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentSession {
+    pub session_id: String,
+    pub title: String,
+    #[serde(rename = "type")]
+    pub session_type: String,
+    pub status: String,
+    pub attached: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub definition_id: Option<String>,
+}
+
+/// A saved connection definition on an agent — mirrors the frontend
+/// `AgentDefinitionInfo`. `config` and `terminalOptions` stay opaque.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentDefinition {
+    pub id: String,
+    pub name: String,
+    pub session_type: String,
+    pub config: Value,
+    pub persistent: bool,
+    pub folder_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_options: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_file: Option<String>,
+}
+
+/// A folder on an agent — mirrors the frontend `AgentFolderInfo`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentFolder {
+    pub id: String,
+    pub name: String,
+    pub parent_id: Option<String>,
+    pub is_expanded: bool,
+}
+
+/// The private mutable core: the ordered agent list plus the per-agent
+/// sessions/definitions/folders maps (keyed by agent id). One mutex guards it so
+/// intents never interleave — the substrate's single-writer contract also holds
+/// within the store.
+#[derive(Default)]
+struct Inner {
+    agents: Vec<AgentEntry>,
+    sessions: HashMap<String, Vec<AgentSession>>,
+    definitions: HashMap<String, Vec<AgentDefinition>>,
+    folders: HashMap<String, Vec<AgentFolder>>,
+}
+
+impl Inner {
+    /// Find one agent by id for in-place mutation.
+    fn agent_mut(&mut self, id: &str) -> Option<&mut AgentEntry> {
+        self.agents.iter_mut().find(|a| a.id == id)
+    }
+}
+
+/// The shadow agents authority. Owns the ordered [`AgentEntry`] list plus the
+/// per-agent live sessions, saved definitions and folders. The single shared
+/// `agents` region projects this state.
+#[derive(Default)]
+pub struct AgentsStore {
+    inner: Mutex<Inner>,
+}
+
+impl AgentsStore {
+    /// A store with no agents yet.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The render-ready view model for the whole region:
+    /// `{ "agents": [AgentEntry, …], "sessions": {…}, "definitions": {…}, "folders": {…} }`.
+    ///
+    /// Pure with respect to agent state (never mutates), so the projector can
+    /// safely diff two consecutive snapshots.
+    pub fn snapshot(&self) -> Value {
+        let inner = self.lock();
+        json!({
+            "agents": inner.agents,
+            "sessions": inner.sessions,
+            "definitions": inner.definitions,
+            "folders": inner.folders,
+        })
+    }
+
+    // ── Agent definition/config lifecycle (the persisted agent list) ──────────
+
+    /// `agent.add` — append a fresh disconnected agent. Ignored if the id already
+    /// exists (idempotent, mirrors the append-only `addRemoteAgent`).
+    pub fn add(&self, id: &str, name: &str, config: Value, agent_settings: Value) {
+        let mut inner = self.lock();
+        if inner.agents.iter().any(|a| a.id == id) {
+            return;
+        }
+        inner
+            .agents
+            .push(AgentEntry::new(id, name, config, agent_settings));
+    }
+
+    /// `agent.update` — update one agent's persisted fields (name, config,
+    /// settings), preserving its live status (connection state, capabilities,
+    /// last error, expansion). Mirrors `updateRemoteAgent`, which the editor drives
+    /// with the runtime fields carried over. A no-op for an unknown id.
+    pub fn update(&self, id: &str, name: &str, config: Value, agent_settings: Value) {
+        let mut inner = self.lock();
+        if let Some(agent) = inner.agent_mut(id) {
+            agent.name = name.to_string();
+            agent.config = config;
+            agent.agent_settings = agent_settings;
+        }
+    }
+
+    /// `agent.applySettings` — update just one agent's `AgentSettings`
+    /// (`updateAgentSettings`). A no-op for an unknown id.
+    pub fn apply_settings(&self, id: &str, agent_settings: Value) {
+        let mut inner = self.lock();
+        if let Some(agent) = inner.agent_mut(id) {
+            agent.agent_settings = agent_settings;
+        }
+    }
+
+    /// `agent.remove` — drop an agent and all of its sessions/definitions/folders
+    /// (`deleteRemoteAgent`). Idempotent.
+    pub fn remove(&self, id: &str) {
+        let mut inner = self.lock();
+        inner.agents.retain(|a| a.id != id);
+        inner.sessions.remove(id);
+        inner.definitions.remove(id);
+        inner.folders.remove(id);
+    }
+
+    /// `agent.reorder` — move the agent at `old_index` to `new_index`
+    /// (`reorderRemoteAgents`). Out-of-range indices are a no-op.
+    pub fn reorder(&self, old_index: usize, new_index: usize) {
+        let mut inner = self.lock();
+        let len = inner.agents.len();
+        if old_index >= len || new_index >= len {
+            return;
+        }
+        let moved = inner.agents.remove(old_index);
+        inner.agents.insert(new_index, moved);
+    }
+
+    /// `agent.toggleExpanded` — flip the sidebar expansion of one agent
+    /// (`toggleRemoteAgent`). A no-op for an unknown id.
+    pub fn toggle_expanded(&self, id: &str) {
+        let mut inner = self.lock();
+        if let Some(agent) = inner.agent_mut(id) {
+            agent.is_expanded = !agent.is_expanded;
+        }
+    }
+
+    // ── Connection status (backend-authoritative single writer, G4/#1234) ─────
+
+    /// `agent.status` — set one agent's connection state, tracking `lastError`
+    /// exactly as `setAgentConnectionState`: record the error on `disconnected`
+    /// (falling back to the stored one), clear it on `connecting`/`connected`, and
+    /// leave it untouched otherwise. A no-op for an unknown id.
+    pub fn set_status(
+        &self,
+        id: &str,
+        state: AgentConnectionState,
+        error: Option<String>,
+    ) {
+        let mut inner = self.lock();
+        if let Some(agent) = inner.agent_mut(id) {
+            let next_error = match state {
+                AgentConnectionState::Disconnected => error.or_else(|| agent.last_error.clone()),
+                AgentConnectionState::Connecting | AgentConnectionState::Connected => None,
+                AgentConnectionState::Reconnecting => agent.last_error.clone(),
+            };
+            agent.connection_state = state;
+            agent.last_error = next_error;
+        }
+    }
+
+    /// `agent.setCapabilities` — record the negotiated capabilities for one agent
+    /// (`setAgentCapabilities`). A no-op for an unknown id.
+    pub fn set_capabilities(&self, id: &str, capabilities: Value) {
+        let mut inner = self.lock();
+        if let Some(agent) = inner.agent_mut(id) {
+            agent.capabilities = Some(capabilities);
+        }
+    }
+
+    /// `agent.disconnect` — the optimistic disconnect path
+    /// (`disconnectRemoteAgent` / `shutdownRemoteAgent`): force the agent to
+    /// `disconnected` and clear its live sessions and folders (definitions are the
+    /// persisted config and stay). A no-op for an unknown id.
+    pub fn disconnect(&self, id: &str) {
+        let mut inner = self.lock();
+        let known = inner.agent_mut(id).is_some();
+        if let Some(agent) = inner.agent_mut(id) {
+            agent.connection_state = AgentConnectionState::Disconnected;
+        }
+        if known {
+            inner.sessions.insert(id.to_string(), Vec::new());
+            inner.folders.insert(id.to_string(), Vec::new());
+        }
+    }
+
+    // ── Live sessions / definitions / folders (refreshed on connect) ──────────
+
+    /// `agent.refresh` — replace one agent's live sessions plus its saved
+    /// definitions and folders in one shot (the `refreshAgentSessions` set that
+    /// runs once per connect). A no-op for an unknown id.
+    pub fn refresh(
+        &self,
+        id: &str,
+        sessions: Vec<AgentSession>,
+        definitions: Vec<AgentDefinition>,
+        folders: Vec<AgentFolder>,
+    ) {
+        let mut inner = self.lock();
+        if inner.agent_mut(id).is_none() {
+            return;
+        }
+        inner.sessions.insert(id.to_string(), sessions);
+        inner.definitions.insert(id.to_string(), definitions);
+        inner.folders.insert(id.to_string(), folders);
+    }
+
+    /// `agent.clearSessions` — empty one agent's live-session list
+    /// (`clearAgentSessions`). A no-op for an unknown id.
+    pub fn clear_sessions(&self, id: &str) {
+        let mut inner = self.lock();
+        if inner.agent_mut(id).is_some() {
+            inner.sessions.insert(id.to_string(), Vec::new());
+        }
+    }
+
+    // ── Definition CRUD (on-agent connection definitions) ─────────────────────
+
+    /// `agent.saveDefinition` — upsert a saved definition on an agent
+    /// (`saveAgentDef`): replace any existing entry with the same id, else append.
+    /// A no-op for an unknown agent id.
+    pub fn save_definition(&self, id: &str, definition: AgentDefinition) {
+        let mut inner = self.lock();
+        if inner.agent_mut(id).is_none() {
+            return;
+        }
+        let list = inner.definitions.entry(id.to_string()).or_default();
+        list.retain(|d| d.id != definition.id);
+        list.push(definition);
+    }
+
+    /// `agent.updateDefinition` — replace an existing definition by id
+    /// (`updateAgentDef`). A no-op if the agent or definition is unknown.
+    pub fn update_definition(&self, id: &str, definition: AgentDefinition) {
+        let mut inner = self.lock();
+        if let Some(list) = inner.definitions.get_mut(id) {
+            if let Some(slot) = list.iter_mut().find(|d| d.id == definition.id) {
+                *slot = definition;
+            }
+        }
+    }
+
+    /// `agent.deleteDefinition` — remove a saved definition by id
+    /// (`deleteAgentDef`). A no-op if the agent or definition is unknown.
+    pub fn delete_definition(&self, id: &str, definition_id: &str) {
+        let mut inner = self.lock();
+        if let Some(list) = inner.definitions.get_mut(id) {
+            list.retain(|d| d.id != definition_id);
+        }
+    }
+
+    // ── Folder CRUD ───────────────────────────────────────────────────────────
+
+    /// `agent.createFolder` — append a folder to an agent (`createAgentFolder`).
+    /// A no-op for an unknown agent id.
+    pub fn create_folder(&self, id: &str, folder: AgentFolder) {
+        let mut inner = self.lock();
+        if inner.agent_mut(id).is_none() {
+            return;
+        }
+        inner.folders.entry(id.to_string()).or_default().push(folder);
+    }
+
+    /// `agent.updateFolder` — replace an existing folder by id
+    /// (`updateAgentFolder` / `toggleAgentFolder`). A no-op if unknown.
+    pub fn update_folder(&self, id: &str, folder: AgentFolder) {
+        let mut inner = self.lock();
+        if let Some(list) = inner.folders.get_mut(id) {
+            if let Some(slot) = list.iter_mut().find(|f| f.id == folder.id) {
+                *slot = folder;
+            }
+        }
+    }
+
+    /// `agent.deleteFolder` — remove a folder and reparent its child definitions
+    /// to the root (`deleteAgentFolder`, mirroring the agent's own reparenting). A
+    /// no-op if the agent or folder is unknown.
+    pub fn delete_folder(&self, id: &str, folder_id: &str) {
+        let mut inner = self.lock();
+        if let Some(list) = inner.folders.get_mut(id) {
+            list.retain(|f| f.id != folder_id);
+        }
+        if let Some(defs) = inner.definitions.get_mut(id) {
+            for def in defs.iter_mut() {
+                if def.folder_id.as_deref() == Some(folder_id) {
+                    def.folder_id = None;
+                }
+            }
+        }
+    }
+
+    /// Read one agent entry (test / diagnostics helper).
+    #[cfg(test)]
+    pub fn get(&self, id: &str) -> Option<AgentEntry> {
+        self.lock().agents.iter().find(|a| a.id == id).cloned()
+    }
+
+    /// Read one agent's ordered id list (test / diagnostics helper).
+    #[cfg(test)]
+    pub fn agent_ids(&self) -> Vec<String> {
+        self.lock().agents.iter().map(|a| a.id.clone()).collect()
+    }
+
+    /// Read one agent's saved definitions (test / diagnostics helper).
+    #[cfg(test)]
+    pub fn definitions_of(&self, id: &str) -> Vec<AgentDefinition> {
+        self.lock().definitions.get(id).cloned().unwrap_or_default()
+    }
+
+    /// Read one agent's folders (test / diagnostics helper).
+    #[cfg(test)]
+    pub fn folders_of(&self, id: &str) -> Vec<AgentFolder> {
+        self.lock().folders.get(id).cloned().unwrap_or_default()
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Inner> {
+        // Short critical sections only; a poisoned lock means another thread
+        // panicked mid-mutation (a bug) — recover rather than cascade.
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod tests;

--- a/src-tauri/src/agents_projection/store.rs
+++ b/src-tauri/src/agents_projection/store.rs
@@ -264,12 +264,7 @@ impl AgentsStore {
     /// exactly as `setAgentConnectionState`: record the error on `disconnected`
     /// (falling back to the stored one), clear it on `connecting`/`connected`, and
     /// leave it untouched otherwise. A no-op for an unknown id.
-    pub fn set_status(
-        &self,
-        id: &str,
-        state: AgentConnectionState,
-        error: Option<String>,
-    ) {
+    pub fn set_status(&self, id: &str, state: AgentConnectionState, error: Option<String>) {
         let mut inner = self.lock();
         if let Some(agent) = inner.agent_mut(id) {
             let next_error = match state {
@@ -381,7 +376,11 @@ impl AgentsStore {
         if inner.agent_mut(id).is_none() {
             return;
         }
-        inner.folders.entry(id.to_string()).or_default().push(folder);
+        inner
+            .folders
+            .entry(id.to_string())
+            .or_default()
+            .push(folder);
     }
 
     /// `agent.updateFolder` — replace an existing folder by id

--- a/src-tauri/src/agents_projection/store_tests.rs
+++ b/src-tauri/src/agents_projection/store_tests.rs
@@ -6,9 +6,7 @@
 
 use serde_json::json;
 
-use super::{
-    AgentConnectionState, AgentDefinition, AgentFolder, AgentSession, AgentsStore,
-};
+use super::{AgentConnectionState, AgentDefinition, AgentFolder, AgentSession, AgentsStore};
 
 /// A deterministic agent config blob.
 fn config(host: &str) -> serde_json::Value {
@@ -100,7 +98,12 @@ fn update_replaces_config_fields_but_preserves_live_status() {
     store.set_capabilities("a1", json!({ "maxSessions": 4 }));
     store.toggle_expanded("a1");
 
-    store.update("a1", "Renamed", config("h2"), json!({ "autoReconnect": false }));
+    store.update(
+        "a1",
+        "Renamed",
+        config("h2"),
+        json!({ "autoReconnect": false }),
+    );
 
     let agent = store.get("a1").unwrap();
     assert_eq!(agent.name, "Renamed");
@@ -118,7 +121,10 @@ fn apply_settings_updates_only_settings() {
     store.add("a1", "One", config("h1"), settings());
     store.apply_settings("a1", json!({ "autoReconnect": false, "extra": 1 }));
     let agent = store.get("a1").unwrap();
-    assert_eq!(agent.agent_settings, json!({ "autoReconnect": false, "extra": 1 }));
+    assert_eq!(
+        agent.agent_settings,
+        json!({ "autoReconnect": false, "extra": 1 })
+    );
     assert_eq!(agent.name, "One");
 }
 
@@ -126,7 +132,12 @@ fn apply_settings_updates_only_settings() {
 fn remove_drops_the_agent_and_all_its_substate() {
     let store = AgentsStore::new();
     store.add("a1", "One", config("h1"), settings());
-    store.refresh("a1", vec![session("s1")], vec![definition("d1", None)], vec![folder("f1")]);
+    store.refresh(
+        "a1",
+        vec![session("s1")],
+        vec![definition("d1", None)],
+        vec![folder("f1")],
+    );
 
     store.remove("a1");
     assert!(store.get("a1").is_none());
@@ -157,7 +168,11 @@ fn status_tracks_last_error_like_the_frontend() {
     store.add("a1", "One", config("h1"), settings());
 
     // disconnected records the error.
-    store.set_status("a1", AgentConnectionState::Disconnected, Some("boom".into()));
+    store.set_status(
+        "a1",
+        AgentConnectionState::Disconnected,
+        Some("boom".into()),
+    );
     assert_eq!(store.get("a1").unwrap().last_error.as_deref(), Some("boom"));
 
     // reconnecting leaves the stored error untouched.
@@ -173,7 +188,11 @@ fn status_tracks_last_error_like_the_frontend() {
     assert_eq!(store.get("a1").unwrap().last_error, None);
 
     // connected clears any error too.
-    store.set_status("a1", AgentConnectionState::Disconnected, Some("again".into()));
+    store.set_status(
+        "a1",
+        AgentConnectionState::Disconnected,
+        Some("again".into()),
+    );
     store.set_status("a1", AgentConnectionState::Connected, None);
     assert_eq!(store.get("a1").unwrap().last_error, None);
     assert_eq!(
@@ -187,7 +206,12 @@ fn disconnect_forces_disconnected_and_clears_live_but_keeps_definitions() {
     let store = AgentsStore::new();
     store.add("a1", "One", config("h1"), settings());
     store.set_status("a1", AgentConnectionState::Connected, None);
-    store.refresh("a1", vec![session("s1")], vec![definition("d1", None)], vec![folder("f1")]);
+    store.refresh(
+        "a1",
+        vec![session("s1")],
+        vec![definition("d1", None)],
+        vec![folder("f1")],
+    );
 
     store.disconnect("a1");
     let agent = store.get("a1").unwrap();
@@ -220,7 +244,14 @@ fn save_definition_upserts_and_update_replaces() {
     let mut updated = definition("d2", None);
     updated.persistent = true;
     store.update_definition("a1", updated);
-    assert!(store.definitions_of("a1").iter().find(|d| d.id == "d2").unwrap().persistent);
+    assert!(
+        store
+            .definitions_of("a1")
+            .iter()
+            .find(|d| d.id == "d2")
+            .unwrap()
+            .persistent
+    );
 }
 
 #[test]
@@ -234,7 +265,11 @@ fn delete_folder_removes_it_and_reparents_child_definitions() {
     store.delete_folder("a1", "f1");
     assert!(store.folders_of("a1").is_empty());
     // The child definition is reparented to the root (folderId → None).
-    let d1 = store.definitions_of("a1").into_iter().find(|d| d.id == "d1").unwrap();
+    let d1 = store
+        .definitions_of("a1")
+        .into_iter()
+        .find(|d| d.id == "d1")
+        .unwrap();
     assert_eq!(d1.folder_id, None);
 }
 
@@ -260,7 +295,12 @@ fn transitions_on_an_unknown_agent_are_no_ops() {
     store.set_status("ghost", AgentConnectionState::Connected, None);
     store.set_capabilities("ghost", json!({}));
     store.disconnect("ghost");
-    store.refresh("ghost", vec![session("s1")], vec![definition("d1", None)], vec![folder("f1")]);
+    store.refresh(
+        "ghost",
+        vec![session("s1")],
+        vec![definition("d1", None)],
+        vec![folder("f1")],
+    );
     store.clear_sessions("ghost");
     store.save_definition("ghost", definition("d1", None));
     store.create_folder("ghost", folder("f1"));

--- a/src-tauri/src/agents_projection/store_tests.rs
+++ b/src-tauri/src/agents_projection/store_tests.rs
@@ -1,0 +1,292 @@
+//! Unit tests for the shadow [`AgentsStore`] transitions (#2226).
+//!
+//! Drives the store directly and asserts on the typed records and the serialised
+//! view model, checking the agent list order, the backend-authoritative
+//! connection-status transitions, and the definition/folder CRUD.
+
+use serde_json::json;
+
+use super::{
+    AgentConnectionState, AgentDefinition, AgentFolder, AgentSession, AgentsStore,
+};
+
+/// A deterministic agent config blob.
+fn config(host: &str) -> serde_json::Value {
+    json!({ "host": host, "port": 22, "authMethod": "password" })
+}
+
+/// A deterministic settings blob.
+fn settings() -> serde_json::Value {
+    json!({ "autoReconnect": true })
+}
+
+fn definition(id: &str, folder: Option<&str>) -> AgentDefinition {
+    AgentDefinition {
+        id: id.to_string(),
+        name: format!("def-{id}"),
+        session_type: "shell".to_string(),
+        config: json!({ "shell": "bash" }),
+        persistent: false,
+        folder_id: folder.map(str::to_string),
+        terminal_options: None,
+        icon: None,
+        source_file: None,
+    }
+}
+
+fn folder(id: &str) -> AgentFolder {
+    AgentFolder {
+        id: id.to_string(),
+        name: format!("folder-{id}"),
+        parent_id: None,
+        is_expanded: true,
+    }
+}
+
+fn session(id: &str) -> AgentSession {
+    AgentSession {
+        session_id: id.to_string(),
+        title: format!("session {id}"),
+        session_type: "shell".to_string(),
+        status: "running".to_string(),
+        attached: true,
+        definition_id: None,
+    }
+}
+
+#[test]
+fn a_fresh_store_snapshots_empty() {
+    let store = AgentsStore::new();
+    assert_eq!(
+        store.snapshot(),
+        json!({ "agents": [], "sessions": {}, "definitions": {}, "folders": {} })
+    );
+}
+
+#[test]
+fn add_creates_a_disconnected_collapsed_agent() {
+    let store = AgentsStore::new();
+    store.add("a1", "Agent One", config("h1"), settings());
+
+    let agent = store.get("a1").expect("agent exists");
+    assert_eq!(agent.name, "Agent One");
+    assert_eq!(agent.connection_state, AgentConnectionState::Disconnected);
+    assert!(!agent.is_expanded);
+    assert_eq!(agent.capabilities, None);
+    assert_eq!(agent.last_error, None);
+    // Optional fields are omitted from the serialised view (matches the frontend
+    // `?`-optional shape, not `| null`).
+    let view = store.snapshot();
+    let entry = &view["agents"][0];
+    assert!(entry.get("capabilities").is_none());
+    assert!(entry.get("lastError").is_none());
+}
+
+#[test]
+fn add_is_idempotent_on_a_duplicate_id() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.add("a1", "One again", config("h2"), settings());
+    assert_eq!(store.agent_ids(), vec!["a1"]);
+    // The first add wins (append-only, no clobber).
+    assert_eq!(store.get("a1").unwrap().name, "One");
+}
+
+#[test]
+fn update_replaces_config_fields_but_preserves_live_status() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.set_status("a1", AgentConnectionState::Connected, None);
+    store.set_capabilities("a1", json!({ "maxSessions": 4 }));
+    store.toggle_expanded("a1");
+
+    store.update("a1", "Renamed", config("h2"), json!({ "autoReconnect": false }));
+
+    let agent = store.get("a1").unwrap();
+    assert_eq!(agent.name, "Renamed");
+    assert_eq!(agent.config["host"], json!("h2"));
+    assert_eq!(agent.agent_settings["autoReconnect"], json!(false));
+    // Live status carried over, not clobbered.
+    assert_eq!(agent.connection_state, AgentConnectionState::Connected);
+    assert_eq!(agent.capabilities, Some(json!({ "maxSessions": 4 })));
+    assert!(agent.is_expanded);
+}
+
+#[test]
+fn apply_settings_updates_only_settings() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.apply_settings("a1", json!({ "autoReconnect": false, "extra": 1 }));
+    let agent = store.get("a1").unwrap();
+    assert_eq!(agent.agent_settings, json!({ "autoReconnect": false, "extra": 1 }));
+    assert_eq!(agent.name, "One");
+}
+
+#[test]
+fn remove_drops_the_agent_and_all_its_substate() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.refresh("a1", vec![session("s1")], vec![definition("d1", None)], vec![folder("f1")]);
+
+    store.remove("a1");
+    assert!(store.get("a1").is_none());
+    assert!(store.definitions_of("a1").is_empty());
+    assert!(store.folders_of("a1").is_empty());
+    let view = store.snapshot();
+    assert!(view["sessions"].get("a1").is_none());
+}
+
+#[test]
+fn reorder_moves_an_agent_and_ignores_out_of_range() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.add("a2", "Two", config("h2"), settings());
+    store.add("a3", "Three", config("h3"), settings());
+
+    store.reorder(0, 2);
+    assert_eq!(store.agent_ids(), vec!["a2", "a3", "a1"]);
+
+    // Out-of-range indices are a no-op.
+    store.reorder(0, 9);
+    assert_eq!(store.agent_ids(), vec!["a2", "a3", "a1"]);
+}
+
+#[test]
+fn status_tracks_last_error_like_the_frontend() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+
+    // disconnected records the error.
+    store.set_status("a1", AgentConnectionState::Disconnected, Some("boom".into()));
+    assert_eq!(store.get("a1").unwrap().last_error.as_deref(), Some("boom"));
+
+    // reconnecting leaves the stored error untouched.
+    store.set_status("a1", AgentConnectionState::Reconnecting, None);
+    assert_eq!(store.get("a1").unwrap().last_error.as_deref(), Some("boom"));
+
+    // connecting clears it.
+    store.set_status("a1", AgentConnectionState::Connecting, None);
+    assert_eq!(store.get("a1").unwrap().last_error, None);
+
+    // disconnected with no error falls back to the stored (now clear) value.
+    store.set_status("a1", AgentConnectionState::Disconnected, None);
+    assert_eq!(store.get("a1").unwrap().last_error, None);
+
+    // connected clears any error too.
+    store.set_status("a1", AgentConnectionState::Disconnected, Some("again".into()));
+    store.set_status("a1", AgentConnectionState::Connected, None);
+    assert_eq!(store.get("a1").unwrap().last_error, None);
+    assert_eq!(
+        store.get("a1").unwrap().connection_state,
+        AgentConnectionState::Connected
+    );
+}
+
+#[test]
+fn disconnect_forces_disconnected_and_clears_live_but_keeps_definitions() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.set_status("a1", AgentConnectionState::Connected, None);
+    store.refresh("a1", vec![session("s1")], vec![definition("d1", None)], vec![folder("f1")]);
+
+    store.disconnect("a1");
+    let agent = store.get("a1").unwrap();
+    assert_eq!(agent.connection_state, AgentConnectionState::Disconnected);
+    let view = store.snapshot();
+    assert_eq!(view["sessions"]["a1"], json!([]));
+    assert_eq!(view["folders"]["a1"], json!([]));
+    // Definitions (persisted config) survive a disconnect.
+    assert_eq!(store.definitions_of("a1").len(), 1);
+}
+
+#[test]
+fn save_definition_upserts_and_update_replaces() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+
+    store.save_definition("a1", definition("d1", None));
+    store.save_definition("a1", definition("d2", None));
+    assert_eq!(store.definitions_of("a1").len(), 2);
+
+    // Re-saving the same id replaces, not appends.
+    let mut renamed = definition("d1", None);
+    renamed.name = "renamed".to_string();
+    store.save_definition("a1", renamed);
+    let defs = store.definitions_of("a1");
+    assert_eq!(defs.len(), 2);
+    assert_eq!(defs.iter().find(|d| d.id == "d1").unwrap().name, "renamed");
+
+    // update replaces an existing definition by id.
+    let mut updated = definition("d2", None);
+    updated.persistent = true;
+    store.update_definition("a1", updated);
+    assert!(store.definitions_of("a1").iter().find(|d| d.id == "d2").unwrap().persistent);
+}
+
+#[test]
+fn delete_folder_removes_it_and_reparents_child_definitions() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.create_folder("a1", folder("f1"));
+    store.save_definition("a1", definition("d1", Some("f1")));
+    store.save_definition("a1", definition("d2", None));
+
+    store.delete_folder("a1", "f1");
+    assert!(store.folders_of("a1").is_empty());
+    // The child definition is reparented to the root (folderId → None).
+    let d1 = store.definitions_of("a1").into_iter().find(|d| d.id == "d1").unwrap();
+    assert_eq!(d1.folder_id, None);
+}
+
+#[test]
+fn update_folder_replaces_by_id() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.create_folder("a1", folder("f1"));
+
+    let mut toggled = folder("f1");
+    toggled.is_expanded = false;
+    store.update_folder("a1", toggled);
+    assert!(!store.folders_of("a1")[0].is_expanded);
+}
+
+#[test]
+fn transitions_on_an_unknown_agent_are_no_ops() {
+    let store = AgentsStore::new();
+    // None of these should panic or create an agent / sub-state.
+    store.update("ghost", "x", config("h"), settings());
+    store.apply_settings("ghost", settings());
+    store.toggle_expanded("ghost");
+    store.set_status("ghost", AgentConnectionState::Connected, None);
+    store.set_capabilities("ghost", json!({}));
+    store.disconnect("ghost");
+    store.refresh("ghost", vec![session("s1")], vec![definition("d1", None)], vec![folder("f1")]);
+    store.clear_sessions("ghost");
+    store.save_definition("ghost", definition("d1", None));
+    store.create_folder("ghost", folder("f1"));
+
+    assert!(store.get("ghost").is_none());
+    assert!(store.definitions_of("ghost").is_empty());
+    assert!(store.folders_of("ghost").is_empty());
+    assert_eq!(
+        store.snapshot(),
+        json!({ "agents": [], "sessions": {}, "definitions": {}, "folders": {} })
+    );
+}
+
+#[test]
+fn the_snapshot_preserves_agent_order() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.add("a2", "Two", config("h2"), settings());
+    store.reorder(1, 0);
+
+    let view = store.snapshot();
+    let ids: Vec<&str> = view["agents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|a| a["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids, vec!["a2", "a1"]);
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,8 @@
+/// Shadow agents authority (#2226, Phase 5 of #2139): the shared `agents`
+/// projection region + `agent.*` intents modeling the `appStore` agents slice
+/// (the ordered agent list + per-agent sessions/definitions/folders). Registered
+/// and served but not yet driving the live UI — see [`agents_projection`].
+mod agents_projection;
 mod commands;
 mod connection;
 mod credential;
@@ -706,6 +711,19 @@ pub fn run() {
                     &mut registry,
                     app.handle().clone(),
                 );
+                // Shadow AgentsStore (#2226, Phase 5): the shared `agents` region
+                // + `agent.*` intents modeling the `appStore` agents slice (the
+                // ordered agent list + per-agent sessions/definitions/folders).
+                // Managed authoritative state that serves intents, but nothing in
+                // the live UI subscribes to or renders the region yet — a pure
+                // shadow foundation (later steps cut rendering, then mutations,
+                // over to it). The shared region is seeded below once the store is
+                // managed.
+                app.manage(Arc::new(agents_projection::AgentsStore::new()));
+                agents_projection::projection::register_agent_intents(
+                    &mut registry,
+                    app.handle().clone(),
+                );
                 // Test-bridge-only: add the diagnostic region's `diag.*` routes so
                 // the projection-assertion harness (#2164) has a self-contained
                 // region to drive. Never registered in production launches. See
@@ -743,6 +761,17 @@ pub fn run() {
                 {
                     projection_state.projector.register_region(
                         system_monitor_projection::projection::SYSTEM_MONITORS_REGION,
+                        store.snapshot(),
+                    );
+                }
+                // Seed the shared `agents` region with the (empty) store baseline
+                // at version 0, so a subscriber attaches to a real region before
+                // the first `agent.*` intent (#2226).
+                if let Some(store) =
+                    app.handle().try_state::<Arc<agents_projection::AgentsStore>>()
+                {
+                    projection_state.projector.register_region(
+                        agents_projection::projection::AGENTS_REGION,
                         store.snapshot(),
                     );
                 }


### PR DESCRIPTION
## Summary

Phase 5, step 1 (shadow) of the Agents-domain migration onto a Rust store + projection region, mirroring the merged Monitors shadow (PR #2230). Backend-only, zero user-facing change.

Adds a new `src-tauri/src/agents_projection/` module:

- **`AgentsStore`** — the authoritative model of the `appStore` agents slice: the ordered `remoteAgents` list (each agent's id/name/opaque config+settings, live `connectionState`, capabilities and `lastError`) plus the per-agent `agentSessions` / `agentDefinitions` / `agentFolders` maps. The view model matches the frontend shapes one-to-one so the eventual render cut is a pure parity swap.
- A single **shared** `agents` projection region + the `agent.*` intent set (add/update/applySettings/remove/reorder/toggleExpanded/status/setCapabilities/disconnect/refresh/clearSessions + definition & folder CRUD), served through the projection substrate.
- Managed and seeded in `lib.rs` alongside the Monitors/session/tunnel shadows.

### Region scope (Open Design Decision #4)

**Shared.** An agent's connection/session status is a property of the agent, not of a viewing client — two clients observing the same configured agent see the same `connected`/`reconnecting` state and the same live sessions (like SSH tunnels and session-lifecycle). Agent definitions and folders are shared, persisted config. Per-client presentation (focus, banner dismissal) stays a frontend concern under partial projection.

The backend-authoritative single-writer rule for `connectionState` (frontend G4/#1234) is preserved: only `agent.status` mutates it, tracking `lastError` exactly as `setAgentConnectionState`.

## Shadow mode — nothing user-facing changed

Nothing subscribes to the `agents` region or dispatches `agent.*`; `appStore` stays authoritative; the agent sidebar and Open Connections are untouched. The diff is confined to `src-tauri/src/` (the new module + `lib.rs` wiring). No frontend files changed.

## Tests

- Store unit tests (`store_tests.rs`): list order, backend-authoritative status/`lastError` transitions, disconnect clearing live-but-keeping-definitions, definition upsert/update, folder delete-with-reparent, unknown-id no-ops.
- Projection-contract tests (`projection_tests.rs`, #2164 harness): subscribe→snapshot parity, one coalesced diff fanned to every subscriber with monotonic versions, rejection/no-op advance nothing, dead-subscriber reaping, and client-cache convergence across a full add→connect→refresh→disconnect→remove lifecycle.

`cargo test`, `cargo clippy -D warnings`, and `cargo fmt --check` all green.

## Follow-up

This is step 1 of 4. The issue stays open for the render cut, mutation cut, and reducer removal.

Part of #2226