### PR TITLE
refactor(sftp): drive desktop sftp command layer on the async core browser (Part of #2104)

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -102,7 +102,10 @@ pub async fn sftp_check_writable(
 ) -> Result<Writability, TerminalError> {
     debug!(session_id, "SFTP check writable");
     let browser = manager.get_session(&session_id)?;
-    browser.check_writable(&remote_path).await.map_err(sftp_op_error)
+    browser
+        .check_writable(&remote_path)
+        .await
+        .map_err(sftp_op_error)
 }
 
 /// Open a dedicated SFTP channel off `browser` and (for downloads) stat the
@@ -408,7 +411,10 @@ pub async fn sftp_read_file_content(
     manager: State<'_, SftpManager>,
 ) -> Result<String, TerminalError> {
     let browser = manager.get_session(&session_id)?;
-    let data = browser.read_file(&remote_path).await.map_err(sftp_op_error)?;
+    let data = browser
+        .read_file(&remote_path)
+        .await
+        .map_err(sftp_op_error)?;
     String::from_utf8(data)
         .map_err(|e| TerminalError::SftpError(format!("read failed: invalid UTF-8: {e}")))
 }

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1,10 +1,11 @@
 use serde::Serialize;
 use tauri::{Emitter, Manager, State};
-use termihub_core::backends::ssh::parse_ssh_settings;
+use termihub_core::backends::ssh::{parse_ssh_settings, SftpAdvancedOps, SftpFileBrowser};
+use termihub_core::files::FileBrowser;
 use tracing::{debug, info};
 
 use crate::connection::manager::ConnectionManager;
-use crate::files::sftp::{lock_session, ElevatedWriteResult, SftpManager, Writability};
+use crate::files::sftp::{sftp_op_error, ElevatedWriteResult, SftpManager, Writability};
 use crate::files::transfer::{self, TransferContext, TransferDirection, TransferRegistry};
 use crate::files::FileEntry;
 use crate::utils::errors::TerminalError;
@@ -29,14 +30,10 @@ pub async fn sftp_open(
         .map_err(|e| TerminalError::ConnectionFailed(e.to_string()))?;
     let config = parse_ssh_settings(&config);
     info!(host = %config.host, port = config.port, "Opening SFTP session");
-    // The SSH handshake blocks (and uses `block_in_place` internally), so run it
-    // on a blocking-pool thread rather than the Tauri command thread — calling it
-    // directly aborts the process (`block_in_place` is only valid on a runtime
-    // worker thread). Mirrors `monitoring_open`.
-    let manager = (*manager).clone();
-    tokio::task::spawn_blocking(move || manager.open_session(&config))
-        .await
-        .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+    // The core SFTP browser is fully async (russh), so the connect is awaited
+    // directly on the command thread — no `spawn_blocking` / `block_in_place`
+    // bridging is needed, exactly as the `ConnectionType` file-browser path does.
+    manager.open_session(&config).await
 }
 
 /// Close an SFTP session.
@@ -54,10 +51,8 @@ pub async fn sftp_list_dir(
     manager: State<'_, SftpManager>,
 ) -> Result<Vec<FileEntry>, TerminalError> {
     debug!(session_id, path, "SFTP list directory");
-    let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || lock_session(&session)?.list_dir(&path))
-        .await
-        .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+    let browser = manager.get_session(&session_id)?;
+    browser.list_dir(&path).await.map_err(sftp_op_error)
 }
 
 /// Get metadata (size, mtime, permissions) for a single remote file via SFTP.
@@ -73,10 +68,8 @@ pub async fn sftp_stat(
     manager: State<'_, SftpManager>,
 ) -> Result<FileEntry, TerminalError> {
     debug!(session_id, path, "SFTP stat");
-    let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || lock_session(&session)?.stat(&path))
-        .await
-        .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+    let browser = manager.get_session(&session_id)?;
+    browser.stat(&path).await.map_err(sftp_op_error)
 }
 
 /// Resolve a remote path to its canonical absolute form via SFTP realpath.
@@ -90,10 +83,8 @@ pub async fn sftp_realpath(
     manager: State<'_, SftpManager>,
 ) -> Result<String, TerminalError> {
     debug!(session_id, path, "SFTP realpath");
-    let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || lock_session(&session)?.realpath(&path))
-        .await
-        .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+    let browser = manager.get_session(&session_id)?;
+    browser.realpath(&path).await.map_err(sftp_op_error)
 }
 
 /// Authoritatively check whether a remote file is writable by the connecting
@@ -110,35 +101,27 @@ pub async fn sftp_check_writable(
     manager: State<'_, SftpManager>,
 ) -> Result<Writability, TerminalError> {
     debug!(session_id, "SFTP check writable");
-    let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || lock_session(&session)?.check_writable(&remote_path))
-        .await
-        .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+    let browser = manager.get_session(&session_id)?;
+    browser.check_writable(&remote_path).await.map_err(sftp_op_error)
 }
 
-/// Open a dedicated SFTP channel off `session` and (for downloads) stat the
-/// remote size, on a blocking-pool thread — the SFTP calls use `block_in_place`,
-/// which is invalid on the async command thread. Returns the dedicated session
-/// plus the known total size (`0` = indeterminate).
+/// Open a dedicated SFTP channel off `browser` and (for downloads) stat the
+/// remote size. Both are awaited directly on the async core browser — no
+/// `spawn_blocking` / `block_in_place` bridging is needed. Returns the dedicated
+/// session plus the known total size (`0` = indeterminate).
 async fn open_transfer_channel(
-    session: std::sync::Arc<std::sync::Mutex<crate::files::sftp::SftpSession>>,
+    browser: std::sync::Arc<SftpFileBrowser>,
     remote_path: Option<String>,
 ) -> Result<(russh_sftp::client::SftpSession, u64), TerminalError> {
-    tokio::task::spawn_blocking(move || {
-        let session = lock_session(&session)?;
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                let dedicated = session.open_dedicated_sftp().await?;
-                let total = match &remote_path {
-                    Some(path) => session.remote_size(path).await,
-                    None => 0,
-                };
-                Ok::<_, TerminalError>((dedicated, total))
-            })
-        })
-    })
-    .await
-    .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+    let dedicated = browser
+        .open_dedicated_channel()
+        .await
+        .map_err(sftp_op_error)?;
+    let total = match &remote_path {
+        Some(path) => browser.remote_size(path).await,
+        None => 0,
+    };
+    Ok((dedicated, total))
 }
 
 /// Start a download (remote → local). Registers a `transfer_id`, runs a chunked
