### PR TITLE
refactor(sftp): converge desktop SFTP session onto core SftpFileBrowser (Part of #2104)

### DIFF
--- a/core/src/backends/ssh/file_browser.rs
+++ b/core/src/backends/ssh/file_browser.rs
@@ -34,16 +34,90 @@ struct SftpState {
 ///
 /// The SFTP session is opened lazily on first use and reused for
 /// subsequent operations. The session is dropped on disconnect.
-pub(crate) struct SftpFileBrowser {
+///
+/// This is the single SFTP implementation shared by the core
+/// [`ConnectionType::file_browser()`](crate::connection::ConnectionType::file_browser)
+/// path and the desktop file-browser/transfer command layer, whose `SftpSession`
+/// wraps one of these (#2104). It reaches jump-host targets through their pooled
+/// gateway via [`connect_target`] (#939).
+pub struct SftpFileBrowser {
     config: SshConfig,
     state: Arc<Mutex<Option<SftpState>>>,
 }
 
 impl SftpFileBrowser {
-    pub(crate) fn new(config: SshConfig) -> Self {
+    pub fn new(config: SshConfig) -> Self {
         Self {
             config,
             state: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    /// Eagerly open the SFTP session, surfacing any connection/auth failure now
+    /// rather than on the first operation.
+    ///
+    /// The browser otherwise connects lazily; callers that need an "open fails
+    /// loudly" contract (e.g. the desktop `sftp_open` command, which returns a
+    /// session id only once the connection succeeds) call this right after
+    /// [`new`](Self::new).
+    pub async fn connect(&self) -> Result<(), FileError> {
+        Self::ensure_connected(&self.state, &self.config).await
+    }
+
+    /// Report whether an exec (command) channel can be opened and used on the
+    /// SSH connection backing this SFTP session.
+    ///
+    /// Runs the shared [`probe_exec_capability`](super::exec::probe_exec_capability)
+    /// marker probe over an exec channel: a normal SSH+shell connection echoes it
+    /// (`true`); an SFTP-only / relayed connection (e.g. `ForceCommand
+    /// internal-sftp`) cannot run the command (`false`). Lets the file editor know
+    /// whether privilege-elevated writes — which need a shell to run `sudo` — are
+    /// possible. Pushed into core so the desktop `SftpSession` no longer forks it
+    /// (#2104, issue-body item 1).
+    pub async fn has_exec_capability(&self) -> Result<bool, FileError> {
+        Self::ensure_connected(&self.state, &self.config).await?;
+        let guard = self.state.lock().await;
+        let state = guard
+            .as_ref()
+            .ok_or_else(|| FileError::OperationFailed("SFTP not connected".to_string()))?;
+        Ok(super::exec::probe_exec_capability(&state.session).await)
+    }
+
+    /// Open a **dedicated** SFTP channel on a fresh channel off the same
+    /// authenticated SSH connection.
+    ///
+    /// Used by the cancellable transfer subsystem (#1245): the returned session
+    /// owns its own channel, so a chunked copy can run on it without holding this
+    /// browser's lock — keeping directory listing / navigation live on the
+    /// browsing channel during a transfer. Pushed into core so the desktop
+    /// `SftpSession` no longer forks it (#2104, issue-body item 1).
+    pub async fn open_dedicated_channel(&self) -> Result<SftpSession, FileError> {
+        Self::ensure_connected(&self.state, &self.config).await?;
+        let guard = self.state.lock().await;
+        let state = guard
+            .as_ref()
+            .ok_or_else(|| FileError::OperationFailed("SFTP not connected".to_string()))?;
+        sftp::open_sftp_subsystem(&state.session)
+            .await
+            .map_err(|e| FileError::OperationFailed(e.to_string()))
+    }
+
+    /// Best-effort size (in bytes) of a remote file via SFTP `stat`.
+    ///
+    /// Returns `0` when the size is unavailable — the transfer UI treats
+    /// `total == 0` as indeterminate and shows a spinner rather than a
+    /// percentage. Never errors, mirroring the previous desktop behavior.
+    pub async fn remote_size(&self, path: &str) -> u64 {
+        if Self::ensure_connected(&self.state, &self.config).await.is_err() {
+            return 0;
+        }
+        let guard = self.state.lock().await;
+        let Some(state) = guard.as_ref() else {
+            return 0;
+        };
+        match state.sftp.metadata(path).await {
+            Ok(meta) => meta.size.unwrap_or(0),
+            Err(_) => 0,
         }
     }
 

--- a/core/src/backends/ssh/file_browser.rs
+++ b/core/src/backends/ssh/file_browser.rs
@@ -108,7 +108,10 @@ impl SftpFileBrowser {
     /// `total == 0` as indeterminate and shows a spinner rather than a
     /// percentage. Never errors, mirroring the previous desktop behavior.
     pub async fn remote_size(&self, path: &str) -> u64 {
-        if Self::ensure_connected(&self.state, &self.config).await.is_err() {
+        if Self::ensure_connected(&self.state, &self.config)
+            .await
+            .is_err()
+        {
             return 0;
         }
         let guard = self.state.lock().await;

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -23,7 +23,7 @@ pub use self::exec::{
     exec_probe_indicates_capability, probe_exec_capability, ssh_exec_with_stdin, SshExecOutput,
     EXEC_PROBE_MARKER,
 };
-pub use self::file_browser::SftpAdvancedOps;
+pub use self::file_browser::{SftpAdvancedOps, SftpFileBrowser};
 
 use std::io::Read;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -45,7 +45,6 @@ use crate::session::shell::osc7_setup_command;
 use crate::session::ssh::validate_ssh_config;
 
 use self::connector::{RusshSshConnector, SshConnector};
-use self::file_browser::SftpFileBrowser;
 use self::monitoring::SshMonitoringProvider;
 
 /// Channel capacity for output data from the SSH reader thread.

--- a/docs/changes/dev1/feature/2104-sftp-command-layer-converge.md
+++ b/docs/changes/dev1/feature/2104-sftp-command-layer-converge.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- SFTP file browsing now reaches jump-host (`ProxyJump`) targets. The desktop
+  SFTP file browser previously connected directly and ignored the configured
+  jump-host chain, so browsing a host only reachable through a bastion failed;
+  it now connects through the pooled gateway like every other SSH provider
+  (#939, part of #2104).

--- a/src-tauri/src/files/sftp.rs
+++ b/src-tauri/src/files/sftp.rs
@@ -6,7 +6,7 @@ use russh_sftp::client::SftpSession as RusshSftp;
 use tracing::{debug, info};
 
 use termihub_core::backends::ssh::{SftpAdvancedOps, SftpFileBrowser};
-use termihub_core::files::FileEntry;
+use termihub_core::files::{FileBrowser, FileEntry};
 
 use crate::terminal::backend::SshConfig;
 use crate::utils::errors::TerminalError;
@@ -143,7 +143,11 @@ impl SftpSession {
     /// Download a remote file to a local path. Returns bytes written.
     pub fn read_file(&self, remote_path: &str, local_path: &str) -> Result<u64, TerminalError> {
         block_on_sftp(async {
-            let data = self.browser.read_file(remote_path).await.map_err(sftp_op_error)?;
+            let data = self
+                .browser
+                .read_file(remote_path)
+                .await
+                .map_err(sftp_op_error)?;
             tokio::fs::write(local_path, &data)
                 .await
                 .map_err(|e| TerminalError::SftpError(format!("write local file: {e}")))?;
@@ -183,7 +187,11 @@ impl SftpSession {
     /// Read a remote file's contents as a UTF-8 string.
     pub fn read_file_content(&self, remote_path: &str) -> Result<String, TerminalError> {
         block_on_sftp(async {
-            let data = self.browser.read_file(remote_path).await.map_err(sftp_op_error)?;
+            let data = self
+                .browser
+                .read_file(remote_path)
+                .await
+                .map_err(sftp_op_error)?;
             String::from_utf8(data)
                 .map_err(|e| TerminalError::SftpError(format!("read failed: invalid UTF-8: {e}")))
         })
@@ -382,6 +390,33 @@ mod tests {
             .is_some()
     }
 
+    /// Trust the loopback fixture host keys before connecting.
+    ///
+    /// The strict default host-key policy (#1969) trusts only a key already in
+    /// the runner's `~/.ssh/known_hosts`, so a freshly-built fixture container is
+    /// otherwise refused with "Unknown server key" (#2105). These loopback
+    /// fixtures are trusted unconditionally, mirroring
+    /// `sftp_transfer.rs::trust_fixture_host_keys` and core's
+    /// `common::trust_fixture_host_keys`. The verifier is process-global and
+    /// first-registration-wins, so calling it per test is a harmless no-op after
+    /// the first.
+    fn trust_fixture_host_keys() {
+        use termihub_core::backends::ssh::host_key::{
+            set_host_key_verifier, HostKeyInfo, HostKeyVerifier,
+        };
+
+        struct TrustLocalFixtures;
+
+        #[async_trait::async_trait]
+        impl HostKeyVerifier for TrustLocalFixtures {
+            async fn verify(&self, _info: &HostKeyInfo) -> bool {
+                true
+            }
+        }
+
+        let _ = set_host_key_verifier(Arc::new(TrustLocalFixtures));
+    }
+
     /// Password-auth config for a fixture container on `127.0.0.1:port`.
     fn testuser_config(port: u16, password: &str) -> SshConfig {
         SshConfig {
@@ -417,6 +452,8 @@ mod tests {
             );
             return;
         }
+
+        trust_fixture_host_keys();
 
         let result = tokio::task::spawn_blocking(move || {
             let config = testuser_config(port, "testpass");
@@ -479,6 +516,8 @@ mod tests {
             return;
         }
 
+        trust_fixture_host_keys();
+
         let result = tokio::task::spawn_blocking(move || {
             let config = testuser_config(port, "testpass");
             let verify = connect_and_authenticate(&config)?;
@@ -528,6 +567,8 @@ mod tests {
             );
             return;
         }
+
+        trust_fixture_host_keys();
 
         let result = tokio::task::spawn_blocking(move || {
             let config = testuser_config(port, "testpass");

--- a/src-tauri/src/files/sftp.rs
+++ b/src-tauri/src/files/sftp.rs
@@ -1,17 +1,15 @@
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::{Arc, Mutex, MutexGuard};
 
 use russh_sftp::client::SftpSession as RusshSftp;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, info};
 
-use termihub_core::backends::ssh::handler::SshSession;
-use termihub_core::backends::ssh::{probe_exec_capability, sftp, sftp_ops};
+use termihub_core::backends::ssh::{SftpAdvancedOps, SftpFileBrowser};
 use termihub_core::files::FileEntry;
 
 use crate::terminal::backend::SshConfig;
 use crate::utils::errors::TerminalError;
-use crate::utils::ssh_auth::connect_and_authenticate;
 
 /// The privilege-elevated write outcome and the writability verdict now live in
 /// [`termihub_core::backends::ssh::sftp_ops`] so a single implementation backs
@@ -19,15 +17,28 @@ use crate::utils::ssh_auth::connect_and_authenticate;
 /// here so the desktop command layer and its callers keep their import paths.
 pub use termihub_core::backends::ssh::sftp_ops::{ElevatedWriteResult, Writability};
 
-/// Map a core [`FileError`](termihub_core::errors::FileError) from an
-/// `sftp_ops` operation to the desktop [`TerminalError::SftpError`], preserving
-/// the operation-specific message (`realpath failed: …`, etc.) rather than
-/// double-wrapping it behind the generic "Operation failed:" prefix.
+/// Map a core [`FileError`](termihub_core::errors::FileError) from an SFTP
+/// operation to the desktop [`TerminalError::SftpError`], preserving the
+/// operation-specific message (`readdir failed: …`, `realpath failed: …`, etc.)
+/// rather than double-wrapping it behind the generic "Operation failed:" prefix.
 fn sftp_op_error(err: termihub_core::errors::FileError) -> TerminalError {
     match err {
         termihub_core::errors::FileError::OperationFailed(msg) => TerminalError::SftpError(msg),
         other => TerminalError::SftpError(other.to_string()),
     }
+}
+
+/// Drive an async core [`SftpFileBrowser`] operation to completion from the
+/// synchronous `SftpSession` API.
+///
+/// The desktop SFTP command layer is synchronous (each Tauri command runs the
+/// blocking session methods on a `spawn_blocking` thread while holding the
+/// session mutex), so it bridges into the fully-async core browser via
+/// `block_in_place` + `Handle::current().block_on`. Both require a multi-threaded
+/// Tokio runtime worker context on the calling thread — always satisfied here
+/// because callers are inside `spawn_blocking` (#828).
+fn block_on_sftp<F: Future>(fut: F) -> F::Output {
+    tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(fut))
 }
 
 /// Lock a mutex, mapping a poisoned lock to a recoverable [`TerminalError`]
@@ -59,47 +70,46 @@ fn drain_sessions<V>(sessions: &Mutex<HashMap<String, V>>) -> usize {
     count
 }
 
-/// SFTP session backed by a dedicated SSH connection.
+/// SFTP session for the desktop file-browser/transfer command layer.
 ///
-/// The canonical implementation is now
-/// [`termihub_core::backends::ssh::SftpFileBrowser`](termihub_core::backends::ssh).
-/// This struct is kept for the legacy SFTP command API used by the desktop file browser.
+/// This is a thin **synchronous adapter** around the single core SFTP
+/// implementation, [`SftpFileBrowser`](termihub_core::backends::ssh::SftpFileBrowser):
+/// every operation delegates to the core browser (which owns the russh-sftp
+/// session and all operation logic), so the desktop no longer maintains a
+/// parallel SFTP implementation (#2104). Because it goes through the core browser
+/// it reaches jump-host targets through their pooled gateway (#939) — the direct
+/// `connect_and_authenticate` path it used before ignored `proxy_jump`.
+///
+/// The adapter exists only to keep the synchronous, session-id-keyed command API
+/// (`SftpManager` + the `sftp_*` Tauri commands) working; migrating that surface
+/// onto the async `FileBrowser`/`ConnectionType` path is tracked as a follow-up.
 pub struct SftpSession {
-    session: SshSession,
-    sftp: RusshSftp,
+    browser: SftpFileBrowser,
 }
 
 impl SftpSession {
     /// Open a new SFTP session to the given SSH host.
+    ///
+    /// Eagerly connects (jump-host aware, via the core browser) so `sftp_open`
+    /// fails loudly on a bad host / auth here rather than deferring the error to
+    /// the first listing.
     pub fn new(config: &SshConfig) -> Result<Self, TerminalError> {
         info!(host = %config.host, port = config.port, "Opening SFTP connection");
-        let session = connect_and_authenticate(config)?;
-
-        let sftp = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                sftp::open_sftp_subsystem(&session)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(e.to_string()))
-            })
-        })?;
-
-        Ok(Self { session, sftp })
+        let browser = SftpFileBrowser::new(config.clone());
+        block_on_sftp(browser.connect()).map_err(sftp_op_error)?;
+        Ok(Self { browser })
     }
 
     /// Report whether an exec (command) channel can be opened and used on the
-    /// retained SSH connection.
+    /// SSH connection backing this SFTP session.
     ///
-    /// Runs a tiny probe that echoes a known marker back over an exec channel.
-    /// A normal SSH+shell connection echoes it (`true`); an SFTP-only or
-    /// relayed connection (e.g. `ForceCommand internal-sftp`) cannot run the
-    /// command, so the marker never appears (`false`). Lets the file editor
-    /// know whether privilege-elevated writes — which need a shell to run
-    /// `sudo` — are possible for this connection.
+    /// A normal SSH+shell connection can run the probe (`true`); an SFTP-only or
+    /// relayed connection (e.g. `ForceCommand internal-sftp`) cannot (`false`).
+    /// Lets the file editor know whether privilege-elevated writes — which need a
+    /// shell to run `sudo` — are possible for this connection. A dropped
+    /// connection maps to `false`.
     pub fn has_exec_capability(&self) -> bool {
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current()
-                .block_on(async { probe_exec_capability(&self.session).await })
-        })
+        block_on_sftp(self.browser.has_exec_capability()).unwrap_or(false)
     }
 
     /// Open a **dedicated** SFTP session on a fresh channel off the same
@@ -110,9 +120,10 @@ impl SftpSession {
     /// without holding this session's `Mutex` — keeping directory listing /
     /// navigation live on the browsing channel during a transfer.
     pub async fn open_dedicated_sftp(&self) -> Result<RusshSftp, TerminalError> {
-        sftp::open_sftp_subsystem(&self.session)
+        self.browser
+            .open_dedicated_channel()
             .await
-            .map_err(|e| TerminalError::SftpError(e.to_string()))
+            .map_err(sftp_op_error)
     }
 
     /// Best-effort size (in bytes) of a remote file via SFTP `stat`.
@@ -120,135 +131,61 @@ impl SftpSession {
     /// Returns `0` when the size is unavailable — the UI treats `total == 0` as
     /// indeterminate and shows a spinner rather than a percentage.
     pub async fn remote_size(&self, remote_path: &str) -> u64 {
-        match self.sftp.metadata(remote_path).await {
-            Ok(meta) => meta.size.unwrap_or(0),
-            Err(_) => 0,
-        }
+        self.browser.remote_size(remote_path).await
     }
 
     /// List directory contents, filtering out `.` and `..`.
     pub fn list_dir(&self, path: &str) -> Result<Vec<FileEntry>, TerminalError> {
         debug!(path, "SFTP listing directory");
-        let path = path.to_string();
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                sftp::list_dir(&self.sftp, &path)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("readdir failed: {e}")))
-            })
-        })
+        block_on_sftp(self.browser.list_dir(path)).map_err(sftp_op_error)
     }
 
     /// Download a remote file to a local path. Returns bytes written.
     pub fn read_file(&self, remote_path: &str, local_path: &str) -> Result<u64, TerminalError> {
-        let remote_path = remote_path.to_string();
-        let local_path = local_path.to_string();
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                let mut remote = self
-                    .sftp
-                    .open(&remote_path)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("open remote file: {e}")))?;
-
-                let mut data = Vec::new();
-                remote
-                    .read_to_end(&mut data)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("read failed: {e}")))?;
-
-                tokio::fs::write(&local_path, &data)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("write local file: {e}")))?;
-
-                Ok::<u64, TerminalError>(data.len() as u64)
-            })
+        block_on_sftp(async {
+            let data = self.browser.read_file(remote_path).await.map_err(sftp_op_error)?;
+            tokio::fs::write(local_path, &data)
+                .await
+                .map_err(|e| TerminalError::SftpError(format!("write local file: {e}")))?;
+            Ok::<u64, TerminalError>(data.len() as u64)
         })
     }
 
     /// Upload a local file to a remote path. Returns bytes written.
     pub fn write_file(&self, local_path: &str, remote_path: &str) -> Result<u64, TerminalError> {
-        let local_path = local_path.to_string();
-        let remote_path = remote_path.to_string();
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                let data = tokio::fs::read(&local_path)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("open local file: {e}")))?;
-
-                let mut remote =
-                    self.sftp.create(&remote_path).await.map_err(|e| {
-                        TerminalError::SftpError(format!("create remote file: {e}"))
-                    })?;
-
-                remote
-                    .write_all(&data)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("write failed: {e}")))?;
-
-                Ok::<u64, TerminalError>(data.len() as u64)
-            })
+        block_on_sftp(async {
+            let data = tokio::fs::read(local_path)
+                .await
+                .map_err(|e| TerminalError::SftpError(format!("open local file: {e}")))?;
+            self.browser
+                .write_file(remote_path, &data)
+                .await
+                .map_err(sftp_op_error)?;
+            Ok::<u64, TerminalError>(data.len() as u64)
         })
     }
 
     /// Create a directory on the remote host.
     pub fn mkdir(&self, path: &str) -> Result<(), TerminalError> {
-        let path = path.to_string();
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                self.sftp
-                    .create_dir(&path)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("mkdir failed: {e}")))
-            })
-        })
+        block_on_sftp(self.browser.mkdir(path)).map_err(sftp_op_error)
     }
 
     /// Remove a file on the remote host.
     pub fn remove_file(&self, path: &str) -> Result<(), TerminalError> {
-        let path = path.to_string();
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                self.sftp
-                    .remove_file(&path)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("unlink failed: {e}")))
-            })
-        })
+        block_on_sftp(self.browser.delete(path)).map_err(sftp_op_error)
     }
 
     /// Remove an empty directory on the remote host.
     pub fn remove_dir(&self, path: &str) -> Result<(), TerminalError> {
-        let path = path.to_string();
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                self.sftp
-                    .remove_dir(&path)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("rmdir failed: {e}")))
-            })
-        })
+        block_on_sftp(self.browser.delete(path)).map_err(sftp_op_error)
     }
 
     /// Read a remote file's contents as a UTF-8 string.
     pub fn read_file_content(&self, remote_path: &str) -> Result<String, TerminalError> {
-        let remote_path = remote_path.to_string();
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                let mut remote = self
-                    .sftp
-                    .open(&remote_path)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("open remote file: {e}")))?;
-
-                let mut content = String::new();
-                remote
-                    .read_to_string(&mut content)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("read failed: {e}")))?;
-
-                Ok::<String, TerminalError>(content)
-            })
+        block_on_sftp(async {
+            let data = self.browser.read_file(remote_path).await.map_err(sftp_op_error)?;
+            String::from_utf8(data)
+                .map_err(|e| TerminalError::SftpError(format!("read failed: invalid UTF-8: {e}")))
         })
     }
 
