### PR TITLE
feat(agent): cut agent mutations over to agent.* intents

### DIFF
--- a/src/store/agentsBridge.ts
+++ b/src/store/agentsBridge.ts
@@ -142,6 +142,63 @@ export function agentRenderFromProjectionEnabled(): boolean {
   return true;
 }
 
+// ── Mutation-cut feature flag (runtime-flippable, on by default) ───────────────
+
+let mutationFlagOverride: boolean | null = null;
+
+interface AgentMutationFlagWindow {
+  __TERMIHUB_AGENT_INTENTS__?: boolean;
+  localStorage?: Storage;
+}
+
+/**
+ * Programmatic override for the mutation-cut flag (tests, and a runtime toggle).
+ * `null` clears the override and falls back to the window/localStorage signal,
+ * then to the default (on).
+ */
+export function setAgentIntentsEnabled(value: boolean | null): void {
+  mutationFlagOverride = value;
+}
+
+/**
+ * Whether the agent lifecycle actions (add/update/applySettings/remove/reorder/
+ * toggleExpanded/connect/disconnect/shutdown/status/setCapabilities/refresh/
+ * clearSessions and the definition/folder CRUD) dispatch granular `agent.*`
+ * intents so the backend {@link import("../../src-tauri/src/agents_projection/store").AgentsStore}
+ * is authoritative — instead of only the render-cut {@link seedAgentsRegion}
+ * `agent.replace` mirror driving the region.
+ *
+ * **On by default** (#2226 mutation cut). When on, each action mirrors its
+ * transition through an `agent.*` intent (via {@link mirrorAgentIntent}), and the
+ * render-cut hook ({@link import("./useProjectedAgents").useProjectedAgents})
+ * reflects the region back into the UI. The local `appStore` reducer path stays in
+ * place as the render source and as a resilience / rollback fallback — any dispatch
+ * failure is logged and the local mutation continues, so a backend hiccup can never
+ * break the agent sidebar (the reducer removal is a later step). When off,
+ * `appStore` drives the slice purely locally (the pre-cut path). The flip was taken
+ * on the automated parity tests plus the instant local fallback, mirroring the
+ * monitor mutation cut (#2224). Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_AGENT_INTENTS__` or `localStorage["termihub.agentIntents"]`
+ * (set `"false"` to restore the pre-cut local-mutation path; `"true"` to force on).
+ */
+export function agentIntentsEnabled(): boolean {
+  if (mutationFlagOverride !== null) return mutationFlagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as AgentMutationFlagWindow;
+      if (typeof w.__TERMIHUB_AGENT_INTENTS__ === "boolean") {
+        return w.__TERMIHUB_AGENT_INTENTS__;
+      }
+      const ls = w.localStorage?.getItem("termihub.agentIntents");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return true;
+}
+
 // ── Transport + shared region client (lazy, mirrors the monitor slice) ─────────
 
 let transportInstance: Transport | null = null;
