### PR TITLE
feat(agent): render the agent sidebar and open connections from the agents projection

### DIFF
--- a/src-tauri/src/agents_projection/projection.rs
+++ b/src-tauri/src/agents_projection/projection.rs
@@ -44,6 +44,7 @@
 //! | `agent.createFolder`      | `{ id, folder }`                             | append a folder                      |
 //! | `agent.updateFolder`      | `{ id, folder }`                             | replace a folder by id               |
 //! | `agent.deleteFolder`      | `{ id, folderId }`                           | remove a folder + reparent defs      |
+//! | `agent.replace`           | `{ agents, sessions, definitions, folders }` | overwrite the whole slice (mirror)   |
 //!
 //! # Shadow mode
 //!
@@ -54,13 +55,14 @@
 //! an intent is never returned inline — it always arrives as a projection diff on
 //! the `agents` region.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use serde_json::Value;
 use tauri::{AppHandle, Manager};
 
 use crate::agents_projection::store::{
-    AgentConnectionState, AgentDefinition, AgentFolder, AgentsStore,
+    AgentConnectionState, AgentDefinition, AgentEntry, AgentFolder, AgentSession, AgentsStore,
 };
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
 
@@ -235,13 +237,21 @@ pub fn register_agent_intents(registry: &mut HandlerRegistry, app_handle: AppHan
         Ok(publish_agents(projector, &store))
     });
 
-    let handle = app_handle;
+    let handle = app_handle.clone();
     registry.route("agent.deleteFolder", move |intent, projector| {
         let store = store_of(&handle)?;
         store.delete_folder(
             &required_str(intent, "id")?,
             &required_str(intent, "folderId")?,
         );
+        Ok(publish_agents(projector, &store))
+    });
+
+    let handle = app_handle;
+    registry.route("agent.replace", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let (agents, sessions, definitions, folders) = required_replace(intent)?;
+        store.replace(agents, sessions, definitions, folders);
         Ok(publish_agents(projector, &store))
     });
 }
@@ -338,6 +348,45 @@ fn required_list<T: serde::de::DeserializeOwned>(
         .get(key)
         .ok_or_else(|| bad_payload(&format!("missing '{key}'")))?;
     serde_json::from_value(value.clone()).map_err(|e| bad_payload(&format!("invalid {key}: {e}")))
+}
+
+/// Parse an optional typed field, treating an absent or `null` value as the type's
+/// default (an empty list/map). Lets a mirror that clears a whole sub-slice be
+/// expressed by omitting the field; a present-but-malformed field is a
+/// `bad_payload` rejection that advances nothing.
+fn optional_typed<T: serde::de::DeserializeOwned + Default>(
+    intent: &Intent,
+    key: &str,
+) -> Result<T, (String, String)> {
+    match intent.payload.get(key) {
+        None | Some(Value::Null) => Ok(T::default()),
+        Some(value) => serde_json::from_value(value.clone())
+            .map_err(|e| bad_payload(&format!("invalid {key}: {e}"))),
+    }
+}
+
+/// Parse an `agent.replace` payload into the whole-slice snapshot the render-cut
+/// mirror carries: `{ agents: [AgentEntry], sessions: {…}, definitions: {…},
+/// folders: {…} }` — the shape of [`AgentsStore::snapshot`]. Any field absent is
+/// treated as empty, so a mirror that clears all agents is expressible.
+#[allow(clippy::type_complexity)]
+fn required_replace(
+    intent: &Intent,
+) -> Result<
+    (
+        Vec<AgentEntry>,
+        HashMap<String, Vec<AgentSession>>,
+        HashMap<String, Vec<AgentDefinition>>,
+        HashMap<String, Vec<AgentFolder>>,
+    ),
+    (String, String),
+> {
+    Ok((
+        optional_typed(intent, "agents")?,
+        optional_typed(intent, "sessions")?,
+        optional_typed(intent, "definitions")?,
+        optional_typed(intent, "folders")?,
+    ))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/agents_projection/projection_tests.rs
+++ b/src-tauri/src/agents_projection/projection_tests.rs
@@ -94,9 +94,36 @@ fn registry_for(store: Arc<AgentsStore>) -> HandlerRegistry {
         s.disconnect(&required_str(intent, "id")?);
         Ok(publish_agents(projector, &s))
     });
-    let s = store;
+    let s = store.clone();
     registry.route("agent.remove", move |intent, projector| {
         s.remove(&required_str(intent, "id")?);
+        Ok(publish_agents(projector, &s))
+    });
+    let s = store;
+    registry.route("agent.replace", move |intent, projector| {
+        let agents =
+            serde_json::from_value(intent.payload.get("agents").cloned().unwrap_or(json!([])))
+                .map_err(|e| ("bad_payload".to_string(), format!("invalid agents: {e}")))?;
+        let sessions =
+            serde_json::from_value(intent.payload.get("sessions").cloned().unwrap_or(json!({})))
+                .map_err(|e| ("bad_payload".to_string(), format!("invalid sessions: {e}")))?;
+        let definitions = serde_json::from_value(
+            intent
+                .payload
+                .get("definitions")
+                .cloned()
+                .unwrap_or(json!({})),
+        )
+        .map_err(|e| {
+            (
+                "bad_payload".to_string(),
+                format!("invalid definitions: {e}"),
+            )
+        })?;
+        let folders =
+            serde_json::from_value(intent.payload.get("folders").cloned().unwrap_or(json!({})))
+                .map_err(|e| ("bad_payload".to_string(), format!("invalid folders: {e}")))?;
+        s.replace(agents, sessions, definitions, folders);
         Ok(publish_agents(projector, &s))
     });
 
@@ -388,4 +415,48 @@ fn a_dead_subscriber_is_reaped_on_publish() {
         1,
         "the dead subscriber was reaped"
     );