@@ -263,115 +200,62 @@ impl SftpSession {
 
     /// Rename a file or directory on the remote host.
     pub fn rename(&self, old_path: &str, new_path: &str) -> Result<(), TerminalError> {
-        let old_path = old_path.to_string();
-        let new_path = new_path.to_string();
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                self.sftp
-                    .rename(&old_path, &new_path)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("rename failed: {e}")))
-            })
-        })
+        block_on_sftp(self.browser.rename(old_path, new_path)).map_err(sftp_op_error)
     }
 
     /// Get metadata for a single file or directory.
-    #[allow(dead_code)]
     pub fn stat(&self, path: &str) -> Result<FileEntry, TerminalError> {
-        let path = path.to_string();
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                sftp::stat(&self.sftp, &path)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("stat failed: {e}")))
-            })
-        })
+        block_on_sftp(self.browser.stat(path)).map_err(sftp_op_error)
     }
 
     /// Authoritatively probe whether the connecting user can write `remote_path`.
     ///
-    /// Delegates to [`sftp_ops::check_writable`], the single core implementation
-    /// (#2104): opens the **existing** file for writing with `OpenFlags::WRITE`
-    /// only — no `CREATE`/`TRUNCATE`/`APPEND` — so the file's contents are never
-    /// modified, and never returns a hard error for the ambiguous case (a
-    /// `PERMISSION_DENIED` maps to [`Writability::ReadOnly`], any other error to
-    /// [`Writability::Unknown`]).
+    /// Delegates to the core [`SftpAdvancedOps::check_writable`] companion-trait
+    /// implementation (#2104): opens the **existing** file for writing with
+    /// `OpenFlags::WRITE` only — no `CREATE`/`TRUNCATE`/`APPEND` — so the file's
+    /// contents are never modified, and never returns a hard error for the
+    /// ambiguous case (a `PERMISSION_DENIED` maps to [`Writability::ReadOnly`],
+    /// any other error to [`Writability::Unknown`]).
     pub fn check_writable(&self, remote_path: &str) -> Result<Writability, TerminalError> {
-        let remote_path = remote_path.to_string();
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current()
-                .block_on(async { Ok(sftp_ops::check_writable(&self.sftp, &remote_path).await) })
-        })
+        block_on_sftp(self.browser.check_writable(remote_path)).map_err(sftp_op_error)
     }
 
     /// Resolve a remote path to its canonical absolute form via SFTP realpath.
     ///
