### PR TITLE
feat(backend): shadow broadcast-membership projection (Part of #2242)

### DIFF
--- a/src-tauri/src/broadcast_projection/mod.rs
+++ b/src-tauri/src/broadcast_projection/mod.rs
@@ -1,0 +1,44 @@
+//! Shadow broadcast-membership authority — Phase 4 step 5b of the stateless-UI
+//! migration (#2242, part of #2206 / #2152 / #2139).
+//!
+//! Moves the broadcast-input **membership** state machine the frontend drives
+//! (`appStore` `broadcastActive` / `broadcastSourceTabId` / `broadcastScope` /
+//! `broadcastTargetTabIds` / `lastBroadcastScope`, #1955 / #1956 / #1958) into a
+//! Rust authority on the projection substrate ([`crate::projection`]). Broadcast
+//! input mirrors what the user types in one *source* terminal to a group of
+//! *target* terminals; this module owns which tabs are in that group, the scope
+//! the group was derived from, and the last scope remembered for the keyboard
+//! toggle — the membership orchestration, not the input fan-out.
+//!
+//! Broadcast is the second of #2206's three machines; the restore-cohort machine
+//! landed its shadow first ([`crate::restore_cohort_projection`], PR #2240), and
+//! the workflow machine migrates as its own step.
+//!
+//! # Client-scoped region — Open Design Decision #4 / #6
+//!
+//! Unlike the shared `session-lifecycle` region (a session's status is a
+//! property of the shared session), broadcast membership is a **per-client
+//! input-fan-out overlay over that client's own tabs**: the target ids are tab
+//! ids from a per-window tab tree, the source is the terminal focused in *this*
+//! window, and two windows can each run an independent broadcast session. It is
+//! a property of the viewing client, not of shared infrastructure — so the
+//! region is **client-scoped** (`broadcast@<clientId>`), mirroring the
+//! client-scoped `layout` ([`crate::layout::projection`]) and `restore-cohort`
+//! ([`crate::restore_cohort_projection`]) regions.
+//!
+//! # Shadow mode — zero user-facing change
+//!
+//! This step is deliberately **not authoritative**. The store exists, accepts
+//! `broadcast.*` intents, and projects diffs, but nothing in the live UI
+//! subscribes to or renders a `broadcast` region, and no frontend code
+//! dispatches `broadcast.*` intents yet. The existing `appStore` broadcast
+//! reducers remain authoritative. Later steps cut rendering, then the mutations,
+//! over to it (keeping the reducers as the parity-safe fallback, per the #2205
+//! reframe). The scope-to-tabs resolution, the connected-terminal fan-out
+//! filter, and dynamic-membership recompute stay frontend — they need the live
+//! tab tree the layout machine owns (see [`store`]).
+
+pub mod projection;
+pub mod store;
+
+pub use store::BroadcastStore;

--- a/src-tauri/src/broadcast_projection/projection.rs
+++ b/src-tauri/src/broadcast_projection/projection.rs
@@ -176,7 +176,10 @@ fn optional_scope(intent: &Intent) -> Result<Option<BroadcastScope>, (String, St
         None | Some(Value::Null) => Ok(None),
         Some(value) => {
             let s = value.as_str().ok_or_else(|| {
-                ("bad_payload".to_string(), "invalid 'scope' (not a string)".to_string())
+                (
+                    "bad_payload".to_string(),
+                    "invalid 'scope' (not a string)".to_string(),
+                )
             })?;
             parse_scope(s).map(Some)
         }
@@ -219,7 +222,10 @@ fn optional_str_array(intent: &Intent, key: &str) -> Result<Vec<String>, (String
         None | Some(Value::Null) => Ok(Vec::new()),
         Some(value) => {
             let arr = value.as_array().ok_or_else(|| {
-                ("bad_payload".to_string(), format!("invalid '{key}' (not an array)"))
+                (
+                    "bad_payload".to_string(),
+                    format!("invalid '{key}' (not an array)"),
+                )
             })?;
             collect_str_array(arr, key)
         }

--- a/src-tauri/src/broadcast_projection/projection.rs
+++ b/src-tauri/src/broadcast_projection/projection.rs
@@ -1,0 +1,242 @@
+//! Broadcast-membership projection: the client-scoped `broadcast@<clientId>`
+//! region and the `broadcast.*` intents (#2242, Phase 4 step 5b of #2139, part
+//! of #2206 / #2152).
+//!
+//! Exposes the authoritative [`BroadcastStore`] to each attached client as its
+//! own versioned, multi-subscriber projection region and turns the broadcast
+//! membership transitions the frontend currently drives into [`Intent`]s —
+//! mirroring the client-scoped `layout` pilot ([`crate::layout::projection`])
+//! and the restore-cohort reference ([`crate::restore_cohort_projection`]).
+//!
+//! # The `broadcast@<clientId>` region
+//!
+//! **Client-scoped** (Open Design Decision #4 / #6: broadcast membership is a
+//! per-client input-fan-out overlay over that client's own tabs, not shared
+//! infrastructure — like `layout` / `restore-cohort`). Each client gets its own
+//! region, seeded lazily and mutated via `intent.client_id`. The view model:
+//!
+//! ```json
+//! {
+//!   "active": false,
+//!   "sourceTabId": "tabId" | null,
+//!   "scope": "all" | "panel" | "custom",
+//!   "targetTabIds": ["tabId"],
+//!   "lastScope": "all" | "panel" | "custom"
+//! }
+//! ```
+//!
+//! # Intents
+//!
+//! | kind                      | payload                                             | effect                                          |
+//! | ------------------------- | --------------------------------------------------- | ----------------------------------------------- |
+//! | `broadcast.start`         | `{ scope, sourceTabId, targetTabIds: [id] }`        | enter broadcast; targets = `{source} ∪ targets` |
+//! | `broadcast.stop`          | `{}`                                                | leave broadcast; keep `scope` / `lastScope`     |
+//! | `broadcast.toggle`        | `{ scope?, sourceTabId?, targetTabIds?: [id] }`     | active → stop; idle + source → start            |
+//! | `broadcast.addTarget`     | `{ tabId }`                                          | add a tab to the target set                     |
+//! | `broadcast.removeTarget`  | `{ tabId }`                                          | remove a tab from the target set                |
+//!
+//! Three frontend concerns need no dedicated intent because they read the
+//! projected set rather than mutate it: `isBroadcastTarget` is a membership read
+//! of `targetTabIds`; `getBroadcastTargetTabIds` intersects the set with the
+//! live *connected* terminals at the fan-out seam; and `refreshBroadcastMembership`
+//! re-derives membership from the scope + tab tree (frontend) and reconciles the
+//! delta via `broadcast.addTarget` / `broadcast.removeTarget`.
+//!
+//! # Shadow mode
+//!
+//! Registered and fully served, but **not** driving the live UI: no frontend
+//! subscribes to `broadcast@<clientId>` or dispatches `broadcast.*` yet, so these
+//! intents mutate only the shadow store and project to regions nobody renders.
+//! The `appStore` broadcast reducers remain authoritative. Per the substrate
+//! contract the result of an intent is never returned inline — it always arrives
+//! as a projection diff on the client's region.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+use crate::broadcast_projection::store::{BroadcastScope, BroadcastStore};
+use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
+
+/// The projection region id for a client's broadcast membership
+/// (`broadcast@<clientId>`).
+pub fn broadcast_region(client_id: &str) -> String {
+    format!("broadcast@{client_id}")
+}
+
+/// Publish a client's `broadcast` region from the store, fanning a diff out to
+/// every subscriber and returning the advanced region for the intent ack (empty
+/// when the view did not change).
+pub fn publish_broadcast(
+    projector: &Projector,
+    store: &BroadcastStore,
+    client_id: &str,
+) -> Vec<ProducedRegion> {
+    let region = broadcast_region(client_id);
+    match projector.publish(&region, store.snapshot(client_id)) {
+        Some(version) => vec![ProducedRegion { region, version }],
+        None => Vec::new(),
+    }
+}
+
+/// Register the `broadcast.*` intents on a handler registry.
+///
+/// Each route resolves the managed [`BroadcastStore`] lazily (so it rejects
+/// gracefully rather than panicking if the store is somehow absent), mutates the
+/// dispatching client's membership via [`intent.client_id`](Intent::client_id),
+/// and publishes that client's region. All transitions are pure/fast map edits,
+/// so they run inline on the dispatcher's single writer.
+pub fn register_broadcast_intents(registry: &mut HandlerRegistry, app_handle: AppHandle) {
+    let handle = app_handle.clone();
+    registry.route("broadcast.start", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let scope = required_scope(intent)?;
+        let source = required_str(intent, "sourceTabId")?;
+        let targets = required_str_array(intent, "targetTabIds")?;
+        store.start(&intent.client_id, scope, &source, &targets);
+        Ok(publish_broadcast(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("broadcast.stop", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.stop(&intent.client_id);
+        Ok(publish_broadcast(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("broadcast.toggle", move |intent, projector| {
+        let store = store_of(&handle)?;
+        // The start branch's payload is optional: it is read only when idle, and
+        // the frontend resolves scope/source/targets from the live tab tree.
+        let scope = optional_scope(intent)?.unwrap_or_default();
+        let source = optional_str(intent, "sourceTabId");
+        let targets = optional_str_array(intent, "targetTabIds")?;
+        store.toggle(&intent.client_id, scope, source.as_deref(), &targets);
+        Ok(publish_broadcast(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("broadcast.addTarget", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let tab_id = required_str(intent, "tabId")?;
+        store.add_target(&intent.client_id, &tab_id);
+        Ok(publish_broadcast(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle;
+    registry.route("broadcast.removeTarget", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let tab_id = required_str(intent, "tabId")?;
+        store.remove_target(&intent.client_id, &tab_id);
+        Ok(publish_broadcast(projector, &store, &intent.client_id))
+    });
+}
+
+/// Resolve the managed broadcast store, or a rejectable error if absent.
+fn store_of(app_handle: &AppHandle) -> Result<Arc<BroadcastStore>, (String, String)> {
+    app_handle
+        .try_state::<Arc<BroadcastStore>>()
+        .map(|state| (*state).clone())
+        .ok_or_else(|| {
+            (
+                "unavailable".to_string(),
+                "broadcast store is not initialized".to_string(),
+            )
+        })
+}
+
+/// Parse a `BroadcastScope` from a JSON string, or a rejectable error.
+fn parse_scope(value: &str) -> Result<BroadcastScope, (String, String)> {
+    match value {
+        "all" => Ok(BroadcastScope::All),
+        "panel" => Ok(BroadcastScope::Panel),
+        "custom" => Ok(BroadcastScope::Custom),
+        _ => Err((
+            "bad_payload".to_string(),
+            "invalid 'scope' (expected \"all\" | \"panel\" | \"custom\")".to_string(),
+        )),
+    }
+}
+
+/// Parse the required `scope` field into a [`BroadcastScope`].
+fn required_scope(intent: &Intent) -> Result<BroadcastScope, (String, String)> {
+    let value = intent
+        .payload
+        .get("scope")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ("bad_payload".to_string(), "missing 'scope'".to_string()))?;
+    parse_scope(value)
+}
+
+/// Parse an optional `scope` field; absent → `None`, present-but-invalid → error.
+fn optional_scope(intent: &Intent) -> Result<Option<BroadcastScope>, (String, String)> {
+    match intent.payload.get("scope") {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => {
+            let s = value.as_str().ok_or_else(|| {
+                ("bad_payload".to_string(), "invalid 'scope' (not a string)".to_string())
+            })?;
+            parse_scope(s).map(Some)
+        }
+    }
+}
+
+/// Extract a required string field from an intent payload.
+fn required_str(intent: &Intent, key: &str) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// Extract an optional string field (absent → `None`).
+fn optional_str(intent: &Intent, key: &str) -> Option<String> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+/// Extract a required array-of-strings field (e.g. `targetTabIds`).
+fn required_str_array(intent: &Intent, key: &str) -> Result<Vec<String>, (String, String)> {
+    let arr = intent
+        .payload
+        .get(key)
+        .and_then(Value::as_array)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))?;
+    collect_str_array(arr, key)
+}
+
+/// Extract an optional array-of-strings field; absent → `[]`, present entries
+/// must all be strings.
+fn optional_str_array(intent: &Intent, key: &str) -> Result<Vec<String>, (String, String)> {
+    match intent.payload.get(key) {
+        None | Some(Value::Null) => Ok(Vec::new()),
+        Some(value) => {
+            let arr = value.as_array().ok_or_else(|| {
+                ("bad_payload".to_string(), format!("invalid '{key}' (not an array)"))
+            })?;
+            collect_str_array(arr, key)
+        }
+    }
+}
+
+/// Collect a JSON array into `Vec<String>`, rejecting any non-string entry.
+fn collect_str_array(arr: &[Value], key: &str) -> Result<Vec<String>, (String, String)> {
+    arr.iter()
+        .map(|v| {
+            v.as_str()
+                .map(str::to_string)
+                .ok_or_else(|| ("bad_payload".to_string(), format!("invalid '{key}' entry")))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[path = "projection_tests.rs"]
+mod tests;

--- a/src-tauri/src/broadcast_projection/projection_tests.rs
+++ b/src-tauri/src/broadcast_projection/projection_tests.rs
@@ -1,0 +1,414 @@
+//! Projection-contract tests for the client-scoped `broadcast@<clientId>` region
+//! (#2242), reusing the substrate harness (#2164): an in-memory [`VecSink`] and
+//! a client cache that applies diffs. The routes here drive a real
+//! [`BroadcastStore`] directly (the production `register_broadcast_intents`
+//! resolves the same store from the Tauri `AppHandle`; that thin wiring is
+//! integration-verified via a local `./scripts/dev.sh` run) through the
+//! identical parse → mutate → publish path.
+//!
+//! Asserted: subscribe → snapshot (identical to every subscriber), an accepted
+//! intent → exactly one coalesced diff fanned to every subscriber with monotonic
+//! versions, client-scoped isolation, rejection paths advance nothing, a no-op
+//! intent coalesces to nothing, a dead subscriber is reaped, and the client
+//! cache converges on the store's authority across a full session.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::{json, Value};
+
+use crate::broadcast_projection::projection::{broadcast_region, publish_broadcast};
+use crate::broadcast_projection::store::{BroadcastScope, BroadcastStore};
+use crate::projection::{
+    apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
+    ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
+};
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+/// The production `broadcast.*` routes, bound to an injected store instead of
+/// resolving one from an `AppHandle` — the exact parse → mutate → publish path
+/// `register_broadcast_intents` runs.
+fn registry_for(store: Arc<BroadcastStore>) -> HandlerRegistry {
+    let mut registry = HandlerRegistry::new();
+
+    let s = store.clone();
+    registry.route("broadcast.start", move |intent, projector| {
+        let scope = scope_field(intent, true)?.unwrap_or_default();
+        let source = str_field(intent, "sourceTabId")?;
+        let targets = str_array(intent, "targetTabIds")?;
+        s.start(&intent.client_id, scope, &source, &targets);
+        Ok(publish_broadcast(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("broadcast.stop", move |intent, projector| {
+        s.stop(&intent.client_id);
+        Ok(publish_broadcast(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("broadcast.toggle", move |intent, projector| {
+        let scope = scope_field(intent, false)?.unwrap_or_default();
+        let source = intent
+            .payload
+            .get("sourceTabId")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let targets = match intent.payload.get("targetTabIds") {
+            None | Some(Value::Null) => Vec::new(),
+            Some(_) => str_array(intent, "targetTabIds")?,
+        };
+        s.toggle(&intent.client_id, scope, source.as_deref(), &targets);
+        Ok(publish_broadcast(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("broadcast.addTarget", move |intent, projector| {
+        let tab_id = str_field(intent, "tabId")?;
+        s.add_target(&intent.client_id, &tab_id);
+        Ok(publish_broadcast(projector, &s, &intent.client_id))
+    });
+
+    let s = store;
+    registry.route("broadcast.removeTarget", move |intent, projector| {
+        let tab_id = str_field(intent, "tabId")?;
+        s.remove_target(&intent.client_id, &tab_id);
+        Ok(publish_broadcast(projector, &s, &intent.client_id))
+    });
+
+    registry
+}
+
+fn scope_field(intent: &Intent, required: bool) -> Result<Option<BroadcastScope>, (String, String)> {
+    match intent.payload.get("scope").and_then(Value::as_str) {
+        Some("all") => Ok(Some(BroadcastScope::All)),
+        Some("panel") => Ok(Some(BroadcastScope::Panel)),
+        Some("custom") => Ok(Some(BroadcastScope::Custom)),
+        Some(_) => Err(("bad_payload".to_string(), "invalid 'scope'".to_string())),
+        None if required => Err(("bad_payload".to_string(), "missing 'scope'".to_string())),
+        None => Ok(None),
+    }
+}
+
+fn str_field(intent: &Intent, key: &str) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+fn str_array(intent: &Intent, key: &str) -> Result<Vec<String>, (String, String)> {
+    let arr = intent
+        .payload
+        .get(key)
+        .and_then(Value::as_array)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))?;
+    arr.iter()
+        .map(|v| {
+            v.as_str()
+                .map(str::to_string)
+                .ok_or_else(|| ("bad_payload".to_string(), "invalid entry".to_string()))
+        })
+        .collect()
+}
+
+/// An in-memory sink recording delivered frames; can be killed to simulate a
+/// dead subscriber (mirrors the substrate/tunnel/layout test double).
+struct VecSink {
+    frames: Mutex<Vec<ProjectionFrame>>,
+    alive: AtomicBool,
+}
+
+impl VecSink {
+    fn new() -> Self {
+        Self {
+            frames: Mutex::new(Vec::new()),
+            alive: AtomicBool::new(true),
+        }
+    }
+
+    fn diffs(&self) -> Vec<DiffFrame> {
+        self.frames
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|f| match f {
+                ProjectionFrame::Diff(d) => Some(d.clone()),
+                ProjectionFrame::Snapshot(_) => None,
+            })
+            .collect()
+    }
+}
+
+impl ProjectionSink for VecSink {
+    fn deliver(&self, frame: &ProjectionFrame) -> Result<(), ProjectionError> {
+        if !self.alive.load(Ordering::SeqCst) {
+            return Err(ProjectionError::SinkClosed("killed".into()));
+        }
+        self.frames.lock().unwrap().push(frame.clone());
+        Ok(())
+    }
+}
+
+/// A minimal client cache mirroring the TypeScript `ProjectionClient`.
+struct ClientCache {
+    version: u64,
+    view: Value,
+}
+
+impl ClientCache {
+    fn from_snapshot(s: &SnapshotFrame) -> Self {
+        Self {
+            version: s.version,
+            view: s.view.clone(),
+        }
+    }
+
+    fn apply(&mut self, diff: &DiffFrame) {
+        assert_eq!(diff.base_version, self.version, "diff must fit the cache");
+        apply_ops(&mut self.view, &diff.ops).expect("diff applies cleanly");
+        self.version = diff.version;
+    }
+}
+
+fn intent(kind: &str, client: &str, payload: Value) -> Intent {
+    Intent {
+        intent_id: format!("01J-{kind}"),
+        kind: kind.to_string(),
+        payload,
+        client_id: client.to_string(),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn subscribe_returns_the_idle_baseline_identically_to_every_subscriber() {
+    let store = Arc::new(BroadcastStore::new());
+    let region = broadcast_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+
+    let snap_a = projector.subscribe(&region, "sub-a", "A", Arc::new(VecSink::new()));
+    let snap_b = projector.subscribe(&region, "sub-b", "A", Arc::new(VecSink::new()));
+
+    assert_eq!(snap_a.version, 0);
+    assert_eq!(snap_a, snap_b, "a late joiner gets an identical baseline");
+    assert_eq!(snap_a.region, "broadcast@A");
+    assert_eq!(snap_a.view["active"], json!(false));
+    assert_eq!(snap_a.view["sourceTabId"], Value::Null);
+    assert_eq!(snap_a.view["targetTabIds"], json!([]));
+    assert_eq!(snap_a.view["scope"], json!("all"));
+}
+
+#[test]
+fn a_start_intent_produces_one_diff_fanned_to_two_subscribers() {
+    let store = Arc::new(BroadcastStore::new());
+    let region = broadcast_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink_a = Arc::new(VecSink::new());
+    let sink_b = Arc::new(VecSink::new());
+    let snap = projector.subscribe(&region, "sub-a", "A", sink_a.clone());
+    projector.subscribe(&region, "sub-b", "A", sink_b.clone());
+    let mut cache_a = ClientCache::from_snapshot(&snap);
+
+    let ack = dispatcher.dispatch(intent(
+        "broadcast.start",
+        "A",
+        json!({ "scope": "all", "sourceTabId": "src", "targetTabIds": ["t1", "t2"] }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(
+        ack.produced,
+        Some(vec![crate::projection::ProducedRegion {
+            region: region.clone(),
+            version: 1,
+        }])
+    );
+
+    let diffs_a = sink_a.diffs();
+    let diffs_b = sink_b.diffs();
+    assert_eq!(diffs_a.len(), 1, "exactly one diff to A");
+    assert_eq!(diffs_b.len(), 1, "exactly one diff to B");
+    assert_eq!(diffs_a[0], diffs_b[0], "identical diff to every subscriber");
+
+    cache_a.apply(&diffs_a[0]);
+    assert_eq!(cache_a.view, store.snapshot("A"), "cache converges");
+    assert_eq!(cache_a.view["active"], json!(true));
+    assert_eq!(cache_a.view["targetTabIds"], json!(["src", "t1", "t2"]));
+}
+
+#[test]
+fn a_full_session_advances_monotonically_and_converges() {
+    let store = Arc::new(BroadcastStore::new());
+    let region = broadcast_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(&region, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    // start(src,t1) → addTarget(t2) → removeTarget(t1) → stop.
+    for (kind, payload) in [
+        (
+            "broadcast.start",
+            json!({ "scope": "panel", "sourceTabId": "src", "targetTabIds": ["t1"] }),
+        ),
+        ("broadcast.addTarget", json!({ "tabId": "t2" })),
+        ("broadcast.removeTarget", json!({ "tabId": "t1" })),
+        ("broadcast.stop", json!({})),
+    ] {
+        let ack = dispatcher.dispatch(intent(kind, "A", payload));
+        assert_eq!(ack.status, IntentStatus::Accepted, "{kind} accepted");
+    }
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 4, "one diff per view-changing intent");
+    for diff in &diffs {
+        cache.apply(diff);
+    }
+    assert_eq!(cache.version, 4);
+    assert_eq!(cache.view, store.snapshot("A"), "cache converges on authority");
+    assert_eq!(cache.view["active"], json!(false));
+    assert_eq!(cache.view["targetTabIds"], json!([]));
+    // stop retains the scope from the start for the keyboard toggle.
+    assert_eq!(cache.view["scope"], json!("panel"));
+    assert_eq!(cache.view["lastScope"], json!("panel"));
+}
+
+#[test]
+fn membership_is_isolated_to_its_client_region() {
+    let store = Arc::new(BroadcastStore::new());
+    let region_a = broadcast_region("A");
+    let region_b = broadcast_region("B");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region_a, store.snapshot("A"));
+    projector.register_region(&region_b, store.snapshot("B"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink_a = Arc::new(VecSink::new());
+    let sink_b = Arc::new(VecSink::new());
+    projector.subscribe(&region_a, "sa", "A", sink_a.clone());
+    projector.subscribe(&region_b, "sb", "B", sink_b.clone());
+
+    dispatcher.dispatch(intent(
+        "broadcast.start",
+        "A",
+        json!({ "scope": "all", "sourceTabId": "src", "targetTabIds": [] }),
+    ));
+
+    assert_eq!(sink_a.diffs().len(), 1, "A's region advanced");
+    assert_eq!(sink_b.diffs().len(), 0, "B's region untouched");
+    assert_eq!(projector.region_version(&region_b), Some(0));
+}
+
+#[test]
+fn an_intent_missing_required_fields_is_rejected_without_advancing() {
+    let store = Arc::new(BroadcastStore::new());
+    let region = broadcast_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(&region, "sub", "A", sink.clone());
+
+    // start with no sourceTabId is rejected.
+    let ack = dispatcher.dispatch(intent(
+        "broadcast.start",
+        "A",
+        json!({ "scope": "all", "targetTabIds": [] }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "bad_payload");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(&region), Some(0));
+}
+
+#[test]
+fn a_no_op_remove_advances_nothing() {
+    // Removing a tab that is not a target leaves the view unchanged, so the
+    // projector coalesces it to no diff and no version bump.
+    let store = Arc::new(BroadcastStore::new());
+    let region = broadcast_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(&region, "sub", "A", sink.clone());
+
+    let ack = dispatcher.dispatch(intent(
+        "broadcast.removeTarget",
+        "A",
+        json!({ "tabId": "ghost" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(ack.produced, Some(vec![]), "no region advanced");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(&region), Some(0));
+}
+
+#[test]
+fn toggle_off_then_on_round_trips_through_the_region() {
+    let store = Arc::new(BroadcastStore::new());
+    let region = broadcast_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(&region, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    // Idle toggle with a source starts; a second toggle stops.
+    for payload in [
+        json!({ "scope": "all", "sourceTabId": "src", "targetTabIds": ["t1"] }),
+        json!({}),
+    ] {
+        let ack = dispatcher.dispatch(intent("broadcast.toggle", "A", payload));
+        assert_eq!(ack.status, IntentStatus::Accepted);
+    }
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 2, "start then stop each produced a diff");
+    for diff in &diffs {
+        cache.apply(diff);
+    }
+    assert_eq!(cache.view, store.snapshot("A"), "cache converges");
+    assert_eq!(cache.view["active"], json!(false));
+}
+
+#[test]
+fn a_dead_subscriber_is_reaped_on_publish() {
+    let store = Arc::new(BroadcastStore::new());
+    let region = broadcast_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let live = Arc::new(VecSink::new());
+    let dead = Arc::new(VecSink::new());
+    projector.subscribe(&region, "live", "A", live.clone());
+    projector.subscribe(&region, "dead", "A", dead.clone());
+    assert_eq!(projector.subscriber_count(&region), 2);
+
+    dead.alive.store(false, Ordering::SeqCst);
+    dispatcher.dispatch(intent(
+        "broadcast.start",
+        "A",
+        json!({ "scope": "all", "sourceTabId": "src", "targetTabIds": [] }),
+    ));
+
+    assert_eq!(live.diffs().len(), 1, "the live subscriber still gets the diff");
+    assert_eq!(
+        projector.subscriber_count(&region),
+        1,
+        "the dead subscriber was reaped"
+    );
+}

--- a/src-tauri/src/broadcast_projection/projection_tests.rs
+++ b/src-tauri/src/broadcast_projection/projection_tests.rs
@@ -80,7 +80,10 @@ fn registry_for(store: Arc<BroadcastStore>) -> HandlerRegistry {
     registry
 }
 
-fn scope_field(intent: &Intent, required: bool) -> Result<Option<BroadcastScope>, (String, String)> {
+fn scope_field(
+    intent: &Intent,
+    required: bool,
+) -> Result<Option<BroadcastScope>, (String, String)> {
     match intent.payload.get("scope").and_then(Value::as_str) {
         Some("all") => Ok(Some(BroadcastScope::All)),
         Some("panel") => Ok(Some(BroadcastScope::Panel)),
@@ -276,7 +279,11 @@ fn a_full_session_advances_monotonically_and_converges() {
         cache.apply(diff);
     }
     assert_eq!(cache.version, 4);
-    assert_eq!(cache.view, store.snapshot("A"), "cache converges on authority");
+    assert_eq!(
+        cache.view,
+        store.snapshot("A"),
+        "cache converges on authority"
+    );
     assert_eq!(cache.view["active"], json!(false));
     assert_eq!(cache.view["targetTabIds"], json!([]));
     // stop retains the scope from the start for the keyboard toggle.
@@ -405,7 +412,11 @@ fn a_dead_subscriber_is_reaped_on_publish() {
         json!({ "scope": "all", "sourceTabId": "src", "targetTabIds": [] }),
     ));
 
-    assert_eq!(live.diffs().len(), 1, "the live subscriber still gets the diff");
+    assert_eq!(
+        live.diffs().len(),
+        1,
+        "the live subscriber still gets the diff"
+    );
     assert_eq!(
         projector.subscriber_count(&region),
         1,

--- a/src-tauri/src/broadcast_projection/store.rs
+++ b/src-tauri/src/broadcast_projection/store.rs
@@ -1,0 +1,282 @@
+//! The authoritative, client-scoped broadcast-membership state machine behind
+//! the shadow `broadcast@<clientId>` region (#2242, Phase 4 step 5b of #2139,
+//! part of #2206 / #2152).
+//!
+//! Models the broadcast-input membership slice the frontend currently drives
+//! (`appStore` `broadcastActive` / `broadcastSourceTabId` / `broadcastScope` /
+//! `broadcastTargetTabIds` / `lastBroadcastScope`, #1955 / #1956 / #1958): which
+//! tabs receive input mirrored from a source terminal, plus the scope the group
+//! was derived from and the last scope remembered for the keyboard toggle. This
+//! module owns only the **membership orchestration** state per client — not the
+//! input fan-out itself, not the tab tree, and not the resolution of a scope to
+//! a concrete tab set (that needs the layout tree, which stays frontend).
+//!
+//! # Client-scoped — Open Design Decision #4 / #6
+//!
+//! Broadcast membership is a **per-client input-fan-out overlay over that
+//! client's own tabs**, not shared infrastructure. The target ids are tab ids,
+//! and a tab tree is per-window (each `appStore` instance owns its own tabs and
+//! groups); the source is the terminal focused in *this* window, and two windows
+//! can each run an independent broadcast session over their own tabs. It is a
+//! property of the viewing client, so the store keys everything by `clientId`
+//! and projects one `broadcast@<clientId>` region per client — mirroring the
+//! client-scoped `layout` ([`crate::layout::projection`]) and `restore-cohort`
+//! ([`crate::restore_cohort_projection`]) regions, and unlike the *shared*
+//! `session-lifecycle` region (a session's status is a property of the shared
+//! session).
+//!
+//! # Shadow mode — zero user-facing change
+//!
+//! This step is deliberately **not authoritative**. The store exists, accepts
+//! `broadcast.*` intents, and projects diffs, but nothing in the live UI
+//! subscribes to or renders a `broadcast` region, and no frontend code
+//! dispatches `broadcast.*` intents yet. The existing `appStore` broadcast
+//! reducers remain authoritative. Later steps cut rendering, then the mutations,
+//! over to it (keeping the reducers as the parity-safe fallback, per the #2205
+//! reframe).
+//!
+//! ## What stays frontend
+//!
+//! Three concerns deliberately stay on the frontend at the render/mutation cut,
+//! keeping a clean per-domain boundary — each needs the live tab tree/registry
+//! that the layout machine, not this one, owns:
+//!
+//! - **`resolveBroadcastTargetTabIds`.** Turning a `"all"` / `"panel"` scope into
+//!   a concrete set of terminal tab ids walks the source tab's own group tree.
+//!   The store never resolves a scope; a `broadcast.start` / `broadcast.toggle`
+//!   carries the already-resolved target ids.
+//! - **`getBroadcastTargetTabIds`.** The connected-terminal filter (only
+//!   *connected* terminal tabs receive input) needs live per-tab session status.
+//!   The store keeps the raw membership set; the frontend intersects it with its
+//!   live connected terminals at the fan-out seam — exactly as the current
+//!   `getBroadcastTargetTabIds` re-filters at dispatch time.
+//! - **`refreshBroadcastMembership`.** Recomputing membership when a tab opens
+//!   during an active broadcast re-derives the set from the scope + tree
+//!   (frontend); it reconciles against the projected set with
+//!   [`add_target`](BroadcastStore::add_target) / [`remove_target`](BroadcastStore::remove_target)
+//!   for the delta, so it needs no dedicated intent (mirroring the restore-cohort
+//!   bulk-retry, which likewise reads the projection and re-drives). `"custom"`
+//!   never auto-adds, so refresh is a no-op there.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// How the broadcast target group was derived. Mirrors the frontend
+/// `BroadcastScope` union (`src/types/terminal.ts`).
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum BroadcastScope {
+    /// Every terminal tab in the source tab's own group.
+    #[default]
+    All,
+    /// Every terminal tab in the same split panel as the source.
+    Panel,
+    /// An explicit user selection; membership does not come from the scope.
+    Custom,
+}
+
+/// One client's broadcast-membership state — the direct mirror of the
+/// `appStore` broadcast slice for that window.
+#[derive(Clone, Debug)]
+struct ClientState {
+    /// Whether broadcast mode is active for this client.
+    active: bool,
+    /// The source terminal tab id (where the user types), or `None` when idle.
+    source_tab_id: Option<String>,
+    /// The scope the current (or most recent) group was derived from.
+    scope: BroadcastScope,
+    /// The target tab ids, in insertion order with the source first — mirrors
+    /// the frontend `Set<string>` (which includes the source as just another
+    /// target so the fan-out loop stays uniform).
+    target_tab_ids: Vec<String>,
+    /// The last scope used, retained across a stop for the keyboard toggle
+    /// (#1958). Never cleared by [`stop`](BroadcastStore::stop).
+    last_scope: BroadcastScope,
+}
+
+impl Default for ClientState {
+    /// The idle baseline — matches the `appStore` initial broadcast state
+    /// (`broadcastActive: false`, `broadcastScope: "all"`, empty targets,
+    /// `lastBroadcastScope: "all"`).
+    fn default() -> Self {
+        Self {
+            active: false,
+            source_tab_id: None,
+            scope: BroadcastScope::All,
+            target_tab_ids: Vec::new(),
+            last_scope: BroadcastScope::All,
+        }
+    }
+}
+
+impl ClientState {
+    /// The complete render-ready view model for this client's region.
+    fn to_view(&self) -> Value {
+        json!({
+            "active": self.active,
+            "sourceTabId": self.source_tab_id,
+            "scope": self.scope,
+            "targetTabIds": self.target_tab_ids,
+            "lastScope": self.last_scope,
+        })
+    }
+}
+
+/// Append the target ids to `out`, source first, de-duplicating while preserving
+/// order — mirrors the frontend `new Set([sourceTabId, ...targetTabIds])`.
+fn ordered_targets(source_tab_id: &str, target_tab_ids: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::with_capacity(target_tab_ids.len() + 1);
+    out.push(source_tab_id.to_string());
+    for id in target_tab_ids {
+        if !out.iter().any(|existing| existing == id) {
+            out.push(id.clone());
+        }
+    }
+    out
+}
+
+/// The shadow broadcast-membership authority. Owns one [`ClientState`] per
+/// attached client, keyed by `clientId`; an unknown client is seeded lazily on
+/// first touch with the idle baseline. Each client projects its own
+/// `broadcast@<clientId>` region.
+pub struct BroadcastStore {
+    clients: Mutex<HashMap<String, ClientState>>,
+}
+
+impl Default for BroadcastStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BroadcastStore {
+    /// A store with no clients yet. Regions are seeded lazily per `clientId`.
+    pub fn new() -> Self {
+        Self {
+            clients: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// The current render-ready view model for a client (seeding it if unknown):
+    /// `{ active, sourceTabId, scope, targetTabIds, lastScope }`.
+    ///
+    /// Pure with respect to broadcast state (never mutates beyond lazy seeding of
+    /// an empty client), so the projector can safely diff two consecutive
+    /// snapshots.
+    pub fn snapshot(&self, client_id: &str) -> Value {
+        self.lock()
+            .entry(client_id.to_string())
+            .or_default()
+            .to_view()
+    }
+
+    /// `broadcast.start` — enter broadcast mode with the given scope, source tab,
+    /// and (frontend-resolved) target tabs. Mirrors `appStore.startBroadcast`:
+    /// activates, records the scope as both the active and the remembered
+    /// `lastScope`, and seeds the target set as `{source} ∪ targets` (source
+    /// first, de-duplicated).
+    pub fn start(
+        &self,
+        client_id: &str,
+        scope: BroadcastScope,
+        source_tab_id: &str,
+        target_tab_ids: &[String],
+    ) {
+        let mut clients = self.lock();
+        let state = clients.entry(client_id.to_string()).or_default();
+        state.active = true;
+        state.scope = scope;
+        state.last_scope = scope;
+        state.source_tab_id = Some(source_tab_id.to_string());
+        state.target_tab_ids = ordered_targets(source_tab_id, target_tab_ids);
+    }
+
+    /// `broadcast.stop` — leave broadcast mode and clear the source/target
+    /// selection. Mirrors `appStore.stopBroadcast`: deactivates, drops the source
+    /// and targets, but deliberately **retains** `scope` and `lastScope` so the
+    /// keyboard toggle can reuse the last scope (#1958).
+    pub fn stop(&self, client_id: &str) {
+        let mut clients = self.lock();
+        let state = clients.entry(client_id.to_string()).or_default();
+        state.active = false;
+        state.source_tab_id = None;
+        state.target_tab_ids = Vec::new();
+    }
+
+    /// `broadcast.toggle` — the pure decision of `appStore.toggleBroadcast`
+    /// (#1958): while active, stop (payload ignored); while idle, start with the
+    /// provided scope/source/targets. The frontend still owns the parts that need
+    /// the live tab tree — picking the focused terminal as the source, the
+    /// `"custom" → "all"` scope fallback, resolving the targets, and the
+    /// "focus a terminal" hint toast — and passes the resolved values here. When
+    /// idle with no source resolved (nothing to broadcast from), this is a no-op.
+    pub fn toggle(
+        &self,
+        client_id: &str,
+        scope: BroadcastScope,
+        source_tab_id: Option<&str>,
+        target_tab_ids: &[String],
+    ) {
+        let is_active = self
+            .lock()
+            .get(client_id)
+            .map(|s| s.active)
+            .unwrap_or(false);
+        if is_active {
+            self.stop(client_id);
+        } else if let Some(source) = source_tab_id {
+            self.start(client_id, scope, source, target_tab_ids);
+        }
+    }
+
+    /// `broadcast.addTarget` — add a tab to the target set. Mirrors
+    /// `appStore.addBroadcastTarget`: a pure set-insert (no-op if already
+    /// present). Like the reducer it does not itself gate on `active`; the
+    /// frontend only issues it during an active broadcast, and the empty idle set
+    /// keeps a stray add harmless.
+    pub fn add_target(&self, client_id: &str, tab_id: &str) {
+        let mut clients = self.lock();
+        let state = clients.entry(client_id.to_string()).or_default();
+        if !state.target_tab_ids.iter().any(|id| id == tab_id) {
+            state.target_tab_ids.push(tab_id.to_string());
+        }
+    }
+
+    /// `broadcast.removeTarget` — remove a tab from the target set. Mirrors
+    /// `appStore.removeBroadcastTarget`: a pure set-delete (no-op if absent).
+    pub fn remove_target(&self, client_id: &str, tab_id: &str) {
+        let mut clients = self.lock();
+        let state = clients.entry(client_id.to_string()).or_default();
+        state.target_tab_ids.retain(|id| id != tab_id);
+    }
+
+    /// Read a client's `(active, source, scope)` (test/diagnostics helper).
+    #[cfg(test)]
+    pub fn status(&self, client_id: &str) -> Option<(bool, Option<String>, BroadcastScope)> {
+        self.lock()
+            .get(client_id)
+            .map(|s| (s.active, s.source_tab_id.clone(), s.scope))
+    }
+
+    /// Read a client's target tab ids in order (test/diagnostics helper).
+    #[cfg(test)]
+    pub fn target_tab_ids(&self, client_id: &str) -> Vec<String> {
+        self.lock()
+            .get(client_id)
+            .map(|s| s.target_tab_ids.clone())
+            .unwrap_or_default()
+    }
+
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, ClientState>> {
+        // Short critical sections only; a poisoned lock means another thread
+        // panicked mid-mutation (a bug) — recover rather than cascade.
+        self.clients.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod tests;

--- a/src-tauri/src/broadcast_projection/store_tests.rs
+++ b/src-tauri/src/broadcast_projection/store_tests.rs
@@ -1,0 +1,166 @@
+//! State-machine tests for [`BroadcastStore`], proving the membership authority
+//! matches the frontend `appStore` broadcast reducers (#1955 / #1956 / #1958)
+//! transition for transition: start → add/remove → stop, the source-in-set and
+//! de-dup rules, the scope/lastScope retention across a stop, the toggle
+//! decision, and the per-client isolation the client-scoped region requires.
+
+use super::*;
+
+const C: &str = "client-1";
+
+fn ids(v: &[&str]) -> Vec<String> {
+    v.iter().map(|s| s.to_string()).collect()
+}
+
+#[test]
+fn a_fresh_client_is_the_idle_baseline() {
+    let store = BroadcastStore::new();
+    let view = store.snapshot(C);
+    assert_eq!(view["active"], json!(false));
+    assert_eq!(view["sourceTabId"], Value::Null);
+    assert_eq!(view["scope"], json!("all"));
+    assert_eq!(view["targetTabIds"], json!([]));
+    assert_eq!(view["lastScope"], json!("all"));
+}
+
+#[test]
+fn start_activates_with_the_source_first_in_the_target_set() {
+    let store = BroadcastStore::new();
+    store.start(C, BroadcastScope::All, "src", &ids(&["t1", "t2"]));
+    let view = store.snapshot(C);
+    assert_eq!(view["active"], json!(true));
+    assert_eq!(view["sourceTabId"], json!("src"));
+    assert_eq!(view["scope"], json!("all"));
+    assert_eq!(view["lastScope"], json!("all"));
+    // Source first, then the resolved targets — mirrors `new Set([source, ...])`.
+    assert_eq!(view["targetTabIds"], json!(["src", "t1", "t2"]));
+}
+
+#[test]
+fn start_dedups_a_source_that_reappears_in_the_targets() {
+    let store = BroadcastStore::new();
+    // resolveBroadcastTargetTabIds returns every terminal in the group including
+    // the source, so the source commonly appears again in `targetTabIds`.
+    store.start(C, BroadcastScope::Panel, "src", &ids(&["t1", "src", "t2", "t1"]));
+    assert_eq!(store.snapshot(C)["targetTabIds"], json!(["src", "t1", "t2"]));
+    assert_eq!(store.snapshot(C)["scope"], json!("panel"));
+}
+
+#[test]
+fn start_records_scope_as_both_active_and_remembered() {
+    let store = BroadcastStore::new();
+    store.start(C, BroadcastScope::Custom, "src", &ids(&["t1"]));
+    let view = store.snapshot(C);
+    assert_eq!(view["scope"], json!("custom"));
+    assert_eq!(view["lastScope"], json!("custom"));
+}
+
+#[test]
+fn stop_clears_source_and_targets_but_retains_scope() {
+    let store = BroadcastStore::new();
+    store.start(C, BroadcastScope::Panel, "src", &ids(&["t1", "t2"]));
+    store.stop(C);
+    let view = store.snapshot(C);
+    assert_eq!(view["active"], json!(false));
+    assert_eq!(view["sourceTabId"], Value::Null);
+    assert_eq!(view["targetTabIds"], json!([]));
+    // stopBroadcast deliberately leaves scope/lastScope for the toggle (#1958).
+    assert_eq!(view["scope"], json!("panel"));
+    assert_eq!(view["lastScope"], json!("panel"));
+}
+
+#[test]
+fn add_target_appends_when_absent_and_is_a_no_op_when_present() {
+    let store = BroadcastStore::new();
+    store.start(C, BroadcastScope::All, "src", &ids(&["t1"]));
+    store.add_target(C, "t2");
+    assert_eq!(store.snapshot(C)["targetTabIds"], json!(["src", "t1", "t2"]));
+    // Adding an existing target changes nothing.
+    store.add_target(C, "t1");
+    assert_eq!(store.snapshot(C)["targetTabIds"], json!(["src", "t1", "t2"]));
+}
+
+#[test]
+fn remove_target_deletes_when_present_and_is_a_no_op_when_absent() {
+    let store = BroadcastStore::new();
+    store.start(C, BroadcastScope::All, "src", &ids(&["t1", "t2"]));
+    store.remove_target(C, "t1");
+    assert_eq!(store.snapshot(C)["targetTabIds"], json!(["src", "t2"]));
+    // Removing an absent target changes nothing.
+    store.remove_target(C, "ghost");
+    assert_eq!(store.snapshot(C)["targetTabIds"], json!(["src", "t2"]));
+}
+
+#[test]
+fn toggle_while_active_stops() {
+    let store = BroadcastStore::new();
+    store.start(C, BroadcastScope::Panel, "src", &ids(&["t1"]));
+    // Payload is ignored on the stop branch.
+    store.toggle(C, BroadcastScope::All, Some("other"), &ids(&["x"]));
+    let view = store.snapshot(C);
+    assert_eq!(view["active"], json!(false));
+    assert_eq!(view["sourceTabId"], Value::Null);
+    assert_eq!(view["targetTabIds"], json!([]));
+    // Scope retained from the start (stop does not reset it).
+    assert_eq!(view["scope"], json!("panel"));
+}
+
+#[test]
+fn toggle_while_idle_with_a_source_starts() {
+    let store = BroadcastStore::new();
+    store.toggle(C, BroadcastScope::All, Some("src"), &ids(&["t1"]));
+    let view = store.snapshot(C);
+    assert_eq!(view["active"], json!(true));
+    assert_eq!(view["sourceTabId"], json!("src"));
+    assert_eq!(view["targetTabIds"], json!(["src", "t1"]));
+}
+
+#[test]
+fn toggle_while_idle_without_a_source_is_a_no_op() {
+    let store = BroadcastStore::new();
+    // Mirrors the frontend "focus a terminal" guard: nothing to broadcast from.
+    store.toggle(C, BroadcastScope::All, None, &[]);
+    assert_eq!(store.snapshot(C)["active"], json!(false));
+    assert_eq!(store.status(C).map(|(a, _, _)| a), Some(false));
+}
+
+#[test]
+fn start_supersedes_a_prior_session() {
+    let store = BroadcastStore::new();
+    store.start(C, BroadcastScope::All, "src1", &ids(&["t1", "t2"]));
+    store.start(C, BroadcastScope::Custom, "src2", &ids(&["t3"]));
+    let view = store.snapshot(C);
+    assert_eq!(view["sourceTabId"], json!("src2"));
+    assert_eq!(view["scope"], json!("custom"));
+    assert_eq!(view["targetTabIds"], json!(["src2", "t3"]));
+}
+
+#[test]
+fn status_and_targets_helpers_reflect_state() {
+    let store = BroadcastStore::new();
+    store.start(C, BroadcastScope::Panel, "src", &ids(&["t1"]));
+    assert_eq!(
+        store.status(C),
+        Some((true, Some("src".to_string()), BroadcastScope::Panel))
+    );
+    assert_eq!(store.target_tab_ids(C), ids(&["src", "t1"]));
+}
+
+#[test]
+fn membership_is_isolated_per_client() {
+    let store = BroadcastStore::new();
+    store.start("a", BroadcastScope::All, "a-src", &ids(&["a1"]));
+    store.start("b", BroadcastScope::Custom, "b-src", &ids(&["b1"]));
+
+    store.add_target("a", "a2");
+    // Client b is untouched by client a's mutation.
+    assert_eq!(store.snapshot("b")["targetTabIds"], json!(["b-src", "b1"]));
+    assert_eq!(store.snapshot("b")["scope"], json!("custom"));
+
+    store.stop("a");
+    // Stopping a does not touch b.
+    assert_eq!(store.snapshot("a")["active"], json!(false));
+    assert_eq!(store.snapshot("b")["active"], json!(true));
+    assert_eq!(store.snapshot("a")["targetTabIds"], json!([]));
+    assert_eq!(store.snapshot("b")["targetTabIds"], json!(["b-src", "b1"]));
+}

--- a/src-tauri/src/broadcast_projection/store_tests.rs
+++ b/src-tauri/src/broadcast_projection/store_tests.rs
@@ -41,8 +41,16 @@ fn start_dedups_a_source_that_reappears_in_the_targets() {
     let store = BroadcastStore::new();
     // resolveBroadcastTargetTabIds returns every terminal in the group including
     // the source, so the source commonly appears again in `targetTabIds`.
-    store.start(C, BroadcastScope::Panel, "src", &ids(&["t1", "src", "t2", "t1"]));
-    assert_eq!(store.snapshot(C)["targetTabIds"], json!(["src", "t1", "t2"]));
+    store.start(
+        C,
+        BroadcastScope::Panel,
+        "src",
+        &ids(&["t1", "src", "t2", "t1"]),
+    );
+    assert_eq!(
+        store.snapshot(C)["targetTabIds"],
+        json!(["src", "t1", "t2"])
+    );
     assert_eq!(store.snapshot(C)["scope"], json!("panel"));
 }
 
@@ -74,10 +82,16 @@ fn add_target_appends_when_absent_and_is_a_no_op_when_present() {
     let store = BroadcastStore::new();
     store.start(C, BroadcastScope::All, "src", &ids(&["t1"]));
     store.add_target(C, "t2");
-    assert_eq!(store.snapshot(C)["targetTabIds"], json!(["src", "t1", "t2"]));
+    assert_eq!(
+        store.snapshot(C)["targetTabIds"],
+        json!(["src", "t1", "t2"])
+    );
     // Adding an existing target changes nothing.
     store.add_target(C, "t1");
-    assert_eq!(store.snapshot(C)["targetTabIds"], json!(["src", "t1", "t2"]));
+    assert_eq!(
+        store.snapshot(C)["targetTabIds"],
+        json!(["src", "t1", "t2"])
+    );
 }
 
 #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,12 @@
 /// (the ordered agent list + per-agent sessions/definitions/folders). Registered
 /// and served but not yet driving the live UI — see [`agents_projection`].
 mod agents_projection;
+/// Shadow broadcast-membership authority (#2242, Phase 4 step 5b of #2139, part
+/// of #2206 / #2152): the client-scoped `broadcast@<clientId>` projection region
+/// + `broadcast.*` intents modeling the `appStore` broadcast-input membership
+/// slice (which tabs receive mirrored input, #1955 / #1956 / #1958). Registered
+/// and served but not yet driving the live UI — see [`broadcast_projection`].
+mod broadcast_projection;
 mod commands;
 mod connection;
 /// Shadow connections-tree authority (#2225, Phase 5 of #2139/#2153): the shared
@@ -722,6 +728,22 @@ pub fn run() {
                 // lazily on a client's first `restore.*` intent.
                 app.manage(Arc::new(restore_cohort_projection::RestoreCohortStore::new()));
                 restore_cohort_projection::projection::register_restore_intents(
+                    &mut registry,
+                    app.handle().clone(),
+                );
+                // Shadow BroadcastStore (#2242, Phase 4 step 5b, part of #2206):
+                // the client-scoped `broadcast@<clientId>` region + `broadcast.*`
+                // intents modeling the broadcast-input membership slice (which
+                // tabs receive mirrored input, #1955 / #1956 / #1958). Managed
+                // authoritative state that serves intents, but nothing in the
+                // live UI subscribes to or renders the region yet — a pure shadow
+                // foundation (later steps cut rendering, then the mutations, over
+                // to it, keeping the appStore reducers as the parity-safe
+                // fallback). No client region is seeded here: like layout and
+                // restore-cohort, broadcast regions are client-scoped and created
+                // lazily on a client's first `broadcast.*` intent.
+                app.manage(Arc::new(broadcast_projection::BroadcastStore::new()));
+                broadcast_projection::projection::register_broadcast_intents(
                     &mut registry,
                     app.handle().clone(),
                 );


### PR DESCRIPTION
## Summary

Shadow foundation for the **broadcast-input membership** machine — Phase 4 step 5b of the stateless-UI migration (broadcast is the second of #2206's three machines; restore-cohort landed its shadow in PR #2240, session-lifecycle in #2202).

Adds a **backend-only** `broadcast_projection` module modeling the `appStore` broadcast-input membership slice (#1955 / #1956 / #1958): `broadcastActive`, `broadcastSourceTabId`, `broadcastScope`, `broadcastTargetTabIds`, `lastBroadcastScope`. Exposed as a client-scoped `broadcast@<clientId>` projection region on the substrate (#2149) with `broadcast.*` intents.

## Region scope — client-scoped (Decision #4 / #6)

Broadcast membership is a **per-client input-fan-out overlay over that client's own tabs**, not shared infrastructure: the target ids come from a per-window tab tree, the source is the terminal focused in *this* window, and two windows can each run an independent broadcast session. So the region is client-scoped (`broadcast@<clientId>`), mirroring `layout` and `restore-cohort` — and unlike the *shared* `session-lifecycle` region (a session's status is a property of the shared session). Justified in the module docs.

## Intents

| kind | payload | effect |
| --- | --- | --- |
| `broadcast.start` | `{ scope, sourceTabId, targetTabIds }` | enter broadcast; targets = `{source} ∪ targets` |
| `broadcast.stop` | `{}` | leave broadcast; retain `scope` / `lastScope` |
| `broadcast.toggle` | `{ scope?, sourceTabId?, targetTabIds? }` | active → stop; idle + source → start |
| `broadcast.addTarget` | `{ tabId }` | add a tab to the target set |
| `broadcast.removeTarget` | `{ tabId }` | remove a tab from the target set |

### What stays frontend (needs the live tab tree the layout machine owns)

- `resolveBroadcastTargetTabIds` — scope→tabs resolution walks the tab tree; the store never resolves a scope (start/toggle carry already-resolved ids).
- `getBroadcastTargetTabIds` — the connected-terminal fan-out filter needs live per-tab session status; the store keeps the raw set.
- `refreshBroadcastMembership` — re-derives membership from scope+tree (frontend) and reconciles the delta via `addTarget` / `removeTarget`, so it needs no dedicated intent (mirrors the restore-cohort bulk-retry).

## Shadow mode — zero user-facing change

Registered and served, but nothing in the live UI subscribes to or renders a `broadcast` region and no frontend code dispatches `broadcast.*` yet. The `appStore` broadcast reducers remain authoritative. Later steps cut rendering, then the mutations, over to it (keeping the reducers as the parity-safe fallback). The entire diff is under `src-tauri/` — no `src/` change.

## Tests

- **Store state-machine tests** (`store_tests.rs`): each reducer transition — start (source-first, de-dup), scope/lastScope retention across stop, add/remove no-ops, the toggle decision (active→stop, idle+source→start, idle-no-source no-op), supersede, per-client isolation.
- **Projection-contract tests** (`projection_tests.rs`, #2164 harness): subscribe baseline, one coalesced diff fanned to every subscriber with monotonic versions, client-scoped isolation, rejection paths advance nothing, a no-op coalesces to nothing, dead-subscriber reaping, full-session cache convergence.

21 tests, all green. `cargo clippy -D warnings` and `cargo fmt --check` clean.

Part of #2242
Part of #2206