@@ -292,6 +349,65 @@ export function seedAgentsRegion(
     // A synchronous transport-construction failure (non-Tauri, no socket).
     lastSeededSignature = null;
     return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+// ── Mutation cut: granular agent.* intent dispatch ────────────────────────────
+
+/**
+ * The granular `agent.*` intent kinds the mutation cut dispatches (twins of the
+ * Rust routes). Excludes `agent.replace`, which is the render-cut whole-slice
+ * mirror ({@link seedAgentsRegion}); the mutation cut drives the region through
+ * these per-transition intents instead so the store becomes authoritative.
+ */
+export type AgentIntentKind =
+  | "agent.add"
+  | "agent.update"
+  | "agent.applySettings"
+  | "agent.remove"
+  | "agent.reorder"
+  | "agent.toggleExpanded"
+  | "agent.status"
+  | "agent.setCapabilities"
+  | "agent.disconnect"
+  | "agent.refresh"
+  | "agent.clearSessions"
+  | "agent.saveDefinition"
+  | "agent.updateDefinition"
+  | "agent.deleteDefinition"
+  | "agent.createFolder"
+  | "agent.updateFolder"
+  | "agent.deleteFolder";
+
+/** Dispatch a granular `agent.*` intent, resolving with the ack (parity tests). */
+export function dispatchAgentIntent(
+  kind: AgentIntentKind,
+  payload: Record<string, unknown>
+): Promise<IntentAck> {
+  return transport().dispatch({ intentId: newIntentId(), kind, payload, clientId });
+}
+
+/**
+ * Fire a granular `agent.*` intent to keep the backend store authoritative,
+ * swallowing and logging any failure so the local `appStore` mutation path is
+ * never disrupted by a bridge hiccup (the resilience fallback). A no-op when the
+ * mutation cut is disabled ({@link agentIntentsEnabled} off — the rollback path).
+ * Never throws — a synchronous transport-construction failure (non-Tauri, no
+ * socket) is caught and logged, leaving the UI on the local slice. The twin of the
+ * monitor bridge's {@link import("./systemMonitorBridge").mirrorMonitorIntent}.
+ */
+export function mirrorAgentIntent(kind: AgentIntentKind, payload: Record<string, unknown>): void {
+  if (!agentIntentsEnabled()) return;
+  try {
+    void dispatchAgentIntent(kind, payload)
+      .then((ack) => {
+        if (ack.status === "rejected") {
+          logAgentBridgeFallback(kind, new Error(ack.error?.message ?? "rejected"));
+        }
+      })
+      .catch((err) => logAgentBridgeFallback(kind, err));
+  } catch (err) {
+    logAgentBridgeFallback(kind, err);
   }
 }
 

--- a/src/store/appStore.agentsMutationCut.test.ts
+++ b/src/store/appStore.agentsMutationCut.test.ts
@@ -1,0 +1,829 @@
+/**
+ * Agents mutation cut (#2226, part of #2139) — cut-vs-local parity.
+ *
+ * The mutation cut routes each agent lifecycle action through a granular
+ * `agent.*` intent so the backend `AgentsStore` becomes authoritative, while the
+ * local `appStore` reducer path stays in place as the render source and the
+ * resilience / rollback fallback (the reducer removal is a later step).
+ *
+ * These tests prove the cut is parity-safe end to end: with the flag **on**, the
+ * intents dispatched by the actions — applied by a faithful in-memory port of the
+ * Rust store (mirroring `agents_projection/store.rs`) — reproduce the exact
+ * `appStore` agents slice (`remoteAgents` + `agentSessions` + `agentDefinitions` +
+ * `agentFolders`) for every action and its fan-out. With the flag **off**, no
+ * intents are dispatched and the local slice is byte-identical — the instant
+ * rollback path the flip relies on.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const {
+  mockConnectAgent,
+  mockDisconnectAgent,
+  mockShutdownAgent,
+  mockApplyAgentSettings,
+  mockListAgentSessions,
+  mockListAgentConnections,
+  mockSaveAgentDefinition,
+  mockUpdateAgentDefinition,
+  mockDeleteAgentDefinition,
+  mockCreateAgentFolder,
+  mockUpdateAgentFolder,
+  mockDeleteAgentFolder,
+} = vi.hoisted(() => ({
+  mockConnectAgent: vi.fn(),
+  mockDisconnectAgent: vi.fn(() => Promise.resolve()),
+  mockShutdownAgent: vi.fn(() => Promise.resolve(0)),
+  mockApplyAgentSettings: vi.fn(() => Promise.resolve()),
+  mockListAgentSessions: vi.fn(() => Promise.resolve([] as AgentSessionInfo[])),
+  mockListAgentConnections: vi.fn(() =>
+    Promise.resolve({
+      connections: [] as AgentDefinitionInfo[],
+      folders: [] as AgentFolderInfo[],
+    })
+  ),
+  mockSaveAgentDefinition: vi.fn(),
+  mockUpdateAgentDefinition: vi.fn(),
+  mockDeleteAgentDefinition: vi.fn(() => Promise.resolve()),
+  mockCreateAgentFolder: vi.fn(),
+  mockUpdateAgentFolder: vi.fn(() => Promise.resolve({})),
+  mockDeleteAgentFolder: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  persistAgent: vi.fn(() => Promise.resolve()),
+  removeAgent: vi.fn(() => Promise.resolve()),
+  reorderAgents: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  connectAgent: mockConnectAgent,
+  disconnectAgent: mockDisconnectAgent,
+  shutdownAgent: mockShutdownAgent,
+  applyAgentSettings: mockApplyAgentSettings,
+  listAgentSessions: mockListAgentSessions,
+  listAgentDefinitions: vi.fn(() => Promise.resolve([])),
+  listAgentConnections: mockListAgentConnections,
+  saveAgentDefinition: mockSaveAgentDefinition,
+  updateAgentDefinition: mockUpdateAgentDefinition,
+  deleteAgentDefinition: mockDeleteAgentDefinition,
+  createAgentFolder: mockCreateAgentFolder,
+  updateAgentFolder: mockUpdateAgentFolder,
+  deleteAgentFolder: mockDeleteAgentFolder,
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  getConnectionTypes: vi.fn(() => Promise.resolve([])),
+}));
+
+import { useAppStore } from "./appStore";
+import { setAgentIntentsEnabled, setAgentTransportForTest } from "./agentsBridge";
+import type { AgentDefinitionInfo, AgentFolderInfo, AgentSessionInfo } from "@/services/api";
+import {
+  DEFAULT_AGENT_SETTINGS,
+  type AgentCapabilities,
+  type RemoteAgentDefinition,
+} from "@/types/connection";
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+
+const AGENT_A = "agent-a";
+const AGENT_B = "agent-b";
+const CAPS: AgentCapabilities = { connectionTypes: [], maxSessions: 5 };
+
+function makeAgent(overrides: Partial<RemoteAgentDefinition> = {}): RemoteAgentDefinition {
+  return {
+    id: AGENT_A,
+    name: "Agent A",
+    config: { host: "a.local", port: 22, username: "user", authMethod: "password" },
+    agentSettings: DEFAULT_AGENT_SETTINGS,
+    isExpanded: false,
+    connectionState: "disconnected",
+    ...overrides,
+  };
+}
+
+function makeDefinition(overrides: Partial<AgentDefinitionInfo> = {}): AgentDefinitionInfo {
+  return {
+    id: `def-${Math.random().toString(36).slice(2, 8)}`,
+    name: "Test Connection",
+    sessionType: "shell",
+    config: {},
+    persistent: false,
+    folderId: null,
+    ...overrides,
+  };
+}
+
+function makeFolder(overrides: Partial<AgentFolderInfo> = {}): AgentFolderInfo {
+  return {
+    id: `folder-${Math.random().toString(36).slice(2, 8)}`,
+    name: "Test Folder",
+    parentId: null,
+    isExpanded: false,
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<AgentSessionInfo> = {}): AgentSessionInfo {
+  return {
+    sessionId: `sess-${Math.random().toString(36).slice(2, 8)}`,
+    title: "shell",
+    type: "shell",
+    status: "running",
+    attached: false,
+    ...overrides,
+  };
+}
+
+interface RegionView {
+  agents: RemoteAgentDefinition[];
+  sessions: Record<string, AgentSessionInfo[]>;
+  definitions: Record<string, AgentDefinitionInfo[]>;
+  folders: Record<string, AgentFolderInfo[]>;
+}
+
+/**
+ * An in-memory substrate double that applies the granular `agent.*` intents with
+ * the same semantics as the Rust `AgentsStore`, so a run of the real `appStore`
+ * actions (which mirror those intents) reconstructs the region view the agent
+ * sidebar and Open Connections would render. Only `agent.replace` (the render-cut
+ * mirror) is intentionally not applied here — the mutation cut drives the region
+ * through the per-transition intents.
+ */
+class AgentsStoreTransport implements Transport {
+  dispatched: Intent[] = [];
+  private agents: RemoteAgentDefinition[] = [];
+  private sessions: Record<string, AgentSessionInfo[]> = {};
+  private definitions: Record<string, AgentDefinitionInfo[]> = {};
+  private folders: Record<string, AgentFolderInfo[]> = {};
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    this.apply(intent);
+    this.version += 1;
+    this.fan();
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: "agents", version: this.version }],
+    };
+  }
+
+  private agentAt(id: string): RemoteAgentDefinition | undefined {
+    return this.agents.find((a) => a.id === id);
+  }
+
+  private apply(intent: Intent): void {
+    const p = intent.payload as Record<string, unknown>;
+    const id = p.id as string;
+    switch (intent.kind) {
+      case "agent.add": {
+        if (this.agentAt(id)) break;
+        this.agents.push({
+          id,
+          name: p.name as string,
+          config: p.config as RemoteAgentDefinition["config"],
+          agentSettings: p.agentSettings as RemoteAgentDefinition["agentSettings"],
+          isExpanded: false,
+          connectionState: "disconnected",
+        });
+        break;
+      }
+      case "agent.update": {
+        const a = this.agentAt(id);
+        if (a) {
+          a.name = p.name as string;
+          a.config = p.config as RemoteAgentDefinition["config"];
+          a.agentSettings = p.agentSettings as RemoteAgentDefinition["agentSettings"];
+        }
+        break;
+      }
+      case "agent.applySettings": {
+        const a = this.agentAt(id);
+        if (a) a.agentSettings = p.agentSettings as RemoteAgentDefinition["agentSettings"];
+        break;
+      }
+      case "agent.remove": {
+        this.agents = this.agents.filter((a) => a.id !== id);
+        delete this.sessions[id];
+        delete this.definitions[id];
+        delete this.folders[id];
+        break;
+      }
+      case "agent.reorder": {
+        const oldIndex = p.oldIndex as number;
+        const newIndex = p.newIndex as number;
+        if (oldIndex >= this.agents.length || newIndex >= this.agents.length) break;
+        const [moved] = this.agents.splice(oldIndex, 1);
+        this.agents.splice(newIndex, 0, moved);
+        break;
+      }
+      case "agent.toggleExpanded": {
+        const a = this.agentAt(id);
+        if (a) a.isExpanded = !a.isExpanded;
+        break;
+      }
+      case "agent.status": {
+        const a = this.agentAt(id);
+        if (a) {
+          const state = p.state as RemoteAgentDefinition["connectionState"];
+          const error = p.error as string | undefined;
+          // Mirror the Rust `set_status` lastError rules exactly.
+          if (state === "disconnected") a.lastError = error ?? a.lastError;
+          else if (state === "connecting" || state === "connected") a.lastError = undefined;
+          a.connectionState = state;
+        }
+        break;
+      }
+      case "agent.setCapabilities": {
+        const a = this.agentAt(id);
+        if (a) a.capabilities = p.capabilities as AgentCapabilities;
+        break;
+      }
+      case "agent.disconnect": {
+        const a = this.agentAt(id);
+        if (a) {
+          a.connectionState = "disconnected";
+          this.sessions[id] = [];
+          this.folders[id] = [];
+        }
+        break;
+      }
+      case "agent.refresh": {
+        if (!this.agentAt(id)) break;
+        this.sessions[id] = p.sessions as AgentSessionInfo[];
+        this.definitions[id] = p.definitions as AgentDefinitionInfo[];
+        this.folders[id] = p.folders as AgentFolderInfo[];
+        break;
+      }
+      case "agent.clearSessions": {
+        if (this.agentAt(id)) this.sessions[id] = [];
+        break;
+      }
+      case "agent.saveDefinition": {
+        if (!this.agentAt(id)) break;
+        const def = p.definition as AgentDefinitionInfo;
+        const list = (this.definitions[id] ?? []).filter((d) => d.id !== def.id);
+        list.push(def);
+        this.definitions[id] = list;
+        break;
+      }
+      case "agent.updateDefinition": {
+        const def = p.definition as AgentDefinitionInfo;
+        const list = this.definitions[id];
+        if (list) this.definitions[id] = list.map((d) => (d.id === def.id ? def : d));
+        break;
+      }
+      case "agent.deleteDefinition": {
+        const list = this.definitions[id];
+        if (list) this.definitions[id] = list.filter((d) => d.id !== (p.definitionId as string));
+        break;
+      }
+      case "agent.createFolder": {
+        if (!this.agentAt(id)) break;
+        this.folders[id] = [...(this.folders[id] ?? []), p.folder as AgentFolderInfo];
+        break;
+      }
+      case "agent.updateFolder": {
+        const folder = p.folder as AgentFolderInfo;
+        const list = this.folders[id];
+        if (list) this.folders[id] = list.map((f) => (f.id === folder.id ? folder : f));
+        break;
+      }
+      case "agent.deleteFolder": {
+        const folderId = p.folderId as string;
+        const list = this.folders[id];
+        if (list) this.folders[id] = list.filter((f) => f.id !== folderId);
+        const defs = this.definitions[id];
+        if (defs) {
+          this.definitions[id] = defs.map((d) =>
+            d.folderId === folderId ? { ...d, folderId: null } : d
+          );
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  /** The reconstructed region view, twin of the store snapshot. */
+  regionView(): RegionView {
+    return structuredClone({
+      agents: this.agents,
+      sessions: this.sessions,
+      definitions: this.definitions,
+      folders: this.folders,
+    });
+  }
+
+  kinds(): string[] {
+    return this.dispatched.map((i) => i.kind);
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: this.regionView() };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot("agents");
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+let transport: AgentsStoreTransport;
+
+/** Assert the region the intents reconstruct equals the local appStore slice. */
+function expectParity() {
+  const state = useAppStore.getState();
+  const region = transport.regionView();
+  expect(region.agents).toEqual(state.remoteAgents);
+  expect(region.sessions).toEqual(state.agentSessions);
+  expect(region.definitions).toEqual(state.agentDefinitions);
+  expect(region.folders).toEqual(state.agentFolders);
+}
+
+/** Let the fire-and-forget refresh (setAgentConnectionState → connected) flush. */
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  vi.clearAllMocks();
+  transport = new AgentsStoreTransport();
+  setAgentTransportForTest(transport);
+  setAgentIntentsEnabled(true);
+});
+
+afterEach(() => {
+  setAgentTransportForTest(null);
+  setAgentIntentsEnabled(null);
+});
+
+describe("agents mutation cut — cut-vs-local parity (flag on)", () => {
+  it("addRemoteAgent reproduces the fresh agent entry", () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+
+    expect(transport.kinds()).toEqual(["agent.add"]);
+    expectParity();
+    expect(transport.regionView().agents[0].connectionState).toBe("disconnected");
+  });
+
+  it("updateRemoteAgent reproduces the edited fields", () => {
+    const agent = makeAgent();
+    useAppStore.getState().addRemoteAgent(agent);
+    useAppStore.getState().updateRemoteAgent({ ...agent, name: "Renamed" });
+
+    expectParity();
+    expect(transport.regionView().agents[0].name).toBe("Renamed");
+  });
+
+  it("updateAgentSettings mirrors the settings-only change", async () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+    const nextSettings = { ...DEFAULT_AGENT_SETTINGS, enableDocker: false };
+
+    await useAppStore.getState().updateAgentSettings(AGENT_A, nextSettings);
+
+    expectParity();
+    expect(transport.regionView().agents[0].agentSettings.enableDocker).toBe(false);
+    expect(transport.kinds()).toContain("agent.applySettings");
+  });
+
+  it("reorderRemoteAgents reproduces the new order", () => {
+    useAppStore.getState().addRemoteAgent(makeAgent({ id: "a1", name: "A1" }));
+    useAppStore.getState().addRemoteAgent(makeAgent({ id: "a2", name: "A2" }));
+    useAppStore.getState().addRemoteAgent(makeAgent({ id: "a3", name: "A3" }));
+
+    useAppStore.getState().reorderRemoteAgents(0, 2);
+
+    expectParity();
+    expect(transport.regionView().agents.map((a) => a.id)).toEqual(["a2", "a3", "a1"]);
+  });
+
+  it("toggleRemoteAgent flips the projected expansion", () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+    useAppStore.getState().toggleRemoteAgent(AGENT_A);
+
+    expectParity();
+    expect(transport.regionView().agents[0].isExpanded).toBe(true);
+  });
+
+  it("connectRemoteAgent mirrors the capabilities and force-expand", async () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+    mockConnectAgent.mockResolvedValue({
+      capabilities: CAPS,
+      agentVersion: "1",
+      protocolVersion: "1",
+    });
+
+    await useAppStore.getState().connectRemoteAgent(AGENT_A);
+
+    expectParity();
+    const agent = transport.regionView().agents[0];
+    expect(agent.capabilities).toEqual(CAPS);
+    expect(agent.isExpanded).toBe(true);
+    // No connectionState write from connect (single writer G4/#1234).
+    expect(agent.connectionState).toBe("disconnected");
+    expect(transport.kinds()).toEqual([
+      "agent.add",
+      "agent.setCapabilities",
+      "agent.toggleExpanded",
+    ]);
+  });
+
+  it("connect does not re-toggle an already-expanded agent", async () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+    // Expand via the real toggle so both the local slice and the region reach
+    // isExpanded:true (add always creates a collapsed agent).
+    useAppStore.getState().toggleRemoteAgent(AGENT_A);
+    mockConnectAgent.mockResolvedValue({
+      capabilities: CAPS,
+      agentVersion: "1",
+      protocolVersion: "1",
+    });
+
+    await useAppStore.getState().connectRemoteAgent(AGENT_A);
+
+    expectParity();
+    expect(transport.regionView().agents[0].isExpanded).toBe(true);
+    // Only one toggle (the explicit one) — connect must not toggle again.
+    expect(transport.kinds()).toEqual([
+      "agent.add",
+      "agent.toggleExpanded",
+      "agent.setCapabilities",
+    ]);
+  });
+
+  it("setAgentConnectionState drives the projected connection state", () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+
+    useAppStore.getState().setAgentConnectionState(AGENT_A, "connecting");
+    expectParity();
+    expect(transport.regionView().agents[0].connectionState).toBe("connecting");
+  });
+
+  it("a terminal disconnect records lastError in the region", () => {
+    useAppStore.getState().addRemoteAgent(makeAgent({ connectionState: "reconnecting" }));
+
+    useAppStore
+      .getState()
+      .setAgentConnectionState(AGENT_A, "disconnected", "gave up after 10 tries");
+
+    expectParity();
+    expect(transport.regionView().agents[0].lastError).toBe("gave up after 10 tries");
+  });
+
+  it("the connected transition fans out a refresh into the region", async () => {
+    useAppStore.getState().addRemoteAgent(makeAgent({ connectionState: "connecting" }));
+    const def = makeDefinition({ id: "d1" });
+    const folder = makeFolder({ id: "f1" });
+    const session = makeSession({ sessionId: "s1" });
+    mockListAgentSessions.mockResolvedValue([session]);
+    mockListAgentConnections.mockResolvedValue({ connections: [def], folders: [folder] });
+
+    useAppStore.getState().setAgentConnectionState(AGENT_A, "connected");
+    await flushMicrotasks();
+
+    expectParity();
+    const view = transport.regionView();
+    expect(view.sessions[AGENT_A]).toEqual([session]);
+    expect(view.definitions[AGENT_A]).toEqual([def]);
+    expect(view.folders[AGENT_A]).toEqual([folder]);
+    expect(transport.kinds()).toContain("agent.refresh");
+  });
+
+  it("disconnectRemoteAgent forces disconnected and clears live sub-state", async () => {
+    useAppStore.getState().addRemoteAgent(makeAgent({ connectionState: "connected" }));
+    useAppStore.setState((s) => ({
+      agentSessions: { ...s.agentSessions, [AGENT_A]: [makeSession()] },
+      agentFolders: { ...s.agentFolders, [AGENT_A]: [makeFolder()] },
+    }));
+
+    await useAppStore.getState().disconnectRemoteAgent(AGENT_A);
+
+    // The local slice cleared sessions/folders; make the region mirror that
+    // starting state via a status intent for the pre-clear content is not needed —
+    // disconnect alone reproduces the cleared slice.
+    expect(transport.regionView().agents[0].connectionState).toBe("disconnected");
+    expect(transport.regionView().sessions[AGENT_A]).toEqual([]);
+    expect(transport.regionView().folders[AGENT_A]).toEqual([]);
+    expect(transport.kinds()).toContain("agent.disconnect");
+  });
+
+  it("shutdownRemoteAgent tears the agent down like disconnect", async () => {
+    useAppStore.getState().addRemoteAgent(makeAgent({ connectionState: "connected" }));
+    mockShutdownAgent.mockResolvedValue(2);
+
+    const detached = await useAppStore.getState().shutdownRemoteAgent(AGENT_A);
+
+    expect(detached).toBe(2);
+    expectParity();
+    expect(transport.regionView().agents[0].connectionState).toBe("disconnected");
+    expect(transport.kinds()).toContain("agent.disconnect");
+  });
+
+  it("clearAgentSessions empties the region's live-session list", () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+    useAppStore.setState((s) => ({
+      agentSessions: { ...s.agentSessions, [AGENT_A]: [makeSession()] },
+    }));
+    // Seed the region's session list so the clear has something to erase.
+    transport.dispatch({
+      intentId: "seed",
+      kind: "agent.refresh",
+      payload: { id: AGENT_A, sessions: [makeSession()], definitions: [], folders: [] },
+      clientId: "seed",
+    });
+
+    useAppStore.getState().clearAgentSessions(AGENT_A);
+
+    expect(useAppStore.getState().agentSessions[AGENT_A]).toEqual([]);
+    expect(transport.regionView().sessions[AGENT_A]).toEqual([]);
+    expect(transport.kinds()).toContain("agent.clearSessions");
+  });
+
+  it("setAgentCapabilities records the capabilities in the region", () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+
+    useAppStore.getState().setAgentCapabilities(AGENT_A, CAPS);
+
+    expectParity();
+    expect(transport.regionView().agents[0].capabilities).toEqual(CAPS);
+  });
+
+  it("saveAgentDef upserts a definition into the region", async () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+    const saved = makeDefinition({ id: "d1", name: "Saved" });
+    mockSaveAgentDefinition.mockResolvedValue(saved);
+
+    await useAppStore.getState().saveAgentDef(AGENT_A, {
+      name: "Saved",
+      type: "shell",
+      config: {},
+      persistent: false,
+    });
+
+    expectParity();
+    expect(transport.regionView().definitions[AGENT_A]).toEqual([saved]);
+  });
+
+  it("updateAgentDef replaces the definition by id", async () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+    const original = makeDefinition({ id: "d1", name: "Old" });
+    useAppStore.setState((s) => ({
+      agentDefinitions: { ...s.agentDefinitions, [AGENT_A]: [original] },
+    }));
+    transport.dispatch({
+      intentId: "seed",
+      kind: "agent.saveDefinition",
+      payload: { id: AGENT_A, definition: original },
+      clientId: "seed",
+    });
+    const updated = { ...original, name: "New" };
+    mockUpdateAgentDefinition.mockResolvedValue(updated);
+
+    await useAppStore.getState().updateAgentDef(AGENT_A, { id: "d1", name: "New" });
+
+    expectParity();
+    expect(transport.regionView().definitions[AGENT_A][0].name).toBe("New");
+  });
+
+  it("deleteAgentDef removes the definition from the region", async () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+    const def = makeDefinition({ id: "d1" });
+    useAppStore.setState((s) => ({
+      agentDefinitions: { ...s.agentDefinitions, [AGENT_A]: [def] },
+    }));
+    transport.dispatch({
+      intentId: "seed",
+      kind: "agent.saveDefinition",
+      payload: { id: AGENT_A, definition: def },
+      clientId: "seed",
+    });
+
+    await useAppStore.getState().deleteAgentDef(AGENT_A, "d1");
+
+    expectParity();
+    expect(transport.regionView().definitions[AGENT_A]).toEqual([]);
+  });
+
+  it("createAgentFolder appends the folder to the region", async () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+    const folder = makeFolder({ id: "f1", name: "New" });
+    mockCreateAgentFolder.mockResolvedValue(folder);
+
+    await useAppStore.getState().createAgentFolder(AGENT_A, "New", null);
+
+    expectParity();
+    expect(transport.regionView().folders[AGENT_A]).toEqual([folder]);
+  });
+
+  it("updateAgentFolder replaces the folder by id (rename)", async () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+    const folder = makeFolder({ id: "f1", name: "Old" });
+    useAppStore.setState((s) => ({
+      agentFolders: { ...s.agentFolders, [AGENT_A]: [folder] },
+    }));
+    transport.dispatch({
+      intentId: "seed",
+      kind: "agent.createFolder",
+      payload: { id: AGENT_A, folder },
+      clientId: "seed",
+    });
+    const renamed = { ...folder, name: "Renamed" };
+    mockUpdateAgentFolder.mockResolvedValue(renamed);
+
+    await useAppStore.getState().updateAgentFolder(AGENT_A, { id: "f1", name: "Renamed" });
+
+    expectParity();
+    expect(transport.regionView().folders[AGENT_A][0].name).toBe("Renamed");
+  });
+
+  it("toggleAgentFolder flips the folder expansion in the region", () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+    const folder = makeFolder({ id: "f1", isExpanded: false });
+    useAppStore.setState((s) => ({
+      agentFolders: { ...s.agentFolders, [AGENT_A]: [folder] },
+    }));
+    transport.dispatch({
+      intentId: "seed",
+      kind: "agent.createFolder",
+      payload: { id: AGENT_A, folder },
+      clientId: "seed",
+    });
+
+    useAppStore.getState().toggleAgentFolder(AGENT_A, "f1");
+
+    expectParity();
+    expect(transport.regionView().folders[AGENT_A][0].isExpanded).toBe(true);
+    expect(transport.kinds()).toContain("agent.updateFolder");
+  });
+
+  it("deleteAgentFolder removes the folder and reparents its definitions", async () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+    const folder = makeFolder({ id: "f1" });
+    const child = makeDefinition({ id: "d1", folderId: "f1" });
+    const root = makeDefinition({ id: "d2", folderId: null });
+    useAppStore.setState((s) => ({
+      agentFolders: { ...s.agentFolders, [AGENT_A]: [folder] },
+      agentDefinitions: { ...s.agentDefinitions, [AGENT_A]: [child, root] },
+    }));
+    transport.dispatch({
+      intentId: "seed-folder",
+      kind: "agent.createFolder",
+      payload: { id: AGENT_A, folder },
+      clientId: "seed",
+    });
+    transport.dispatch({
+      intentId: "seed-child",
+      kind: "agent.saveDefinition",
+      payload: { id: AGENT_A, definition: child },
+      clientId: "seed",
+    });
+    transport.dispatch({
+      intentId: "seed-root",
+      kind: "agent.saveDefinition",
+      payload: { id: AGENT_A, definition: root },
+      clientId: "seed",
+    });
+
+    await useAppStore.getState().deleteAgentFolder(AGENT_A, "f1");
+
+    expectParity();
+    const view = transport.regionView();
+    expect(view.folders[AGENT_A]).toEqual([]);
+    expect(view.definitions[AGENT_A].find((d) => d.id === "d1")?.folderId).toBeNull();
+  });
+
+  it("deleteRemoteAgent drops the agent and all of its sub-state", async () => {
+    useAppStore.getState().addRemoteAgent(makeAgent());
+    const def = makeDefinition({ id: "d1" });
+    const folder = makeFolder({ id: "f1" });
+    useAppStore.setState((s) => ({
+      agentDefinitions: { ...s.agentDefinitions, [AGENT_A]: [def] },
+      agentFolders: { ...s.agentFolders, [AGENT_A]: [folder] },
+    }));
+    transport.dispatch({
+      intentId: "seed",
+      kind: "agent.refresh",
+      payload: { id: AGENT_A, sessions: [], definitions: [def], folders: [folder] },
+      clientId: "seed",
+    });
+
+    useAppStore.getState().deleteRemoteAgent(AGENT_A);
+
+    expectParity();
+    const view = transport.regionView();
+    expect(view.agents).toEqual([]);
+    expect(view.definitions[AGENT_A]).toBeUndefined();
+    expect(view.folders[AGENT_A]).toBeUndefined();
+    expect(transport.kinds()).toContain("agent.remove");
+  });
+
+  it("multi-agent fan-out stays independent", () => {
+    useAppStore.getState().addRemoteAgent(makeAgent({ id: AGENT_A, name: "A" }));
+    useAppStore.getState().addRemoteAgent(makeAgent({ id: AGENT_B, name: "B" }));
+    useAppStore.getState().toggleRemoteAgent(AGENT_A);
+
+    expectParity();
+    const view = transport.regionView();
+    expect(view.agents.find((a) => a.id === AGENT_A)?.isExpanded).toBe(true);
+    expect(view.agents.find((a) => a.id === AGENT_B)?.isExpanded).toBe(false);
+  });
+
+  it("a full lifecycle stays in parity across every step", async () => {
+    mockConnectAgent.mockResolvedValue({
+      capabilities: CAPS,
+      agentVersion: "1",
+      protocolVersion: "1",
+    });
+    const def = makeDefinition({ id: "d1" });
+    const folder = makeFolder({ id: "f1" });
+    mockListAgentSessions.mockResolvedValue([makeSession({ sessionId: "s1" })]);
+    mockListAgentConnections.mockResolvedValue({ connections: [def], folders: [folder] });
+
+    useAppStore.getState().addRemoteAgent(makeAgent());
+    expectParity();
+    useAppStore.getState().setAgentConnectionState(AGENT_A, "connecting");
+    expectParity();
+    await useAppStore.getState().connectRemoteAgent(AGENT_A);
+    expectParity();
+    useAppStore.getState().setAgentConnectionState(AGENT_A, "connected");
+    await flushMicrotasks();
+    expectParity();
+    await useAppStore.getState().disconnectRemoteAgent(AGENT_A);
+    expectParity();
+  });
+});
+
+describe("agents mutation cut — flag off (rollback path)", () => {
+  beforeEach(() => setAgentIntentsEnabled(false));
+
+  it("dispatches no intents and drives the slice locally", async () => {
+    mockConnectAgent.mockResolvedValue({
+      capabilities: CAPS,
+      agentVersion: "1",
+      protocolVersion: "1",
+    });
+
+    useAppStore.getState().addRemoteAgent(makeAgent());
+    useAppStore.getState().toggleRemoteAgent(AGENT_A);
+    await useAppStore.getState().connectRemoteAgent(AGENT_A);
+    useAppStore.getState().setAgentConnectionState(AGENT_A, "connected");
+    await flushMicrotasks();
+    await useAppStore.getState().disconnectRemoteAgent(AGENT_A);
+    useAppStore.getState().deleteRemoteAgent(AGENT_A);
+
+    // No mirror reached the region — the pre-cut local path is intact.
+    expect(transport.dispatched).toHaveLength(0);
+    // The local slice still behaves exactly as before the cut.
+    expect(useAppStore.getState().remoteAgents).toEqual([]);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -285,6 +285,7 @@ import {
   type SessionIntentKind,
 } from "@/store/sessionBridge";
 import { mirrorMonitorIntent } from "@/store/systemMonitorBridge";
+import { mirrorAgentIntent } from "@/store/agentsBridge";
 
 export type SidebarView =
   | "connections"
@@ -6608,6 +6609,15 @@ export const useAppStore = create<AppState>((set, get, store) => {
 
     addRemoteAgent: (agent) => {
       set((state) => ({ remoteAgents: [...state.remoteAgents, agent] }));
+      // Mutation cut (#2226): append the agent to the authoritative region. A
+      // no-op / logged fallback when the flag is off or the transport is
+      // unavailable — the local slice above already applied.
+      mirrorAgentIntent("agent.add", {
+        id: agent.id,
+        name: agent.name,
+        config: agent.config,
+        agentSettings: agent.agentSettings,
+      });
       persistAgent({
         id: agent.id,
         name: agent.name,
@@ -6628,6 +6638,13 @@ export const useAppStore = create<AppState>((set, get, store) => {
       set((state) => ({
         remoteAgents: state.remoteAgents.map((a) => (a.id === agent.id ? agent : a)),
       }));
+      // Mutation cut (#2226): update the persisted fields in the region.
+      mirrorAgentIntent("agent.update", {
+        id: agent.id,
+        name: agent.name,
+        config: agent.config,
+        agentSettings: agent.agentSettings,
+      });
       persistAgent({
         id: agent.id,
         name: agent.name,
@@ -6651,6 +6668,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
         agents.splice(newIndex, 0, moved);
         return { remoteAgents: agents };
       });
+      // Mutation cut (#2226): reorder the agent in the region.
+      mirrorAgentIntent("agent.reorder", { oldIndex, newIndex });
       const agentIds = get().remoteAgents.map((a) => a.id);
       persistAgentOrder(agentIds).catch((err) => {
         frontendLog(
@@ -6682,6 +6701,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
           Object.entries(s.agentFolders).filter(([k]) => k !== agentId)
         ),
       }));
+      // Mutation cut (#2226): drop the agent and all of its sub-state from the
+      // region (the store's `remove` clears sessions/definitions/folders too).
+      mirrorAgentIntent("agent.remove", { id: agentId });
       removeAgent(agentId).catch((err) => {
         frontendLog(
           "app_store",
@@ -6699,6 +6721,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
           a.id === agentId ? { ...a, isExpanded: !a.isExpanded } : a
         ),
       }));
+      // Mutation cut (#2226): flip the sidebar expansion in the region.
+      mirrorAgentIntent("agent.toggleExpanded", { id: agentId });
     },
 
     connectRemoteAgent: async (agentId, password) => {
@@ -6714,6 +6738,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // "connecting" up front and "connected"/"disconnected" on the outcome),
       // so an optimistic write here could clobber a fast drop → "reconnecting"
       // event that arrives before this promise settles.
+      // The agent's expansion before this connect: connect force-expands the
+      // sidebar entry, so the region only needs a toggle when it was collapsed.
+      const wasExpanded = agent.isExpanded;
       try {
         const config: RemoteAgentConfig = { ...agent.config };
         if (password && config.authMethod === "password") {
@@ -6728,6 +6755,16 @@ export const useAppStore = create<AppState>((set, get, store) => {
             a.id === agentId ? { ...a, capabilities: result.capabilities, isExpanded: true } : a
           ),
         }));
+
+        // Mutation cut (#2226): mirror the capabilities and the force-expand into
+        // the region. `connectionState` stays a single-writer field driven by the
+        // `agent-state-change` event (`setAgentConnectionState` → `agent.status`),
+        // so it is deliberately not written here.
+        mirrorAgentIntent("agent.setCapabilities", {
+          id: agentId,
+          capabilities: result.capabilities,
+        });
+        if (!wasExpanded) mirrorAgentIntent("agent.toggleExpanded", { id: agentId });
 
         // The session/definition refresh is owned by the "connected" event
         // (`setAgentConnectionState`), so it runs exactly once per connect and
@@ -6762,6 +6799,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
         agentSessions: { ...s.agentSessions, [agentId]: [] },
         agentFolders: { ...s.agentFolders, [agentId]: [] },
       }));
+      // Mutation cut (#2226): force the region entry to disconnected and clear its
+      // live sessions/folders (the store's `disconnect` does exactly this).
+      mirrorAgentIntent("agent.disconnect", { id: agentId });
     },
 
     shutdownRemoteAgent: async (agentId) => {
@@ -6776,6 +6816,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
         agentSessions: { ...s.agentSessions, [agentId]: [] },
         agentFolders: { ...s.agentFolders, [agentId]: [] },
       }));
+      // Mutation cut (#2226): as with disconnect, force the region entry to
+      // disconnected and clear its live sessions/folders.
+      mirrorAgentIntent("agent.disconnect", { id: agentId });
       return detached;
     },
 
@@ -6798,6 +6841,11 @@ export const useAppStore = create<AppState>((set, get, store) => {
         ),
       }));
 
