### PR TITLE
feat(workflow): cut workflow-run render + mutations to server authority (Closes #2243)

### DIFF
--- a/src-tauri/src/workflow_projection/mod.rs
+++ b/src-tauri/src/workflow_projection/mod.rs
@@ -34,17 +34,19 @@
 //! client that launched it. A second client viewing the same terminal does not
 //! see or drive this client's run.)
 //!
-//! # Shadow mode — zero user-facing change
+//! # Render + mutation cut landed (#2243)
 //!
-//! This step is deliberately **not authoritative**. The store exists, accepts
-//! `workflow.*` intents, and projects diffs, but nothing in the live UI
-//! subscribes to or renders a `workflow-run` region, and no frontend code
-//! dispatches `workflow.*` intents yet. The existing `appStore` run reducers,
-//! the progress toast, and the output panel remain authoritative. Later steps
-//! cut rendering, then the mutations, over to it (keeping the reducers as the
-//! parity-safe fallback, per the #2205 reframe); the sibling restore-cohort and
-//! broadcast machines migrated as their own steps and keep a clean per-domain
-//! boundary.
+//! The shadow landed the store; the render + mutation cut (frontend
+//! `workflowRunBridge` / `useProjectedWorkflowRun`, both flags on by default) then
+//! made this store authoritative: the Workflow Manager's running badge + output
+//! panel status render from the projected `workflow-run@<clientId>` region when it
+//! faithfully mirrors `appStore`, and the run transitions dispatch the `workflow.*`
+//! intents below. The `appStore` run reducers are **retained as the parity-safe
+//! fallback** (removal is a later step, per the #2205 reframe), so a backend hiccup
+//! degrades to the local path. The transient progress toast stays a frontend
+//! side-effect notification. The step side-effects and streamed output stay
+//! frontend (see below); the sibling restore-cohort and broadcast machines migrated
+//! as their own steps and keep a clean per-domain boundary.
 
 pub mod projection;
 pub mod store;

--- a/src-tauri/src/workflow_projection/projection.rs
+++ b/src-tauri/src/workflow_projection/projection.rs
@@ -45,15 +45,14 @@
 //! (send / macro / local-process execution) likewise stay frontend; the store
 //! learns of progress only through these intents.
 //!
-//! # Shadow mode
+//! # Authoritative after the render + mutation cut (#2243)
 //!
-//! Registered and fully served, but **not** driving the live UI: no frontend
-//! subscribes to `workflow-run@<clientId>` or dispatches `workflow.*` yet, so
-//! these intents mutate only the shadow store and project to regions nobody
-//! renders. The `appStore` run reducers, progress toast, and output panel
-//! remain authoritative. Per the substrate contract the result of an intent is
-//! never returned inline — it always arrives as a projection diff on the
-//! client's region.
+//! Registered, fully served, and now driving the live UI: the frontend subscribes
+//! to `workflow-run@<clientId>` (rendering the run status when it mirrors `appStore`)
+//! and dispatches these `workflow.*` intents so the store is authoritative. The
+//! `appStore` run reducers are retained as the parity-safe fallback (removal is a
+//! later step). Per the substrate contract the result of an intent is never returned
+//! inline — it always arrives as a projection diff on the client's region.
 
 use std::sync::Arc;
 

--- a/src-tauri/src/workflow_projection/store.rs
+++ b/src-tauri/src/workflow_projection/store.rs
@@ -18,13 +18,13 @@
 //! `workflow-run@<clientId>` region per client — mirroring `restore-cohort`,
 //! `broadcast`, and `layout`.
 //!
-//! # Shadow mode — zero user-facing change
+//! # Authoritative after the render + mutation cut (#2243)
 //!
-//! This step is deliberately **not authoritative**. The store exists, accepts
-//! `workflow.*` intents, and projects diffs, but nothing in the live UI
-//! subscribes to or renders a `workflow-run` region, and no frontend code
-//! dispatches `workflow.*` intents yet. The `appStore` run reducers, progress
-//! toast, and output panel remain authoritative.
+//! The shadow landed this store; the frontend render + mutation cut then made it
+//! authoritative — the UI renders the run status from the projected region and
+//! dispatches the `workflow.*` intents. The `appStore` run reducers are retained as
+//! the parity-safe fallback (removal is a later step), so the local path still runs
+//! and takes over on any dispatch failure.
 //!
 //! ## What stays frontend
 //!

--- a/src/components/WorkflowSidebar/WorkflowRunOutput.tsx
+++ b/src/components/WorkflowSidebar/WorkflowRunOutput.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { Loader2, CheckCircle2, XCircle, Ban, X, Square, Terminal } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedWorkflowRun } from "@/store/useProjectedWorkflowRun";
 import { Button, Tooltip } from "@/components/ui";
 import type { WorkflowRunOutputState } from "@/store/appStore";
 import "./WorkflowRunOutput.css";