-    /// Delegates to [`sftp_ops::realpath`] (#2104). Passing `"."` yields the
-    /// session's home directory, avoiding the fragile `/home/<user>` guess that
-    /// breaks on non-Linux layouts (audit GAP C2, issue #1143).
+    /// Delegates to the core [`SftpAdvancedOps::realpath`] companion-trait
+    /// implementation (#2104). Passing `"."` yields the session's home directory,
+    /// avoiding the fragile `/home/<user>` guess that breaks on non-Linux layouts
+    /// (audit GAP C2, issue #1143).
     pub fn realpath(&self, path: &str) -> Result<String, TerminalError> {
-        let path = path.to_string();
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                sftp_ops::realpath(&self.sftp, &path)
-                    .await
-                    .map_err(sftp_op_error)
-            })
-        })
+        block_on_sftp(self.browser.realpath(path)).map_err(sftp_op_error)
     }
 
     /// Write raw bytes to a remote file, creating or overwriting it.
-    #[allow(dead_code)]
     pub fn write_bytes(&self, remote_path: &str, data: &[u8]) -> Result<(), TerminalError> {
-        let data = data.to_vec();
-        let remote_path = remote_path.to_string();
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                let mut remote =
-                    self.sftp.create(&remote_path).await.map_err(|e| {
-                        TerminalError::SftpError(format!("create remote file: {e}"))
-                    })?;
-
-                remote
-                    .write_all(&data)
-                    .await
-                    .map_err(|e| TerminalError::SftpError(format!("write failed: {e}")))
-            })
-        })
+        block_on_sftp(self.browser.write_file(remote_path, data)).map_err(sftp_op_error)
     }
 
     /// Write `content` to `remote_path` with `sudo`-elevated privileges (#1328).
     ///