+      // Mutation cut (#2226): set the connection state in the region. This is the
+      // single writer for `connectionState` (G4/#1234); the store's `set_status`
+      // tracks `lastError` with the same rules as `nextLastError` above.
+      mirrorAgentIntent("agent.status", { id: agentId, state: connectionState, error });
+
       // The refresh of sessions/definitions is owned by the transition INTO
       // "connected" — this is the single, de-duped refresh per connect (G4).
       // Guarding on the previous state keeps a redundant/duplicate "connected"
@@ -6813,6 +6861,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
       set((s) => ({
         agentSessions: { ...s.agentSessions, [agentId]: [] },
       }));
+      // Mutation cut (#2226): empty the region's live-session list for the agent.
+      mirrorAgentIntent("agent.clearSessions", { id: agentId });
     },
 
     setAgentCapabilities: (agentId, capabilities) => {
@@ -6821,6 +6871,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
           a.id === agentId ? { ...a, capabilities } : a
         ),
       }));
+      // Mutation cut (#2226): record the negotiated capabilities in the region.
+      mirrorAgentIntent("agent.setCapabilities", { id: agentId, capabilities });
     },
 
     updateAgentSettings: async (agentId, settings) => {
@@ -6830,6 +6882,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
           a.id === agentId ? { ...a, agentSettings: settings } : a
         ),
       }));