@@ -45,7 +46,10 @@ function describeOutcome(run: WorkflowRunOutputState): string | null {
  * backend channel. Nothing renders when there is no run output to show.
  */
 export function WorkflowRunOutput() {
-  const run = useAppStore((s) => s.workflowRunOutput);
+  // Render cut (#2243): the panel's identity + status are sourced from the
+  // projected `workflow-run` region when it faithfully mirrors appStore, else from
+  // appStore verbatim; the streamed lines/exitCode/timedOut always stay frontend.
+  const { workflowRunOutput: run } = useProjectedWorkflowRun();
   const dismiss = useAppStore((s) => s.dismissWorkflowRunOutput);
   const cancelRun = useAppStore((s) => s.cancelWorkflowRun);
 

--- a/src/components/WorkflowSidebar/WorkflowSidebar.tsx
+++ b/src/components/WorkflowSidebar/WorkflowSidebar.tsx
@@ -4,6 +4,7 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { save, open } from "@tauri-apps/plugin-dialog";
 import { writeTextFile, readTextFile } from "@tauri-apps/plugin-fs";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedWorkflowRun } from "@/store/useProjectedWorkflowRun";
 import { Button, Input, toast, Tooltip } from "@/components/ui";
 import { ConfirmDeleteDialog } from "@/components/Sidebar/ConfirmDeleteDialog";
 import { useFlatRovingNav } from "@/hooks/useFlatRovingNav";
@@ -71,7 +72,9 @@ export function WorkflowSidebar() {
   const importWorkflows = useAppStore((s) => s.importWorkflows);
   const runWorkflow = useAppStore((s) => s.runWorkflow);
   const cancelWorkflowRun = useAppStore((s) => s.cancelWorkflowRun);
-  const workflowRun = useAppStore((s) => s.workflowRun);
+  // Render cut (#2243): the per-workflow "running" badge reads run progress from
+  // the projected `workflow-run` region when it mirrors appStore, else appStore.
+  const { workflowRun } = useProjectedWorkflowRun();
 
   const [query, setQuery] = useState("");
   // The workflow being edited: an existing one (isNew=false) or a fresh draft.

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -292,6 +292,13 @@ import {
   mirrorRestoreSettle,
   restoreRenderFromProjectionEnabled,
 } from "@/store/restoreCohortBridge";
+import {
+  mirrorWorkflowDismissOutput,
+  mirrorWorkflowOutputOpened,
+  mirrorWorkflowRunSettled,
+  mirrorWorkflowRunStarted,
+  mirrorWorkflowStepAdvanced,
+} from "@/store/workflowRunBridge";
 
 export type SidebarView =
   | "connections"
@@ -7926,6 +7933,10 @@ export const useAppStore = create<AppState>((set, get, store) => {
             timedOut: false,
           },
         });
+        // Mutation + render cut (#2243): mirror the panel open (its status seam)
+        // to the store + region. The streamed lines/exitCode/timedOut stay
+        // frontend (#1865) — the store models only the panel's identity + status.
+        mirrorWorkflowOutputOpened({ workflowId, workflowName: workflow.name, program, args });
 
         // Reuse the exact streamed-output events #1857 already emits (keyed by
         // run id): each line lands in the LogViewer AND the inline surface.
@@ -8017,6 +8028,15 @@ export const useAppStore = create<AppState>((set, get, store) => {
         // recreated lazily only if this run spawns a local process (#1865).
         workflowRunOutput: null,
       });
+      // Mutation + render cut (#2243): mirror the run start to the backend
+      // `WorkflowRunStore` and the render region. Off/failure falls back to the
+      // local reducers, which already ran above.
+      mirrorWorkflowRunStarted({
+        workflowId,
+        workflowName: workflow.name,
+        tabId: targetTabId,
+        total,
+      });
 
       const handle = runWorkflowSteps(
         workflow.steps,
@@ -8030,6 +8050,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
                 ? { workflowRun: { ...s.workflowRun, completed } }
                 : {}
             );
+            // Mutation + render cut (#2243): mirror the progress to the store +
+            // region (guarded server-side to the still-current run).
+            mirrorWorkflowStepAdvanced({ workflowId, tabId: targetTabId, completed });
             toast.loading(`Running workflow "${workflow.name}"…`, {
               id: toastId,
               description: `${completed} / ${stepTotal} steps`,
@@ -8058,6 +8081,13 @@ export const useAppStore = create<AppState>((set, get, store) => {
               }
             : null,
         }));
+        // Mutation + render cut (#2243): mirror the run's terminal outcome to the
+        // store + region (settles the run and stamps the panel status). Only for
+        // the still-current run — matching the `activeWorkflowRun === handle` guard.
+        mirrorWorkflowRunSettled(
+          result.status,
+          result.status === "failed" ? result.error : undefined
+        );
       }
 
       if (result.status === "completed") {
@@ -8085,6 +8115,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
     workflowRunOutput: null,
     dismissWorkflowRunOutput: () => {
       set({ workflowRunOutput: null });
+      // Mutation + render cut (#2243): mirror the dismissal to the store + region.
+      mirrorWorkflowDismissOutput();
     },
 
     localProcessPrompt: null,

--- a/src/store/appStore.workflowRunCut.test.ts
+++ b/src/store/appStore.workflowRunCut.test.ts
@@ -1,0 +1,509 @@
+/**
+ * Workflow-run render + mutation cut (#2243, part of #2206 / #2152 / #2139) —
+ * cut-vs-local parity.
+ *
+ * The cut routes the run transitions (`runStarted` / `stepAdvanced` /
+ * `outputOpened` / `runCompleted` / `runCancelled` / `runFailed` / `dismissOutput`)
+ * through the `workflow.*` intents so the backend `WorkflowRunStore` becomes
+ * authoritative, while the local `appStore` reducers stay in place as the render
+ * source and the resilience / rollback fallback (removal is a later step).
+ *
+ * These tests prove the cut is parity-safe: with the intents flag **on**, the
+ * intents dispatched by `runWorkflow` — applied by a faithful in-memory port of the
+ * Rust store (mirroring `workflow_projection/store.rs`) — reconstruct the
+ * `workflow-run@<clientId>` region whose `run` + `output` status seam match the
+ * local `appStore` slice at every settle. With both flags **off**, no intents are
+ * dispatched — the instant rollback path the flip relies on. The streamed
+ * `lines` / `exitCode` / `timedOut` stay frontend and are never sent.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { LeafPanel, TerminalTab } from "@/types/terminal";
+import type { Workflow, WorkflowStep } from "@/types/workflow";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/workflowApi", () => ({
+  listWorkflows: vi.fn(() => Promise.resolve([])),
+  getWorkflow: vi.fn(),
+  saveWorkflow: vi.fn((w: Workflow) => Promise.resolve(w)),
+  deleteWorkflow: vi.fn(() => Promise.resolve()),
+}));
+
+const invokeRunLocalProcess = vi.fn((_args: { program: string; args: string[] }) =>
+  Promise.resolve({ exitCode: 0 as number | null, timedOut: false, cancelled: false })
+);
+const cancelLocalProcess = vi.fn((_runId: string) => Promise.resolve(true));
+const subscribeLocalProcessOutput = vi.fn((_runId: string, _onChunk: unknown) =>
+  Promise.resolve(() => undefined)
+);
+vi.mock("@/services/localProcessApi", () => ({
+  invokeRunLocalProcess: (args: { program: string; args: string[] }) => invokeRunLocalProcess(args),
+  cancelLocalProcess: (runId: string) => cancelLocalProcess(runId),
+  subscribeLocalProcessOutput: (runId: string, onChunk: unknown) =>
+    subscribeLocalProcessOutput(runId, onChunk),
+}));
+
+import { useAppStore } from "./appStore";
+import {
+  setWorkflowIntentsEnabled,
+  setWorkflowRenderFromProjectionEnabled,
+  setWorkflowTransportForTest,
+} from "./workflowRunBridge";
+import { registerTerminalInputInjector } from "@/services/macroPlayback";
+import { toast } from "@/components/ui";
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+
+// ── In-memory twin of the Rust WorkflowRunStore (client-scoped) ────────────────
+
+interface Run {
+  workflowId: string;
+  workflowName: string;
+  tabId: string;
+  total: number;
+  completed: number;
+}
+interface Output {
+  workflowId: string;
+  workflowName: string;
+  program: string;
+  args: string[];
+  status: "running" | "completed" | "cancelled" | "failed";
+  error: string | null;
+}
+interface ClientState {
+  run: Run | null;
+  output: Output | null;
+}
+interface RegionView {
+  run: Run | null;
+  output: Output | null;
+}
+
+/** A transport double that applies `workflow.*` intents with the same semantics as
+ * the Rust `WorkflowRunStore`, keyed by `clientId`, fanning the client's region
+ * snapshot to subscribers on every mutation. */
+class WorkflowStoreTransport implements Transport {
+  dispatched: Intent[] = [];
+  private clients = new Map<string, ClientState>();
+  private version = 0;
+  private handlers = new Map<string, FrameHandler[]>();
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    this.apply(intent);
+    this.version += 1;
+    this.fan(intent.clientId);
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: this.region(intent.clientId), version: this.version }],
+    };
+  }
+
+  private state(clientId: string): ClientState {
+    let s = this.clients.get(clientId);
+    if (!s) {
+      s = { run: null, output: null };
+      this.clients.set(clientId, s);
+    }
+    return s;
+  }
+
+  private apply(intent: Intent): void {
+    const p = intent.payload as Record<string, unknown>;
+    const s = this.state(intent.clientId);
+    switch (intent.kind) {
+      case "workflow.runStarted": {
+        s.run = {
+          workflowId: p.workflowId as string,
+          workflowName: p.workflowName as string,
+          tabId: p.tabId as string,
+          total: p.total as number,
+          completed: 0,
+        };
+        s.output = null;
+        break;
+      }
+      case "workflow.stepAdvanced": {
+        if (
+          s.run &&
+          s.run.workflowId === (p.workflowId as string) &&
+          s.run.tabId === (p.tabId as string)
+        ) {
+          s.run.completed = p.completed as number;
+        }
+        break;
+      }
+      case "workflow.outputOpened": {
+        s.output = {
+          workflowId: p.workflowId as string,
+          workflowName: p.workflowName as string,
+          program: p.program as string,
+          args: ((p.args as string[] | undefined) ?? []).slice(),
+          status: "running",
+          error: null,
+        };
+        break;
+      }
+      case "workflow.runCompleted":
+        this.finishRun(s, "completed", null);
+        break;
+      case "workflow.runCancelled":
+        this.finishRun(s, "cancelled", null);
+        break;
+      case "workflow.runFailed":
+        this.finishRun(s, "failed", (p.error as string | undefined) ?? null);
+        break;
+      case "workflow.dismissOutput":
+        s.output = null;
+        break;
+      default:
+        break;
+    }
+  }
+
+  private finishRun(
+    s: ClientState,
+    outcome: "completed" | "cancelled" | "failed",
+    error: string | null
+  ): void {
+    if (s.run === null) return; // no active run → leave the panel as-is
+    s.run = null;
+    if (s.output) {
+      s.output.status = outcome;
+      s.output.error = outcome === "failed" ? error : null;
+    }
+  }
+
+  regionView(clientId: string): RegionView {
+    const s = this.state(clientId);
+    return structuredClone({ run: s.run, output: s.output });
+  }
+
+  /** The single client's region view (there is one per-session client id). */
+  onlyRegionView(): RegionView {
+    const [clientId] = [...this.clients.keys()];
+    return this.regionView(clientId ?? "");
+  }
+
+  kinds(): string[] {
+    return this.dispatched.map((i) => i.kind);
+  }
+
+  private region(clientId: string): string {
+    return `workflow-run@${clientId}`;
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    const list = this.handlers.get(region) ?? [];
+    list.push(onFrame);
+    this.handlers.set(region, list);
+    const clientId = region.slice("workflow-run@".length);
+    return {
+      snapshot: this.snapshot(region, clientId),
+      unsubscribe: () => {
+        this.handlers.set(
+          region,
+          (this.handlers.get(region) ?? []).filter((h) => h !== onFrame)
+        );
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string, clientId: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: this.regionView(clientId) };
+  }
+
+  private fan(clientId: string): void {
+    const region = this.region(clientId);
+    const frame: ProjectionFrame = this.snapshot(region, clientId);
+    for (const h of this.handlers.get(region) ?? []) h(frame);
+  }
+}
+
+let transport: WorkflowStoreTransport;
+
+const workflow = (id: string, steps: WorkflowStep[]): Workflow => ({
+  id,
+  name: `Workflow ${id}`,
+  description: "",
+  tags: [],
+  steps,
+  triggers: [{ kind: "manual" }],
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+});
+
+const cmd = (command: string): WorkflowStep => ({ kind: "send-command", command });
+const lp = (program: string, args: string[]): WorkflowStep => ({
+  kind: "run-local-process",
+  program,
+  args,
+});
+
+/** Seed an active, connected terminal tab so a run has a valid target. */
+function seedConnectedTerminal(tabId = "tab-active", sessionId: string | null = "sess-1") {
+  const tab: TerminalTab = {
+    id: tabId,
+    sessionId,
+    title: "term",
+    connectionType: "local",
+    contentType: "terminal",
+    config: { type: "local", config: {} },
+    panelId: "leaf-1",
+    isActive: true,
+  };
+  const leaf: LeafPanel = { type: "leaf", id: "leaf-1", tabs: [tab], activeTabId: tabId };
+  useAppStore.setState({ rootPanel: leaf, activePanelId: "leaf-1", terminalExitedTabs: {} });
+}
+
+/** The `workflow-run` region view that appStore's slice currently projects to —
+ * the local baseline the cut must reproduce. Streamed content is excluded. */
+function appStoreView(): RegionView {
+  const s = useAppStore.getState();
+  return {
+    run: s.workflowRun
+      ? {
+          workflowId: s.workflowRun.workflowId,
+          workflowName: s.workflowRun.workflowName,
+          tabId: s.workflowRun.tabId,
+          total: s.workflowRun.total,
+          completed: s.workflowRun.completed,
+        }
+      : null,
+    output: s.workflowRunOutput
+      ? {
+          workflowId: s.workflowRunOutput.workflowId,
+          workflowName: s.workflowRunOutput.workflowName,
+          program: s.workflowRunOutput.program,
+          args: s.workflowRunOutput.args,
+          status: s.workflowRunOutput.status,
+          error: s.workflowRunOutput.error ?? null,
+        }
+      : null,
+  };
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  vi.clearAllMocks();
+  transport = new WorkflowStoreTransport();
+  setWorkflowTransportForTest(transport);
+  setWorkflowIntentsEnabled(true);
+  setWorkflowRenderFromProjectionEnabled(true);
+  registerTerminalInputInjector(async () => true);
+  vi.spyOn(toast, "error");
+  vi.spyOn(toast, "info");
+  vi.spyOn(toast, "success");
+  vi.spyOn(toast, "loading");
+});
+
+afterEach(() => {
+  registerTerminalInputInjector(null);
+  setWorkflowTransportForTest(null);
+  setWorkflowIntentsEnabled(null);
+  setWorkflowRenderFromProjectionEnabled(null);
+  vi.restoreAllMocks();
+});
+
+describe("workflow-run cut — mutation parity (intents on)", () => {
+  it("a send-command run reconstructs the region matching appStore at settle", async () => {
+    seedConnectedTerminal();
+    useAppStore.setState({
+      workflows: [workflow("w1", [cmd("a"), cmd("b"), cmd("c")])],
+    });
+
+    await useAppStore.getState().runWorkflow("w1");
+    await flush();
+
+    // appStore cleared the run; the store settled the run to null too.
+    expect(appStoreView()).toEqual({ run: null, output: null });
+    expect(transport.onlyRegionView()).toEqual(appStoreView());
+    // The full transition sequence was mirrored (start → 3 steps → completed).
+    expect(transport.kinds()).toEqual([
+      "workflow.runStarted",
+      "workflow.stepAdvanced",
+      "workflow.stepAdvanced",
+      "workflow.stepAdvanced",
+      "workflow.runCompleted",
+    ]);
+  });
+
+  it("mid-run, the projected run progress mirrors appStore step by step", async () => {
+    // Gate the injector so the run is genuinely in flight between steps.
+    let markStarted!: () => void;
+    const started = new Promise<void>((r) => (markStarted = r));
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    let call = 0;
+    registerTerminalInputInjector(async () => {
+      call += 1;
+      if (call === 1) {
+        markStarted();
+        await gate;
+      }
+      return true;
+    });
+    seedConnectedTerminal();
+    useAppStore.setState({ workflows: [workflow("w1", [cmd("a"), cmd("b")])] });
+
+    const done = useAppStore.getState().runWorkflow("w1");
+    await started;
+    await flush();
+
+    // The run is active; the region mirrors appStore's in-flight progress.
+    expect(appStoreView().run).not.toBeNull();
+    expect(transport.onlyRegionView()).toEqual(appStoreView());
+
+    release();
+    await done;
+    await flush();
+    expect(transport.onlyRegionView()).toEqual(appStoreView());
+  });
+
+  it("a run-local-process run mirrors the output-panel status seam (not the stream)", async () => {
+    seedConnectedTerminal();
+    useAppStore.setState({
+      workflows: [workflow("w1", [lp("echo", ["hi"])])],
+      settings: {
+        ...useAppStore.getState().settings,
+        workflowLocalProcessEnabled: true,
+        workflowLocalProcessAllowlist: ["echo"],
+      },
+    });
+
+    await useAppStore.getState().runWorkflow("w1");
+    await flush();
+
+    // The panel persists after the run with its terminal status; the region's
+    // output status seam matches appStore's (identity + status), and the run is
+    // cleared. The streamed lines/exitCode/timedOut are never sent.
+    const view = transport.onlyRegionView();
+    expect(view.run).toBeNull();
+    expect(view.output).not.toBeNull();
+    expect(view.output?.status).toBe("completed");
+    expect(view).toEqual(appStoreView());
+    expect(transport.kinds()).toContain("workflow.outputOpened");
+    expect(transport.kinds()).toContain("workflow.runCompleted");
+  });
+
+  it("a failed run stamps the panel error onto the projected output", async () => {
+    seedConnectedTerminal();
+    // A local process that reports a non-zero exit fails the step → run fails.
+    invokeRunLocalProcess.mockResolvedValueOnce({ exitCode: 1, timedOut: false, cancelled: false });
+    useAppStore.setState({
+      workflows: [workflow("w1", [lp("boom", [])])],
+      settings: {
+        ...useAppStore.getState().settings,
+        workflowLocalProcessEnabled: true,
+        workflowLocalProcessAllowlist: ["boom"],
+      },
+    });
+
+    await useAppStore.getState().runWorkflow("w1");
+    await flush();
+
+    const view = transport.onlyRegionView();
+    expect(view.output?.status).toBe("failed");
+    // Whatever error appStore stamped, the region carries the same one.
+    expect(view).toEqual(appStoreView());
+    expect(transport.kinds()).toContain("workflow.runFailed");
+  });
+
+  it("dismissing the output panel mirrors dismissOutput and clears the region", async () => {
+    seedConnectedTerminal();
+    useAppStore.setState({
+      workflows: [workflow("w1", [lp("echo", ["hi"])])],
+      settings: {
+        ...useAppStore.getState().settings,
+        workflowLocalProcessEnabled: true,
+        workflowLocalProcessAllowlist: ["echo"],
+      },
+    });
+    await useAppStore.getState().runWorkflow("w1");
+    await flush();
+    expect(transport.onlyRegionView().output).not.toBeNull();
+
+    useAppStore.getState().dismissWorkflowRunOutput();
+    await flush();
+
+    expect(useAppStore.getState().workflowRunOutput).toBeNull();
+    expect(transport.onlyRegionView().output).toBeNull();
+    expect(transport.kinds()).toContain("workflow.dismissOutput");
+  });
+});
+
+describe("workflow-run cut — rollback (both flags off)", () => {
+  it("dispatches no intents when render + intents are off; appStore still drives", async () => {
+    setWorkflowIntentsEnabled(false);
+    setWorkflowRenderFromProjectionEnabled(false);
+    seedConnectedTerminal();
+    useAppStore.setState({ workflows: [workflow("w1", [cmd("a"), cmd("b")])] });
+
+    await useAppStore.getState().runWorkflow("w1");
+    await flush();
+
+    expect(transport.dispatched).toEqual([]);
+    // The local reducer path still ran to completion.
+    expect(useAppStore.getState().workflowRun).toBeNull();
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it("render on but intents off still populates the region (render independence)", async () => {
+    setWorkflowIntentsEnabled(false);
+    setWorkflowRenderFromProjectionEnabled(true);
+    seedConnectedTerminal();
+    useAppStore.setState({ workflows: [workflow("w1", [cmd("a")])] });
+
+    await useAppStore.getState().runWorkflow("w1");
+    await flush();
+
+    // The mirror intents are dispatched to keep the render region populated even
+    // with the mutation flag off, and the region matches appStore.
+    expect(transport.kinds().length).toBeGreaterThan(0);
+    expect(transport.onlyRegionView()).toEqual(appStoreView());
+  });
+});

--- a/src/store/useProjectedWorkflowRun.test.tsx
+++ b/src/store/useProjectedWorkflowRun.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * `useProjectedWorkflowRun` — the Workflow Manager cut to the projected
+ * `workflow-run@<clientId>` region (#2243 render cut). Drives the hook against an
+ * in-memory substrate double and asserts: flag-off returns the appStore slice;
+ * flag-on renders run progress + output status from the projection when it mirrors
+ * appStore (byte-identical); a region that has not caught up (diverges from
+ * appStore) falls back to the appStore slice; and the frontend-owned streamed
+ * lines/exitCode/timedOut are always kept from appStore.
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import { useAppStore, type WorkflowRunOutputState, type WorkflowRunState } from "@/store/appStore";
+
+import {
+  dispatchWorkflowIntent,
+  setWorkflowRenderFromProjectionEnabled,
+  setWorkflowTransportForTest,
+  stopWorkflowSubscription,
+} from "./workflowRunBridge";
+import { useProjectedWorkflowRun, type ProjectedWorkflowRunSlice } from "./useProjectedWorkflowRun";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  getSettings: vi.fn(() =>
+    Promise.resolve({ version: "1", externalConnectionFiles: [], powerMonitoringEnabled: true })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn(() => vi.fn()) }));
+
+interface Run {
+  workflowId: string;
+  workflowName: string;
+  tabId: string;
+  total: number;
+  completed: number;
+}
+interface Output {
+  workflowId: string;
+  workflowName: string;
+  program: string;
+  args: string[];
+  status: "running" | "completed" | "cancelled" | "failed";
+  error: string | null;
+}
+interface View {
+  run: Run | null;
+  output: Output | null;
+}
+
+/** In-memory substrate double applying the `workflow.*` intents this test uses. */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  private view: View = { run: null, output: null };
+  private version = 0;
+  private handlers = new Map<string, FrameHandler[]>();
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    const p = intent.payload as Record<string, unknown>;
+    if (intent.kind === "workflow.runStarted") {
+      this.view = {
+        run: {
+          workflowId: p.workflowId as string,
+          workflowName: p.workflowName as string,
+          tabId: p.tabId as string,
+          total: p.total as number,
+          completed: 0,
+        },
+        output: null,
+      };
+    } else if (intent.kind === "workflow.outputOpened") {
+      this.view = {
+        ...this.view,
+        output: {
+          workflowId: p.workflowId as string,
+          workflowName: p.workflowName as string,
+          program: p.program as string,
+          args: ((p.args as string[] | undefined) ?? []).slice(),
+          status: "running",
+          error: null,
+        },
+      };
+    }
+    this.version += 1;
+    this.fan(`workflow-run@${intent.clientId}`);
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: `workflow-run@${intent.clientId}`, version: this.version }],
+    };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    const list = this.handlers.get(region) ?? [];
+    list.push(onFrame);
+    this.handlers.set(region, list);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers.set(
+          region,
+          (this.handlers.get(region) ?? []).filter((h) => h !== onFrame)
+        );
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(region: string): void {
+    const frame: ProjectionFrame = this.snapshot(region);
+    for (const h of this.handlers.get(region) ?? []) h(frame);
+  }
+}
+
+function renderHook(): { get: () => ProjectedWorkflowRunSlice; unmount: () => void } {
+  const container = document.createElement("div");
+  const root: Root = createRoot(container);
+  let latest: ProjectedWorkflowRunSlice = { workflowRun: null, workflowRunOutput: null };
+  function Probe() {
+    latest = useProjectedWorkflowRun();
+    return null;
+  }
+  act(() => root.render(<Probe />));
+  return { get: () => latest, unmount: () => act(() => root.unmount()) };
+}
+
+const run = (over: Partial<WorkflowRunState> = {}): WorkflowRunState => ({
+  workflowId: "w1",
+  workflowName: "Deploy",
+  tabId: "tab-1",
+  total: 3,
+  completed: 0,
+  ...over,
+});
+
+let transport: FakeTransport;
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setWorkflowTransportForTest(transport);
+  useAppStore.setState({ workflowRun: null, workflowRunOutput: null });
+});
+
+afterEach(() => {
+  stopWorkflowSubscription();
+  setWorkflowTransportForTest(null);
+  setWorkflowRenderFromProjectionEnabled(null);
+});
+
+const flush = () => act(async () => await Promise.resolve());
+
+describe("useProjectedWorkflowRun", () => {
+  it("flag off: returns the appStore slice and does not subscribe", async () => {
+    setWorkflowRenderFromProjectionEnabled(false);
+    useAppStore.setState({ workflowRun: run({ completed: 2 }) });
+
+    const hook = renderHook();
+    await flush();
+
+    expect(hook.get().workflowRun?.completed).toBe(2);
+    hook.unmount();
+  });
+
+  it("flag on: renders run progress from the projection when it mirrors appStore", async () => {
+    const r = run();
+    useAppStore.setState({ workflowRun: r });
+    // Populate the region to match appStore's run.
+    await dispatchWorkflowIntent("workflow.runStarted", {
+      workflowId: r.workflowId,
+      workflowName: r.workflowName,
+      tabId: r.tabId,
+      total: r.total,
+    });
+
+    const hook = renderHook();
+    await flush();
+    await flush();
+
+    expect(hook.get().workflowRun).toEqual(r);
+    hook.unmount();
+  });
+
+  it("region diverged from appStore: falls back to the appStore slice", async () => {
+    // Region says total 5; appStore says total 3 → gate rejects, hook shows appStore.
+    await dispatchWorkflowIntent("workflow.runStarted", {
+      workflowId: "w1",
+      workflowName: "Deploy",
+      tabId: "tab-1",
+      total: 5,
+    });
+    useAppStore.setState({ workflowRun: run({ total: 3 }) });
+
+    const hook = renderHook();
+    await flush();
+    await flush();
+
+    expect(hook.get().workflowRun?.total).toBe(3);
+    hook.unmount();
+  });
+
+  it("keeps frontend-owned streamed content while rendering projected status", async () => {
+    const output: WorkflowRunOutputState = {
+      workflowId: "w1",
+      workflowName: "Deploy",
+      program: "echo",
+      args: ["hi"],
+      lines: [{ id: 0, stream: "stdout", text: "hi" }],
+      status: "running",
+      exitCode: null,
+      timedOut: false,
+    };
+    useAppStore.setState({ workflowRunOutput: output });
+    await dispatchWorkflowIntent("workflow.outputOpened", {
+      workflowId: "w1",
+      workflowName: "Deploy",
+      program: "echo",
+      args: ["hi"],
+    });
+
+    const hook = renderHook();
+    await flush();
+    await flush();
+
+    const got = hook.get().workflowRunOutput;
+    // Status + identity from the projection; streamed lines kept from appStore.
+    expect(got?.status).toBe("running");
+    expect(got?.lines).toEqual(output.lines);
+    hook.unmount();
+  });
+});

