### PR TITLE
feat(ui): cut broadcast membership to server-side authority (Closes #2242)

### DIFF
--- a/src-tauri/src/broadcast_projection/projection.rs
+++ b/src-tauri/src/broadcast_projection/projection.rs
@@ -121,7 +121,14 @@ pub fn register_broadcast_intents(registry: &mut HandlerRegistry, app_handle: Ap
         let scope = required_scope(intent, "scope")?;
         let targets = required_str_array(intent, "targetTabIds")?;
         let last_scope = required_scope(intent, "lastScope")?;
-        store.replace(&intent.client_id, active, source, scope, targets, last_scope);
+        store.replace(
+            &intent.client_id,
+            active,
+            source,
+            scope,
+            targets,
+            last_scope,
+        );
         Ok(publish_broadcast(projector, &store, &intent.client_id))
     });
 

--- a/src-tauri/src/broadcast_projection/projection.rs
+++ b/src-tauri/src/broadcast_projection/projection.rs
@@ -34,6 +34,14 @@
 //! | `broadcast.toggle`        | `{ scope?, sourceTabId?, targetTabIds?: [id] }`     | active → stop; idle + source → start            |
 //! | `broadcast.addTarget`     | `{ tabId }`                                          | add a tab to the target set                     |
 //! | `broadcast.removeTarget`  | `{ tabId }`                                          | remove a tab from the target set                |
+//! | `broadcast.replace`       | `{ active, sourceTabId, scope, targetTabIds, lastScope }` | overwrite the whole slice (render mirror) |
+//!
+//! `broadcast.replace` is the render-cut whole-state mirror (twin of
+//! `monitor.replace`): the frontend keeps the region a faithful copy of its
+//! `appStore` broadcast slice through it while the reducers stay authoritative,
+//! so the UI can render from the projection with byte parity. The per-transition
+//! `start`/`stop`/`toggle`/`addTarget`/`removeTarget` intents are the mutation
+//! cut, which makes this store authoritative.
 //!
 //! Three frontend concerns need no dedicated intent because they read the
 //! projected set rather than mutate it: `isBroadcastTarget` is a membership read
@@ -42,14 +50,18 @@
 //! re-derives membership from the scope + tab tree (frontend) and reconciles the
 //! delta via `broadcast.addTarget` / `broadcast.removeTarget`.
 //!
-//! # Shadow mode
+//! # Render + mutation cut
 //!
-//! Registered and fully served, but **not** driving the live UI: no frontend
-//! subscribes to `broadcast@<clientId>` or dispatches `broadcast.*` yet, so these
-//! intents mutate only the shadow store and project to regions nobody renders.
-//! The `appStore` broadcast reducers remain authoritative. Per the substrate
-//! contract the result of an intent is never returned inline — it always arrives
-//! as a projection diff on the client's region.
+//! Now driving the live UI (PR for #2242, following the #2254 shadow): the
+//! frontend subscribes to `broadcast@<clientId>`, seeds it with `broadcast.replace`
+//! to keep it a faithful mirror of `appStore`, renders the broadcast UI from it
+//! (render cut, on by default), and routes the membership actions through the
+//! per-transition `broadcast.*` intents (mutation cut, on by default) so this
+//! store is authoritative. The `appStore` broadcast reducers remain in place as
+//! the parity-safe fallback (the render gate falls back when the region has not
+//! caught up; each mirrored intent is best-effort). Per the substrate contract the
+//! result of an intent is never returned inline — it always arrives as a
+//! projection diff on the client's region.
 
 use std::sync::Arc;
 
