### PR TITLE
feat(backend): switch sandbox plugin loader to plugin:// and drop blob: from script-src

### DIFF
--- a/docs/changes/dev0/feature/2266-drop-blob-loader-switch.md
+++ b/docs/changes/dev0/feature/2266-drop-blob-loader-switch.md
@@ -1,0 +1,9 @@
+### Security
+
+- Hardened the Content-Security-Policy: `blob:` is no longer an allowed
+  `script-src`. Frontend plugin code now loads inside its Web Worker sandbox from
+  the app-controlled `plugin://` origin (served already wrapped by the plugin
+  protocol) instead of a `blob:` URL, so the policy no longer needs to permit
+  scripts from `blob:` at all. Frontend plugins continue to work exactly as
+  before; this only removes an execution avenue an injected script could have
+  abused (#2266, completes #2251/#2136).

--- a/docs/concepts/implemented/plugin-system.html
+++ b/docs/concepts/implemented/plugin-system.html
@@ -2593,11 +2593,13 @@ disablePlugin: (pluginId: string) => Promise&lt;void&gt;;</code></pre>
             byte-exact), and status-bar widgets are described declaratively (<code>render()</code>
             returns a serialisable node, not a live element) and materialised by the host through a
             strict tag/attribute allowlist — never <code>innerHTML</code>. Plugin code is loaded into