--- a/src/store/useProjectedWorkflowRun.ts
+++ b/src/store/useProjectedWorkflowRun.ts
@@ -1,0 +1,130 @@
+/**
+ * `useProjectedWorkflowRun` — the Workflow Manager cut to the projected
+ * `workflow-run@<clientId>` region (#2243 render cut, part of #2206 / #2139).
+ *
+ * The Workflow Manager renders a per-workflow "running" badge (from
+ * `appStore.workflowRun`) and the inline run-output panel's live status (from
+ * `appStore.workflowRunOutput`). Through the shadow step both read `appStore`
+ * directly. This hook makes them source the run progress + output-panel status from
+ * the client-scoped `workflow-run` projection region instead — the direct analog of
+ * {@link import("./useProjectedMonitors").useProjectedMonitors} (#2224) and
+ * {@link import("./useLayoutRenderTree").useLayoutRenderTree} (#2151).
+ *
+ * # Safety (strangler)
+ *
+ * - **Gated** by {@link workflowRenderFromProjectionEnabled} (on by default). Flag
+ *   off ⇒ the hook returns `appStore`'s slice verbatim.
+ * - **Faithful-mirror gate.** The projection sources the render only when it mirrors
+ *   the `appStore` run + output status seam ({@link workflowRunMirrors}); otherwise
+ *   the hook falls back to `appStore` (never a stale view). The region is kept
+ *   populated by the `workflow.*` mirror intents the `runWorkflow` reducer dispatches
+ *   whenever either flag is on, so the cut is parity-safe and independent of the
+ *   mutation flag.
+ * - **Streamed output stays frontend.** The projection models only the panel's
+ *   *status* seam; the streamed `lines` / `exitCode` / `timedOut` are kept from
+ *   `appStore` and merged back in when rendering from the region (matching the
+ *   shadow's frontend-owned boundary).
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+import { useAppStore, type WorkflowRunOutputState, type WorkflowRunState } from "@/store/appStore";
+import {
+  currentWorkflowRunView,
+  ensureWorkflowSubscribed,
+  logWorkflowBridgeFallback,
+  onWorkflowRunView,
+  workflowRenderFromProjectionEnabled,
+  workflowRunMirrors,
+  type WorkflowRunView,
+} from "@/store/workflowRunBridge";
+
+/** The effective workflow-run slice for rendering: `workflowRun` (run progress) +
+ * `workflowRunOutput` (the run-output panel). */
+export interface ProjectedWorkflowRunSlice {
+  workflowRun: WorkflowRunState | null;
+  workflowRunOutput: WorkflowRunOutputState | null;
+}
+
+/**
+ * The effective workflow-run slice for rendering, sourced from the projected
+ * `workflow-run@<clientId>` region when it faithfully mirrors `appStore`, otherwise
+ * `appStore`'s slice verbatim (flag off, region not yet caught up, or a transport
+ * that cannot subscribe).
+ *
+ * When rendering from the region, the run progress comes wholly from the projection
+ * (a one-to-one twin), while the output panel merges the projected identity/status
+ * with `appStore`'s frontend-owned streamed `lines` / `exitCode` / `timedOut`.
+ */
+export function useProjectedWorkflowRun(): ProjectedWorkflowRunSlice {
+  const workflowRun = useAppStore((s) => s.workflowRun);
+  const workflowRunOutput = useAppStore((s) => s.workflowRunOutput);
+
+  // Read the flag once at mount: it flips only via dev tooling, and the
+  // subscription lifecycle is keyed off it below.
+  const [enabled] = useState(() => workflowRenderFromProjectionEnabled());
+
+  const [view, setView] = useState<WorkflowRunView | undefined>(undefined);
+
+  // Subscribe to the client-scoped workflow-run region while enabled; a transport
+  // that cannot subscribe (non-Tauri without a socket) just leaves the UI on the
+  // appStore fallback.
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const unsubscribe = onWorkflowRunView((next) => {
+      if (!cancelled) setView(next);
+    });
+    try {
+      ensureWorkflowSubscribed()
+        .then(() => {
+          if (!cancelled) setView(currentWorkflowRunView());
+        })
+        .catch((err) => logWorkflowBridgeFallback("subscribe", err));
+    } catch (err) {
+      logWorkflowBridgeFallback("subscribe", err);
+    }
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [enabled]);
+
+  const outputSeam = workflowRunOutput
+    ? {
+        workflowId: workflowRunOutput.workflowId,
+        workflowName: workflowRunOutput.workflowName,
+        program: workflowRunOutput.program,
+        args: workflowRunOutput.args,
+        status: workflowRunOutput.status,
+        error: workflowRunOutput.error,
+      }
+    : null;
+
+  const matches = enabled && workflowRunMirrors(view, workflowRun, outputSeam);
+
+  return useMemo(() => {
+    if (!matches || !view) {
+      return { workflowRun, workflowRunOutput };
+    }
+    // Render from the region. Run progress is a one-to-one twin; the output panel
+    // takes its identity + status from the projection and keeps the frontend-owned
+    // streamed content from appStore (the gate guarantees these agree, so the merge
+    // is byte-identical to appStore).
+    const projectedOutput: WorkflowRunOutputState | null =
+      view.output && workflowRunOutput
+        ? {
+            workflowId: view.output.workflowId,
+            workflowName: view.output.workflowName,
+            program: view.output.program,
+            args: view.output.args,
+            status: view.output.status,
+            error: view.output.error ?? undefined,
+            lines: workflowRunOutput.lines,
+            exitCode: workflowRunOutput.exitCode,
+            timedOut: workflowRunOutput.timedOut,
+          }
+        : null;
+    return { workflowRun: view.run, workflowRunOutput: projectedOutput };
+  }, [matches, view, workflowRun, workflowRunOutput]);
+}

