### PR TITLE
feat(workspace): cut restore-cohort render + mutations to server authority (Closes #2241)

### DIFF
--- a/src/store/appStore.restoreCohortMutationCut.test.ts
+++ b/src/store/appStore.restoreCohortMutationCut.test.ts
@@ -1,0 +1,457 @@
+/**
+ * Restore-cohort mutation cut (#2241, part of #2206 / #2139) — cut-vs-local parity.
+ *
+ * The mutation cut routes `beginRestoreCohort` / `settleRestoreTab` through the
+ * `restore.beginCohort` / `restore.settleTab` intents so the backend
+ * `RestoreCohortStore` becomes authoritative, while the local `appStore` cohort
+ * reducers stay in place as the render source and the resilience / rollback
+ * fallback (removal is a later step).
+ *
+ * These tests prove the cut is parity-safe: with the intents flag **on**, the
+ * intents dispatched by the actions — applied by a faithful in-memory port of the
+ * Rust store (mirroring `restore_cohort_projection/store.rs`) — reconstruct the
+ * `restore-cohort@<clientId>` region whose settled summary + captured failed-tab
+ * set match the local slice. With the flag **off**, no intents are dispatched — the
+ * instant rollback path the flip relies on.
+ *
+ * The render flag is held **off** here so the summary toast fires straight from the
+ * local reducer (isolating the mutation cut); the render cut is covered separately
+ * in `restoreCohortBridge.test.ts`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const toastSuccess = vi.fn((_m: unknown, _o?: unknown) => undefined);
+const toastError = vi.fn((_m: unknown, _o?: unknown) => undefined);
+const toastInfo = vi.fn((_m: unknown, _o?: unknown) => undefined);
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: (m: unknown, o?: unknown) => (o === undefined ? toastSuccess(m) : toastSuccess(m, o)),
+    error: (m: unknown, o?: unknown) => (o === undefined ? toastError(m) : toastError(m, o)),
+    info: (m: unknown, o?: unknown) => (o === undefined ? toastInfo(m) : toastInfo(m, o)),
+    loading: vi.fn(() => "toast-id"),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  closeTerminal: vi.fn(() => Promise.resolve()),
+  detachPersistentTab: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/services/lastSessionApi", () => ({
+  saveLastSession: vi.fn(() => Promise.resolve()),
+  loadLastSession: vi.fn(() => Promise.resolve(null)),
+  clearLastSession: vi.fn(() => Promise.resolve()),
+}));
+
+import { useAppStore } from "./appStore";
+import {
+  setRestoreIntentsEnabled,
+  setRestoreRenderFromProjectionEnabled,
+  setRestoreTransportForTest,
+} from "./restoreCohortBridge";
+import { loadLastSession } from "@/services/lastSessionApi";
+import { getAllLeaves } from "@/utils/panelTree";
+import type { LastSession } from "@/types/lastSession";
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+
+const mockLoad = vi.mocked(loadLastSession);
+
+// ── In-memory twin of the Rust RestoreCohortStore (client-scoped) ──────────────
+
+interface Cohort {
+  pending: string[];
+  total: number;
+  failed: number;
+  failedTabIds: string[];
+  toastId: string | null;
+}
+interface Settlement {
+  seq: number;
+  total: number;
+  restored: number;
+  failed: number;
+  retryTabIds: string[];
+  toastId: string | null;
+}
+interface ClientState {
+  cohort: Cohort | null;
+  failedTabIds: string[];
+  settlement: Settlement | null;
+  settleSeq: number;
+}
+interface RegionView {
+  cohort: (Omit<Cohort, "toastId"> & { toastId: string | null }) | null;
+  failedTabIds: string[];
+  settlement: Settlement | null;
+}
+
+/** A transport double that applies `restore.*` intents with the same semantics as
+ * the Rust `RestoreCohortStore`, keyed by `clientId`, and fans the client's region
+ * snapshot to subscribers on every mutation. */
+class RestoreStoreTransport implements Transport {
+  dispatched: Intent[] = [];
+  private clients = new Map<string, ClientState>();
+  private version = 0;
+  private handlers = new Map<string, FrameHandler[]>();
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    this.apply(intent);
+    this.version += 1;
+    this.fan(intent.clientId);
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: this.region(intent.clientId), version: this.version }],
+    };
+  }
+
+  private state(clientId: string): ClientState {
+    let s = this.clients.get(clientId);
+    if (!s) {
+      s = { cohort: null, failedTabIds: [], settlement: null, settleSeq: 0 };
+      this.clients.set(clientId, s);
+    }
+    return s;
+  }
+
+  private apply(intent: Intent): void {
+    const p = intent.payload as Record<string, unknown>;
+    const s = this.state(intent.clientId);
+    switch (intent.kind) {
+      case "restore.beginCohort": {
+        const raw = (p.pendingTabIds as string[]) ?? [];
+        const pending: string[] = [];
+        for (const id of raw) if (!pending.includes(id)) pending.push(id);
+        const preFailed = (p.preFailedCount as number | undefined) ?? 0;
+        const total = pending.length + preFailed;
+        if (total === 0) break;
+        s.cohort = {
+          pending,
+          total,
+          failed: preFailed,
+          failedTabIds: [],
+          toastId: (p.toastId as string | undefined) ?? null,
+        };
+        s.failedTabIds = [];
+        if (pending.length === 0) this.settleCohort(intent.clientId);
+        break;
+      }
+      case "restore.settleTab": {
+        if (!s.cohort) break;
+        const tabId = p.tabId as string;
+        const pos = s.cohort.pending.indexOf(tabId);
+        if (pos < 0) break;
+        s.cohort.pending.splice(pos, 1);
+        if (p.outcome === "failed") {
+          s.cohort.failed += 1;
+          if (!s.cohort.failedTabIds.includes(tabId)) s.cohort.failedTabIds.push(tabId);
+        }
+        if (s.cohort.pending.length === 0) this.settleCohort(intent.clientId);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  private settleCohort(clientId: string): void {
+    const s = this.state(clientId);
+    const cohort = s.cohort;
+    if (!cohort) return;
+    s.cohort = null;
+    s.failedTabIds = [...cohort.failedTabIds];
+    s.settleSeq += 1;
+    s.settlement = {
+      seq: s.settleSeq,
+      total: cohort.total,
+      restored: cohort.total - cohort.failed,
+      failed: cohort.failed,
+      retryTabIds: [...cohort.failedTabIds],
+      toastId: cohort.toastId,
+    };
+  }
+
+  regionView(clientId: string): RegionView {
+    const s = this.state(clientId);
+    return structuredClone({
+      cohort: s.cohort
+        ? {
+            pending: s.cohort.pending,
+            total: s.cohort.total,
+            failed: s.cohort.failed,
+            failedTabIds: s.cohort.failedTabIds,
+            toastId: s.cohort.toastId,
+          }
+        : null,
+      failedTabIds: s.failedTabIds,
+      settlement: s.settlement,
+    });
+  }
+
+  /** The single client's region view (there is one per-session client id). */
+  onlyRegionView(): RegionView {
+    const [clientId] = [...this.clients.keys()];
+    return this.regionView(clientId ?? "");
+  }
+
+  kinds(): string[] {
+    return this.dispatched.map((i) => i.kind);
+  }
+
+  private region(clientId: string): string {
+    return `restore-cohort@${clientId}`;
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    const list = this.handlers.get(region) ?? [];
+    list.push(onFrame);
+    this.handlers.set(region, list);
+    const clientId = region.slice("restore-cohort@".length);
+    return {
+      snapshot: this.snapshot(region, clientId),
+      unsubscribe: () => {
+        this.handlers.set(
+          region,
+          (this.handlers.get(region) ?? []).filter((h) => h !== onFrame)
+        );
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string, clientId: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: this.regionView(clientId) };
+  }
+
+  private fan(clientId: string): void {
+    const region = this.region(clientId);
+    const frame: ProjectionFrame = this.snapshot(region, clientId);
+    for (const h of this.handlers.get(region) ?? []) h(frame);
+  }
+}
+
+let transport: RestoreStoreTransport;
+
+/** A three-tab session that all resolve to plain local terminals. */
+function threeLocalTabsSession(): LastSession {
+  return {
+    version: "1",
+    activeGroupIndex: 0,
+    tabGroups: [
+      {
+        name: "Restored",
+        layout: {
+          type: "leaf",
+          tabs: [
+            { inlineConfig: { type: "local", config: { shell: "bash" } }, title: "Shell A" },
+            { inlineConfig: { type: "local", config: { shell: "bash" } }, title: "Shell B" },
+            { inlineConfig: { type: "local", config: { shell: "bash" } }, title: "Shell C" },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+function restoredTabIds(): string[] {
+  return getAllLeaves(useAppStore.getState().rootPanel)
+    .flatMap((l) => l.tabs)
+    .map((t) => t.id);
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  vi.clearAllMocks();
+  mockLoad.mockResolvedValue(null);
+  useAppStore.setState({
+    connections: [],
+    remoteAgents: [],
+    agentDefinitions: {},
+    defaultShell: "bash",
+    restoreCohort: null,
+    failedRestoreTabIds: [],
+    settings: { ...useAppStore.getState().settings, restoreLastSessionOnStartup: true },
+  });
+  transport = new RestoreStoreTransport();
+  setRestoreTransportForTest(transport);
+  setRestoreIntentsEnabled(true);
+  // Isolate the mutation cut: the summary toast fires straight from the local
+  // reducer here (the render cut is covered separately).
+  setRestoreRenderFromProjectionEnabled(false);
+});
+
+afterEach(() => {
+  setRestoreTransportForTest(null);
+  setRestoreIntentsEnabled(null);
+  setRestoreRenderFromProjectionEnabled(null);
+});
+
+describe("restore-cohort mutation cut — cut-vs-local parity (intents on)", () => {
+  it("a partial restore reproduces the settled region + captured failed set", async () => {
+    mockLoad.mockResolvedValue(threeLocalTabsSession());
+    await useAppStore.getState().restoreLastSession();
+    const ids = restoredTabIds();
+    expect(ids).toHaveLength(3);
+
+    useAppStore.getState().setTabSessionId(ids[0], "sess-a");
+    useAppStore.getState().setTabSessionId(ids[1], "sess-b");
+    useAppStore.getState().setTerminalDisconnectWithError(ids[2], "connection refused");
+    await flush();
+
+    // The intent stream: one begin, then one settle per tab.
+    expect(transport.kinds()).toEqual([
+      "restore.beginCohort",
+      "restore.settleTab",
+      "restore.settleTab",
+      "restore.settleTab",
+    ]);
+
+    const region = transport.onlyRegionView();
+    // The cohort settled and the summary matches the local computation.
+    expect(region.cohort).toBeNull();
+    expect(region.settlement).toMatchObject({ total: 3, restored: 2, failed: 1 });
+    expect(region.settlement?.retryTabIds).toEqual([ids[2]]);
+    // The captured failed set matches the local slice (all failed tabs are live).
+    expect(region.failedTabIds).toEqual(useAppStore.getState().failedRestoreTabIds);
+    expect(useAppStore.getState().failedRestoreTabIds).toEqual([ids[2]]);
+  });
+
+  it("a full success reproduces a zero-failure settlement", async () => {
+    mockLoad.mockResolvedValue(threeLocalTabsSession());
+    await useAppStore.getState().restoreLastSession();
+    const ids = restoredTabIds();
+
+    ids.forEach((id, i) => useAppStore.getState().setTabSessionId(id, `sess-${i}`));
+    await flush();
+
+    const region = transport.onlyRegionView();
+    expect(region.settlement).toMatchObject({ total: 3, restored: 3, failed: 0 });
+    expect(region.settlement?.retryTabIds).toEqual([]);
+    expect(region.failedTabIds).toEqual([]);
+    expect(useAppStore.getState().failedRestoreTabIds).toEqual([]);
+  });
+
+  it("mirrors the in-flight cohort before it settles", async () => {
+    mockLoad.mockResolvedValue(threeLocalTabsSession());
+    await useAppStore.getState().restoreLastSession();
+    const ids = restoredTabIds();
+
+    // Settle only one tab — the cohort is still in flight.
+    useAppStore.getState().setTabSessionId(ids[0], "sess-a");
+    await flush();
+
+    const region = transport.onlyRegionView();
+    expect(region.settlement).toBeNull();
+    expect(region.cohort).not.toBeNull();
+    // The projected in-flight cohort mirrors the local one.
+    const local = useAppStore.getState().restoreCohort;
+    expect(region.cohort?.total).toBe(local?.total);
+    expect(new Set(region.cohort?.pending)).toEqual(local?.pending);
+    expect(region.cohort?.failed).toBe(local?.failed);
+  });
+
+  it("bulk-retry reconnect dispatches a fresh cohort + settle", async () => {
+    mockLoad.mockResolvedValue(threeLocalTabsSession());
+    await useAppStore.getState().restoreLastSession();
+    const ids = restoredTabIds();
+    useAppStore.getState().setTabSessionId(ids[0], "sess-a");
+    useAppStore.getState().setTabSessionId(ids[1], "sess-b");
+    useAppStore.getState().setTerminalDisconnectWithError(ids[2], "refused");
+    await flush();
+    const before = transport.dispatched.length;
+
+    useAppStore.getState().reconnectFailedRestoreTabs();
+    useAppStore.getState().setTabSessionId(ids[2], "sess-c-retry");
+    await flush();
+
+    // A fresh beginCohort covering the retried tab, then its settle.
+    expect(transport.kinds().slice(before)).toEqual(["restore.beginCohort", "restore.settleTab"]);
+    const region = transport.onlyRegionView();
+    expect(region.settlement).toMatchObject({ total: 1, restored: 1, failed: 0 });
+    expect(region.failedTabIds).toEqual([]);
+    expect(useAppStore.getState().failedRestoreTabIds).toEqual([]);
+  });
+
+  it("a stray settle for a non-pending tab dispatches nothing", async () => {
+    mockLoad.mockResolvedValue(threeLocalTabsSession());
+    await useAppStore.getState().restoreLastSession();
+    const ids = restoredTabIds();
+    ids.forEach((id, i) => useAppStore.getState().setTabSessionId(id, `sess-${i}`));
+    await flush();
+    const before = transport.dispatched.length;
+
+    // The cohort has settled — a later settle on the same tab is a no-op locally
+    // and dispatches nothing (mirrors the store ignoring a non-pending settle).
+    useAppStore.getState().setTerminalDisconnectWithError(ids[0], "later drop");
+    await flush();
+    expect(transport.dispatched.length).toBe(before);
+  });
+});
+
+describe("restore-cohort mutation cut — flags off (rollback path)", () => {
+  beforeEach(() => {
+    setRestoreIntentsEnabled(false);
+    setRestoreRenderFromProjectionEnabled(false);
+  });
+
+  it("dispatches no intents and drives the cohort locally", async () => {
+    mockLoad.mockResolvedValue(threeLocalTabsSession());
+    await useAppStore.getState().restoreLastSession();
+    const ids = restoredTabIds();
+    useAppStore.getState().setTabSessionId(ids[0], "sess-a");
+    useAppStore.getState().setTabSessionId(ids[1], "sess-b");
+    useAppStore.getState().setTerminalDisconnectWithError(ids[2], "refused");
+    await flush();
+
+    // No mirror reached the region — the pre-cut local path is intact.
+    expect(transport.dispatched).toHaveLength(0);
+    expect(useAppStore.getState().failedRestoreTabIds).toEqual([ids[2]]);
+    expect(useAppStore.getState().restoreCohort).toBeNull();
+  });
+});

--- a/src/store/appStore.restoreCohortRenderCut.test.ts
+++ b/src/store/appStore.restoreCohortRenderCut.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Restore-cohort render cut (#2241, part of #2206 / #2139).
+ *
+ * The render cut fires the aggregate restore/launch summary toast once per new
+ * projected settlement `seq` from the `restore-cohort@<clientId>` region, instead
+ * of straight from the local reducer — the fired content is the gate-validated
+ * local summary, so it is byte-identical to the pre-cut toast.
+ *
+ * These tests prove:
+ * - with the render flag **on** and a live region, the summary fires from the
+ *   projection (asynchronously, after the settle round-trips) exactly once;
+ * - a dispatch failure falls back to firing the summary locally, so the toast is
+ *   never lost (the parity-safe fallback);
+ * - with the render flag **off**, the summary fires straight from the local
+ *   reducer, synchronously (the pre-cut path).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+const toastSuccess = vi.fn((_m: unknown, _o?: unknown) => undefined);
+const toastError = vi.fn((_m: unknown, _o?: unknown) => undefined);
+const toastInfo = vi.fn((_m: unknown, _o?: unknown) => undefined);
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: (m: unknown, o?: unknown) => (o === undefined ? toastSuccess(m) : toastSuccess(m, o)),
+    error: (m: unknown, o?: unknown) => (o === undefined ? toastError(m) : toastError(m, o)),
+    info: (m: unknown, o?: unknown) => (o === undefined ? toastInfo(m) : toastInfo(m, o)),
+    loading: vi.fn(() => "toast-id"),
+    dismiss: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  closeTerminal: vi.fn(() => Promise.resolve()),
+  detachPersistentTab: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/services/lastSessionApi", () => ({
+  saveLastSession: vi.fn(() => Promise.resolve()),
+  loadLastSession: vi.fn(() => Promise.resolve(null)),
+  clearLastSession: vi.fn(() => Promise.resolve()),
+}));
+
+import { useAppStore } from "./appStore";
+import {
+  setRestoreIntentsEnabled,
+  setRestoreRenderFromProjectionEnabled,
+  setRestoreTransportForTest,
+} from "./restoreCohortBridge";
+import { loadLastSession } from "@/services/lastSessionApi";
+import { getAllLeaves } from "@/utils/panelTree";
+import type { LastSession } from "@/types/lastSession";
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+
+const mockLoad = vi.mocked(loadLastSession);
+
+interface Cohort {
+  pending: string[];
+  total: number;
+  failed: number;
+  failedTabIds: string[];
+  toastId: string | null;
+}
+interface Settlement {
+  seq: number;
+  total: number;
+  restored: number;
+  failed: number;
+  retryTabIds: string[];
+  toastId: string | null;
+}
+interface ClientState {
+  cohort: Cohort | null;
+  failedTabIds: string[];
+  settlement: Settlement | null;
+  settleSeq: number;
+}
+
+/** Subscription-capable twin of the Rust store; `rejectDispatch` forces every
+ * intent ack to `rejected` (the transport-down fallback path). */
+class RestoreStoreTransport implements Transport {
+  rejectDispatch = false;
+  private clients = new Map<string, ClientState>();
+  private version = 0;
+  private handlers = new Map<string, FrameHandler[]>();
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    // Real IPC round-trips asynchronously — yield before applying/fanning so the
+    // projected settlement (and its toast) never lands synchronously.
+    await Promise.resolve();
+    if (this.rejectDispatch) {
+      return {
+        intentId: intent.intentId,
+        status: "rejected",
+        error: { code: "unavailable", message: "store down" },
+      };
+    }
+    this.apply(intent);
+    this.version += 1;
+    this.fan(intent.clientId);
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: this.region(intent.clientId), version: this.version }],
+    };
+  }
+
+  private state(clientId: string): ClientState {
+    let s = this.clients.get(clientId);
+    if (!s) {
+      s = { cohort: null, failedTabIds: [], settlement: null, settleSeq: 0 };
+      this.clients.set(clientId, s);
+    }
+    return s;
+  }
+
+  private apply(intent: Intent): void {
+    const p = intent.payload as Record<string, unknown>;
+    const s = this.state(intent.clientId);
+    if (intent.kind === "restore.beginCohort") {
+      const raw = (p.pendingTabIds as string[]) ?? [];
+      const pending: string[] = [];
+      for (const id of raw) if (!pending.includes(id)) pending.push(id);
+      const preFailed = (p.preFailedCount as number | undefined) ?? 0;
+      const total = pending.length + preFailed;
+      if (total === 0) return;
+      s.cohort = {
+        pending,
+        total,
+        failed: preFailed,
+        failedTabIds: [],
+        toastId: (p.toastId as string | undefined) ?? null,
+      };
+      s.failedTabIds = [];
+      if (pending.length === 0) this.settleCohort(intent.clientId);
+    } else if (intent.kind === "restore.settleTab") {
+      if (!s.cohort) return;
+      const tabId = p.tabId as string;
+      const pos = s.cohort.pending.indexOf(tabId);
+      if (pos < 0) return;
+      s.cohort.pending.splice(pos, 1);
+      if (p.outcome === "failed") {
+        s.cohort.failed += 1;
+        if (!s.cohort.failedTabIds.includes(tabId)) s.cohort.failedTabIds.push(tabId);
+      }
+      if (s.cohort.pending.length === 0) this.settleCohort(intent.clientId);
+    }
+  }
+
+  private settleCohort(clientId: string): void {
+    const s = this.state(clientId);
+    const cohort = s.cohort;
+    if (!cohort) return;
+    s.cohort = null;
+    s.failedTabIds = [...cohort.failedTabIds];
+    s.settleSeq += 1;
+    s.settlement = {
+      seq: s.settleSeq,
+      total: cohort.total,
+      restored: cohort.total - cohort.failed,
+      failed: cohort.failed,
+      retryTabIds: [...cohort.failedTabIds],
+      toastId: cohort.toastId,
+    };
+  }
+
+  private regionView(clientId: string) {
+    const s = this.state(clientId);
+    return structuredClone({
+      cohort: s.cohort,
+      failedTabIds: s.failedTabIds,
+      settlement: s.settlement,
+    });
+  }
+
+  private region(clientId: string): string {
+    return `restore-cohort@${clientId}`;
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    const list = this.handlers.get(region) ?? [];
+    list.push(onFrame);
+    this.handlers.set(region, list);
+    const clientId = region.slice("restore-cohort@".length);
+    return {
+      snapshot: this.snapshot(region, clientId),
+      unsubscribe: () => {
+        this.handlers.set(
+          region,
+          (this.handlers.get(region) ?? []).filter((h) => h !== onFrame)
+        );
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string, clientId: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: this.regionView(clientId) };
+  }
+
+  private fan(clientId: string): void {
+    const region = this.region(clientId);
+    const frame: ProjectionFrame = this.snapshot(region, clientId);
+    for (const h of this.handlers.get(region) ?? []) h(frame);
+  }
+}
+
+let transport: RestoreStoreTransport;
+
+function threeLocalTabsSession(): LastSession {
+  return {
+    version: "1",
+    activeGroupIndex: 0,
+    tabGroups: [
+      {
+        name: "Restored",
+        layout: {
+          type: "leaf",
+          tabs: [
+            { inlineConfig: { type: "local", config: { shell: "bash" } }, title: "Shell A" },
+            { inlineConfig: { type: "local", config: { shell: "bash" } }, title: "Shell B" },
+            { inlineConfig: { type: "local", config: { shell: "bash" } }, title: "Shell C" },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+function restoredTabIds(): string[] {
+  return getAllLeaves(useAppStore.getState().rootPanel)
+    .flatMap((l) => l.tabs)
+    .map((t) => t.id);
+}
+
+/** Let the subscribe/dispatch promise chain settle so projection diffs land. */
+async function settleAsync(): Promise<void> {
+  for (let i = 0; i < 8; i++) await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+  for (let i = 0; i < 4; i++) await Promise.resolve();
+}
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  vi.clearAllMocks();
+  mockLoad.mockResolvedValue(null);
+  useAppStore.setState({
+    connections: [],
+    remoteAgents: [],
+    agentDefinitions: {},
+    defaultShell: "bash",
+    restoreCohort: null,
+    failedRestoreTabIds: [],
+    settings: { ...useAppStore.getState().settings, restoreLastSessionOnStartup: true },
+  });
+  transport = new RestoreStoreTransport();
+  setRestoreTransportForTest(transport);
+  setRestoreIntentsEnabled(true);
+  setRestoreRenderFromProjectionEnabled(true);
+});
+
+afterEach(() => {
+  setRestoreTransportForTest(null);
+  setRestoreIntentsEnabled(null);
+  setRestoreRenderFromProjectionEnabled(null);
+});
+
+describe("restore-cohort render cut — summary fires from the projection", () => {
+  it("fires the partial summary from the projected settlement, once, asynchronously", async () => {
+    mockLoad.mockResolvedValue(threeLocalTabsSession());
+    await useAppStore.getState().restoreLastSession();
+    const ids = restoredTabIds();
+
+    useAppStore.getState().setTabSessionId(ids[0], "sess-a");
+    useAppStore.getState().setTabSessionId(ids[1], "sess-b");
+    useAppStore.getState().setTerminalDisconnectWithError(ids[2], "connection refused");
+
+    // Not fired synchronously — the render cut waits for the projected settlement.
+    expect(toastInfo).not.toHaveBeenCalled();
+
+    await settleAsync();
+
+    // Exactly one aggregate partial summary, sourced from the projected region.
+    expect(toastInfo).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).not.toHaveBeenCalled();
+    const msg = String(toastInfo.mock.calls[0][0]);
+    expect(msg).toContain("2");
+    expect(msg).toContain("3");
+    expect(msg).toContain("1");
+    // The bulk-retry action is attached from the projected retry set (live-filtered).
+    const opts = toastInfo.mock.calls[0][1] as { action?: { label: string; onClick: () => void } };
+    expect(opts?.action?.label).toBe("Reconnect failed tabs");
+    expect(useAppStore.getState().failedRestoreTabIds).toEqual([ids[2]]);
+  });
+
+  it("fires the success summary from the projection when every tab connects", async () => {
+    mockLoad.mockResolvedValue(threeLocalTabsSession());
+    await useAppStore.getState().restoreLastSession();
+    const ids = restoredTabIds();
+
+    ids.forEach((id, i) => useAppStore.getState().setTabSessionId(id, `sess-${i}`));
+    expect(toastSuccess).not.toHaveBeenCalled();
+
+    await settleAsync();
+
+    expect(toastSuccess).toHaveBeenCalledTimes(1);
+    expect(toastInfo).not.toHaveBeenCalled();
+    expect(String(toastSuccess.mock.calls[0][0])).toContain("3");
+  });
+
+  it("falls back to firing the summary locally when the dispatch is rejected", async () => {
+    transport.rejectDispatch = true;
+    mockLoad.mockResolvedValue(threeLocalTabsSession());
+    await useAppStore.getState().restoreLastSession();
+    const ids = restoredTabIds();
+
+    useAppStore.getState().setTabSessionId(ids[0], "sess-a");
+    useAppStore.getState().setTabSessionId(ids[1], "sess-b");
+    useAppStore.getState().setTerminalDisconnectWithError(ids[2], "refused");
+
+    await settleAsync();
+
+    // The rejected mirror can never advance the region, so the fallback fires the
+    // local summary — exactly once, never lost.
+    expect(toastInfo).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().failedRestoreTabIds).toEqual([ids[2]]);
+  });
+});
+
+describe("restore-cohort render cut — flag off fires locally (pre-cut path)", () => {
+  beforeEach(() => setRestoreRenderFromProjectionEnabled(false));
+
+  it("fires the summary synchronously from the local reducer", async () => {
+    mockLoad.mockResolvedValue(threeLocalTabsSession());
+    await useAppStore.getState().restoreLastSession();
+    const ids = restoredTabIds();
+
+    useAppStore.getState().setTabSessionId(ids[0], "sess-a");
+    useAppStore.getState().setTabSessionId(ids[1], "sess-b");
+    useAppStore.getState().setTerminalDisconnectWithError(ids[2], "refused");
+
+    // Fired synchronously, before any async round-trip.
+    expect(toastInfo).toHaveBeenCalledTimes(1);
+    expect(useAppStore.getState().failedRestoreTabIds).toEqual([ids[2]]);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -286,6 +286,12 @@ import {
 } from "@/store/sessionBridge";
 import { mirrorMonitorIntent } from "@/store/systemMonitorBridge";
 import { mirrorAgentIntent } from "@/store/agentsBridge";
+import {
+  expectProjectedRestoreSettlement,
+  mirrorRestoreBegin,
+  mirrorRestoreSettle,
+  restoreRenderFromProjectionEnabled,
+} from "@/store/restoreCohortBridge";
 
 export type SidebarView =
   | "connections"
@@ -2028,6 +2034,39 @@ function collectRestoreCohort(groups: TabGroup[]): {
   const pendingTabIds = tabs.filter((t) => t.contentType === "terminal").map((t) => t.id);
   const preFailedCount = tabs.filter((t) => t.contentType === "agent-error").length;
   return { pendingTabIds, preFailedCount };
+}
+
+/**
+ * The aggregate restore/launch summary toast — the render surface of the
+ * restore-cohort machine (#1146 / #1227). Extracted so the local reducer path and
+ * the projection-driven render cut ({@link restoreCohortBridge}) fire byte-identical
+ * feedback: a success toast when every tab connected, otherwise the partial-failure
+ * info toast carrying the one-tap bulk "Reconnect failed tabs" action (persisted
+ * while offered so it is not lost to auto-dismiss). `retryTabIds` is the live
+ * terminal tabs still available to retry; `onReconnect` re-drives them.
+ */
+function raiseRestoreSummary(
+  summary: { total: number; restored: number; failed: number; toastId?: string | number },
+  retryTabIds: string[],
+  onReconnect: () => void
+): void {
+  const { total, restored, failed, toastId } = summary;
+  if (failed === 0) {
+    // Resolve the pending bulk-retry toast in place when present.
+    toast.success(`Restored ${total} ${total === 1 ? "tab" : "tabs"}`, { id: toastId });
+    return;
+  }
+  // No toast.warning primitive — use info for the partial-failure case. Offer a
+  // one-tap bulk retry when there are reconnectable failed tabs.
+  const action =
+    retryTabIds.length > 0 ? { label: "Reconnect failed tabs", onClick: onReconnect } : undefined;
+  toast.info(`Restored ${restored} of ${total} tabs — ${failed} could not reconnect`, {
+    id: toastId,
+    action,
+    // Persist while a bulk retry is offered so the action is not lost to
+    // auto-dismiss (matches the "recoverable" feedback pillar).
+    duration: action ? Infinity : undefined,
+  });
 }
 
 /**
@@ -6363,10 +6402,18 @@ export const useAppStore = create<AppState>((set, get, store) => {
         failedRestoreTabIds: [],
       });
       // A cohort with no live tabs to wait on (e.g. all agent-error) settles now.
+      // Settle locally first so the projected-render summary is registered before
+      // the mirror dispatch (a synchronous transport failure then fires it now).
       if (pending.size === 0) get().settleRestoreCohort();
+      // Mutation + render cut (#2241): mirror the cohort to the backend
+      // `RestoreCohortStore` and the render region. Off/failure falls back to the
+      // local reducers, which already ran above.
+      mirrorRestoreBegin({ pendingTabIds, preFailedCount, toastId });
     },
     settleRestoreTab: (tabId, outcome) => {
       const cohort = get().restoreCohort;
+      // Ignore a tab that is not pending in the current cohort (mirrors the store):
+      // dispatch no intent for a stray/duplicate settle.
       if (!cohort || !cohort.pending.has(tabId)) return;
       const pending = new Set(cohort.pending);
       pending.delete(tabId);
@@ -6375,12 +6422,17 @@ export const useAppStore = create<AppState>((set, get, store) => {
       const failedTabIds = new Set(cohort.failedTabIds);
       if (outcome === "failed") failedTabIds.add(tabId);
       set({ restoreCohort: { ...cohort, pending, failed, failedTabIds } });
+      // Settle locally first so the projected-render summary is registered before
+      // the mirror dispatch (see beginRestoreCohort).
       if (pending.size === 0) get().settleRestoreCohort();
+      // Mutation + render cut (#2241): mirror the settle to the store + region.
+      mirrorRestoreSettle({ tabId, outcome });
     },
     settleRestoreCohort: () => {
       const cohort = get().restoreCohort;
       if (!cohort) return;
-      // Restrict the retry set to tabs that still exist as live terminal tabs.
+      // Restrict the retry set to tabs that still exist as live terminal tabs (a
+      // frontend concern — it needs the tab registry; the store keeps the raw set).
       const liveTerminalIds = new Set(
         collectLiveTabs(get())
           .filter((t) => t.contentType === "terminal")
@@ -6396,23 +6448,24 @@ export const useAppStore = create<AppState>((set, get, store) => {
         "workspace_restore",
         `restore cohort settled: ${restored}/${total} connected, ${failed} failed`
       );
-      if (failed === 0) {
-        // Resolve the pending bulk-retry toast in place when present.
-        toast.success(`Restored ${total} ${total === 1 ? "tab" : "tabs"}`, { id: toastId });
-      } else {
-        // No toast.warning primitive — use info for the partial-failure case.
-        // Offer a one-tap bulk retry when there are reconnectable failed tabs.
-        const action =
-          retryTabIds.length > 0
-            ? { label: "Reconnect failed tabs", onClick: () => get().reconnectFailedRestoreTabs() }
-            : undefined;
-        toast.info(`Restored ${restored} of ${total} tabs — ${failed} could not reconnect`, {
-          id: toastId,
-          action,
-          // Persist while a bulk retry is offered so the action is not lost to
-          // auto-dismiss (matches the "recoverable" feedback pillar).
-          duration: action ? Infinity : undefined,
+      const summary = { total, restored, failed, toastId };
+      const fire = () =>
+        raiseRestoreSummary(summary, retryTabIds, () => get().reconnectFailedRestoreTabs());
+      if (restoreRenderFromProjectionEnabled()) {
+        // Render cut (#2241): fire the summary toast once per new projected
+        // settlement `seq` — the fired content is this gate-validated local summary.
+        // The upcoming begin/settle mirror dispatch drives the region; if it fails,
+        // the fallback fires this same closure, so the toast is never lost. The raw
+        // failed set is the gate baseline (the store keeps the retry set unfiltered).
+        expectProjectedRestoreSettlement(fire, {
+          total,
+          restored,
+          failed,
+          retryTabIds: [...cohort.failedTabIds],
         });
+      } else {
+        // Pre-cut path: fire straight from the local reducer.
+        fire();
       }
     },
     reconnectFailedRestoreTabs: () => {

--- a/src/store/restoreCohortBridge.test.ts
+++ b/src/store/restoreCohortBridge.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for the restore-cohort bridge flags + region id (#2241).
+ *
+ * Behavioural coverage (mirror dispatch, projected-settlement rendering, and the
+ * local fallback) lives in `appStore.restoreCohortMutationCut.test.ts` and
+ * `appStore.restoreCohortRenderCut.test.ts`, which drive the bridge through the
+ * real `appStore` actions.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+
+import {
+  restoreCohortRegion,
+  restoreIntentsEnabled,
+  restoreRenderFromProjectionEnabled,
+  setRestoreIntentsEnabled,
+  setRestoreRenderFromProjectionEnabled,
+} from "./restoreCohortBridge";
+
+interface RestoreFlagWindow {
+  __TERMIHUB_RESTORE_INTENTS__?: boolean;
+  __TERMIHUB_RESTORE_RENDER__?: boolean;
+}
+
+afterEach(() => {
+  setRestoreIntentsEnabled(null);
+  setRestoreRenderFromProjectionEnabled(null);
+  const w = window as unknown as RestoreFlagWindow;
+  delete w.__TERMIHUB_RESTORE_INTENTS__;
+  delete w.__TERMIHUB_RESTORE_RENDER__;
+});
+
+describe("restoreCohortBridge flags", () => {
+  it("both flags default on", () => {
+    expect(restoreIntentsEnabled()).toBe(true);
+    expect(restoreRenderFromProjectionEnabled()).toBe(true);
+  });
+
+  it("programmatic overrides win, and null restores the default", () => {
+    setRestoreIntentsEnabled(false);
+    setRestoreRenderFromProjectionEnabled(false);
+    expect(restoreIntentsEnabled()).toBe(false);
+    expect(restoreRenderFromProjectionEnabled()).toBe(false);
+
+    setRestoreIntentsEnabled(null);
+    setRestoreRenderFromProjectionEnabled(null);
+    expect(restoreIntentsEnabled()).toBe(true);
+    expect(restoreRenderFromProjectionEnabled()).toBe(true);
+  });
+
+  it("a window override flips a flag off (rollback switch)", () => {
+    const w = window as unknown as RestoreFlagWindow;
+    w.__TERMIHUB_RESTORE_INTENTS__ = false;
+    w.__TERMIHUB_RESTORE_RENDER__ = false;
+    expect(restoreIntentsEnabled()).toBe(false);
+    expect(restoreRenderFromProjectionEnabled()).toBe(false);
+  });
+});
+
+describe("restoreCohortRegion", () => {
+  it("is client-scoped, matching the Rust region id", () => {
+    expect(restoreCohortRegion("abc123")).toBe("restore-cohort@abc123");
+  });
+});

--- a/src/store/restoreCohortBridge.ts
+++ b/src/store/restoreCohortBridge.ts
@@ -1,0 +1,409 @@
+/**
+ * Restore-cohort projection bridge — Phase 4 step 5a render + mutation cut of the
+ * restore-cohort machine (#2241, part of #2206 / #2152 / #2139).
+ *
+ * The restore-cohort **shadow** (PR #2240) landed a backend-authoritative,
+ * client-scoped [`RestoreCohortStore`](../../src-tauri/src/restore_cohort_projection/store.rs)
+ * served as the `restore-cohort@<clientId>` projection region, with `restore.*`
+ * intents (`restore.beginCohort` / `restore.settleTab`), but nothing in the UI
+ * touched it. This step cuts the live UI over to it — the direct analog of the
+ * session render cut ({@link import("./useSessionLifecycle")}, #2204), the monitor
+ * render + mutation cuts ({@link import("./systemMonitorBridge")}, #2224) and the
+ * agents cut ({@link import("./agentsBridge")}, #2226).
+ *
+ * Unlike the declarative render cuts (agents/monitors read a slice from the region
+ * every render), the restore-cohort render surface is a single **fire-once side
+ * effect**: the aggregate summary toast raised when a restore/launch cohort
+ * settles. So the "render cut" here is a projection subscriber that fires the toast
+ * exactly once per new monotonic settlement `seq`, driven by the region.
+ *
+ * # Two independent flags, both on by default
+ *
+ * - {@link restoreRenderFromProjectionEnabled} (render cut) — when on, the summary
+ *   toast is fired under the projected settlement `seq` (validated to faithfully
+ *   mirror the locally-computed summary) instead of straight from the local
+ *   reducer. Parity-safe: the fired content is the gate-validated local summary, so
+ *   it is byte-identical to the pre-cut toast, and any dispatch failure falls back
+ *   to firing locally **synchronously**, so the toast can never be lost.
+ * - {@link restoreIntentsEnabled} (mutation cut) — when on, the cohort transitions
+ *   dispatch `restore.beginCohort` / `restore.settleTab` so the backend store is
+ *   authoritative. The local `appStore` reducers stay in place as the resilience /
+ *   rollback fallback (removal is a later step).
+ *
+ * The region is populated by these same begin/settle intents, dispatched whenever
+ * **either** flag is on ({@link shouldMirrorRestore}); that keeps the render cut
+ * independent of the mutation flag (the region is always populated when rendering
+ * from it). Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_RESTORE_RENDER__` / `localStorage["termihub.restoreRender"]`
+ * and `window.__TERMIHUB_RESTORE_INTENTS__` / `localStorage["termihub.restoreIntents"]`
+ * (set `"false"` to restore the pre-cut local path).
+ */
+
+import {
+  createTransport,
+  newClientId,
+  newIntentId,
+  ProjectionClient,
+  type IntentAck,
+  type ProjectionCacheState,
+  type Transport,
+} from "@/services/transport";
+import { frontendLog } from "@/utils/frontendLog";
+
+/** The projection region id for a client's restore cohort
+ * (`restore-cohort@<clientId>`, twin of the Rust `restore_cohort_region`). */
+export function restoreCohortRegion(clientId: string): string {
+  return `restore-cohort@${clientId}`;
+}
+
+// ── Projected view model (twin of the Rust store snapshot) ─────────────────────
+
+/** The in-flight cohort projected by the region. */
+export interface ProjectedCohort {
+  pending: string[];
+  total: number;
+  failed: number;
+  failedTabIds: string[];
+  toastId?: string | null;
+}
+
+/** The settlement summary projected by the region — the render-cut seam. `seq`
+ * increments per settle so the subscriber fires the toast once per new settle. */
+export interface ProjectedSettlement {
+  seq: number;
+  total: number;
+  restored: number;
+  failed: number;
+  retryTabIds: string[];
+  toastId?: string | null;
+}
+
+/** The `restore-cohort@<clientId>` region view model:
+ * `{ cohort, failedTabIds, settlement }` (twin of `ClientState::to_view`). */
+export interface RestoreCohortView {
+  cohort: ProjectedCohort | null;
+  failedTabIds: string[];
+  settlement: ProjectedSettlement | null;
+}
+
+// ── Feature flags (runtime-flippable so a dev build can verify either path) ────
+
+interface RestoreFlagWindow {
+  __TERMIHUB_RESTORE_RENDER__?: boolean;
+  __TERMIHUB_RESTORE_INTENTS__?: boolean;
+  localStorage?: Storage;
+}
+
+let renderFlagOverride: boolean | null = null;
+let intentsFlagOverride: boolean | null = null;
+
+/** Programmatic override for the render-cut flag (tests, runtime toggle). `null`
+ * clears it and falls back to the window/localStorage signal, then the default. */
+export function setRestoreRenderFromProjectionEnabled(value: boolean | null): void {
+  renderFlagOverride = value;
+}
+
+/** Programmatic override for the mutation-cut flag (tests, runtime toggle). */
+export function setRestoreIntentsEnabled(value: boolean | null): void {
+  intentsFlagOverride = value;
+}
+
+/** Read a boolean feature signal from `window`/`localStorage`, else `dflt`. */
+function readFlag(
+  override: boolean | null,
+  windowKey: keyof RestoreFlagWindow,
+  storageKey: string,
+  dflt: boolean
+): boolean {
+  if (override !== null) return override;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as RestoreFlagWindow;
+      const wv = w[windowKey];
+      if (typeof wv === "boolean") return wv;
+      const ls = w.localStorage?.getItem(storageKey);
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return dflt;
+}
+
+/**
+ * Whether the aggregate restore-cohort summary toast is fired under the projected
+ * settlement `seq` (render cut) instead of straight from the local reducer.
+ *
+ * **On by default.** Parity-safe: the fired content is the local summary validated
+ * to faithfully mirror the projected settlement, so the toast is byte-identical to
+ * the pre-cut path; a dispatch failure falls back to firing locally. Independent of
+ * the mutation cut — the region is populated whenever either flag is on. Overridable
+ * via `window.__TERMIHUB_RESTORE_RENDER__` / `localStorage["termihub.restoreRender"]`.
+ */
+export function restoreRenderFromProjectionEnabled(): boolean {
+  return readFlag(
+    renderFlagOverride,
+    "__TERMIHUB_RESTORE_RENDER__",
+    "termihub.restoreRender",
+    true
+  );
+}
+
+/**
+ * Whether the cohort transitions (`beginRestoreCohort` / `settleRestoreTab`)
+ * dispatch `restore.beginCohort` / `restore.settleTab` intents so the backend
+ * {@link import("../../src-tauri/src/restore_cohort_projection/store").RestoreCohortStore}
+ * is authoritative (mutation cut).
+ *
+ * **On by default.** The local `appStore` reducers stay in place as the render
+ * source and the resilience / rollback fallback (removal is a later step) — a
+ * dispatch failure is logged and the local mutation continues, so a backend hiccup
+ * can never break restore feedback. Overridable via
+ * `window.__TERMIHUB_RESTORE_INTENTS__` / `localStorage["termihub.restoreIntents"]`.
+ */
+export function restoreIntentsEnabled(): boolean {
+  return readFlag(
+    intentsFlagOverride,
+    "__TERMIHUB_RESTORE_INTENTS__",
+    "termihub.restoreIntents",
+    true
+  );
+}
+
+/** The begin/settle intents are dispatched whenever either flag is on: the
+ * mutation cut needs them for authority, and the render cut needs them to keep the
+ * region populated (making the render cut independent of the mutation flag). */
+function shouldMirrorRestore(): boolean {
+  return restoreIntentsEnabled() || restoreRenderFromProjectionEnabled();
+}
+
+// ── Transport + client-scoped region client (lazy, mirrors the layout slice) ───
+
+// A stable per-session client identity. The client-scoped region is
+// `restore-cohort@<clientId>`, and dispatched intents carry the same id, so this
+// checkout mutates and subscribes to its own restore-cohort region.
+const clientId = newClientId();
+const region = restoreCohortRegion(clientId);
+
+let transportInstance: Transport | null = null;
+let regionClient: ProjectionClient | null = null;
+let startPromise: Promise<ProjectionClient> | null = null;
+
+/** Inject a transport for tests; `null` restores the lazily-created real one and
+ * drops any active subscription and pending settlement. */
+export function setRestoreTransportForTest(t: Transport | null): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  transportInstance = t;
+  lastObservedSeq = 0;
+  pendingSettlement = null;
+}
+
+function transport(): Transport {
+  if (!transportInstance) {
+    transportInstance = createTransport();
+  }
+  return transportInstance;
+}
+
+/**
+ * Ensure the `restore-cohort@<clientId>` region client is subscribed so settlement
+ * diffs are received and the summary toast can be fired from them. Idempotent and
+ * de-duplicated across concurrent callers; a transport/subscribe failure is logged
+ * and rethrown so the caller can fall back to the local reducer.
+ */
+export function ensureRestoreSubscribed(): Promise<ProjectionClient> {
+  if (regionClient) return Promise.resolve(regionClient);
+  if (!startPromise) {
+    const client = new ProjectionClient(transport(), region);
+    client.onChange((state) => onRegionChange(state));
+    startPromise = client
+      .start()
+      .then(() => {
+        regionClient = client;
+        return client;
+      })
+      .catch((err) => {
+        startPromise = null;
+        logRestoreBridgeFallback("subscribe", err);
+        throw err;
+      });
+  }
+  return startPromise;
+}
+
+/** Drop the region subscription (tests / re-init). */
+export function stopRestoreSubscription(): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  lastObservedSeq = 0;
+  pendingSettlement = null;
+}
+
+// ── Fire-once settlement rendering ─────────────────────────────────────────────
+
+/**
+ * A settlement awaiting its toast: the local closure that fires it (using the
+ * gate-validated local summary) plus the expected numbers used to check the
+ * projection faithfully mirrors it. Set by {@link expectProjectedRestoreSettlement}
+ * when the render cut is on; consumed exactly once — by the projection subscriber
+ * on the matching `seq` (the happy path) or by {@link firePendingRestoreFallback}
+ * on a dispatch failure (the fallback). Whichever runs first clears it, so the
+ * toast fires exactly once.
+ */
+interface PendingSettlement {
+  fire: () => void;
+  expected: { total: number; restored: number; failed: number; retryTabIds: string[] };
+}
+
+let pendingSettlement: PendingSettlement | null = null;
+let lastObservedSeq = 0;
+
+/**
+ * Register the local summary to be fired under the projected settlement `seq`
+ * (render cut). Called by `appStore.settleRestoreCohort` when the render flag is on,
+ * in place of firing the toast directly. The subsequent begin/settle mirror
+ * dispatch drives the region; its diff fires this via {@link onRegionChange}, or a
+ * dispatch failure fires it via {@link firePendingRestoreFallback}.
+ */
+export function expectProjectedRestoreSettlement(
+  fire: () => void,
+  expected: { total: number; restored: number; failed: number; retryTabIds: string[] }
+): void {
+  pendingSettlement = { fire, expected };
+}
+
+/** Whether the projected settlement faithfully mirrors the locally-computed one:
+ * identical tallies and the same raw failed-tab set (the backend keeps the retry
+ * set raw; the frontend live-filters it, so compare against the raw expectation). */
+function settlementMirrors(
+  settlement: ProjectedSettlement,
+  expected: PendingSettlement["expected"]
+): boolean {
+  return (
+    settlement.total === expected.total &&
+    settlement.restored === expected.restored &&
+    settlement.failed === expected.failed &&
+    sameSet(settlement.retryTabIds, expected.retryTabIds)
+  );
+}
+
+/** Unordered set equality over two string arrays. */
+function sameSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  return b.every((id) => set.has(id));
+}
+
+/** React to a region diff: fire the pending settlement once per new `seq`. */
+function onRegionChange(state: ProjectionCacheState): void {
+  const view = state.view as RestoreCohortView | undefined;
+  const settlement = view?.settlement;
+  if (!settlement || settlement.seq <= lastObservedSeq) return;
+  lastObservedSeq = settlement.seq;
+  const pending = pendingSettlement;
+  if (!pending) return; // already fired locally, or nothing awaiting render
+  pendingSettlement = null;
+  if (!settlementMirrors(settlement, pending.expected)) {
+    // Not a faithful mirror — still fire the local summary (never lose the toast),
+    // but log the divergence so the render-cut drift is visible.
+    logRestoreBridgeFallback("settlement", new Error("projected settlement diverged from local"));
+  }
+  pending.fire();
+}
+
+/** Fire a pending settlement's local toast now (the fallback path), if one is
+ * awaiting. Called when a begin/settle mirror dispatch cannot reach the region
+ * (synchronous transport failure, rejected ack, or async error), so the projected
+ * `seq` will never arrive — the toast must still fire. No-op if already consumed. */
+function firePendingRestoreFallback(reason: string, err: unknown): void {
+  const pending = pendingSettlement;
+  if (!pending) return;
+  pendingSettlement = null;
+  logRestoreBridgeFallback(reason, err);
+  pending.fire();
+}
+
+// ── Mutation cut: begin/settle intent dispatch (also seeds the render region) ──
+
+/** Dispatch a `restore.*` intent, resolving with the ack (parity tests). */
+export function dispatchRestoreIntent(
+  kind: "restore.beginCohort" | "restore.settleTab",
+  payload: Record<string, unknown>
+): Promise<IntentAck> {
+  return transport().dispatch({ intentId: newIntentId(), kind, payload, clientId });
+}
+
+/** Fire a `restore.*` mirror intent, keeping the backend store authoritative and
+ * the render region populated. Any failure falls back to firing the pending
+ * settlement's local toast so a bridge hiccup never loses the summary and never
+ * disrupts the local reducer path. A no-op when both flags are off (pure rollback).
+ * A synchronous transport-construction failure (non-Tauri, no socket) fires the
+ * fallback synchronously — preserving the pre-cut synchronous toast in that env. */
+function mirrorRestore(
+  kind: "restore.beginCohort" | "restore.settleTab",
+  payload: Record<string, unknown>
+): void {
+  if (!shouldMirrorRestore()) {
+    // Both flags off: the local reducer already fired the toast; nothing to mirror.
+    return;
+  }
+  // Keep the subscription warm so settlement diffs are received. Guarded because a
+  // non-Tauri env without a socket throws *synchronously* from transport
+  // construction (not as a rejection) — the dispatch below then fires the fallback.
+  try {
+    void ensureRestoreSubscribed().catch(() => {
+      /* logged in ensureRestoreSubscribed; fallback handled per-dispatch below */
+    });
+  } catch {
+    /* handled by the dispatch try/catch below */
+  }
+  let dispatchPromise: Promise<IntentAck>;
+  try {
+    dispatchPromise = dispatchRestoreIntent(kind, payload);
+  } catch (err) {
+    // Synchronous transport-construction failure — fire the fallback now so the
+    // toast still appears synchronously (the pre-cut behaviour without a transport).
+    firePendingRestoreFallback(kind, err);
+    return;
+  }
+  void dispatchPromise
+    .then((ack) => {
+      if (ack.status === "rejected") {
+        firePendingRestoreFallback(kind, new Error(ack.error?.message ?? "rejected"));
+      }
+      // Accepted: the region diff will fire the pending settlement via onRegionChange.
+    })
+    .catch((err) => firePendingRestoreFallback(kind, err));
+}
+
+/** Mirror `restore.beginCohort` (register a restore/launch cohort). */
+export function mirrorRestoreBegin(payload: {
+  pendingTabIds: string[];
+  preFailedCount: number;
+  toastId?: string | number;
+}): void {
+  const body: Record<string, unknown> = {
+    pendingTabIds: payload.pendingTabIds,
+    preFailedCount: payload.preFailedCount,
+  };
+  if (payload.toastId !== undefined) body.toastId = String(payload.toastId);
+  mirrorRestore("restore.beginCohort", body);
+}
+
+/** Mirror `restore.settleTab` (settle one tab of the active cohort). */
+export function mirrorRestoreSettle(payload: {
+  tabId: string;
+  outcome: "connected" | "failed";
+}): void {
+  mirrorRestore("restore.settleTab", { tabId: payload.tabId, outcome: payload.outcome });
+}
+
+/** Log a bridge fallback so the local-path recovery is visible in the LogViewer. */
+export function logRestoreBridgeFallback(kind: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  frontendLog("restore_cohort_bridge", `${kind} fell back to local restore summary: ${message}`);
+}


### PR DESCRIPTION
Cuts the startup **restore-cohort** machine (#1146 / #1227) over to the shadow `RestoreCohortStore` (PR #2240), following the proven session/monitor/agents sequence (shadow → render-cut → flag-gated mutation-cut → keep reducers as fallback).

## Render cut
The aggregate restore/launch **summary toast** now fires from the projected `restore-cohort@<clientId>` region's `settlement` — once per new monotonic `seq`. Extracted `raiseRestoreSummary` so the local and projected paths fire **byte-identical** feedback (success toast, or the partial-failure info toast with the bulk "Reconnect failed tabs" action). The fired content is the gate-validated local summary, so it can never diverge, and the **live-terminal filter stays frontend** (it needs the tab registry). Gated by `restoreRenderFromProjectionEnabled` — on by default.

## Mutation cut
`beginRestoreCohort` / `settleRestoreTab` dispatch `restore.beginCohort` / `restore.settleTab` so the backend store is authoritative. Gated by `restoreIntentsEnabled` — on by default. The `appStore` cohort reducers are **retained as the resilience / rollback fallback** (removal is a later step): any dispatch failure fires the summary locally, and — because `createTransport()` throws synchronously without a transport — the fallback stays **synchronous** in that env, preserving the pre-cut behaviour.

The begin/settle intents are dispatched whenever **either** flag is on, so the render cut stays independent of the mutation flag (the region is always populated when rendering from it). Both flags are runtime-flippable for instant rollback (`window.__TERMIHUB_RESTORE_RENDER__` / `__TERMIHUB_RESTORE_INTENTS__`, or the matching `localStorage` keys → `"false"`).

## Tests
- `appStore.restoreCohortMutationCut.test.ts` — cut-vs-local parity via a faithful in-memory port of the Rust store: the intents reconstruct the settled region + captured failed set; flag off dispatches nothing.
- `appStore.restoreCohortRenderCut.test.ts` — the summary fires from the projected settlement (async, once), the rejected-dispatch fallback fires it locally, and flag-off fires synchronously from the reducer.
- `restoreCohortBridge.test.ts` — flag defaults / overrides / region id.
- Existing `restoreSummary` / `bulkReconnect` suites still green (synchronous firing preserved).

Maintainer decision: **proceed-on-tests** (parity tests + instant local fallback, no hands-on GUI gate) — same as the Monitors / session / Agents cuts.

No backend changes; the shadow store + intents from #2240 are unchanged. No user-visible change.

Part of #2206
Closes #2241

🤖 Generated with [Claude Code](https://claude.com/claude-code)