+      // Mutation cut (#2226): apply just the settings in the region.
+      mirrorAgentIntent("agent.applySettings", { id: agentId, agentSettings: settings });
     },
 
     refreshAgentSessions: async (agentId) => {
@@ -6843,6 +6897,15 @@ export const useAppStore = create<AppState>((set, get, store) => {
           agentDefinitions: { ...s.agentDefinitions, [agentId]: connectionsData.connections },
           agentFolders: { ...s.agentFolders, [agentId]: connectionsData.folders },
         }));
+        // Mutation cut (#2226): replace the agent's live sessions plus its saved
+        // definitions and folders in the region in one shot (the once-per-connect
+        // refresh set).
+        mirrorAgentIntent("agent.refresh", {
+          id: agentId,
+          sessions,
+          definitions: connectionsData.connections,
+          folders: connectionsData.folders,
+        });
       } catch (err) {
         frontendLog(
           "app_store",
@@ -6866,6 +6929,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
             ],
           },
         }));
+        // Mutation cut (#2226): upsert the saved definition in the region.
+        mirrorAgentIntent("agent.saveDefinition", { id: agentId, definition: saved });
       } catch (err) {
         frontendLog(
           "app_store",
@@ -6902,6 +6967,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
             [agentId]: (s.agentDefinitions[agentId] ?? []).filter((d) => d.id !== definitionId),
           },
         }));