--- a/src/store/workflowRunBridge.test.ts
+++ b/src/store/workflowRunBridge.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for the workflow-run bridge flags, region id, and faithful-mirror
+ * gate (#2243).
+ *
+ * Behavioural coverage (mirror dispatch, projected rendering, and the local
+ * fallback) lives in `appStore.workflowRunCut.test.ts`, which drives the bridge
+ * through the real `appStore.runWorkflow` action against an in-memory twin of the
+ * Rust store.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+
+import {
+  setWorkflowIntentsEnabled,
+  setWorkflowRenderFromProjectionEnabled,
+  workflowIntentsEnabled,
+  workflowRenderFromProjectionEnabled,
+  workflowRunMirrors,
+  workflowRunRegion,
+  type WorkflowRunOutputStatusSeam,
+  type WorkflowRunView,
+} from "./workflowRunBridge";
+import type { WorkflowRunState } from "./appStore";
+
+interface WorkflowFlagWindow {
+  __TERMIHUB_WORKFLOW_INTENTS__?: boolean;
+  __TERMIHUB_WORKFLOW_RENDER__?: boolean;
+}
+
+afterEach(() => {
+  setWorkflowIntentsEnabled(null);
+  setWorkflowRenderFromProjectionEnabled(null);
+  const w = window as unknown as WorkflowFlagWindow;
+  delete w.__TERMIHUB_WORKFLOW_INTENTS__;
+  delete w.__TERMIHUB_WORKFLOW_RENDER__;
+});
+
+describe("workflowRunBridge flags", () => {
+  it("both flags default on", () => {
+    expect(workflowIntentsEnabled()).toBe(true);
+    expect(workflowRenderFromProjectionEnabled()).toBe(true);
+  });
+
+  it("programmatic overrides win, and null restores the default", () => {
+    setWorkflowIntentsEnabled(false);
+    setWorkflowRenderFromProjectionEnabled(false);
+    expect(workflowIntentsEnabled()).toBe(false);
+    expect(workflowRenderFromProjectionEnabled()).toBe(false);
+
+    setWorkflowIntentsEnabled(null);
+    setWorkflowRenderFromProjectionEnabled(null);
+    expect(workflowIntentsEnabled()).toBe(true);
+    expect(workflowRenderFromProjectionEnabled()).toBe(true);
+  });
+
+  it("a window override flips a flag off (rollback switch)", () => {
+    const w = window as unknown as WorkflowFlagWindow;
+    w.__TERMIHUB_WORKFLOW_INTENTS__ = false;
+    w.__TERMIHUB_WORKFLOW_RENDER__ = false;
+    expect(workflowIntentsEnabled()).toBe(false);
+    expect(workflowRenderFromProjectionEnabled()).toBe(false);
+  });
+});
+
+describe("workflowRunRegion", () => {
+  it("is client-scoped, matching the Rust region id", () => {
+    expect(workflowRunRegion("abc123")).toBe("workflow-run@abc123");
+  });
+});
+
+describe("workflowRunMirrors", () => {
+  const run: WorkflowRunState = {
+    workflowId: "w1",
+    workflowName: "Deploy",
+    tabId: "tab-1",
+    total: 3,
+    completed: 1,
+  };
+  const output: WorkflowRunOutputStatusSeam = {
+    workflowId: "w1",
+    workflowName: "Deploy",
+    program: "echo",
+    args: ["hi", "there"],
+    status: "running",
+  };
+
+  it("is false when no view has arrived", () => {
+    expect(workflowRunMirrors(undefined, run, output)).toBe(false);
+  });
+
+  it("mirrors an exact run + output match", () => {
+    const view: WorkflowRunView = {
+      run: { ...run },
+      output: { ...output, args: ["hi", "there"], error: null },
+    };
+    expect(workflowRunMirrors(view, run, output)).toBe(true);
+  });
+
+  it("mirrors when both halves are absent", () => {
+    expect(workflowRunMirrors({ run: null, output: null }, null, null)).toBe(true);
+  });
+
+  it("does not mirror when progress diverges (region lagging)", () => {
+    const view: WorkflowRunView = { run: { ...run, completed: 0 }, output: null };
+    expect(workflowRunMirrors(view, run, null)).toBe(false);
+  });
+
+  it("does not mirror when the output status diverges", () => {
+    const view: WorkflowRunView = {
+      run: { ...run },
+      output: { ...output, status: "completed" },
+    };
+    expect(workflowRunMirrors(view, run, output)).toBe(false);
+  });
+
+  it("does not mirror when args diverge in order", () => {
+    const view: WorkflowRunView = {
+      run: { ...run },
+      output: { ...output, args: ["there", "hi"] },
+    };
+    expect(workflowRunMirrors(view, run, output)).toBe(false);
+  });
+
+  it("treats projected null error and local undefined error as equal", () => {
+    const failed: WorkflowRunOutputStatusSeam = { ...output, status: "failed" };
+    const view: WorkflowRunView = {
+      run: null,
+      output: { ...output, status: "failed", error: null },
+    };
+    // local error undefined, projected error null → still a mirror.
+    expect(workflowRunMirrors(view, null, failed)).toBe(true);
+    // and a real error string must match.
+    const withError: WorkflowRunView = {
+      run: null,
+      output: { ...output, status: "failed", error: "boom" },
+    };
+    expect(workflowRunMirrors(withError, null, { ...failed, error: "boom" })).toBe(true);
+    expect(workflowRunMirrors(withError, null, failed)).toBe(false);
+  });
+
+  it("does not compare frontend-owned streamed content (lines/exitCode/timedOut)", () => {
+    // The seam carries only identity + status + error; a view that matches those
+    // mirrors regardless of what streamed content appStore holds alongside it.
+    const view: WorkflowRunView = { run: null, output: { ...output } };
+    expect(workflowRunMirrors(view, null, output)).toBe(true);
+  });
+});

--- a/src/store/workflowRunBridge.ts
+++ b/src/store/workflowRunBridge.ts
@@ -1,0 +1,485 @@
+/**
+ * Workflow-run projection bridge — Phase 4 step 5c render + mutation cut of the
+ * workflow-run machine (#2243, part of #2206 / #2152 / #2139).
+ *
+ * The workflow-run **shadow** (PR #2256) landed a backend-authoritative,
+ * client-scoped [`WorkflowRunStore`](../../src-tauri/src/workflow_projection/store.rs)
+ * served as the `workflow-run@<clientId>` projection region, with `workflow.*`
+ * intents (`runStarted` / `stepAdvanced` / `outputOpened` / `runCompleted` /
+ * `runCancelled` / `runFailed` / `dismissOutput`), but nothing in the UI touched
+ * it. This step cuts the live UI over to it — the sibling of the restore-cohort
+ * cut ({@link import("./restoreCohortBridge")}, #2241) and the monitor render +
+ * mutation cuts ({@link import("./systemMonitorBridge")}, #2224).
+ *
+ * Unlike restore-cohort's single fire-once settlement toast, the workflow-run
+ * render surface is **durable rendered state**: the Workflow Manager's per-workflow
+ * "running" badge (from `appStore.workflowRun`) and the inline run-output panel's
+ * live status (from `appStore.workflowRunOutput`). So the render cut is a
+ * declarative one — the direct analog of the monitors/agents cut: a hook
+ * ({@link import("./useProjectedWorkflowRun").useProjectedWorkflowRun}) reads the
+ * projected region and renders from it **only when it faithfully mirrors**
+ * `appStore` ({@link workflowRunMirrors}); otherwise it falls back to `appStore`
+ * verbatim, so the rendered output is byte-identical to the pre-cut path.
+ *
+ * The transient progress toast (`toast.loading` step counter + the terminal
+ * success/info/error toast) stays a **local side-effect notification** fired from
+ * the `runWorkflow` reducer: it is transient feedback threaded through the run's
+ * async loop, not durable projected state, so driving it from the region would add
+ * fragility with no parity benefit. Recorded here as Decision #4/#6 of this cut.
+ *
+ * # Two independent flags, both on by default
+ *
+ * - {@link workflowRenderFromProjectionEnabled} (render cut) — when on, the running
+ *   badge + output-panel status render from the projected region when it mirrors
+ *   `appStore`, else fall back. Parity-safe: the mirror gate guarantees the
+ *   projected view deep-equals the rendered slice.
+ * - {@link workflowIntentsEnabled} (mutation cut) — when on, the run transitions
+ *   dispatch `workflow.*` intents so the backend store is authoritative. The local
+ *   `appStore` reducers stay in place as the render source and the resilience /
+ *   rollback fallback (removal is a later step); a dispatch failure is logged and
+ *   the local mutation continues, so a backend hiccup can never break a run.
+ *
+ * The `workflow.*` mirror intents are dispatched whenever **either** flag is on
+ * ({@link shouldMirrorWorkflow}); that keeps the render cut independent of the
+ * mutation flag (the region is always populated when rendering from it — the same
+ * shared-dispatch model restore-cohort uses). Overridable at runtime for rollback /
+ * tests via `window.__TERMIHUB_WORKFLOW_RENDER__` /
+ * `localStorage["termihub.workflowRender"]` and `window.__TERMIHUB_WORKFLOW_INTENTS__`
+ * / `localStorage["termihub.workflowIntents"]` (set `"false"` to restore the pre-cut
+ * local path).
+ */
+
+import {
+  createTransport,
+  newClientId,
+  newIntentId,
+  ProjectionClient,
+  type IntentAck,
+  type ProjectionCacheState,
+  type Transport,
+} from "@/services/transport";
+import type { WorkflowRunOutputStatus, WorkflowRunState } from "@/store/appStore";
+import { frontendLog } from "@/utils/frontendLog";
+
+/** The projection region id for a client's workflow run
+ * (`workflow-run@<clientId>`, twin of the Rust `workflow_run_region`). */
+export function workflowRunRegion(clientId: string): string {
+  return `workflow-run@${clientId}`;
+}
+
+// ── Projected view model (twin of the Rust store snapshot) ─────────────────────
+
+/** The in-flight run's step-progress, projected by the region — a one-to-one twin
+ * of the frontend {@link WorkflowRunState}. */
+export interface ProjectedWorkflowRun {
+  workflowId: string;
+  workflowName: string;
+  tabId: string;
+  total: number;
+  completed: number;
+}
+
+/** The inline run-output panel's *status* seam, projected by the region. The
+ * streamed `lines` / `exitCode` / `timedOut` stay frontend (see the module docs),
+ * so the projection carries only the panel's identity + status. */
+export interface ProjectedWorkflowRunOutput {
+  workflowId: string;
+  workflowName: string;
+  program: string;
+  args: string[];
+  status: WorkflowRunOutputStatus;
+  /** A human-readable failure reason (`failed` only); `null`/absent otherwise. */
+  error?: string | null;
+}
+
+/** The `workflow-run@<clientId>` region view model: `{ run, output }` (twin of the
+ * Rust `ClientState::to_view`). */
+export interface WorkflowRunView {
+  run: ProjectedWorkflowRun | null;
+  output: ProjectedWorkflowRunOutput | null;
+}
+
+/** The empty view a fresh region reports (twin of the empty store snapshot). */
+const EMPTY_VIEW: WorkflowRunView = { run: null, output: null };
+
+// ── Feature flags (runtime-flippable so a dev build can verify either path) ────
+
+interface WorkflowFlagWindow {
+  __TERMIHUB_WORKFLOW_RENDER__?: boolean;
+  __TERMIHUB_WORKFLOW_INTENTS__?: boolean;
+  localStorage?: Storage;
+}
+
+let renderFlagOverride: boolean | null = null;
+let intentsFlagOverride: boolean | null = null;
+
+/** Programmatic override for the render-cut flag (tests, runtime toggle). `null`
+ * clears it and falls back to the window/localStorage signal, then the default. */
+export function setWorkflowRenderFromProjectionEnabled(value: boolean | null): void {
+  renderFlagOverride = value;
+}
+
+/** Programmatic override for the mutation-cut flag (tests, runtime toggle). */
+export function setWorkflowIntentsEnabled(value: boolean | null): void {
+  intentsFlagOverride = value;
+}
+
+/** Read a boolean feature signal from `window`/`localStorage`, else `dflt`. */
+function readFlag(
+  override: boolean | null,
+  windowKey: keyof WorkflowFlagWindow,
+  storageKey: string,
+  dflt: boolean
+): boolean {
+  if (override !== null) return override;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as WorkflowFlagWindow;
+      const wv = w[windowKey];
+      if (typeof wv === "boolean") return wv;
+      const ls = w.localStorage?.getItem(storageKey);
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return dflt;
+}
+
+/**
+ * Whether the running badge + output-panel status render from the projected
+ * `workflow-run@<clientId>` region instead of straight from `appStore` (render cut).
+ *
+ * **On by default.** Parity-safe: the hook renders from the region only when it
+ * faithfully mirrors `appStore` ({@link workflowRunMirrors}), else falls back to
+ * `appStore` verbatim, so the output is byte-identical to the pre-cut path.
+ * Independent of the mutation cut — the region is populated whenever either flag is
+ * on. Overridable via `window.__TERMIHUB_WORKFLOW_RENDER__` /
+ * `localStorage["termihub.workflowRender"]`.
+ */
+export function workflowRenderFromProjectionEnabled(): boolean {
+  return readFlag(
+    renderFlagOverride,
+    "__TERMIHUB_WORKFLOW_RENDER__",
+    "termihub.workflowRender",
+    true
+  );
+}
+
+/**
+ * Whether the run transitions dispatch `workflow.*` intents so the backend
+ * {@link import("../../src-tauri/src/workflow_projection/store").WorkflowRunStore}
+ * is authoritative (mutation cut).
+ *
+ * **On by default.** The local `appStore` reducers stay in place as the render
+ * source and the resilience / rollback fallback (removal is a later step) — a
+ * dispatch failure is logged and the local mutation continues, so a backend hiccup
+ * can never break a workflow run. Overridable via
+ * `window.__TERMIHUB_WORKFLOW_INTENTS__` / `localStorage["termihub.workflowIntents"]`.
+ */
+export function workflowIntentsEnabled(): boolean {
+  return readFlag(
+    intentsFlagOverride,
+    "__TERMIHUB_WORKFLOW_INTENTS__",
+    "termihub.workflowIntents",
+    true
+  );
+}
+
+/** The `workflow.*` mirror intents are dispatched whenever either flag is on: the
+ * mutation cut needs them for authority, and the render cut needs them to keep the
+ * region populated (making the render cut independent of the mutation flag). */
+function shouldMirrorWorkflow(): boolean {
+  return workflowIntentsEnabled() || workflowRenderFromProjectionEnabled();
+}
+
+// ── Transport + client-scoped region client (lazy, mirrors the layout slice) ───
+
+// A stable per-session client identity. The client-scoped region is
+// `workflow-run@<clientId>`, and dispatched intents carry the same id, so this
+// checkout mutates and subscribes to its own workflow-run region.
+const clientId = newClientId();
+const region = workflowRunRegion(clientId);
+
+let transportInstance: Transport | null = null;
+let regionClient: ProjectionClient | null = null;
+let startPromise: Promise<ProjectionClient> | null = null;
+
+/** Inject a transport for tests; `null` restores the lazily-created real one and
+ * drops any active subscription and cached view. */
+export function setWorkflowTransportForTest(t: Transport | null): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  transportInstance = t;
+  lastView = EMPTY_VIEW;
+}
+
+function transport(): Transport {
+  if (!transportInstance) {
+    transportInstance = createTransport();
+  }
+  return transportInstance;
+}
+
+// ── View fan-out (one subscription, many consuming hooks) ──────────────────────
+
+/** A change listener for the projected `workflow-run` view. */
+export type WorkflowRunViewListener = (view: WorkflowRunView) => void;
+
+const viewListeners = new Set<WorkflowRunViewListener>();
+let lastView: WorkflowRunView = EMPTY_VIEW;
+
+/**
+ * Register a listener, invoked with the projected view on every diff. Returns an
+ * unsubscribe. The region client is started on first {@link ensureWorkflowSubscribed}.
+ */
+export function onWorkflowRunView(listener: WorkflowRunViewListener): () => void {
+  viewListeners.add(listener);
+  return () => viewListeners.delete(listener);
+}
+
+/** The last view fanned out (for a hook that subscribes after the first diff). */
+export function currentWorkflowRunView(): WorkflowRunView {
+  return lastView;
+}
+
+/** Coerce a raw region view to the {@link WorkflowRunView} shape (nulls for absent
+ * halves), so a partial/empty snapshot never leaks `undefined` into the gate. */
+function normalizeView(raw: unknown): WorkflowRunView {
+  const view = (raw ?? EMPTY_VIEW) as Partial<WorkflowRunView>;
+  return { run: view.run ?? null, output: view.output ?? null };
+}
+
+/**
+ * Ensure the `workflow-run@<clientId>` region client is subscribed so projected
+ * diffs are received and fanned out to the {@link onWorkflowRunView} listeners.
+ * Idempotent and de-duplicated across concurrent callers; a transport/subscribe
+ * failure is logged and rethrown so the caller can fall back to `appStore`.
+ */
+export function ensureWorkflowSubscribed(): Promise<ProjectionClient> {
+  if (regionClient) return Promise.resolve(regionClient);
+  if (!startPromise) {
+    const client = new ProjectionClient(transport(), region);
+    client.onChange((state: ProjectionCacheState) => {
+      lastView = normalizeView(state.view);
+      for (const listener of viewListeners) {
+        try {
+          listener(lastView);
+        } catch (err) {
+          logWorkflowBridgeFallback("reconcile", err);
+        }
+      }
+    });
+    startPromise = client
+      .start()
+      .then(() => {
+        regionClient = client;
+        return client;
+      })
+      .catch((err) => {
+        startPromise = null;
+        logWorkflowBridgeFallback("subscribe", err);
+        throw err;
+      });
+  }
+  return startPromise;
+}
+
+/** Drop the region subscription (tests / re-init). */
+export function stopWorkflowSubscription(): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  lastView = EMPTY_VIEW;
+}
+
+// ── Faithful-mirror gate (render cut) ──────────────────────────────────────────
+
+/** Ordered string-array equality (args are position-significant). */
+function sameArgs(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((v, i) => v === b[i]);
+}
+
+/** Whether the projected `run` faithfully mirrors `appStore.workflowRun` — an
+ * exact field-for-field match (both null counts as a mirror). */
+function runMirrors(
+  projected: ProjectedWorkflowRun | null,
+  local: WorkflowRunState | null
+): boolean {
+  if (projected === null || local === null) return projected === null && local === null;
+  return (
+    projected.workflowId === local.workflowId &&
+    projected.workflowName === local.workflowName &&
+    projected.tabId === local.tabId &&
+    projected.total === local.total &&
+    projected.completed === local.completed
+  );
+}
+
+/** Whether the projected `output` faithfully mirrors the *status seam* of
+ * `appStore.workflowRunOutput` — identity + status + error. The streamed
+ * `lines` / `exitCode` / `timedOut` stay frontend and are deliberately not
+ * compared (the store does not model them). `error` is normalised so the store's
+ * `null` and `appStore`'s `undefined` compare equal. */
+function outputMirrors(
+  projected: ProjectedWorkflowRunOutput | null,
+  local: WorkflowRunOutputStatusSeam | null
+): boolean {
+  if (projected === null || local === null) return projected === null && local === null;
+  return (
+    projected.workflowId === local.workflowId &&
+    projected.workflowName === local.workflowName &&
+    projected.program === local.program &&
+    sameArgs(projected.args, local.args) &&
+    projected.status === local.status &&
+    (projected.error ?? null) === (local.error ?? null)
+  );
+}
+
+/** The subset of `appStore.workflowRunOutput` the projection models (its status
+ * seam); the frontend keeps the streamed content alongside it. */
+export interface WorkflowRunOutputStatusSeam {
+  workflowId: string;
+  workflowName: string;
+  program: string;
+  args: string[];
+  status: WorkflowRunOutputStatus;
+  error?: string;
+}
+
+/**
+ * Whether the whole projected view faithfully mirrors `appStore`'s run + output
+ * status seam — the render-cut gate. When true the hook renders from the region
+ * (byte-identical to `appStore`); when false it falls back to `appStore` verbatim
+ * (flag off, region not yet caught up, or a transport that cannot subscribe).
+ */
+export function workflowRunMirrors(
+  view: WorkflowRunView | undefined,
+  run: WorkflowRunState | null,
+  output: WorkflowRunOutputStatusSeam | null
+): boolean {
+  if (!view) return false;
+  return runMirrors(view.run, run) && outputMirrors(view.output, output);
+}
+
+// ── Mutation cut: workflow.* intent dispatch (also seeds the render region) ─────
+
+/** The `workflow.*` intent kinds the cut dispatches (twins of the Rust routes). */
+export type WorkflowIntentKind =
+  | "workflow.runStarted"
+  | "workflow.stepAdvanced"
+  | "workflow.outputOpened"
+  | "workflow.runCompleted"
+  | "workflow.runCancelled"
+  | "workflow.runFailed"
+  | "workflow.dismissOutput";
+
+/** Dispatch a `workflow.*` intent, resolving with the ack (parity tests). */
+export function dispatchWorkflowIntent(
+  kind: WorkflowIntentKind,
+  payload: Record<string, unknown>
+): Promise<IntentAck> {
+  return transport().dispatch({ intentId: newIntentId(), kind, payload, clientId });
+}
+
+/**
+ * Fire a `workflow.*` mirror intent to keep the backend store authoritative and
+ * the render region populated, swallowing and logging any failure so the local
+ * `appStore` mutation path is never disrupted by a bridge hiccup (the resilience
+ * fallback). A no-op when both flags are off (pure rollback). Never throws — a
+ * synchronous transport-construction failure (non-Tauri, no socket) is caught and
+ * logged, leaving the UI on the local slice. Keeps the subscription warm so the
+ * render cut receives the resulting diff.
+ */
+function mirrorWorkflow(kind: WorkflowIntentKind, payload: Record<string, unknown>): void {
+  if (!shouldMirrorWorkflow()) return;
+  // Keep the subscription warm so region diffs reach the render hook. Guarded
+  // because a non-Tauri env without a socket throws *synchronously* from transport
+  // construction (not as a rejection) — the dispatch below then logs + falls back.
+  try {
+    void ensureWorkflowSubscribed().catch(() => {
+      /* logged in ensureWorkflowSubscribed; the local reducer already rendered */
+    });
+  } catch {
+    /* handled by the dispatch try/catch below */
+  }
+  try {
+    void dispatchWorkflowIntent(kind, payload)
+      .then((ack) => {
+        if (ack.status === "rejected") {
+          logWorkflowBridgeFallback(kind, new Error(ack.error?.message ?? "rejected"));
+        }
+      })
+      .catch((err) => logWorkflowBridgeFallback(kind, err));
+  } catch (err) {
+    logWorkflowBridgeFallback(kind, err);
+  }
+}
+
+/** Mirror `workflow.runStarted` (begin a run at `completed == 0`; clears panel). */
+export function mirrorWorkflowRunStarted(payload: {
+  workflowId: string;
+  workflowName: string;
+  tabId: string;
+  total: number;
+}): void {
+  mirrorWorkflow("workflow.runStarted", {
+    workflowId: payload.workflowId,
+    workflowName: payload.workflowName,
+    tabId: payload.tabId,
+    total: payload.total,
+  });
+}
+
+/** Mirror `workflow.stepAdvanced` (update progress when the ids still match). */
+export function mirrorWorkflowStepAdvanced(payload: {
+  workflowId: string;
+  tabId: string;
+  completed: number;
+}): void {
+  mirrorWorkflow("workflow.stepAdvanced", {
+    workflowId: payload.workflowId,
+    tabId: payload.tabId,
+    completed: payload.completed,
+  });
+}
+
+/** Mirror `workflow.outputOpened` (open the run-output panel in `running`). */
+export function mirrorWorkflowOutputOpened(payload: {
+  workflowId: string;
+  workflowName: string;
+  program: string;
+  args: string[];
+}): void {
+  mirrorWorkflow("workflow.outputOpened", {
+    workflowId: payload.workflowId,
+    workflowName: payload.workflowName,
+    program: payload.program,
+    args: payload.args,
+  });
+}
+
+/** Mirror a run's terminal outcome (`completed` / `cancelled` / `failed`). */
+export function mirrorWorkflowRunSettled(status: WorkflowRunOutputStatus, error?: string): void {
+  if (status === "completed") {
+    mirrorWorkflow("workflow.runCompleted", {});
+  } else if (status === "cancelled") {
+    mirrorWorkflow("workflow.runCancelled", {});
+  } else if (status === "failed") {
+    mirrorWorkflow("workflow.runFailed", error !== undefined ? { error } : {});
+  }
+}
+
+/** Mirror `workflow.dismissOutput` (dismiss the run-output panel). */
+export function mirrorWorkflowDismissOutput(): void {
+  mirrorWorkflow("workflow.dismissOutput", {});
+}
+
+/** Log a bridge fallback so the local-path recovery is visible in the LogViewer. */
+export function logWorkflowBridgeFallback(kind: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  frontendLog("workflow_run_bridge", `${kind} fell back to local workflow run: ${message}`);
+}