-    /// Delegates to [`sftp_ops::write_file_content_elevated`], the single core
-    /// implementation (#2104): SFTP-upload the buffer to a termiHub-generated
-    /// `/tmp/termihub-<uuid>`, then `sudo -S -p ''` a fixed `/bin/sh` script
-    /// (`cat "$1" > "$2" && rm -f "$1"`) that rewrites the destination in place
-    /// (preserving owner/mode/ACLs), classified into an [`ElevatedWriteResult`].
-    /// The destination path is POSIX-quoted and passed as a positional argument,
-    /// so a hostile remote path cannot inject shell commands; the password is
-    /// only ever sent on stdin and is **never** logged.
+    /// Delegates to the core [`SftpAdvancedOps::write_file_content_elevated`]
+    /// companion-trait implementation (#2104): SFTP-upload the buffer to a
+    /// termiHub-generated `/tmp/termihub-<uuid>`, then `sudo -S -p ''` a fixed
+    /// `/bin/sh` script (`cat "$1" > "$2" && rm -f "$1"`) that rewrites the
+    /// destination in place (preserving owner/mode/ACLs), classified into an
+    /// [`ElevatedWriteResult`]. The destination path is POSIX-quoted and passed as
+    /// a positional argument, so a hostile remote path cannot inject shell
+    /// commands; the password is only ever sent on stdin and is **never** logged.
     pub fn write_file_content_elevated(
         &self,
         remote_path: &str,
         content: &str,
         sudo_password: &str,
     ) -> Result<ElevatedWriteResult, TerminalError> {
-        let remote_path = remote_path.to_string();
-        let content = content.to_string();
-        let sudo_password = sudo_password.to_string();
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                sftp_ops::write_file_content_elevated(
-                    &self.session,
-                    &self.sftp,
-                    &remote_path,
-                    &content,
-                    &sudo_password,
-                )
-                .await
-                .map_err(sftp_op_error)
-            })
-        })
+        block_on_sftp(
+            self.browser
+                .write_file_content_elevated(remote_path, content, sudo_password),
+        )
+        .map_err(sftp_op_error)
     }
 }
 