-            the worker from a <code>blob:</code> URL (still permitted by <code>script-src 'self'
-            blob:</code>, now confined to the worker); dropping <code>blob:</code> from
-            <code>script-src</code> entirely is a tracked follow-up. Earlier versions injected plugin
-            JS as a <code>&lt;script&gt;</code> into the main document (weak, shared-context
-            isolation); that gap is now closed.
+            the worker by <code>importScripts</code>-ing it from the app-controlled
+            <code>plugin://</code> origin (#2251/#2266): the plugin protocol serves each entry point
+            already wrapped in its per-plugin loader IIFE, so no <code>blob:</code> URL is built and
+            <code>script-src</code> no longer permits <code>blob:</code> at all
+            (<code>script-src 'self' plugin://localhost http://plugin.localhost</code>). Earlier
+            versions injected plugin JS as a <code>&lt;script&gt;</code> into the main document (weak,
+            shared-context isolation); that gap is now closed.
           </li>
           <li>
             <strong>File system access</strong>: Plugins requesting <code>filesystem</code>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -354,10 +354,10 @@ pub fn run() {
         .manage(log_buffer)
         // App-controlled origin for installed plugin files (#2251): serves
         // `<app-data>/plugins/<id>/<path>` over `plugin://localhost/<id>/<path>`
-        // (macOS/Linux) / `http://plugin.localhost/...` (Windows). Substrate for
-        // loading frontend plugin code without a `blob:` `script-src` allowance;
-        // the sandbox-worker loader switch + CSP change follow in #2251's next
-        // slice. Fails closed on any bad request (see `plugin_protocol`).
+        // (macOS/Linux) / `http://plugin.localhost/...` (Windows), plus the wrapped
+        // `/load/<id>/<path>` entry-point mode the sandbox worker `importScripts`.
+        // This is what lets frontend plugin code load without a `blob:` `script-src`
+        // allowance (#2266). Fails closed on any bad request (see `plugin_protocol`).
         .register_uri_scheme_protocol(plugin_protocol::PLUGIN_URI_SCHEME, plugin_protocol::handle);
 
     // In test mode (TERMIHUB_TEST_BRIDGE_PORT set), inject the bridge globals into

--- a/src-tauri/src/plugin_protocol.rs
+++ b/src-tauri/src/plugin_protocol.rs
@@ -263,7 +263,12 @@ mod tests {
 
     #[test]
     fn parse_splits_id_and_relative() {
-        assert_parse("/demo/frontend/index.js", "demo", "frontend/index.js", false);
+        assert_parse(
+            "/demo/frontend/index.js",
+            "demo",
+            "frontend/index.js",
+            false,
+        );
     }
 
     #[test]

--- a/src-tauri/src/plugin_protocol.rs
+++ b/src-tauri/src/plugin_protocol.rs
@@ -4,20 +4,29 @@
 //!
 //! # Why this exists
 //!
-//! Frontend plugin JS runs inside a least-privilege Web Worker (#2136). Today the
-//! worker executes each plugin by turning its source into a `blob:` URL and
-//! `importScripts`-ing that — which only works because `script-src` still allows
-//! `blob:`. To drop `blob:` from `script-src`, plugin code has to load from a URL
-//! whose origin already satisfies `script-src`. This protocol provides exactly
-//! that origin: `plugin://localhost/<id>/<relative-path>` (macOS/iOS/Linux) /
+//! Frontend plugin JS runs inside a least-privilege Web Worker (#2136). The worker
+//! executes each plugin by `importScripts`-ing it from this origin, so plugin code
+//! loads from a URL whose origin already satisfies `script-src` — no `blob:`
+//! allowance is needed there any more (#2266). This protocol provides that origin:
+//! `plugin://localhost/<id>/<relative-path>` (macOS/iOS/Linux) /
 //! `http://plugin.localhost/<id>/<relative-path>` (Windows/Android) reads
 //! `<app-data>/plugins/<id>/<relative-path>` and returns its bytes.
 //!
-//! This module is the **substrate only**: registering the scheme and serving the
-//! bytes safely. Switching the sandbox worker's loader onto it, adding the origin
-//! to `script-src`, and finally removing `blob:` are the follow-up slice — until
-//! then this origin is not listed in the CSP, so the webview cannot yet reach it
-//! (the handler is nonetheless fully exercised by the unit tests below).
+//! # Two serving modes
+//!
+//! - **Raw** (`/<id>/<relative>`) returns the file bytes unchanged — for assets a
+//!   plugin references directly (themes, images, worklets).
+//! - **Wrapped** (`/load/<id>/<relative>`) returns a JS entry point already wrapped
+//!   in the per-plugin IIFE that binds `self.__termihubMakePluginApi("<id>")`
+//!   (#2020). This wrapping used to live in the worker (`wrapPluginSource` in TS),
+//!   but building the wrapped string there required a `blob:` URL; moving it
+//!   server-side is what lets `blob:` leave `script-src` (#2266). The wrap is a
+//!   pure prepend/append around the untouched body — exactly what the TS wrapper
+//!   did — so the plugin's own source is never rewritten, only enveloped.
+//!
+//! `load` is a **reserved leading segment**: a raw request whose plugin id is
+//! literally `load` is not reachable, which is acceptable because the raw mode has
+//! no consumer that could name a plugin `load` and request it un-wrapped.
 //!
 //! # Path safety
 //!
@@ -40,8 +49,20 @@ use termihub_core::plugin::{PluginManager, PluginManagerError};
 /// account for when it adds the origin to `script-src`.
 pub const PLUGIN_URI_SCHEME: &str = "plugin";
 
-/// Split a request path (`/<id>/<relative...>`) into the plugin id and the
-/// relative path within that plugin's directory.
+/// The reserved leading path segment that selects the wrapped serving mode.
+const WRAP_SEGMENT: &str = "load";
+
+/// A parsed protocol request: which plugin file to read, and whether to wrap it in
+/// the per-plugin loader IIFE (#2020/#2266).
+struct PluginRequest {
+    id: String,
+    relative: String,
+    /// `true` for a `/load/<id>/<relative>` request — serve the wrapped entry point.
+    wrap: bool,
+}
+
+/// Split a request path into the plugin id, the relative path within that plugin's
+/// directory, and whether the wrapped (`/load/...`) mode was requested.
 ///
 /// Returns `None` when there is no id segment or no relative path (a bare
 /// `plugin://localhost/` or `plugin://localhost/<id>` has nothing to serve). Both
@@ -49,9 +70,22 @@ pub const PLUGIN_URI_SCHEME: &str = "plugin";
 /// decoding is rejected. Traversal is *not* checked here — that is
 /// [`PluginManager::read_file`]'s job, so there is a single source of truth for
 /// containment.
-fn parse_request_path(path: &str) -> Option<(String, String)> {
+fn parse_request_path(path: &str) -> Option<PluginRequest> {
     let trimmed = path.trim_start_matches('/');
-    let (id_enc, rest_enc) = trimmed.split_once('/')?;
+    // A leading `load/` segment selects the wrapped mode; the remainder is the
+    // usual `<id>/<relative>`.
+    let (rest, wrap) = match trimmed.strip_prefix(WRAP_SEGMENT) {
+        Some(after) => match after.strip_prefix('/') {
+            Some(inner) => (inner, true),
+            // `/load` with no trailing slash is a raw request for a plugin whose id
+            // happens to be `load` — but that id is unreachable by design, and a
+            // bare `/load` has no relative path anyway, so it falls through to the
+            // raw split below, which rejects it.
+            None => (trimmed, false),
+        },
+        None => (trimmed, false),
+    };
+    let (id_enc, rest_enc) = rest.split_once('/')?;
     if id_enc.is_empty() || rest_enc.is_empty() {
         return None;
     }
@@ -63,7 +97,33 @@ fn parse_request_path(path: &str) -> Option<(String, String)> {
     if id.is_empty() || relative.is_empty() {
         return None;
     }
-    Some((id, relative))
+    Some(PluginRequest { id, relative, wrap })
+}
+
+/// Wrap a plugin entry point's bytes in the per-plugin loader IIFE (#2020) so the
+/// worker runs it against its **own** `termihub` API instance bound to `id`. This
+/// is the server-side move of the former `wrapPluginSource` TS helper (#2266): the
+/// body is placed unchanged inside the function, with a prefix/suffix around it, so
+/// every register call it makes — sync or from a later timer/promise/event
+/// callback — is attributed to this plugin regardless of load timing.
+///
+/// The output must stay byte-for-byte compatible with the TS wrapper the worker
+/// used to build, so the id is JSON-encoded exactly as `JSON.stringify` would, and
+/// the bridge lookup falls back to the shared global `termihub` when the bridge is
+/// somehow absent.
+fn wrap_plugin_source(id: &str, body: &[u8]) -> Vec<u8> {
+    // `id` is a validated slug (`[a-z0-9-]`), so this never escapes; using
+    // `serde_json` keeps it identical to the TS `JSON.stringify(pluginId)`.
+    let id_json = serde_json::to_string(id).unwrap_or_else(|_| format!("\"{id}\""));
+    let prefix = b"(function (termihub) {\n";
+    let suffix = format!(
+        "\n}})((self.__termihubMakePluginApi ? self.__termihubMakePluginApi({id_json}) : self.termihub));"
+    );
+    let mut out = Vec::with_capacity(prefix.len() + body.len() + suffix.len());
+    out.extend_from_slice(prefix);
+    out.extend_from_slice(body);
+    out.extend_from_slice(suffix.as_bytes());
+    out
 }
 
 /// Best-effort `Content-Type` for a served asset, by file extension. Plugin
@@ -119,16 +179,23 @@ fn empty(status: StatusCode) -> Response<Cow<'static, [u8]>> {
 /// empty error response. This is the testable core of the protocol, independent
 /// of Tauri's request/response plumbing.
 pub fn serve(manager: &PluginManager, uri_path: &str) -> Response<Cow<'static, [u8]>> {
-    let Some((id, relative)) = parse_request_path(uri_path) else {
+    let Some(req) = parse_request_path(uri_path) else {
         return empty(StatusCode::BAD_REQUEST);
     };
 
-    match manager.read_file(&id, &relative) {
-        Ok(bytes) => Response::builder()
-            .status(StatusCode::OK)
-            .header(CONTENT_TYPE, content_type_for(&relative))
-            .body(Cow::Owned(bytes))
-            .unwrap_or_else(|_| empty(StatusCode::INTERNAL_SERVER_ERROR)),
+    match manager.read_file(&req.id, &req.relative) {
+        Ok(bytes) => {
+            let body = if req.wrap {
+                wrap_plugin_source(&req.id, &bytes)
+            } else {
+                bytes
+            };
+            Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, content_type_for(&req.relative))
+                .body(Cow::Owned(body))
+                .unwrap_or_else(|_| empty(StatusCode::INTERNAL_SERVER_ERROR))
+        }
         Err(err) => empty(status_for_error(&err)),
     }
 }
@@ -186,29 +253,50 @@ mod tests {
         resp.body().as_ref()
     }
 
+    /// Assert a parse yields the expected id, relative path and wrap flag.
+    fn assert_parse(path: &str, id: &str, relative: &str, wrap: bool) {
+        let req = parse_request_path(path).expect("request should parse");
+        assert_eq!(req.id, id);
+        assert_eq!(req.relative, relative);
+        assert_eq!(req.wrap, wrap);
+    }
+
     #[test]
     fn parse_splits_id_and_relative() {
-        assert_eq!(
-            parse_request_path("/demo/frontend/index.js"),
-            Some(("demo".into(), "frontend/index.js".into()))
+        assert_parse("/demo/frontend/index.js", "demo", "frontend/index.js", false);
+    }
+
+    #[test]
+    fn parse_load_prefix_selects_wrapped_mode() {
+        assert_parse(
+            "/load/demo/frontend/index.js",
+            "demo",
+            "frontend/index.js",
+            true,
         );
     }
 
     #[test]
     fn parse_percent_decodes_segments() {
         // A space encoded in the path decodes back to the real filename.
-        assert_eq!(
-            parse_request_path("/demo/frontend/my%20file.js"),
-            Some(("demo".into(), "frontend/my file.js".into()))
+        assert_parse(
+            "/demo/frontend/my%20file.js",
+            "demo",
+            "frontend/my file.js",
+            false,
         );
     }
 
     #[test]
     fn parse_rejects_missing_relative_or_id() {
-        assert_eq!(parse_request_path("/"), None);
-        assert_eq!(parse_request_path("/demo"), None);
-        assert_eq!(parse_request_path("/demo/"), None);
-        assert_eq!(parse_request_path("//index.js"), None);
+        assert!(parse_request_path("/").is_none());
+        assert!(parse_request_path("/demo").is_none());
+        assert!(parse_request_path("/demo/").is_none());
+        assert!(parse_request_path("//index.js").is_none());
+        // `/load` and `/load/<id>` (no relative) have nothing to serve.
+        assert!(parse_request_path("/load").is_none());
+        assert!(parse_request_path("/load/demo").is_none());
+        assert!(parse_request_path("/load/demo/").is_none());
     }
 
     #[test]
@@ -226,6 +314,26 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(resp.headers().get(CONTENT_TYPE).unwrap(), "text/javascript");
         assert_eq!(body_bytes(&resp), b"self.termihub = self.termihub;");
+    }
+
+    #[test]
+    fn serve_wrapped_mode_envelopes_the_entry_point() {
+        let (_tmp, manager) = manager_with_demo_plugin();
+        let resp = serve(&manager, "/load/demo/frontend/index.js");
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers().get(CONTENT_TYPE).unwrap(), "text/javascript");
+        // Byte-for-byte identical to the former TS `wrapPluginSource("demo", body)`.
+        let expected = b"(function (termihub) {\nself.termihub = self.termihub;\n})((self.__termihubMakePluginApi ? self.__termihubMakePluginApi(\"demo\") : self.termihub));";
+        assert_eq!(body_bytes(&resp), expected);
+    }
+
+    #[test]
+    fn wrap_plugin_source_matches_ts_wrapper_shape() {
+        // Mirrors `wrapPluginSource` in `src/plugins/sandbox/protocol.ts` before the
+        // logic moved here: `(function (termihub) {\n<body>\n})(<api>);`.
+        let out = wrap_plugin_source("my-plugin", b"registerX();");
+        let expected = "(function (termihub) {\nregisterX();\n})((self.__termihubMakePluginApi ? self.__termihubMakePluginApi(\"my-plugin\") : self.termihub));";
+        assert_eq!(String::from_utf8(out).unwrap(), expected);
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
+      "csp": "default-src 'self'; script-src 'self' plugin://localhost http://plugin.localhost 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
       "dangerousDisableAssetCspModification": ["style-src"]
     }
   },

--- a/src-tauri/tauri.test.conf.json
+++ b/src-tauri/tauri.test.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "app": {
     "security": {
-      "csp": "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
+      "csp": "default-src 'self'; script-src 'self' plugin://localhost http://plugin.localhost 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://127.0.0.1:* ws://localhost:*; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'",
       "dangerousDisableAssetCspModification": ["style-src"]
     }
   }

--- a/src/plugins/frontendPlugins.test.ts
+++ b/src/plugins/frontendPlugins.test.ts
@@ -1,9 +1,10 @@
 /**
- * Tests for the frontend plugin loader (#1998, sandboxed #2136): reading a
- * plugin's JS entry point(s), handing the source to the sandbox host, unloading,
- * and reconciling the loaded set against the active plugin list. Plugin code no
- * longer runs in the main document — it runs in the sandbox worker — so these
- * tests mock the sandbox host and assert the loader drives it correctly.
+ * Tests for the frontend plugin loader (#1998, sandboxed #2136, plugin:// loader
+ * #2266): resolving a plugin's JS entry point(s) to `plugin://` URLs, handing them
+ * to the sandbox host, unloading, and reconciling the loaded set against the
+ * active plugin list. Plugin code no longer runs in the main document — it runs in
+ * the sandbox worker, which `importScripts` the entry-point URLs — so these tests
+ * mock the sandbox host and assert the loader drives it with the right URLs.
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { InstalledPlugin, PluginState } from "@/types/plugin";
@@ -23,6 +24,7 @@ import {
   hasFrontendExtension,
   loadedFrontendPluginIds,
   resetLoadedFrontendPlugins,
+  pluginEntryUrl,
 } from "./frontendPlugins";
 
 /** Build an installed plugin with the given frontend extensions. */
@@ -54,15 +56,28 @@ const parserPlugin = (id: string, state: PluginState = "active", entry = "fronte
     protocolParser: { name: id, description: "d", entryPoint: entry },
   });
 
-const SRC = "/* plugin entry point */";
-
-/** A file reader returning {@link SRC} for any path. */
-const reader = () => vi.fn(async () => new TextEncoder().encode(SRC));
+/** The `plugin://` URL the loader builds for an entry point on non-Windows. */
+const url = (id: string, entry: string) => `plugin://localhost/load/${id}/${entry}`;
 
 beforeEach(() => {
   resetLoadedFrontendPlugins();
   loadPluginInSandbox.mockClear();
   unloadPluginFromSandbox.mockClear();
+});
+
+describe("pluginEntryUrl", () => {
+  it("builds a wrapped-mode plugin:// URL with literal path separators", () => {
+    // jsdom's user agent is not Windows, so the custom-scheme form is used.
+    expect(pluginEntryUrl("p", "frontend/index.js")).toBe(
+      "plugin://localhost/load/p/frontend/index.js"
+    );
+  });
+
+  it("URI-encodes each path segment but keeps the separators literal", () => {
+    expect(pluginEntryUrl("my-plugin", "front end/main file.js")).toBe(
+      "plugin://localhost/load/my-plugin/front%20end/main%20file.js"
+    );
+  });
 });
 
 describe("frontendEntryPoints / hasFrontendExtension", () => {
@@ -91,49 +106,41 @@ describe("frontendEntryPoints / hasFrontendExtension", () => {
 });
 
 describe("loadFrontendPlugin", () => {
-  it("reads the entry point and loads its source into the sandbox", async () => {
-    const read = reader();
-    const errors = await loadFrontendPlugin(parserPlugin("p"), read);
+  it("resolves the entry point to its plugin:// URL and loads it into the sandbox", () => {
+    loadFrontendPlugin(parserPlugin("p"));
 
-    expect(errors).toEqual([]);
-    expect(read).toHaveBeenCalledWith("p", "frontend/index.js");
-    expect(loadPluginInSandbox).toHaveBeenCalledWith("p", [SRC]);
+    expect(loadPluginInSandbox).toHaveBeenCalledWith("p", [url("p", "frontend/index.js")]);
     expect(loadedFrontendPluginIds()).toEqual(["p"]);
   });
 
-  it("does not re-load an already-loaded plugin", async () => {
-    const read = reader();
-    await loadFrontendPlugin(parserPlugin("p"), read);
-    await loadFrontendPlugin(parserPlugin("p"), read);
+  it("does not re-load an already-loaded plugin", () => {
+    loadFrontendPlugin(parserPlugin("p"));
+    loadFrontendPlugin(parserPlugin("p"));
     expect(loadPluginInSandbox).toHaveBeenCalledTimes(1);
-    expect(read).toHaveBeenCalledTimes(1);
   });
 
-  it("collects a read failure as an error and does not load", async () => {
-    const read = vi.fn(async () => {
-      throw new Error("no such file");
-    });
-    const errors = await loadFrontendPlugin(parserPlugin("p"), read);
-    expect(errors).toEqual([
-      { pluginId: "p", entryPoint: "frontend/index.js", message: "no such file" },
-    ]);
+  it("does not touch the sandbox for a plugin with no frontend entry point", () => {
+    loadFrontendPlugin(plugin("t", "active", { theme: { themes: [] } }));
     expect(loadPluginInSandbox).not.toHaveBeenCalled();
     expect(loadedFrontendPluginIds()).toEqual([]);
   });
 
-  it("passes one source per distinct entry point", async () => {
+  it("passes one URL per distinct entry point", () => {
     const p = plugin("p", "active", {
       protocolParser: { name: "p", description: "d", entryPoint: "parser.js" },
       statusBarWidget: { entryPoint: "widget.js", position: "right" },
     });
-    await loadFrontendPlugin(p, reader());
-    expect(loadPluginInSandbox).toHaveBeenCalledWith("p", [SRC, SRC]);
+    loadFrontendPlugin(p);
+    expect(loadPluginInSandbox).toHaveBeenCalledWith("p", [
+      url("p", "parser.js"),
+      url("p", "widget.js"),
+    ]);
   });
 });
 
 describe("unloadFrontendPlugin", () => {
-  it("unloads the plugin from the sandbox and forgets it", async () => {
-    await loadFrontendPlugin(parserPlugin("p"), reader());
+  it("unloads the plugin from the sandbox and forgets it", () => {
+    loadFrontendPlugin(parserPlugin("p"));
     unloadFrontendPlugin("p");
     expect(unloadPluginFromSandbox).toHaveBeenCalledWith("p");
     expect(loadedFrontendPluginIds()).toEqual([]);
@@ -146,61 +153,54 @@ describe("unloadFrontendPlugin", () => {
 });
 
 describe("reconcileFrontendPlugins", () => {
-  it("loads active frontend plugins and skips inactive / theme-only ones", async () => {
+  it("loads active frontend plugins and skips inactive / theme-only ones", () => {
     const plugins = [
       parserPlugin("active-parser", "active"),
       parserPlugin("disabled-parser", "disabled"),
       plugin("theme-only", "active", { theme: { themes: [] } }),
     ];
-    await reconcileFrontendPlugins(plugins, reader());
+    reconcileFrontendPlugins(plugins);
     expect(loadedFrontendPluginIds()).toEqual(["active-parser"]);
   });
 
-  it("unloads a plugin that is no longer active", async () => {
-    await reconcileFrontendPlugins([parserPlugin("p", "active")], reader());
+  it("unloads a plugin that is no longer active", () => {
+    reconcileFrontendPlugins([parserPlugin("p", "active")]);
     expect(loadedFrontendPluginIds()).toEqual(["p"]);
 
-    await reconcileFrontendPlugins([parserPlugin("p", "disabled")], reader());
+    reconcileFrontendPlugins([parserPlugin("p", "disabled")]);
     expect(loadedFrontendPluginIds()).toEqual([]);
     expect(unloadPluginFromSandbox).toHaveBeenCalledWith("p");
   });
 
-  it("is idempotent across repeated reconciles of the same set", async () => {
+  it("is idempotent across repeated reconciles of the same set", () => {
     const plugins = [parserPlugin("p", "active")];
-    const read = reader();
-    await reconcileFrontendPlugins(plugins, read);
-    await reconcileFrontendPlugins(plugins, read);
+    reconcileFrontendPlugins(plugins);
+    reconcileFrontendPlugins(plugins);
     expect(loadPluginInSandbox).toHaveBeenCalledTimes(1);
-    expect(read).toHaveBeenCalledTimes(1);
   });
 
   // Experimental frontend-plugin gate (#2048): the default-off opt-in.
-  it("loads nothing when the experimental gate is disabled", async () => {
-    const read = reader();
-    const errors = await reconcileFrontendPlugins([parserPlugin("p", "active")], read, false);
-    expect(errors).toEqual([]);
-    expect(read).not.toHaveBeenCalled();
+  it("loads nothing when the experimental gate is disabled", () => {
+    reconcileFrontendPlugins([parserPlugin("p", "active")], false);
     expect(loadedFrontendPluginIds()).toEqual([]);
     expect(loadPluginInSandbox).not.toHaveBeenCalled();
   });
 
-  it("unloads already-loaded plugins when the gate is toggled off", async () => {
-    const read = reader();
-    await reconcileFrontendPlugins([parserPlugin("p", "active")], read, true);
+  it("unloads already-loaded plugins when the gate is toggled off", () => {
+    reconcileFrontendPlugins([parserPlugin("p", "active")], true);
     expect(loadedFrontendPluginIds()).toEqual(["p"]);
 
-    await reconcileFrontendPlugins([parserPlugin("p", "active")], read, false);
+    reconcileFrontendPlugins([parserPlugin("p", "active")], false);
     expect(loadedFrontendPluginIds()).toEqual([]);
     expect(unloadPluginFromSandbox).toHaveBeenCalledWith("p");
   });
 
-  it("loads active plugins again when the gate is toggled back on", async () => {
+  it("loads active plugins again when the gate is toggled back on", () => {
     const plugins = [parserPlugin("p", "active")];
-    const read = reader();
-    await reconcileFrontendPlugins(plugins, read, false);
+    reconcileFrontendPlugins(plugins, false);
     expect(loadedFrontendPluginIds()).toEqual([]);
 
-    await reconcileFrontendPlugins(plugins, read, true);
+    reconcileFrontendPlugins(plugins, true);
     expect(loadedFrontendPluginIds()).toEqual(["p"]);
   });
 });

--- a/src/plugins/frontendPlugins.ts
+++ b/src/plugins/frontendPlugins.ts
@@ -41,11 +41,7 @@ const loadedPlugins = new Set<string>();
 export function pluginEntryUrl(pluginId: string, entryPoint: string): string {
   const origin = isWindows() ? "http://plugin.localhost" : "plugin://localhost";
   const id = encodeURIComponent(pluginId);
-  const path = entryPoint
-    .split("/")
-    .filter(Boolean)
-    .map(encodeURIComponent)
-    .join("/");
+  const path = entryPoint.split("/").filter(Boolean).map(encodeURIComponent).join("/");
   return `${origin}/load/${id}/${path}`;
 }
 

--- a/src/plugins/frontendPlugins.ts
+++ b/src/plugins/frontendPlugins.ts
@@ -3,38 +3,51 @@
  * widgets (#1998), now executed inside a least-privilege Web Worker sandbox
  * (#2136).
  *
- * On plugin activation this reads the plugin's declared JS entry point(s) via the
- * injected file reader (the `read_plugin_file` command in the app) and hands the
- * source to the sandbox host ({@link ./sandbox/pluginSandboxHost}), which runs it
- * inside a Worker with no DOM, no `window`, and no Tauri IPC. The worker wraps
- * each entry point so the plugin runs against its **own** per-plugin API instance
- * (bound to that plugin's id), so every register call it makes — synchronous or
- * from a later timer/promise/event callback — is attributed to that plugin and
- * cleanly removed on unload (#2020). On deactivation the plugin is unloaded from
- * the sandbox and its registrations are torn down.
+ * On plugin activation this hands the plugin's declared JS entry point(s) — as
+ * URLs on the app-controlled `plugin://` origin — to the sandbox host ({@link
+ * ./sandbox/pluginSandboxHost}), which `importScripts` them inside a Worker with
+ * no DOM, no `window`, and no Tauri IPC. The protocol serves those URLs in its
+ * wrapped mode, so each entry point arrives already enveloped in the per-plugin
+ * loader IIFE bound to that plugin's id — every register call it makes,
+ * synchronous or from a later timer/promise/event callback, is attributed to that
+ * plugin and cleanly removed on unload (#2020). On deactivation the plugin is
+ * unloaded from the sandbox and its registrations are torn down.
  *
- * This mirrors the theme loader's "enumerate active plugins → read declared
- * files → register into a runtime registry" shape (`src/store/appStore.ts` →
- * `loadActivePluginThemes`, `src/themes/pluginThemes.ts`). It stays free of any
- * Tauri import: file reading is injected, keeping the module unit-testable.
+ * The switch to `plugin://` (#2266) means this module no longer reads plugin files
+ * into strings: the bytes never touch the main thread, and — crucially — loading
+ * from the `plugin://` origin satisfies `script-src` directly, which is what let
+ * `blob:` leave `script-src`. A file that cannot be read now surfaces as an
+ * `importScripts` failure inside the worker (reported back as a `loadError`),
+ * rather than a read rejection here.
  *
- * Concept: `docs/concepts/implemented/plugin-system.html` (§8, §13). Frontend
- * plugin JS runs in a sandbox worker; `blob:` is still used *inside* the worker
- * to run plugin code, and its removal from `script-src` is a tracked follow-up.
+ * Concept: `docs/concepts/implemented/plugin-system.html` (§8, §13).
  */
 
-import type { InstalledPlugin, PluginFileReader } from "@/types/plugin";
+import type { InstalledPlugin } from "@/types/plugin";
+import { isWindows } from "@/utils/platform";
 import { loadPluginInSandbox, unloadPluginFromSandbox } from "./sandbox/pluginSandboxHost";
-
-/** A frontend entry point that failed to load, for surfacing/logging. */
-export interface FrontendPluginLoadError {
-  pluginId: string;
-  entryPoint: string;
-  message: string;
-}
 
 /** Ids of plugins whose frontend entry points are currently loaded in the sandbox. */
 const loadedPlugins = new Set<string>();
+
+/**
+ * Build the `plugin://` URL for a plugin's entry point, in the protocol's wrapped
+ * mode (`/load/<id>/<path>`). The origin form is platform-specific: `plugin://`
+ * (a custom scheme) on macOS/Linux, `http://plugin.localhost` on Windows — the two
+ * forms Tauri assigns and both listed in `script-src`. Each path segment is
+ * URI-encoded but the separators stay literal `/`, matching how the Rust handler
+ * splits the request path (#2251/#2266).
+ */
+export function pluginEntryUrl(pluginId: string, entryPoint: string): string {
+  const origin = isWindows() ? "http://plugin.localhost" : "plugin://localhost";
+  const id = encodeURIComponent(pluginId);
+  const path = entryPoint
+    .split("/")
+    .filter(Boolean)
+    .map(encodeURIComponent)
+    .join("/");
+  return `${origin}/load/${id}/${path}`;
+}
 
 /**
  * The distinct JS entry points a plugin declares across its frontend extensions
@@ -56,39 +69,24 @@ export function hasFrontendExtension(plugin: InstalledPlugin): boolean {
 }
 
 /**
- * Load a single plugin's frontend entry point(s): read each JS file and hand the
- * sources to the sandbox worker to execute. A file that fails to read is
- * collected as an error rather than thrown, so one bad plugin never blocks the
- * rest. No-ops when the plugin is already loaded. When every entry point fails to
- * read, nothing is sent to the sandbox.
+ * Load a single plugin's frontend entry point(s): resolve each declared entry
+ * point to its `plugin://` URL and hand them to the sandbox worker to
+ * `importScripts` and execute. No-ops when the plugin is already loaded or
+ * declares no frontend entry point. A file that cannot be read no longer fails
+ * here — it surfaces as a `loadError` from the worker (the protocol returns 404
+ * and `importScripts` throws), so one bad plugin never blocks the rest.
  */
-export async function loadFrontendPlugin(
-  plugin: InstalledPlugin,
-  readFile: PluginFileReader
-): Promise<FrontendPluginLoadError[]> {
+export function loadFrontendPlugin(plugin: InstalledPlugin): void {
   const pluginId = plugin.manifest.id;
-  if (loadedPlugins.has(pluginId)) return [];
+  if (loadedPlugins.has(pluginId)) return;
 
-  const codes: string[] = [];
-  const errors: FrontendPluginLoadError[] = [];
-  for (const entryPoint of frontendEntryPoints(plugin)) {
-    try {
-      const bytes = await readFile(pluginId, entryPoint);
-      codes.push(new TextDecoder().decode(bytes));
-    } catch (err) {
-      errors.push({
-        pluginId,
-        entryPoint,
-        message: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }
-
-  if (codes.length > 0) {
-    loadPluginInSandbox(pluginId, codes);
+  const entryUrls = frontendEntryPoints(plugin).map((entryPoint) =>
+    pluginEntryUrl(pluginId, entryPoint)
+  );
+  if (entryUrls.length > 0) {
+    loadPluginInSandbox(pluginId, entryUrls);
     loadedPlugins.add(pluginId);
   }
-  return errors;
 }
 
 /**
@@ -104,9 +102,9 @@ export function unloadFrontendPlugin(pluginId: string): void {
 /**
  * Reconcile the sandboxed frontend plugins against the current plugin list: load
  * every *active* plugin that declares a frontend extension and is not yet loaded,
- * and unload every previously-loaded plugin that is no longer active. Returns any
- * load errors, for logging by the caller. This is the single entry point the
- * store calls on every plugin refresh (install/enable/disable).
+ * and unload every previously-loaded plugin that is no longer active. This is the
+ * single entry point the store calls on every plugin refresh
+ * (install/enable/disable).
  *
  * `enabled` is the experimental frontend-plugin opt-in (#2048). Frontend plugins
  * execute untrusted JS, so for v0.1.0 their execution is gated behind an
@@ -114,11 +112,7 @@ export function unloadFrontendPlugin(pluginId: string): void {
  * unloads any already-loaded plugin — toggling the setting off therefore tears
  * the sandbox down live.
  */
-export async function reconcileFrontendPlugins(
-  plugins: InstalledPlugin[],
-  readFile: PluginFileReader,
-  enabled = true
-): Promise<FrontendPluginLoadError[]> {
+export function reconcileFrontendPlugins(plugins: InstalledPlugin[], enabled = true): void {
   const activeIds = new Set(
     enabled
       ? plugins
@@ -131,19 +125,17 @@ export async function reconcileFrontendPlugins(
     if (!activeIds.has(pluginId)) unloadFrontendPlugin(pluginId);
   }
 
-  if (!enabled) return [];
+  if (!enabled) return;
 
-  const errors: FrontendPluginLoadError[] = [];
   for (const plugin of plugins) {
     if (
       plugin.state === "active" &&
       hasFrontendExtension(plugin) &&
       !loadedPlugins.has(plugin.manifest.id)
     ) {
-      errors.push(...(await loadFrontendPlugin(plugin, readFile)));
+      loadFrontendPlugin(plugin);
     }
   }
-  return errors;
 }
 
 /** Ids of the plugins whose frontend entry points are currently loaded (testing/introspection). */

--- a/src/plugins/sandbox/pluginSandboxHost.test.ts
+++ b/src/plugins/sandbox/pluginSandboxHost.test.ts
@@ -66,10 +66,12 @@ const enc = (s: string) => new TextEncoder().encode(s);
 const dec = (b: Uint8Array) => new TextDecoder().decode(b);
 
 describe("worker lifecycle", () => {
-  it("creates the worker on first load and posts the code", () => {
-    loadPluginInSandbox("p", ["/*a*/"]);
+  it("creates the worker on first load and posts the entry URLs", () => {
+    loadPluginInSandbox("p", ["plugin://localhost/load/p/frontend/index.js"]);
     expect(sandboxLoadedCount()).toBe(1);
-    expect(fake.postsOfType("load")).toEqual([{ t: "load", pluginId: "p", codes: ["/*a*/"] }]);
+    expect(fake.postsOfType("load")).toEqual([
+      { t: "load", pluginId: "p", entryUrls: ["plugin://localhost/load/p/frontend/index.js"] },
+    ]);
   });
 
   it("terminates the worker once the last plugin unloads", () => {

--- a/src/plugins/sandbox/pluginSandboxHost.ts
+++ b/src/plugins/sandbox/pluginSandboxHost.ts
@@ -190,11 +190,15 @@ function onWatchdog(): void {
 
 // ─── Host → worker: plugin lifecycle ─────────────────────────────────────────
 
-/** Load a plugin's entry-point source(s) into the sandbox and run them. */
-export function loadPluginInSandbox(pluginId: string, codes: string[]): void {
+/**
+ * Load a plugin's entry point(s) into the sandbox and run them. `entryUrls` are
+ * the plugin's entry points on the app-controlled `plugin://` origin, which the
+ * worker `importScripts` in order (#2266).
+ */
+export function loadPluginInSandbox(pluginId: string, entryUrls: string[]): void {
   ensureWorker();
   loadedPlugins.add(pluginId);
-  post({ t: "load", pluginId, codes });
+  post({ t: "load", pluginId, entryUrls });
 }
 
 /** Unload a plugin from the sandbox; terminates the worker once none remain. */

--- a/src/plugins/sandbox/pluginSandboxWorker.ts
+++ b/src/plugins/sandbox/pluginSandboxWorker.ts
@@ -6,9 +6,11 @@
  * plugin code loaded here cannot reach the host app, the document, or the
  * backend. The worker installs the per-plugin registration API on its own global
  * ({@link ./pluginRuntimeCore.ensureTermiHubApi}), then, for each plugin the host
- * sends, wraps the entry-point source and runs it via a `blob:`-URL
- * `importScripts` — the same CSP-compatible mechanism (`script-src 'self'
- * blob:`) the old main-document loader used, now confined to the worker.
+ * sends, `importScripts` its entry point from the app-controlled `plugin://`
+ * origin (the wrapped `/load/<id>/<path>` mode — the protocol serves it already
+ * enveloped in the per-plugin loader IIFE, #2020/#2266). Loading from that origin
+ * satisfies `script-src` directly, so the worker no longer builds a `blob:` URL
+ * and `blob:` could leave `script-src`.
  *
  * All communication is over `postMessage` per {@link ./protocol}:
  * - plugin registrations become `widgetUpsert` / `parsersActive` messages;
@@ -28,7 +30,6 @@ import {
   transformChunk,
   unregisterPlugin,
 } from "./pluginRuntimeCore";
-import { wrapPluginSource } from "./protocol";
 import type { HostToWorkerMessage, TermiHubPluginAPI, WorkerToHostMessage } from "./protocol";
 
 /** The worker global, typed enough to install the plugin API and post messages. */
@@ -71,19 +72,18 @@ subscribeParsersActive((active) => post({ t: "parsersActive", active }));
 onFrontendLog((entry) => post({ t: "log", message: `${entry.target}: ${entry.message}` }));
 
 /**
- * Run a plugin's entry point inside the sandbox. The source is wrapped so it
- * receives its own per-plugin API instance (#2020) and loaded from a blob URL —
- * creating the URL already requires script execution, so it is not an injection
- * vector, and `script-src 'self' blob:` runs it under the enforced CSP. A syntax
- * or top-level runtime error is reported to the host, never thrown out of the
- * message handler.
+ * Run a plugin's entry point(s) inside the sandbox by `importScripts`-ing each
+ * URL on the app-controlled `plugin://` origin. The protocol serves the wrapped
+ * mode (`/load/<id>/<path>`), so the fetched body already carries the per-plugin
+ * loader IIFE that binds this plugin's own API instance (#2020/#2266) — no `blob:`
+ * URL and no client-side wrapping. Loading from that origin satisfies `script-src`
+ * directly. A failed fetch (missing file → the protocol's 404), syntax error, or
+ * top-level runtime error is reported to the host, never thrown out of the message
+ * handler.
  */
-function loadPlugin(pluginId: string, codes: string[]): void {
-  for (const code of codes) {
-    const wrapped = wrapPluginSource(pluginId, code);
-    let url: string | undefined;
+function loadPlugin(pluginId: string, entryUrls: string[]): void {
+  for (const url of entryUrls) {
     try {
-      url = URL.createObjectURL(new Blob([wrapped], { type: "text/javascript" }));
       (self as unknown as { importScripts(...urls: string[]): void }).importScripts(url);
     } catch (err) {
       post({
@@ -91,8 +91,6 @@ function loadPlugin(pluginId: string, codes: string[]): void {
         pluginId,
         message: err instanceof Error ? err.message : String(err),
       });
-    } finally {
-      if (url) URL.revokeObjectURL(url);
     }
   }
 }
@@ -101,7 +99,7 @@ ctx.addEventListener("message", (e: MessageEvent<HostToWorkerMessage>) => {
   const msg = e.data;
   switch (msg.t) {
     case "load":
-      loadPlugin(msg.pluginId, msg.codes);
+      loadPlugin(msg.pluginId, msg.entryUrls);
       break;
     case "unload":
       unregisterPlugin(msg.pluginId);

--- a/src/plugins/sandbox/protocol.ts
+++ b/src/plugins/sandbox/protocol.ts
@@ -100,16 +100,20 @@ export interface WidgetNode {
 
 // ─── Messages: host → worker ─────────────────────────────────────────────────
 
-/** Load a plugin's entry-point source(s) into the sandbox and run them. */
+/** Load a plugin's entry point(s) into the sandbox and run them. */
 export interface LoadMessage {
   t: "load";
   pluginId: string;
   /**
-   * The plugin's raw entry-point JS, one string per distinct entry point (the
-   * host reads them via Tauri IPC). A plugin declaring both a parser and a widget
-   * from one file yields a single entry; two files yield two, run in order.
+   * The plugin's entry-point URLs on the app-controlled `plugin://` origin — one
+   * per distinct entry point — which the worker `importScripts` in order. Each URL
+   * targets the protocol's wrapped mode (`/load/<id>/<path>`), so the served body
+   * already carries the per-plugin loader IIFE (#2020/#2266); the worker no longer
+   * builds a `blob:` URL, which is what let `blob:` leave `script-src`. A plugin
+   * declaring both a parser and a widget from one file yields a single URL; two
+   * files yield two, run in order.
    */
-  codes: string[];
+  entryUrls: string[];
 }
 
 /** Unload a plugin: dispose its widgets and drop its parsers inside the sandbox. */
@@ -213,23 +217,7 @@ export type WorkerToHostMessage =
   | LoadErrorMessage
   | LogMessage;
 
-/**
- * Wrap a plugin's entry-point source so it runs against its own per-plugin API
- * instance. The plugin body executes inside a function whose `termihub`
- * parameter is the instance bound to `pluginId` (via the
- * `__termihubMakePluginApi` bridge the worker installs on its global). That
- * local `termihub` shadows the shared global, so every register call — sync or
- * from a later timer/promise/event callback — is attributed to this plugin
- * regardless of load timing (#2020). The plugin id is JSON-encoded, so it is
- * safely quoted into the wrapper.
- *
- * The bridge lookup falls back to the shared global `termihub` if the bridge is
- * somehow absent, so evaluating the wrapper can never throw before the plugin
- * body runs.
- */
-export function wrapPluginSource(pluginId: string, code: string): string {
-  const api = `(self.__termihubMakePluginApi ? self.__termihubMakePluginApi(${JSON.stringify(
-    pluginId
-  )}) : self.termihub)`;
-  return `(function (termihub) {\n${code}\n})(${api});`;
-}
+// The per-plugin loader IIFE that used to be built here (`wrapPluginSource`, #2020)
+// now lives server-side in the `plugin://` protocol's wrapped mode
+// (`src-tauri/src/plugin_protocol.rs`), so the worker can `importScripts` an
+// already-wrapped entry point without a `blob:` URL (#2266).

--- a/src/security/cspConfig.test.ts
+++ b/src/security/cspConfig.test.ts
@@ -44,6 +44,23 @@ describe("production CSP (tauri.conf.json)", () => {
     expect(prod["script-src"]).not.toContain("'unsafe-eval'");
   });
 
+  it("no longer allows blob: in script-src — plugin code loads from plugin:// (#2266)", () => {
+    // The sandbox worker used to `importScripts` a `blob:` URL; it now loads each
+    // plugin entry point from the app-controlled `plugin://` origin (served
+    // already-wrapped by the protocol handler), so `blob:` must not remain a
+    // script source. It stays in worker-src/child-src for Monaco/xterm.
+    expect(prod["script-src"]).not.toContain("blob:");
+  });
+
+  it("allows the plugin origin(s) in script-src, in both platform forms (#2266)", () => {
+    // Tauri assigns the custom scheme a different webview origin per platform:
+    // `plugin://localhost` (macOS/iOS/Linux) and `http://plugin.localhost`
+    // (Windows/Android). Both must be listed so the worker's importScripts is
+    // allowed on every platform.
+    expect(prod["script-src"]).toContain("plugin://localhost");
+    expect(prod["script-src"]).toContain("http://plugin.localhost");
+  });
+
   it("allows no WebSocket (ws://) origin in connect-src — the bridge allowance is test-only (#2059)", () => {
     expect(prod["connect-src"]).toBeDefined();
     expect(prod["connect-src"].some((s) => s.startsWith("ws://") || s.startsWith("wss://"))).toBe(
@@ -57,10 +74,10 @@ describe("production CSP (tauri.conf.json)", () => {
   });
 
   it("keeps the Worker sandbox substrate (worker-src / child-src 'self' blob:) available", () => {
-    // Frontend plugins execute in a Web Worker loaded from 'self', running plugin
-    // code from a blob URL inside the worker (#2136). This locks that substrate so
-    // a later CSP tidy-up cannot silently remove it. `blob:` in `script-src`
-    // stays for now — dropping it is the deferred final step of #2136.
+    // Frontend plugins execute in a Web Worker loaded from 'self' (#2136); the
+    // worker itself, and Monaco/xterm's blob workers, still need `blob:` here. This
+    // locks that substrate so a later CSP tidy-up cannot silently remove it —
+    // independently of `script-src`, which no longer carries `blob:` (#2266).
     expect(prod["worker-src"]).toEqual(["'self'", "blob:"]);
     expect(prod["child-src"]).toEqual(["'self'", "blob:"]);
   });

--- a/src/store/appStore.plugins.test.ts
+++ b/src/store/appStore.plugins.test.ts
@@ -11,10 +11,19 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 // Toast hub — assert feedback without real DOM toasts. Declared via vi.hoisted
 // so the (hoisted) vi.mock factory can reference them at init time.
-const { toastSuccess, toastError, toastLoading } = vi.hoisted(() => ({
-  toastSuccess: vi.fn(),
-  toastError: vi.fn(),
-  toastLoading: vi.fn(() => "toast-id"),
+const { toastSuccess, toastError, toastLoading, loadPluginInSandbox, unloadPluginFromSandbox } =
+  vi.hoisted(() => ({
+    toastSuccess: vi.fn(),
+    toastError: vi.fn(),
+    toastLoading: vi.fn(() => "toast-id"),
+    // Mock the sandbox host so the frontend-plugin reconcile is observable without
+    // spinning up a real Web Worker (#2266).
+    loadPluginInSandbox: vi.fn(),
+    unloadPluginFromSandbox: vi.fn(),
+  }));
+vi.mock("@/plugins/sandbox/pluginSandboxHost", () => ({
+  loadPluginInSandbox,
+  unloadPluginFromSandbox,
 }));
 vi.mock("@/components/ui", () => ({
   toast: {
@@ -205,23 +214,19 @@ describe("appStore — plugins (#1993)", () => {
   });
 
   // Frontend-plugin execution is gated behind the experimental opt-in (#2048):
-  // loadPlugins must read `settings.frontendPluginsEnabled` and only read/inject
-  // plugin JS when it is on.
+  // loadPlugins must read `settings.frontendPluginsEnabled` and only load plugin
+  // JS into the sandbox when it is on.
   it("loadPlugins does not execute frontend plugins while the experimental gate is off (#2048)", async () => {
-    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock");
-    vi.spyOn(URL, "revokeObjectURL").mockReturnValue(undefined);
     vi.mocked(apiListPlugins).mockResolvedValueOnce([frontendPlugin("fe")]);
 
     // Default settings leave frontendPluginsEnabled unset (off).
     await useAppStore.getState().loadPlugins();
 
-    expect(readPluginFile).not.toHaveBeenCalled();
+    expect(loadPluginInSandbox).not.toHaveBeenCalled();
     resetLoadedFrontendPlugins();
   });
 
   it("loadPlugins executes frontend plugins once the experimental gate is on (#2048)", async () => {
-    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:mock");
-    vi.spyOn(URL, "revokeObjectURL").mockReturnValue(undefined);
     vi.mocked(apiListPlugins).mockResolvedValueOnce([frontendPlugin("fe")]);
     useAppStore.setState({
       settings: { ...useAppStore.getState().settings, frontendPluginsEnabled: true },
@@ -229,7 +234,11 @@ describe("appStore — plugins (#1993)", () => {
 
     await useAppStore.getState().loadPlugins();
 
-    expect(readPluginFile).toHaveBeenCalledWith("fe", "frontend/index.js");
+    // The plugin's entry point is handed to the sandbox as its `plugin://` URL
+    // (wrapped mode), which the worker importScripts — no `blob:` (#2266).
+    expect(loadPluginInSandbox).toHaveBeenCalledWith("fe", [
+      "plugin://localhost/load/fe/frontend/index.js",
+    ]);
     resetLoadedFrontendPlugins();
   });
 

--- a/src/store/slices/pluginsSlice.ts
+++ b/src/store/slices/pluginsSlice.ts
@@ -154,22 +154,14 @@ export const createPluginsSlice: StateCreator<AppState, [], [], PluginsSlice> = 
       setRegisteredPluginThemes(pluginThemes);
       set({ plugins, pluginBackendTypes: derivePluginBackendTypes(plugins), pluginThemes });
       // Load/unload frontend JS plugins — protocol parsers + status-bar
-      // widgets (#1998). Reconciles the injected scripts against the active
-      // set; individual load failures are logged and skipped. Frontend-plugin
-      // execution is gated behind the experimental opt-in (#2048): when it is
-      // off, reconcile loads nothing and unloads anything already injected.
+      // widgets (#1998). Reconciles the sandbox against the active set: each
+      // plugin's entry point is `importScripts`-ed from the `plugin://` origin,
+      // so a load failure now surfaces as a `loadError` inside the worker (#2266)
+      // rather than here. Frontend-plugin execution is gated behind the
+      // experimental opt-in (#2048): when it is off, reconcile loads nothing and
+      // unloads anything already loaded.
       const frontendEnabled = get().settings.frontendPluginsEnabled ?? false;
-      const frontendErrors = await reconcileFrontendPlugins(
-        plugins,
-        readPluginFile,
-        frontendEnabled
-      );
-      for (const err of frontendErrors) {
-        frontendLog(
-          "app_store",
-          `Skipped frontend plugin ${err.pluginId} (${err.entryPoint}): ${err.message}`
-        );
-      }
+      reconcileFrontendPlugins(plugins, frontendEnabled);
       // Re-apply the active theme: a just-registered plugin theme now takes
       // effect, and a theme whose plugin was disabled/uninstalled falls back
       // to the default (concept edge case).

--- a/tests/system/tests/test_plugin_sandbox.py
+++ b/tests/system/tests/test_plugin_sandbox.py
@@ -53,11 +53,12 @@ class TestFrontendPluginBaseline(PluginsUi, SettingsUi, TerminalUi, SystemTest):
 
     def test_enabling_the_gate_renders_the_widget_with_zero_csp_violations(self):
         # Persist the gate on and restart: startup loadPlugins loads the active
-        # plugin's JS into the sandbox worker (#2136), which runs it from a blob URL
-        # inside the worker. A rendered widget proves the script executed (its
+        # plugin's JS into the sandbox worker (#2136), which importScripts it from
+        # the app-controlled ``plugin://`` origin (#2266) — no ``blob:`` in
+        # ``script-src``. A rendered widget proves the script executed (its
         # render() produced a descriptor the host materialised into the status-bar
-        # span); the CSP sink proves the worker + blob load + that DOM did not trip
-        # the enforced policy.
+        # span); the CSP sink proves the worker + plugin:// load + that DOM did not
+        # trip the enforced policy (which no longer allows ``blob:`` scripts).
         self.enable_frontend_plugins_via_restart()
 
         self.wait(


### PR DESCRIPTION
Completes the plugin sandbox CSP hardening: frontend plugin code no longer loads from a `blob:` URL, so `blob:` is removed from `script-src`.

## What changed

**Server-side wrapping (Rust).** The per-plugin loader IIFE (#2020) moved out of the worker and into the `plugin://` protocol handler (`src-tauri/src/plugin_protocol.rs`). A new **wrapped mode** — `plugin://localhost/load/<id>/<path>` — serves the entry point already enveloped in the IIFE that binds `self.__termihubMakePluginApi("<id>")`, byte-for-byte identical to the old TS `wrapPluginSource`. The raw mode (`/<id>/<path>`) is unchanged. The worker could not build the wrapped string without a `blob:` URL, which is exactly why the wrap had to move server-side.

**Loader switch (TS).** The host→worker `load` contract now carries **entry-point URLs** (`entryUrls`) instead of raw `codes[]`. The worker `importScripts` each `plugin://` URL directly — no `blob:`, no client-side wrapping. `frontendPlugins.ts` stops reading plugin files into strings and instead resolves each entry point to its platform-correct `plugin://` URL; a missing file now surfaces as a `loadError` from the worker (404 → `importScripts` throws) rather than a read rejection. `wrapPluginSource` is deleted from `protocol.ts`.

**CSP (both configs + invariant test).** `script-src` drops `blob:` and gains the plugin origin in **both** platform forms — `plugin://localhost` (macOS/iOS/Linux) and `http://plugin.localhost` (Windows/Android). `worker-src`/`child-src` keep `'self' blob:` for the worker itself and Monaco/xterm. `src/security/cspConfig.test.ts` now asserts `blob:` is gone from `script-src` and both plugin origins are present; the prod/test drift-lock still holds.

The worker isolation, ordered transform pipeline, and widget allowlist (#2250) are untouched.

## Verification

- Rust: `cargo test -p termihub plugin_protocol` (13 pass, incl. wrapped-mode byte-exactness), `clippy -D warnings`, `fmt` clean.
- Frontend: full `src/plugins`, `src/security`, `src/store` plugin suites green; `tsc`, eslint, prettier clean.
- **Production-CSP local run (macOS/WKWebView):** built a CSP-enforced app and ran the `test_plugin_sandbox.py` baseline — the enabled plugin activates, its widget renders and its parser transforms terminal output **in the worker loading via `plugin://`**, with **zero CSP violations** under a `script-src` that no longer contains `blob:`. (Result summarized in a PR comment.)
- Cross-platform CSP risk: the custom-scheme origin may be treated differently by WKWebView vs WebView2 vs webkit2gtk. macOS is verified locally; Windows + Linux rely on CI's 3-platform Run Tests + builds — a CSP break may surface as a runtime/e2e failure rather than a unit failure.

Closes #2266
Part of #2251

Merging this should let **#2251** and **#2136**'s final step close as well — flagging for the coordinator.