### PR TITLE
feat(backend): shadow workflow-run projection store (5c)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,6 +79,13 @@ mod window;
 /// into local apps with delayed rendering (`CF_HDROP`, #1814). Windows-only.
 #[cfg(windows)]
 mod windows_clipboard;
+/// Shadow workflow-run authority (#2243, Phase 4 step 5c of #2139, part of
+/// #2206 / #2152): the client-scoped `workflow-run@<clientId>` projection region
+/// + `workflow.*` intents modeling the `appStore` workflow-run state machine
+/// (in-flight run progress + the dismissible local-process output panel, #1852 /
+/// #1865). Registered and served but not yet driving the live UI — see
+/// [`workflow_projection`].
+mod workflow_projection;
 mod workflows;
 mod workspace;
 
@@ -744,6 +751,23 @@ pub fn run() {
                 // lazily on a client's first `broadcast.*` intent.
                 app.manage(Arc::new(broadcast_projection::BroadcastStore::new()));
                 broadcast_projection::projection::register_broadcast_intents(
+                    &mut registry,
+                    app.handle().clone(),
+                );
+                // Shadow WorkflowRunStore (#2243, Phase 4 step 5c, part of
+                // #2206): the client-scoped `workflow-run@<clientId>` region +
+                // `workflow.*` intents modeling the in-flight workflow-run state
+                // machine (run step-progress + the dismissible local-process
+                // output panel, #1852 / #1865). Managed authoritative state that
+                // serves intents, but nothing in the live UI subscribes to or
+                // renders the region yet — a pure shadow foundation (later steps
+                // cut rendering, then the mutations, over to it, keeping the
+                // appStore reducers as the parity-safe fallback). No client
+                // region is seeded here: like layout, restore-cohort, and
+                // broadcast, workflow-run regions are client-scoped and created
+                // lazily on a client's first `workflow.*` intent.
+                app.manage(Arc::new(workflow_projection::WorkflowRunStore::new()));
+                workflow_projection::projection::register_workflow_intents(
                     &mut registry,
                     app.handle().clone(),
                 );

--- a/src-tauri/src/workflow_projection/mod.rs
+++ b/src-tauri/src/workflow_projection/mod.rs
@@ -1,0 +1,52 @@
+//! Shadow workflow-run authority — Phase 4 step 5c of the stateless-UI
+//! migration (#2243, part of #2206 / #2152 / #2139).
+//!
+//! Moves the in-flight **workflow-run** state machine the frontend drives
+//! (`appStore` `workflowRun` + `workflowRunOutput`, #1852 / #1865) into a Rust
+//! authority on the projection substrate ([`crate::projection`]). The run
+//! machine tracks a single active run's step progress (`run`) and the
+//! dismissible inline output panel a `run-local-process` step opens (`output`),
+//! settling both through the run's terminal outcome (completed / cancelled /
+//! failed).
+//!
+//! This is the **run** machine, not the workflow **library**: the library CRUD
+//! is already backend-backed (`workflowApi`). The step-execution side-effects
+//! (the send / macro / local-process seams in `workflowRunner`) stay frontend
+//! orchestration; this store owns only the run *status* — which run is active,
+//! how far it has progressed, and the status of its output panel.
+//!
+//! # Client-scoped region — Open Design Decision #4 / #6
+//!
+//! A workflow run is launched by one client against one of *that client's*
+//! target terminals, and its feedback — the progress toast and the inline
+//! run-output panel — is the launching client's own UI overlay. Only one run is
+//! active per client at a time (`appStore` cancels any in-flight run before
+//! starting another). Like the client-scoped `restore-cohort`
+//! ([`crate::restore_cohort_projection`]) and `broadcast`
+//! ([`crate::broadcast_projection`]) regions — and unlike the shared
+//! `session-lifecycle` region — the run is an **orchestration overlay owned by
+//! the launching client, not shared infrastructure**. So the region is
+//! **client-scoped** (`workflow-run@<clientId>`), mirroring the client-scoped
+//! `layout` region ([`crate::layout::projection`]).
+//!
+//! (The terminal *session* the run targets is shared, but the *run
+//! orchestration over it* — progress, cancel, output panel — belongs to the one
+//! client that launched it. A second client viewing the same terminal does not
+//! see or drive this client's run.)
+//!
+//! # Shadow mode — zero user-facing change
+//!
+//! This step is deliberately **not authoritative**. The store exists, accepts
+//! `workflow.*` intents, and projects diffs, but nothing in the live UI
+//! subscribes to or renders a `workflow-run` region, and no frontend code
+//! dispatches `workflow.*` intents yet. The existing `appStore` run reducers,
+//! the progress toast, and the output panel remain authoritative. Later steps
+//! cut rendering, then the mutations, over to it (keeping the reducers as the
+//! parity-safe fallback, per the #2205 reframe); the sibling restore-cohort and
+//! broadcast machines migrated as their own steps and keep a clean per-domain
+//! boundary.
+
+pub mod projection;
+pub mod store;
+
+pub use store::WorkflowRunStore;

--- a/src-tauri/src/workflow_projection/projection.rs
+++ b/src-tauri/src/workflow_projection/projection.rs
@@ -1,0 +1,231 @@
+//! Workflow-run projection: the client-scoped `workflow-run@<clientId>` region
+//! and the `workflow.*` intents (#2243, part of #2206 / #2152 / #2139).
+//!
+//! Exposes the authoritative [`WorkflowRunStore`] to each attached client as
+//! its own versioned, multi-subscriber projection region and turns the run
+//! transitions the frontend currently drives into [`Intent`]s — mirroring the
+//! client-scoped `restore-cohort` ([`crate::restore_cohort_projection`]) and
+//! `broadcast` ([`crate::broadcast_projection`]) siblings and the reference
+//! substrate registration pattern ([`crate::projection`]).
+//!
+//! # The `workflow-run@<clientId>` region
+//!
+//! **Client-scoped** (Open Design Decision #4 / #6: a workflow run is an
+//! orchestration overlay owned by the launching client, not shared
+//! infrastructure — like `restore-cohort` and `layout`). Each client gets its
+//! own region, seeded lazily and mutated via `intent.client_id`. The view
+//! model:
+//!
+//! ```json
+//! {
+//!   "run": { "workflowId": "…", "workflowName": "…", "tabId": "…",
+//!            "total": N, "completed": N } | null,
+//!   "output": { "workflowId": "…", "workflowName": "…", "program": "…",
+//!               "args": ["…"], "status": "running" | "completed"
+//!                 | "cancelled" | "failed", "error": "…"? } | null
+//! }
+//! ```
+//!
+//! # Intents
+//!
+//! | kind                     | payload                                                    | effect                                          |
+//! | ------------------------ | ---------------------------------------------------------- | ----------------------------------------------- |
+//! | `workflow.runStarted`    | `{ workflowId, workflowName, tabId, total }`               | begin a run at `completed == 0`; clear panel    |
+//! | `workflow.stepAdvanced`  | `{ workflowId, tabId, completed }`                         | update progress if the ids match the active run |
+//! | `workflow.outputOpened`  | `{ workflowId, workflowName, program, args }`              | open the run-output panel in `running` status   |
+//! | `workflow.runCompleted`  | `{}`                                                       | settle the run as completed                     |
+//! | `workflow.runCancelled`  | `{}`                                                       | settle the run as cancelled                     |
+//! | `workflow.runFailed`     | `{ error? }`                                               | settle the run as failed; stamp panel error     |
+//! | `workflow.dismissOutput` | `{}`                                                       | dismiss the run-output panel                    |
+//!
+//! `outputOpened` models the panel's *status* seam only: the streamed
+//! stdout/stderr lines, the process exit code, and the timeout flag stay
+//! frontend orchestration (see [`crate::workflow_projection::store`]), reusing
+//! the existing `subscribeLocalProcessOutput` stream. The step side-effects
+//! (send / macro / local-process execution) likewise stay frontend; the store
+//! learns of progress only through these intents.
+//!
+//! # Shadow mode
+//!
+//! Registered and fully served, but **not** driving the live UI: no frontend
+//! subscribes to `workflow-run@<clientId>` or dispatches `workflow.*` yet, so
+//! these intents mutate only the shadow store and project to regions nobody
+//! renders. The `appStore` run reducers, progress toast, and output panel
+//! remain authoritative. Per the substrate contract the result of an intent is
+//! never returned inline — it always arrives as a projection diff on the
+//! client's region.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
+use crate::workflow_projection::store::WorkflowRunStore;
+
+/// The projection region id for a client's workflow run
+/// (`workflow-run@<clientId>`).
+pub fn workflow_run_region(client_id: &str) -> String {
+    format!("workflow-run@{client_id}")
+}
+
+/// Publish a client's `workflow-run` region from the store, fanning a diff out
+/// to every subscriber and returning the advanced region for the intent ack
+/// (empty when the view did not change).
+pub fn publish_workflow_run(
+    projector: &Projector,
+    store: &WorkflowRunStore,
+    client_id: &str,
+) -> Vec<ProducedRegion> {
+    let region = workflow_run_region(client_id);
+    match projector.publish(&region, store.snapshot(client_id)) {
+        Some(version) => vec![ProducedRegion { region, version }],
+        None => Vec::new(),
+    }
+}
+
+/// Register the `workflow.*` intents on a handler registry.
+///
+/// Each route resolves the managed [`WorkflowRunStore`] lazily (so it rejects
+/// gracefully rather than panicking if the store is somehow absent), mutates
+/// the dispatching client's run via [`intent.client_id`](Intent::client_id),
+/// and publishes that client's region. All transitions are pure/fast map edits,
+/// so they run inline on the dispatcher's single writer.
+pub fn register_workflow_intents(registry: &mut HandlerRegistry, app_handle: AppHandle) {
+    let handle = app_handle.clone();
+    registry.route("workflow.runStarted", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let workflow_id = required_str(intent, "workflowId")?;
+        let workflow_name = required_str(intent, "workflowName")?;
+        let tab_id = required_str(intent, "tabId")?;
+        let total = required_usize(intent, "total")?;
+        store.run_started(
+            &intent.client_id,
+            &workflow_id,
+            &workflow_name,
+            &tab_id,
+            total,
+        );
+        Ok(publish_workflow_run(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("workflow.stepAdvanced", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let workflow_id = required_str(intent, "workflowId")?;
+        let tab_id = required_str(intent, "tabId")?;
+        let completed = required_usize(intent, "completed")?;
+        store.step_advanced(&intent.client_id, &workflow_id, &tab_id, completed);
+        Ok(publish_workflow_run(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("workflow.outputOpened", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let workflow_id = required_str(intent, "workflowId")?;
+        let workflow_name = required_str(intent, "workflowName")?;
+        let program = required_str(intent, "program")?;
+        let args = optional_str_array(intent, "args")?;
+        store.output_opened(
+            &intent.client_id,
+            &workflow_id,
+            &workflow_name,
+            &program,
+            &args,
+        );
+        Ok(publish_workflow_run(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("workflow.runCompleted", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.run_completed(&intent.client_id);
+        Ok(publish_workflow_run(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("workflow.runCancelled", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.run_cancelled(&intent.client_id);
+        Ok(publish_workflow_run(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("workflow.runFailed", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let error = optional_str(intent, "error");
+        store.run_failed(&intent.client_id, error);
+        Ok(publish_workflow_run(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle;
+    registry.route("workflow.dismissOutput", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.dismiss_output(&intent.client_id);
+        Ok(publish_workflow_run(projector, &store, &intent.client_id))
+    });
+}
+
+/// Resolve the managed workflow-run store, or a rejectable error if absent.
+fn store_of(app_handle: &AppHandle) -> Result<Arc<WorkflowRunStore>, (String, String)> {
+    app_handle
+        .try_state::<Arc<WorkflowRunStore>>()
+        .map(|state| (*state).clone())
+        .ok_or_else(|| {
+            (
+                "unavailable".to_string(),
+                "workflow-run store is not initialized".to_string(),
+            )
+        })
+}
+
+/// Extract a required string field from an intent payload.
+fn required_str(intent: &Intent, key: &str) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// Extract a required non-negative integer field.
+fn required_usize(intent: &Intent, key: &str) -> Result<usize, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_u64)
+        .map(|n| n as usize)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// Extract an optional array-of-strings field (e.g. `args`), defaulting to an
+/// empty vec when absent. Rejects a present-but-malformed value.
+fn optional_str_array(intent: &Intent, key: &str) -> Result<Vec<String>, (String, String)> {
+    let Some(value) = intent.payload.get(key) else {
+        return Ok(Vec::new());
+    };
+    let arr = value
+        .as_array()
+        .ok_or_else(|| ("bad_payload".to_string(), format!("invalid '{key}'")))?;
+    arr.iter()
+        .map(|v| {
+            v.as_str()
+                .map(str::to_string)
+                .ok_or_else(|| ("bad_payload".to_string(), format!("invalid '{key}' entry")))
+        })
+        .collect()
+}
+
+/// Extract an optional string field (e.g. a failure reason); absent → `None`.
+fn optional_str(intent: &Intent, key: &str) -> Option<String> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+#[path = "projection_tests.rs"]
+mod tests;

--- a/src-tauri/src/workflow_projection/projection_tests.rs
+++ b/src-tauri/src/workflow_projection/projection_tests.rs
@@ -1,0 +1,413 @@
+//! Projection-contract tests for the client-scoped `workflow-run@<clientId>`
+//! region (#2243), reusing the substrate harness (#2164): an in-memory
+//! [`ProjectionSink`] and a client cache that applies diffs. The routes here
+//! drive a real [`WorkflowRunStore`] directly (the production
+//! `register_workflow_intents` resolves the same store from the Tauri
+//! `AppHandle`; that thin wiring is integration-verified via a local
+//! `./scripts/dev.sh` run) through the identical parse → mutate → publish path.
+//!
+//! Asserted: subscribe → snapshot (identical to every subscriber), an accepted
+//! intent → exactly one coalesced diff fanned to every subscriber with
+//! monotonic versions, client-scoped isolation, rejection paths advance
+//! nothing, a no-op intent coalesces to nothing, a dead subscriber is reaped,
+//! and the client cache converges on the store's authority across a full run.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::{json, Value};
+
+use crate::projection::{
+    apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
+    ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
+};
+use crate::workflow_projection::projection::{publish_workflow_run, workflow_run_region};
+use crate::workflow_projection::store::WorkflowRunStore;
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+/// The production `workflow.*` routes, bound to an injected store instead of
+/// resolving one from an `AppHandle` — the exact parse → mutate → publish path
+/// `register_workflow_intents` runs.
+fn registry_for(store: Arc<WorkflowRunStore>) -> HandlerRegistry {
+    let mut registry = HandlerRegistry::new();
+
+    let s = store.clone();
+    registry.route("workflow.runStarted", move |intent, projector| {
+        let workflow_id = req_str(intent, "workflowId")?;
+        let workflow_name = req_str(intent, "workflowName")?;
+        let tab_id = req_str(intent, "tabId")?;
+        let total = req_usize(intent, "total")?;
+        s.run_started(
+            &intent.client_id,
+            &workflow_id,
+            &workflow_name,
+            &tab_id,
+            total,
+        );
+        Ok(publish_workflow_run(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("workflow.stepAdvanced", move |intent, projector| {
+        let workflow_id = req_str(intent, "workflowId")?;
+        let tab_id = req_str(intent, "tabId")?;
+        let completed = req_usize(intent, "completed")?;
+        s.step_advanced(&intent.client_id, &workflow_id, &tab_id, completed);
+        Ok(publish_workflow_run(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("workflow.outputOpened", move |intent, projector| {
+        let workflow_id = req_str(intent, "workflowId")?;
+        let workflow_name = req_str(intent, "workflowName")?;
+        let program = req_str(intent, "program")?;
+        let args: Vec<String> = intent
+            .payload
+            .get("args")
+            .and_then(Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default();
+        s.output_opened(
+            &intent.client_id,
+            &workflow_id,
+            &workflow_name,
+            &program,
+            &args,
+        );
+        Ok(publish_workflow_run(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("workflow.runCompleted", move |intent, projector| {
+        s.run_completed(&intent.client_id);
+        Ok(publish_workflow_run(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("workflow.runCancelled", move |intent, projector| {
+        s.run_cancelled(&intent.client_id);
+        Ok(publish_workflow_run(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("workflow.runFailed", move |intent, projector| {
+        let error = intent
+            .payload
+            .get("error")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        s.run_failed(&intent.client_id, error);
+        Ok(publish_workflow_run(projector, &s, &intent.client_id))
+    });
+
+    let s = store;
+    registry.route("workflow.dismissOutput", move |intent, projector| {
+        s.dismiss_output(&intent.client_id);
+        Ok(publish_workflow_run(projector, &s, &intent.client_id))
+    });
+
+    registry
+}
+
+fn req_str(intent: &Intent, key: &str) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+fn req_usize(intent: &Intent, key: &str) -> Result<usize, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_u64)
+        .map(|n| n as usize)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// An in-memory sink recording delivered frames; can be killed to simulate a
+/// dead subscriber (mirrors the substrate/tunnel/layout test double).
+struct VecSink {
+    frames: Mutex<Vec<ProjectionFrame>>,
+    alive: AtomicBool,
+}
+
+impl VecSink {
+    fn new() -> Self {
+        Self {
+            frames: Mutex::new(Vec::new()),
+            alive: AtomicBool::new(true),
+        }
+    }
+
+    fn diffs(&self) -> Vec<DiffFrame> {
+        self.frames
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|f| match f {
+                ProjectionFrame::Diff(d) => Some(d.clone()),
+                ProjectionFrame::Snapshot(_) => None,
+            })
+            .collect()
+    }
+}
+
+impl ProjectionSink for VecSink {
+    fn deliver(&self, frame: &ProjectionFrame) -> Result<(), ProjectionError> {
+        if !self.alive.load(Ordering::SeqCst) {
+            return Err(ProjectionError::SinkClosed("killed".into()));
+        }
+        self.frames.lock().unwrap().push(frame.clone());
+        Ok(())
+    }
+}
+
+/// A minimal client cache mirroring the TypeScript `ProjectionClient`.
+struct ClientCache {
+    version: u64,
+    view: Value,
+}
+
+impl ClientCache {
+    fn from_snapshot(s: &SnapshotFrame) -> Self {
+        Self {
+            version: s.version,
+            view: s.view.clone(),
+        }
+    }
+
+    fn apply(&mut self, diff: &DiffFrame) {
+        assert_eq!(diff.base_version, self.version, "diff must fit the cache");
+        apply_ops(&mut self.view, &diff.ops).expect("diff applies cleanly");
+        self.version = diff.version;
+    }
+}
+
+fn intent(kind: &str, client: &str, payload: Value) -> Intent {
+    Intent {
+        intent_id: format!("01J-{kind}"),
+        kind: kind.to_string(),
+        payload,
+        client_id: client.to_string(),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn subscribe_returns_the_empty_baseline_identically_to_every_subscriber() {
+    let store = Arc::new(WorkflowRunStore::new());
+    let region = workflow_run_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+
+    let snap_a = projector.subscribe(&region, "sub-a", "A", Arc::new(VecSink::new()));
+    let snap_b = projector.subscribe(&region, "sub-b", "A", Arc::new(VecSink::new()));
+
+    assert_eq!(snap_a.version, 0);
+    assert_eq!(snap_a, snap_b, "a late joiner gets an identical baseline");
+    assert_eq!(snap_a.region, "workflow-run@A");
+    assert_eq!(snap_a.view["run"], Value::Null);
+    assert_eq!(snap_a.view["output"], Value::Null);
+}
+
+#[test]
+fn a_run_started_intent_produces_one_diff_fanned_to_two_subscribers() {
+    let store = Arc::new(WorkflowRunStore::new());
+    let region = workflow_run_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink_a = Arc::new(VecSink::new());
+    let sink_b = Arc::new(VecSink::new());
+    let snap = projector.subscribe(&region, "sub-a", "A", sink_a.clone());
+    projector.subscribe(&region, "sub-b", "A", sink_b.clone());
+    let mut cache_a = ClientCache::from_snapshot(&snap);
+
+    let ack = dispatcher.dispatch(intent(
+        "workflow.runStarted",
+        "A",
+        json!({ "workflowId": "wf-1", "workflowName": "Deploy", "tabId": "t1", "total": 3 }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(
+        ack.produced,
+        Some(vec![crate::projection::ProducedRegion {
+            region: region.clone(),
+            version: 1,
+        }])
+    );
+
+    let diffs_a = sink_a.diffs();
+    let diffs_b = sink_b.diffs();
+    assert_eq!(diffs_a.len(), 1, "exactly one diff to A");
+    assert_eq!(diffs_b.len(), 1, "exactly one diff to B");
+    assert_eq!(diffs_a[0], diffs_b[0], "identical diff to every subscriber");
+
+    cache_a.apply(&diffs_a[0]);
+    assert_eq!(cache_a.view, store.snapshot("A"), "cache converges");
+    assert_eq!(cache_a.view["run"]["total"], json!(3));
+    assert_eq!(cache_a.view["run"]["completed"], json!(0));
+}
+
+#[test]
+fn a_full_run_advances_monotonically_and_converges() {
+    let store = Arc::new(WorkflowRunStore::new());
+    let region = workflow_run_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(&region, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    // start(2) → open panel → step 1 → step 2 → fail (settles the run).
+    for (kind, payload) in [
+        (
+            "workflow.runStarted",
+            json!({ "workflowId": "wf-1", "workflowName": "Deploy", "tabId": "t1", "total": 2 }),
+        ),
+        (
+            "workflow.outputOpened",
+            json!({ "workflowId": "wf-1", "workflowName": "Deploy", "program": "make", "args": ["build"] }),
+        ),
+        (
+            "workflow.stepAdvanced",
+            json!({ "workflowId": "wf-1", "tabId": "t1", "completed": 1 }),
+        ),
+        ("workflow.runFailed", json!({ "error": "exit 1" })),
+    ] {
+        let ack = dispatcher.dispatch(intent(kind, "A", payload));
+        assert_eq!(ack.status, IntentStatus::Accepted, "{kind} accepted");
+    }
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 4, "one diff per view-changing intent");
+    for diff in &diffs {
+        cache.apply(diff);
+    }
+    assert_eq!(cache.version, 4);
+    assert_eq!(
+        cache.view,
+        store.snapshot("A"),
+        "cache converges on authority"
+    );
+    assert_eq!(cache.view["run"], Value::Null);
+    assert_eq!(cache.view["output"]["status"], json!("failed"));
+    assert_eq!(cache.view["output"]["error"], json!("exit 1"));
+    assert_eq!(cache.view["output"]["program"], json!("make"));
+}
+
+#[test]
+fn a_run_is_isolated_to_its_client_region() {
+    let store = Arc::new(WorkflowRunStore::new());
+    let region_a = workflow_run_region("A");
+    let region_b = workflow_run_region("B");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region_a, store.snapshot("A"));
+    projector.register_region(&region_b, store.snapshot("B"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink_a = Arc::new(VecSink::new());
+    let sink_b = Arc::new(VecSink::new());
+    projector.subscribe(&region_a, "sa", "A", sink_a.clone());
+    projector.subscribe(&region_b, "sb", "B", sink_b.clone());
+
+    dispatcher.dispatch(intent(
+        "workflow.runStarted",
+        "A",
+        json!({ "workflowId": "wf-1", "workflowName": "Deploy", "tabId": "t1", "total": 1 }),
+    ));
+
+    assert_eq!(sink_a.diffs().len(), 1, "A's region advanced");
+    assert_eq!(sink_b.diffs().len(), 0, "B's region untouched");
+    assert_eq!(projector.region_version(&region_b), Some(0));
+}
+
+#[test]
+fn an_intent_missing_required_fields_is_rejected_without_advancing() {
+    let store = Arc::new(WorkflowRunStore::new());
+    let region = workflow_run_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(&region, "sub", "A", sink.clone());
+
+    // Missing `total`.
+    let ack = dispatcher.dispatch(intent(
+        "workflow.runStarted",
+        "A",
+        json!({ "workflowId": "wf-1", "workflowName": "Deploy", "tabId": "t1" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "bad_payload");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(&region), Some(0));
+}
+
+#[test]
+fn a_no_op_step_advance_advances_nothing() {
+    // Advancing with no active run leaves the view unchanged, so the projector
+    // coalesces it to no diff and no version bump.
+    let store = Arc::new(WorkflowRunStore::new());
+    let region = workflow_run_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(&region, "sub", "A", sink.clone());
+
+    let ack = dispatcher.dispatch(intent(
+        "workflow.stepAdvanced",
+        "A",
+        json!({ "workflowId": "ghost", "tabId": "t1", "completed": 1 }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(ack.produced, Some(vec![]), "no region advanced");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(&region), Some(0));
+}
+
+#[test]
+fn a_dead_subscriber_is_reaped_on_publish() {
+    let store = Arc::new(WorkflowRunStore::new());
+    let region = workflow_run_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let live = Arc::new(VecSink::new());
+    let dead = Arc::new(VecSink::new());
+    projector.subscribe(&region, "live", "A", live.clone());
+    projector.subscribe(&region, "dead", "A", dead.clone());
+    assert_eq!(projector.subscriber_count(&region), 2);
+
+    dead.alive.store(false, Ordering::SeqCst);
+    dispatcher.dispatch(intent(
+        "workflow.runStarted",
+        "A",
+        json!({ "workflowId": "wf-1", "workflowName": "Deploy", "tabId": "t1", "total": 1 }),
+    ));
+
+    assert_eq!(
+        live.diffs().len(),
+        1,
+        "the live subscriber still gets the diff"
+    );
+    assert_eq!(
+        projector.subscriber_count(&region),
+        1,
+        "the dead subscriber was reaped"
+    );
+}

--- a/src-tauri/src/workflow_projection/store.rs
+++ b/src-tauri/src/workflow_projection/store.rs
@@ -1,0 +1,335 @@
+//! The authoritative, client-scoped workflow-run state machine behind the
+//! shadow `workflow-run@<clientId>` region (#2243, Phase 4 step 5c of #2139).
+//!
+//! Models the in-flight workflow run the frontend currently drives (`appStore`
+//! `workflowRun` + `workflowRunOutput`, #1852 / #1865): a single active run per
+//! client that advances step by step and settles on a terminal outcome, plus
+//! the dismissible inline output panel a `run-local-process` step opens. This
+//! module owns only the run **status** per client — not the workflow library
+//! (already backend-backed via `workflowApi`), and not the step side-effects.
+//!
+//! # Client-scoped — Open Design Decision #4 / #6
+//!
+//! A run belongs to the client that launched it: that client picks the target
+//! terminal, sees the progress toast, and owns the output panel. Only one run
+//! is active per client (a fresh `runStarted` supersedes any prior run's
+//! panel). It is a property of the launching client, not of shared
+//! infrastructure, so the store keys everything by `clientId` and projects one
+//! `workflow-run@<clientId>` region per client — mirroring `restore-cohort`,
+//! `broadcast`, and `layout`.
+//!
+//! # Shadow mode — zero user-facing change
+//!
+//! This step is deliberately **not authoritative**. The store exists, accepts
+//! `workflow.*` intents, and projects diffs, but nothing in the live UI
+//! subscribes to or renders a `workflow-run` region, and no frontend code
+//! dispatches `workflow.*` intents yet. The `appStore` run reducers, progress
+//! toast, and output panel remain authoritative.
+//!
+//! ## What stays frontend
+//!
+//! The step-execution side-effects stay frontend orchestration, keeping a clean
+//! per-domain boundary between run *status* (this store) and run *effects*:
+//!
+//! - **The step seams.** Sending commands, replaying macros, and spawning /
+//!   authorizing local processes (`workflowRunner`'s `send` / `runMacro` /
+//!   `runLocalProcess` seams) are effects; the store learns of their progress
+//!   only through `workflow.stepAdvanced` and the run's terminal intent.
+//! - **The output panel's streamed content.** The store models the panel's
+//!   *status* lifecycle — opened (`running`) → terminal (`completed` /
+//!   `cancelled` / `failed`) → dismissed — because that is run status. The
+//!   streamed stdout/stderr `lines`, the process `exitCode`, and the `timedOut`
+//!   flag are per-process content the frontend keeps (they reuse the existing
+//!   `subscribeLocalProcessOutput` stream, #1857 / #1865); the store carries
+//!   only the panel's identity (workflow, program, args) and status.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// The terminal outcome of a workflow run, mirroring the frontend
+/// `WorkflowRunStatus` (#1865). `Running` is the non-terminal state the output
+/// panel opens in; the other three are the run's settle outcomes.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum RunOutcome {
+    /// Every step ran successfully.
+    Completed,
+    /// The run was cancelled before finishing.
+    Cancelled,
+    /// A step failed and stopped the run.
+    Failed,
+}
+
+impl RunOutcome {
+    /// The lowercase status string projected into the view (matches the
+    /// frontend `WorkflowRunOutputStatus`).
+    fn as_str(self) -> &'static str {
+        match self {
+            RunOutcome::Completed => "completed",
+            RunOutcome::Cancelled => "cancelled",
+            RunOutcome::Failed => "failed",
+        }
+    }
+}
+
+/// The in-flight run's step-progress metadata (`appStore` `WorkflowRunState`).
+#[derive(Clone, Debug, PartialEq)]
+struct WorkflowRun {
+    workflow_id: String,
+    workflow_name: String,
+    tab_id: String,
+    total: usize,
+    completed: usize,
+}
+
+impl WorkflowRun {
+    fn to_view(&self) -> Value {
+        json!({
+            "workflowId": self.workflow_id,
+            "workflowName": self.workflow_name,
+            "tabId": self.tab_id,
+            "total": self.total,
+            "completed": self.completed,
+        })
+    }
+}
+
+/// The inline run-output panel a `run-local-process` step opens (`appStore`
+/// `WorkflowRunOutputState`). The store owns its *status* lifecycle; the
+/// streamed lines / exit code / timeout stay frontend (see the module docs).
+#[derive(Clone, Debug, PartialEq)]
+struct WorkflowRunOutput {
+    workflow_id: String,
+    workflow_name: String,
+    program: String,
+    args: Vec<String>,
+    /// `None` while the process runs; `Some(outcome)` once the run settles.
+    outcome: Option<RunOutcome>,
+    /// A human-readable failure reason, set only when `outcome == Failed`.
+    error: Option<String>,
+}
+
+impl WorkflowRunOutput {
+    fn to_view(&self) -> Value {
+        let status = match self.outcome {
+            None => "running",
+            Some(o) => o.as_str(),
+        };
+        json!({
+            "workflowId": self.workflow_id,
+            "workflowName": self.workflow_name,
+            "program": self.program,
+            "args": self.args,
+            "status": status,
+            "error": self.error,
+        })
+    }
+}
+
+/// One client's workflow-run state.
+#[derive(Clone, Debug, Default)]
+struct ClientState {
+    /// The active run, or `None` when nothing is running.
+    run: Option<WorkflowRun>,
+    /// The inline output panel, or `None` when no local process has opened one
+    /// (or it was dismissed / superseded).
+    output: Option<WorkflowRunOutput>,
+}
+
+impl ClientState {
+    /// The complete render-ready view model for this client's region.
+    fn to_view(&self) -> Value {
+        json!({
+            "run": self.run.as_ref().map(WorkflowRun::to_view),
+            "output": self.output.as_ref().map(WorkflowRunOutput::to_view),
+        })
+    }
+}
+
+/// The shadow workflow-run authority. Owns one [`ClientState`] per attached
+/// client, keyed by `clientId`; an unknown client is seeded lazily on first
+/// touch. Each client projects its own `workflow-run@<clientId>` region.
+pub struct WorkflowRunStore {
+    clients: Mutex<HashMap<String, ClientState>>,
+}
+
+impl Default for WorkflowRunStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WorkflowRunStore {
+    /// A store with no clients yet. Regions are seeded lazily per `clientId`.
+    pub fn new() -> Self {
+        Self {
+            clients: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// The current render-ready view model for a client (seeding it if
+    /// unknown): `{ run, output }`.
+    ///
+    /// Pure with respect to run state (never mutates beyond lazy seeding of an
+    /// empty client), so the projector can safely diff two consecutive
+    /// snapshots.
+    pub fn snapshot(&self, client_id: &str) -> Value {
+        self.lock()
+            .entry(client_id.to_string())
+            .or_default()
+            .to_view()
+    }
+
+    /// `workflow.runStarted` — begin a run against a target terminal. Sets the
+    /// active run at `completed == 0` and clears any prior run's output panel
+    /// (mirroring `appStore`, which nulls `workflowRunOutput` on a fresh run —
+    /// the panel is recreated lazily only if this run spawns a local process).
+    /// A fresh run supersedes any run still recorded as active.
+    pub fn run_started(
+        &self,
+        client_id: &str,
+        workflow_id: &str,
+        workflow_name: &str,
+        tab_id: &str,
+        total: usize,
+    ) {
+        let mut clients = self.lock();
+        let state = clients.entry(client_id.to_string()).or_default();
+        state.run = Some(WorkflowRun {
+            workflow_id: workflow_id.to_string(),
+            workflow_name: workflow_name.to_string(),
+            tab_id: tab_id.to_string(),
+            total,
+            completed: 0,
+        });
+        state.output = None;
+    }
+
+    /// `workflow.stepAdvanced` — record run progress. Updates `completed` only
+    /// when the active run still matches the reported `workflow_id` and
+    /// `tab_id` (mirroring `appStore`'s `onProgress` guard, which ignores
+    /// progress from a run a newer `runStarted` has replaced). A no-op when no
+    /// run is active or the ids do not match.
+    pub fn step_advanced(
+        &self,
+        client_id: &str,
+        workflow_id: &str,
+        tab_id: &str,
+        completed: usize,
+    ) {
+        let mut clients = self.lock();
+        let Some(state) = clients.get_mut(client_id) else {
+            return;
+        };
+        let Some(run) = state.run.as_mut() else {
+            return;
+        };
+        if run.workflow_id == workflow_id && run.tab_id == tab_id {
+            run.completed = completed;
+        }
+    }
+
+    /// `workflow.outputOpened` — open the inline run-output panel a
+    /// `run-local-process` step spawns, in the non-terminal `running` status
+    /// (mirroring `appStore`, which sets `workflowRunOutput` with
+    /// `status: "running"` when a local process starts). A fresh spawn owns the
+    /// panel: it replaces any prior panel's identity and resets its status. The
+    /// streamed lines / exit code / timeout stay frontend (see module docs).
+    ///
+    /// Modeled here because the panel's *status* is run status; the run's
+    /// terminal intent later stamps [`RunOutcome`] onto it, and `dismissOutput`
+    /// clears it.
+    pub fn output_opened(
+        &self,
+        client_id: &str,
+        workflow_id: &str,
+        workflow_name: &str,
+        program: &str,
+        args: &[String],
+    ) {
+        let mut clients = self.lock();
+        let state = clients.entry(client_id.to_string()).or_default();
+        state.output = Some(WorkflowRunOutput {
+            workflow_id: workflow_id.to_string(),
+            workflow_name: workflow_name.to_string(),
+            program: program.to_string(),
+            args: args.to_vec(),
+            outcome: None,
+            error: None,
+        });
+    }
+
+    /// `workflow.runCompleted` — settle the active run as completed.
+    pub fn run_completed(&self, client_id: &str) {
+        self.finish_run(client_id, RunOutcome::Completed, None);
+    }
+
+    /// `workflow.runCancelled` — settle the active run as cancelled.
+    pub fn run_cancelled(&self, client_id: &str) {
+        self.finish_run(client_id, RunOutcome::Cancelled, None);
+    }
+
+    /// `workflow.runFailed` — settle the active run as failed, recording the
+    /// failure reason (stamped onto the output panel when one is open).
+    pub fn run_failed(&self, client_id: &str, error: Option<String>) {
+        self.finish_run(client_id, RunOutcome::Failed, error);
+    }
+
+    /// Settle the active run with a terminal outcome: clear the run and stamp
+    /// the outcome (and any error) onto the output panel when one is open —
+    /// mirroring `appStore`, which nulls `workflowRun` and stamps
+    /// `workflowRunOutput.status` in the same update, but only for the run still
+    /// current. Idempotent when no run is active: a stray terminal intent
+    /// leaves the panel's status untouched (the panel keeps its prior status).
+    fn finish_run(&self, client_id: &str, outcome: RunOutcome, error: Option<String>) {
+        let mut clients = self.lock();
+        let Some(state) = clients.get_mut(client_id) else {
+            return;
+        };
+        // No active run → nothing to settle; leave the output panel as-is,
+        // matching appStore's `activeWorkflowRun === handle` guard.
+        if state.run.take().is_none() {
+            return;
+        }
+        if let Some(output) = state.output.as_mut() {
+            output.outcome = Some(outcome);
+            output.error = if outcome == RunOutcome::Failed {
+                error
+            } else {
+                None
+            };
+        }
+    }
+
+    /// `workflow.dismissOutput` — dismiss the inline output panel (mirroring
+    /// `appStore.dismissWorkflowRunOutput`). A no-op when no panel is open.
+    pub fn dismiss_output(&self, client_id: &str) {
+        let mut clients = self.lock();
+        if let Some(state) = clients.get_mut(client_id) {
+            state.output = None;
+        }
+    }
+
+    /// Read a client's active-run tallies (test/diagnostics helper):
+    /// `(total, completed)`.
+    #[cfg(test)]
+    pub fn run_progress(&self, client_id: &str) -> Option<(usize, usize)> {
+        self.lock()
+            .get(client_id)
+            .and_then(|s| s.run.as_ref())
+            .map(|r| (r.total, r.completed))
+    }
+
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, ClientState>> {
+        // Short critical sections only; a poisoned lock means another thread
+        // panicked mid-mutation (a bug) — recover rather than cascade.
+        self.clients.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod tests;

--- a/src-tauri/src/workflow_projection/store_tests.rs
+++ b/src-tauri/src/workflow_projection/store_tests.rs
@@ -1,0 +1,223 @@
+//! State-machine tests for [`WorkflowRunStore`], proving the run authority
+//! matches the frontend `appStore` reducers (#1852 / #1865) transition for
+//! transition: runStarted → stepAdvanced → terminal outcome, the lazy output
+//! panel and its status stamping, the stale-progress and stray-terminal guards,
+//! dismissal, and the per-client isolation the client-scoped region requires.
+
+use super::*;
+
+const C: &str = "client-1";
+
+fn ids(v: &[&str]) -> Vec<String> {
+    v.iter().map(|s| s.to_string()).collect()
+}
+
+#[test]
+fn a_fresh_client_is_empty() {
+    let store = WorkflowRunStore::new();
+    let view = store.snapshot(C);
+    assert_eq!(view["run"], Value::Null);
+    assert_eq!(view["output"], Value::Null);
+}
+
+#[test]
+fn run_started_registers_the_run_at_zero_progress() {
+    let store = WorkflowRunStore::new();
+    store.run_started(C, "wf-1", "Deploy", "tab-9", 3);
+    assert_eq!(store.run_progress(C), Some((3, 0)));
+    let view = store.snapshot(C);
+    assert_eq!(view["run"]["workflowId"], json!("wf-1"));
+    assert_eq!(view["run"]["workflowName"], json!("Deploy"));
+    assert_eq!(view["run"]["tabId"], json!("tab-9"));
+    assert_eq!(view["run"]["total"], json!(3));
+    assert_eq!(view["run"]["completed"], json!(0));
+    assert_eq!(view["output"], Value::Null);
+}
+
+#[test]
+fn step_advanced_updates_progress_for_the_matching_run() {
+    let store = WorkflowRunStore::new();
+    store.run_started(C, "wf-1", "Deploy", "tab-9", 3);
+    store.step_advanced(C, "wf-1", "tab-9", 1);
+    assert_eq!(store.run_progress(C), Some((3, 1)));
+    store.step_advanced(C, "wf-1", "tab-9", 2);
+    assert_eq!(store.snapshot(C)["run"]["completed"], json!(2));
+}
+
+#[test]
+fn step_advanced_from_a_stale_run_is_ignored() {
+    let store = WorkflowRunStore::new();
+    store.run_started(C, "wf-1", "Deploy", "tab-9", 3);
+    // A newer run replaced the first; progress from the old workflow/tab must
+    // not clobber it (mirrors appStore's onProgress workflowId/tabId guard).
+    store.run_started(C, "wf-2", "Backup", "tab-4", 2);
+    store.step_advanced(C, "wf-1", "tab-9", 3); // stale workflow id
+    store.step_advanced(C, "wf-2", "tab-9", 1); // stale tab id
+    assert_eq!(store.run_progress(C), Some((2, 0)), "progress unchanged");
+    store.step_advanced(C, "wf-2", "tab-4", 1); // matches → applies
+    assert_eq!(store.run_progress(C), Some((2, 1)));
+}
+
+#[test]
+fn step_advanced_with_no_active_run_is_a_no_op() {
+    let store = WorkflowRunStore::new();
+    store.step_advanced(C, "wf-1", "tab-9", 1);
+    assert_eq!(store.run_progress(C), None);
+    assert_eq!(store.snapshot(C)["run"], Value::Null);
+}
+
+#[test]
+fn run_started_clears_a_prior_runs_output_panel() {
+    let store = WorkflowRunStore::new();
+    store.run_started(C, "wf-1", "Deploy", "tab-9", 1);
+    store.output_opened(C, "wf-1", "Deploy", "echo", &ids(&["hi"]));
+    store.run_completed(C);
+    assert_eq!(store.snapshot(C)["output"]["status"], json!("completed"));
+
+    // A fresh run nulls the leftover panel (recreated only if it spawns one).
+    store.run_started(C, "wf-2", "Backup", "tab-4", 1);
+    assert_eq!(store.snapshot(C)["output"], Value::Null);
+}
+
+#[test]
+fn output_opened_starts_the_panel_running() {
+    let store = WorkflowRunStore::new();
+    store.run_started(C, "wf-1", "Deploy", "tab-9", 2);
+    store.output_opened(C, "wf-1", "Deploy", "make", &ids(&["build", "-j4"]));
+    let view = store.snapshot(C);
+    assert_eq!(view["output"]["workflowId"], json!("wf-1"));
+    assert_eq!(view["output"]["workflowName"], json!("Deploy"));
+    assert_eq!(view["output"]["program"], json!("make"));
+    assert_eq!(view["output"]["args"], json!(["build", "-j4"]));
+    assert_eq!(view["output"]["status"], json!("running"));
+    assert_eq!(view["output"]["error"], Value::Null);
+}
+
+#[test]
+fn a_second_local_process_takes_over_the_panel() {
+    let store = WorkflowRunStore::new();
+    store.run_started(C, "wf-1", "Deploy", "tab-9", 2);
+    store.output_opened(C, "wf-1", "Deploy", "make", &ids(&["build"]));
+    store.output_opened(C, "wf-1", "Deploy", "curl", &ids(&["https://x"]));
+    let view = store.snapshot(C);
+    assert_eq!(view["output"]["program"], json!("curl"));
+    assert_eq!(view["output"]["args"], json!(["https://x"]));
+    assert_eq!(view["output"]["status"], json!("running"));
+}
+
+#[test]
+fn run_completed_clears_the_run_and_stamps_the_panel() {
+    let store = WorkflowRunStore::new();
+    store.run_started(C, "wf-1", "Deploy", "tab-9", 2);
+    store.output_opened(C, "wf-1", "Deploy", "echo", &ids(&["done"]));
+    store.step_advanced(C, "wf-1", "tab-9", 2);
+    store.run_completed(C);
+
+    let view = store.snapshot(C);
+    assert_eq!(view["run"], Value::Null, "run cleared on settle");
+    assert_eq!(store.run_progress(C), None);
+    assert_eq!(view["output"]["status"], json!("completed"));
+    assert_eq!(view["output"]["error"], Value::Null);
+}
+
+#[test]
+fn run_cancelled_clears_the_run_and_stamps_the_panel() {
+    let store = WorkflowRunStore::new();
+    store.run_started(C, "wf-1", "Deploy", "tab-9", 3);
+    store.output_opened(C, "wf-1", "Deploy", "sleep", &ids(&["100"]));
+    store.run_cancelled(C);
+
+    let view = store.snapshot(C);
+    assert_eq!(view["run"], Value::Null);
+    assert_eq!(view["output"]["status"], json!("cancelled"));
+    assert_eq!(view["output"]["error"], Value::Null);
+}
+
+#[test]
+fn run_failed_stamps_status_and_error_on_the_panel() {
+    let store = WorkflowRunStore::new();
+    store.run_started(C, "wf-1", "Deploy", "tab-9", 3);
+    store.output_opened(C, "wf-1", "Deploy", "make", &ids(&["build"]));
+    store.run_failed(C, Some("exit code 1".to_string()));
+
+    let view = store.snapshot(C);
+    assert_eq!(view["run"], Value::Null);
+    assert_eq!(view["output"]["status"], json!("failed"));
+    assert_eq!(view["output"]["error"], json!("exit code 1"));
+}
+
+#[test]
+fn a_terminal_native_run_settles_with_no_output_panel() {
+    // A run that never spawns a local process has no output panel; settling it
+    // clears the run and leaves output null (appStore leaves it untouched).
+    let store = WorkflowRunStore::new();
+    store.run_started(C, "wf-1", "Deploy", "tab-9", 2);
+    store.step_advanced(C, "wf-1", "tab-9", 2);
+    store.run_completed(C);
+
+    let view = store.snapshot(C);
+    assert_eq!(view["run"], Value::Null);
+    assert_eq!(view["output"], Value::Null);
+}
+
+#[test]
+fn a_terminal_intent_with_no_active_run_leaves_the_panel_untouched() {
+    // A stray terminal intent after the run already settled must not re-stamp a
+    // dismissed-or-settled panel (mirrors appStore's `activeWorkflowRun ===
+    // handle` guard: only the current run clears/stamps).
+    let store = WorkflowRunStore::new();
+    store.run_started(C, "wf-1", "Deploy", "tab-9", 1);
+    store.output_opened(C, "wf-1", "Deploy", "echo", &ids(&["hi"]));
+    store.run_completed(C);
+    assert_eq!(store.snapshot(C)["output"]["status"], json!("completed"));
+
+    // No active run now — a stray failed intent is a no-op on the panel.
+    store.run_failed(C, Some("late".to_string()));
+    let view = store.snapshot(C);
+    assert_eq!(
+        view["output"]["status"],
+        json!("completed"),
+        "not restamped"
+    );
+    assert_eq!(view["output"]["error"], Value::Null);
+}
+
+#[test]
+fn dismiss_output_clears_the_panel_only() {
+    let store = WorkflowRunStore::new();
+    store.run_started(C, "wf-1", "Deploy", "tab-9", 1);
+    store.output_opened(C, "wf-1", "Deploy", "echo", &ids(&["hi"]));
+    store.run_completed(C);
+    store.dismiss_output(C);
+    assert_eq!(store.snapshot(C)["output"], Value::Null);
+}
+
+#[test]
+fn dismiss_output_with_no_panel_is_a_no_op() {
+    let store = WorkflowRunStore::new();
+    store.dismiss_output(C);
+    assert_eq!(store.snapshot(C)["output"], Value::Null);
+}
+
+#[test]
+fn output_opened_with_no_args_projects_an_empty_array() {
+    let store = WorkflowRunStore::new();
+    store.output_opened(C, "wf-1", "Deploy", "ls", &[]);
+    assert_eq!(store.snapshot(C)["output"]["args"], json!([]));
+}
+
+#[test]
+fn runs_are_isolated_per_client() {
+    let store = WorkflowRunStore::new();
+    store.run_started("a", "wf-a", "A", "tab-a", 2);
+    store.run_started("b", "wf-b", "B", "tab-b", 3);
+
+    store.step_advanced("a", "wf-a", "tab-a", 1);
+    // Client b is untouched by client a's progress.
+    assert_eq!(store.run_progress("b"), Some((3, 0)));
+    store.run_failed("b", Some("boom".to_string()));
+
+    assert_eq!(store.run_progress("a"), Some((2, 1)));
+    assert_eq!(store.snapshot("a")["run"]["completed"], json!(1));
+    assert_eq!(store.snapshot("b")["run"], Value::Null, "b settled");
+}


### PR DESCRIPTION
Phase 4 **step 5c** of the stateless-UI migration — the third and final of #2206's three machines, following the broadcast (PR #2254) and restore-cohort (PR #2240) shadows.

Part of #2243
Part of #2206

## What this adds

A **backend-only shadow authority** modeling the `appStore` **workflow-run** state machine on the projection substrate — zero user-facing change.

New `src-tauri/src/workflow_projection/` module:

- **Store** (`WorkflowRunStore`) modeling the two run slices the frontend drives (`workflowRun` + `workflowRunOutput`, #1852 / #1865):
  - `run` — the active run's step progress `{ workflowId, workflowName, tabId, total, completed }`, one per client.
  - `output` — the dismissible inline output panel a `run-local-process` step opens, with its `running | completed | cancelled | failed` **status** lifecycle.
- **Region + intents** — a client-scoped `workflow-run@<clientId>` region and `workflow.*` intents: `runStarted`, `stepAdvanced`, `outputOpened`, `runCompleted`, `runCancelled`, `runFailed`, `dismissOutput`.

## Region scope — client-scoped (Decision #4 / #6)

A workflow run is launched by one client against one of *that client's* target terminals, and its feedback (the progress toast + the inline output panel) is the launching client's own UI overlay — and only one run is active per client at a time. Like the client-scoped `restore-cohort` and `broadcast` regions (and unlike the shared `session-lifecycle` region), the run is an orchestration overlay owned by the launching client, not shared infrastructure. So the region is **client-scoped** (`workflow-run@<clientId>`), mirroring `layout`. The terminal *session* it targets is shared, but the *run orchestration over it* belongs to the launching client. Justified in the module docs.

## What stays frontend

Per the issue, the step side-effects (send / macro / local-process seams in `workflowRunner`) stay frontend orchestration; the store owns only the run *status*. The output panel's streamed stdout/stderr `lines`, the process `exitCode`, and the `timedOut` flag stay frontend (they reuse the existing `subscribeLocalProcessOutput` stream, #1857 / #1865); the store carries only the panel's identity and status lifecycle.

## Shadow only

Nothing in the live UI subscribes to or renders the region, and no frontend code dispatches `workflow.*` intents yet. The `appStore` run reducers, progress toast, and output panel remain authoritative. The diff touches only `src-tauri/` — **no `src/` changes**. Later steps cut rendering, then the mutations, over to it (keeping the reducers as the parity-safe fallback).

## Tests

- **Store state-machine tests** (`store_tests.rs`) proving parity with the appStore reducers transition-for-transition: runStarted → stepAdvanced → terminal outcome, the lazy output panel + status stamping, stale-progress and stray-terminal guards, dismissal, per-client isolation.
- **Projection-contract tests** (`projection_tests.rs`, #2164 harness): subscribe/snapshot, one coalesced diff fanned to every subscriber with monotonic versions across a full run, client-scoped isolation, rejection paths, no-op coalescing, dead-subscriber reaping, client-cache convergence on authority.

`cargo test` (24 new tests pass), `clippy -D warnings`, and `cargo fmt --check` all green locally.

Completing this with steps 5a (session-lifecycle) and 5b (restore-cohort / broadcast) meets the rest of #2152's acceptance, so #2152 can then close.