### PR TITLE
feat(ui): render the monitors UI from the system-monitors projection (Part of #2224)

### DIFF
--- a/src-tauri/src/system_monitor_projection/mod.rs
+++ b/src-tauri/src/system_monitor_projection/mod.rs
@@ -11,14 +11,15 @@
 //! ([`crate::tunnel::projection`]) and the session-lifecycle shadow
 //! ([`crate::session_projection`]).
 //!
-//! # Shadow mode — zero user-facing change
+//! # Render cut — zero user-facing change
 //!
-//! This step is deliberately **not** authoritative. The store exists, accepts
-//! intents, and projects diffs, but nothing in the live UI subscribes to or
-//! renders the `system-monitors` region, and no frontend code dispatches
-//! `monitor.*` intents yet. The existing `appStore` monitoring slice and the
-//! status-bar / Open-Connections rendering are untouched. Later steps cut
-//! rendering, then mutation, over to the region, then remove the `appStore` state.
+//! The store is **not yet authoritative**: the status bar and Open Connections now
+//! render from the `system-monitors` region, but `appStore` still owns the state
+//! and the frontend keeps the region a faithful mirror of it via `monitor.replace`
+//! (rendering from the region only when it deep-equals `appStore`, else falling
+//! back to `appStore`). The granular `monitor.*` transitions stay served for the
+//! later mutation cut, which makes the store authoritative before the `appStore`
+//! state is finally removed. Parity-safe at every step.
 
 pub mod projection;
 pub mod store;

--- a/src-tauri/src/system_monitor_projection/projection.rs
+++ b/src-tauri/src/system_monitor_projection/projection.rs
@@ -31,16 +31,21 @@
 //! | `monitor.setInterval`  | `{ key, intervalMs }`         | change refresh cadence (#1233)           |
 //! | `monitor.clearError`   | `{ key }`                     | dismiss the error banner                 |
 //! | `monitor.close`        | `{ key }`                     | disconnect and drop the entry            |
+//! | `monitor.replace`      | `{ monitors, statsCache }`    | overwrite the whole map (render mirror)  |
 //!
-//! # Shadow mode
+//! # Render cut (#2224 step 2)
 //!
-//! Registered and fully served, but **not** driving the live UI: no frontend
-//! subscribes to `system-monitors` or dispatches `monitor.*` yet, so these
-//! intents mutate only the shadow store and project to a region nobody renders.
-//! The `appStore` monitoring slice remains authoritative. Per the substrate
+//! The status bar and Open Connections now **render** monitor stats/status from
+//! this region (`useProjectedMonitors`), but `appStore` remains **authoritative**
+//! — the mutation cut is a later step. To keep the render cut parity-safe, the
+//! frontend keeps the region a faithful copy of `appStore` via `monitor.replace`
+//! (the whole-map mirror) and only renders from the region when it deep-equals
+//! `appStore`, falling back to `appStore` otherwise. The granular `monitor.*`
+//! transitions stay served for the eventual mutation cut. Per the substrate
 //! contract the result of an intent is never returned inline — it always arrives
 //! as a projection diff on the `system-monitors` region.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use serde_json::Value;
@@ -49,7 +54,7 @@ use tauri::{AppHandle, Manager};
 use termihub_core::monitoring::{MonitorStatus, SystemStats};
 
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
-use crate::system_monitor_projection::store::SystemMonitorStore;
+use crate::system_monitor_projection::store::{MonitorEntry, SystemMonitorStore};
 
 /// The projection region id for the system-monitor domain (shared, per Open
 /// Design Decision #4).
@@ -143,11 +148,19 @@ pub fn register_monitor_intents(registry: &mut HandlerRegistry, app_handle: AppH
         Ok(publish_monitors(projector, &store))
     });
 
-    let handle = app_handle;
+    let handle = app_handle.clone();
     registry.route("monitor.close", move |intent, projector| {
         let store = store_of(&handle)?;
         let key = required_str(intent, "key")?;
         store.close(&key);
+        Ok(publish_monitors(projector, &store))
+    });
+
+    let handle = app_handle;
+    registry.route("monitor.replace", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let (monitors, stats_cache) = required_replace(intent)?;
+        store.replace(monitors, stats_cache);
         Ok(publish_monitors(projector, &store))
     });
 }
@@ -215,6 +228,32 @@ fn required_stats(intent: &Intent) -> Result<SystemStats, (String, String)> {
         .ok_or_else(|| ("bad_payload".to_string(), "missing 'stats'".to_string()))?;
     serde_json::from_value(value.clone())
         .map_err(|e| ("bad_payload".to_string(), format!("invalid stats: {e}")))
+}
+
+/// Parse a `monitor.replace` payload into the whole-map snapshot the render-cut
+/// mirror carries: `{ monitors: { <key>: MonitorEntry }, statsCache: { <key>:
+/// SystemStats } }`. Either field absent is treated as an empty map, so a mirror
+/// that clears all monitors is expressible; a present-but-malformed field is a
+/// `bad_payload` rejection that advances nothing.
+#[allow(clippy::type_complexity)]
+fn required_replace(
+    intent: &Intent,
+) -> Result<(HashMap<String, MonitorEntry>, HashMap<String, SystemStats>), (String, String)> {
+    let monitors = match intent.payload.get("monitors") {
+        None | Some(Value::Null) => HashMap::new(),
+        Some(value) => serde_json::from_value(value.clone())
+            .map_err(|e| ("bad_payload".to_string(), format!("invalid monitors: {e}")))?,
+    };
+    let stats_cache = match intent.payload.get("statsCache") {
+        None | Some(Value::Null) => HashMap::new(),
+        Some(value) => serde_json::from_value(value.clone()).map_err(|e| {
+            (
+                "bad_payload".to_string(),
+                format!("invalid statsCache: {e}"),
+            )
+        })?,
+    };
+    Ok((monitors, stats_cache))
 }
 
 /// Parse the required `status` field as a [`MonitorStatus`].

--- a/src-tauri/src/system_monitor_projection/projection_tests.rs
+++ b/src-tauri/src/system_monitor_projection/projection_tests.rs
@@ -113,9 +113,28 @@ fn registry_for(store: Arc<SystemMonitorStore>) -> HandlerRegistry {
         s.set_paused(&required_key(intent)?, paused);
         Ok(publish_monitors(projector, &s))
     });