@@ -158,8 +141,8 @@ pub async fn sftp_download(
     app_handle: tauri::AppHandle,
 ) -> Result<String, TerminalError> {
     debug!(session_id, remote_path, local_path, "SFTP download");
-    let session = manager.get_session(&session_id)?;
-    let (dedicated, total) = open_transfer_channel(session, Some(remote_path.clone())).await?;
+    let browser = manager.get_session(&session_id)?;
+    let (dedicated, total) = open_transfer_channel(browser, Some(remote_path.clone())).await?;
 
     let transfer_id = uuid::Uuid::new_v4().to_string();
     let file_name = file_name_of(&remote_path);
@@ -209,8 +192,8 @@ pub async fn sftp_upload(
     app_handle: tauri::AppHandle,
 ) -> Result<String, TerminalError> {
     debug!(session_id, local_path, remote_path, "SFTP upload");
-    let session = manager.get_session(&session_id)?;
-    let (dedicated, _total) = open_transfer_channel(session, None).await?;
+    let browser = manager.get_session(&session_id)?;
+    let (dedicated, _total) = open_transfer_channel(browser, None).await?;
 
     // Local files are cheap to stat, so we can report a real total for uploads.
     let total = tokio::fs::metadata(&local_path)
@@ -274,13 +257,15 @@ pub async fn sftp_mkdir(
     path: String,
     manager: State<'_, SftpManager>,
 ) -> Result<(), TerminalError> {
-    let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || lock_session(&session)?.mkdir(&path))
-        .await
-        .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+    let browser = manager.get_session(&session_id)?;
+    browser.mkdir(&path).await.map_err(sftp_op_error)
 }
 
 /// Delete a file or empty directory on the remote host.
+///
+/// `is_directory` is retained for the frontend IPC shape; the core browser's
+/// `delete` self-detects a directory via `stat` and picks `rmdir`/`unlink`
+/// accordingly, so the flag is advisory only.
 #[tauri::command]
 pub async fn sftp_delete(
     session_id: String,
@@ -288,17 +273,9 @@ pub async fn sftp_delete(
     is_directory: bool,
     manager: State<'_, SftpManager>,
 ) -> Result<(), TerminalError> {
-    let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || {
-        let session = lock_session(&session)?;
-        if is_directory {
-            session.remove_dir(&path)
-        } else {
-            session.remove_file(&path)
-        }
-    })
-    .await
-    .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+    let _ = is_directory;
+    let browser = manager.get_session(&session_id)?;
+    browser.delete(&path).await.map_err(sftp_op_error)
 }
 
 /// Rename a file or directory on the remote host.
@@ -309,10 +286,11 @@ pub async fn sftp_rename(
     new_path: String,
     manager: State<'_, SftpManager>,
 ) -> Result<(), TerminalError> {
-    let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || lock_session(&session)?.rename(&old_path, &new_path))
+    let browser = manager.get_session(&session_id)?;
+    browser
+        .rename(&old_path, &new_path)
         .await
-        .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+        .map_err(sftp_op_error)
 }
 
 // --- Local filesystem commands ---
@@ -429,10 +407,10 @@ pub async fn sftp_read_file_content(
     remote_path: String,
     manager: State<'_, SftpManager>,
 ) -> Result<String, TerminalError> {
-    let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || lock_session(&session)?.read_file_content(&remote_path))
-        .await
-        .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+    let browser = manager.get_session(&session_id)?;
+    let data = browser.read_file(&remote_path).await.map_err(sftp_op_error)?;
+    String::from_utf8(data)
+        .map_err(|e| TerminalError::SftpError(format!("read failed: invalid UTF-8: {e}")))
 }
 
 /// Write a string to a remote file via SFTP.
@@ -443,12 +421,11 @@ pub async fn sftp_write_file_content(
     content: String,
     manager: State<'_, SftpManager>,
 ) -> Result<(), TerminalError> {
-    let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || {
-        lock_session(&session)?.write_file_content(&remote_path, &content)
-    })
-    .await
-    .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+    let browser = manager.get_session(&session_id)?;
+    browser
+        .write_file(&remote_path, content.as_bytes())
+        .await
+        .map_err(sftp_op_error)
 }
 
 /// Write a string to a remote file with `sudo`-elevated privileges (#1328).
@@ -469,12 +446,11 @@ pub async fn sftp_write_file_content_elevated(
 ) -> Result<ElevatedWriteResult, TerminalError> {
     // Do not log `sudo_password`.
     debug!(session_id, remote_path, "SFTP elevated write");
-    let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || {
-        lock_session(&session)?.write_file_content_elevated(&remote_path, &content, &sudo_password)
-    })
-    .await
-    .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+    let browser = manager.get_session(&session_id)?;
+    browser
+        .write_file_content_elevated(&remote_path, &content, &sudo_password)
+        .await
+        .map_err(sftp_op_error)
 }
 
 /// Report whether the SFTP session's SSH connection can open an exec channel
@@ -488,10 +464,10 @@ pub async fn sftp_has_exec_capability(
     session_id: String,
     manager: State<'_, SftpManager>,
 ) -> Result<bool, TerminalError> {
-    let session = manager.get_session(&session_id)?;
-    tokio::task::spawn_blocking(move || Ok(lock_session(&session)?.has_exec_capability()))
-        .await
-        .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
+    let browser = manager.get_session(&session_id)?;
+    // A dropped / SFTP-only connection maps to `false` (as before) rather than
+    // surfacing an error to the editor.
+    Ok(browser.has_exec_capability().await.unwrap_or(false))
 }
 
 // --- VS Code integration ---