+}
+
+#[test]
+fn replace_mirrors_a_whole_snapshot_in_one_diff_and_converges() {
+    // The render-cut mirror (#2226): an `agent.replace` carrying `appStore`'s
+    // whole agents slice converges the region on it in a single coalesced diff.
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(AGENTS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(AGENTS_REGION, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    let ack = dispatcher.dispatch(intent(
+        "agent.replace",
+        json!({
+            "agents": [{
+                "id": "a1",
+                "name": "Only",
+                "config": { "host": "h1" },
+                "agentSettings": {},
+                "isExpanded": true,
+                "connectionState": "connected"
+            }],
+            "sessions": { "a1": [{ "sessionId": "s1", "title": "t", "type": "shell", "status": "running", "attached": true }] },
+            "definitions": { "a1": [{ "id": "d1", "name": "def", "sessionType": "shell", "config": {}, "persistent": false, "folderId": null }] },
+            "folders": { "a1": [{ "id": "f1", "name": "F", "parentId": null, "isExpanded": true }] }
+        }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "one coalesced diff for the whole replace");
+    cache.apply(&diffs[0]);
+    assert_eq!(
+        cache.view,
+        store.snapshot(),
+        "cache converges on the mirror"
+    );
+    assert_eq!(cache.view["agents"].as_array().unwrap().len(), 1);
+    assert_eq!(cache.view["agents"][0]["name"], json!("Only"));
+    assert!(store.get("a2").is_none(), "replace dropped the prior agent");
 }

--- a/src-tauri/src/agents_projection/store.rs
+++ b/src-tauri/src/agents_projection/store.rs
@@ -411,6 +411,29 @@ impl AgentsStore {
         }
     }
 
+    // ── Whole-region mirror (render-cut seed) ─────────────────────────────────
+
+    /// `agent.replace` — overwrite the whole agents slice (the ordered agent list
+    /// plus the per-agent sessions/definitions/folders maps) with a
+    /// caller-supplied snapshot. Used by the frontend render-cut mirror (#2226) to
+    /// keep the shared `agents` region a faithful copy of `appStore`'s agents slice
+    /// while `appStore` remains authoritative (the mutation cut is a later step) —
+    /// the analog of the system-monitor bridge's `monitor.replace` seed. Idempotent
+    /// server-side: replacing with the same content yields no diff.
+    pub fn replace(
+        &self,
+        agents: Vec<AgentEntry>,
+        sessions: HashMap<String, Vec<AgentSession>>,
+        definitions: HashMap<String, Vec<AgentDefinition>>,
+        folders: HashMap<String, Vec<AgentFolder>>,
+    ) {
+        let mut inner = self.lock();
+        inner.agents = agents;
+        inner.sessions = sessions;
+        inner.definitions = definitions;
+        inner.folders = folders;
+    }
+
     /// Read one agent entry (test / diagnostics helper).
     #[cfg(test)]
     pub fn get(&self, id: &str) -> Option<AgentEntry> {

--- a/src-tauri/src/agents_projection/store_tests.rs
+++ b/src-tauri/src/agents_projection/store_tests.rs
@@ -330,3 +330,64 @@ fn the_snapshot_preserves_agent_order() {
         .collect();
     assert_eq!(ids, vec!["a2", "a1"]);
 }
+
+#[test]
+fn replace_overwrites_the_whole_slice_with_a_snapshot() {
+    // Build a populated source store the render-cut mirror would copy from.
+    let source = AgentsStore::new();
+    source.add("a1", "One", config("h1"), settings());
+    source.add("a2", "Two", config("h2"), settings());
+    source.set_status("a1", AgentConnectionState::Connected, None);
+    source.refresh(
+        "a1",
+        vec![session("s1")],
+        vec![definition("d1", Some("f1"))],
+        vec![folder("f1")],
+    );
+    let snapshot = source.snapshot();
+
+    // Deserialize the source view back into the typed slice the replace carries.
+    let agents: Vec<super::AgentEntry> =
+        serde_json::from_value(snapshot["agents"].clone()).unwrap();
+    let sessions = serde_json::from_value(snapshot["sessions"].clone()).unwrap();
+    let definitions = serde_json::from_value(snapshot["definitions"].clone()).unwrap();
+    let folders = serde_json::from_value(snapshot["folders"].clone()).unwrap();
+
+    // Prime a target with unrelated state that replace must fully overwrite.
+    let target = AgentsStore::new();
+    target.add("old", "Stale", config("old"), settings());
+    target.refresh("old", vec![session("x")], vec![], vec![]);
+
+    target.replace(agents, sessions, definitions, folders);
+
+    assert!(target.get("old").is_none(), "replace drops prior agents");
+    assert_eq!(
+        target.snapshot(),
+        source.snapshot(),
+        "replace makes the store a faithful copy of the source slice"
+    );
+}
+
+#[test]
+fn replace_with_empty_maps_clears_everything() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.refresh(
+        "a1",
+        vec![session("s1")],
+        vec![definition("d1", None)],
+        vec![],
+    );
+
+    store.replace(
+        Vec::new(),
+        Default::default(),
+        Default::default(),
+        Default::default(),
+    );
+
+    assert_eq!(
+        store.snapshot(),
+        json!({ "agents": [], "sessions": {}, "definitions": {}, "folders": {} })
+    );
+}

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -36,6 +36,7 @@ import type { TransferState } from "@/types/connection";
 import type { MonitoringEntry } from "@/types/monitoring";
 import { MONITORING_INTERVAL_OPTIONS, DEFAULT_MONITORING_INTERVAL_MS } from "@/types/monitoring";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedAgents } from "@/store/useProjectedAgents";
 import { useProjectedMonitors } from "@/store/useProjectedMonitors";
 import { getAllLeaves } from "@/utils/panelTree";
 import {
@@ -86,7 +87,9 @@ interface ProxySessionsState {
  * user kill individual connections or entire sections at once.
  */
 export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModalProps) {
-  const remoteAgents = useAppStore((s) => s.remoteAgents);
+  // The ordered remote-agent list, sourced from the projected `agents` region when
+  // it faithfully mirrors `appStore`, else `appStore` verbatim (#2226 render cut).
+  const { remoteAgents } = useProjectedAgents();
   const desktopVersion = useDesktopVersion();
   // How many native windows are open. The owning-window badge/focus affordance
   // (#1926) is shown only with >1 window, so single-window users see no change —

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -39,6 +39,7 @@ import {
 import { ConnectionIcon } from "@/utils/connectionIcons";
 import { Button, Tooltip, toast } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedAgents } from "@/store/useProjectedAgents";
 import { frontendLog } from "@/utils/frontendLog";
 import { RemoteAgentDefinition } from "@/types/connection";
 import {
@@ -688,9 +689,17 @@ export function AgentNode({ agent, style, sectionRef, filterQuery = "" }: AgentN
   const openConnectionEditorTab = useAppStore((s) => s.openConnectionEditorTab);
   const requestPassword = useAppStore((s) => s.requestPassword);
   const addTab = useAppStore((s) => s.addTab);
-  const agentSessions = useAppStore((s) => s.agentSessions[agent.id]) ?? EMPTY_SESSIONS;
-  const agentDefinitions = useAppStore((s) => s.agentDefinitions[agent.id]) ?? EMPTY_DEFINITIONS;
-  const agentFolders = useAppStore((s) => s.agentFolders[agent.id]) ?? EMPTY_FOLDERS;
+  // This agent's live sessions, saved definitions and folders, sourced from the
+  // projected `agents` region when it faithfully mirrors `appStore`, else
+  // `appStore` verbatim (#2226 render cut).
+  const {
+    agentSessions: projectedSessions,
+    agentDefinitions: projectedDefinitions,
+    agentFolders: projectedFolders,
+  } = useProjectedAgents();
+  const agentSessions = projectedSessions[agent.id] ?? EMPTY_SESSIONS;
+  const agentDefinitions = projectedDefinitions[agent.id] ?? EMPTY_DEFINITIONS;
+  const agentFolders = projectedFolders[agent.id] ?? EMPTY_FOLDERS;
   const refreshAgentSessions = useAppStore((s) => s.refreshAgentSessions);
   const createAgentFolder = useAppStore((s) => s.createAgentFolder);
   const openAgentDefinitionEditorTab = useAppStore((s) => s.openAgentDefinitionEditorTab);

--- a/src/components/Sidebar/ConnectionList.tsx
+++ b/src/components/Sidebar/ConnectionList.tsx
@@ -37,6 +37,7 @@ import {
 } from "lucide-react";
 import { open as openFileDialog } from "@tauri-apps/plugin-dialog";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedAgents } from "@/store/useProjectedAgents";
 import { SavedConnection, ConnectionFolder, InventoryHost } from "@/types/connection";
 import { type AgentDefinitionInfo, importInventoryHosts } from "@/services/api";
 import { toast } from "@/components/ui";
@@ -622,7 +623,10 @@ export function ConnectionList() {
   const folders = useAppStore((s) => s.folders);
   const allConnections = useAppStore((s) => s.connections);
   const connectionTypes = useAppStore((s) => s.connectionTypes);
-  const remoteAgents = useAppStore((s) => s.remoteAgents);
+  // The ordered remote-agent list + per-agent saved-definition map, sourced from
+  // the projected `agents` region when it faithfully mirrors `appStore`, else
+  // `appStore` verbatim (#2226 render cut).
+  const { remoteAgents, agentDefinitions } = useProjectedAgents();
   const experimental = useExperimentalFeatures();
 
   // Gate experimental (graphical remote-desktop) connections out of the sidebar
@@ -648,7 +652,6 @@ export function ConnectionList() {
   const reorderRemoteAgents = useAppStore((s) => s.reorderRemoteAgents);
   const moveAgentDefToFolder = useAppStore((s) => s.moveAgentDefToFolder);
   const bulkMoveAgentDefsToFolder = useAppStore((s) => s.bulkMoveAgentDefsToFolder);
-  const agentDefinitions = useAppStore((s) => s.agentDefinitions);
 
   const pointerSensor = useSensor(PointerSensor, {
     activationConstraint: { distance: 8 },

--- a/src/store/agentsBridge.test.ts
+++ b/src/store/agentsBridge.test.ts
@@ -1,0 +1,288 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { AgentDefinitionInfo, AgentFolderInfo, AgentSessionInfo } from "@/services/api";
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import type { RemoteAgentDefinition } from "@/types/connection";
+
+import {
+  AGENTS_REGION,
+  agentRenderFromProjectionEnabled,
+  agentsViewMirrors,
+  currentAgentsView,
+  deepEqual,
+  ensureAgentsSubscribed,
+  onAgentsView,
+  seedAgentsRegion,
+  setAgentRenderFromProjectionEnabled,
+  setAgentTransportForTest,
+  stopAgentsSubscription,
+  type AgentsView,
+} from "./agentsBridge";
+
+/** A deterministic remote-agent definition. */
+function agent(
+  id: string,
+  connectionState: RemoteAgentDefinition["connectionState"] = "disconnected"
+): RemoteAgentDefinition {
+  return {
+    id,
+    name: `Agent ${id}`,
+    config: { host: `h-${id}`, port: 22, authMethod: "password" } as never,
+    agentSettings: { autoReconnect: true } as never,
+    isExpanded: false,
+    connectionState,
+  };
+}
+
+function session(id: string): AgentSessionInfo {
+  return { sessionId: id, title: `s ${id}`, type: "shell", status: "running", attached: true };
+}
+
+function definition(id: string): AgentDefinitionInfo {
+  return {
+    id,
+    name: `def ${id}`,
+    sessionType: "shell",
+    config: {},
+    persistent: false,
+    folderId: null,
+  };
+}
+
+function folder(id: string): AgentFolderInfo {
+  return { id, name: `F ${id}`, parentId: null, isExpanded: true };
+}
+
+/**
+ * An in-memory substrate double: holds one `agents` view, applies an
+ * `agent.replace` intent by overwriting the view from its payload (keyed to the
+ * Rust snapshot shape `agents/sessions/definitions/folders`), and fans a fresh
+ * snapshot to every subscriber — so the seed round-trip and multi-subscriber
+ * fan-out are exercised without a backend.
+ */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  private view: Record<string, unknown> = {
+    agents: [],
+    sessions: {},
+    definitions: {},
+    folders: {},
+  };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (intent.kind === "agent.replace") {
+      const p = intent.payload as Record<string, unknown>;
+      this.view = {
+        agents: p.agents ?? [],
+        sessions: p.sessions ?? {},
+        definitions: p.definitions ?? {},
+        folders: p.folders ?? {},
+      };
+      this.version += 1;
+      this.fan();
+      return {
+        intentId: intent.intentId,
+        status: "accepted",
+        produced: [{ region: AGENTS_REGION, version: this.version }],
+      };
+    }
+    return { intentId: intent.intentId, status: "accepted", produced: [] };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(AGENTS_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+let transport: FakeTransport;
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setAgentTransportForTest(transport);
+});
+
+afterEach(() => {
+  stopAgentsSubscription();
+  setAgentTransportForTest(null);
+  setAgentRenderFromProjectionEnabled(null);
+});
+
+describe("agentRenderFromProjectionEnabled flag", () => {
+  it("defaults on and honours the programmatic override", () => {
+    expect(agentRenderFromProjectionEnabled()).toBe(true);
+    setAgentRenderFromProjectionEnabled(false);
+    expect(agentRenderFromProjectionEnabled()).toBe(false);
+    setAgentRenderFromProjectionEnabled(true);
+    expect(agentRenderFromProjectionEnabled()).toBe(true);
+    setAgentRenderFromProjectionEnabled(null);
+    expect(agentRenderFromProjectionEnabled()).toBe(true);
+  });
+});
+
+describe("deepEqual", () => {
+  it("treats an integer and its float round-trip as equal", () => {
+    expect(deepEqual(40, 40.0)).toBe(true);
+    expect(deepEqual({ a: [1, 2] }, { a: [1, 2] })).toBe(true);
+  });
+
+  it("distinguishes differing values, key sets, and null", () => {
+    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(deepEqual(null, {})).toBe(false);
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+  });
+});
+
+describe("agentsViewMirrors", () => {
+  const remoteAgents = [agent("a1", "connected")];
+  const agentSessions = { a1: [session("s1")] };
+  const agentDefinitions = { a1: [definition("d1")] };
+  const agentFolders = { a1: [folder("f1")] };
+
+  it("is false for an undefined view", () => {
+    expect(
+      agentsViewMirrors(undefined, remoteAgents, agentSessions, agentDefinitions, agentFolders)
+    ).toBe(false);
+  });
+
+  it("is true when the view value-matches the appStore slice", () => {
+    const view: AgentsView = {
+      remoteAgents: structuredClone(remoteAgents),
+      agentSessions: structuredClone(agentSessions),
+      agentDefinitions: structuredClone(agentDefinitions),
+      agentFolders: structuredClone(agentFolders),
+    };
+    expect(
+      agentsViewMirrors(view, remoteAgents, agentSessions, agentDefinitions, agentFolders)
+    ).toBe(true);
+  });
+
+  it("is false when the connection status diverges", () => {
+    const view: AgentsView = {
+      remoteAgents: [{ ...remoteAgents[0], connectionState: "disconnected" }],
+      agentSessions,
+      agentDefinitions,
+      agentFolders,
+    };
+    expect(
+      agentsViewMirrors(view, remoteAgents, agentSessions, agentDefinitions, agentFolders)
+    ).toBe(false);
+  });
+
+  it("is false when a per-agent sub-map diverges", () => {
+    const view: AgentsView = {
+      remoteAgents,
+      agentSessions: { a1: [session("s1"), session("s2")] },
+      agentDefinitions,
+      agentFolders,
+    };
+    expect(
+      agentsViewMirrors(view, remoteAgents, agentSessions, agentDefinitions, agentFolders)
+    ).toBe(false);
+  });
+
+  it("is false when the agent list order diverges", () => {
+    const twoAgents = [agent("a1", "connected"), agent("a2")];
+    const reversed = [agent("a2"), agent("a1", "connected")];
+    const view: AgentsView = {
+      remoteAgents: reversed,
+      agentSessions: {},
+      agentDefinitions: {},
+      agentFolders: {},
+    };
+    expect(agentsViewMirrors(view, twoAgents, {}, {}, {})).toBe(false);
+  });
+});
+
+describe("seedAgentsRegion", () => {
+  it("dispatches agent.replace carrying the whole slice, keyed to the Rust shape", async () => {
+    const remoteAgents = [agent("a1", "connected")];
+    const agentSessions = { a1: [session("s1")] };
+    const agentDefinitions = { a1: [definition("d1")] };
+    const agentFolders = { a1: [folder("f1")] };
+    await seedAgentsRegion(remoteAgents, agentSessions, agentDefinitions, agentFolders);
+    expect(transport.dispatched).toHaveLength(1);
+    expect(transport.dispatched[0]).toMatchObject({
+      kind: "agent.replace",
+      payload: {
+        agents: remoteAgents,
+        sessions: agentSessions,
+        definitions: agentDefinitions,
+        folders: agentFolders,
+      },
+    });
+  });
+
+  it("de-dupes an identical slice but re-seeds after a change", async () => {
+    const remoteAgents = [agent("a1")];
+    await seedAgentsRegion(remoteAgents, {}, {}, {});
+    await seedAgentsRegion(remoteAgents, {}, {}, {});
+    expect(transport.dispatched).toHaveLength(1);
+
+    const changed = [agent("a1", "connected")];
+    await seedAgentsRegion(changed, {}, {}, {});
+    expect(transport.dispatched).toHaveLength(2);
+  });
+});
+
+describe("seed round-trip → the region mirrors appStore", () => {
+  it("makes the projected view a faithful mirror of the seeded slice", async () => {
+    const received: AgentsView[] = [];
+    const unsubscribe = onAgentsView((v) => received.push(v));
+    await ensureAgentsSubscribed();
+
+    const remoteAgents = [agent("a1", "connected")];
+    const agentSessions = { a1: [session("s1")] };
+    const agentDefinitions = { a1: [definition("d1")] };
+    const agentFolders = { a1: [folder("f1")] };
+    await seedAgentsRegion(remoteAgents, agentSessions, agentDefinitions, agentFolders);
+
+    // The region now carries the seeded slice and the gate accepts it.
+    expect(
+      agentsViewMirrors(
+        currentAgentsView(),
+        remoteAgents,
+        agentSessions,
+        agentDefinitions,
+        agentFolders
+      )
+    ).toBe(true);
+    expect(received[received.length - 1]).toEqual({
+      remoteAgents,
+      agentSessions,
+      agentDefinitions,
+      agentFolders,
+    });
+    unsubscribe();
+  });
+});

--- a/src/store/agentsBridge.ts
+++ b/src/store/agentsBridge.ts
@@ -1,0 +1,357 @@
+/**
+ * Agents projection bridge — Phase 5 render cut of the Agents domain (#2226,
+ * part of #2139).
+ *
+ * The Agents **shadow** (PR #2232) landed a backend-authoritative
+ * [`AgentsStore`](../../src-tauri/src/agents_projection/store.rs) served as the
+ * shared `agents` projection region, with `agent.*` intents, but nothing in the
+ * UI touched it. This step makes the **agent sidebar** and **Open Connections**
+ * source the agent list, connection status and per-agent
+ * sessions/definitions/folders from that region — the parity-safe render cut (the
+ * direct analog of the system-monitor render cut
+ * {@link import("./systemMonitorBridge")}, #2224, and the session render cut
+ * {@link import("./useSessionLifecycle")}, #2204).
+ *
+ * # Strangler safety — flag-gated, on by default, faithful-mirror gate
+ *
+ * The `appStore` agents slice is still authoritative (the mutation cut is a later
+ * step). To keep the render cut parity-safe **independent of any mutation flag**,
+ * the region is kept a faithful copy of `appStore` by {@link seedAgentsRegion} (an
+ * `agent.replace` mirror, the analog of the monitor bridge's `monitor.replace`
+ * seed), and the UI renders from the region **only when it faithfully mirrors**
+ * `appStore` ({@link agentsViewMirrors}); otherwise it falls back to `appStore`
+ * verbatim. Because the gate guarantees the projected view deep-equals `appStore`'s
+ * slice, the rendered output is byte-identical to the pre-cut path.
+ *
+ * Gated by {@link agentRenderFromProjectionEnabled} — **on by default**.
+ * Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_AGENT_RENDER_FROM_PROJECTION__` or
+ * `localStorage["termihub.agentRenderFromProjection"]` (set `"false"` to render
+ * straight from `appStore`).
+ */
+
+import {
+  createTransport,
+  newClientId,
+  newIntentId,
+  ProjectionClient,
+  type IntentAck,
+  type Transport,
+} from "@/services/transport";
+import type { AgentDefinitionInfo, AgentFolderInfo, AgentSessionInfo } from "@/services/api";
+import type { RemoteAgentDefinition } from "@/types/connection";
+import { frontendLog } from "@/utils/frontendLog";
+
+/** The projection region id for the agents domain (twin of the Rust
+ * `AGENTS_REGION` const). Shared (Open Design Decision #4). */
+export const AGENTS_REGION = "agents";
+
+/**
+ * The projected agents view model, in `appStore` terms — a twin of the Rust store
+ * snapshot with the frontend slice's field names: the ordered agent list plus the
+ * per-agent live sessions, saved definitions and folders. The projected records
+ * match the frontend {@link RemoteAgentDefinition} / {@link AgentSessionInfo} /
+ * {@link AgentDefinitionInfo} / {@link AgentFolderInfo} shapes one-to-one, so the
+ * render cut is a pure parity swap.
+ */
+export interface AgentsView {
+  remoteAgents: RemoteAgentDefinition[];
+  agentSessions: Record<string, AgentSessionInfo[]>;
+  agentDefinitions: Record<string, AgentDefinitionInfo[]>;
+  agentFolders: Record<string, AgentFolderInfo[]>;
+}
+
+/** The empty view a fresh region reports (twin of the empty store snapshot). */
+const EMPTY_VIEW: AgentsView = {
+  remoteAgents: [],
+  agentSessions: {},
+  agentDefinitions: {},
+  agentFolders: {},
+};
+
+/**
+ * The raw region view model as the Rust store serialises it, keyed
+ * `agents/sessions/definitions/folders` (see `AgentsStore::snapshot`). Mapped to
+ * the `appStore`-named {@link AgentsView} on the way in ({@link toView}) and back
+ * on the way out ({@link seedAgentsRegion}).
+ */
+interface AgentsRegionSnapshot {
+  agents?: RemoteAgentDefinition[];
+  sessions?: Record<string, AgentSessionInfo[]>;
+  definitions?: Record<string, AgentDefinitionInfo[]>;
+  folders?: Record<string, AgentFolderInfo[]>;
+}
+
+/** Translate the raw region snapshot into the `appStore`-named view. */
+function toView(raw: AgentsRegionSnapshot): AgentsView {
+  return {
+    remoteAgents: raw.agents ?? [],
+    agentSessions: raw.sessions ?? {},
+    agentDefinitions: raw.definitions ?? {},
+    agentFolders: raw.folders ?? {},
+  };
+}
+
+// ── Render-cut feature flag (runtime-flippable, on by default) ─────────────────
+
+let renderFlagOverride: boolean | null = null;
+
+interface AgentRenderFlagWindow {
+  __TERMIHUB_AGENT_RENDER_FROM_PROJECTION__?: boolean;
+  localStorage?: Storage;
+}
+
+/**
+ * Programmatic override for the render-cut flag (tests, and a runtime toggle).
+ * `null` clears the override and falls back to the window/localStorage signal,
+ * then to the default (on).
+ */
+export function setAgentRenderFromProjectionEnabled(value: boolean | null): void {
+  renderFlagOverride = value;
+}
+
+/**
+ * Whether the agent sidebar and Open Connections render the agent list,
+ * connection status and per-agent sessions/definitions/folders from the projected
+ * `agents` region instead of reading `appStore`'s agents slice directly.
+ *
+ * **On by default** — the render cut is parity-safe: the UI renders from the
+ * region only when it faithfully mirrors `appStore` ({@link agentsViewMirrors}),
+ * and otherwise falls back to `appStore` verbatim, so the output is byte-identical
+ * to the pre-cut path. Independent of the (later) mutation cut: the region is kept
+ * a mirror of `appStore` by {@link seedAgentsRegion}, so it is always populated.
+ * Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_AGENT_RENDER_FROM_PROJECTION__` or
+ * `localStorage["termihub.agentRenderFromProjection"]`.
+ */
+export function agentRenderFromProjectionEnabled(): boolean {
+  if (renderFlagOverride !== null) return renderFlagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as AgentRenderFlagWindow;
+      if (typeof w.__TERMIHUB_AGENT_RENDER_FROM_PROJECTION__ === "boolean") {
+        return w.__TERMIHUB_AGENT_RENDER_FROM_PROJECTION__;
+      }
+      const ls = w.localStorage?.getItem("termihub.agentRenderFromProjection");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return true;
+}
+
+// ── Transport + shared region client (lazy, mirrors the monitor slice) ─────────
+
+let transportInstance: Transport | null = null;
+let regionClient: ProjectionClient | null = null;
+let startPromise: Promise<ProjectionClient> | null = null;
+
+// A stable per-session client identity for dispatched intents (fan-out / audit
+// only; the shared region's diff reaches every subscriber regardless of who
+// dispatched it).
+const clientId = newClientId();
+
+/** Inject a transport for tests; `null` restores the lazily-created real one and
+ * drops any active subscription / seed dedup. */
+export function setAgentTransportForTest(t: Transport | null): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  transportInstance = t;
+  lastView = EMPTY_VIEW;
+  lastSeededSignature = null;
+}
+
+function transport(): Transport {
+  if (!transportInstance) {
+    transportInstance = createTransport();
+  }
+  return transportInstance;
+}
+
+// ── View fan-out (one subscription, many consuming hooks) ──────────────────────
+
+/** A change listener for the projected `agents` view. */
+export type AgentsViewListener = (view: AgentsView) => void;
+
+const viewListeners = new Set<AgentsViewListener>();
+let lastView: AgentsView = EMPTY_VIEW;
+
+/**
+ * Register a listener, invoked with the projected view on every diff. Returns an
+ * unsubscribe. The region client is started on first use.
+ */
+export function onAgentsView(listener: AgentsViewListener): () => void {
+  viewListeners.add(listener);
+  return () => viewListeners.delete(listener);
+}
+
+/**
+ * Ensure the shared `agents` region client is subscribed so projected diffs are
+ * received and fanned out to the {@link onAgentsView} listeners. Idempotent and
+ * de-duplicated across concurrent callers; a transport/subscribe failure is logged
+ * and rethrown so the caller can fall back to `appStore`.
+ */
+export function ensureAgentsSubscribed(): Promise<ProjectionClient> {
+  if (regionClient) return Promise.resolve(regionClient);
+  if (!startPromise) {
+    const client = new ProjectionClient(transport(), AGENTS_REGION);
+    client.onChange((state) => {
+      lastView = toView((state.view ?? {}) as AgentsRegionSnapshot);
+      for (const listener of viewListeners) {
+        try {
+          listener(lastView);
+        } catch (err) {
+          logAgentBridgeFallback("reconcile", err);
+        }
+      }
+    });
+    startPromise = client
+      .start()
+      .then(() => {
+        regionClient = client;
+        return client;
+      })
+      .catch((err) => {
+        startPromise = null;
+        logAgentBridgeFallback("subscribe", err);
+        throw err;
+      });
+  }
+  return startPromise;
+}
+
+/** Drop the region subscription (tests / re-init). */
+export function stopAgentsSubscription(): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  lastView = EMPTY_VIEW;
+  lastSeededSignature = null;
+}
+
+/** The last view fanned out (for a hook that subscribes after the first diff). */
+export function currentAgentsView(): AgentsView {
+  return lastView;
+}
+
+// ── Seed: keep the region a faithful mirror of appStore (agent.replace) ────────
+
+let lastSeededSignature: string | null = null;
+
+/**
+ * Seed the shared region with `appStore`'s whole agents slice via an
+ * `agent.replace` intent, so the projection tracks `appStore`'s current state
+ * while `appStore` stays authoritative (the render-side counterpart to the monitor
+ * bridge's seed). The payload is keyed to the Rust snapshot shape
+ * (`agents/sessions/definitions/folders`). De-duplicated: a slice identical to the
+ * last seeded one is not re-dispatched. Never throws synchronously — a transport
+ * that cannot dispatch surfaces as a rejected promise the caller logs and ignores
+ * (staying on the `appStore` fallback). Idempotent server-side: replacing with the
+ * same content yields no diff.
+ */
+export function seedAgentsRegion(
+  remoteAgents: RemoteAgentDefinition[],
+  agentSessions: Record<string, AgentSessionInfo[]>,
+  agentDefinitions: Record<string, AgentDefinitionInfo[]>,
+  agentFolders: Record<string, AgentFolderInfo[]>
+): Promise<void> {
+  const payload = {
+    agents: remoteAgents,
+    sessions: agentSessions,
+    definitions: agentDefinitions,
+    folders: agentFolders,
+  };
+  const signature = JSON.stringify(payload);
+  if (signature === lastSeededSignature) return Promise.resolve();
+  // Set before dispatching so concurrent callers (sidebar + Open Connections) do
+  // not double-dispatch the same seed.
+  lastSeededSignature = signature;
+  try {
+    return transport()
+      .dispatch({
+        intentId: newIntentId(),
+        kind: "agent.replace",
+        payload,
+        clientId,
+      })
+      .then((ack: IntentAck) => {
+        if (ack.status === "rejected") {
+          // Let a later change retry the seed rather than latch on a failure.
+          lastSeededSignature = null;
+          throw new Error(ack.error?.message ?? "agent.replace rejected");
+        }
+      })
+      .catch((err) => {
+        lastSeededSignature = null;
+        throw err;
+      });
+  } catch (err) {
+    // A synchronous transport-construction failure (non-Tauri, no socket).
+    lastSeededSignature = null;
+    return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+// ── Faithful-mirror gate ───────────────────────────────────────────────────────
+
+/**
+ * Whether a projected `view` faithfully mirrors `appStore`'s agents slice — the
+ * gate deciding whether the UI may render from the projection (true) or must fall
+ * back to `appStore` (false). A deep value comparison of the ordered agent list
+ * and the per-agent sessions/definitions/folders maps; because the projected
+ * records match the frontend shapes one-to-one, a mirroring view is
+ * value-identical to the `appStore` slice, so rendering from it can never diverge.
+ *
+ * The twin of the monitor render cut's `monitorsViewMirrors`.
+ */
+export function agentsViewMirrors(
+  view: AgentsView | undefined,
+  remoteAgents: RemoteAgentDefinition[],
+  agentSessions: Record<string, AgentSessionInfo[]>,
+  agentDefinitions: Record<string, AgentDefinitionInfo[]>,
+  agentFolders: Record<string, AgentFolderInfo[]>
+): boolean {
+  if (!view) return false;
+  return (
+    deepEqual(view.remoteAgents, remoteAgents) &&
+    deepEqual(view.agentSessions, agentSessions) &&
+    deepEqual(view.agentDefinitions, agentDefinitions) &&
+    deepEqual(view.agentFolders, agentFolders)
+  );
+}
+
+/**
+ * A structural deep-equal for the JSON-ish agents view model (objects, arrays, and
+ * primitives — no functions/dates/maps). Numbers compare with `===`, so an integer
+ * that round-tripped through JSON as a float (`40` vs `40.0`) still matches.
+ * Exported for the bridge's parity tests.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const ao = a as Record<string, unknown>;
+    const bo = b as Record<string, unknown>;
+    const aKeys = Object.keys(ao);
+    const bKeys = Object.keys(bo);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every(
+      (k) => Object.prototype.hasOwnProperty.call(bo, k) && deepEqual(ao[k], bo[k])
+    );
+  }
+  return false;
+}
+
+/** Log a bridge fallback so the appStore-path recovery is visible in the LogViewer. */
+export function logAgentBridgeFallback(kind: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  frontendLog("agent_bridge", `${kind} fell back to appStore agents: ${message}`);
+}

--- a/src/store/useProjectedAgents.test.tsx
+++ b/src/store/useProjectedAgents.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * `useProjectedAgents` — the agent sidebar & Open Connections cut to the projected
+ * `agents` region (#2226 render cut). Drives the hook against an in-memory
+ * substrate double and asserts: flag-off returns the appStore slice and dispatches
+ * nothing; flag-on seeds the region (an `agent.replace` mirror) and then renders
+ * the slice from the projection, value-identical to appStore; and a region that
+ * has not caught up falls back to the appStore slice.
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AgentDefinitionInfo, AgentFolderInfo, AgentSessionInfo } from "@/services/api";
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import { useAppStore } from "@/store/appStore";
+import type { RemoteAgentDefinition } from "@/types/connection";
+
+import {
+  AGENTS_REGION,
+  setAgentRenderFromProjectionEnabled,
+  setAgentTransportForTest,
+  stopAgentsSubscription,
+  type AgentsView,
+} from "./agentsBridge";
+import { useProjectedAgents } from "./useProjectedAgents";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  getSettings: vi.fn(() =>
+    Promise.resolve({ version: "1", externalConnectionFiles: [], powerMonitoringEnabled: true })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn(() => vi.fn()) }));
+
+function agent(
+  id: string,
+  connectionState: RemoteAgentDefinition["connectionState"] = "disconnected"
+): RemoteAgentDefinition {
+  return {
+    id,
+    name: `Agent ${id}`,
+    config: { host: `h-${id}`, port: 22, authMethod: "password" } as never,
+    agentSettings: { autoReconnect: true } as never,
+    isExpanded: false,
+    connectionState,
+  };
+}
+
+function session(id: string): AgentSessionInfo {
+  return { sessionId: id, title: `s ${id}`, type: "shell", status: "running", attached: true };
+}
+
+function definition(id: string): AgentDefinitionInfo {
+  return {
+    id,
+    name: `def ${id}`,
+    sessionType: "shell",
+    config: {},
+    persistent: false,
+    folderId: null,
+  };
+}
+
+function folder(id: string): AgentFolderInfo {
+  return { id, name: `F ${id}`, parentId: null, isExpanded: true };
+}
+
+/** In-memory substrate double: applies `agent.replace` and fans a snapshot. */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  /** When false, `agent.replace` acks but does NOT advance the region. */
+  applyReplace = true;
+  private view: Record<string, unknown> = {
+    agents: [],
+    sessions: {},
+    definitions: {},
+    folders: {},
+  };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (intent.kind === "agent.replace" && this.applyReplace) {
+      const p = intent.payload as Record<string, unknown>;
+      this.view = {
+        agents: p.agents ?? [],
+        sessions: p.sessions ?? {},
+        definitions: p.definitions ?? {},
+        folders: p.folders ?? {},
+      };
+      this.version += 1;
+      this.fan();
+    }
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: AGENTS_REGION, version: this.version }],
+    };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(AGENTS_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+/** Render the hook into a throwaway component, exposing the latest return value. */
+function renderHook(): { get: () => AgentsView; unmount: () => void } {
+  const container = document.createElement("div");
+  const root: Root = createRoot(container);
+  let latest: AgentsView = {
+    remoteAgents: [],
+    agentSessions: {},
+    agentDefinitions: {},
+    agentFolders: {},
+  };
+
+  function Probe() {
+    latest = useProjectedAgents();
+    return null;
+  }
+
+  act(() => root.render(<Probe />));
+  return { get: () => latest, unmount: () => act(() => root.unmount()) };
+}
+
+let transport: FakeTransport;
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setAgentTransportForTest(transport);
+  useAppStore.setState({
+    remoteAgents: [],
+    agentSessions: {},
+    agentDefinitions: {},
+    agentFolders: {},
+  });
+});
+
+afterEach(() => {
+  stopAgentsSubscription();
+  setAgentTransportForTest(null);
+  setAgentRenderFromProjectionEnabled(null);
+});
+
+const flush = () => act(async () => await Promise.resolve());
+
+describe("useProjectedAgents", () => {
+  it("flag off: returns the appStore slice and dispatches nothing", async () => {
+    setAgentRenderFromProjectionEnabled(false);
+    useAppStore.setState({
+      remoteAgents: [agent("a1", "connected")],
+      agentSessions: { a1: [session("s1")] },
+    });
+
+    const hook = renderHook();
+    await flush();
+
+    expect(hook.get().remoteAgents[0].connectionState).toBe("connected");
+    expect(hook.get().agentSessions.a1).toHaveLength(1);
+    expect(transport.dispatched).toHaveLength(0);
+    hook.unmount();
+  });
+
+  it("flag on: seeds the region then renders the slice from the projection", async () => {
+    const remoteAgents = [agent("a1", "connected")];
+    const agentSessions = { a1: [session("s1")] };
+    const agentDefinitions = { a1: [definition("d1")] };
+    const agentFolders = { a1: [folder("f1")] };
+    useAppStore.setState({ remoteAgents, agentSessions, agentDefinitions, agentFolders });
+
+    const hook = renderHook();
+    await flush();
+    await flush();
+
+    // The hook seeded appStore's slice via agent.replace…
+    expect(transport.dispatched.some((d) => d.kind === "agent.replace")).toBe(true);
+    // …and now renders a value-identical slice (sourced from the projection).
+    expect(hook.get().remoteAgents).toEqual(remoteAgents);
+    expect(hook.get().agentSessions).toEqual(agentSessions);
+    expect(hook.get().agentDefinitions).toEqual(agentDefinitions);
+    expect(hook.get().agentFolders).toEqual(agentFolders);
+    hook.unmount();
+  });
+
+  it("region not caught up: falls back to the appStore slice", async () => {
+    transport.applyReplace = false; // the replace acks but never advances the region
+    const remoteAgents = [agent("a2", "reconnecting")];
+    useAppStore.setState({ remoteAgents });
+
+    const hook = renderHook();
+    await flush();
+    await flush();
+
+    // The projection stays empty, so the gate rejects it and the hook renders the
+    // appStore slice verbatim — parity preserved.
+    expect(hook.get().remoteAgents).toEqual(remoteAgents);
+    hook.unmount();
+  });
+});

--- a/src/store/useProjectedAgents.ts
+++ b/src/store/useProjectedAgents.ts
@@ -1,0 +1,104 @@
+/**
+ * `useProjectedAgents` — the agent sidebar & Open Connections cut to the projected
+ * `agents` region (#2226 render cut, part of #2139).
+ *
+ * The agent sidebar renders the ordered remote-agent list (each agent's connection
+ * status plus its live sessions, saved definitions and folders) and Open
+ * Connections renders one row per connected/establishing agent and its sessions.
+ * Through the shadow step both read `appStore`'s agents slice (`remoteAgents` /
+ * `agentSessions` / `agentDefinitions` / `agentFolders`) directly. This hook makes
+ * them source that slice from the shared `agents` projection region instead — the
+ * direct analog of {@link import("./useProjectedMonitors").useProjectedMonitors}
+ * (#2224) and {@link import("./useSessionLifecycle").useSessionAutoReconnect}
+ * (#2204).
+ *
+ * # Safety (strangler)
+ *
+ * - **Gated** by {@link agentRenderFromProjectionEnabled} (on by default). Flag
+ *   off ⇒ the hook returns `appStore`'s slice verbatim.
+ * - **Faithful-mirror gate.** The projection sources the render only when it
+ *   deep-equals the `appStore` slice ({@link agentsViewMirrors}); otherwise the
+ *   hook falls back to `appStore` (never a stale view). While `appStore` stays
+ *   authoritative (the mutation cut is a later step) the region is kept a mirror
+ *   by {@link seedAgentsRegion}, so it is always populated — making the cut
+ *   parity-safe and independent of the mutation flag.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+import { useAppStore } from "@/store/appStore";
+import {
+  agentRenderFromProjectionEnabled,
+  agentsViewMirrors,
+  currentAgentsView,
+  ensureAgentsSubscribed,
+  logAgentBridgeFallback,
+  onAgentsView,
+  seedAgentsRegion,
+  type AgentsView,
+} from "@/store/agentsBridge";
+
+/**
+ * The effective agents slice for rendering: the ordered `remoteAgents` list plus
+ * the per-agent `agentSessions` / `agentDefinitions` / `agentFolders` maps, sourced
+ * from the projected `agents` region when it faithfully mirrors `appStore`,
+ * otherwise `appStore`'s slice verbatim (flag off, region not yet caught up, or a
+ * transport that cannot subscribe).
+ */
+export function useProjectedAgents(): AgentsView {
+  const remoteAgents = useAppStore((s) => s.remoteAgents);
+  const agentSessions = useAppStore((s) => s.agentSessions);
+  const agentDefinitions = useAppStore((s) => s.agentDefinitions);
+  const agentFolders = useAppStore((s) => s.agentFolders);
+
+  // Read the flag once at mount: it flips only via dev tooling, and the
+  // subscription lifecycle is keyed off it below.
+  const [enabled] = useState(() => agentRenderFromProjectionEnabled());
+
+  const [view, setView] = useState<AgentsView | undefined>(undefined);
+
+  // Subscribe to the shared agents region while enabled; a transport that cannot
+  // subscribe (non-Tauri without a socket) just leaves the UI on the appStore
+  // fallback.
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const unsubscribe = onAgentsView((next) => {
+      if (!cancelled) setView(next);
+    });
+    // `ensureAgentsSubscribed` builds the transport eagerly, so a non-Tauri env
+    // without a socket throws synchronously (not just a rejection) — guard both so
+    // the UI silently stays on the appStore fallback.
+    try {
+      ensureAgentsSubscribed()
+        .then(() => {
+          if (!cancelled) setView(currentAgentsView());
+        })
+        .catch((err) => logAgentBridgeFallback("subscribe", err));
+    } catch (err) {
+      logAgentBridgeFallback("subscribe", err);
+    }
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [enabled]);
+
+  const matches =
+    enabled && agentsViewMirrors(view, remoteAgents, agentSessions, agentDefinitions, agentFolders);
+
+  // Keep the region a faithful mirror of appStore's slice. Only once a view has
+  // arrived (so we are subscribed) and it is not already a mirror; de-duped inside
+  // `seedAgentsRegion` so a settled slice is not re-seeded on every render.
+  useEffect(() => {
+    if (!enabled || matches || view === undefined) return;
+    seedAgentsRegion(remoteAgents, agentSessions, agentDefinitions, agentFolders).catch((err) =>
+      logAgentBridgeFallback("seed", err)
+    );
+  }, [enabled, matches, view, remoteAgents, agentSessions, agentDefinitions, agentFolders]);
+
+  return useMemo(() => {
+    if (matches && view) return view;
+    return { remoteAgents, agentSessions, agentDefinitions, agentFolders };
+  }, [matches, view, remoteAgents, agentSessions, agentDefinitions, agentFolders]);
+}


### PR DESCRIPTION
## What

Phase 5 **render cut** of the Agents domain — the parity-safe step after the Agents shadow (PR #2232). Cuts the agent sidebar and Open Connections to render the agent list, connection status and per-agent sessions/definitions/folders from the shared \`agents\` projection region, while \`appStore\` stays authoritative.

Follows the just-merged Monitors render cut (#2224, PR #2244) one-to-one.

## How

- **Backend seed intent.** Adds a whole-slice \`agent.replace\` intent + \`AgentsStore::replace\` (the analog of \`monitor.replace\`) so the frontend can keep the region a faithful copy of \`appStore\`.
- **\`agentsBridge.ts\`.** Region subscription + fan-out, an \`agent.replace\` seed that mirrors \`appStore\` into the region, a faithful-mirror gate (\`agentsViewMirrors\`), and a render flag \`agentRenderFromProjectionEnabled\` — **on by default**, runtime-overridable via \`window.__TERMIHUB_AGENT_RENDER_FROM_PROJECTION__\` / \`localStorage["termihub.agentRenderFromProjection"]\` for instant rollback.
- **\`useProjectedAgents.ts\`.** Returns the agents slice from the projection **only when it faithfully deep-equals \`appStore\`**, else \`appStore\` verbatim (flag off, region not caught up, or a transport that cannot subscribe). Keeps the region seeded so it is always populated — parity-safe and independent of the (later) mutation cut.
- **Wiring.** \`ConnectionList\`, \`AgentNode\` (sidebar) and \`OpenConnectionsModal\` now source their agent reads from the hook instead of \`appStore\` directly. The \`appStore\` agents *fields* stay in place (removed in a later step).

## Parity / safety

No user-visible change: the gate guarantees the projected view is value-identical to the \`appStore\` slice before it is ever rendered, and otherwise falls back to \`appStore\`. The mutation cut and reducer removal are separate later steps in #2226.

## Tests

- Rust: \`AgentsStore::replace\` overwrites/clears the whole slice; \`agent.replace\` mirrors a whole snapshot in one coalesced diff and converges.
- Frontend: \`agentsBridge\` (flag default/override, deepEqual, mirror gate incl. status/order/sub-map divergence, seed dispatch + de-dupe, seed round-trip) and \`useProjectedAgents\` (flag off → appStore + no dispatch; flag on → seed then render from projection; region-not-caught-up → appStore fallback).
- Full \`Sidebar\` + \`OpenConnections\` suites (333 tests) green; \`tsc\`, eslint, prettier, \`cargo fmt\`, \`cargo clippy -D warnings\` all clean.

Part of #2226