### PR TITLE
feat(backend): shadow settings projection region (#2227)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,6 +65,13 @@ mod session_history;
 /// the ported auto-reconnect engine (#2144). Registered and served but not yet
 /// driving the live UI — see [`session_projection`].
 mod session_projection;
+/// Shadow app-settings authority (#2227, Phase 5 of #2139/#2153): the shared
+/// `settings` projection region + `settings.*` intents modeling the `appStore`
+/// `AppSettings` document (the persisted user-preferences slice behind
+/// `updateSettings` / `saveSettings`), held as an opaque JSON document.
+/// Registered and served but not yet driving the live UI — see
+/// [`settings_projection`].
+mod settings_projection;
 mod spawn;
 /// Shadow system-monitor authority (#2224, Phase 5 of #2139): the shared
 /// `system-monitors` projection region + `monitor.*` intents, built on the
@@ -808,6 +815,19 @@ pub fn run() {
                     &mut registry,
                     app.handle().clone(),
                 );
+                // Shadow SettingsStore (#2227, Phase 5): the shared `settings`
+                // region + `settings.*` intents modeling the `appStore`
+                // `AppSettings` document (the persisted user-preferences slice),
+                // held opaquely as JSON. Managed authoritative state that serves
+                // intents, but nothing in the live UI subscribes to or renders the
+                // region yet — a pure shadow foundation (later steps cut rendering,
+                // then mutations, over to it). The shared region is seeded below
+                // once the store is managed.
+                app.manage(Arc::new(settings_projection::SettingsStore::new()));
+                settings_projection::projection::register_settings_intents(
+                    &mut registry,
+                    app.handle().clone(),
+                );
                 // Test-bridge-only: add the diagnostic region's `diag.*` routes so
                 // the projection-assertion harness (#2164) has a self-contained
                 // region to drive. Never registered in production launches. See
@@ -867,6 +887,17 @@ pub fn run() {
                 {
                     projection_state.projector.register_region(
                         connections_projection::projection::CONNECTIONS_REGION,
+                        store.snapshot(),
+                    );
+                }
+                // Seed the shared `settings` region with the default settings
+                // document at version 0, so a subscriber attaches to a real region
+                // before the first `settings.*` intent (#2227).
+                if let Some(store) =
+                    app.handle().try_state::<Arc<settings_projection::SettingsStore>>()
+                {
+                    projection_state.projector.register_region(
+                        settings_projection::projection::SETTINGS_REGION,
                         store.snapshot(),
                     );
                 }

--- a/src-tauri/src/settings_projection/mod.rs
+++ b/src-tauri/src/settings_projection/mod.rs
@@ -1,0 +1,51 @@
+//! Shadow app-settings authority — Phase 5 of the stateless-UI migration
+//! (#2227, part of #2153 / #2139).
+//!
+//! Moves the app-settings slice the frontend drives in `appStore` (the
+//! `AppSettings` document — `settings` / `savedSettings`, the persisted user
+//! preferences behind `updateSettings` / `saveSettings`) into a Rust authority.
+//! The store owns a single **shared** `settings` projection region (Open Design
+//! Decision #4: `AppSettings` is a single persisted document every client sees)
+//! and serves the `settings.*` intents through the projection substrate
+//! ([`crate::projection`]), mirroring the shared system-monitor
+//! ([`crate::system_monitor_projection`]) and agents
+//! ([`crate::agents_projection`]) shadows.
+//!
+//! # The settings document is modeled opaquely
+//!
+//! `AppSettings` is one large, open-ended JSON document (~50 keys, forward-
+//! compatible: older files omit keys, newer clients add them) that the app loads
+//! and saves as a whole (`get_settings` / `save_settings`, persisted in
+//! [`crate::connection::settings`]). The frontend `AppSettings` (`appStore`'s
+//! authoritative shape) also carries presentation keys the backend's typed
+//! struct does not mirror. So — like the backend already treats `customThemes` /
+//! `syntaxHighlighting` as opaque `serde_json::Value` — this store models the
+//! document as an **opaque JSON object**: it owns the whole-document replace and
+//! shallow-patch semantics `appStore` drives without duplicating (and drifting
+//! from) the 50-field typed struct. This is the coherent core the shadow needs;
+//! per-key typing is neither required by the render/mutation cuts nor desirable.
+//!
+//! # Shared region — Open Design Decision #4 / #6
+//!
+//! `AppSettings` is a single persisted document: in a multi-client world every
+//! client sees the same settings and an edit projects to all (like SSH tunnels,
+//! [`crate::tunnel::projection`], and the shared session-lifecycle region,
+//! [`crate::session_projection`]). The region is therefore a single **shared**
+//! `settings` region. Any device-local preference that should *not* sync (were
+//! one ever carved out) would become a client-scoped presentation region instead
+//! — none exists today, so the whole `AppSettings` document is shared here.
+//!
+//! # Shadow mode — zero user-facing change
+//!
+//! This step is deliberately **not** authoritative. The store exists, accepts
+//! `settings.*` intents, and projects diffs, but nothing in the live UI
+//! subscribes to or renders the `settings` region, and no frontend code
+//! dispatches `settings.*` intents yet. The existing `appStore` `settings` slice
+//! and its `updateSettings` / `saveSettings` persistence remain authoritative.
+//! Later steps cut rendering, then mutation, over to the region, then remove the
+//! `appStore` state.
+
+pub mod projection;
+pub mod store;
+
+pub use store::SettingsStore;

--- a/src-tauri/src/settings_projection/projection.rs
+++ b/src-tauri/src/settings_projection/projection.rs
@@ -1,0 +1,132 @@
+//! Settings projection: the shared `settings` region and the `settings.*`
+//! intents (#2227, part of #2153 / #2139).
+//!
+//! Exposes the authoritative [`SettingsStore`] as one versioned, multi-subscriber
+//! projection region and turns the settings mutations the frontend currently
+//! drives into [`Intent`]s — mirroring the shared system-monitor shadow
+//! ([`crate::system_monitor_projection::projection`]) and agents shadow
+//! ([`crate::agents_projection::projection`]).
+//!
+//! # The `settings` region
+//!
+//! **Shared** (Open Design Decision #4 / #6: `AppSettings` is a single persisted
+//! document every client sees). The view model is the settings document itself —
+//! the frontend `AppSettings` shape (camelCase keys):
+//!
+//! ```json
+//! {
+//!   "version": "1",
+//!   "externalConnectionFiles": [],
+//!   "powerMonitoringEnabled": true,
+//!   "fileBrowserEnabled": true,
+//!   "theme": "dark",
+//!   "fontSize": 14,
+//!   …
+//! }
+//! ```
+//!
+//! # Intents
+//!
+//! | kind               | payload             | effect                                        |
+//! | ------------------ | ------------------- | --------------------------------------------- |
+//! | `settings.replace` | `{ settings: {…} }` | overwrite the whole settings document         |
+//! | `settings.patch`   | `{ patch: {…} }`    | shallow-merge top-level keys into the document |
+//! | `settings.reset`   | `{}`                | reset the document to the default baseline     |
+//!
+//! `replace` mirrors `updateSettings` / `saveSettings` (a whole-document save);
+//! `patch` mirrors the targeted `{ ...current.settings, <field> }` spreads
+//! (`updateShellIntegration`, the layout persists); `reset` resets to defaults.
+//!
+//! # Shadow mode
+//!
+//! Registered and fully served, but **not** driving the live UI: no frontend
+//! subscribes to `settings` or dispatches `settings.*` yet, so these intents
+//! mutate only the shadow store and project to a region nobody renders. The
+//! `appStore` `settings` slice remains authoritative. Per the substrate contract
+//! the result of an intent is never returned inline — it always arrives as a
+//! projection diff on the `settings` region.
+
+use std::sync::Arc;
+
+use serde_json::{Map, Value};
+use tauri::{AppHandle, Manager};
+
+use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
+use crate::settings_projection::store::SettingsStore;
+
+/// The projection region id for the settings domain (shared, per Open Design
+/// Decision #4 / #6).
+pub const SETTINGS_REGION: &str = "settings";
+
+/// Publish the `settings` region from the store, fanning a diff out to every
+/// subscriber and returning the advanced region for the intent ack (empty when
+/// the view did not change).
+pub fn publish_settings(projector: &Projector, store: &SettingsStore) -> Vec<ProducedRegion> {
+    match projector.publish(SETTINGS_REGION, store.snapshot()) {
+        Some(version) => vec![ProducedRegion {
+            region: SETTINGS_REGION.to_string(),
+            version,
+        }],
+        None => Vec::new(),
+    }
+}
+
+/// Register the `settings.*` intents on a handler registry.
+///
+/// Each route resolves the managed [`SettingsStore`] lazily (so it rejects
+/// gracefully rather than panicking if the store is somehow absent), applies the
+/// transition, and publishes the shared region. All transitions are pure/fast
+/// in-memory map edits, so they run inline on the dispatcher's single writer.
+pub fn register_settings_intents(registry: &mut HandlerRegistry, app_handle: AppHandle) {
+    let handle = app_handle.clone();
+    registry.route("settings.replace", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.replace(required_object(intent, "settings")?);
+        Ok(publish_settings(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("settings.patch", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.patch(required_object(intent, "patch")?);
+        Ok(publish_settings(projector, &store))
+    });
+
+    let handle = app_handle;
+    registry.route("settings.reset", move |_intent, projector| {
+        let store = store_of(&handle)?;
+        store.reset();
+        Ok(publish_settings(projector, &store))
+    });
+}
+
+/// Resolve the managed settings store, or a rejectable error if absent.
+fn store_of(app_handle: &AppHandle) -> Result<Arc<SettingsStore>, (String, String)> {
+    app_handle
+        .try_state::<Arc<SettingsStore>>()
+        .map(|state| (*state).clone())
+        .ok_or_else(|| {
+            (
+                "unavailable".to_string(),
+                "settings store is not initialized".to_string(),
+            )
+        })
+}
+
+/// Extract a required JSON-object field from an intent payload (the whole
+/// document for `settings.replace`, the partial for `settings.patch`). A missing
+/// or non-object value is a `bad_payload` rejection that advances nothing.
+fn required_object(intent: &Intent, key: &str) -> Result<Map<String, Value>, (String, String)> {
+    match intent.payload.get(key) {
+        Some(Value::Object(map)) => Ok(map.clone()),
+        Some(_) => Err((
+            "bad_payload".to_string(),
+            format!("'{key}' must be an object"),
+        )),
+        None => Err(("bad_payload".to_string(), format!("missing '{key}'"))),
+    }
+}
+
+#[cfg(test)]
+#[path = "projection_tests.rs"]
+mod tests;

--- a/src-tauri/src/settings_projection/projection_tests.rs
+++ b/src-tauri/src/settings_projection/projection_tests.rs
@@ -1,0 +1,314 @@
+//! Projection-contract tests for the shared `settings` region (#2227), reusing
+//! the substrate harness (#2164): an in-memory [`ProjectionSink`] and a client
+//! cache that applies diffs. The routes here drive a real [`SettingsStore`]
+//! directly (the production `register_settings_intents` resolves the same store
+//! from the Tauri `AppHandle`; that thin wiring is integration-verified via a
+//! local `./scripts/dev.sh` run) through the identical parse → mutate → publish
+//! path.
+//!
+//! Asserted: subscribe → snapshot (identical to every subscriber), an accepted
+//! intent → exactly one coalesced diff fanned to every subscriber with monotonic
+//! versions, rejection paths advance nothing, a no-op intent advances nothing, a
+//! dead subscriber is reaped, and the client cache converges on the store's
+//! authority across a replace → patch → reset lifecycle.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::{json, Map, Value};
+
+use crate::projection::{
+    apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
+    ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
+};
+use crate::settings_projection::projection::{publish_settings, SETTINGS_REGION};
+use crate::settings_projection::store::SettingsStore;
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+/// The production `settings.*` routes, bound to an injected store instead of
+/// resolving one from an `AppHandle` — the exact parse → mutate → publish path
+/// `register_settings_intents` runs. Each closure mirrors the production route so
+/// the test drives real logic, not a stand-in.
+fn registry_for(store: Arc<SettingsStore>) -> HandlerRegistry {
+    let mut registry = HandlerRegistry::new();
+
+    let s = store.clone();
+    registry.route("settings.replace", move |intent, projector| {
+        s.replace(required_object(intent, "settings")?);
+        Ok(publish_settings(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("settings.patch", move |intent, projector| {
+        s.patch(required_object(intent, "patch")?);
+        Ok(publish_settings(projector, &s))
+    });
+    let s = store;
+    registry.route("settings.reset", move |_intent, projector| {
+        s.reset();
+        Ok(publish_settings(projector, &s))
+    });
+
+    registry
+}
+
+/// The route-side object parse — the rejection path shared by replace/patch.
+fn required_object(intent: &Intent, key: &str) -> Result<Map<String, Value>, (String, String)> {
+    match intent.payload.get(key) {
+        Some(Value::Object(map)) => Ok(map.clone()),
+        Some(_) => Err((
+            "bad_payload".to_string(),
+            format!("'{key}' must be an object"),
+        )),
+        None => Err(("bad_payload".to_string(), format!("missing '{key}'"))),
+    }
+}
+
+/// An in-memory sink recording delivered frames; can be killed to simulate a
+/// dead subscriber (mirrors the substrate/agents/session test double).
+struct VecSink {
+    frames: Mutex<Vec<ProjectionFrame>>,
+    alive: AtomicBool,
+}
+
+impl VecSink {
+    fn new() -> Self {
+        Self {
+            frames: Mutex::new(Vec::new()),
+            alive: AtomicBool::new(true),
+        }
+    }
+
+    fn diffs(&self) -> Vec<DiffFrame> {
+        self.frames
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|f| match f {
+                ProjectionFrame::Diff(d) => Some(d.clone()),
+                ProjectionFrame::Snapshot(_) => None,
+            })
+            .collect()
+    }
+}
+
+impl ProjectionSink for VecSink {
+    fn deliver(&self, frame: &ProjectionFrame) -> Result<(), ProjectionError> {
+        if !self.alive.load(Ordering::SeqCst) {
+            return Err(ProjectionError::SinkClosed("killed".into()));
+        }
+        self.frames.lock().unwrap().push(frame.clone());
+        Ok(())
+    }
+}
+
+/// A minimal client cache mirroring the TypeScript `ProjectionClient`.
+struct ClientCache {
+    version: u64,
+    view: Value,
+}
+
+impl ClientCache {
+    fn from_snapshot(s: &SnapshotFrame) -> Self {
+        Self {
+            version: s.version,
+            view: s.view.clone(),
+        }
+    }
+
+    fn apply(&mut self, diff: &DiffFrame) {
+        assert_eq!(diff.base_version, self.version, "diff must fit the cache");
+        apply_ops(&mut self.view, &diff.ops).expect("diff applies cleanly");
+        self.version = diff.version;
+    }
+}
+
+fn intent(kind: &str, payload: Value) -> Intent {
+    Intent {
+        intent_id: format!("01J-{kind}"),
+        kind: kind.to_string(),
+        payload,
+        client_id: "client-1".to_string(),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn subscribe_returns_the_default_snapshot_identically_to_every_subscriber() {
+    let store = Arc::new(SettingsStore::new());
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SETTINGS_REGION, store.snapshot());
+
+    let snap_a = projector.subscribe(SETTINGS_REGION, "sub-a", "A", Arc::new(VecSink::new()));
+    let snap_b = projector.subscribe(SETTINGS_REGION, "sub-b", "B", Arc::new(VecSink::new()));
+
+    assert_eq!(snap_a.version, 0);
+    assert_eq!(snap_a, snap_b, "a late joiner gets an identical baseline");
+    assert_eq!(snap_a.region, "settings");
+    assert_eq!(snap_a.view["version"], json!("1"));
+    assert_eq!(snap_a.view["powerMonitoringEnabled"], json!(true));
+}
+
+#[test]
+fn a_settings_intent_produces_one_diff_fanned_to_two_subscribers() {
+    let store = Arc::new(SettingsStore::new());
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SETTINGS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink_a = Arc::new(VecSink::new());
+    let sink_b = Arc::new(VecSink::new());
+    let snap = projector.subscribe(SETTINGS_REGION, "sub-a", "A", sink_a.clone());
+    projector.subscribe(SETTINGS_REGION, "sub-b", "B", sink_b.clone());
+    let mut cache_a = ClientCache::from_snapshot(&snap);
+
+    let ack = dispatcher.dispatch(intent(
+        "settings.patch",
+        json!({ "patch": { "theme": "light", "fontSize": 16 } }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(
+        ack.produced,
+        Some(vec![crate::projection::ProducedRegion {
+            region: SETTINGS_REGION.to_string(),
+            version: 1,
+        }])
+    );
+
+    let diffs_a = sink_a.diffs();
+    let diffs_b = sink_b.diffs();
+    assert_eq!(diffs_a.len(), 1, "exactly one diff to A");
+    assert_eq!(diffs_b.len(), 1, "exactly one diff to B");
+    assert_eq!(diffs_a[0], diffs_b[0], "identical diff to every subscriber");
+    assert_eq!(diffs_a[0].base_version, 0);
+    assert_eq!(diffs_a[0].version, 1);
+
+    cache_a.apply(&diffs_a[0]);
+    assert_eq!(
+        cache_a.view,
+        store.snapshot(),
+        "cache converges on authority"
+    );
+    assert_eq!(cache_a.view["theme"], json!("light"));
+    assert_eq!(cache_a.view["fontSize"], json!(16));
+}
+
+#[test]
+fn a_full_settings_lifecycle_advances_monotonically_and_converges() {
+    let store = Arc::new(SettingsStore::new());
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SETTINGS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(SETTINGS_REGION, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    // replace (whole save) → patch a field → patch another → reset. Each
+    // accepted intent that changes the view = one diff.
+    for kind_payload in [
+        (
+            "settings.replace",
+            json!({ "settings": { "version": "1", "theme": "dark", "fontSize": 12 } }),
+        ),
+        ("settings.patch", json!({ "patch": { "fontSize": 18 } })),
+        (
+            "settings.patch",
+            json!({ "patch": { "cursorBlink": true } }),
+        ),
+        ("settings.reset", json!({})),
+    ] {
+        let ack = dispatcher.dispatch(intent(kind_payload.0, kind_payload.1));
+        assert_eq!(
+            ack.status,
+            IntentStatus::Accepted,
+            "{} accepted",
+            kind_payload.0
+        );
+    }
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 4, "one diff per view-changing intent");
+    for diff in &diffs {
+        cache.apply(diff);
+    }
+    assert_eq!(cache.version, 4);
+    assert_eq!(cache.view, store.snapshot(), "cache converges on authority");
+    // reset returned the document to the default baseline.
+    assert_eq!(cache.view, SettingsStore::new().snapshot());
+}
+
+#[test]
+fn an_intent_missing_its_object_is_rejected_without_advancing() {
+    let store = Arc::new(SettingsStore::new());
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SETTINGS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(SETTINGS_REGION, "sub", "A", sink.clone());
+
+    // Missing `patch` field.
+    let ack = dispatcher.dispatch(intent("settings.patch", json!({})));
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "bad_payload");
+    // Non-object `settings` field.
+    let ack2 = dispatcher.dispatch(intent("settings.replace", json!({ "settings": "nope" })));
+    assert_eq!(ack2.status, IntentStatus::Rejected);
+    assert_eq!(ack2.error.unwrap().code, "bad_payload");
+
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(SETTINGS_REGION), Some(0));
+}
+
+#[test]
+fn a_no_op_intent_advances_nothing() {
+    // A patch that sets keys to their current values leaves the view unchanged,
+    // so the projector coalesces it to no diff and no version bump.
+    let store = Arc::new(SettingsStore::new());
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SETTINGS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(SETTINGS_REGION, "sub", "A", sink.clone());
+
+    let ack = dispatcher.dispatch(intent(
+        "settings.patch",
+        json!({ "patch": { "powerMonitoringEnabled": true } }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(ack.produced, Some(vec![]), "no region advanced");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(SETTINGS_REGION), Some(0));
+}
+
+#[test]
+fn a_dead_subscriber_is_reaped_on_publish() {
+    let store = Arc::new(SettingsStore::new());
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SETTINGS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let live = Arc::new(VecSink::new());
+    let dead = Arc::new(VecSink::new());
+    projector.subscribe(SETTINGS_REGION, "live", "A", live.clone());
+    projector.subscribe(SETTINGS_REGION, "dead", "B", dead.clone());
+    assert_eq!(projector.subscriber_count(SETTINGS_REGION), 2);
+
+    dead.alive.store(false, Ordering::SeqCst);
+    dispatcher.dispatch(intent(
+        "settings.patch",
+        json!({ "patch": { "theme": "light" } }),
+    ));
+
+    assert_eq!(
+        live.diffs().len(),
+        1,
+        "the live subscriber still gets the diff"
+    );
+    assert_eq!(
+        projector.subscriber_count(SETTINGS_REGION),
+        1,
+        "the dead subscriber was reaped"
+    );
+}

--- a/src-tauri/src/settings_projection/store.rs
+++ b/src-tauri/src/settings_projection/store.rs
@@ -1,0 +1,135 @@
+//! The authoritative, shared app-settings document behind the shadow `settings`
+//! projection region (#2227, Phase 5 of #2139).
+//!
+//! Models the app-settings slice the frontend drives in `appStore` (the
+//! `AppSettings` document behind `settings` / `savedSettings`): a single
+//! persisted preferences document that the app loads once and mutates by
+//! whole-document save (`updateSettings` / `saveSettings`) or targeted field
+//! patch (`updateShellIntegration` and the `{ ...current.settings, layout }`
+//! spreads). The store owns the document as an opaque JSON object so it mirrors
+//! those semantics faithfully without duplicating the large typed struct (see
+//! the module docs, [`super`]).
+//!
+//! # Shared region — Open Design Decision #4 / #6
+//!
+//! `AppSettings` is a single persisted document shared by every client, so the
+//! store holds one document projected into the shared `settings` region. There
+//! is no per-client keying here (contrast the client-scoped `layout` /
+//! `workflow-run` stores): a settings edit projects to all subscribers.
+//!
+//! # Shadow mode — zero user-facing change
+//!
+//! Not yet authoritative: the store accepts `settings.*` intents and projects
+//! diffs, but nothing in the live UI subscribes to or renders the `settings`
+//! region, and no frontend code dispatches `settings.*` intents yet. The
+//! `appStore` `settings` slice remains authoritative.
+
+use std::sync::{Mutex, MutexGuard};
+
+use serde_json::{Map, Value};
+
+/// The frontend `appStore` initial `settings` baseline (`appStore.ts`), used to
+/// seed a fresh store and to service `settings.reset`. Mirrors the default
+/// document a first run starts with, so a fresh subscriber sees the same
+/// defaults the app does. Keys are camelCase — the exact frontend `AppSettings`
+/// view shape.
+fn default_settings_document() -> Map<String, Value> {
+    let mut doc = Map::new();
+    doc.insert("version".to_string(), Value::from("1"));
+    doc.insert(
+        "externalConnectionFiles".to_string(),
+        Value::Array(Vec::new()),
+    );
+    doc.insert("powerMonitoringEnabled".to_string(), Value::Bool(true));
+    doc.insert("fileBrowserEnabled".to_string(), Value::Bool(true));
+    doc.insert("confirmCloseTabOnShortcut".to_string(), Value::Bool(true));
+    doc.insert("confirmCloseLiveSession".to_string(), Value::Bool(true));
+    doc.insert("confirmCloseAttachedTab".to_string(), Value::Bool(true));
+    doc.insert("askOpenSavedFileInTab".to_string(), Value::Bool(true));
+    doc.insert("warnLargePortScan".to_string(), Value::Bool(true));
+    doc.insert("warnLargePingSweep".to_string(), Value::Bool(true));
+    doc
+}
+
+/// The shadow app-settings authority. Owns the single `AppSettings` document as
+/// an opaque JSON object; the shared `settings` region projects it.
+pub struct SettingsStore {
+    /// The whole settings document. One mutex guards it so intents never
+    /// interleave — the substrate's single-writer contract also holds here.
+    settings: Mutex<Map<String, Value>>,
+}
+
+impl Default for SettingsStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SettingsStore {
+    /// A store seeded with the frontend default settings document, so a
+    /// subscriber attaching before the first `settings.*` intent sees the same
+    /// defaults a first-run app does.
+    pub fn new() -> Self {
+        Self {
+            settings: Mutex::new(default_settings_document()),
+        }
+    }
+
+    /// The render-ready view model: the settings document itself (a JSON object).
+    ///
+    /// Pure (never mutates), so the projector can safely diff two consecutive
+    /// snapshots.
+    pub fn snapshot(&self) -> Value {
+        Value::Object(self.lock().clone())
+    }
+
+    /// `settings.replace` — overwrite the whole settings document with a
+    /// caller-supplied one (mirrors `updateSettings` / `saveSettings`, which
+    /// persist and set both `settings` and `savedSettings` to the new object).
+    /// Idempotent server-side: replacing with the same content yields no diff.
+    pub fn replace(&self, settings: Map<String, Value>) {
+        *self.lock() = settings;
+    }
+
+    /// `settings.patch` — shallow-merge a partial document into the current one,
+    /// overwriting or inserting each top-level key (mirrors the frontend
+    /// `{ ...current.settings, <field> }` spreads, e.g. `updateShellIntegration`
+    /// and the layout persists). Merge is shallow, exactly like the JS spread; a
+    /// key present in the patch with a `null` value sets that key to `null`
+    /// (spread semantics — it does not delete). Keys absent from the patch are
+    /// left untouched.
+    pub fn patch(&self, patch: Map<String, Value>) {
+        let mut settings = self.lock();
+        for (key, value) in patch {
+            settings.insert(key, value);
+        }
+    }
+
+    /// `settings.reset` — reset the document to the frontend default baseline
+    /// (mirrors a reset-to-defaults). Idempotent when already at defaults.
+    pub fn reset(&self) {
+        *self.lock() = default_settings_document();
+    }
+
+    /// Read one top-level settings value by key (test / diagnostics helper).
+    #[cfg(test)]
+    pub fn get(&self, key: &str) -> Option<Value> {
+        self.lock().get(key).cloned()
+    }
+
+    /// The document's current top-level key count (test / diagnostics helper).
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.lock().len()
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Map<String, Value>> {
+        // Short critical sections only; a poisoned lock means another thread
+        // panicked mid-mutation (a bug) — recover rather than cascade.
+        self.settings.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod tests;

--- a/src-tauri/src/settings_projection/store_tests.rs
+++ b/src-tauri/src/settings_projection/store_tests.rs
@@ -1,0 +1,113 @@
+//! Unit tests for the shadow [`SettingsStore`] transitions (#2227).
+//!
+//! Drives the store directly and asserts on the serialised view model: the
+//! seeded default document, whole-document replace, shallow patch (insert /
+//! overwrite / null-set / untouched keys), and reset-to-defaults.
+
+use serde_json::{json, Map, Value};
+
+use super::SettingsStore;
+
+/// Extract a `serde_json::Map` from a JSON object literal (test helper).
+fn object(value: Value) -> Map<String, Value> {
+    value.as_object().expect("object literal").clone()
+}
+
+#[test]
+fn a_fresh_store_snapshots_the_default_document() {
+    let store = SettingsStore::new();
+    let snap = store.snapshot();
+    assert_eq!(snap["version"], json!("1"));
+    assert_eq!(snap["externalConnectionFiles"], json!([]));
+    assert_eq!(snap["powerMonitoringEnabled"], json!(true));
+    assert_eq!(snap["fileBrowserEnabled"], json!(true));
+    assert_eq!(snap["confirmCloseTabOnShortcut"], json!(true));
+    assert_eq!(snap["confirmCloseLiveSession"], json!(true));
+    assert_eq!(snap["confirmCloseAttachedTab"], json!(true));
+    assert_eq!(snap["askOpenSavedFileInTab"], json!(true));
+    assert_eq!(snap["warnLargePortScan"], json!(true));
+    assert_eq!(snap["warnLargePingSweep"], json!(true));
+    assert_eq!(store.len(), 10);
+}
+
+#[test]
+fn replace_overwrites_the_whole_document() {
+    let store = SettingsStore::new();
+    store.replace(object(json!({
+        "version": "1",
+        "theme": "solarized-dark",
+        "fontSize": 16,
+        "powerMonitoringEnabled": false,
+    })));
+
+    let snap = store.snapshot();
+    assert_eq!(snap["theme"], json!("solarized-dark"));
+    assert_eq!(snap["fontSize"], json!(16));
+    assert_eq!(snap["powerMonitoringEnabled"], json!(false));
+    // Keys not present in the replacement are gone — replace is a full swap, not
+    // a merge.
+    assert!(snap.get("fileBrowserEnabled").is_none());
+    assert_eq!(store.len(), 4);
+}
+
+#[test]
+fn patch_inserts_and_overwrites_only_the_named_keys() {
+    let store = SettingsStore::new();
+    store.patch(object(json!({
+        "theme": "light",          // insert (absent in the default doc)
+        "fileBrowserEnabled": false, // overwrite an existing key
+    })));
+
+    let snap = store.snapshot();
+    assert_eq!(snap["theme"], json!("light"), "new key inserted");
+    assert_eq!(
+        snap["fileBrowserEnabled"],
+        json!(false),
+        "existing key overwritten"
+    );
+    // Untouched keys survive the shallow merge.
+    assert_eq!(snap["powerMonitoringEnabled"], json!(true));
+    assert_eq!(snap["version"], json!("1"));
+}
+
+#[test]
+fn patch_with_a_null_value_sets_the_key_to_null_not_delete() {
+    // Mirrors the JS `{ ...current, theme: null }` spread, which sets the key to
+    // null rather than removing it.
+    let store = SettingsStore::new();
+    store.patch(object(json!({ "confirmCloseLiveSession": null })));
+    assert_eq!(store.get("confirmCloseLiveSession"), Some(Value::Null));
+    assert!(
+        store
+            .snapshot()
+            .as_object()
+            .unwrap()
+            .contains_key("confirmCloseLiveSession"),
+        "the key is present-but-null, not removed"
+    );
+}
+
+#[test]
+fn an_empty_patch_leaves_the_document_unchanged() {
+    let store = SettingsStore::new();
+    let before = store.snapshot();
+    store.patch(Map::new());
+    assert_eq!(store.snapshot(), before);
+}
+
+#[test]
+fn reset_restores_the_default_document_after_edits() {
+    let store = SettingsStore::new();
+    store.replace(object(json!({ "theme": "light", "fontSize": 20 })));
+    assert_eq!(store.len(), 2);
+
+    store.reset();
+    let snap = store.snapshot();
+    assert_eq!(store.len(), 10, "back to the default key set");
+    assert_eq!(snap["powerMonitoringEnabled"], json!(true));
+    assert!(
+        snap.get("theme").is_none(),
+        "edited keys are gone after reset"
+    );
+    assert_eq!(snap, SettingsStore::new().snapshot());
+}


### PR DESCRIPTION
## Summary

Backend-only **shadow foundation** for the **Settings** domain — Phase 5 of the stateless-UI migration. Adds `src-tauri/src/settings_projection/`: a `SettingsStore` modeling the `appStore` `AppSettings` document, exposed as a single **shared** `settings` projection region plus `settings.*` intents, mirroring the recent shared shadows (system-monitor #2224, agents #2226).

**Zero user-facing change.** Nothing in the live UI subscribes to or renders the region, and no frontend code dispatches `settings.*` intents. `appStore`'s `settings` slice and its `updateSettings` / `saveSettings` persistence remain authoritative. The diff touches only `src-tauri/` — no `src/` changes.

## What the shadow models

The app-settings slice the frontend drives (`appStore` `settings` / `savedSettings` — the persisted `AppSettings` document). `AppSettings` is one large, open-ended, forward-compatible JSON document the app loads and saves as a whole, and the frontend shape carries presentation keys the backend's typed struct doesn't mirror. So — like the backend already treats `customThemes` / `syntaxHighlighting` as opaque `serde_json::Value` — the store models the document **opaquely** (a JSON object), owning the whole-document replace + shallow-patch semantics without duplicating (and drifting from) the ~50-field typed struct. This is the coherent core; per-key typing is neither required by the later render/mutation cuts nor desirable.

### Intents

| kind | payload | effect |
| --- | --- | --- |
| `settings.replace` | `{ settings: {…} }` | overwrite the whole document (mirrors `updateSettings` / `saveSettings`) |
| `settings.patch` | `{ patch: {…} }` | shallow-merge top-level keys (mirrors the `{ ...current.settings, <field> }` spreads, e.g. `updateShellIntegration`) |
| `settings.reset` | `{}` | reset to the default baseline |

## Region scope — Shared (Open Design Decision #4 / #6)

`AppSettings` is a **single persisted document** every client sees: in a multi-client world every client sees the same settings and an edit projects to all — like SSH tunnels and the shared session-lifecycle region. So a single **shared** `settings` region, seeded at version 0 with the frontend default document. Any device-local preference that should *not* sync (were one ever carved out) would become a client-scoped presentation region instead — none exists today, so the whole document is shared here.

## Tests

- **Store unit tests** — default snapshot, whole-document replace, shallow patch (insert / overwrite / null-set / untouched keys), reset-to-defaults.
- **Projection-contract tests** (over the #2164 harness) — subscribe snapshot identical to every subscriber, one coalesced diff fanned to two subscribers with monotonic versions, rejection paths advance nothing, a no-op advances nothing, a dead subscriber is reaped, and the client cache converges across a replace → patch → reset lifecycle.

`cargo test -p termihub settings_projection` (12 pass), `cargo clippy -p termihub --all-targets --all-features -- -D warnings`, and `cargo fmt --all --check` all green locally.

Part of #2227 · Part of #2153 · Part of #2139