### PR DESCRIPTION
## Summary

Phase 4 step 5c: cut the in-flight **workflow-run** state machine (#1852 / #1865) over to the shadow `WorkflowRunStore` (PR #2256). The last of #2206's three machine cuts.

- **Render cut** (flag on by default): the Workflow Manager's per-workflow "running" badge and the inline run-output panel's live **status** now render from the projected `workflow-run@<clientId>` region **when it faithfully mirrors `appStore`**, else fall back to `appStore` verbatim — a declarative hook (`useProjectedWorkflowRun`), the direct analog of the monitors/agents render cut. Byte-identical to the pre-cut path (the mirror gate guarantees agreement).
- **Mutation cut** (flag on by default, instant-revert): `runStarted` / `stepAdvanced` / `outputOpened` / `runCompleted` / `runCancelled` / `runFailed` / `dismissOutput` dispatch `workflow.*` intents so the backend store is authoritative. The `appStore` run reducers are **retained as the parity-safe fallback** — a dispatch failure is logged and the local mutation continues, so a backend hiccup can never break a run.
- Both flags are independent and dispatched under a shared `shouldMirrorWorkflow()` gate (restore-cohort's model), so the render cut is independent of the mutation flag. Runtime-flippable via `window.__TERMIHUB_WORKFLOW_RENDER__` / `__TERMIHUB_WORKFLOW_INTENTS__` (or the matching `localStorage` keys) for rollback.
- **Kept frontend** (per the shadow's boundary): the streamed output `lines` / `exitCode` / `timedOut`, and the transient progress toast (a side-effect notification threaded through the run's async loop, not durable projected state). Recorded as Decision #4/#6 in the bridge module docs.

Maintainer decision: **proceed-on-tests**.

## Tests

- `workflowRunBridge.test.ts` — flags, region id, faithful-mirror gate (progress/status/args divergence, null-vs-undefined error, streamed content excluded).
- `appStore.workflowRunCut.test.ts` — cut-vs-local parity: drives the real `appStore.runWorkflow` against an in-memory twin of the Rust store and asserts the reconstructed region matches `appStore` at every settle (send-command, mid-run progress, run-local-process status seam, failed run, dismiss); both-flags-off dispatches nothing; render-on/intents-off still populates the region.
- `useProjectedWorkflowRun.test.tsx` — render-cut hook: flag-off returns `appStore`; flag-on renders from the projection when it mirrors; diverged region falls back; frontend-owned streamed content kept from `appStore`.

Full frontend suite (4914) green; `cargo fmt`/`clippy -D warnings` and the `workflow_projection` Rust tests green.

Part of #2206

Closes #2243