@@ -91,10 +103,25 @@ pub fn register_broadcast_intents(registry: &mut HandlerRegistry, app_handle: Ap
     let handle = app_handle.clone();
     registry.route("broadcast.start", move |intent, projector| {
         let store = store_of(&handle)?;
-        let scope = required_scope(intent)?;
+        let scope = required_scope(intent, "scope")?;
         let source = required_str(intent, "sourceTabId")?;
         let targets = required_str_array(intent, "targetTabIds")?;
         store.start(&intent.client_id, scope, &source, &targets);
+        Ok(publish_broadcast(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("broadcast.replace", move |intent, projector| {
+        // The render-cut whole-state mirror of the frontend `appStore` slice: set
+        // every field verbatim (no source-prepend/de-dup — the mirrored set is
+        // already canonical).
+        let store = store_of(&handle)?;
+        let active = required_bool(intent, "active")?;
+        let source = optional_str(intent, "sourceTabId");
+        let scope = required_scope(intent, "scope")?;
+        let targets = required_str_array(intent, "targetTabIds")?;
+        let last_scope = required_scope(intent, "lastScope")?;
+        store.replace(&intent.client_id, active, source, scope, targets, last_scope);
         Ok(publish_broadcast(projector, &store, &intent.client_id))
     });
 
@@ -110,7 +137,7 @@ pub fn register_broadcast_intents(registry: &mut HandlerRegistry, app_handle: Ap
         let store = store_of(&handle)?;
         // The start branch's payload is optional: it is read only when idle, and
         // the frontend resolves scope/source/targets from the live tab tree.
-        let scope = optional_scope(intent)?.unwrap_or_default();
+        let scope = optional_scope(intent, "scope")?.unwrap_or_default();
         let source = optional_str(intent, "sourceTabId");
         let targets = optional_str_array(intent, "targetTabIds")?;
         store.toggle(&intent.client_id, scope, source.as_deref(), &targets);
@@ -160,30 +187,39 @@ fn parse_scope(value: &str) -> Result<BroadcastScope, (String, String)> {
     }
 }
 
-/// Parse the required `scope` field into a [`BroadcastScope`].
-fn required_scope(intent: &Intent) -> Result<BroadcastScope, (String, String)> {
+/// Parse a required scope field (`key`) into a [`BroadcastScope`].
+fn required_scope(intent: &Intent, key: &str) -> Result<BroadcastScope, (String, String)> {
     let value = intent
         .payload
-        .get("scope")
+        .get(key)
         .and_then(Value::as_str)
-        .ok_or_else(|| ("bad_payload".to_string(), "missing 'scope'".to_string()))?;
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))?;
     parse_scope(value)
 }
 
-/// Parse an optional `scope` field; absent → `None`, present-but-invalid → error.
-fn optional_scope(intent: &Intent) -> Result<Option<BroadcastScope>, (String, String)> {
-    match intent.payload.get("scope") {
+/// Parse an optional scope field (`key`); absent → `None`, present-but-invalid → error.
+fn optional_scope(intent: &Intent, key: &str) -> Result<Option<BroadcastScope>, (String, String)> {
+    match intent.payload.get(key) {
         None | Some(Value::Null) => Ok(None),
         Some(value) => {
             let s = value.as_str().ok_or_else(|| {
                 (
                     "bad_payload".to_string(),
-                    "invalid 'scope' (not a string)".to_string(),
+                    format!("invalid '{key}' (not a string)"),
                 )
             })?;
             parse_scope(s).map(Some)
         }
     }
+}
+
+/// Extract a required boolean field from an intent payload.
+fn required_bool(intent: &Intent, key: &str) -> Result<bool, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_bool)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
 }
 
 /// Extract a required string field from an intent payload.

--- a/src-tauri/src/broadcast_projection/projection_tests.rs
+++ b/src-tauri/src/broadcast_projection/projection_tests.rs
@@ -70,14 +70,50 @@ fn registry_for(store: Arc<BroadcastStore>) -> HandlerRegistry {
         Ok(publish_broadcast(projector, &s, &intent.client_id))
     });
 
-    let s = store;
+    let s = store.clone();
     registry.route("broadcast.removeTarget", move |intent, projector| {
         let tab_id = str_field(intent, "tabId")?;
         s.remove_target(&intent.client_id, &tab_id);
         Ok(publish_broadcast(projector, &s, &intent.client_id))
     });
 
+    let s = store;
+    registry.route("broadcast.replace", move |intent, projector| {
+        let active = intent
+            .payload
+            .get("active")
+            .and_then(Value::as_bool)
+            .ok_or_else(|| ("bad_payload".to_string(), "missing 'active'".to_string()))?;
+        let source = intent
+            .payload
+            .get("sourceTabId")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let scope = scope_field(intent, true)?.unwrap_or_default();
+        let targets = str_array(intent, "targetTabIds")?;
+        let last_scope = last_scope_field(intent)?;
+        s.replace(
+            &intent.client_id,
+            active,
+            source,
+            scope,
+            targets,
+            last_scope,
+        );
+        Ok(publish_broadcast(projector, &s, &intent.client_id))
+    });
+
     registry
+}
+
+fn last_scope_field(intent: &Intent) -> Result<BroadcastScope, (String, String)> {
+    match intent.payload.get("lastScope").and_then(Value::as_str) {
+        Some("all") => Ok(BroadcastScope::All),
+        Some("panel") => Ok(BroadcastScope::Panel),
+        Some("custom") => Ok(BroadcastScope::Custom),
+        Some(_) => Err(("bad_payload".to_string(), "invalid 'lastScope'".to_string())),
+        None => Err(("bad_payload".to_string(), "missing 'lastScope'".to_string())),
+    }
 }
 
 fn scope_field(
@@ -389,6 +425,44 @@ fn toggle_off_then_on_round_trips_through_the_region() {
     }
     assert_eq!(cache.view, store.snapshot("A"), "cache converges");
     assert_eq!(cache.view["active"], json!(false));
+}
+
+#[test]
+fn a_replace_mirror_overwrites_the_region_verbatim_and_converges() {
+    // The render-cut mirror: a `broadcast.replace` sets the whole slice from the
+    // frontend snapshot, and the client cache converges on it byte-for-byte.
+    let store = Arc::new(BroadcastStore::new());
+    let region = broadcast_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(&region, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    let ack = dispatcher.dispatch(intent(
+        "broadcast.replace",
+        "A",
+        json!({
+            "active": true,
+            "sourceTabId": "s2",
+            "scope": "custom",
+            "targetTabIds": ["s2", "a", "b"],
+            "lastScope": "panel",
+        }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "one diff for the whole-state mirror");
+    cache.apply(&diffs[0]);
+    assert_eq!(cache.view, store.snapshot("A"), "cache converges on mirror");
+    assert_eq!(cache.view["active"], json!(true));
+    assert_eq!(cache.view["sourceTabId"], json!("s2"));
+    assert_eq!(cache.view["scope"], json!("custom"));
+    assert_eq!(cache.view["lastScope"], json!("panel"));
+    // Verbatim: no source-prepend/de-dup, unlike start.
+    assert_eq!(cache.view["targetTabIds"], json!(["s2", "a", "b"]));
 }
 
 #[test]

--- a/src-tauri/src/broadcast_projection/store.rs
+++ b/src-tauri/src/broadcast_projection/store.rs
@@ -25,15 +25,19 @@
 //! `session-lifecycle` region (a session's status is a property of the shared
 //! session).
 //!
-//! # Shadow mode — zero user-facing change
+//! # Render + mutation cut — parity-safe, reducers retained
 //!
-//! This step is deliberately **not authoritative**. The store exists, accepts
-//! `broadcast.*` intents, and projects diffs, but nothing in the live UI
-//! subscribes to or renders a `broadcast` region, and no frontend code
-//! dispatches `broadcast.*` intents yet. The existing `appStore` broadcast
-//! reducers remain authoritative. Later steps cut rendering, then the mutations,
-//! over to it (keeping the reducers as the parity-safe fallback, per the #2205
-//! reframe).
+//! The shadow landed first (PR #2254); this step cuts the live UI over to the
+//! store. The frontend now (a) keeps the `broadcast@<clientId>` region a faithful
+//! mirror of `appStore` via [`replace`](BroadcastStore::replace) and **renders**
+//! the broadcast UI from the region when it mirrors `appStore` (render cut, on by
+//! default), and (b) routes the membership actions through the granular
+//! `broadcast.*` intents so **this store is authoritative** (mutation cut, on by
+//! default). The `appStore` broadcast reducers stay in place as the parity-safe
+//! fallback — the render gate falls back to `appStore` when the region has not
+//! caught up, and each mirrored intent is best-effort so a transport hiccup never
+//! disrupts the local mutation (per the #2205 reframe). The reducer removal is a
+//! later step.
 //!
 //! ## What stays frontend
 //!
@@ -204,6 +208,33 @@ impl BroadcastStore {
         state.active = false;
         state.source_tab_id = None;
         state.target_tab_ids = Vec::new();
+    }
+
+    /// `broadcast.replace` — overwrite this client's whole membership slice from a
+    /// frontend snapshot of the `appStore` broadcast state. This is the render-cut
+    /// mirror (the twin of `monitor.replace`): while the `appStore` reducers stay
+    /// authoritative it keeps the `broadcast@<clientId>` region a faithful copy of
+    /// the frontend slice, so the UI can render from the projection with byte
+    /// parity. Unlike [`start`](BroadcastStore::start) it is a **verbatim
+    /// whole-state set** — it does not prepend the source or de-duplicate, because
+    /// the `appStore` `broadcastTargetTabIds` set it mirrors is already canonical
+    /// (source-first, de-duped by the reducers).
+    pub fn replace(
+        &self,
+        client_id: &str,
+        active: bool,
+        source_tab_id: Option<String>,
+        scope: BroadcastScope,
+        target_tab_ids: Vec<String>,
+        last_scope: BroadcastScope,
+    ) {
+        let mut clients = self.lock();
+        let state = clients.entry(client_id.to_string()).or_default();
+        state.active = active;
+        state.source_tab_id = source_tab_id;
+        state.scope = scope;
+        state.target_tab_ids = target_tab_ids;
+        state.last_scope = last_scope;
     }
 
     /// `broadcast.toggle` — the pure decision of `appStore.toggleBroadcast`

--- a/src-tauri/src/broadcast_projection/store_tests.rs
+++ b/src-tauri/src/broadcast_projection/store_tests.rs
@@ -161,6 +161,49 @@ fn status_and_targets_helpers_reflect_state() {
 }
 
 #[test]
+fn replace_overwrites_the_whole_slice_verbatim() {
+    let store = BroadcastStore::new();
+    store.start(C, BroadcastScope::All, "src", &ids(&["t1"]));
+    // The render-cut mirror sets every field verbatim — no source-prepend/de-dup,
+    // because the appStore set it mirrors is already canonical.
+    store.replace(
+        C,
+        true,
+        Some("s2".to_string()),
+        BroadcastScope::Custom,
+        ids(&["s2", "a", "b"]),
+        BroadcastScope::Panel,
+    );
+    let view = store.snapshot(C);
+    assert_eq!(view["active"], json!(true));
+    assert_eq!(view["sourceTabId"], json!("s2"));
+    assert_eq!(view["scope"], json!("custom"));
+    assert_eq!(view["lastScope"], json!("panel"));
+    assert_eq!(view["targetTabIds"], json!(["s2", "a", "b"]));
+}
+
+#[test]
+fn replace_can_mirror_the_idle_baseline() {
+    let store = BroadcastStore::new();
+    store.start(C, BroadcastScope::Panel, "src", &ids(&["t1", "t2"]));
+    // Mirroring an inactive appStore slice (e.g. after a local stop) clears the
+    // source/targets but retains the remembered scope, exactly like the slice.
+    store.replace(
+        C,
+        false,
+        None,
+        BroadcastScope::Panel,
+        Vec::new(),
+        BroadcastScope::Panel,
+    );
+    let view = store.snapshot(C);
+    assert_eq!(view["active"], json!(false));
+    assert_eq!(view["sourceTabId"], Value::Null);
+    assert_eq!(view["targetTabIds"], json!([]));
+    assert_eq!(view["lastScope"], json!("panel"));
+}
+
+#[test]
 fn membership_is_isolated_per_client() {
     let store = BroadcastStore::new();
     store.start("a", BroadcastScope::All, "a-src", &ids(&["a1"]));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,11 +3,14 @@
 /// (the ordered agent list + per-agent sessions/definitions/folders). Registered
 /// and served but not yet driving the live UI — see [`agents_projection`].
 mod agents_projection;
-/// Shadow broadcast-membership authority (#2242, Phase 4 step 5b of #2139, part
-/// of #2206 / #2152): the client-scoped `broadcast@<clientId>` projection region
-/// + `broadcast.*` intents modeling the `appStore` broadcast-input membership
-/// slice (which tabs receive mirrored input, #1955 / #1956 / #1958). Registered
-/// and served but not yet driving the live UI — see [`broadcast_projection`].
+/// Broadcast-membership authority (#2242, Phase 4 step 5b of #2139, part of
+/// #2206 / #2152): the client-scoped `broadcast@<clientId>` projection region +
+/// `broadcast.*` intents modeling the `appStore` broadcast-input membership slice
+/// (which tabs receive mirrored input, #1955 / #1956 / #1958). Now drives the
+/// live UI — the frontend renders the broadcast UI from the region and routes the
+/// membership actions through the intents (render + mutation cut, both on by
+/// default), with the `appStore` reducers retained as the parity-safe fallback —
+/// see [`broadcast_projection`].
 mod broadcast_projection;
 mod commands;
 mod connection;
@@ -738,15 +741,15 @@ pub fn run() {
                     &mut registry,
                     app.handle().clone(),
                 );
-                // Shadow BroadcastStore (#2242, Phase 4 step 5b, part of #2206):
-                // the client-scoped `broadcast@<clientId>` region + `broadcast.*`
+                // BroadcastStore (#2242, Phase 4 step 5b, part of #2206): the
+                // client-scoped `broadcast@<clientId>` region + `broadcast.*`
                 // intents modeling the broadcast-input membership slice (which
-                // tabs receive mirrored input, #1955 / #1956 / #1958). Managed
-                // authoritative state that serves intents, but nothing in the
-                // live UI subscribes to or renders the region yet — a pure shadow
-                // foundation (later steps cut rendering, then the mutations, over
-                // to it, keeping the appStore reducers as the parity-safe
-                // fallback). No client region is seeded here: like layout and
+                // tabs receive mirrored input, #1955 / #1956 / #1958). The live
+                // UI now renders the broadcast UI from the region (kept a mirror
+                // of appStore via `broadcast.replace`) and routes the membership
+                // actions through the intents (render + mutation cut, both on by
+                // default), with the appStore reducers retained as the parity-safe
+                // fallback. No client region is seeded here: like layout and
                 // restore-cohort, broadcast regions are client-scoped and created
                 // lazily on a client's first `broadcast.*` intent.
                 app.manage(Arc::new(broadcast_projection::BroadcastStore::new()));

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -33,6 +33,7 @@ import {
   X,
 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedBroadcast } from "@/store/useProjectedBroadcast";
 import { useLayoutRenderTree } from "@/store/useLayoutRenderTree";
 import { PanelNode, LeafPanel, TerminalTab, DropEdge } from "@/types/terminal";
 import { getAllLeaves, findLeafByTab, isWindowEmpty, normalizeSizes } from "@/utils/panelTree";
@@ -640,9 +641,12 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
   // terminal it currently shows (its active tab) is in the broadcast set; the
   // source panel additionally glows. Keyed off the visible tab so the ring
   // tracks what the user actually sees, not an inactive participant behind it.
-  const broadcastActive = useAppStore((s) => s.broadcastActive);
-  const broadcastSourceTabId = useAppStore((s) => s.broadcastSourceTabId);
-  const broadcastTargetTabIds = useAppStore((s) => s.broadcastTargetTabIds);
+  // Render cut (#2242): active/source/membership sourced from the projected
+  // broadcast region when it mirrors appStore, else appStore verbatim.
+  const broadcast = useProjectedBroadcast();
+  const broadcastActive = broadcast.active;
+  const broadcastSourceTabId = broadcast.sourceTabId;
+  const broadcastTargetTabIds = broadcast.targetTabIds;
   const panelBroadcastClass = broadcastPanelClass(panel.activeTabId, {
     broadcastActive,
     broadcastSourceTabId,

--- a/src/components/StatusBar/BroadcastStatus.tsx
+++ b/src/components/StatusBar/BroadcastStatus.tsx
@@ -1,5 +1,6 @@
 import { Radio } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedBroadcast } from "@/store/useProjectedBroadcast";
 import { Tooltip } from "@/components/ui";
 
 /**
@@ -17,12 +18,15 @@ import { Tooltip } from "@/components/ui";
  * uncluttered.
  */
 export function BroadcastStatus() {
-  const broadcastActive = useAppStore((s) => s.broadcastActive);
-  // Total participating tabs (includes the source). Set size is a stable number,
-  // so the selector re-renders only when the target set actually changes.
-  const totalTargets = useAppStore((s) => s.broadcastTargetTabIds.size);
-  // Connected subset — recomputed from the live tab/session state on every store
-  // change; returning a number keeps re-renders limited to real count changes.
+  // Render cut (#2242): active + membership sourced from the projected broadcast
+  // region when it mirrors appStore, else appStore verbatim.
+  const broadcast = useProjectedBroadcast();
+  const broadcastActive = broadcast.active;
+  // Total participating tabs (includes the source).
+  const totalTargets = broadcast.targetTabIds.size;
+  // Connected subset — the connected-terminal fan-out filter stays on appStore
+  // (it needs the live tab/session state); returning a number keeps re-renders
+  // limited to real count changes.
   const connectedTargets = useAppStore((s) =>
     s.broadcastActive ? s.getBroadcastTargetTabIds().length : 0
   );

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortable";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedBroadcast } from "@/store/useProjectedBroadcast";
 import { TerminalTab } from "@/types/terminal";
 import type { WindowInfo } from "@/types/window";
 import { listWindows } from "@/services/api";
@@ -45,9 +46,11 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
   const terminalDisconnectErrors = useAppStore((s) => s.terminalDisconnectErrors);
   const terminalExitedTabs = useAppStore((s) => s.terminalExitedTabs);
   // Broadcast participation (#1957): the badge shows on every tab in the target
-  // set, active or not, so participation is visible at a glance.
-  const broadcastActive = useAppStore((s) => s.broadcastActive);
-  const broadcastTargetTabIds = useAppStore((s) => s.broadcastTargetTabIds);
+  // set, active or not, so participation is visible at a glance. Render cut
+  // (#2242): sourced from the projected broadcast region (falls back to appStore).
+  const broadcast = useProjectedBroadcast();
+  const broadcastActive = broadcast.active;
+  const broadcastTargetTabIds = broadcast.targetTabIds;
   const { clearTerminal, saveTerminalToFile, copyTerminalToClipboard, openTerminalInEditor } =
     useTerminalRegistry();
 

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -14,6 +14,7 @@ import {
 import { listen } from "@tauri-apps/api/event";
 import { toast } from "sonner";
 import { useAppStore, getActiveTab } from "@/store/appStore";
+import { useProjectedBroadcast } from "@/store/useProjectedBroadcast";
 import { TerminalTab } from "@/types/terminal";
 import { getAllLeaves } from "@/utils/panelTree";
 import { countLiveSessions } from "@/utils/tabLiveSession";
@@ -271,7 +272,9 @@ export function TerminalView() {
   const macroRecordingStepCount = useAppStore((s) => s.macroRecordingSteps.length);
   const saveRecordedMacro = useAppStore((s) => s.saveRecordedMacro);
   const discardRecordedMacro = useAppStore((s) => s.discardRecordedMacro);
-  const broadcastActive = useAppStore((s) => s.broadcastActive);
+  // Render cut (#2242): the toolbar's active/pressed state is sourced from the
+  // projected broadcast region when it mirrors appStore, else appStore verbatim.
+  const broadcastActive = useProjectedBroadcast().active;
   const stopBroadcast = useAppStore((s) => s.stopBroadcast);
   const macros = useAppStore((s) => s.macros);
   const macroPlayback = useAppStore((s) => s.macroPlayback);

--- a/src/store/appStore.broadcastMutationCut.test.ts
+++ b/src/store/appStore.broadcastMutationCut.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Broadcast mutation cut (#2242, part of #2206 / #2139) — cut-vs-local parity.
+ *
+ * The mutation cut routes each broadcast membership action through a granular
+ * `broadcast.*` intent so the backend `BroadcastStore` becomes authoritative, while
+ * the local `appStore` reducer path stays in place as the render source and the
+ * resilience / rollback fallback (the reducer removal is a later step).
+ *
+ * These tests prove the cut is parity-safe: with the flag **on**, the intents the
+ * actions dispatch — applied by a faithful in-memory port of the Rust store
+ * (mirroring `broadcast_projection/store.rs`) — reproduce the exact `appStore`
+ * broadcast slice (`broadcastActive` / `broadcastSourceTabId` / `broadcastScope` /
+ * `broadcastTargetTabIds` / `lastBroadcastScope`) for every action. With the flag
+ * **off**, no intents are dispatched and the local slice is byte-identical — the
+ * instant rollback path the flip relies on.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  getSettings: vi.fn(() =>
+    Promise.resolve({ version: "1", externalConnectionFiles: [], powerMonitoringEnabled: true })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn(() => vi.fn()) }));
+
+import type { BroadcastScope } from "@/types/terminal";
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+
+import { useAppStore } from "./appStore";
+import { setBroadcastIntentsEnabled, setBroadcastTransportForTest } from "./broadcastBridge";
+
+interface RegionView {
+  active: boolean;
+  sourceTabId: string | null;
+  scope: BroadcastScope;
+  targetTabIds: string[];
+  lastScope: BroadcastScope;
+}
+
+const EMPTY: RegionView = {
+  active: false,
+  sourceTabId: null,
+  scope: "all",
+  targetTabIds: [],
+  lastScope: "all",
+};
+
+/** Append `{source} ∪ targets`, source first, de-duped — twin of `ordered_targets`. */
+function orderedTargets(source: string, targets: string[]): string[] {
+  const out = [source];
+  for (const id of targets) if (!out.includes(id)) out.push(id);
+  return out;
+}
+
+/**
+ * An in-memory substrate double applying the granular `broadcast.*` intents with
+ * the same semantics as the Rust `BroadcastStore`, so a run of the real `appStore`
+ * actions (which mirror those intents) reconstructs the region view the broadcast
+ * UI would render. `broadcast.replace` (the render-cut mirror) is intentionally not
+ * applied — the mutation cut drives the region through the per-transition intents.
+ */
+class BroadcastStoreTransport implements Transport {
+  dispatched: Intent[] = [];
+  private view: RegionView = { ...EMPTY };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    this.apply(intent);
+    this.version += 1;
+    this.fan();
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: "broadcast@test", version: this.version }],
+    };
+  }
+
+  private apply(intent: Intent): void {
+    const p = intent.payload as Record<string, unknown>;
+    switch (intent.kind) {
+      case "broadcast.start": {
+        const scope = p.scope as BroadcastScope;
+        const source = p.sourceTabId as string;
+        const targets = (p.targetTabIds as string[]) ?? [];
+        this.view = {
+          active: true,
+          sourceTabId: source,
+          scope,
+          targetTabIds: orderedTargets(source, targets),
+          lastScope: scope,
+        };
+        break;
+      }
+      case "broadcast.stop": {
+        // Retains scope / lastScope, exactly like the reducer.
+        this.view = { ...this.view, active: false, sourceTabId: null, targetTabIds: [] };
+        break;
+      }
+      case "broadcast.addTarget": {
+        const tabId = p.tabId as string;
+        if (!this.view.targetTabIds.includes(tabId)) {
+          this.view = { ...this.view, targetTabIds: [...this.view.targetTabIds, tabId] };
+        }
+        break;
+      }
+      case "broadcast.removeTarget": {
+        const tabId = p.tabId as string;
+        this.view = {
+          ...this.view,
+          targetTabIds: this.view.targetTabIds.filter((id) => id !== tabId),
+        };
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  regionView(): RegionView {
+    return structuredClone(this.view);
+  }
+
+  kinds(): string[] {
+    return this.dispatched.map((i) => i.kind);
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: this.regionView() };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot("broadcast@test");
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+let transport: BroadcastStoreTransport;
+
+/** Assert the region the intents reconstruct equals the local appStore slice. */
+function expectParity() {
+  const s = useAppStore.getState();
+  const region = transport.regionView();
+  expect(region.active).toBe(s.broadcastActive);
+  expect(region.sourceTabId).toBe(s.broadcastSourceTabId);
+  expect(region.scope).toBe(s.broadcastScope);
+  expect(region.lastScope).toBe(s.lastBroadcastScope);
+  // Membership compares as a set (order-independent — the UI reads `.has()`/`.size`).
+  expect(new Set(region.targetTabIds)).toEqual(s.broadcastTargetTabIds);
+}
+
+beforeEach(() => {
+  useAppStore.setState({
+    broadcastActive: false,
+    broadcastSourceTabId: null,
+    broadcastScope: "all",
+    broadcastTargetTabIds: new Set<string>(),
+    lastBroadcastScope: "all",
+  });
+  transport = new BroadcastStoreTransport();
+  setBroadcastTransportForTest(transport);
+  setBroadcastIntentsEnabled(true);
+});
+
+afterEach(() => {
+  setBroadcastTransportForTest(null);
+  setBroadcastIntentsEnabled(null);
+});
+
+describe("broadcast mutation cut — cut-vs-local parity (flag on)", () => {
+  it("startBroadcast reproduces the active membership (source first)", () => {
+    useAppStore.getState().startBroadcast("panel", "src", ["src", "t1", "t2"]);
+    expect(transport.kinds()).toEqual(["broadcast.start"]);
+    expectParity();
+    expect(transport.regionView().active).toBe(true);
+    expect(transport.regionView().targetTabIds).toEqual(["src", "t1", "t2"]);
+    expect(transport.regionView().lastScope).toBe("panel");
+  });
+
+  it("addTarget then removeTarget stay in parity", () => {
+    useAppStore.getState().startBroadcast("all", "src", ["t1"]);
+    useAppStore.getState().addBroadcastTarget("t2");
+    expectParity();
+    expect(new Set(transport.regionView().targetTabIds)).toEqual(new Set(["src", "t1", "t2"]));
+
+    useAppStore.getState().removeBroadcastTarget("t1");
+    expectParity();
+    expect(new Set(transport.regionView().targetTabIds)).toEqual(new Set(["src", "t2"]));
+  });
+
+  it("a no-op add / remove dispatches nothing (matches the pure store)", () => {
+    useAppStore.getState().startBroadcast("all", "src", ["t1"]);
+    transport.dispatched.length = 0;
+    // t1 already a target; ghost never was.
+    useAppStore.getState().addBroadcastTarget("t1");
+    useAppStore.getState().removeBroadcastTarget("ghost");
+    expect(transport.kinds()).toEqual([]);
+    expectParity();
+  });
+
+  it("stopBroadcast leaves broadcast but retains scope / lastScope", () => {
+    useAppStore.getState().startBroadcast("panel", "src", ["t1"]);
+    useAppStore.getState().stopBroadcast();
+    expect(transport.kinds()).toEqual(["broadcast.start", "broadcast.stop"]);
+    expectParity();
+    const region = transport.regionView();
+    expect(region.active).toBe(false);
+    expect(region.sourceTabId).toBeNull();
+    expect(region.targetTabIds).toEqual([]);
+    // Retained for the keyboard toggle (#1958).
+    expect(region.scope).toBe("panel");
+    expect(region.lastScope).toBe("panel");
+  });
+
+  it("a restart supersedes the prior session in parity", () => {
+    useAppStore.getState().startBroadcast("all", "src1", ["t1", "t2"]);
+    useAppStore.getState().startBroadcast("custom", "src2", ["t3"]);
+    expectParity();
+    expect(transport.regionView().sourceTabId).toBe("src2");
+    expect(new Set(transport.regionView().targetTabIds)).toEqual(new Set(["src2", "t3"]));
+    expect(transport.regionView().scope).toBe("custom");
+  });
+});
+
+describe("broadcast mutation cut — flag off (instant rollback)", () => {
+  beforeEach(() => setBroadcastIntentsEnabled(false));
+
+  it("dispatches nothing and the local slice is unchanged", () => {
+    useAppStore.getState().startBroadcast("panel", "src", ["t1"]);
+    useAppStore.getState().addBroadcastTarget("t2");
+    useAppStore.getState().removeBroadcastTarget("t1");
+    useAppStore.getState().stopBroadcast();
+
+    expect(transport.dispatched).toHaveLength(0);
+    // The region double never advanced past its idle baseline.
+    expect(transport.regionView()).toEqual(EMPTY);
+    // But the local slice applied every transition (source retained scope after stop).
+    const s = useAppStore.getState();
+    expect(s.broadcastActive).toBe(false);
+    expect(s.broadcastScope).toBe("panel");
+    expect(s.lastBroadcastScope).toBe("panel");
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -286,6 +286,7 @@ import {
 } from "@/store/sessionBridge";
 import { mirrorMonitorIntent } from "@/store/systemMonitorBridge";
 import { mirrorAgentIntent } from "@/store/agentsBridge";
+import { mirrorBroadcastIntent } from "@/store/broadcastBridge";
 
 export type SidebarView =
   | "connections"
@@ -7608,6 +7609,12 @@ export const useAppStore = create<AppState>((set, get, store) => {
         // The source is just another target — keeping the fan-out loop uniform.
         broadcastTargetTabIds: new Set<string>([sourceTabId, ...targetTabIds]),
       });
+      // Mutation cut (#2242): mirror the start into the authoritative region. The
+      // store reproduces `{source} ∪ targets` from the same args, so pass the raw
+      // resolved targets (not the source-prefixed set). A no-op / logged fallback
+      // when the flag is off or the transport is unavailable — the local slice
+      // above already applied.
+      mirrorBroadcastIntent("broadcast.start", { scope, sourceTabId, targetTabIds });
     },
 
     stopBroadcast: () => {
@@ -7616,6 +7623,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
         broadcastSourceTabId: null,
         broadcastTargetTabIds: new Set<string>(),
       });
+      // Mutation cut (#2242): leave broadcast in the region too (scope/lastScope
+      // retained by the store for the keyboard toggle, exactly as the slice).
+      mirrorBroadcastIntent("broadcast.stop", {});
     },
 
     toggleBroadcast: () => {
@@ -7642,21 +7652,29 @@ export const useAppStore = create<AppState>((set, get, store) => {
     },
 
     addBroadcastTarget: (tabId) => {
+      // Read-then-set so the mirror fires only on a real change (a no-op add must
+      // not dispatch a redundant intent), matching the store's pure set-insert.
+      if (get().broadcastTargetTabIds.has(tabId)) return;
       set((state) => {
         if (state.broadcastTargetTabIds.has(tabId)) return {};
         const next = new Set(state.broadcastTargetTabIds);
         next.add(tabId);
         return { broadcastTargetTabIds: next };
       });
+      // Mutation cut (#2242): mirror the membership add into the region.
+      mirrorBroadcastIntent("broadcast.addTarget", { tabId });
     },
 
     removeBroadcastTarget: (tabId) => {
+      if (!get().broadcastTargetTabIds.has(tabId)) return;
       set((state) => {
         if (!state.broadcastTargetTabIds.has(tabId)) return {};
         const next = new Set(state.broadcastTargetTabIds);
         next.delete(tabId);
         return { broadcastTargetTabIds: next };
       });
+      // Mutation cut (#2242): mirror the membership removal into the region.
+      mirrorBroadcastIntent("broadcast.removeTarget", { tabId });
     },
 
     isBroadcastTarget: (tabId) => get().broadcastTargetTabIds.has(tabId),
@@ -7698,6 +7716,15 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // Skip the update (and its re-render) when membership is unchanged.
       if (next.size === prev.size && [...next].every((id) => prev.has(id))) return;
       set({ broadcastTargetTabIds: next });
+      // Mutation cut (#2242): the store owns no bulk-set intent, so reconcile the
+      // region to the recomputed membership via granular add/remove intents for the
+      // delta (mirroring the connected-terminal refresh at the fan-out seam).
+      for (const id of next) {
+        if (!prev.has(id)) mirrorBroadcastIntent("broadcast.addTarget", { tabId: id });
+      }
+      for (const id of prev) {
+        if (!next.has(id)) mirrorBroadcastIntent("broadcast.removeTarget", { tabId: id });
+      }
     },
 
     // Workflows (#1852)

--- a/src/store/broadcastBridge.test.ts
+++ b/src/store/broadcastBridge.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Broadcast-membership projection bridge (#2242) — flags, the faithful-mirror
+ * gate, and the `broadcast.replace` seed round-trip. Drives the bridge against an
+ * in-memory substrate double that applies `broadcast.replace` and fans a snapshot,
+ * without a backend.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+
+import {
+  BROADCAST_REGION,
+  broadcastIntentsEnabled,
+  broadcastRenderFromProjectionEnabled,
+  broadcastViewMirrors,
+  currentBroadcastView,
+  ensureBroadcastSubscribed,
+  EMPTY_BROADCAST_VIEW,
+  onBroadcastView,
+  seedBroadcastRegion,
+  setBroadcastIntentsEnabled,
+  setBroadcastRenderFromProjectionEnabled,
+  setBroadcastTransportForTest,
+  stopBroadcastSubscription,
+  type BroadcastSlice,
+  type BroadcastView,
+} from "./broadcastBridge";
+
+/** An in-memory substrate double: holds one broadcast view, applies a
+ * `broadcast.replace` by overwriting it, and fans a fresh snapshot to subscribers. */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  private view: BroadcastView = { ...EMPTY_BROADCAST_VIEW };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (intent.kind === "broadcast.replace") {
+      const p = intent.payload as Partial<BroadcastView>;
+      this.view = {
+        active: p.active ?? false,
+        sourceTabId: p.sourceTabId ?? null,
+        scope: p.scope ?? "all",
+        targetTabIds: p.targetTabIds ?? [],
+        lastScope: p.lastScope ?? "all",
+      };
+      this.version += 1;
+      this.fan();
+      return {
+        intentId: intent.intentId,
+        status: "accepted",
+        produced: [{ region: BROADCAST_REGION, version: this.version }],
+      };
+    }
+    return { intentId: intent.intentId, status: "accepted", produced: [] };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(BROADCAST_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+let transport: FakeTransport;
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setBroadcastTransportForTest(transport);
+});
+
+afterEach(() => {
+  stopBroadcastSubscription();
+  setBroadcastTransportForTest(null);
+  setBroadcastRenderFromProjectionEnabled(null);
+  setBroadcastIntentsEnabled(null);
+});
+
+describe("broadcastRenderFromProjectionEnabled flag", () => {
+  it("defaults on and honours the programmatic override", () => {
+    expect(broadcastRenderFromProjectionEnabled()).toBe(true);
+    setBroadcastRenderFromProjectionEnabled(false);
+    expect(broadcastRenderFromProjectionEnabled()).toBe(false);
+    setBroadcastRenderFromProjectionEnabled(true);
+    expect(broadcastRenderFromProjectionEnabled()).toBe(true);
+    setBroadcastRenderFromProjectionEnabled(null);
+    expect(broadcastRenderFromProjectionEnabled()).toBe(true);
+  });
+});
+
+describe("broadcastIntentsEnabled flag", () => {
+  it("defaults on and honours the programmatic override", () => {
+    expect(broadcastIntentsEnabled()).toBe(true);
+    setBroadcastIntentsEnabled(false);
+    expect(broadcastIntentsEnabled()).toBe(false);
+    setBroadcastIntentsEnabled(null);
+    expect(broadcastIntentsEnabled()).toBe(true);
+  });
+});
+
+function slice(over: Partial<BroadcastSlice> = {}): BroadcastSlice {
+  return {
+    active: false,
+    sourceTabId: null,
+    scope: "all",
+    targetTabIds: new Set<string>(),
+    lastScope: "all",
+    ...over,
+  };
+}
+
+describe("broadcastViewMirrors gate", () => {
+  it("is false for an undefined view", () => {
+    expect(broadcastViewMirrors(undefined, slice())).toBe(false);
+  });
+
+  it("mirrors when every field matches (targets order-independent)", () => {
+    const view: BroadcastView = {
+      active: true,
+      sourceTabId: "src",
+      scope: "panel",
+      targetTabIds: ["src", "t1", "t2"],
+      lastScope: "panel",
+    };
+    // Same members, different order — still a mirror (the UI reads set membership).
+    const s = slice({
+      active: true,
+      sourceTabId: "src",
+      scope: "panel",
+      targetTabIds: new Set(["t2", "src", "t1"]),
+      lastScope: "panel",
+    });
+    expect(broadcastViewMirrors(view, s)).toBe(true);
+  });
+
+  it("rejects on any field divergence", () => {
+    const view: BroadcastView = {
+      active: true,
+      sourceTabId: "src",
+      scope: "all",
+      targetTabIds: ["src"],
+      lastScope: "all",
+    };
+    expect(broadcastViewMirrors(view, slice({ active: false }))).toBe(false);
+    expect(
+      broadcastViewMirrors(view, slice({ active: true, sourceTabId: "src", scope: "panel" }))
+    ).toBe(false);
+    // Same size, different member.
+    expect(
+      broadcastViewMirrors(
+        view,
+        slice({ active: true, sourceTabId: "src", targetTabIds: new Set(["x"]) })
+      )
+    ).toBe(false);
+  });
+});
+
+describe("seedBroadcastRegion (broadcast.replace mirror)", () => {
+  const view: BroadcastView = {
+    active: true,
+    sourceTabId: "src",
+    scope: "custom",
+    targetTabIds: ["src", "t1"],
+    lastScope: "custom",
+  };
+
+  it("dispatches a broadcast.replace and fans the mirrored view", async () => {
+    const received: BroadcastView[] = [];
+    onBroadcastView((v) => received.push(v));
+    await ensureBroadcastSubscribed();
+
+    await seedBroadcastRegion(view);
+
+    const replace = transport.dispatched.filter((d) => d.kind === "broadcast.replace");
+    expect(replace).toHaveLength(1);
+    expect(currentBroadcastView()).toEqual(view);
+    expect(received[received.length - 1]).toEqual(view);
+  });
+
+  it("de-duplicates an identical seed", async () => {
+    await ensureBroadcastSubscribed();
+    await seedBroadcastRegion(view);
+    await seedBroadcastRegion(view);
+    expect(transport.dispatched.filter((d) => d.kind === "broadcast.replace")).toHaveLength(1);
+  });
+});

--- a/src/store/broadcastBridge.ts
+++ b/src/store/broadcastBridge.ts
@@ -1,0 +1,450 @@
+/**
+ * Broadcast-membership projection bridge — Phase 4 step 5b render + mutation cut
+ * of the broadcast machine (#2242, part of #2206 / #2139).
+ *
+ * The broadcast **shadow** (PR #2254) landed a backend-authoritative,
+ * client-scoped `BroadcastStore` served as the `broadcast@<clientId>` projection
+ * region with `broadcast.*` intents, but nothing in the UI touched it. This step
+ * makes the broadcast UI (the status-bar pill, the tab badges, the panel
+ * ring/glow, the toolbar toggle) source its membership from that region — the
+ * parity-safe render cut — and routes the membership actions through the intents
+ * so the store becomes authoritative — the flag-gated mutation cut. It mirrors the
+ * Monitors render cut ({@link import("./systemMonitorBridge")}, #2224) and the
+ * client-scoped `layout` pilot ({@link import("./layoutBridge")}, #2151).
+ *
+ * # Client-scoped region
+ *
+ * Unlike the shared `system-monitors` region, broadcast membership is a
+ * **per-client input-fan-out overlay over that client's own tabs** (Open Design
+ * Decision #4 / #6), so the region is `broadcast@<clientId>` — a stable per-session
+ * client identity, mirroring the layout bridge.
+ *
+ * # Strangler safety — two flags, both on by default
+ *
+ * - **Render cut** ({@link broadcastRenderFromProjectionEnabled}, on by default).
+ *   The region is kept a faithful copy of `appStore`'s broadcast slice by
+ *   {@link seedBroadcastRegion} (a `broadcast.replace` mirror, the analog of the
+ *   monitors `monitor.replace` seed), and the UI renders from the region **only
+ *   when it faithfully mirrors** `appStore` ({@link broadcastViewMirrors}),
+ *   otherwise it falls back to `appStore` verbatim — so the rendered output is
+ *   value-identical to the pre-cut path.
+ * - **Mutation cut** ({@link broadcastIntentsEnabled}, on by default). The
+ *   membership actions (`startBroadcast` / `stopBroadcast` / `toggleBroadcast` /
+ *   `addBroadcastTarget` / `removeBroadcastTarget` / `refreshBroadcastMembership`)
+ *   mirror their transition through granular `broadcast.*` intents (via
+ *   {@link mirrorBroadcastIntent}), so the backend store is authoritative. The
+ *   local `appStore` reducer path stays in place as the render source and the
+ *   resilience / rollback fallback — any dispatch failure is logged and the local
+ *   mutation continues, so a backend hiccup can never break broadcast (the reducer
+ *   removal is a later step).
+ *
+ * # What stays frontend
+ *
+ * The scope→tabs resolution (`resolveBroadcastTargetTabIds`), the connected-terminal
+ * fan-out filter (`getBroadcastTargetTabIds`), and the dynamic-membership recompute
+ * (`refreshBroadcastMembership`) deliberately stay on the frontend — they need the
+ * live tab tree the layout machine owns. This bridge owns only the membership
+ * orchestration state.
+ */
+
+import {
+  createTransport,
+  newClientId,
+  newIntentId,
+  ProjectionClient,
+  type IntentAck,
+  type Transport,
+} from "@/services/transport";
+import type { BroadcastScope } from "@/types/terminal";
+import { frontendLog } from "@/utils/frontendLog";
+
+/**
+ * The `broadcast@<clientId>` region view model — a twin of the Rust store
+ * snapshot. `targetTabIds` is an ordered array (source first) mirroring the
+ * `appStore` `broadcastTargetTabIds` `Set`.
+ */
+export interface BroadcastView {
+  active: boolean;
+  sourceTabId: string | null;
+  scope: BroadcastScope;
+  targetTabIds: string[];
+  lastScope: BroadcastScope;
+}
+
+/** The idle baseline a fresh region reports (twin of the empty store snapshot). */
+export const EMPTY_BROADCAST_VIEW: BroadcastView = {
+  active: false,
+  sourceTabId: null,
+  scope: "all",
+  targetTabIds: [],
+  lastScope: "all",
+};
+
+// ── Render-cut feature flag (runtime-flippable, on by default) ─────────────────
+
+let renderFlagOverride: boolean | null = null;
+
+interface BroadcastRenderFlagWindow {
+  __TERMIHUB_BROADCAST_RENDER_FROM_PROJECTION__?: boolean;
+  localStorage?: Storage;
+}
+
+/**
+ * Programmatic override for the render-cut flag (tests, and a runtime toggle).
+ * `null` clears the override and falls back to the window/localStorage signal,
+ * then to the default (on).
+ */
+export function setBroadcastRenderFromProjectionEnabled(value: boolean | null): void {
+  renderFlagOverride = value;
+}
+
+/**
+ * Whether the broadcast UI renders its membership from the projected
+ * `broadcast@<clientId>` region instead of reading `appStore`'s broadcast slice
+ * directly.
+ *
+ * **On by default** — the render cut is parity-safe: the UI renders from the
+ * region only when it faithfully mirrors `appStore` ({@link broadcastViewMirrors}),
+ * and otherwise falls back to `appStore` verbatim, so the output is value-identical
+ * to the pre-cut path. The region is kept a mirror of `appStore` by
+ * {@link seedBroadcastRegion}, so it is always populated. Overridable at runtime
+ * for rollback / tests via `window.__TERMIHUB_BROADCAST_RENDER_FROM_PROJECTION__`
+ * or `localStorage["termihub.broadcastRenderFromProjection"]` (set `"false"` to
+ * render straight from `appStore`).
+ */
+export function broadcastRenderFromProjectionEnabled(): boolean {
+  if (renderFlagOverride !== null) return renderFlagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as BroadcastRenderFlagWindow;
+      if (typeof w.__TERMIHUB_BROADCAST_RENDER_FROM_PROJECTION__ === "boolean") {
+        return w.__TERMIHUB_BROADCAST_RENDER_FROM_PROJECTION__;
+      }
+      const ls = w.localStorage?.getItem("termihub.broadcastRenderFromProjection");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return true;
+}
+
+// ── Mutation-cut feature flag (runtime-flippable, on by default) ───────────────
+
+let mutationFlagOverride: boolean | null = null;
+
+interface BroadcastMutationFlagWindow {
+  __TERMIHUB_BROADCAST_INTENTS__?: boolean;
+  localStorage?: Storage;
+}
+
+/**
+ * Programmatic override for the mutation-cut flag (tests, and a runtime toggle).
+ * `null` clears the override and falls back to the window/localStorage signal,
+ * then to the default (on).
+ */
+export function setBroadcastIntentsEnabled(value: boolean | null): void {
+  mutationFlagOverride = value;
+}
+
+/**
+ * Whether the broadcast membership actions dispatch granular `broadcast.*` intents
+ * so the backend {@link BroadcastStore} is authoritative — instead of only the
+ * render-cut {@link seedBroadcastRegion} `broadcast.replace` mirror driving the
+ * region.
+ *
+ * **On by default** (#2242 mutation cut). When on, each action mirrors its
+ * transition through a `broadcast.*` intent (via {@link mirrorBroadcastIntent}),
+ * and the render-cut hook ({@link import("./useProjectedBroadcast").useProjectedBroadcast})
+ * reflects the region back into the UI. The local `appStore` reducer path stays in
+ * place as the render source and as a resilience / rollback fallback — any dispatch
+ * failure is logged and the local mutation continues, so a backend hiccup can never
+ * break broadcast (the reducer removal is a later step). When off, `appStore` drives
+ * the slice purely locally (the pre-cut path). The flip was taken on the automated
+ * parity tests plus the instant local fallback, mirroring the monitors mutation cut
+ * (#2224). Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_BROADCAST_INTENTS__` or `localStorage["termihub.broadcastIntents"]`
+ * (set `"false"` to restore the pre-cut local-mutation path; `"true"` to force on).
+ */
+export function broadcastIntentsEnabled(): boolean {
+  if (mutationFlagOverride !== null) return mutationFlagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as BroadcastMutationFlagWindow;
+      if (typeof w.__TERMIHUB_BROADCAST_INTENTS__ === "boolean") {
+        return w.__TERMIHUB_BROADCAST_INTENTS__;
+      }
+      const ls = w.localStorage?.getItem("termihub.broadcastIntents");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return true;
+}
+
+// ── Transport + client-scoped region client (lazy, mirrors the layout slice) ───
+
+let transportInstance: Transport | null = null;
+let regionClient: ProjectionClient | null = null;
+let startPromise: Promise<ProjectionClient> | null = null;
+
+// A stable per-session client identity. The region is `broadcast@<clientId>` and
+// dispatched intents carry the same id, so this checkout mutates and subscribes to
+// its own broadcast region (mirroring the client-scoped layout bridge).
+const clientId = newClientId();
+
+/** The client-scoped projection region id for this session's broadcast membership. */
+export const BROADCAST_REGION = `broadcast@${clientId}`;
+
+/** Inject a transport for tests; `null` restores the lazily-created real one and
+ * drops any active subscription / seed dedup. */
+export function setBroadcastTransportForTest(t: Transport | null): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  transportInstance = t;
+  lastView = EMPTY_BROADCAST_VIEW;
+  lastSeededSignature = null;
+}
+
+function transport(): Transport {
+  if (!transportInstance) {
+    transportInstance = createTransport();
+  }
+  return transportInstance;
+}
+
+// ── View fan-out (one subscription, many consuming hooks) ──────────────────────
+
+/** A change listener for the projected `broadcast` view. */
+export type BroadcastViewListener = (view: BroadcastView) => void;
+
+const viewListeners = new Set<BroadcastViewListener>();
+let lastView: BroadcastView = EMPTY_BROADCAST_VIEW;
+
+/**
+ * Register a listener, invoked with the projected view on every diff. Returns an
+ * unsubscribe. The region client is started on first use.
+ */
+export function onBroadcastView(listener: BroadcastViewListener): () => void {
+  viewListeners.add(listener);
+  return () => viewListeners.delete(listener);
+}
+
+/** Normalize a possibly-partial projected view into a full {@link BroadcastView}. */
+function normalizeView(view: Partial<BroadcastView> | undefined): BroadcastView {
+  return {
+    active: view?.active ?? false,
+    sourceTabId: view?.sourceTabId ?? null,
+    scope: view?.scope ?? "all",
+    targetTabIds: view?.targetTabIds ?? [],
+    lastScope: view?.lastScope ?? "all",
+  };
+}
+
+/**
+ * Ensure the `broadcast@<clientId>` region client is subscribed so projected diffs
+ * are received and fanned out to the {@link onBroadcastView} listeners. Idempotent
+ * and de-duplicated across concurrent callers; a transport/subscribe failure is
+ * logged and rethrown so the caller can fall back to `appStore`.
+ */
+export function ensureBroadcastSubscribed(): Promise<ProjectionClient> {
+  if (regionClient) return Promise.resolve(regionClient);
+  if (!startPromise) {
+    const client = new ProjectionClient(transport(), BROADCAST_REGION);
+    client.onChange((state) => {
+      lastView = normalizeView(state.view as Partial<BroadcastView> | undefined);
+      for (const listener of viewListeners) {
+        try {
+          listener(lastView);
+        } catch (err) {
+          logBroadcastBridgeFallback("reconcile", err);
+        }
+      }
+    });
+    startPromise = client
+      .start()
+      .then(() => {
+        regionClient = client;
+        return client;
+      })
+      .catch((err) => {
+        startPromise = null;
+        logBroadcastBridgeFallback("subscribe", err);
+        throw err;
+      });
+  }
+  return startPromise;
+}
+
+/** Drop the region subscription (tests / re-init). */
+export function stopBroadcastSubscription(): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  lastView = EMPTY_BROADCAST_VIEW;
+  lastSeededSignature = null;
+}
+
+/** The last view fanned out (for a hook that subscribes after the first diff). */
+export function currentBroadcastView(): BroadcastView {
+  return lastView;
+}
+
+// ── Seed: keep the region a faithful mirror of appStore (broadcast.replace) ────
+
+let lastSeededSignature: string | null = null;
+
+/**
+ * Seed the region with `appStore`'s whole broadcast slice via a `broadcast.replace`
+ * intent, so the projection tracks `appStore`'s current state while `appStore` stays
+ * authoritative (the render-side counterpart of the monitors bridge seed).
+ * De-duplicated: a slice identical to the last seeded one is not re-dispatched.
+ * Never throws synchronously — a transport that cannot dispatch surfaces as a
+ * rejected promise the caller logs and ignores (staying on the `appStore` fallback).
+ * Idempotent server-side: replacing with the same content yields no diff.
+ */
+export function seedBroadcastRegion(view: BroadcastView): Promise<void> {
+  const signature = JSON.stringify(view);
+  if (signature === lastSeededSignature) return Promise.resolve();
+  // Set before dispatching so concurrent callers do not double-dispatch the seed.
+  lastSeededSignature = signature;
+  try {
+    return transport()
+      .dispatch({
+        intentId: newIntentId(),
+        kind: "broadcast.replace",
+        payload: {
+          active: view.active,
+          sourceTabId: view.sourceTabId,
+          scope: view.scope,
+          targetTabIds: view.targetTabIds,
+          lastScope: view.lastScope,
+        },
+        clientId,
+      })
+      .then((ack: IntentAck) => {
+        if (ack.status === "rejected") {
+          // Let a later change retry the seed rather than latch on a failure.
+          lastSeededSignature = null;
+          throw new Error(ack.error?.message ?? "broadcast.replace rejected");
+        }
+      })
+      .catch((err) => {
+        lastSeededSignature = null;
+        throw err;
+      });
+  } catch (err) {
+    // A synchronous transport-construction failure (non-Tauri, no socket).
+    lastSeededSignature = null;
+    return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+// ── Mutation cut: granular broadcast.* intent dispatch ─────────────────────────
+
+/**
+ * The granular `broadcast.*` intent kinds the mutation cut dispatches (twins of the
+ * Rust routes). Excludes `broadcast.replace`, which is the render-cut whole-state
+ * mirror ({@link seedBroadcastRegion}); the mutation cut drives the region through
+ * these per-transition intents instead so the store becomes authoritative.
+ * `toggle` is covered by the store's own `start`/`stop` (which the reducer delegates
+ * to), so the frontend mirrors the resolved `start`/`stop` rather than a separate
+ * `broadcast.toggle`.
+ */
+export type BroadcastIntentKind =
+  | "broadcast.start"
+  | "broadcast.stop"
+  | "broadcast.addTarget"
+  | "broadcast.removeTarget";
+
+/** Dispatch a granular `broadcast.*` intent, resolving with the ack (parity tests). */
+export function dispatchBroadcastIntent(
+  kind: BroadcastIntentKind,
+  payload: Record<string, unknown>
+): Promise<IntentAck> {
+  return transport().dispatch({ intentId: newIntentId(), kind, payload, clientId });
+}
+
+/**
+ * Fire a granular `broadcast.*` intent to keep the backend store authoritative,
+ * swallowing and logging any failure so the local `appStore` mutation path is never
+ * disrupted by a bridge hiccup (the resilience fallback). A no-op when the mutation
+ * cut is disabled ({@link broadcastIntentsEnabled} off — the rollback path). Never
+ * throws — a synchronous transport-construction failure (non-Tauri, no socket) is
+ * caught and logged, leaving the UI on the local slice. The twin of the monitors
+ * bridge's {@link import("./systemMonitorBridge").mirrorMonitorIntent}.
+ */
+export function mirrorBroadcastIntent(
+  kind: BroadcastIntentKind,
+  payload: Record<string, unknown>
+): void {
+  if (!broadcastIntentsEnabled()) return;
+  try {
+    void dispatchBroadcastIntent(kind, payload)
+      .then((ack) => {
+        if (ack.status === "rejected") {
+          logBroadcastBridgeFallback(kind, new Error(ack.error?.message ?? "rejected"));
+        }
+      })
+      .catch((err) => logBroadcastBridgeFallback(kind, err));
+  } catch (err) {
+    logBroadcastBridgeFallback(kind, err);
+  }
+}
+
+// ── Faithful-mirror gate ───────────────────────────────────────────────────────
+
+/**
+ * The `appStore` broadcast slice, shaped for the mirror comparison. `targetTabIds`
+ * is the live `Set` (order-independent membership is what the UI reads: `.has()`,
+ * `.size`, and the connected-terminal filter).
+ */
+export interface BroadcastSlice {
+  active: boolean;
+  sourceTabId: string | null;
+  scope: BroadcastScope;
+  targetTabIds: Set<string>;
+  lastScope: BroadcastScope;
+}
+
+/** Compare a projected `targetTabIds` array with an `appStore` `Set` as sets. */
+function targetsEqual(view: string[], slice: Set<string>): boolean {
+  if (view.length !== slice.size) return false;
+  for (const id of view) {
+    if (!slice.has(id)) return false;
+  }
+  return true;
+}
+
+/**
+ * Whether a projected `view` faithfully mirrors `appStore`'s broadcast slice — the
+ * gate deciding whether the UI may render from the projection (true) or must fall
+ * back to `appStore` (false). `active` / `sourceTabId` / `scope` / `lastScope`
+ * compare by value; `targetTabIds` compares as a **set** (order-independent), since
+ * the UI reads membership, size, and the connected filter, never order. A mirroring
+ * view is value-identical to what the UI renders from `appStore`, so rendering from
+ * it can never diverge. The twin of the monitors render cut's `monitorsViewMirrors`.
+ */
+export function broadcastViewMirrors(
+  view: BroadcastView | undefined,
+  slice: BroadcastSlice
+): boolean {
+  if (!view) return false;
+  return (
+    view.active === slice.active &&
+    view.sourceTabId === slice.sourceTabId &&
+    view.scope === slice.scope &&
+    view.lastScope === slice.lastScope &&
+    targetsEqual(view.targetTabIds, slice.targetTabIds)
+  );
+}
+
+/** Log a bridge fallback so the appStore-path recovery is visible in the LogViewer. */
+export function logBroadcastBridgeFallback(kind: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  frontendLog("broadcast_bridge", `${kind} fell back to appStore broadcast: ${message}`);
+}

--- a/src/store/useProjectedBroadcast.test.tsx
+++ b/src/store/useProjectedBroadcast.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * `useProjectedBroadcast` — the broadcast UI cut to the projected `broadcast`
+ * region (#2242 render cut). Drives the hook against an in-memory substrate double
+ * and asserts: flag-off returns the appStore slice and dispatches nothing; flag-on
+ * seeds the region (a `broadcast.replace` mirror) and then renders the slice from
+ * the projection, value-identical to appStore; and a region that has not caught up
+ * falls back to the appStore slice.
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import { useAppStore } from "@/store/appStore";
+
+import {
+  BROADCAST_REGION,
+  EMPTY_BROADCAST_VIEW,
+  setBroadcastRenderFromProjectionEnabled,
+  setBroadcastTransportForTest,
+  stopBroadcastSubscription,
+  type BroadcastSlice,
+  type BroadcastView,
+} from "./broadcastBridge";
+import { useProjectedBroadcast } from "./useProjectedBroadcast";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  getSettings: vi.fn(() =>
+    Promise.resolve({ version: "1", externalConnectionFiles: [], powerMonitoringEnabled: true })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn(() => vi.fn()) }));
+
+/** In-memory substrate double: applies `broadcast.replace` and fans a snapshot. */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  /** When false, `broadcast.replace` acks but does NOT advance the region. */
+  applyReplace = true;
+  private view: BroadcastView = { ...EMPTY_BROADCAST_VIEW };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (intent.kind === "broadcast.replace" && this.applyReplace) {
+      const p = intent.payload as Partial<BroadcastView>;
+      this.view = {
+        active: p.active ?? false,
+        sourceTabId: p.sourceTabId ?? null,
+        scope: p.scope ?? "all",
+        targetTabIds: p.targetTabIds ?? [],
+        lastScope: p.lastScope ?? "all",
+      };
+      this.version += 1;
+      this.fan();
+    }
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: BROADCAST_REGION, version: this.version }],
+    };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(BROADCAST_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+/** Render the hook into a throwaway component, exposing the latest return value. */
+function renderHook(): { get: () => BroadcastSlice; unmount: () => void } {
+  const container = document.createElement("div");
+  const root: Root = createRoot(container);
+  let latest: BroadcastSlice = {
+    active: false,
+    sourceTabId: null,
+    scope: "all",
+    targetTabIds: new Set(),
+    lastScope: "all",
+  };
+
+  function Probe() {
+    latest = useProjectedBroadcast();
+    return null;
+  }
+
+  act(() => root.render(<Probe />));
+  return { get: () => latest, unmount: () => act(() => root.unmount()) };
+}
+
+let transport: FakeTransport;
+
+/** Set the appStore broadcast slice for a test. */
+function setBroadcast(over: {
+  active: boolean;
+  sourceTabId: string | null;
+  scope: BroadcastView["scope"];
+  targetTabIds: string[];
+  lastScope: BroadcastView["lastScope"];
+}) {
+  useAppStore.setState({
+    broadcastActive: over.active,
+    broadcastSourceTabId: over.sourceTabId,
+    broadcastScope: over.scope,
+    broadcastTargetTabIds: new Set(over.targetTabIds),
+    lastBroadcastScope: over.lastScope,
+  });
+}
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setBroadcastTransportForTest(transport);
+  setBroadcast({
+    active: false,
+    sourceTabId: null,
+    scope: "all",
+    targetTabIds: [],
+    lastScope: "all",
+  });
+});
+
+afterEach(() => {
+  stopBroadcastSubscription();
+  setBroadcastTransportForTest(null);
+  setBroadcastRenderFromProjectionEnabled(null);
+});
+
+const flush = () => act(async () => await Promise.resolve());
+
+describe("useProjectedBroadcast", () => {
+  it("flag off: returns the appStore slice and dispatches nothing", async () => {
+    setBroadcastRenderFromProjectionEnabled(false);
+    setBroadcast({
+      active: true,
+      sourceTabId: "src",
+      scope: "panel",
+      targetTabIds: ["src", "t1"],
+      lastScope: "panel",
+    });
+
+    const hook = renderHook();
+    await flush();
+
+    expect(hook.get().active).toBe(true);
+    expect(hook.get().sourceTabId).toBe("src");
+    expect([...hook.get().targetTabIds].sort()).toEqual(["src", "t1"]);
+    expect(transport.dispatched).toHaveLength(0);
+    hook.unmount();
+  });
+
+  it("flag on: seeds the region then renders the slice from the projection", async () => {
+    setBroadcast({
+      active: true,
+      sourceTabId: "src",
+      scope: "custom",
+      targetTabIds: ["src", "t1", "t2"],
+      lastScope: "custom",
+    });
+
+    const hook = renderHook();
+    await flush();
+    await flush();
+
+    // Seeded appStore's slice via broadcast.replace…
+    expect(transport.dispatched.some((d) => d.kind === "broadcast.replace")).toBe(true);
+    // …and now renders a value-identical slice (sourced from the projection).
+    const s = hook.get();
+    expect(s.active).toBe(true);
+    expect(s.sourceTabId).toBe("src");
+    expect(s.scope).toBe("custom");
+    expect([...s.targetTabIds].sort()).toEqual(["src", "t1", "t2"]);
+    expect(s.lastScope).toBe("custom");
+    hook.unmount();
+  });
+
+  it("region not caught up: falls back to the appStore slice", async () => {
+    transport.applyReplace = false; // the replace acks but never advances the region
+    setBroadcast({
+      active: true,
+      sourceTabId: "src",
+      scope: "all",
+      targetTabIds: ["src"],
+      lastScope: "all",
+    });
+
+    const hook = renderHook();
+    await flush();
+    await flush();
+
+    // The projection stays empty, so the gate rejects it and the hook renders the
+    // appStore slice verbatim — parity preserved.
+    const s = hook.get();
+    expect(s.active).toBe(true);
+    expect([...s.targetTabIds]).toEqual(["src"]);
+    hook.unmount();
+  });
+});

--- a/src/store/useProjectedBroadcast.ts
+++ b/src/store/useProjectedBroadcast.ts
@@ -1,0 +1,121 @@
+/**
+ * `useProjectedBroadcast` — the broadcast UI cut to the projected
+ * `broadcast@<clientId>` region (#2242 render cut, part of #2206 / #2139).
+ *
+ * The status-bar pill, tab badges, panel ring/glow, and toolbar toggle render the
+ * broadcast membership. Through the shadow step they read `appStore`'s broadcast
+ * slice directly. This hook makes them source that slice from the client-scoped
+ * `broadcast` projection region instead — the direct analog of
+ * {@link import("./useProjectedMonitors").useProjectedMonitors} (#2224) and
+ * {@link import("./useLayoutRenderTree").useLayoutRenderTree} (#2151).
+ *
+ * # Safety (strangler)
+ *
+ * - **Gated** by {@link broadcastRenderFromProjectionEnabled} (on by default). Flag
+ *   off ⇒ the hook returns `appStore`'s slice verbatim.
+ * - **Faithful-mirror gate.** The projection sources the render only when it mirrors
+ *   the `appStore` slice ({@link broadcastViewMirrors}); otherwise the hook falls
+ *   back to `appStore` (never a stale view). While `appStore` stays authoritative
+ *   the region is kept a mirror by {@link seedBroadcastRegion}, so it is always
+ *   populated — making the cut parity-safe and independent of the mutation flag.
+ *
+ * The connected-terminal fan-out filter (`getBroadcastTargetTabIds`), the scope→tabs
+ * resolution, and the membership recompute stay on `appStore` — they need the live
+ * tab tree — so consumers keep calling those store methods; only the membership
+ * *state* (`active` / `sourceTabId` / `scope` / `targetTabIds` / `lastScope`) is
+ * sourced here.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  broadcastRenderFromProjectionEnabled,
+  broadcastViewMirrors,
+  currentBroadcastView,
+  ensureBroadcastSubscribed,
+  logBroadcastBridgeFallback,
+  onBroadcastView,
+  seedBroadcastRegion,
+  type BroadcastSlice,
+  type BroadcastView,
+} from "@/store/broadcastBridge";
+import { useAppStore } from "@/store/appStore";
+
+/**
+ * The effective broadcast membership slice for rendering: sourced from the
+ * projected `broadcast` region when it faithfully mirrors `appStore`, otherwise
+ * `appStore`'s slice verbatim (flag off, region not yet caught up, or a transport
+ * that cannot subscribe). `targetTabIds` is a `Set<string>`, so the return value is
+ * a drop-in for the previous direct `appStore` reads.
+ */
+export function useProjectedBroadcast(): BroadcastSlice {
+  const active = useAppStore((s) => s.broadcastActive);
+  const sourceTabId = useAppStore((s) => s.broadcastSourceTabId);
+  const scope = useAppStore((s) => s.broadcastScope);
+  const targetTabIds = useAppStore((s) => s.broadcastTargetTabIds);
+  const lastScope = useAppStore((s) => s.lastBroadcastScope);
+
+  const slice: BroadcastSlice = useMemo(
+    () => ({ active, sourceTabId, scope, targetTabIds, lastScope }),
+    [active, sourceTabId, scope, targetTabIds, lastScope]
+  );
+
+  // Read the flag once at mount: it flips only via dev tooling, and the
+  // subscription lifecycle is keyed off it below.
+  const [enabled] = useState(() => broadcastRenderFromProjectionEnabled());
+
+  const [view, setView] = useState<BroadcastView | undefined>(undefined);
+
+  // Subscribe to the client-scoped broadcast region while enabled; a transport that
+  // cannot subscribe (non-Tauri without a socket) just leaves the UI on the appStore
+  // fallback.
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const unsubscribe = onBroadcastView((next) => {
+      if (!cancelled) setView(next);
+    });
+    try {
+      ensureBroadcastSubscribed()
+        .then(() => {
+          if (!cancelled) setView(currentBroadcastView());
+        })
+        .catch((err) => logBroadcastBridgeFallback("subscribe", err));
+    } catch (err) {
+      logBroadcastBridgeFallback("subscribe", err);
+    }
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [enabled]);
+
+  const matches = enabled && broadcastViewMirrors(view, slice);
+
+  // Keep the region a faithful mirror of appStore's slice. Only once a view has
+  // arrived (so we are subscribed) and it is not already a mirror; de-duped inside
+  // `seedBroadcastRegion` so a settled slice is not re-seeded on every render.
+  useEffect(() => {
+    if (!enabled || matches || view === undefined) return;
+    seedBroadcastRegion({
+      active,
+      sourceTabId,
+      scope,
+      targetTabIds: [...targetTabIds],
+      lastScope,
+    }).catch((err) => logBroadcastBridgeFallback("seed", err));
+  }, [enabled, matches, view, active, sourceTabId, scope, targetTabIds, lastScope]);
+
+  return useMemo(() => {
+    if (matches && view) {
+      return {
+        active: view.active,
+        sourceTabId: view.sourceTabId,
+        scope: view.scope,
+        targetTabIds: new Set(view.targetTabIds),
+        lastScope: view.lastScope,
+      };
+    }
+    return slice;
+  }, [matches, view, slice]);
+}


### PR DESCRIPTION
## Summary

Cuts the **broadcast-input membership machine** over to the server-side `BroadcastStore` authority — Phase 4 step 5b of the stateless-UI migration (part of #2206 / #2139). The broadcast **shadow** landed in PR #2254; this PR does the **render cut** and the **mutation cut**, both flag-gated (default ON) with the `appStore` reducers retained as the parity-safe fallback.

Follows the Monitors render cut (#2244) + mutation cut (#2249) templates faithfully, adapted to the client-scoped `broadcast@<clientId>` region (like `layout`).

## Render cut (on by default)

- New `broadcast.replace` whole-state intent (twin of `monitor.replace`) keeps the region a faithful mirror of the `appStore` broadcast slice while the reducers stay authoritative.
- New `broadcastBridge.ts` (client-scoped region, seed, faithful-mirror gate) + `useProjectedBroadcast` hook.
- The status-bar pill, tab badges, panel ring/glow, and terminal toolbar now source `active` / `sourceTabId` / membership from the projection **only when it faithfully mirrors** `appStore` (`broadcastViewMirrors`), else fall back verbatim — so output is value-identical to the pre-cut path.
- Gate compares `targetTabIds` as a **set** (order-independent) since the UI reads `.has()` / `.size` / the connected filter, never order.

## Mutation cut (on by default, instant local fallback)

- `startBroadcast` / `stopBroadcast` / `addBroadcastTarget` / `removeBroadcastTarget` / `refreshBroadcastMembership` (delta) mirror their transition through granular `broadcast.*` intents so the store is authoritative. `toggleBroadcast` is covered via its delegation to start/stop.
- Each mirror is best-effort (logged, swallowed) — a backend hiccup never disrupts the local mutation. Flag off ⇒ pure local path (instant rollback).

## What stays frontend

Per the shadow design: scope→tabs resolution (`resolveBroadcastTargetTabIds`), the connected-terminal fan-out filter (`getBroadcastTargetTabIds`), and dynamic-membership recompute (`refreshBroadcastMembership`) — they need the live tab tree the layout machine owns.

## Maintainer decision

Proceed-on-tests: thorough cut-vs-local **parity tests** + instant fallback, no hands-on gate.

## Tests

- Backend: `broadcast.replace` store + projection tests (24 broadcast tests green).
- Frontend: `broadcastBridge.test.ts` (flags, gate, seed round-trip), `useProjectedBroadcast.test.tsx` (render cut: flag-off / flag-on / region-not-caught-up), `appStore.broadcastMutationCut.test.ts` (cut-vs-local parity across every membership action, flag-on and flag-off). Full frontend suite green (4893).

No user-visible change to broadcast behaviour.

Part of #2206
Closes #2242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