-    let s = store;
+    let s = store.clone();
     registry.route("monitor.close", move |intent, projector| {
         s.close(&required_key(intent)?);
+        Ok(publish_monitors(projector, &s))
+    });
+    let s = store;
+    registry.route("monitor.replace", move |intent, projector| {
+        let monitors = match intent.payload.get("monitors") {
+            None | Some(Value::Null) => std::collections::HashMap::new(),
+            Some(value) => serde_json::from_value(value.clone())
+                .map_err(|e| ("bad_payload".to_string(), format!("invalid monitors: {e}")))?,
+        };
+        let stats_cache = match intent.payload.get("statsCache") {
+            None | Some(Value::Null) => std::collections::HashMap::new(),
+            Some(value) => serde_json::from_value(value.clone()).map_err(|e| {
+                (
+                    "bad_payload".to_string(),
+                    format!("invalid statsCache: {e}"),
+                )
+            })?,
+        };
+        s.replace(monitors, stats_cache);
         Ok(publish_monitors(projector, &s))
     });
 
@@ -316,6 +335,45 @@ fn a_full_monitor_lifecycle_advances_monotonically_and_converges() {
         cache.view["statsCache"]["s1"]["cpuUsagePercent"],
         json!(34.0)
     );
+}
+
+#[test]
+fn replace_mirrors_a_whole_snapshot_in_one_diff_and_converges() {
+    // The render-cut mirror (#2224): a `monitor.replace` carrying `appStore`'s
+    // whole monitoring slice overwrites the region in a single diff, and the
+    // client cache converges on that snapshot.
+    let store = seeded_store(); // s1 connecting, s2 live
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SYSTEM_MONITORS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(SYSTEM_MONITORS_REGION, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    // Build the mirror payload from an independent store, exactly as the frontend
+    // seed serialises `appStore` (a fresh monitor `s3`, no s1/s2).
+    let source = Arc::new(SystemMonitorStore::new());
+    source.open("s3", Some("host-c".to_string()), None);
+    source.opened("s3");
+    source.stats("s3", stats("host-c", 7.0));
+    let view = source.snapshot();
+
+    let ack = dispatcher.dispatch(intent(
+        "monitor.replace",
+        json!({ "monitors": view["monitors"], "statsCache": view["statsCache"] }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "one coalesced diff for the whole replace");
+    cache.apply(&diffs[0]);
+    assert_eq!(
+        cache.view,
+        source.snapshot(),
+        "the region now faithfully mirrors the source snapshot"
+    );
+    assert_eq!(cache.view["monitors"].get("s1"), None, "prior entries gone");
+    assert_eq!(cache.view["monitors"]["s3"]["status"], json!("live"));
 }
 
 #[test]

--- a/src-tauri/src/system_monitor_projection/store.rs
+++ b/src-tauri/src/system_monitor_projection/store.rs
@@ -19,14 +19,14 @@
 //! monitor the status bar renders (the active tab) is layout/presentation and
 //! stays a frontend concern under partial projection.
 //!
-//! # Shadow mode — zero user-facing change
+//! # Render cut — zero user-facing change
 //!
-//! This step is deliberately **not** authoritative. The store exists, accepts
-//! `monitor.*` intents, and projects diffs, but nothing in the live UI subscribes
-//! to or renders the `system-monitors` region, and no frontend code dispatches
-//! `monitor.*` intents yet. The existing `appStore` monitoring slice remains
-//! authoritative. Later steps cut rendering, then mutation, over to the region,
-//! then remove the `appStore` state.
+//! The store is **not yet authoritative**: the status bar and Open Connections now
+//! render from the `system-monitors` region, but `appStore` still owns the state
+//! and the frontend keeps the region a faithful mirror of it via the whole-map
+//! [`SystemMonitorStore::replace`] (`monitor.replace`) seed, rendering from the
+//! region only when it deep-equals `appStore`. Later steps cut mutation over to
+//! the region, then remove the `appStore` state.
 
 use std::collections::HashMap;
 use std::sync::{Mutex, MutexGuard};
@@ -234,6 +234,22 @@ impl SystemMonitorStore {
     /// `disconnectMonitoring`, which keeps the cache). Idempotent.
     pub fn close(&self, key: &str) {
         self.lock().monitors.remove(key);
+    }
+
+    /// `monitor.replace` — overwrite the whole monitor map and stats cache with a
+    /// caller-supplied snapshot. Used by the frontend render-cut mirror (#2224) to
+    /// keep the shared region a faithful copy of `appStore`'s monitoring slice
+    /// while `appStore` remains authoritative (the mutation cut is a later step) —
+    /// the analog of the layout bridge's `layout.replace` seed. Idempotent
+    /// server-side: replacing with the same content yields no diff.
+    pub fn replace(
+        &self,
+        monitors: HashMap<String, MonitorEntry>,
+        stats_cache: HashMap<String, SystemStats>,
+    ) {
+        let mut inner = self.lock();
+        inner.monitors = monitors;
+        inner.stats_cache = stats_cache;
     }
 
     /// Read one monitor entry (test / diagnostics helper).

--- a/src-tauri/src/system_monitor_projection/store_tests.rs
+++ b/src-tauri/src/system_monitor_projection/store_tests.rs
@@ -164,6 +164,51 @@ fn set_interval_and_status_and_clear_error() {
 }
 
 #[test]
+fn replace_overwrites_the_whole_map_and_cache() {
+    let store = SystemMonitorStore::new();
+    // Prime some existing state that `replace` must fully overwrite.
+    store.open("old", Some("gone".to_string()), None);
+    store.stats("old", sample("gone", 99.0));
+
+    // A snapshot mirroring `appStore`: build it by driving a second store, then
+    // hand its serialised view straight back through `replace`.
+    let source = SystemMonitorStore::new();
+    source.open("s1", Some("host-a".to_string()), None);
+    source.opened("s1");
+    source.stats("s1", sample("host-a", 42.0));
+    let view = source.snapshot();
+
+    let monitors = serde_json::from_value(view["monitors"].clone()).unwrap();
+    let stats_cache = serde_json::from_value(view["statsCache"].clone()).unwrap();
+    store.replace(monitors, stats_cache);
+
+    // The old entry is gone; the mirrored one is present and byte-identical to
+    // the source's projection.
+    assert!(store.get("old").is_none(), "replace drops prior entries");
+    assert_eq!(
+        store.snapshot(),
+        source.snapshot(),
+        "replace makes the store a faithful copy of the source"
+    );
+}
+
+#[test]
+fn replace_with_empty_maps_clears_everything() {
+    let store = SystemMonitorStore::new();
+    store.open("s1", None, None);
+    store.stats("s1", sample("host-a", 1.0));
+
+    store.replace(
+        std::collections::HashMap::new(),
+        std::collections::HashMap::new(),
+    );
+    assert_eq!(
+        store.snapshot(),
+        json!({ "monitors": {}, "statsCache": {} })
+    );
+}
+
+#[test]
 fn transitions_on_an_unknown_key_are_no_ops() {
     let store = SystemMonitorStore::new();
     // None of these should panic or create an entry.

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -36,6 +36,7 @@ import type { TransferState } from "@/types/connection";
 import type { MonitoringEntry } from "@/types/monitoring";
 import { MONITORING_INTERVAL_OPTIONS, DEFAULT_MONITORING_INTERVAL_MS } from "@/types/monitoring";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedMonitors } from "@/store/useProjectedMonitors";
 import { getAllLeaves } from "@/utils/panelTree";
 import {
   listLocalSessions,
@@ -106,8 +107,10 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const tabGroups = useAppStore((s) => s.tabGroups);
   const activeTabGroupId = useAppStore((s) => s.activeTabGroupId);
   // Every monitored host with a live backend subscription (#1231, audit gap G6);
-  // each renders its own killable row. Derived from the keyed `monitors` map.
-  const monitors = useAppStore((s) => s.monitors);
+  // each renders its own killable row. Derived from the keyed `monitors` map,
+  // sourced from the projected `system-monitors` region when it faithfully
+  // mirrors `appStore`, else `appStore` verbatim (#2224 render cut).
+  const { monitors } = useProjectedMonitors();
   const openMonitors = useMemo(
     () => Object.values(monitors).filter((m) => m.monitorSessionId !== null),
     [monitors]

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -19,7 +19,8 @@ import {
   Infinity as InfinityIcon,
   Puzzle,
 } from "lucide-react";
-import { useAppStore, getActiveTab, monitorKeyForTab, selectMonitor } from "@/store/appStore";
+import { useAppStore, getActiveTab, monitorKeyForTab } from "@/store/appStore";
+import { useProjectedMonitors } from "@/store/useProjectedMonitors";
 import { resolveHighlightingConfig } from "@/services/syntaxHighlightingConfig";
 import { frontendLog } from "@/utils/frontendLog";
 import { useDesktopVersion } from "@/hooks/useDesktopVersion";
@@ -531,7 +532,12 @@ function MonitoringStatus() {
   // Switching tabs just changes which entry we show — other hosts keep
   // monitoring independently.
   const activeMonitorKey = useAppStore((s) => monitorKeyForTab(getActiveTab(s)));
-  const activeMonitor = useAppStore((s) => selectMonitor(s, monitorKeyForTab(getActiveTab(s))));
+  // The active tab's monitor entry, sourced from the projected `system-monitors`
+  // region when it faithfully mirrors `appStore`, else `appStore` verbatim
+  // (#2224 render cut). Picking the active key stays a per-client (presentation)
+  // concern under partial projection.
+  const { monitors: projectedMonitors } = useProjectedMonitors();
+  const activeMonitor = activeMonitorKey ? (projectedMonitors[activeMonitorKey] ?? null) : null;
   const monitoringConnected = !!activeMonitor?.monitorSessionId;
   const monitoringHost = activeMonitor?.host ?? null;
   const monitoringStats = activeMonitor?.stats ?? null;

--- a/src/store/systemMonitorBridge.test.ts
+++ b/src/store/systemMonitorBridge.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import type { MonitoringEntry, SystemStats } from "@/types/monitoring";
+
+import {
+  currentMonitorsView,
+  deepEqual,
+  ensureMonitorsSubscribed,
+  monitorRenderFromProjectionEnabled,
+  monitorsViewMirrors,
+  onMonitorsView,
+  seedMonitorsRegion,
+  setMonitorRenderFromProjectionEnabled,
+  setMonitorTransportForTest,
+  stopMonitorsSubscription,
+  SYSTEM_MONITORS_REGION,
+  type SystemMonitorsView,
+} from "./systemMonitorBridge";
+
+/** A deterministic stats sample. */
+function stats(hostname: string, cpu: number): SystemStats {
+  return {
+    hostname,
+    uptimeSeconds: 100,
+    loadAverage: [0.1, 0.2, 0.3],
+    cpuUsagePercent: cpu,
+    memoryTotalKb: 16_000_000,
+    memoryAvailableKb: 8_000_000,
+    memoryUsedPercent: 50,
+    diskTotalKb: 100_000_000,
+    diskUsedKb: 40_000_000,
+    diskUsedPercent: 40,
+    osInfo: "Linux 6.1",
+  };
+}
+
+/** A live monitor entry for a key. */
+function entry(key: string, host: string, s: SystemStats | null): MonitoringEntry {
+  return {
+    key,
+    host,
+    monitorSessionId: key,
+    stats: s,
+    loading: false,
+    error: null,
+    status: "live",
+    sampleCount: s ? 1 : 0,
+    paused: false,
+    intervalMs: 2000,
+  };
+}
+
+/**
+ * An in-memory substrate double: holds one `system-monitors` view, applies a
+ * `monitor.replace` intent by overwriting the view from its payload, and fans a
+ * fresh snapshot to every subscriber — so the seed round-trip and multi-subscriber
+ * fan-out are exercised without a backend.
+ */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  private view: SystemMonitorsView = { monitors: {}, statsCache: {} };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (intent.kind === "monitor.replace") {
+      const payload = intent.payload as Partial<SystemMonitorsView>;
+      this.view = { monitors: payload.monitors ?? {}, statsCache: payload.statsCache ?? {} };
+      this.version += 1;
+      this.fan();
+      return {
+        intentId: intent.intentId,
+        status: "accepted",
+        produced: [{ region: SYSTEM_MONITORS_REGION, version: this.version }],
+      };
+    }
+    return { intentId: intent.intentId, status: "accepted", produced: [] };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(SYSTEM_MONITORS_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+let transport: FakeTransport;
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setMonitorTransportForTest(transport);
+});
+
+afterEach(() => {
+  stopMonitorsSubscription();
+  setMonitorTransportForTest(null);
+  setMonitorRenderFromProjectionEnabled(null);
+});
+
+describe("monitorRenderFromProjectionEnabled flag", () => {
+  it("defaults on and honours the programmatic override", () => {
+    expect(monitorRenderFromProjectionEnabled()).toBe(true);
+    setMonitorRenderFromProjectionEnabled(false);
+    expect(monitorRenderFromProjectionEnabled()).toBe(false);
+    setMonitorRenderFromProjectionEnabled(true);
+    expect(monitorRenderFromProjectionEnabled()).toBe(true);
+    setMonitorRenderFromProjectionEnabled(null);
+    expect(monitorRenderFromProjectionEnabled()).toBe(true);
+  });
+});
+
+describe("deepEqual", () => {
+  it("treats an integer and its float round-trip as equal", () => {
+    expect(deepEqual(40, 40.0)).toBe(true);
+    expect(deepEqual({ a: [1, 2] }, { a: [1, 2] })).toBe(true);
+  });
+
+  it("distinguishes differing values, key sets, and null", () => {
+    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(deepEqual(null, {})).toBe(false);
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+  });
+});
+
+describe("monitorsViewMirrors", () => {
+  const monitors = { s1: entry("s1", "host-a", stats("host-a", 12)) };
+  const statsCache = { s1: stats("host-a", 12) };
+
+  it("is false for an undefined view", () => {
+    expect(monitorsViewMirrors(undefined, monitors, statsCache)).toBe(false);
+  });
+
+  it("is true when the view value-matches the appStore slice", () => {
+    const view: SystemMonitorsView = { monitors: structuredClone(monitors), statsCache };
+    expect(monitorsViewMirrors(view, monitors, statsCache)).toBe(true);
+  });
+
+  it("is false when any entry field diverges", () => {
+    const view: SystemMonitorsView = {
+      monitors: { s1: { ...monitors.s1, paused: true } },
+      statsCache,
+    };
+    expect(monitorsViewMirrors(view, monitors, statsCache)).toBe(false);
+  });
+});
+
+describe("seedMonitorsRegion", () => {
+  it("dispatches monitor.replace carrying the whole slice", async () => {
+    const monitors = { s1: entry("s1", "host-a", stats("host-a", 5)) };
+    const statsCache = { s1: stats("host-a", 5) };
+    await seedMonitorsRegion(monitors, statsCache);
+    expect(transport.dispatched).toHaveLength(1);
+    expect(transport.dispatched[0]).toMatchObject({
+      kind: "monitor.replace",
+      payload: { monitors, statsCache },
+    });
+  });
+
+  it("de-dupes an identical slice but re-seeds after a change", async () => {
+    const monitors = { s1: entry("s1", "host-a", stats("host-a", 5)) };
+    await seedMonitorsRegion(monitors, {});
+    await seedMonitorsRegion(monitors, {});
+    expect(transport.dispatched).toHaveLength(1);
+
+    const changed = { s1: entry("s1", "host-a", stats("host-a", 9)) };
+    await seedMonitorsRegion(changed, {});
+    expect(transport.dispatched).toHaveLength(2);
+  });
+});
+
+describe("seed round-trip → the region mirrors appStore", () => {
+  it("makes the projected view a faithful mirror of the seeded slice", async () => {
+    const received: SystemMonitorsView[] = [];
+    const unsubscribe = onMonitorsView((v) => received.push(v));
+    await ensureMonitorsSubscribed();
+
+    const monitors = { s1: entry("s1", "host-a", stats("host-a", 21)) };
+    const statsCache = { s1: stats("host-a", 21) };
+    await seedMonitorsRegion(monitors, statsCache);
+
+    // The region now carries the seeded slice and the gate accepts it.
+    expect(monitorsViewMirrors(currentMonitorsView(), monitors, statsCache)).toBe(true);
+    expect(received[received.length - 1]).toEqual({ monitors, statsCache });
+    unsubscribe();
+  });
+});

--- a/src/store/systemMonitorBridge.ts
+++ b/src/store/systemMonitorBridge.ts
@@ -295,7 +295,9 @@ export function deepEqual(a: unknown, b: unknown): boolean {
     const aKeys = Object.keys(ao);
     const bKeys = Object.keys(bo);
     if (aKeys.length !== bKeys.length) return false;
-    return aKeys.every((k) => Object.prototype.hasOwnProperty.call(bo, k) && deepEqual(ao[k], bo[k]));
+    return aKeys.every(
+      (k) => Object.prototype.hasOwnProperty.call(bo, k) && deepEqual(ao[k], bo[k])
+    );
   }
   return false;
 }

--- a/src/store/systemMonitorBridge.ts
+++ b/src/store/systemMonitorBridge.ts
@@ -1,0 +1,307 @@
+/**
+ * System-monitor projection bridge — Phase 5 render cut of the Monitors domain
+ * (#2224, part of #2139).
+ *
+ * The Monitors **shadow** (PR #2230) landed a backend-authoritative
+ * `SystemMonitorStore` served as the shared `system-monitors` projection region,
+ * with `monitor.*` intents, but nothing in the UI touched it. This step makes the
+ * **status bar** and **Open Connections** source their monitor stats/status from
+ * that region — the parity-safe render cut (the direct analog of the layout
+ * render cut {@link import("./useLayoutRenderTree").useLayoutRenderTree}, #2151,
+ * and the session render cut {@link import("./useSessionLifecycle")}, #2204).
+ *
+ * # Strangler safety — flag-gated, on by default, faithful-mirror gate
+ *
+ * The `appStore` monitoring slice is still authoritative (the mutation cut is a
+ * later step). To keep the render cut parity-safe **independent of any mutation
+ * flag**, the region is kept a faithful copy of `appStore` by
+ * {@link seedMonitorsRegion} (a `monitor.replace` mirror, the analog of the layout
+ * bridge's `layout.replace` seed), and the UI renders from the region **only when
+ * it faithfully mirrors** `appStore` ({@link monitorsViewMirrors}); otherwise it
+ * falls back to `appStore` verbatim. Because the gate guarantees the projected
+ * view deep-equals `appStore`'s slice, the rendered output is byte-identical to
+ * the pre-cut path.
+ *
+ * Gated by {@link monitorRenderFromProjectionEnabled} — **on by default**.
+ * Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_MONITOR_RENDER_FROM_PROJECTION__` or
+ * `localStorage["termihub.monitorRenderFromProjection"]` (set `"false"` to render
+ * straight from `appStore`).
+ */
+
+import {
+  createTransport,
+  newClientId,
+  newIntentId,
+  ProjectionClient,
+  type IntentAck,
+  type Transport,
+} from "@/services/transport";
+import type { MonitoringEntry, SystemStats } from "@/types/monitoring";
+import { frontendLog } from "@/utils/frontendLog";
+
+/** The projection region id for the system-monitor domain (twin of the Rust
+ * `SYSTEM_MONITORS_REGION` const). Shared (Open Design Decision #4). */
+export const SYSTEM_MONITORS_REGION = "system-monitors";
+
+/**
+ * The `system-monitors` region view model — a twin of the Rust store snapshot:
+ * `{ monitors: { <key>: MonitorEntry }, statsCache: { <key>: SystemStats } }`.
+ * The projected `MonitorEntry` shape matches the frontend {@link MonitoringEntry}
+ * one-to-one, so the render cut is a pure parity swap.
+ */
+export interface SystemMonitorsView {
+  monitors: Record<string, MonitoringEntry>;
+  statsCache: Record<string, SystemStats>;
+}
+
+/** The empty view a fresh region reports (twin of the empty store snapshot). */
+const EMPTY_VIEW: SystemMonitorsView = { monitors: {}, statsCache: {} };
+
+// ── Render-cut feature flag (runtime-flippable, on by default) ─────────────────
+
+let renderFlagOverride: boolean | null = null;
+
+interface MonitorRenderFlagWindow {
+  __TERMIHUB_MONITOR_RENDER_FROM_PROJECTION__?: boolean;
+  localStorage?: Storage;
+}
+
+/**
+ * Programmatic override for the render-cut flag (tests, and a runtime toggle).
+ * `null` clears the override and falls back to the window/localStorage signal,
+ * then to the default (on).
+ */
+export function setMonitorRenderFromProjectionEnabled(value: boolean | null): void {
+  renderFlagOverride = value;
+}
+
+/**
+ * Whether the status bar and Open Connections render their monitor stats/status
+ * from the projected `system-monitors` region instead of reading `appStore`'s
+ * monitoring slice directly.
+ *
+ * **On by default** — the render cut is parity-safe: the UI renders from the
+ * region only when it faithfully mirrors `appStore` ({@link monitorsViewMirrors}),
+ * and otherwise falls back to `appStore` verbatim, so the output is byte-identical
+ * to the pre-cut path. Independent of the (later) mutation cut: the region is kept
+ * a mirror of `appStore` by {@link seedMonitorsRegion}, so it is always populated.
+ * Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_MONITOR_RENDER_FROM_PROJECTION__` or
+ * `localStorage["termihub.monitorRenderFromProjection"]`.
+ */
+export function monitorRenderFromProjectionEnabled(): boolean {
+  if (renderFlagOverride !== null) return renderFlagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as MonitorRenderFlagWindow;
+      if (typeof w.__TERMIHUB_MONITOR_RENDER_FROM_PROJECTION__ === "boolean") {
+        return w.__TERMIHUB_MONITOR_RENDER_FROM_PROJECTION__;
+      }
+      const ls = w.localStorage?.getItem("termihub.monitorRenderFromProjection");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return true;
+}
+
+// ── Transport + shared region client (lazy, mirrors the session slice) ─────────
+
+let transportInstance: Transport | null = null;
+let regionClient: ProjectionClient | null = null;
+let startPromise: Promise<ProjectionClient> | null = null;
+
+// A stable per-session client identity for dispatched intents (fan-out / audit
+// only; the shared region's diff reaches every subscriber regardless of who
+// dispatched it).
+const clientId = newClientId();
+
+/** Inject a transport for tests; `null` restores the lazily-created real one and
+ * drops any active subscription / seed dedup. */
+export function setMonitorTransportForTest(t: Transport | null): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  transportInstance = t;
+  lastView = EMPTY_VIEW;
+  lastSeededSignature = null;
+}
+
+function transport(): Transport {
+  if (!transportInstance) {
+    transportInstance = createTransport();
+  }
+  return transportInstance;
+}
+
+// ── View fan-out (one subscription, many consuming hooks) ──────────────────────
+
+/** A change listener for the projected `system-monitors` view. */
+export type MonitorsViewListener = (view: SystemMonitorsView) => void;
+
+const viewListeners = new Set<MonitorsViewListener>();
+let lastView: SystemMonitorsView = EMPTY_VIEW;
+
+/**
+ * Register a listener, invoked with the projected view on every diff. Returns an
+ * unsubscribe. The region client is started on first use.
+ */
+export function onMonitorsView(listener: MonitorsViewListener): () => void {
+  viewListeners.add(listener);
+  return () => viewListeners.delete(listener);
+}
+
+/**
+ * Ensure the shared `system-monitors` region client is subscribed so projected
+ * diffs are received and fanned out to the {@link onMonitorsView} listeners.
+ * Idempotent and de-duplicated across concurrent callers; a transport/subscribe
+ * failure is logged and rethrown so the caller can fall back to `appStore`.
+ */
+export function ensureMonitorsSubscribed(): Promise<ProjectionClient> {
+  if (regionClient) return Promise.resolve(regionClient);
+  if (!startPromise) {
+    const client = new ProjectionClient(transport(), SYSTEM_MONITORS_REGION);
+    client.onChange((state) => {
+      const view = (state.view ?? EMPTY_VIEW) as Partial<SystemMonitorsView>;
+      lastView = { monitors: view.monitors ?? {}, statsCache: view.statsCache ?? {} };
+      for (const listener of viewListeners) {
+        try {
+          listener(lastView);
+        } catch (err) {
+          logMonitorBridgeFallback("reconcile", err);
+        }
+      }
+    });
+    startPromise = client
+      .start()
+      .then(() => {
+        regionClient = client;
+        return client;
+      })
+      .catch((err) => {
+        startPromise = null;
+        logMonitorBridgeFallback("subscribe", err);
+        throw err;
+      });
+  }
+  return startPromise;
+}
+
+/** Drop the region subscription (tests / re-init). */
+export function stopMonitorsSubscription(): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  lastView = EMPTY_VIEW;
+  lastSeededSignature = null;
+}
+
+/** The last view fanned out (for a hook that subscribes after the first diff). */
+export function currentMonitorsView(): SystemMonitorsView {
+  return lastView;
+}
+
+// ── Seed: keep the region a faithful mirror of appStore (monitor.replace) ──────
+
+let lastSeededSignature: string | null = null;
+
+/**
+ * Seed the shared region with `appStore`'s whole monitoring slice via a
+ * `monitor.replace` intent, so the projection tracks `appStore`'s current state
+ * while `appStore` stays authoritative (the render-side counterpart to the layout
+ * bridge's seed). De-duplicated: a slice identical to the last seeded one is not
+ * re-dispatched. Never throws synchronously — a transport that cannot dispatch
+ * surfaces as a rejected promise the caller logs and ignores (staying on the
+ * `appStore` fallback). Idempotent server-side: replacing with the same content
+ * yields no diff.
+ */
+export function seedMonitorsRegion(
+  monitors: Record<string, MonitoringEntry>,
+  statsCache: Record<string, SystemStats>
+): Promise<void> {
+  const signature = JSON.stringify({ monitors, statsCache });
+  if (signature === lastSeededSignature) return Promise.resolve();
+  // Set before dispatching so concurrent callers (status bar + Open Connections)
+  // do not double-dispatch the same seed.
+  lastSeededSignature = signature;
+  try {
+    return transport()
+      .dispatch({
+        intentId: newIntentId(),
+        kind: "monitor.replace",
+        payload: { monitors, statsCache },
+        clientId,
+      })
+      .then((ack: IntentAck) => {
+        if (ack.status === "rejected") {
+          // Let a later change retry the seed rather than latch on a failure.
+          lastSeededSignature = null;
+          throw new Error(ack.error?.message ?? "monitor.replace rejected");
+        }
+      })
+      .catch((err) => {
+        lastSeededSignature = null;
+        throw err;
+      });
+  } catch (err) {
+    // A synchronous transport-construction failure (non-Tauri, no socket).
+    lastSeededSignature = null;
+    return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+// ── Faithful-mirror gate ───────────────────────────────────────────────────────
+
+/**
+ * Whether a projected `view` faithfully mirrors `appStore`'s monitoring slice —
+ * the gate deciding whether the UI may render from the projection (true) or must
+ * fall back to `appStore` (false). A deep value comparison of both the `monitors`
+ * map and the `statsCache`; because the projected `MonitorEntry` shape matches
+ * {@link MonitoringEntry} one-to-one, a mirroring view is value-identical to the
+ * `appStore` slice, so rendering from it can never diverge.
+ *
+ * The twin of the layout render cut's `viewMatchesTree` and the session render
+ * cut's `projectedReconnectMirrors`.
+ */
+export function monitorsViewMirrors(
+  view: SystemMonitorsView | undefined,
+  monitors: Record<string, MonitoringEntry>,
+  statsCache: Record<string, SystemStats>
+): boolean {
+  if (!view) return false;
+  return deepEqual(view.monitors, monitors) && deepEqual(view.statsCache, statsCache);
+}
+
+/**
+ * A structural deep-equal for the JSON-ish monitoring view model (objects,
+ * arrays, and primitives — no functions/dates/maps). Numbers compare with `===`,
+ * so an integer that round-tripped through JSON as a float (`40` vs `40.0`) still
+ * matches. Exported for the bridge's parity tests.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const ao = a as Record<string, unknown>;
+    const bo = b as Record<string, unknown>;
+    const aKeys = Object.keys(ao);
+    const bKeys = Object.keys(bo);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every((k) => Object.prototype.hasOwnProperty.call(bo, k) && deepEqual(ao[k], bo[k]));
+  }
+  return false;
+}
+
+/** Log a bridge fallback so the appStore-path recovery is visible in the LogViewer. */
+export function logMonitorBridgeFallback(kind: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  frontendLog("monitor_bridge", `${kind} fell back to appStore monitoring: ${message}`);
+}

--- a/src/store/useProjectedMonitors.test.tsx
+++ b/src/store/useProjectedMonitors.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * `useProjectedMonitors` — the status bar & Open Connections cut to the projected
+ * `system-monitors` region (#2224 render cut). Drives the hook against an
+ * in-memory substrate double and asserts: flag-off returns the appStore slice and
+ * dispatches nothing; flag-on seeds the region (a `monitor.replace` mirror) and
+ * then renders the slice from the projection, value-identical to appStore; and a
+ * region that has not caught up falls back to the appStore slice.
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import { useAppStore } from "@/store/appStore";
+import type { MonitoringEntry, SystemStats } from "@/types/monitoring";
+
+import {
+  setMonitorRenderFromProjectionEnabled,
+  setMonitorTransportForTest,
+  stopMonitorsSubscription,
+  SYSTEM_MONITORS_REGION,
+  type SystemMonitorsView,
+} from "./systemMonitorBridge";
+import { useProjectedMonitors } from "./useProjectedMonitors";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  getSettings: vi.fn(() =>
+    Promise.resolve({ version: "1", externalConnectionFiles: [], powerMonitoringEnabled: true })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn(() => vi.fn()) }));
+
+function stats(hostname: string, cpu: number): SystemStats {
+  return {
+    hostname,
+    uptimeSeconds: 100,
+    loadAverage: [0.1, 0.2, 0.3],
+    cpuUsagePercent: cpu,
+    memoryTotalKb: 16_000_000,
+    memoryAvailableKb: 8_000_000,
+    memoryUsedPercent: 50,
+    diskTotalKb: 100_000_000,
+    diskUsedKb: 40_000_000,
+    diskUsedPercent: 40,
+    osInfo: "Linux 6.1",
+  };
+}
+
+function entry(key: string, host: string, s: SystemStats): MonitoringEntry {
+  return {
+    key,
+    host,
+    monitorSessionId: key,
+    stats: s,
+    loading: false,
+    error: null,
+    status: "live",
+    sampleCount: 1,
+    paused: false,
+    intervalMs: 2000,
+  };
+}
+
+/** In-memory substrate double: applies `monitor.replace` and fans a snapshot. */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  /** When false, `monitor.replace` acks but does NOT advance the region. */
+  applyReplace = true;
+  private view: SystemMonitorsView = { monitors: {}, statsCache: {} };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (intent.kind === "monitor.replace" && this.applyReplace) {
+      const p = intent.payload as Partial<SystemMonitorsView>;
+      this.view = { monitors: p.monitors ?? {}, statsCache: p.statsCache ?? {} };
+      this.version += 1;
+      this.fan();
+    }
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: SYSTEM_MONITORS_REGION, version: this.version }],
+    };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(SYSTEM_MONITORS_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+/** Render the hook into a throwaway component, exposing the latest return value. */
+function renderHook(): { get: () => SystemMonitorsView; unmount: () => void } {
+  const container = document.createElement("div");
+  const root: Root = createRoot(container);
+  let latest: SystemMonitorsView = { monitors: {}, statsCache: {} };
+
+  function Probe() {
+    latest = useProjectedMonitors();
+    return null;
+  }
+
+  act(() => root.render(<Probe />));
+  return { get: () => latest, unmount: () => act(() => root.unmount()) };
+}
+
+let transport: FakeTransport;
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setMonitorTransportForTest(transport);
+  useAppStore.setState({ monitors: {}, monitoringStatsCache: {} });
+});
+
+afterEach(() => {
+  stopMonitorsSubscription();
+  setMonitorTransportForTest(null);
+  setMonitorRenderFromProjectionEnabled(null);
+});
+
+const flush = () => act(async () => await Promise.resolve());
+
+describe("useProjectedMonitors", () => {
+  it("flag off: returns the appStore slice and dispatches nothing", async () => {
+    setMonitorRenderFromProjectionEnabled(false);
+    const s = stats("host-a", 12);
+    useAppStore.setState({ monitors: { s1: entry("s1", "host-a", s) }, monitoringStatsCache: { s1: s } });
+
+    const hook = renderHook();
+    await flush();
+
+    expect(hook.get().monitors.s1.stats?.cpuUsagePercent).toBe(12);
+    expect(transport.dispatched).toHaveLength(0);
+    hook.unmount();
+  });
+
+  it("flag on: seeds the region then renders the slice from the projection", async () => {
+    const s = stats("host-a", 21);
+    const monitors = { s1: entry("s1", "host-a", s) };
+    useAppStore.setState({ monitors, monitoringStatsCache: { s1: s } });
+
+    const hook = renderHook();
+    await flush();
+    await flush();
+
+    // The hook seeded appStore's slice via monitor.replace…
+    expect(transport.dispatched.some((d) => d.kind === "monitor.replace")).toBe(true);
+    // …and now renders a value-identical slice (sourced from the projection).
+    expect(hook.get().monitors.s1).toEqual(monitors.s1);
+    hook.unmount();
+  });
+
+  it("region not caught up: falls back to the appStore slice", async () => {
+    transport.applyReplace = false; // the replace acks but never advances the region
+    const s = stats("host-b", 7);
+    const monitors = { s2: entry("s2", "host-b", s) };
+    useAppStore.setState({ monitors, monitoringStatsCache: { s2: s } });
+
+    const hook = renderHook();
+    await flush();
+    await flush();
+
+    // The projection stays empty, so the gate rejects it and the hook renders
+    // the appStore slice verbatim — parity preserved.
+    expect(hook.get().monitors.s2).toEqual(monitors.s2);
+    hook.unmount();
+  });
+});

