### PR TITLE
feat(session): enable session mutation cut by default

### DIFF
--- a/src/store/appStore.autoReconnect.test.ts
+++ b/src/store/appStore.autoReconnect.test.ts
@@ -56,6 +56,7 @@ import { useAppStore } from "./appStore";
 import { getAllLeaves } from "@/utils/panelTree";
 import { DEFAULT_BACKOFF } from "@/utils/reconnectBackoff";
 import { registerTerminalInputInjector } from "@/services/macroPlayback";
+import { setSessionIntentsEnabled } from "./sessionBridge";
 
 function findTab(tabId: string) {
   const state = useAppStore.getState();
@@ -93,9 +94,15 @@ describe("appStore — agentless auto-reconnect (#1962)", () => {
   beforeEach(() => {
     useAppStore.setState(useAppStore.getInitialState());
     vi.useFakeTimers();
+    // Pin the local `setTimeout` reconnect loop: these tests assert the local
+    // reducer/timer path, which stays as the resilience fallback after the
+    // session mutation cut flipped on by default (#2152). The intent path keeps
+    // its own coverage in sessionBridge/appStore.sessionBridge tests.
+    setSessionIntentsEnabled(false);
   });
 
   afterEach(() => {
+    setSessionIntentsEnabled(null);
     vi.clearAllTimers();
     vi.useRealTimers();
   });
@@ -259,6 +266,10 @@ describe("appStore — on-reconnect command (#1978)", () => {
   beforeEach(() => {
     useAppStore.setState(useAppStore.getInitialState());
     vi.useFakeTimers();
+    // Pin the local `setTimeout` reconnect loop — see the note above. The local
+    // reducer/timer path is the resilience fallback after the session mutation
+    // cut flipped on by default (#2152).
+    setSessionIntentsEnabled(false);
     injected = [];
     registerTerminalInputInjector((tabId, data) => {
       injected.push({ tabId, data });
@@ -267,6 +278,7 @@ describe("appStore — on-reconnect command (#1978)", () => {
   });
 
   afterEach(() => {
+    setSessionIntentsEnabled(null);
     registerTerminalInputInjector(null);
     vi.clearAllTimers();
     vi.useRealTimers();

--- a/src/store/sessionBridge.test.ts
+++ b/src/store/sessionBridge.test.ts
@@ -117,14 +117,14 @@ afterEach(() => {
 });
 
 describe("sessionIntentsEnabled flag", () => {
-  it("defaults off and honours the programmatic override", () => {
-    expect(sessionIntentsEnabled()).toBe(false);
-    setSessionIntentsEnabled(true);
+  it("defaults on and honours the programmatic override", () => {
     expect(sessionIntentsEnabled()).toBe(true);
     setSessionIntentsEnabled(false);
     expect(sessionIntentsEnabled()).toBe(false);
+    setSessionIntentsEnabled(true);
+    expect(sessionIntentsEnabled()).toBe(true);
     setSessionIntentsEnabled(null);
-    expect(sessionIntentsEnabled()).toBe(false);
+    expect(sessionIntentsEnabled()).toBe(true);
   });
 });
 

--- a/src/store/sessionBridge.ts
+++ b/src/store/sessionBridge.ts
@@ -21,20 +21,19 @@
  * `terminalAutoReconnect`) is keyed by tab id. So the bridge uses the tab id as
  * the region's opaque session key; the store treats it as an opaque string.
  *
- * # Strangler safety — flag-gated, off by default, local fallback retained
+ * # Strangler safety — flag-gated, on by default, local fallback retained
  *
- * The cut is gated by {@link sessionIntentsEnabled} — **off by default**. When
- * off, `appStore` drives the lifecycle exactly as it always has (the local
- * `setTimeout` reconnect loop included). When on, the transitions additionally
- * dispatch `session.*` intents and the backend timer drives the reconnect
- * schedule; the local path stays in place as the render source (this step) and
- * as a resilience fallback — any dispatch/subscription failure is logged and the
- * local behaviour continues, so a backend hiccup can never break connect or
- * reconnect. The flag flips to on (and is GUI-verified) in a later
- * coordinator-managed step, exactly as the layout mutation cut did (#2184).
- * Overridable at runtime for rollback / tests via
- * `window.__TERMIHUB_SESSION_INTENTS__` or
- * `localStorage["termihub.sessionIntents"]`.
+ * The cut is gated by {@link sessionIntentsEnabled} — **on by default** (#2152
+ * Phase 4). When on, the transitions dispatch `session.*` intents and the backend
+ * timer drives the reconnect schedule; the local path stays in place as the render
+ * source and as a resilience fallback — any dispatch/subscription failure is
+ * logged and the local behaviour continues, so a backend hiccup can never break
+ * connect or reconnect. When off, `appStore` drives the lifecycle purely locally
+ * (the local `setTimeout` reconnect loop included) — the rollback / resilience
+ * path. The flip mirrors the layout mutation cut (#2184). Overridable at runtime
+ * for rollback / tests via `window.__TERMIHUB_SESSION_INTENTS__` or
+ * `localStorage["termihub.sessionIntents"]` (set `"false"` to restore the pre-cut
+ * local-mutation path).
  */
 
 import {
@@ -123,11 +122,16 @@ export function setSessionIntentsEnabled(value: boolean | null): void {
  * backend timer driver drive the reconnect loop — instead of `appStore` driving
  * the lifecycle purely locally.
  *
- * **Off by default.** The local path stays authoritative for rendering this step
- * and as a resilience fallback. Overridable at runtime via
+ * **On by default** (#2152 Phase 4). The backend `SessionLifecycleStore` is
+ * authoritative for status and the backend timer drives the reconnect schedule;
+ * the local path stays in place as the render source and as a resilience fallback
+ * (any dispatch/subscription failure falls back to the local lifecycle). The flip
+ * was taken on the automated tests — cut-vs-local parity plus deterministic
+ * backend-timer coverage plus the instant local fallback — mirroring the layout
+ * mutation cut (#2184). Overridable at runtime via
  * `window.__TERMIHUB_SESSION_INTENTS__` or
- * `localStorage["termihub.sessionIntents"]` (set `"true"` to opt in for a dev
- * build; `"false"` to force off).
+ * `localStorage["termihub.sessionIntents"]` (set `"false"` to restore the pre-cut
+ * local-mutation path; `"true"` to force on).
  */
 export function sessionIntentsEnabled(): boolean {
   if (flagOverride !== null) return flagOverride;
@@ -144,7 +148,7 @@ export function sessionIntentsEnabled(): boolean {
   } catch {
     // A missing/blocked window or storage just means "use the default".
   }
-  return false;
+  return true;
 }
 
 // ── Render-cut feature flag (step 3 #2204, on by default) ──────────────────────


### PR DESCRIPTION
## Summary

Enables the **session-lifecycle mutation cut by default** — the session analog of the layout mutation-cut flip (#2184). This is Phase 4 of the stateless-UI migration.

Phase 4 step 2 (#2203) shipped the session-lifecycle mutation cut behind `sessionIntentsEnabled()` in `src/store/sessionBridge.ts`, defaulting **off**. This flips the default `false` → `true`, so session `connect`/`connected`/`disconnect`/`dropped`/`reconnect`/`error` transitions route through `session.*` intents and the backend timer drives the reconnect backoff loop.

The change is a single behavioral flip plus the docstring/test updates it requires.

## What stays

- **Local reducer path retained as the resilience/rollback fallback** — not deleted. Any dispatch/subscription failure logs and continues on the local lifecycle, so a backend hiccup can never break connect or reconnect.
- **Instant revert:** `localStorage["termihub.sessionIntents"] = "false"` (or `window.__TERMIHUB_SESSION_INTENTS__ = false`) restores the pre-cut local-mutation path. The override plumbing and `setSessionIntentsEnabled()` are untouched.

## Decision basis

Per the maintainer's decision, the flip was taken on the **automated tests** rather than a hands-on GUI pass:

- cut-vs-local **parity** tests (`projectedToAutoReconnect` reproduces the local record),
- **deterministic backend-timer** tests (the cut arms no local timer; the backend owns the Waiting→Attempt edge),
- **instant local fallback** on any intent/subscription failure.

**GUI parity was not hand-verified**, by maintainer decision; `localStorage["termihub.sessionIntents"]="false"` is the instant revert if a regression surfaces.

## Tests updated

Mirrors the layout flip (#2189): tests that assert the **local reducer/timer path** are now pinned to it via `setSessionIntentsEnabled(false)`; the intent path keeps its own coverage.

- `src/store/appStore.autoReconnect.test.ts` — both describe blocks (`#1962` backoff loop, `#1978` on-reconnect command) pinned to the local `setTimeout` path in `beforeEach`, reset to `null` in `afterEach`.
- `src/store/sessionBridge.test.ts` — the flag default test updated `defaults off` → `defaults on`.

Full frontend suite green (520 files, 4791 tests).

Part of #2152