@@ -471,6 +355,8 @@ mod tests {
     // to verify contents/owner/mode and to confirm no `/tmp/termihub-*` temp
     // leaked — never the elevated write path itself.
     use crate::utils::remote_exec::run_remote_command;
+    use crate::utils::ssh_auth::connect_and_authenticate;
+    use termihub_core::backends::ssh::handler::SshSession;
 
     /// Root-owned file the fixtures ship (see `tests/docker/ssh-sudo`).
     const ELEVATED_TARGET: &str = "/etc/termihub-elevated-target.txt";


### PR DESCRIPTION
Part of #2104.

## What this does
Collapses the desktop SFTP command layer's parallel russh-sftp implementation onto the **single** core `SftpFileBrowser`. The desktop `SftpSession` is now a thin **synchronous adapter** that delegates every operation to the core browser (which owns the russh-sftp session and all operation logic); the forked russh calls (`open`/`create`/`create_dir`/`remove_file`/`remove_dir`/`rename`/`metadata`) are gone.

### Migrated onto the core path
- All `FileBrowser` ops (`list_dir`, `read`/`write`, `delete`, `rename`, `stat`, `mkdir`) now route through `core::backends::ssh::SftpFileBrowser`.
- The three `SftpAdvancedOps` companion-trait ops (elevated `sudo` write, writability probe, `realpath`) were already delegating to core `sftp_ops` (#2219/#2222); they now go through the browser's trait impl.
- The last two desktop-only capabilities are **pushed into core** (completing #2104 issue-body item 1): `has_exec_capability` and the dedicated per-transfer channel (`open_dedicated_channel`), plus `remote_size`, added as inherent methods on `SftpFileBrowser`; the type is now exported.

### User-facing fix (#939)
Because it now connects through the core `connect_target`, **desktop SFTP browsing reaches jump-host (`ProxyJump`) targets**. The old direct `connect_and_authenticate` path ignored `proxy_jump`, so browsing a host only reachable through a bastion failed.

## FileBrowser vs FileBackend reconciliation (the design question)
The direction is settled: **converge onto `FileBrowser`, retire `FileBackend`.** `FileBrowser` is the primary capability surface implemented by every backend and returned by `ConnectionType::file_browser()`; `FileBackend` is a near-duplicate (differs only in method names and a `delete(is_directory)` flag) with a single implementor (`LocalFileBackend`), consumed only by the agent JSON-RPC dispatch. Executing that removal touches the **agent crate**, so it is tracked as a dedicated follow-up rather than folded into this SFTP-scoped PR.

## Scope boundary / why a slice
This lands the highest-value coherent slice — the parallel *implementation* is collapsed. The remaining #2104 work (migrating the `SftpManager`/`sftp_*` **command surface** onto the async `ConnectionType` path, and the `FileBackend` removal) stays open as follow-ups, so #2104 is **not** closed by this PR.

Follow-ups filed: #2236 (command-surface migration), #2237 (FileBackend→FileBrowser convergence), #2238 (elevated-save test isolation).

## Verification (local Docker SFTP fixtures — not run in per-PR CI)
Ran against `sftp-stress`, `ssh-sudo`, `ssh-nosudo` on this checkout's offset ports:
- `core/tests/sftp_stress.rs` — **16/16 pass** (downloads 1/10/100 MB, upload roundtrip, wide dir, deep tree, symlinks, unicode/space/long/hidden names, permission edge cases).
- `src-tauri/tests/sftp_transfer.rs` — **3/3 pass** (dedicated-channel transfer subsystem).
- Docker-backed elevated-save tests in `src-tauri/src/files/sftp.rs` — **all pass** (Success rewrites the root file preserving owner/mode, IncorrectPassword leaves it untouched, no-sudo -> Other, no `/tmp/termihub-*` leak).

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, and the files-module unit tests (44 core / 88 desktop) are green. Backend-only change; Tauri command signatures are unchanged, so the frontend is unaffected.

Two pre-existing test notes surfaced while verifying against freshly-built fixtures (neither caused by this change): the desktop elevated-save tests lacked the loopback host-key trust the sibling suites use (#2105 class) — added here; and they race on a shared fixture file under parallel execution — filed as #2238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)