+        // Mutation cut (#2226): remove the definition from the region.
+        mirrorAgentIntent("agent.deleteDefinition", { id: agentId, definitionId });
       } catch (err) {
         frontendLog(
           "app_store",
@@ -6924,6 +6991,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
             ),
           },
         }));
+        // Mutation cut (#2226): replace the definition by id in the region.
+        mirrorAgentIntent("agent.updateDefinition", { id: agentId, definition: updated });
       } catch (err) {
         frontendLog(
           "app_store",
@@ -6954,6 +7023,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
             [agentId]: [...(s.agentFolders[agentId] ?? []), folder],
           },
         }));
+        // Mutation cut (#2226): append the folder to the region.
+        mirrorAgentIntent("agent.createFolder", { id: agentId, folder });
         toast.success(`Created folder ${folder.name}`);
       } catch (err) {
         frontendLog(
@@ -6978,6 +7049,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
             ),
           },
         }));
+        // Mutation cut (#2226): replace the folder by id in the region.
+        mirrorAgentIntent("agent.updateFolder", { id: agentId, folder: updated });
         if (isRename) toast.success(`Renamed folder to ${updated.name}`);
       } catch (err) {
         frontendLog(
@@ -7008,6 +7081,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
             ),
           },
         }));
+        // Mutation cut (#2226): remove the folder and reparent its child
+        // definitions to the root (the store's `delete_folder` does both).
+        mirrorAgentIntent("agent.deleteFolder", { id: agentId, folderId });
       } catch (err) {
         frontendLog(
           "app_store",
@@ -7029,6 +7105,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // Fire-and-forget: persist expansion state on agent
       const folder = (get().agentFolders[agentId] ?? []).find((f) => f.id === folderId);
       if (folder) {
+        // Mutation cut (#2226): replace the folder (with its flipped expansion) in
+        // the region.
+        mirrorAgentIntent("agent.updateFolder", { id: agentId, folder });
         apiUpdateAgentFolder(agentId, { id: folderId, is_expanded: folder.isExpanded }).catch(
           () => {}
         );


### PR DESCRIPTION
## Summary

Phase 5 **mutation cut** for the Agents domain: the agent lifecycle actions in `appStore` now dispatch granular `agent.*` intents so the backend `AgentsStore` becomes authoritative, exactly as the Monitors mutation cut did (#2249). Agents shadow (#2232) and render cut (#2252) are already merged; this is the third of four steps (shadow ✅ → render cut ✅ → **mutation cut** → remove reducers).

Frontend-only — the `agent.*` intents were all defined by the shadow, so no Rust change was needed (same shape as the Monitors cut).

## What changed

- **`agentsBridge.ts`** — adds the `agentIntentsEnabled` flag (**default on**, with `window.__TERMIHUB_AGENT_INTENTS__` / `localStorage["termihub.agentIntents"]` override for instant revert), plus `dispatchAgentIntent` / `mirrorAgentIntent` and the `AgentIntentKind` type. `mirrorAgentIntent` swallows + logs any dispatch failure so the local path is never disrupted (resilience / rollback fallback), and is a no-op when the flag is off.
- **`appStore.ts`** — mirrors every agent mutation through an `agent.*` intent: add / update / applySettings / remove / reorder / toggleExpanded, connect (capabilities + force-expand) / disconnect / shutdown, the single-writer `status` transition, refresh / clearSessions, and the definition + folder CRUD. The local reducer path stays in place as the render source and the resilience / rollback fallback (reducer removal is the next step).

## Safety

- **Flag defaults on**, taken on the automated parity tests + instant local fallback per the maintainer's proceed-on-tests decision (same as Monitors/session). Instant revert via the window/localStorage override.
- **Parity is the safety net**: `appStore.agentsMutationCut.test.ts` runs a faithful in-memory port of the Rust `AgentsStore`, applies the dispatched intents, and asserts the reconstructed `agents` region equals the appStore agents slice for every action + fan-out (flag on), plus a flag-off test proving zero dispatches and a byte-identical local slice.
- **Local fallback retained** — the appStore reducers are untouched; they still drive the render and act as the rollback path.

## Testing

- `pnpm exec vitest run` over `src/store`, `src/components/Sidebar`, `src/components/OpenConnections` — 1095 passed (25 new).
- `tsc --noEmit`, `eslint`, `prettier --check` clean. No Rust touched.

Part of #2226