@@ -518,11 +494,10 @@ pub fn vscode_open_local(path: String) -> Result<(), TerminalError> {
 
 /// Open a remote file in VS Code: download, open with --wait, re-upload on close.
 ///
-/// `async` + `spawn_blocking`: the SFTP read/write use `block_in_place`
-/// internally, which aborts the process on the synchronous Tauri command thread
-/// (and on a raw `std::thread`, which has no runtime context). Both the initial
-/// download and the background wait/re-upload therefore run on `spawn_blocking`
-/// threads, which carry a Tokio runtime context. Mirrors `monitoring_open`. See #828.
+/// The SFTP read/write go through the fully-async core browser and are awaited
+/// directly. Only VS Code's blocking `--wait` is run on a `spawn_blocking` thread
+/// inside the background task; the re-upload afterwards is a normal `.await` on
+/// the core browser. Mirrors `monitoring_open`. See #828.
 #[tauri::command]
 pub async fn vscode_open_remote(
     session_id: String,
@@ -530,8 +505,8 @@ pub async fn vscode_open_remote(
     manager: State<'_, SftpManager>,
     app_handle: tauri::AppHandle,
 ) -> Result<(), TerminalError> {
-    // Get a clone of the session Arc before spawning the background task
-    let session_arc = manager.get_session(&session_id)?;
+    // Clone the session browser Arc before spawning the background task.
+    let browser = manager.get_session(&session_id)?;
 
     // Extract the filename from the remote path
     let filename = std::path::Path::new(&remote_path)
@@ -547,31 +522,26 @@ pub async fn vscode_open_remote(
     let temp_path = temp_dir.join(format!("{}-{}", uuid::Uuid::new_v4(), filename));
     let temp_path_str = temp_path.to_string_lossy().to_string();
 
-    // Download the remote file to temp on a blocking-pool thread (the SFTP read
-    // uses `block_in_place`, which is invalid on the command thread).
-    {
-        let session = session_arc.clone();
-        let remote_path = remote_path.clone();
-        let temp_path_str = temp_path_str.clone();
-        tokio::task::spawn_blocking(move || {
-            lock_session(&session)?.read_file(&remote_path, &temp_path_str)
-        })
+    // Download the remote file to temp via the async core browser.
+    let data = browser
+        .read_file(&remote_path)
         .await
-        .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))??;
-    }
+        .map_err(sftp_op_error)?;
+    tokio::fs::write(&temp_path, &data)
+        .await
+        .map_err(|e| TerminalError::EditorError(format!("Failed to write temp file: {e}")))?;
 
-    // Wait for VS Code to close, then re-upload — on a blocking-pool thread so
-    // the SFTP write's `block_in_place` has a runtime context (a raw
-    // `std::thread` would have none and abort the process).
-    tauri::async_runtime::spawn_blocking(move || {
-        let result = vscode::open_in_vscode_wait(&temp_path_str);
+    // Wait for VS Code to close, then re-upload. The `--wait` blocks, so it runs
+    // on a `spawn_blocking` thread; the re-read + re-upload are awaited on the
+    // core browser.
+    tauri::async_runtime::spawn(async move {
+        let wait_path = temp_path_str.clone();
+        let wait_result =
+            tokio::task::spawn_blocking(move || vscode::open_in_vscode_wait(&wait_path)).await;
 
-        let event = match result {
-            Ok(()) => {
-                // Re-upload the edited file
-                let upload_result = lock_session(&session_arc)
-                    .and_then(|session| session.write_file(&temp_path_str, &remote_path));
-                match upload_result {
+        let event = match wait_result {
+            Ok(Ok(())) => match tokio::fs::read(&temp_path).await {
+                Ok(edited) => match browser.write_file(&remote_path, &edited).await {
                     Ok(_) => VscodeEditCompleteEvent {
                         remote_path,
                         success: true,
@@ -582,17 +552,27 @@ pub async fn vscode_open_remote(
                         success: false,
                         error: Some(format!("Upload failed: {}", e)),
                     },
-                }
-            }
-            Err(e) => VscodeEditCompleteEvent {
+                },
+                Err(e) => VscodeEditCompleteEvent {
+                    remote_path,
+                    success: false,
+                    error: Some(format!("Failed to re-read edited file: {}", e)),
+                },
+            },
+            Ok(Err(e)) => VscodeEditCompleteEvent {
                 remote_path,
                 success: false,
                 error: Some(format!("VS Code error: {}", e)),
             },
+            Err(e) => VscodeEditCompleteEvent {
+                remote_path,
+                success: false,
+                error: Some(format!("VS Code wait task failed: {}", e)),
+            },
         };
 
         // Clean up temp file (best-effort)
-        let _ = std::fs::remove_file(&temp_path);
+        let _ = tokio::fs::remove_file(&temp_path).await;
 
         // Emit event to frontend
         let _ = app_handle.emit("vscode-edit-complete", event);

--- a/src-tauri/src/files/sftp.rs
+++ b/src-tauri/src/files/sftp.rs
@@ -458,14 +458,19 @@ mod tests {
         });
         assert!(handle.join().is_err(), "poisoning thread should panic");
 
-        // A raw `.lock().unwrap()` would panic here; the helper must not.
-        let result = lock_sessions(&sessions);
+        // A raw `.lock().unwrap()` would panic here; the helper must not. The
+        // Ok variant holds a `MutexGuard` that is not `Debug`, so match by hand
+        // rather than `unwrap_err()`.
+        let err = match lock_sessions(&sessions) {
+            Ok(_) => panic!("poisoned lock should return a recoverable error, got Ok"),
+            Err(e) => e,
+        };
         assert!(
-            matches!(result, Err(TerminalError::SftpError(_))),
-            "poisoned lock should return a recoverable SftpError, got {result:?}"
+            matches!(err, TerminalError::SftpError(_)),
+            "poisoned lock should return a recoverable SftpError"
         );
         // The failure is an SFTP-session error, not a generic SSH error (#2094).
-        let rendered = result.unwrap_err().to_string();
+        let rendered = err.to_string();
         assert!(
             rendered.starts_with("SFTP error:"),
             "SFTP session errors must carry the SFTP label, got {rendered:?}"

--- a/src-tauri/src/files/sftp.rs
+++ b/src-tauri/src/files/sftp.rs
@@ -1,57 +1,48 @@
 use std::collections::HashMap;
-use std::future::Future;
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use russh_sftp::client::SftpSession as RusshSftp;
-use tracing::{debug, info};
+use tracing::info;
 
-use termihub_core::backends::ssh::{SftpAdvancedOps, SftpFileBrowser};
-use termihub_core::files::{FileBrowser, FileEntry};
+use termihub_core::backends::ssh::SftpFileBrowser;
 
 use crate::terminal::backend::SshConfig;
 use crate::utils::errors::TerminalError;
 
 /// The privilege-elevated write outcome and the writability verdict now live in
 /// [`termihub_core::backends::ssh::sftp_ops`] so a single implementation backs
-/// both the core `FileBrowser` path and this desktop session (#2104). Re-exported
-/// here so the desktop command layer and its callers keep their import paths.
+/// both the core `FileBrowser` path and this desktop command layer (#2104).
+/// Re-exported here so the command layer and its callers keep their import paths.
 pub use termihub_core::backends::ssh::sftp_ops::{ElevatedWriteResult, Writability};
 
 /// Map a core [`FileError`](termihub_core::errors::FileError) from an SFTP
 /// operation to the desktop [`TerminalError::SftpError`], preserving the
 /// operation-specific message (`readdir failed: …`, `realpath failed: …`, etc.)
 /// rather than double-wrapping it behind the generic "Operation failed:" prefix.
-fn sftp_op_error(err: termihub_core::errors::FileError) -> TerminalError {
+///
+/// Shared by every `sftp_*` Tauri command so they map the core browser's errors
+/// uniformly (#2104).
+pub(crate) fn sftp_op_error(err: termihub_core::errors::FileError) -> TerminalError {
     match err {
         termihub_core::errors::FileError::OperationFailed(msg) => TerminalError::SftpError(msg),
         other => TerminalError::SftpError(other.to_string()),
     }
 }
 
-/// Drive an async core [`SftpFileBrowser`] operation to completion from the
-/// synchronous `SftpSession` API.
+/// Lock the session map, mapping a poisoned lock to a recoverable
+/// [`TerminalError`] instead of panicking.
 ///
-/// The desktop SFTP command layer is synchronous (each Tauri command runs the
-/// blocking session methods on a `spawn_blocking` thread while holding the
-/// session mutex), so it bridges into the fully-async core browser via
-/// `block_in_place` + `Handle::current().block_on`. Both require a multi-threaded
-/// Tokio runtime worker context on the calling thread — always satisfied here
-/// because callers are inside `spawn_blocking` (#828).
-fn block_on_sftp<F: Future>(fut: F) -> F::Output {
-    tokio::task::block_in_place(|| tokio::runtime::Handle::current().block_on(fut))
-}
-
-/// Lock a mutex, mapping a poisoned lock to a recoverable [`TerminalError`]
-/// instead of panicking.
-///
-/// A prior SFTP op that panicked while holding the lock poisons the `Mutex`;
+/// A prior operation that panicked while holding the lock poisons the `Mutex`;
 /// a raw `.lock().unwrap()` would then abort the whole process on every
-/// subsequent command. Mapping the error keeps the session recoverable
-/// (audit GAP C1, issue #1143).
-pub fn lock_session<T>(mutex: &Mutex<T>) -> Result<MutexGuard<'_, T>, TerminalError> {
-    mutex
+/// subsequent command. Mapping the error keeps the manager recoverable
+/// (audit GAP C1, issue #1143). The guard is only ever held for the brief,
+/// non-async map mutation (insert / remove / clone-out), never across an
+/// `.await`.
+fn lock_sessions(
+    sessions: &Mutex<HashMap<String, Arc<SftpFileBrowser>>>,
+) -> Result<MutexGuard<'_, HashMap<String, Arc<SftpFileBrowser>>>, TerminalError> {
+    sessions
         .lock()
-        .map_err(|_| TerminalError::SftpError("SFTP session lock poisoned".to_string()))
+        .map_err(|_| TerminalError::SftpError("SFTP session map lock poisoned".to_string()))
 }
 
 /// Drain every entry from a keyed session map, poison-safe, and drop the values.
@@ -70,212 +61,25 @@ fn drain_sessions<V>(sessions: &Mutex<HashMap<String, V>>) -> usize {
     count
 }
 
-/// SFTP session for the desktop file-browser/transfer command layer.
+/// Manages the desktop file-browser/transfer command layer's SFTP sessions,
+/// keyed by UUID.
 ///
-/// This is a thin **synchronous adapter** around the single core SFTP
-/// implementation, [`SftpFileBrowser`](termihub_core::backends::ssh::SftpFileBrowser):
-/// every operation delegates to the core browser (which owns the russh-sftp
-/// session and all operation logic), so the desktop no longer maintains a
-/// parallel SFTP implementation (#2104). Because it goes through the core browser
-/// it reaches jump-host targets through their pooled gateway (#939) — the direct
-/// `connect_and_authenticate` path it used before ignored `proxy_jump`.
+/// Each session is a single core [`SftpFileBrowser`] — the **one** SFTP
+/// implementation, shared with the core
+/// [`ConnectionType::file_browser()`](termihub_core::connection::ConnectionType::file_browser)
+/// path. The desktop no longer wraps it in a synchronous adapter: the `sftp_*`
+/// Tauri commands drive the fully-async browser directly with `.await`, exactly
+/// as [`session::file_ops`](crate::session) does for session-scoped browsing
+/// (#2104). Because the browser connects through the core `connect_target`, every
+/// session reaches jump-host (`ProxyJump`) targets through their pooled gateway
+/// (#939).
 ///
-/// The adapter exists only to keep the synchronous, session-id-keyed command API
-/// (`SftpManager` + the `sftp_*` Tauri commands) working; migrating that surface
-/// onto the async `FileBrowser`/`ConnectionType` path is tracked as a follow-up.
-pub struct SftpSession {
-    browser: SftpFileBrowser,
-}
-
-impl SftpSession {
-    /// Open a new SFTP session to the given SSH host.
-    ///
-    /// Eagerly connects (jump-host aware, via the core browser) so `sftp_open`
-    /// fails loudly on a bad host / auth here rather than deferring the error to
-    /// the first listing.
-    pub fn new(config: &SshConfig) -> Result<Self, TerminalError> {
-        info!(host = %config.host, port = config.port, "Opening SFTP connection");
-        let browser = SftpFileBrowser::new(config.clone());
-        block_on_sftp(browser.connect()).map_err(sftp_op_error)?;
-        Ok(Self { browser })
-    }
-
-    /// Report whether an exec (command) channel can be opened and used on the
-    /// SSH connection backing this SFTP session.
-    ///
-    /// A normal SSH+shell connection can run the probe (`true`); an SFTP-only or
-    /// relayed connection (e.g. `ForceCommand internal-sftp`) cannot (`false`).
-    /// Lets the file editor know whether privilege-elevated writes — which need a
-    /// shell to run `sudo` — are possible for this connection. A dropped
-    /// connection maps to `false`.
-    pub fn has_exec_capability(&self) -> bool {
-        block_on_sftp(self.browser.has_exec_capability()).unwrap_or(false)
-    }
-
-    /// Open a **dedicated** SFTP session on a fresh channel off the same
-    /// authenticated SSH connection.
-    ///
-    /// Used by the cancellable transfer subsystem (#1245): the returned
-    /// [`RusshSftp`] owns its own channel, so a chunked copy can run on it
-    /// without holding this session's `Mutex` — keeping directory listing /
-    /// navigation live on the browsing channel during a transfer.
-    pub async fn open_dedicated_sftp(&self) -> Result<RusshSftp, TerminalError> {
-        self.browser
-            .open_dedicated_channel()
-            .await
-            .map_err(sftp_op_error)
-    }
-
-    /// Best-effort size (in bytes) of a remote file via SFTP `stat`.
-    ///
-    /// Returns `0` when the size is unavailable — the UI treats `total == 0` as
-    /// indeterminate and shows a spinner rather than a percentage.
-    pub async fn remote_size(&self, remote_path: &str) -> u64 {
-        self.browser.remote_size(remote_path).await
-    }
-
-    /// List directory contents, filtering out `.` and `..`.
-    pub fn list_dir(&self, path: &str) -> Result<Vec<FileEntry>, TerminalError> {
-        debug!(path, "SFTP listing directory");
-        block_on_sftp(self.browser.list_dir(path)).map_err(sftp_op_error)
-    }
-
-    /// Download a remote file to a local path. Returns bytes written.
-    pub fn read_file(&self, remote_path: &str, local_path: &str) -> Result<u64, TerminalError> {
-        block_on_sftp(async {
-            let data = self
-                .browser
-                .read_file(remote_path)
-                .await
-                .map_err(sftp_op_error)?;
-            tokio::fs::write(local_path, &data)
-                .await
-                .map_err(|e| TerminalError::SftpError(format!("write local file: {e}")))?;
-            Ok::<u64, TerminalError>(data.len() as u64)
-        })
-    }
-
-    /// Upload a local file to a remote path. Returns bytes written.
-    pub fn write_file(&self, local_path: &str, remote_path: &str) -> Result<u64, TerminalError> {
-        block_on_sftp(async {
-            let data = tokio::fs::read(local_path)
-                .await
-                .map_err(|e| TerminalError::SftpError(format!("open local file: {e}")))?;
-            self.browser
-                .write_file(remote_path, &data)
-                .await
-                .map_err(sftp_op_error)?;
-            Ok::<u64, TerminalError>(data.len() as u64)
-        })
-    }
-
-    /// Create a directory on the remote host.
-    pub fn mkdir(&self, path: &str) -> Result<(), TerminalError> {
-        block_on_sftp(self.browser.mkdir(path)).map_err(sftp_op_error)
-    }
-
-    /// Remove a file on the remote host.
-    pub fn remove_file(&self, path: &str) -> Result<(), TerminalError> {
-        block_on_sftp(self.browser.delete(path)).map_err(sftp_op_error)
-    }
-
-    /// Remove an empty directory on the remote host.
-    pub fn remove_dir(&self, path: &str) -> Result<(), TerminalError> {
-        block_on_sftp(self.browser.delete(path)).map_err(sftp_op_error)
-    }
-
-    /// Read a remote file's contents as a UTF-8 string.
-    pub fn read_file_content(&self, remote_path: &str) -> Result<String, TerminalError> {
-        block_on_sftp(async {
-            let data = self
-                .browser
-                .read_file(remote_path)
-                .await
-                .map_err(sftp_op_error)?;
-            String::from_utf8(data)
-                .map_err(|e| TerminalError::SftpError(format!("read failed: invalid UTF-8: {e}")))
-        })
-    }
-
-    /// Write a string to a remote file, creating or overwriting it.
-    pub fn write_file_content(
-        &self,
-        remote_path: &str,
-        content: &str,
-    ) -> Result<(), TerminalError> {
-        self.write_bytes(remote_path, content.as_bytes())
-    }
-
-    /// Rename a file or directory on the remote host.
-    pub fn rename(&self, old_path: &str, new_path: &str) -> Result<(), TerminalError> {
-        block_on_sftp(self.browser.rename(old_path, new_path)).map_err(sftp_op_error)
-    }
-
-    /// Get metadata for a single file or directory.
-    pub fn stat(&self, path: &str) -> Result<FileEntry, TerminalError> {
-        block_on_sftp(self.browser.stat(path)).map_err(sftp_op_error)
-    }
-
-    /// Authoritatively probe whether the connecting user can write `remote_path`.
-    ///
-    /// Delegates to the core [`SftpAdvancedOps::check_writable`] companion-trait
-    /// implementation (#2104): opens the **existing** file for writing with
-    /// `OpenFlags::WRITE` only — no `CREATE`/`TRUNCATE`/`APPEND` — so the file's
-    /// contents are never modified, and never returns a hard error for the
-    /// ambiguous case (a `PERMISSION_DENIED` maps to [`Writability::ReadOnly`],
-    /// any other error to [`Writability::Unknown`]).
-    pub fn check_writable(&self, remote_path: &str) -> Result<Writability, TerminalError> {
-        block_on_sftp(self.browser.check_writable(remote_path)).map_err(sftp_op_error)
-    }
-
-    /// Resolve a remote path to its canonical absolute form via SFTP realpath.
-    ///
-    /// Delegates to the core [`SftpAdvancedOps::realpath`] companion-trait
-    /// implementation (#2104). Passing `"."` yields the session's home directory,
-    /// avoiding the fragile `/home/<user>` guess that breaks on non-Linux layouts
-    /// (audit GAP C2, issue #1143).
-    pub fn realpath(&self, path: &str) -> Result<String, TerminalError> {
-        block_on_sftp(self.browser.realpath(path)).map_err(sftp_op_error)
-    }
-
-    /// Write raw bytes to a remote file, creating or overwriting it.
-    pub fn write_bytes(&self, remote_path: &str, data: &[u8]) -> Result<(), TerminalError> {
-        block_on_sftp(self.browser.write_file(remote_path, data)).map_err(sftp_op_error)
-    }
-
-    /// Write `content` to `remote_path` with `sudo`-elevated privileges (#1328).
-    ///
-    /// Delegates to the core [`SftpAdvancedOps::write_file_content_elevated`]
-    /// companion-trait implementation (#2104): SFTP-upload the buffer to a
-    /// termiHub-generated `/tmp/termihub-<uuid>`, then `sudo -S -p ''` a fixed
-    /// `/bin/sh` script (`cat "$1" > "$2" && rm -f "$1"`) that rewrites the
-    /// destination in place (preserving owner/mode/ACLs), classified into an
-    /// [`ElevatedWriteResult`]. The destination path is POSIX-quoted and passed as
-    /// a positional argument, so a hostile remote path cannot inject shell
-    /// commands; the password is only ever sent on stdin and is **never** logged.
-    pub fn write_file_content_elevated(
-        &self,
-        remote_path: &str,
-        content: &str,
-        sudo_password: &str,
-    ) -> Result<ElevatedWriteResult, TerminalError> {
-        block_on_sftp(
-            self.browser
-                .write_file_content_elevated(remote_path, content, sudo_password),
-        )
-        .map_err(sftp_op_error)
-    }
-}
-
-/// Manages multiple SFTP sessions keyed by UUID.
-///
-/// `Clone` (the session map is behind an `Arc`) so SFTP commands can move a
-/// handle into `spawn_blocking` — the SSH/SFTP calls block, and running them on
-/// a blocking-pool thread (rather than the Tauri command thread) is what keeps
-/// `block_in_place` valid and avoids starving the async runtime.
+/// `Clone` (the session map is behind an `Arc`) so commands can hold a handle;
+/// the browser is itself `Send + Sync` and serialises concurrent operations on
+/// its own async mutex, so no per-session outer lock is needed.
 #[derive(Clone)]
 pub struct SftpManager {
-    sessions: Arc<Mutex<HashMap<String, Arc<Mutex<SftpSession>>>>>,
+    sessions: Arc<Mutex<HashMap<String, Arc<SftpFileBrowser>>>>,
 }
 
 impl Default for SftpManager {
@@ -291,16 +95,24 @@ impl SftpManager {
         }
     }
 
-    /// Open a new SFTP session. Returns the session UUID.
-    pub fn open_session(&self, config: &SshConfig) -> Result<String, TerminalError> {
-        let session = SftpSession::new(config)?;
+    /// Open a new SFTP session to the given SSH host and return its UUID.
+    ///
+    /// Eagerly connects (jump-host aware, via the core browser) so `sftp_open`
+    /// fails loudly on a bad host / auth here rather than deferring the error to
+    /// the first listing. The connection is fully async — no `spawn_blocking` /
+    /// `block_in_place` bridging is needed (the core browser is what the
+    /// `ConnectionType` path already awaits directly).
+    pub async fn open_session(&self, config: &SshConfig) -> Result<String, TerminalError> {
+        info!(host = %config.host, port = config.port, "Opening SFTP session");
+        let browser = SftpFileBrowser::new(config.clone());
+        browser.connect().await.map_err(sftp_op_error)?;
         let id = uuid::Uuid::new_v4().to_string();
-        let mut sessions = lock_session(&self.sessions)?;
-        sessions.insert(id.clone(), Arc::new(Mutex::new(session)));
+        let mut sessions = lock_sessions(&self.sessions)?;
+        sessions.insert(id.clone(), Arc::new(browser));
         Ok(id)
     }
 
-    /// Close and drop an SFTP session.
+    /// Close and drop an SFTP session, tearing down its SSH+SFTP connection.
     pub fn close_session(&self, id: &str) {
         info!(session_id = id, "Closing SFTP session");
         // Recover the guard even if the map mutex is poisoned — removing a
@@ -323,9 +135,11 @@ impl SftpManager {
         info!(session_count = count, "Closing all SFTP sessions");
     }
 
-    /// Get a session Arc for use outside the manager lock.
-    pub fn get_session(&self, id: &str) -> Result<Arc<Mutex<SftpSession>>, TerminalError> {
-        let sessions = lock_session(&self.sessions)?;
+    /// Get the [`SftpFileBrowser`] for a session for use outside the manager
+    /// lock. Clones the `Arc`, so the returned handle keeps the session alive and
+    /// its operations run on the shared async browser.
+    pub fn get_session(&self, id: &str) -> Result<Arc<SftpFileBrowser>, TerminalError> {
+        let sessions = lock_sessions(&self.sessions)?;
         sessions
             .get(id)
             .cloned()
@@ -339,14 +153,15 @@ mod tests {
     use std::thread;
 
     // The pure command-composition and classification unit tests for the
-    // elevated (sudo) save and the writability probe now live beside the single
-    // core implementation in `core::backends::ssh::sftp_ops` (#2104). The
-    // Docker-backed integration tests below stay here because they drive the
-    // desktop `SftpSession` end-to-end over a live SSH connection.
+    // elevated (sudo) save and the writability probe live beside the single core
+    // implementation in `core::backends::ssh::sftp_ops` (#2104). The Docker-backed
+    // integration tests below stay here because they drive the desktop command
+    // layer's SFTP session (the core `SftpFileBrowser`) end-to-end over a live SSH
+    // connection.
 
     // ── Docker-backed elevated-save integration tests ────────────────────
     //
-    // Exercise the real `SftpSession::write_file_content_elevated` path
+    // Exercise the real `SftpFileBrowser::write_file_content_elevated` path
     // end-to-end over a live SSH connection (temp SFTP upload → `sudo -S`
     // rewrite → typed classification → temp cleanup), covering the three
     // outcomes the #1328 unit tests can only stub: correct password, wrong
@@ -362,9 +177,15 @@ mod tests {
     // session (as `testuser`) reads the world-readable root-owned target back
     // to verify contents/owner/mode and to confirm no `/tmp/termihub-*` temp
     // leaked — never the elevated write path itself.
+    //
+    // The three tests share the one root-owned fixture file, so they must not
+    // run concurrently against the same container (they clobber each other's
+    // before/after expectations); run them with `--test-threads=1` until the
+    // per-test fixture isolation tracked in #2238 lands.
     use crate::utils::remote_exec::run_remote_command;
     use crate::utils::ssh_auth::connect_and_authenticate;
     use termihub_core::backends::ssh::handler::SshSession;
+    use termihub_core::backends::ssh::SftpAdvancedOps;
 
     /// Root-owned file the fixtures ship (see `tests/docker/ssh-sudo`).
     const ELEVATED_TARGET: &str = "/etc/termihub-elevated-target.txt";
@@ -432,12 +253,30 @@ mod tests {
     /// Count of leftover `/tmp/termihub-*` temp files as seen by `testuser`.
     fn temp_leftover_count(verify: &SshSession) -> Result<usize, TerminalError> {
         // `2>/dev/null` swallows the "No such file" when the glob matches
-        // nothing; `printf %s` avoids `wc`'s leading whitespace.
+        // nothing; `grep -c` avoids `wc`'s leading whitespace.
         let out = run_remote_command(
             verify,
             "ls -1d /tmp/termihub-* 2>/dev/null | grep -c . || true",
         )?;
         Ok(out.trim().parse().unwrap_or(0))
+    }
+
+    /// Run `f` with a fresh, plain SSH verify session (as `testuser`) on a
+    /// blocking-pool thread — `connect_and_authenticate` and `run_remote_command`
+    /// are synchronous, so they cannot run on the async test thread. Used only to
+    /// read the target file back and count temp leftovers, never for the elevated
+    /// write path itself (that goes through the async core browser under test).
+    async fn with_verify<T, F>(config: SshConfig, f: F) -> Result<T, TerminalError>
+    where
+        F: FnOnce(&SshSession) -> Result<T, TerminalError> + Send + 'static,
+        T: Send + 'static,
+    {
+        tokio::task::spawn_blocking(move || {
+            let verify = connect_and_authenticate(&config)?;
+            f(&verify)
+        })
+        .await
+        .map_err(|e| TerminalError::SshError(format!("Task join error: {e}")))?
     }
 
     /// Correct password → `Success`: the root-owned file is rewritten, its
@@ -454,37 +293,35 @@ mod tests {
         }
 
         trust_fixture_host_keys();
+        let config = testuser_config(port, "testpass");
+        let stat_cmd = format!("stat -c '%U %G %a' {ELEVATED_TARGET}");
 
-        let result = tokio::task::spawn_blocking(move || {
-            let config = testuser_config(port, "testpass");
-            let verify = connect_and_authenticate(&config)?;
-
-            let stat_cmd = format!("stat -c '%U %G %a' {ELEVATED_TARGET}");
-            let stat_before = run_remote_command(&verify, &stat_cmd)?;
-
-            let session = SftpSession::new(&config)?;
-            let new_content = format!("elevated-rewrite-{}\n", uuid::Uuid::new_v4());
-            let outcome =
-                session.write_file_content_elevated(ELEVATED_TARGET, &new_content, "testpass")?;
-
-            let after = run_remote_command(&verify, &format!("cat {ELEVATED_TARGET}"))?;
-            let stat_after = run_remote_command(&verify, &stat_cmd)?;
-            let leftover = temp_leftover_count(&verify)?;
-
-            Ok::<_, TerminalError>((
-                outcome,
-                new_content,
-                after,
-                stat_before,
-                stat_after,
-                leftover,
-            ))
+        // Capture owner/group/mode before the elevated rewrite.
+        let stat_before = with_verify(config.clone(), {
+            let stat_cmd = stat_cmd.clone();
+            move |v| run_remote_command(v, &stat_cmd)
         })
         .await
-        .expect("spawn_blocking join");
+        .expect("stat before should succeed");
 
-        let (outcome, new_content, after, stat_before, stat_after, leftover) =
-            result.expect("elevated save (success) should complete");
+        // Elevated write through the single core browser (the desktop command
+        // layer's SFTP path).
+        let browser = SftpFileBrowser::new(config.clone());
+        let new_content = format!("elevated-rewrite-{}\n", uuid::Uuid::new_v4());
+        let outcome = browser
+            .write_file_content_elevated(ELEVATED_TARGET, &new_content, "testpass")
+            .await
+            .expect("elevated save (success) should complete");
+
+        // Read the target back and confirm no temp leaked.
+        let (after, stat_after, leftover) = with_verify(config.clone(), move |v| {
+            let after = run_remote_command(v, &format!("cat {ELEVATED_TARGET}"))?;
+            let stat_after = run_remote_command(v, &stat_cmd)?;
+            let leftover = temp_leftover_count(v)?;
+            Ok((after, stat_after, leftover))
+        })
+        .await
+        .expect("readback after should succeed");
 
         assert_eq!(outcome, ElevatedWriteResult::Success, "expected Success");
         assert_eq!(
@@ -517,31 +354,32 @@ mod tests {
         }
 
         trust_fixture_host_keys();
+        let config = testuser_config(port, "testpass");
 
-        let result = tokio::task::spawn_blocking(move || {
-            let config = testuser_config(port, "testpass");
-            let verify = connect_and_authenticate(&config)?;
+        let before = with_verify(config.clone(), move |v| {
+            run_remote_command(v, &format!("cat {ELEVATED_TARGET}"))
+        })
+        .await
+        .expect("read before should succeed");
 
-            let before = run_remote_command(&verify, &format!("cat {ELEVATED_TARGET}"))?;
-
-            let session = SftpSession::new(&config)?;
-            let new_content = format!("should-not-land-{}\n", uuid::Uuid::new_v4());
-            let outcome = session.write_file_content_elevated(
+        let browser = SftpFileBrowser::new(config.clone());
+        let new_content = format!("should-not-land-{}\n", uuid::Uuid::new_v4());
+        let outcome = browser
+            .write_file_content_elevated(
                 ELEVATED_TARGET,
                 &new_content,
                 "definitely-the-wrong-password",
-            )?;
+            )
+            .await
+            .expect("elevated save (wrong password) should complete");
 
-            let after = run_remote_command(&verify, &format!("cat {ELEVATED_TARGET}"))?;
-            let leftover = temp_leftover_count(&verify)?;
-
-            Ok::<_, TerminalError>((outcome, before, after, leftover))
+        let (after, leftover) = with_verify(config.clone(), move |v| {
+            let after = run_remote_command(v, &format!("cat {ELEVATED_TARGET}"))?;
+            let leftover = temp_leftover_count(v)?;
+            Ok((after, leftover))
         })
         .await
-        .expect("spawn_blocking join");
-
-        let (outcome, before, after, leftover) =
-            result.expect("elevated save (wrong password) should complete");
+        .expect("readback after should succeed");
 
         assert_eq!(
             outcome,
@@ -569,28 +407,28 @@ mod tests {
         }
 
         trust_fixture_host_keys();
+        let config = testuser_config(port, "testpass");
 
-        let result = tokio::task::spawn_blocking(move || {
-            let config = testuser_config(port, "testpass");
-            let verify = connect_and_authenticate(&config)?;
-
-            let before = run_remote_command(&verify, &format!("cat {ELEVATED_TARGET}"))?;
-
-            let session = SftpSession::new(&config)?;
-            let new_content = format!("should-not-land-{}\n", uuid::Uuid::new_v4());
-            let outcome =
-                session.write_file_content_elevated(ELEVATED_TARGET, &new_content, "testpass")?;
-
-            let after = run_remote_command(&verify, &format!("cat {ELEVATED_TARGET}"))?;
-            let leftover = temp_leftover_count(&verify)?;
-
-            Ok::<_, TerminalError>((outcome, before, after, leftover))
+        let before = with_verify(config.clone(), move |v| {
+            run_remote_command(v, &format!("cat {ELEVATED_TARGET}"))
         })
         .await
-        .expect("spawn_blocking join");
+        .expect("read before should succeed");
 
-        let (outcome, before, after, leftover) =
-            result.expect("elevated save (no sudo) should complete");
+        let browser = SftpFileBrowser::new(config.clone());
+        let new_content = format!("should-not-land-{}\n", uuid::Uuid::new_v4());
+        let outcome = browser
+            .write_file_content_elevated(ELEVATED_TARGET, &new_content, "testpass")
+            .await
+            .expect("elevated save (no sudo) should complete");
+
+        let (after, leftover) = with_verify(config.clone(), move |v| {
+            let after = run_remote_command(v, &format!("cat {ELEVATED_TARGET}"))?;
+            let leftover = temp_leftover_count(v)?;
+            Ok((after, leftover))
+        })
+        .await
+        .expect("readback after should succeed");
 
         match outcome {
             ElevatedWriteResult::Other(msg) => {
@@ -605,14 +443,15 @@ mod tests {
         assert_eq!(leftover, 0, "temp upload must be cleaned up on failure");
     }
 
-    /// The lock helper must map a poisoned mutex to a recoverable
+    /// The session-map lock helper must map a poisoned mutex to a recoverable
     /// `TerminalError` instead of panicking (audit GAP C1, #1143).
     #[test]
-    fn lock_session_maps_poisoned_mutex_to_error() {
-        let mutex = Arc::new(Mutex::new(0i32));
+    fn lock_sessions_maps_poisoned_mutex_to_error() {
+        let sessions: Arc<Mutex<HashMap<String, Arc<SftpFileBrowser>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
 
         // Poison the mutex by panicking while holding the lock.
-        let poisoner = Arc::clone(&mutex);
+        let poisoner = Arc::clone(&sessions);
         let handle = thread::spawn(move || {
             let _guard = poisoner.lock().expect("first lock should succeed");
             panic!("intentional panic to poison the mutex");
@@ -620,7 +459,7 @@ mod tests {
         assert!(handle.join().is_err(), "poisoning thread should panic");
 
         // A raw `.lock().unwrap()` would panic here; the helper must not.
-        let result = lock_session(&mutex);
+        let result = lock_sessions(&sessions);
         assert!(
             matches!(result, Err(TerminalError::SftpError(_))),
             "poisoned lock should return a recoverable SftpError, got {result:?}"
@@ -635,11 +474,10 @@ mod tests {
 
     /// On a healthy mutex the helper returns a usable guard.
     #[test]
-    fn lock_session_returns_guard_when_healthy() {
-        let mutex = Mutex::new(41i32);
-        let mut guard = lock_session(&mutex).expect("healthy lock should succeed");
-        *guard += 1;
-        assert_eq!(*guard, 42);
+    fn lock_sessions_returns_guard_when_healthy() {
+        let sessions: Mutex<HashMap<String, Arc<SftpFileBrowser>>> = Mutex::new(HashMap::new());
+        let guard = lock_sessions(&sessions).expect("healthy lock should succeed");
+        assert!(guard.is_empty());
     }
 
     /// `close_all`'s drain must empty the map even when the map mutex is

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,7 +13,7 @@ mod connections_projection;
 mod credential;
 mod embedded_servers;
 /// File-system access: local FS, SFTP sessions, and the cancellable transfer
-/// subsystem (public so integration tests can drive `SftpSession` /
+/// subsystem (public so integration tests can drive `SftpManager` /
 /// `TransferRegistry` directly — issue #1245).
 pub mod files;
 /// Shadow `LayoutStore` (#2151, Phase 3 step 1 of #2139): the client-scoped

--- a/src-tauri/tests/sftp_transfer.rs
+++ b/src-tauri/tests/sftp_transfer.rs
@@ -21,8 +21,10 @@ use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use termihub_core::backends::ssh::{SftpAdvancedOps, SftpFileBrowser};
 use termihub_core::config::SshConfig;
-use termihub_lib::files::sftp::{lock_session, SftpManager, SftpSession, Writability};
+use termihub_core::files::FileBrowser;
+use termihub_lib::files::sftp::{SftpManager, Writability};
 use termihub_lib::files::transfer::{
     run_download, ProgressSink, TransferContext, TransferDirection, TransferPhase,
     TransferProgress, TransferRegistry,
@@ -55,7 +57,7 @@ fn is_port_reachable(port: u16) -> bool {
 /// fixture containers, so these desktop SFTP integration tests connect
 /// deterministically under the strict default host-key policy (#1969, #2032).
 ///
-/// `SftpSession::new` goes through the same strict host-key path as the rest of
+/// Opening a session goes through the same strict host-key path as the rest of
 /// the app: with no verifier registered it trusts only keys already recorded in
 /// the runner's `~/.ssh/known_hosts` and refuses everything else with "Unknown
 /// server key". CI runners (and any freshly-(re)built fixture image) never have
@@ -138,14 +140,13 @@ impl RecordingSink {
 }
 
 /// Open a session against the container and return the manager (kept alive) and
-/// the session Arc.
-async fn connect() -> (SftpManager, Arc<Mutex<SftpSession>>) {
+/// the session's core SFTP browser.
+async fn connect() -> (SftpManager, Arc<SftpFileBrowser>) {
     let manager = SftpManager::new();
     let config = stress_config(sftp_stress_port());
-    let mgr = manager.clone();
-    let session_id = tokio::task::spawn_blocking(move || mgr.open_session(&config))
+    let session_id = manager
+        .open_session(&config)
         .await
-        .expect("join")
         .expect("SFTP session should open");
     let session = manager
         .get_session(&session_id)
@@ -153,19 +154,13 @@ async fn connect() -> (SftpManager, Arc<Mutex<SftpSession>>) {
     (manager, session)
 }
 
-/// Open a dedicated SFTP channel off `session` (mirrors the command layer):
-/// lock briefly and drive the async open under `block_in_place` so the std
-/// guard never spans an `.await`.
-async fn open_dedicated(session: Arc<Mutex<SftpSession>>) -> russh_sftp::client::SftpSession {
-    tokio::task::spawn_blocking(move || {
-        let guard = lock_session(&session).expect("lock");
-        tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async { guard.open_dedicated_sftp().await })
-        })
-    })
-    .await
-    .expect("join")
-    .expect("dedicated SFTP channel should open")
+/// Open a dedicated SFTP channel off `session` (mirrors the command layer),
+/// awaited directly on the async core browser.
+async fn open_dedicated(session: Arc<SftpFileBrowser>) -> russh_sftp::client::SftpSession {
+    session
+        .open_dedicated_channel()
+        .await
+        .expect("dedicated SFTP channel should open")
 }
 
 /// Cancel-mid-transfer: the partial local file is removed and the terminal
@@ -258,20 +253,21 @@ async fn check_writable_distinguishes_owner_from_root_owned() {
         uuid::Uuid::new_v4()
     );
     let user_writable = {
-        let session = session.clone();
-        let user_path = user_path.clone();
-        tokio::task::spawn_blocking(move || {
-            let guard = lock_session(&session)?;
-            guard.write_file_content(&user_path, "probe-content")?;
-            let writability = guard.check_writable(&user_path);
-            // Content must survive the probe unchanged (no truncate/write).
-            let content = guard.read_file_content(&user_path)?;
-            let _ = guard.remove_file(&user_path);
-            writability.map(|w| (w, content))
-        })
-        .await
-        .expect("join")
-        .expect("probe on a user-owned file should not error")
+        session
+            .write_file(&user_path, b"probe-content")
+            .await
+            .expect("writing the user-owned probe file should succeed");
+        let writability = session
+            .check_writable(&user_path)
+            .await
+            .expect("probe on a user-owned file should not error");
+        // Content must survive the probe unchanged (no truncate/write).
+        let content = session
+            .read_file(&user_path)
+            .await
+            .expect("reading the probe file back should succeed");
+        let _ = session.delete(&user_path).await;
+        (writability, String::from_utf8(content).expect("utf-8"))
     };
     assert_eq!(
         user_writable.0,
@@ -284,13 +280,10 @@ async fn check_writable_distinguishes_owner_from_root_owned() {
     );
 
     // A root-owned file the user cannot write (mode 644, owned by root).
-    let root_writability = {
-        let session = session.clone();
-        tokio::task::spawn_blocking(move || lock_session(&session)?.check_writable("/etc/hostname"))
-            .await
-            .expect("join")
-            .expect("probe on a root-owned file should not error")
-    };
+    let root_writability = session
+        .check_writable("/etc/hostname")
+        .await
+        .expect("probe on a root-owned file should not error");
     assert_eq!(
         root_writability,
         Writability::ReadOnly,
@@ -347,14 +340,11 @@ async fn browsing_stays_live_during_transfer() {
 
     // While it runs, a directory listing on the browsing session must complete
     // promptly (the copy does not hold the session mutex).
-    let list_session = session.clone();
     let start = Instant::now();
-    let entries = tokio::task::spawn_blocking(move || {
-        lock_session(&list_session)?.list_dir("/home/testuser/sftp-test/large-files")
-    })
-    .await
-    .expect("join")
-    .expect("list_dir on the browsing session should succeed during a transfer");
+    let entries = session
+        .list_dir("/home/testuser/sftp-test/large-files")
+        .await
+        .expect("list_dir on the browsing session should succeed during a transfer");
     let elapsed = start.elapsed();
 
     assert!(


### PR DESCRIPTION
Part of #2104. Part of #2236.

## What this does

Retires the synchronous desktop `SftpSession` adapter. After #2239 collapsed
the parallel russh-sftp *implementation* onto the single core
`SftpFileBrowser`, `SftpSession` was already just a thin **sync facade** that
bridged into that fully-async browser via `block_in_place` +
`Handle::current().block_on`. This slice removes that facade entirely and drives
the browser directly:

- **`SftpManager` now stores `Arc<SftpFileBrowser>`** (the one core SFTP
  implementation) instead of `Arc<Mutex<SftpSession>>`. It keeps only the
  session-id → browser map and the poison-safe teardown.
- **Every `sftp_*` Tauri command `.await`s the core browser directly** —
  `list_dir`/`stat`/`read`/`write`/`delete`/`rename`/`mkdir`, `realpath`/
  `check_writable`/`write_file_content_elevated` (via `SftpAdvancedOps`),
  `has_exec_capability`, and the dedicated per-transfer channel + `remote_size`.
  The per-command `spawn_blocking` + `block_in_place` + `block_on` dance and the
  `block_on_sftp` helper are gone. This mirrors `session::file_ops`, which
  already awaits the same browser directly with no blocking bridge.
- **`sftp_open` and the transfer-channel open are now plain `.await`s.**
  `vscode_open_remote` awaits the download/upload on the browser; only VS Code's
  blocking `--wait` still runs on a `spawn_blocking` thread.
- Removed the now-dead `SftpSession` struct, `block_on_sftp`, and the public
  `lock_session` helper.

`SftpFileBrowser` owns its own async mutex and serialises concurrent ops
internally, so no outer per-session lock is needed. Tauri command **signatures
are unchanged** (same names/args, incl. `sftp_delete`'s advisory `is_directory`),
so the frontend is unaffected. Because sessions connect through the core
`connect_target`, jump-host (`ProxyJump`) targets keep working (#939).

## Scope boundary

This lands #2236's headline deliverable — *no synchronous `SftpSession` adapter
remains and the commands drive the core `FileBrowser` trait directly*. The
remaining #2236 bullet, **unifying the standalone `SftpManager` UUID session
registry with the `ConnectionType::file_browser()` session model** (one
file-browsing entry point), is a distinct, larger change and stays open under
#2236. The `FileBrowser`-vs-`FileBackend` trait reconciliation stays open under
#2237. So **#2104 is not closed** by this PR.

## Verification (local Docker SFTP fixtures — not run in per-PR CI)

Ran on this checkout's offset ports (`termihub-test-1`, offset 1000): `ssh-sudo`
(3212), `ssh-nosudo` (3213), `sftp-stress` (3210).

- **`core/tests/sftp_stress.rs`** — 16/16 pass (browse, 1/10/100 MB downloads,
  upload roundtrip, wide dir, deep tree, symlinks, unicode/space/long/hidden
  names, permission edge cases).
- **`src-tauri/tests/sftp_transfer.rs`** — 3/3 pass (cancel-mid-transfer cleanup,
  browsing-stays-live-during-transfer, writability probe), now driving the core
  browser directly.
- **Desktop elevated-save Docker tests** (`src-tauri/src/files/sftp.rs`) — 3/3
  pass, rewritten to drive `SftpFileBrowser::write_file_content_elevated`
  directly: Success rewrites the root file preserving owner/mode (root root 644),
  IncorrectPassword leaves it untouched, no-sudo → Other, no `/tmp/termihub-*`
  leak. (Run with `--test-threads=1`; the three share one fixture file — the
  isolation fix is tracked in #2238.)

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features
-D warnings`, and the files-module unit tests are green. Backend-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