--- a/src/store/useProjectedMonitors.test.tsx
+++ b/src/store/useProjectedMonitors.test.tsx
@@ -158,7 +158,10 @@ describe("useProjectedMonitors", () => {
   it("flag off: returns the appStore slice and dispatches nothing", async () => {
     setMonitorRenderFromProjectionEnabled(false);
     const s = stats("host-a", 12);
-    useAppStore.setState({ monitors: { s1: entry("s1", "host-a", s) }, monitoringStatsCache: { s1: s } });
+    useAppStore.setState({
+      monitors: { s1: entry("s1", "host-a", s) },
+      monitoringStatsCache: { s1: s },
+    });
 
     const hook = renderHook();
     await flush();

--- a/src/store/useProjectedMonitors.ts
+++ b/src/store/useProjectedMonitors.ts
@@ -1,0 +1,97 @@
+/**
+ * `useProjectedMonitors` — the status bar & Open Connections cut to the projected
+ * `system-monitors` region (#2224 render cut, part of #2139).
+ *
+ * The status bar renders the active tab's monitor stats/status and Open
+ * Connections renders one row per live monitor. Through the shadow step both read
+ * `appStore.monitors` / `appStore.monitoringStatsCache` directly. This hook makes
+ * them source that slice from the shared `system-monitors` projection region
+ * instead — the direct analog of {@link import("./useLayoutRenderTree").useLayoutRenderTree}
+ * (#2151) and {@link import("./useSessionLifecycle").useSessionAutoReconnect} (#2204).
+ *
+ * # Safety (strangler)
+ *
+ * - **Gated** by {@link monitorRenderFromProjectionEnabled} (on by default). Flag
+ *   off ⇒ the hook returns `appStore`'s slice verbatim.
+ * - **Faithful-mirror gate.** The projection sources the render only when it
+ *   deep-equals the `appStore` slice ({@link monitorsViewMirrors}); otherwise the
+ *   hook falls back to `appStore` (never a stale view). While `appStore` stays
+ *   authoritative (the mutation cut is a later step) the region is kept a mirror
+ *   by {@link seedMonitorsRegion}, so it is always populated — making the cut
+ *   parity-safe and independent of the mutation flag.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+import { useAppStore } from "@/store/appStore";
+import {
+  currentMonitorsView,
+  ensureMonitorsSubscribed,
+  logMonitorBridgeFallback,
+  monitorRenderFromProjectionEnabled,
+  monitorsViewMirrors,
+  onMonitorsView,
+  seedMonitorsRegion,
+  type SystemMonitorsView,
+} from "@/store/systemMonitorBridge";
+
+/**
+ * The effective monitoring slice for rendering: the `monitors` map + `statsCache`
+ * sourced from the projected `system-monitors` region when it faithfully mirrors
+ * `appStore`, otherwise `appStore`'s slice verbatim (flag off, region not yet
+ * caught up, or a transport that cannot subscribe).
+ */
+export function useProjectedMonitors(): SystemMonitorsView {
+  const monitors = useAppStore((s) => s.monitors);
+  const statsCache = useAppStore((s) => s.monitoringStatsCache);
+
+  // Read the flag once at mount: it flips only via dev tooling, and the
+  // subscription lifecycle is keyed off it below.
+  const [enabled] = useState(() => monitorRenderFromProjectionEnabled());
+
+  const [view, setView] = useState<SystemMonitorsView | undefined>(undefined);
+
+  // Subscribe to the shared system-monitors region while enabled; a transport
+  // that cannot subscribe (non-Tauri without a socket) just leaves the UI on the
+  // appStore fallback.
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const unsubscribe = onMonitorsView((next) => {
+      if (!cancelled) setView(next);
+    });
+    // `ensureMonitorsSubscribed` builds the transport eagerly, so a non-Tauri env
+    // without a socket throws synchronously (not just a rejection) — guard both so
+    // the UI silently stays on the appStore fallback.
+    try {
+      ensureMonitorsSubscribed()
+        .then(() => {
+          if (!cancelled) setView(currentMonitorsView());
+        })
+        .catch((err) => logMonitorBridgeFallback("subscribe", err));
+    } catch (err) {
+      logMonitorBridgeFallback("subscribe", err);
+    }
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [enabled]);
+
+  const matches = enabled && monitorsViewMirrors(view, monitors, statsCache);
+
+  // Keep the region a faithful mirror of appStore's slice. Only once a view has
+  // arrived (so we are subscribed) and it is not already a mirror; de-duped inside
+  // `seedMonitorsRegion` so a settled slice is not re-seeded on every render.
+  useEffect(() => {
+    if (!enabled || matches || view === undefined) return;
+    seedMonitorsRegion(monitors, statsCache).catch((err) =>
+      logMonitorBridgeFallback("seed", err)
+    );
+  }, [enabled, matches, view, monitors, statsCache]);
+
+  return useMemo(() => {
+    if (matches && view) return view;
+    return { monitors, statsCache };
+  }, [matches, view, monitors, statsCache]);
+}

--- a/src/store/useProjectedMonitors.ts
+++ b/src/store/useProjectedMonitors.ts
@@ -85,9 +85,7 @@ export function useProjectedMonitors(): SystemMonitorsView {
   // `seedMonitorsRegion` so a settled slice is not re-seeded on every render.
   useEffect(() => {
     if (!enabled || matches || view === undefined) return;
-    seedMonitorsRegion(monitors, statsCache).catch((err) =>
-      logMonitorBridgeFallback("seed", err)
-    );
+    seedMonitorsRegion(monitors, statsCache).catch((err) => logMonitorBridgeFallback("seed", err));
   }, [enabled, matches, view, monitors, statsCache]);
 
   return useMemo(() => {


### PR DESCRIPTION
Part of #2224 (Phase 5, Monitors domain · part of #2139). The Monitors **shadow** (PR #2230) landed a backend-authoritative `SystemMonitorStore` served as the shared `system-monitors` region with `monitor.*` intents, but nothing in the UI touched it. This is the **render cut**: the status bar and Open Connections now render CPU/mem/disk stats + status from the projected region — parity-safe, and the step that starts reducing `appStore`'s authority.

Mirrors the session render cut (#2204) and layout render cut (#2151/#2183) exactly.

## What changed

**Backend** — a `monitor.replace` whole-map mirror intent (`SystemMonitorStore::replace`), the analog of `layout.replace`. Because `appStore` stays authoritative until the mutation cut, the frontend keeps the shared region a faithful copy of `appStore`'s monitoring slice through this seed.

**Frontend**
- `systemMonitorBridge.ts` — subscribes the shared `system-monitors` region, seeds it from `appStore` via `monitor.replace` (de-duped), and a faithful-mirror gate (`monitorsViewMirrors`, a deep value-equal of `{ monitors, statsCache }`).
- `useProjectedMonitors()` — returns the effective monitoring slice: the projection **only when it deep-equals `appStore`**, otherwise `appStore` verbatim. Gated by `monitorRenderFromProjectionEnabled` (**on by default**, runtime-overridable via `window.__TERMIHUB_MONITOR_RENDER_FROM_PROJECTION__` / `localStorage["termihub.monitorRenderFromProjection"]`) for instant rollback.
- `StatusBar` and `OpenConnectionsModal` now read monitors through the hook instead of the `appStore` slice directly.

## Parity / safety

Because the gate guarantees a rendered projection deep-equals the `appStore` slice, output is byte-identical to the pre-cut path. Independent of any (future) mutation flag: the region is always populated by the seed, and any transport that cannot subscribe falls back to `appStore`. The `appStore` `monitors` / `monitoringStatsCache` **fields remain** for the mutation cut + reducer-removal steps.

## Tests
- Rust: `SystemMonitorStore::replace` (overwrite + clear) and a projection-contract test that `monitor.replace` mirrors a whole snapshot in one diff and converges.
- Frontend: bridge unit tests (flag, deep-equal, mirror gate, seed dedup, seed round-trip) + `useProjectedMonitors` hook tests (flag-off appStore passthrough, flag-on renders from projection, region-not-caught-up fallback).
- Full frontend suite (4803) and the monitor Rust suite green; existing StatusBar/OpenConnections tests (123) confirm fallback parity. `clippy -D warnings`, `fmt`, `tsc`, `eslint` clean.

No user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)