### PR TITLE
feat(ui): cut monitor mutations to monitor.* intents (#2224)

### DIFF
--- a/src/store/appStore.monitoringMutationCut.test.ts
+++ b/src/store/appStore.monitoringMutationCut.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Monitors mutation cut (#2224, part of #2139) — cut-vs-local parity.
+ *
+ * The mutation cut routes each monitor lifecycle action through a granular
+ * `monitor.*` intent so the backend `SystemMonitorStore` becomes authoritative,
+ * while the local `appStore` reducer path stays in place as the render source and
+ * the resilience / rollback fallback (the reducer removal is a later step).
+ *
+ * These tests prove the cut is parity-safe end to end: with the flag **on**, the
+ * intents dispatched by the actions — applied by a faithful in-memory port of the
+ * Rust store (mirroring `system_monitor_projection/store.rs`) — reproduce the exact
+ * `appStore` monitoring slice (`monitors` + `monitoringStatsCache`) for every
+ * action and its fan-out. With the flag **off**, no intents are dispatched and the
+ * local slice is byte-identical — the instant rollback path the flip relies on.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+const mockSessionMonitoringOpen = vi.fn();
+const mockSessionMonitoringClose = vi.fn();
+const mockSessionMonitoringSetPaused = vi.fn();
+const mockSessionMonitoringSetInterval = vi.fn();
+const mockSessionMonitoringCancel = vi.fn();
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  sessionMonitoringOpen: (...args: unknown[]) => mockSessionMonitoringOpen(...args),
+  sessionMonitoringClose: (...args: unknown[]) => mockSessionMonitoringClose(...args),
+  sessionMonitoringSetPaused: (...args: unknown[]) => mockSessionMonitoringSetPaused(...args),
+  sessionMonitoringSetInterval: (...args: unknown[]) => mockSessionMonitoringSetInterval(...args),
+  sessionMonitoringCancel: (...args: unknown[]) => mockSessionMonitoringCancel(...args),
+}));
+
+type StatsCallback = (sessionId: string, stats: SystemStats) => void;
+type StatusCallback = (sessionId: string, status: MonitorStatus) => void;
+let statsCallbacks: StatsCallback[] = [];
+let statusCallbacks: StatusCallback[] = [];
+const mockStatsUnlisten = vi.fn();
+const mockStatusUnlisten = vi.fn();
+
+function pushStats(sessionId: string, stats: SystemStats) {
+  statsCallbacks.forEach((cb) => cb(sessionId, stats));
+}
+function pushStatus(sessionId: string, status: MonitorStatus) {
+  statusCallbacks.forEach((cb) => cb(sessionId, status));
+}
+
+vi.mock("@/services/events", () => ({
+  onSessionMonitoringStats: (cb: StatsCallback) => {
+    statsCallbacks.push(cb);
+    return Promise.resolve(mockStatsUnlisten);
+  },
+  onSessionMonitoringStatus: (cb: StatusCallback) => {
+    statusCallbacks.push(cb);
+    return Promise.resolve(mockStatusUnlisten);
+  },
+  onPersistentSessionStateChanged: vi.fn(() => Promise.resolve(() => {})),
+}));
+
+import { useAppStore } from "./appStore";
+import { setMonitorIntentsEnabled, setMonitorTransportForTest } from "./systemMonitorBridge";
+import {
+  DEFAULT_MONITORING_INTERVAL_MS,
+  type MonitoringEntry,
+  type MonitorStatus,
+  type SystemStats,
+} from "@/types/monitoring";
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+
+const SESSION_A = "term-sess-a";
+const SESSION_B = "term-sess-b";
+const HOST_A = "pi@pi.local:22";
+const HOST_B = "admin@server.local:2222";
+
+const TEST_STATS: SystemStats = {
+  hostname: "pi",
+  uptimeSeconds: 86400,
+  loadAverage: [0.5, 0.3, 0.2],
+  cpuUsagePercent: 25.0,
+  memoryTotalKb: 1048576,
+  memoryAvailableKb: 524288,
+  memoryUsedPercent: 50.0,
+  diskTotalKb: 10485760,
+  diskUsedKb: 5242880,
+  diskUsedPercent: 50.0,
+  osInfo: "Linux 6.1",
+};
+
+interface RegionView {
+  monitors: Record<string, MonitoringEntry>;
+  statsCache: Record<string, SystemStats>;
+}
+
+/** A fresh idle entry — the twin of the Rust `MonitorEntry::empty`. */
+function emptyEntry(key: string, host: string | null): MonitoringEntry {
+  return {
+    key,
+    host,
+    monitorSessionId: null,
+    stats: null,
+    loading: false,
+    error: null,
+    status: null,
+    sampleCount: 0,
+    paused: false,
+    intervalMs: DEFAULT_MONITORING_INTERVAL_MS,
+  };
+}
+
+/**
+ * An in-memory substrate double that applies the granular `monitor.*` intents
+ * with the same semantics as the Rust `SystemMonitorStore`, so a run of the real
+ * `appStore` actions (which mirror those intents) reconstructs the region view the
+ * status bar and Open Connections would render. Only `monitor.replace` (the
+ * render-cut mirror) is intentionally not applied here — the mutation cut drives
+ * the region through the per-transition intents.
+ */
+class MonitorStoreTransport implements Transport {
+  dispatched: Intent[] = [];
+  private monitors: Record<string, MonitoringEntry> = {};
+  private statsCache: Record<string, SystemStats> = {};
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    this.apply(intent);
+    this.version += 1;
+    this.fan();
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: "system-monitors", version: this.version }],
+    };
+  }
+
+  private apply(intent: Intent): void {
+    const p = intent.payload as Record<string, unknown>;
+    const key = p.key as string;
+    switch (intent.kind) {
+      case "monitor.open": {
+        const host = (p.host as string | undefined) ?? null;
+        const intervalMs = (p.intervalMs as number | undefined) ?? DEFAULT_MONITORING_INTERVAL_MS;
+        const cached = this.statsCache[key] ?? null;
+        this.monitors[key] = {
+          ...emptyEntry(key, host),
+          loading: true,
+          status: "connecting",
+          stats: cached,
+          intervalMs,
+        };
+        break;
+      }
+      case "monitor.opened": {
+        const e = this.monitors[key];
+        if (e)
+          this.monitors[key] = {
+            ...e,
+            monitorSessionId: key,
+            loading: false,
+            status: "live",
+            error: null,
+          };
+        break;
+      }
+      case "monitor.openFailed": {
+        const e = this.monitors[key];
+        if (e)
+          this.monitors[key] = {
+            ...e,
+            monitorSessionId: null,
+            loading: false,
+            status: null,
+            error: (p.error as string | undefined) ?? null,
+          };
+        break;
+      }
+      case "monitor.stats": {
+        const stats = p.stats as SystemStats;
+        this.statsCache[key] = stats;
+        const e = this.monitors[key];
+        if (e) this.monitors[key] = { ...e, stats, sampleCount: e.sampleCount + 1 };
+        break;
+      }
+      case "monitor.status": {
+        const e = this.monitors[key];
+        if (e) this.monitors[key] = { ...e, status: p.status as MonitorStatus };
+        break;
+      }
+      case "monitor.setPaused": {
+        const paused = p.paused as boolean;
+        const e = this.monitors[key];
+        if (e) this.monitors[key] = { ...e, paused, status: paused ? "paused" : "live" };
+        break;
+      }
+      case "monitor.setInterval": {
+        const e = this.monitors[key];
+        if (e) this.monitors[key] = { ...e, intervalMs: p.intervalMs as number };
+        break;
+      }
+      case "monitor.clearError": {
+        const e = this.monitors[key];
+        if (e) this.monitors[key] = { ...e, error: null };
+        break;
+      }
+      case "monitor.close": {
+        delete this.monitors[key];
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  /** The reconstructed region view, twin of the store snapshot. */
+  regionView(): RegionView {
+    return structuredClone({ monitors: this.monitors, statsCache: this.statsCache });
+  }
+
+  kinds(): string[] {
+    return this.dispatched.map((i) => i.kind);
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: this.regionView() };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot("system-monitors");
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+let transport: MonitorStoreTransport;
+
+/** Assert the region the intents reconstruct equals the local appStore slice. */
+function expectParity() {
+  const state = useAppStore.getState();
+  const region = transport.regionView();
+  expect(region.monitors).toEqual(state.monitors);
+  expect(region.statsCache).toEqual(state.monitoringStatsCache);
+}
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  vi.clearAllMocks();
+  statsCallbacks = [];
+  statusCallbacks = [];
+  transport = new MonitorStoreTransport();
+  setMonitorTransportForTest(transport);
+  setMonitorIntentsEnabled(true);
+});
+
+afterEach(() => {
+  setMonitorTransportForTest(null);
+  setMonitorIntentsEnabled(null);
+});
+
+describe("monitors mutation cut — cut-vs-local parity (flag on)", () => {
+  it("connect → opened reproduces the live entry", async () => {
+    mockSessionMonitoringOpen.mockResolvedValue(undefined);
+    await useAppStore.getState().connectMonitoring(SESSION_A, HOST_A);
+
+    expect(transport.kinds()).toEqual(["monitor.open", "monitor.opened"]);
+    expectParity();
+    expect(transport.regionView().monitors[SESSION_A].status).toBe("live");
+  });
+
+  it("a failed open reproduces the error entry", async () => {
+    mockSessionMonitoringOpen.mockRejectedValue(new Error("Connection refused"));
+    await useAppStore.getState().connectMonitoring(SESSION_A, HOST_A);
+
+    expect(transport.kinds()).toEqual(["monitor.open", "monitor.openFailed"]);
+    expectParity();
+    const entry = transport.regionView().monitors[SESSION_A];
+    expect(entry.error).toBe("Connection refused");
+    expect(entry.monitorSessionId).toBeNull();
+  });
+
+  it("pushed stats fan out into the entry and the cache", async () => {
+    mockSessionMonitoringOpen.mockResolvedValue(undefined);
+    await useAppStore.getState().connectMonitoring(SESSION_A, HOST_A);
+
+    pushStats(SESSION_A, { ...TEST_STATS, hostname: "s1" });
+    pushStats(SESSION_A, { ...TEST_STATS, hostname: "s2" });
+
+    expectParity();
+    const view = transport.regionView();
+    expect(view.monitors[SESSION_A].sampleCount).toBe(2);
+    expect(view.monitors[SESSION_A].stats!.hostname).toBe("s2");
+    expect(view.statsCache[SESSION_A].hostname).toBe("s2");
+  });
+
+  it("a status push flips the projected badge", async () => {
+    mockSessionMonitoringOpen.mockResolvedValue(undefined);
+    await useAppStore.getState().connectMonitoring(SESSION_A, HOST_A);
+
+    pushStatus(SESSION_A, "stale");
+
+    expectParity();
+    expect(transport.regionView().monitors[SESSION_A].status).toBe("stale");
+  });
+
+  it("setMonitoringPaused mirrors the pause", async () => {
+    mockSessionMonitoringOpen.mockResolvedValue(undefined);
+    mockSessionMonitoringSetPaused.mockResolvedValue(undefined);
+    await useAppStore.getState().connectMonitoring(SESSION_A, HOST_A);
+
+    await useAppStore.getState().setMonitoringPaused(SESSION_A, true);
+    expectParity();
+    expect(transport.regionView().monitors[SESSION_A].paused).toBe(true);
+    expect(transport.regionView().monitors[SESSION_A].status).toBe("paused");
+
+    await useAppStore.getState().setMonitoringPaused(SESSION_A, false);
+    expectParity();
+    expect(transport.regionView().monitors[SESSION_A].paused).toBe(false);
+  });
+
+  it("a failed pause rolls back locally and re-mirrors the revert", async () => {
+    mockSessionMonitoringOpen.mockResolvedValue(undefined);
+    mockSessionMonitoringSetPaused.mockRejectedValue(new Error("nope"));
+    await useAppStore.getState().connectMonitoring(SESSION_A, HOST_A);
+
+    await expect(useAppStore.getState().setMonitoringPaused(SESSION_A, true)).rejects.toThrow(
+      "nope"
+    );
+
+    // Local rollback: the entry is not paused (the resilience path held).
+    expect(useAppStore.getState().monitors[SESSION_A].paused).toBe(false);
+    // Both the optimistic pause and its revert were mirrored.
+    expect(transport.kinds()).toEqual([
+      "monitor.open",
+      "monitor.opened",
+      "monitor.setPaused",
+      "monitor.setPaused",
+    ]);
+    expect(transport.regionView().monitors[SESSION_A].paused).toBe(false);
+  });
+
+  it("setMonitoringInterval mirrors the new cadence", async () => {
+    mockSessionMonitoringOpen.mockResolvedValue(undefined);
+    mockSessionMonitoringSetInterval.mockResolvedValue(undefined);
+    await useAppStore.getState().connectMonitoring(SESSION_A, HOST_A);
+
+    await useAppStore.getState().setMonitoringInterval(SESSION_A, 5000);
+    expectParity();
+    expect(transport.regionView().monitors[SESSION_A].intervalMs).toBe(5000);
+  });
+
+  it("clearMonitoringError mirrors the dismissal", async () => {
+    mockSessionMonitoringOpen.mockRejectedValue(new Error("boom"));
+    await useAppStore.getState().connectMonitoring(SESSION_A, HOST_A);
+    expect(transport.regionView().monitors[SESSION_A].error).toBe("boom");
+
+    useAppStore.getState().clearMonitoringError(SESSION_A);
+    expectParity();
+    expect(transport.regionView().monitors[SESSION_A].error).toBeNull();
+    expect(transport.kinds()).toContain("monitor.clearError");
+  });
+
+  it("clearMonitoringError with nothing to clear dispatches nothing", async () => {
+    mockSessionMonitoringOpen.mockResolvedValue(undefined);
+    await useAppStore.getState().connectMonitoring(SESSION_A, HOST_A);
+    const before = transport.dispatched.length;
+
+    useAppStore.getState().clearMonitoringError(SESSION_A);
+    expect(transport.dispatched.length).toBe(before);
+  });
+
+  it("disconnect drops the entry and retains the cache", async () => {
+    mockSessionMonitoringOpen.mockResolvedValue(undefined);
+    mockSessionMonitoringClose.mockResolvedValue(undefined);
+    await useAppStore.getState().connectMonitoring(SESSION_A, HOST_A);
+    pushStats(SESSION_A, TEST_STATS);
+
+    await useAppStore.getState().disconnectMonitoring(SESSION_A);
+
+    expectParity();
+    const view = transport.regionView();
+    expect(view.monitors[SESSION_A]).toBeUndefined();
+    // The cache is retained for an instant reconnect (parity with the local path).
+    expect(view.statsCache[SESSION_A]).toEqual(TEST_STATS);
+  });
+
+  it("cancelMonitoring tears the entry down via close", async () => {
+    mockSessionMonitoringOpen.mockResolvedValue(undefined);
+    mockSessionMonitoringClose.mockResolvedValue(undefined);
+    mockSessionMonitoringCancel.mockResolvedValue(undefined);
+    await useAppStore.getState().connectMonitoring(SESSION_A, HOST_A);
+
+    await useAppStore.getState().cancelMonitoring(SESSION_A);
+
+    expectParity();
+    expect(transport.regionView().monitors[SESSION_A]).toBeUndefined();
+    expect(transport.kinds()).toContain("monitor.close");
+  });
+
+  it("multi-monitor fan-out stays independent", async () => {
+    mockSessionMonitoringOpen.mockResolvedValue(undefined);
+    mockSessionMonitoringClose.mockResolvedValue(undefined);
+    await useAppStore.getState().connectMonitoring(SESSION_A, HOST_A);
+    await useAppStore.getState().connectMonitoring(SESSION_B, HOST_B);
+    pushStats(SESSION_A, { ...TEST_STATS, hostname: "A" });
+    pushStats(SESSION_B, { ...TEST_STATS, hostname: "B" });
+
+    expectParity();
+
+    await useAppStore.getState().disconnectMonitoring(SESSION_A);
+    expectParity();
+    const view = transport.regionView();
+    expect(view.monitors[SESSION_A]).toBeUndefined();
+    expect(view.monitors[SESSION_B].stats!.hostname).toBe("B");
+  });
+
+  it("disconnect with no key tears down every entry", async () => {
+    mockSessionMonitoringOpen.mockResolvedValue(undefined);
+    mockSessionMonitoringClose.mockResolvedValue(undefined);
+    await useAppStore.getState().connectMonitoring(SESSION_A, HOST_A);
+    await useAppStore.getState().connectMonitoring(SESSION_B, HOST_B);
+
+    await useAppStore.getState().disconnectMonitoring();
+
+    expectParity();
+    expect(transport.regionView().monitors).toEqual({});
+  });
+
+  it("a full lifecycle stays in parity across every step", async () => {
+    mockSessionMonitoringOpen.mockResolvedValue(undefined);
+    mockSessionMonitoringClose.mockResolvedValue(undefined);
+    mockSessionMonitoringSetPaused.mockResolvedValue(undefined);
+    mockSessionMonitoringSetInterval.mockResolvedValue(undefined);
+
+    await useAppStore.getState().connectMonitoring(SESSION_A, HOST_A);
+    expectParity();
+    pushStats(SESSION_A, TEST_STATS);
+    expectParity();
+    pushStatus(SESSION_A, "stale");
+    expectParity();
+    await useAppStore.getState().setMonitoringInterval(SESSION_A, 10000);
+    expectParity();
+    await useAppStore.getState().setMonitoringPaused(SESSION_A, true);
+    expectParity();
+    await useAppStore.getState().setMonitoringPaused(SESSION_A, false);
+    expectParity();
+    await useAppStore.getState().disconnectMonitoring(SESSION_A);
+    expectParity();
+  });
+});
+
+describe("monitors mutation cut — flag off (rollback path)", () => {
+  beforeEach(() => setMonitorIntentsEnabled(false));
+
+  it("dispatches no intents and drives the slice locally", async () => {
+    mockSessionMonitoringOpen.mockResolvedValue(undefined);
+    mockSessionMonitoringClose.mockResolvedValue(undefined);
+    mockSessionMonitoringSetPaused.mockResolvedValue(undefined);
+
+    await useAppStore.getState().connectMonitoring(SESSION_A, HOST_A);
+    pushStats(SESSION_A, TEST_STATS);
+    await useAppStore.getState().setMonitoringPaused(SESSION_A, true);
+    await useAppStore.getState().disconnectMonitoring(SESSION_A);
+
+    // No mirror reached the region — the pre-cut local path is intact.
+    expect(transport.dispatched).toHaveLength(0);
+    // The local slice still behaves exactly as before the cut.
+    expect(useAppStore.getState().monitors[SESSION_A]).toBeUndefined();
+    expect(useAppStore.getState().monitoringStatsCache[SESSION_A]).toEqual(TEST_STATS);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -284,6 +284,7 @@ import {
   sessionIntentsEnabled,
   type SessionIntentKind,
 } from "@/store/sessionBridge";
+import { mirrorMonitorIntent } from "@/store/systemMonitorBridge";
 
 export type SidebarView =
   | "connections"
@@ -7196,12 +7197,17 @@ export const useAppStore = create<AppState>((set, get, store) => {
     sessionCapabilities: {},
     remoteDesktopResolutions: {},
 
-    clearMonitoringError: (key) =>
+    clearMonitoringError: (key) => {
+      const entry = useAppStore.getState().monitors[key];
+      if (!entry || entry.error === null) return;
       set((state) => {
-        const entry = state.monitors[key];
-        if (!entry || entry.error === null) return {};
-        return { monitors: { ...state.monitors, [key]: { ...entry, error: null } } };
-      }),
+        const current = state.monitors[key];
+        if (!current || current.error === null) return {};
+        return { monitors: { ...state.monitors, [key]: { ...current, error: null } } };
+      });
+      // Mutation cut (#2224): dismiss the error in the authoritative region too.
+      mirrorMonitorIntent("monitor.clearError", { key });
+    },
 
     setSessionCapabilities: (sessionId, caps) =>
       set((state) => ({
@@ -7252,6 +7258,10 @@ export const useAppStore = create<AppState>((set, get, store) => {
         status: "connecting",
         intervalMs,
       });
+      // Mutation cut (#2224): mirror the connect start into the authoritative
+      // `system-monitors` region. A no-op / logged fallback when the flag is off
+      // or the transport is unavailable — the local slice above already applied.
+      mirrorMonitorIntent("monitor.open", { key, host: host ?? key, intervalMs });
 
       try {
         // Attach the stats listener; it filters by sessionId and folds fresh
@@ -7269,6 +7279,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
               monitoringStatsCache: { ...state.monitoringStatsCache, [key]: stats },
             };
           });
+          mirrorMonitorIntent("monitor.stats", { key, stats });
         });
         _monitoringStatsUnlisten.set(key, statsUnlisten);
 
@@ -7282,11 +7293,13 @@ export const useAppStore = create<AppState>((set, get, store) => {
             if (!entry) return {};
             return { monitors: { ...state.monitors, [key]: { ...entry, status } } };
           });
+          mirrorMonitorIntent("monitor.status", { key, status });
         });
         _monitoringStatusUnlisten.set(key, statusUnlisten);
 
         await sessionMonitoringOpen(key, intervalMs);
         upsertMonitor(key, { monitorSessionId: key, loading: false, status: "live" });
+        mirrorMonitorIntent("monitor.opened", { key });
       } catch (err) {
         // The stats/status listeners are attached before the open that may throw
         // here. Detach them so a failed open never leaks a dangling Tauri
@@ -7294,12 +7307,14 @@ export const useAppStore = create<AppState>((set, get, store) => {
         // not clean it up either). See audit gap G5.
         frontendLog("monitoring", "detaching monitoring listeners after failed open");
         detachMonitorListeners(key);
+        const errorMessage = err instanceof Error ? err.message : String(err);
         upsertMonitor(key, {
           monitorSessionId: null,
           loading: false,
-          error: err instanceof Error ? err.message : String(err),
+          error: errorMessage,
           status: null,
         });
+        mirrorMonitorIntent("monitor.openFailed", { key, error: errorMessage });
       }
     },
 
@@ -7332,6 +7347,12 @@ export const useAppStore = create<AppState>((set, get, store) => {
         }
         return { monitors: nextMonitors, monitoringStatsCache: nextCache };
       });
+
+      // Mutation cut (#2224): drop each entry from the authoritative region. The
+      // store's `close` retains the stats cache (as the local teardown does), and
+      // the cache already tracks the last stats via `monitor.stats`, so the region
+      // stays a faithful mirror of `appStore`.
+      for (const k of keys) mirrorMonitorIntent("monitor.close", { key: k });
     },
 
     setMonitoringPaused: async (key, paused) => {
@@ -7341,6 +7362,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // authoritative `status`, but the flag gates the local UI (neutral badge +
       // dimmed stats) immediately (#1233).
       upsertMonitor(key, { paused, status: paused ? "paused" : "live" });
+      // Mutation cut (#2224): mirror the optimistic pause into the region.
+      mirrorMonitorIntent("monitor.setPaused", { key, paused });
       if (entry.monitorSessionId) {
         try {
           await sessionMonitoringSetPaused(entry.monitorSessionId, paused);
@@ -7348,6 +7371,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
           frontendLog("monitoring", `set paused failed for ${key}: ${err}`);
           // Roll back the optimistic flag so the UI reflects reality.
           upsertMonitor(key, { paused: !paused });
+          mirrorMonitorIntent("monitor.setPaused", { key, paused: !paused });
           throw err;
         }
       }
@@ -7357,6 +7381,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
       const entry = useAppStore.getState().monitors[key];
       if (!entry) return;
       upsertMonitor(key, { intervalMs });
+      // Mutation cut (#2224): mirror the new cadence into the region.
+      mirrorMonitorIntent("monitor.setInterval", { key, intervalMs });
       if (entry.monitorSessionId) {
         try {
           await sessionMonitoringSetInterval(entry.monitorSessionId, intervalMs);

--- a/src/store/systemMonitorBridge.ts
+++ b/src/store/systemMonitorBridge.ts
@@ -108,6 +108,63 @@ export function monitorRenderFromProjectionEnabled(): boolean {
   return true;
 }
 
+// ── Mutation-cut feature flag (runtime-flippable, on by default) ───────────────
+
+let mutationFlagOverride: boolean | null = null;
+
+interface MonitorMutationFlagWindow {
+  __TERMIHUB_MONITOR_INTENTS__?: boolean;
+  localStorage?: Storage;
+}
+
+/**
+ * Programmatic override for the mutation-cut flag (tests, and a runtime toggle).
+ * `null` clears the override and falls back to the window/localStorage signal,
+ * then to the default (on).
+ */
+export function setMonitorIntentsEnabled(value: boolean | null): void {
+  mutationFlagOverride = value;
+}
+
+/**
+ * Whether the monitor lifecycle actions (`connectMonitoring` /
+ * `disconnectMonitoring` / `setMonitoringPaused` / `setMonitoringInterval` /
+ * `clearMonitoringError` / `cancelMonitoring`) dispatch granular `monitor.*`
+ * intents so the backend {@link SystemMonitorStore} is authoritative — instead of
+ * only the render-cut {@link seedMonitorsRegion} `monitor.replace` mirror driving
+ * the region.
+ *
+ * **On by default** (#2224 mutation cut). When on, each action mirrors its
+ * transition through a `monitor.*` intent (via {@link mirrorMonitorIntent}), and
+ * the render-cut hook ({@link import("./useProjectedMonitors").useProjectedMonitors})
+ * reflects the region back into the UI. The local `appStore` reducer path stays in
+ * place as the render source and as a resilience / rollback fallback — any
+ * dispatch failure is logged and the local mutation continues, so a backend hiccup
+ * can never break monitoring (the reducer removal is a later step). When off,
+ * `appStore` drives the slice purely locally (the pre-cut path). The flip was taken
+ * on the automated parity tests plus the instant local fallback, mirroring the
+ * session mutation cut (#2233). Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_MONITOR_INTENTS__` or `localStorage["termihub.monitorIntents"]`
+ * (set `"false"` to restore the pre-cut local-mutation path; `"true"` to force on).
+ */
+export function monitorIntentsEnabled(): boolean {
+  if (mutationFlagOverride !== null) return mutationFlagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as MonitorMutationFlagWindow;
+      if (typeof w.__TERMIHUB_MONITOR_INTENTS__ === "boolean") {
+        return w.__TERMIHUB_MONITOR_INTENTS__;
+      }
+      const ls = w.localStorage?.getItem("termihub.monitorIntents");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return true;
+}
+
 // ── Transport + shared region client (lazy, mirrors the session slice) ─────────
 
 let transportInstance: Transport | null = null;
@@ -250,6 +307,60 @@ export function seedMonitorsRegion(
     // A synchronous transport-construction failure (non-Tauri, no socket).
     lastSeededSignature = null;
     return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+// ── Mutation cut: granular monitor.* intent dispatch (mutation cut) ────────────
+
+/**
+ * The granular `monitor.*` intent kinds the mutation cut dispatches (twins of the
+ * Rust routes). Excludes `monitor.replace`, which is the render-cut whole-map
+ * mirror ({@link seedMonitorsRegion}); the mutation cut drives the region through
+ * these per-transition intents instead so the store becomes authoritative.
+ */
+export type MonitorIntentKind =
+  | "monitor.open"
+  | "monitor.opened"
+  | "monitor.openFailed"
+  | "monitor.stats"
+  | "monitor.status"
+  | "monitor.setPaused"
+  | "monitor.setInterval"
+  | "monitor.clearError"
+  | "monitor.close";
+
+/** Dispatch a granular `monitor.*` intent, resolving with the ack (parity tests). */
+export function dispatchMonitorIntent(
+  kind: MonitorIntentKind,
+  payload: Record<string, unknown>
+): Promise<IntentAck> {
+  return transport().dispatch({ intentId: newIntentId(), kind, payload, clientId });
+}
+
+/**
+ * Fire a granular `monitor.*` intent to keep the backend store authoritative,
+ * swallowing and logging any failure so the local `appStore` mutation path is
+ * never disrupted by a bridge hiccup (the resilience fallback). A no-op when the
+ * mutation cut is disabled ({@link monitorIntentsEnabled} off — the rollback path).
+ * Never throws — a synchronous transport-construction failure (non-Tauri, no
+ * socket) is caught and logged, leaving the UI on the local slice. The twin of the
+ * session bridge's {@link import("./sessionBridge").mirrorSessionIntent}.
+ */
+export function mirrorMonitorIntent(
+  kind: MonitorIntentKind,
+  payload: Record<string, unknown>
+): void {
+  if (!monitorIntentsEnabled()) return;
+  try {
+    void dispatchMonitorIntent(kind, payload)
+      .then((ack) => {
+        if (ack.status === "rejected") {
+          logMonitorBridgeFallback(kind, new Error(ack.error?.message ?? "rejected"));
+        }
+      })
+      .catch((err) => logMonitorBridgeFallback(kind, err));
+  } catch (err) {
+    logMonitorBridgeFallback(kind, err);
   }
 }
 


### PR DESCRIPTION
Part of #2224 (Phase 5 · Monitors — mutation cut). The shadow (#2230) and render cut (#2244) are merged; this cuts the monitor **actions** over to the backend `monitor.*` intents so the `SystemMonitorStore` becomes authoritative. The render-cut mirror (`useProjectedMonitors`) already reflects the region back into the status bar and Open Connections. The reducer removal is the next (final) step and is intentionally out of scope here.

## What changed

- **`systemMonitorBridge.ts`** — adds `monitorIntentsEnabled()` (default **on**, runtime-flippable via `window.__TERMIHUB_MONITOR_INTENTS__` / `localStorage["termihub.monitorIntents"]` for **instant revert**), plus `dispatchMonitorIntent` / `mirrorMonitorIntent` (fire-and-forget granular dispatch that logs and swallows failures). Twin of the session bridge's `mirrorSessionIntent`.
- **`appStore.ts`** — the monitor lifecycle actions mirror their transitions through the granular intents:
  - `connectMonitoring` → `monitor.open` / `monitor.opened` / `monitor.openFailed`, and its stats/status event listeners → `monitor.stats` / `monitor.status`
  - `setMonitoringPaused` → `monitor.setPaused` (incl. the rollback revert), `setMonitoringInterval` → `monitor.setInterval`, `clearMonitoringError` → `monitor.clearError`
  - `disconnectMonitoring` / `cancelMonitoring` → `monitor.close` per key
  - The **local reducer path is retained unchanged** as the render source and the resilience/rollback fallback — deleting it is the reducer-removal step.
- **Parity tests** (`appStore.monitoringMutationCut.test.ts`) — a faithful in-memory port of the Rust store applies the dispatched intents; the tests assert the reconstructed `system-monitors` region equals the `appStore` slice (`monitors` + `monitoringStatsCache`) for **each action and its fan-out** (connect, failed open, stats/status pushes, pause + rollback, interval, clear-error, disconnect, cancel, multi-monitor, full lifecycle), plus a **flag-off** test proving no intents dispatch and the local path is byte-identical.

## Verification

- Frontend suite green (4818 passed), ESLint clean, `prettier --check` clean.
- No Rust changed — the `monitor.*` intents already exist from the shadow (#2230); their effects are covered by the Rust store/projection tests.
- Per the maintainer's **proceed-on-tests** decision (same as the session flip #2233), GUI parity relies on the comprehensive automated parity tests + the instant local fallback rather than a hands-on GUI gate. Ships **on by default**; flip the flag off to revert instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)