### PR TITLE
fix(backend): activate enabled plugins so extension points load (Closes #2234)

### DIFF
--- a/core/src/plugin/host.rs
+++ b/core/src/plugin/host.rs
@@ -34,7 +34,7 @@
 //!
 //! [`PluginConnectionType`]: super::connection::PluginConnectionType
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -410,6 +410,13 @@ pub struct PluginHost {
     root: PathBuf,
     registry: Arc<Mutex<ConnectionTypeRegistry>>,
     loaded: Mutex<HashMap<String, HostEntry>>,
+    /// Ids the host has successfully activated, so the management layer can
+    /// promote them to [`PluginState::Active`](super::PluginState). This is a
+    /// superset of [`loaded`](Self::loaded): a **frontend-only** plugin (theme /
+    /// JS parser / widget, no `terminalBackend` library) is active once its
+    /// [`load`](Self::load) succeeds even though it registers no connection type,
+    /// so it is tracked here but not in `loaded`.
+    active: Mutex<HashSet<String>>,
     /// Per-plugin error-recovery counters (concept "Error recovery state
     /// machine"). Keyed by plugin id; created lazily on first failure.
     recovery: Mutex<HashMap<String, RestartTracker>>,
@@ -426,6 +433,7 @@ impl PluginHost {
             root: plugins_root.into(),
             registry,
             loaded: Mutex::new(HashMap::new()),
+            active: Mutex::new(HashSet::new()),
             recovery: Mutex::new(HashMap::new()),
         }
     }
@@ -436,13 +444,30 @@ impl PluginHost {
         &self.registry
     }
 
-    /// Whether a plugin id is currently loaded.
+    /// Whether a plugin id currently has a loaded **backend library**. A
+    /// frontend-only plugin (no `terminalBackend`) is never "loaded" in this
+    /// sense even when active — use [`is_active`](Self::is_active) for the
+    /// activation state the management layer promotes on.
     #[must_use]
     pub fn is_loaded(&self, id: &str) -> bool {
         self.loaded
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .contains_key(id)
+    }
+
+    /// Whether a plugin id is currently **active** — its [`load`](Self::load)
+    /// succeeded and it has not since been unloaded. Unlike
+    /// [`is_loaded`](Self::is_loaded) this is `true` for a frontend-only plugin
+    /// (theme / JS, no backend library) too. The management layer queries this
+    /// to promote an enabled, compatible plugin to
+    /// [`PluginState::Active`](super::PluginState).
+    #[must_use]
+    pub fn is_active(&self, id: &str) -> bool {
+        self.active
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains(id)
     }
 
     /// Load a plugin's backend and register its connection type.
@@ -466,6 +491,14 @@ impl PluginHost {
         permissions.check_consistency(&plugin.manifest.extensions)?;
 
         let Some(backend) = plugin.manifest.extensions.terminal_backend.as_ref() else {
+            // Frontend-only plugin (theme / JS parser / widget): there is no
+            // native library to open, but activation still succeeded — the
+            // frontend loaders pick it up once its state is `Active`. Record it
+            // as active so the management layer promotes it (#2234).
+            self.active
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .insert(plugin.manifest.id.clone());
             return Ok(());
         };
 
@@ -542,6 +575,10 @@ impl PluginHost {
                     library,
                 },
             );
+        self.active
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(plugin.manifest.id.clone());
         // A clean (re)load means the plugin is healthy again: reset any prior
         // recovery counter so a future, unrelated failure gets a full budget.
         self.clear_recovery(&plugin.manifest.id);
@@ -552,6 +589,10 @@ impl PluginHost {
     /// reference to the library. The library unmaps once every session created
     /// from it has also been dropped. A no-op if the id is not loaded.
     pub fn unload(&self, id: &str) {
+        self.active
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(id);
         let entry = self
             .loaded
             .lock()
@@ -632,6 +673,10 @@ impl super::manager::PluginLifecycleHook for HostLifecycleHook {
     fn on_disable(&self, id: &str) -> Result<(), String> {
         self.host.unload(id);
         Ok(())
+    }
+
+    fn is_active(&self, id: &str) -> bool {
+        self.host.is_active(id)
     }
 
     fn on_uninstall(&self, id: &str) -> Result<(), String> {

--- a/core/src/plugin/manager.rs
+++ b/core/src/plugin/manager.rs
@@ -1826,6 +1826,83 @@ mod tests {
         assert!(healthy.error_message.is_none());
     }
 
+    /// End-to-end through the **real** [`HostLifecycleHook`]/[`PluginHost`]: a
+    /// frontend-only plugin (theme, no `terminalBackend` library) installed and
+    /// enabled must reach `Active`, and `get`/`list` — the frontend's source of
+    /// truth — must report it, so the theme/JS loaders that gate on `active`
+    /// actually pick it up (#2234). Disable/re-enable round-trips the state.
+    #[test]
+    fn real_host_activates_a_frontend_only_plugin() {
+        use crate::connection::ConnectionTypeRegistry;
+        use crate::plugin::{HostLifecycleHook, PluginHost};
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("plugins");
+        let host = Arc::new(PluginHost::new(
+            root.clone(),
+            Arc::new(Mutex::new(ConnectionTypeRegistry::new())),
+        ));
+        let mgr =
+            PluginManager::with_hook(&root, Arc::new(HostLifecycleHook::new(Arc::clone(&host))));
+
+        let pkg_dir = TempDir::new().unwrap();
+        let pkg = make_package(pkg_dir.path(), &manifest_json("themer", "1.0"), &[]);
+        let installed = mgr.install(&pkg, true, false).unwrap();
+
+        // Install enables + loads: the plugin is Active, and the list()/get() the
+        // frontend reads report Active too — not stuck at Installed.
+        assert_eq!(installed.state, PluginState::Active);
+        assert_eq!(mgr.get("themer").unwrap().state, PluginState::Active);
+        assert_eq!(mgr.list().unwrap()[0].state, PluginState::Active);
+        // Active without a backend library (frontend-only).
+        assert!(host.is_active("themer"));
+        assert!(!host.is_loaded("themer"));
+
+        // Disable tears it down; re-enable brings it back to Active.
+        assert_eq!(mgr.disable("themer").unwrap().state, PluginState::Disabled);
+        assert!(!host.is_active("themer"));
+        assert_eq!(mgr.get("themer").unwrap().state, PluginState::Disabled);
+
+        assert_eq!(mgr.enable("themer").unwrap().state, PluginState::Active);
+        assert!(host.is_active("themer"));
+        assert_eq!(mgr.get("themer").unwrap().state, PluginState::Active);
+    }
+
+    /// The startup path through the real host: a plugin persisted as enabled in a
+    /// previous session (installed with no host, so left at `Installed`) is
+    /// promoted to `Active` when `load_enabled_plugins` drives the host at boot.
+    #[test]
+    fn real_host_activates_enabled_plugins_at_startup() {
+        use crate::connection::ConnectionTypeRegistry;
+        use crate::plugin::{HostLifecycleHook, PluginHost};
+
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("plugins");
+
+        // Session 1: install with a plain manager (no host) — nothing loads, so
+        // the plugin persists as enabled-but-not-active.
+        {
+            let mgr = PluginManager::new(&root);
+            let pkg_dir = TempDir::new().unwrap();
+            let pkg = make_package(pkg_dir.path(), &manifest_json("persisted", "1.0"), &[]);
+            mgr.install(&pkg, true, false).unwrap();
+            assert_eq!(mgr.get("persisted").unwrap().state, PluginState::Installed);
+        }
+
+        // Session 2 (restart): a real host loads already-enabled plugins at
+        // startup, which promotes the persisted plugin to Active.
+        let host = Arc::new(PluginHost::new(
+            root.clone(),
+            Arc::new(Mutex::new(ConnectionTypeRegistry::new())),
+        ));
+        let mgr =
+            PluginManager::with_hook(&root, Arc::new(HostLifecycleHook::new(Arc::clone(&host))));
+        let loaded = mgr.load_enabled_plugins().unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].state, PluginState::Active);
+        assert_eq!(mgr.get("persisted").unwrap().state, PluginState::Active);
+    }
+
     #[test]
     fn reconcile_leaves_compatible_plugins_enabled() {
         let (mgr, tmp) = manager();

--- a/core/src/plugin/manager.rs
+++ b/core/src/plugin/manager.rs
@@ -64,14 +64,18 @@ const SETTINGS_FILE_NAME: &str = "plugin-settings.json";
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PluginState {
-    /// Extracted and enabled, but not yet loaded into a running host. This is
-    /// the resting state for an enabled plugin in this foundation layer, which
-    /// does no loading — a later host issue promotes it to [`Active`].
+    /// Extracted and enabled, but not (yet) loaded into a running host — the
+    /// resting state before load, and the state an enabled plugin reports when
+    /// no host is wired (e.g. the management layer in isolation). Once a host
+    /// loads it, it advances to [`Active`].
     ///
     /// [`Active`]: PluginState::Active
     Installed,
-    /// Loaded and running. Only a later plugin-host issue can produce this; the
-    /// management layer never assigns it on its own.
+    /// Loaded and running: the lifecycle host has activated the plugin (a backend
+    /// library, or a frontend-only theme/JS plugin) and its extension points are
+    /// live. The management layer promotes an enabled, compatible plugin to this
+    /// once the host reports it active
+    /// ([`PluginLifecycleHook::is_active`]) — #2234.
     Active,
     /// The user has turned the plugin off; it stays extracted but is not loaded.
     Disabled,
@@ -120,6 +124,18 @@ pub trait PluginLifecycleHook: Send + Sync {
     /// Called before a plugin's directory is removed (the "shutdown hook").
     fn on_uninstall(&self, _id: &str) -> Result<(), String> {
         Ok(())
+    }
+    /// Whether the plugin `id` is currently loaded and running in the host.
+    ///
+    /// This is the seam through which the management layer learns that an
+    /// enabled, compatible plugin has actually been activated, so it can promote
+    /// it from [`PluginState::Installed`] to [`PluginState::Active`] (#2234). The
+    /// default (no host wired) reports `false`, so an enabled plugin rests at
+    /// `Installed`; the [`HostLifecycleHook`](super::host::HostLifecycleHook)
+    /// reports `true` once [`on_enable`](Self::on_enable) has loaded it,
+    /// including for frontend-only plugins that register no backend library.
+    fn is_active(&self, _id: &str) -> bool {
+        false
     }
 }
 
@@ -438,9 +454,12 @@ impl PluginManager {
         self.write_state_store(&state)?;
 
         let mut plugin = self.installed_plugin_from(manifest, &state, &dest);
-        if let Err(msg) = self.hook.on_enable(&plugin) {
-            plugin.state = PluginState::Error;
-            plugin.error_message = Some(msg);
+        match self.hook.on_enable(&plugin) {
+            Ok(()) => self.reflect_activation(&mut plugin),
+            Err(msg) => {
+                plugin.state = PluginState::Error;
+                plugin.error_message = Some(msg);
+            }
         }
         Ok(plugin)
     }
@@ -550,7 +569,8 @@ impl PluginManager {
     /// next launch or an explicit re-enable.
     ///
     /// Returns every plugin it attempted to load, each with its state reflecting
-    /// the outcome ([`PluginState::Installed`] on success,
+    /// the outcome ([`PluginState::Active`] once the host has loaded it —
+    /// [`PluginState::Installed`] if no host is wired — and
     /// [`PluginState::Error`] on failure), so the caller can notify the user of
     /// any that failed.
     pub fn load_enabled_plugins(&self) -> Result<Vec<InstalledPlugin>, PluginManagerError> {
@@ -565,9 +585,12 @@ impl PluginManager {
             if plugin.state != PluginState::Installed {
                 continue;
             }
-            if let Err(msg) = self.hook.on_enable(&plugin) {
-                plugin.state = PluginState::Error;
-                plugin.error_message = Some(msg);
+            match self.hook.on_enable(&plugin) {
+                Ok(()) => self.reflect_activation(&mut plugin),
+                Err(msg) => {
+                    plugin.state = PluginState::Error;
+                    plugin.error_message = Some(msg);
+                }
             }
             attempted.push(plugin);
         }
@@ -602,9 +625,13 @@ impl PluginManager {
             } else {
                 self.hook.on_disable(id)
             };
-            if let Err(msg) = hook_result {
-                plugin.state = PluginState::Error;
-                plugin.error_message = Some(msg);
+            match hook_result {
+                Ok(()) if enabled => self.reflect_activation(&mut plugin),
+                Ok(()) => {}
+                Err(msg) => {
+                    plugin.state = PluginState::Error;
+                    plugin.error_message = Some(msg);
+                }
             }
         }
         Ok(plugin)
@@ -669,8 +696,20 @@ impl PluginManager {
         self.root.join(id)
     }
 
-    /// Build an [`InstalledPlugin`], deriving its state from API compatibility
-    /// and the persisted enabled flag.
+    /// Promote a just-enabled plugin to [`PluginState::Active`] if the lifecycle
+    /// host now reports it loaded (#2234). Called after a successful `on_enable`;
+    /// a no-op when the plugin is not resting at [`PluginState::Installed`] or no
+    /// host is wired (the default hook reports every plugin inactive, so the
+    /// management layer alone rests an enabled plugin at `Installed`).
+    fn reflect_activation(&self, plugin: &mut InstalledPlugin) {
+        if plugin.state == PluginState::Installed && self.hook.is_active(&plugin.manifest.id) {
+            plugin.state = PluginState::Active;
+        }
+    }
+
+    /// Build an [`InstalledPlugin`], deriving its state from API compatibility,
+    /// the persisted enabled flag, and — for an enabled, compatible plugin —
+    /// whether the lifecycle host reports it active (#2234).
     fn installed_plugin_from(
         &self,
         manifest: PluginManifest,
@@ -686,9 +725,15 @@ impl PluginManager {
         let plugin_state = if manifest.api_compatibility() == ApiCompatibility::Incompatible {
             PluginState::Incompatible
         } else if enabled {
-            // Enabled but not loaded — this layer does no loading, so an enabled
-            // plugin rests at `installed` until a host promotes it to `active`.
-            PluginState::Installed
+            // Enabled and compatible: `active` once the host has actually loaded
+            // it (a backend library, or a frontend-only theme/JS plugin), else
+            // `installed` — the resting state before load, or when no host is
+            // wired (#2234).
+            if self.hook.is_active(&manifest.id) {
+                PluginState::Active
+            } else {
+                PluginState::Installed
+            }
         } else {
             PluginState::Disabled
         };
@@ -1683,6 +1728,11 @@ mod tests {
                     .push(plugin.manifest.id.clone());
                 Ok(())
             }
+            // Simulate a real host: a plugin whose load succeeded is now active,
+            // so the manager promotes it to `Active` (#2234).
+            fn is_active(&self, id: &str) -> bool {
+                self.enabled.lock().unwrap().iter().any(|i| i == id)
+            }
         }
 
         let tmp = TempDir::new().unwrap();
@@ -1717,21 +1767,32 @@ mod tests {
         );
         assert_eq!(loaded.len(), 1);
         assert_eq!(loaded[0].manifest.id, "keep-on");
-        assert_eq!(loaded[0].state, PluginState::Installed);
+        // A successful host load promotes the plugin to `Active` (#2234) — it is
+        // no longer left at `Installed`.
+        assert_eq!(loaded[0].state, PluginState::Active);
         assert!(loaded[0].error_message.is_none());
     }
 
     #[test]
     fn load_enabled_plugins_surfaces_a_failure_as_error_without_aborting() {
         // Fails to load one specific plugin; every other load succeeds.
-        struct FailFor(&'static str);
+        // Stateful like the real host: a plugin is only active once its load
+        // actually succeeded, so `is_active` is false until `on_enable` ran (the
+        // failing one never becomes active).
+        struct FailFor {
+            fail: &'static str,
+            active: Mutex<Vec<String>>,
+        }
         impl PluginLifecycleHook for FailFor {
             fn on_enable(&self, plugin: &InstalledPlugin) -> Result<(), String> {
-                if plugin.manifest.id == self.0 {
-                    Err("boom".into())
-                } else {
-                    Ok(())
+                if plugin.manifest.id == self.fail {
+                    return Err("boom".into());
                 }
+                self.active.lock().unwrap().push(plugin.manifest.id.clone());
+                Ok(())
+            }
+            fn is_active(&self, id: &str) -> bool {
+                self.active.lock().unwrap().iter().any(|i| i == id)
             }
         }
 
@@ -1746,7 +1807,13 @@ mod tests {
             }
         }
 
-        let mgr2 = PluginManager::with_hook(&root, Arc::new(FailFor("broken")));
+        let mgr2 = PluginManager::with_hook(
+            &root,
+            Arc::new(FailFor {
+                fail: "broken",
+                active: Mutex::new(Vec::new()),
+            }),
+        );
         let loaded = mgr2.load_enabled_plugins().unwrap();
 
         // Both enabled+compatible plugins were attempted; the failing one surfaces
@@ -1755,7 +1822,7 @@ mod tests {
         assert_eq!(broken.state, PluginState::Error);
         assert_eq!(broken.error_message.as_deref(), Some("boom"));
         let healthy = loaded.iter().find(|p| p.manifest.id == "healthy").unwrap();
-        assert_eq!(healthy.state, PluginState::Installed);
+        assert_eq!(healthy.state, PluginState::Active);
         assert!(healthy.error_message.is_none());
     }
 

--- a/core/tests/plugin_connection_wiring.rs
+++ b/core/tests/plugin_connection_wiring.rs
@@ -282,7 +282,9 @@ async fn already_enabled_plugin_is_loaded_at_startup_without_a_toggle() {
     conn.disconnect().await.unwrap();
 
     // The broken plugin surfaced as Error, but startup carried on and the healthy
-    // one still loaded.
+    // one still loaded — and, being enabled and successfully loaded by the wired
+    // host, it is promoted to `Active` (the state the frontend loaders gate on),
+    // not left resting at `Installed` (#2234).
     let broken = loaded
         .iter()
         .find(|p| p.manifest.id == "broken")
@@ -290,7 +292,7 @@ async fn already_enabled_plugin_is_loaded_at_startup_without_a_toggle() {
     assert_eq!(broken.state, PluginState::Error);
     assert!(broken.error_message.is_some());
     let echo = loaded.iter().find(|p| p.manifest.id == "echo").unwrap();
-    assert_eq!(echo.state, PluginState::Installed);
+    assert_eq!(echo.state, PluginState::Active);
     assert!(echo.error_message.is_none());
 }
 

--- a/docs/changes/dev0/feature/2234-plugin-activation.md
+++ b/docs/changes/dev0/feature/2234-plugin-activation.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- Plugins now actually **activate**. An enabled, compatible plugin whose host
+  load succeeds is reported with `state: "active"` — both at startup and on a
+  live enable — instead of resting at `installed` forever. Previously no plugin
+  ever reached `active`, so the three activation-gated extension points were
+  silently inert in real builds: frontend JS plugins (protocol parsers /
+  status-bar widgets), plugin color themes, and plugin backend connection types.
+  Frontend-only plugins (theme / JS, no native backend library) activate too.
+  Frontend-plugin JS execution remains behind its existing default-off
+  experimental opt-in (#2234).


### PR DESCRIPTION
## Summary

Plugins never reached `PluginState::Active`, so none of the three activation-gated extension points ever came alive in a real build:

- **Frontend JS plugins** — `reconcileFrontendPlugins` only loads `p.state === "active"`.
- **Plugin themes** — `loadActivePluginThemes` skips non-`active` plugins.
- **Plugin backend connection types** — `derivePluginBackendTypes` only projects a backend for `active` plugins.

The Rust management layer only ever derived `Installed`/`Disabled`/`Incompatible`, and the frontend's source of truth (`PluginManager::list`/`get`) derived state purely from compatibility + the enabled flag — so even the `Active` value transiently returned by `enable()` was thrown away on the next `list()`.

## Fix

- The `PluginHost` now tracks an **active** set (a superset of loaded backend libraries that also includes **frontend-only** plugins — theme/JS — which have no native library). `load` records activation, `unload` clears it.
- A new `PluginLifecycleHook::is_active` seam (default `false`; `HostLifecycleHook` delegates to the host) lets the management layer learn a plugin is loaded without doing loading itself.
- `installed_plugin_from` promotes an enabled, compatible plugin to `Active` when the host reports it active, so `list`/`get` — what the frontend reads — report `active`. The install / live-enable / startup paths reflect activation after a successful `on_enable`.

The existing frontend loaders were already written waiting for `active`; no frontend code change was needed — they now pick plugins up.

## Coordination with #2136 (sandbox)

This is a **Rust state-machine** fix. It does not touch `frontendPlugins.ts`, the CSP, or the `blob:` allowance. Frontend-plugin **JS execution** stays behind its existing default-off experimental opt-in (`frontendPluginsEnabled`, #2048). So in a default build, backend + theme activation (both safe) come alive, while frontend JS stays inert until the user opts in — the exact path #2136 will harden. #2136 remains "tighten + drop `blob:`", not "re-architect".

## Tests

- Updated the two startup-load tests that asserted `Installed`-after-load to assert `Active` (with stateful hooks that mirror the real host).
- Added two end-to-end tests through the **real** `HostLifecycleHook`/`PluginHost`: a frontend-only theme plugin reaches `Active` on install/enable (round-tripping through disable), and an already-enabled plugin persisted from a prior session is promoted to `Active` by `load_enabled_plugins` at startup.
- All 778 core lib tests pass with `--features plugin`; `cargo fmt`/`clippy -D warnings` clean.

## Test plan

- [x] `cargo test -p termihub-core --lib --features plugin`
- [x] `cargo clippy -p termihub-core --lib --features plugin --all-targets -- -D warnings`

Closes #2234