### PR TITLE
feat(ui): render the settings screen from the projected settings region

### DIFF
--- a/src/components/Settings/CustomGrammarsSettings.tsx
+++ b/src/components/Settings/CustomGrammarsSettings.tsx
@@ -3,6 +3,7 @@ import { FileCode, Trash2 } from "lucide-react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { readTextFile } from "@tauri-apps/plugin-fs";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { registerCustomGrammars } from "@/utils/monacoCustomLanguages";
 import type { CustomLanguageGrammar } from "@/types/connection";
 import { Button, Tooltip } from "@/components/ui";
@@ -42,7 +43,7 @@ interface ImportDraft {
  * the original file being present after import.
  */
 export function CustomGrammarsSettings({ visibleFields }: CustomGrammarsSettingsProps) {
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
   const updateSettings = useAppStore((s) => s.updateSettings);
 
   const [draft, setDraft] = useState<ImportDraft | null>(null);

--- a/src/components/Settings/ExternalFilesSettings.tsx
+++ b/src/components/Settings/ExternalFilesSettings.tsx
@@ -3,6 +3,7 @@ import { open, save } from "@tauri-apps/plugin-dialog";
 import { writeTextFile } from "@tauri-apps/plugin-fs";
 import { FilePlus2, Plus, Trash2, RefreshCw } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { ExternalFileConfig } from "@/types/connection";
 import { Button, Toggle, Tooltip } from "@/components/ui";
 import { frontendLog } from "@/utils/frontendLog";
@@ -12,7 +13,7 @@ import { SettingsField } from "./SettingsField";
  * External connection file management, extracted from SettingsPanel.
  */
 export function ExternalFilesSettings() {
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
   const updateSettings = useAppStore((s) => s.updateSettings);
   const reloadExternalConnections = useAppStore((s) => s.reloadExternalConnections);
   const [reloading, setReloading] = useState(false);

--- a/src/components/Settings/FileTypeSettings.tsx
+++ b/src/components/Settings/FileTypeSettings.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useMemo } from "react";
 import { Plus, Trash2, RotateCcw, Copy } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { BUILT_IN_FILENAME_MAPPINGS, BUILT_IN_EXTENSION_MAPPINGS } from "@/utils/languageMapping";
 import { getAvailableLanguages } from "@/utils/monacoLanguages";
 import { Button, Tooltip } from "@/components/ui";
@@ -39,7 +40,7 @@ interface FileTypeSettingsProps {
  * User overrides take precedence over the built-in defaults.
  */
 export function FileTypeSettings({ visibleFields }: FileTypeSettingsProps) {
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
   const updateSettings = useAppStore((s) => s.updateSettings);
 
   const userMappings = useMemo(

--- a/src/components/Settings/FrontendPluginGateSettings.tsx
+++ b/src/components/Settings/FrontendPluginGateSettings.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { ShieldAlert } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { Toggle } from "@/components/ui";
 import { SettingsField } from "./SettingsField";
 
@@ -19,8 +20,8 @@ import { SettingsField } from "./SettingsField";
  * down live.
  */
 export function FrontendPluginGateSettings() {
-  const enabled = useAppStore((s) => s.settings.frontendPluginsEnabled ?? false);
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
+  const enabled = settings.frontendPluginsEnabled ?? false;
   const updateSettings = useAppStore((s) => s.updateSettings);
 
   const handleToggle = useCallback(

--- a/src/components/Settings/KeyboardSettings.tsx
+++ b/src/components/Settings/KeyboardSettings.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { RotateCcw, Download, X } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { KeyCombo, KeyBinding, ShortcutCategory } from "@/types/keybindings";
 import {
   getDefaultBindings,
@@ -42,7 +43,7 @@ export function KeyboardSettings({ visibleFields }: KeyboardSettingsProps) {
   const [recordingAction, setRecordingAction] = useState<string | null>(null);
   const [conflictWarning, setConflictWarning] = useState<string | null>(null);
   const updateSettings = useAppStore((s) => s.updateSettings);
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
 
   // Force re-render when overrides change
   const [, forceRender] = useState(0);

--- a/src/components/Settings/LanguagePackagesSettings.tsx
+++ b/src/components/Settings/LanguagePackagesSettings.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useCallback } from "react";
 import { PackagePlus, PackageMinus, Search } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { ALL_LANGUAGE_PACKAGES, BUILTIN_PACKAGE_IDS } from "@/utils/monacoLanguagePackages";
 import { registerAdditionalLanguagePackages } from "@/utils/monacoCustomLanguages";
 import { Button, Tooltip } from "@/components/ui";
@@ -18,7 +19,7 @@ interface LanguagePackagesSettingsProps {
  * be removed.
  */
 export function LanguagePackagesSettings({ visibleFields }: LanguagePackagesSettingsProps) {
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
   const updateSettings = useAppStore((s) => s.updateSettings);
 
   const [searchQuery, setSearchQuery] = useState("");

--- a/src/components/Settings/SecuritySettings.tsx
+++ b/src/components/Settings/SecuritySettings.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo } from "react";
 import { Shield, Trash2 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { CredentialStorageMode } from "@/types/credential";
 import { switchCredentialStore, changeMasterPassword, setAutoLockTimeout } from "@/services/api";
 import { PasswordInput } from "@/components/PasswordInput/PasswordInput";
@@ -73,7 +74,7 @@ export function SecuritySettings({ visibleFields }: SecuritySettingsProps) {
   const credentialStoreStatus = useAppStore((s) => s.credentialStoreStatus);
   const loadCredentialStoreStatus = useAppStore((s) => s.loadCredentialStoreStatus);
   const requestUnlock = useAppStore((s) => s.requestUnlock);
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
   const updateSettings = useAppStore((s) => s.updateSettings);
 
   const [switching, setSwitching] = useState(false);

--- a/src/components/Settings/SerialPortSettings.projection.test.tsx
+++ b/src/components/Settings/SerialPortSettings.projection.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * `SerialPortSettings` render-cut parity (#2227). Proves the settings screen reader
+ * sources its document from the projected `settings` region: with the render flag
+ * on and the region a faithful mirror of `appStore`, the panel renders the
+ * projected serial-port prefixes; when the region cannot catch up it falls back to
+ * `appStore` verbatim, so the output is byte-identical to the pre-cut path.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import { useAppStore } from "@/store/appStore";
+import { TooltipProvider } from "@/components/ui";
+import type { AppSettings } from "@/types/connection";
+import {
+  SETTINGS_REGION,
+  setSettingsRenderFromProjectionEnabled,
+  setSettingsTransportForTest,
+  stopSettingsSubscription,
+} from "@/store/settingsBridge";
+
+import { SerialPortSettings } from "./SerialPortSettings";
+
+vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn(() => vi.fn()) }));
+
+function settings(overrides: Partial<AppSettings> = {}): AppSettings {
+  return {
+    version: "1",
+    externalConnectionFiles: [],
+    powerMonitoringEnabled: true,
+    fileBrowserEnabled: true,
+    ...overrides,
+  };
+}
+
+/** In-memory substrate double: applies `settings.replace` and fans a snapshot. */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  applyReplace = true;
+  private view: Record<string, unknown> = { version: "1", externalConnectionFiles: [] };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (intent.kind === "settings.replace" && this.applyReplace) {
+      const p = intent.payload as Record<string, unknown>;
+      this.view = (p.settings ?? {}) as Record<string, unknown>;
+      this.version += 1;
+      this.fan();
+    }
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: SETTINGS_REGION, version: this.version }],
+    };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(SETTINGS_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let transport: FakeTransport;
+
+const flush = () => act(async () => await Promise.resolve());
+
+function render() {
+  act(() => {
+    root.render(
+      <TooltipProvider delayDuration={0}>
+        <SerialPortSettings />
+      </TooltipProvider>
+    );
+  });
+}
+
+function prefixItems(): string[] {
+  return Array.from(container.querySelectorAll(".settings-panel__file-path")).map(
+    (el) => el.textContent ?? ""
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useAppStore.setState(useAppStore.getInitialState());
+  transport = new FakeTransport();
+  setSettingsTransportForTest(transport);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  stopSettingsSubscription();
+  setSettingsTransportForTest(null);
+  setSettingsRenderFromProjectionEnabled(null);
+  vi.clearAllMocks();
+});
+
+describe("SerialPortSettings render cut (#2227)", () => {
+  it("renders the prefixes sourced from the projected region", async () => {
+    useAppStore.setState({
+      settings: settings({
+        serialPortScanPrefixes: [
+          { prefix: "ttyAMA", enabled: true, builtIn: true },
+          { prefix: "ttyXYZ", enabled: false, builtIn: false },
+        ],
+      }),
+    });
+
+    render();
+    await flush();
+    await flush();
+
+    // The panel seeded the region and now renders the projected prefixes.
+    expect(transport.dispatched.some((d) => d.kind === "settings.replace")).toBe(true);
+    expect(prefixItems()).toEqual(["ttyAMA", "ttyXYZ"]);
+  });
+
+  it("falls back to the appStore document when the region cannot catch up", async () => {
+    transport.applyReplace = false; // acks but never advances the region
+    useAppStore.setState({
+      settings: settings({
+        serialPortScanPrefixes: [{ prefix: "ttyBACKUP", enabled: true, builtIn: true }],
+      }),
+    });
+
+    render();
+    await flush();
+    await flush();
+
+    // Gate rejects the stale projection → appStore verbatim, parity preserved.
+    expect(prefixItems()).toEqual(["ttyBACKUP"]);
+  });
+});

--- a/src/components/Settings/SerialPortSettings.tsx
+++ b/src/components/Settings/SerialPortSettings.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useMemo } from "react";
 import { Plus, Trash2 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { SerialPortScanPrefix } from "@/types/connection";
 import { Button, Toggle, Tooltip } from "@/components/ui";
 
@@ -13,7 +14,7 @@ interface SerialPortSettingsProps {
  * Built-in prefixes can be toggled on/off. User-added prefixes can also be deleted.
  */
 export function SerialPortSettings({ visibleFields }: SerialPortSettingsProps) {
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
   const updateSettings = useAppStore((s) => s.updateSettings);
   const [newPrefix, setNewPrefix] = useState("");
   const [addError, setAddError] = useState("");

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { applyTheme } from "@/themes/engine";
 import { AppSettings } from "@/types/connection";
 import { SettingsCategory, CATEGORIES } from "./settingsRegistry";
@@ -66,7 +67,7 @@ interface SettingsPanelProps {
  * Two-panel settings layout with categorized navigation, search, and version footer.
  */
 export function SettingsPanel({ tabId, isVisible }: SettingsPanelProps) {
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
   const updateSettings = useAppStore((s) => s.updateSettings);
   const setEditorDirty = useAppStore((s) => s.setEditorDirty);
   const pendingCloseRequest = useAppStore((s) => s.pendingCloseRequest);

--- a/src/components/Settings/ShellIntegrationSettings.tsx
+++ b/src/components/Settings/ShellIntegrationSettings.tsx
@@ -4,6 +4,7 @@ import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors } from "
 import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { frontendLog } from "@/utils/frontendLog";
 import { getPlatform } from "@/utils/platform";
 import type {
@@ -49,7 +50,7 @@ const LINUX_MANAGERS: {
  * install toggles.
  */
 export function ShellIntegrationSettings() {
-  const storedSi = useAppStore((s) => s.settings.shellIntegration);
+  const storedSi = useProjectedSettings().shellIntegration;
   const connections = useAppStore((s) => s.connections);
   const updateShellIntegration = useAppStore((s) => s.updateShellIntegration);
 

--- a/src/components/Settings/UpdateSettings.tsx
+++ b/src/components/Settings/UpdateSettings.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { RefreshCw, Loader2 } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { setUpdateAutoCheck } from "@/services/api";
 import { useAppInfo } from "@/hooks/useAppInfo";
 import { frontendLog } from "@/utils/frontendLog";
@@ -27,7 +28,7 @@ export function UpdateSettings({ visibleFields }: UpdateSettingsProps) {
   const updateInfo = useAppStore((s) => s.updateInfo);
   const checkForUpdates = useAppStore((s) => s.checkForUpdates);
   const clearSkippedUpdateVersion = useAppStore((s) => s.clearSkippedUpdateVersion);
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
   const updateSettings = useAppStore((s) => s.updateSettings);
 
   const [savingAutoCheck, setSavingAutoCheck] = useState(false);

--- a/src/store/settingsBridge.ts
+++ b/src/store/settingsBridge.ts
@@ -1,0 +1,308 @@
+/**
+ * Settings projection bridge — Phase 5 render cut of the Settings domain (#2227,
+ * part of #2153 / #2139).
+ *
+ * The Settings **shadow** (PR #2260) landed a backend-authoritative
+ * [`SettingsStore`](../../src-tauri/src/settings_projection/store.rs) served as the
+ * shared `settings` projection region, with `settings.*` intents, but nothing in
+ * the UI touched it. This step makes the **Settings screen** source the persisted
+ * `AppSettings` document from that region — the parity-safe render cut (the direct
+ * analog of the system-monitor render cut
+ * {@link import("./systemMonitorBridge")}, #2224, and the agents render cut
+ * {@link import("./agentsBridge")}, #2226).
+ *
+ * # The settings document is opaque
+ *
+ * `AppSettings` is one large, open-ended JSON document the app loads and saves as a
+ * whole. The Rust store models it opaquely (see the shadow's `store.rs`); the
+ * region snapshot **is** that document, so the projected view maps one-to-one to
+ * the frontend {@link AppSettings} shape and the render cut is a pure parity swap.
+ *
+ * # Strangler safety — flag-gated, on by default, faithful-mirror gate
+ *
+ * The `appStore` settings slice is still authoritative (the mutation cut is a later
+ * step). To keep the render cut parity-safe **independent of any mutation flag**,
+ * the region is kept a faithful copy of `appStore` by {@link seedSettingsRegion} (a
+ * `settings.replace` mirror, the analog of the monitor bridge's `monitor.replace`
+ * seed), and the UI renders from the region **only when it faithfully mirrors**
+ * `appStore` ({@link settingsViewMirrors}); otherwise it falls back to `appStore`
+ * verbatim. Because the gate guarantees the projected view deep-equals `appStore`'s
+ * slice, the rendered output is byte-identical to the pre-cut path.
+ *
+ * Gated by {@link settingsRenderFromProjectionEnabled} — **on by default**.
+ * Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_SETTINGS_RENDER_FROM_PROJECTION__` or
+ * `localStorage["termihub.settingsRenderFromProjection"]` (set `"false"` to render
+ * straight from `appStore`).
+ */
+
+import {
+  createTransport,
+  newClientId,
+  newIntentId,
+  ProjectionClient,
+  type IntentAck,
+  type Transport,
+} from "@/services/transport";
+import type { AppSettings } from "@/types/connection";
+import { frontendLog } from "@/utils/frontendLog";
+
+/** The projection region id for the settings domain (twin of the Rust
+ * `SETTINGS_REGION` const). Shared (Open Design Decision #4 / #6). */
+export const SETTINGS_REGION = "settings";
+
+/**
+ * The projected `settings` region view model — the persisted `AppSettings`
+ * document itself. The Rust store snapshots the document opaquely, so the region
+ * view maps one-to-one to the frontend {@link AppSettings} shape and rendering from
+ * it is a pure parity swap.
+ */
+export type SettingsView = AppSettings;
+
+// ── Render-cut feature flag (runtime-flippable, on by default) ─────────────────
+
+let renderFlagOverride: boolean | null = null;
+
+interface SettingsRenderFlagWindow {
+  __TERMIHUB_SETTINGS_RENDER_FROM_PROJECTION__?: boolean;
+  localStorage?: Storage;
+}
+
+/**
+ * Programmatic override for the render-cut flag (tests, and a runtime toggle).
+ * `null` clears the override and falls back to the window/localStorage signal,
+ * then to the default (on).
+ */
+export function setSettingsRenderFromProjectionEnabled(value: boolean | null): void {
+  renderFlagOverride = value;
+}
+
+/**
+ * Whether the Settings screen renders the persisted `AppSettings` document from the
+ * projected `settings` region instead of reading `appStore`'s settings slice
+ * directly.
+ *
+ * **On by default** — the render cut is parity-safe: the UI renders from the region
+ * only when it faithfully mirrors `appStore` ({@link settingsViewMirrors}), and
+ * otherwise falls back to `appStore` verbatim, so the output is byte-identical to
+ * the pre-cut path. Independent of the (later) mutation cut: the region is kept a
+ * mirror of `appStore` by {@link seedSettingsRegion}, so it is always populated.
+ * Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_SETTINGS_RENDER_FROM_PROJECTION__` or
+ * `localStorage["termihub.settingsRenderFromProjection"]`.
+ */
+export function settingsRenderFromProjectionEnabled(): boolean {
+  if (renderFlagOverride !== null) return renderFlagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as SettingsRenderFlagWindow;
+      if (typeof w.__TERMIHUB_SETTINGS_RENDER_FROM_PROJECTION__ === "boolean") {
+        return w.__TERMIHUB_SETTINGS_RENDER_FROM_PROJECTION__;
+      }
+      const ls = w.localStorage?.getItem("termihub.settingsRenderFromProjection");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return true;
+}
+
+// ── Transport + shared region client (lazy, mirrors the monitor slice) ─────────
+
+let transportInstance: Transport | null = null;
+let regionClient: ProjectionClient | null = null;
+let startPromise: Promise<ProjectionClient> | null = null;
+
+// A stable per-session client identity for dispatched intents (fan-out / audit
+// only; the shared region's diff reaches every subscriber regardless of who
+// dispatched it).
+const clientId = newClientId();
+
+/** Inject a transport for tests; `null` restores the lazily-created real one and
+ * drops any active subscription / seed dedup. */
+export function setSettingsTransportForTest(t: Transport | null): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  transportInstance = t;
+  lastView = undefined;
+  lastSeededSignature = null;
+}
+
+function transport(): Transport {
+  if (!transportInstance) {
+    transportInstance = createTransport();
+  }
+  return transportInstance;
+}
+
+// ── View fan-out (one subscription, many consuming hooks) ──────────────────────
+
+/** A change listener for the projected `settings` view. */
+export type SettingsViewListener = (view: SettingsView) => void;
+
+const viewListeners = new Set<SettingsViewListener>();
+// `undefined` until the first diff arrives, so the gate falls back to `appStore`
+// before the region has been observed.
+let lastView: SettingsView | undefined = undefined;
+
+/**
+ * Register a listener, invoked with the projected view on every diff. Returns an
+ * unsubscribe. The region client is started on first use.
+ */
+export function onSettingsView(listener: SettingsViewListener): () => void {
+  viewListeners.add(listener);
+  return () => viewListeners.delete(listener);
+}
+
+/**
+ * Ensure the shared `settings` region client is subscribed so projected diffs are
+ * received and fanned out to the {@link onSettingsView} listeners. Idempotent and
+ * de-duplicated across concurrent callers; a transport/subscribe failure is logged
+ * and rethrown so the caller can fall back to `appStore`.
+ */
+export function ensureSettingsSubscribed(): Promise<ProjectionClient> {
+  if (regionClient) return Promise.resolve(regionClient);
+  if (!startPromise) {
+    const client = new ProjectionClient(transport(), SETTINGS_REGION);
+    client.onChange((state) => {
+      lastView = (state.view ?? {}) as SettingsView;
+      for (const listener of viewListeners) {
+        try {
+          listener(lastView);
+        } catch (err) {
+          logSettingsBridgeFallback("reconcile", err);
+        }
+      }
+    });
+    startPromise = client
+      .start()
+      .then(() => {
+        regionClient = client;
+        return client;
+      })
+      .catch((err) => {
+        startPromise = null;
+        logSettingsBridgeFallback("subscribe", err);
+        throw err;
+      });
+  }
+  return startPromise;
+}
+
+/** Drop the region subscription (tests / re-init). */
+export function stopSettingsSubscription(): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  lastView = undefined;
+  lastSeededSignature = null;
+}
+
+/** The last view fanned out (for a hook that subscribes after the first diff). */
+export function currentSettingsView(): SettingsView | undefined {
+  return lastView;
+}
+
+// ── Seed: keep the region a faithful mirror of appStore (settings.replace) ─────
+
+let lastSeededSignature: string | null = null;
+
+/**
+ * Seed the shared region with `appStore`'s whole settings document via a
+ * `settings.replace` intent, so the projection tracks `appStore`'s current state
+ * while `appStore` stays authoritative (the render-side counterpart to the monitor
+ * bridge's seed). The payload is keyed to the Rust intent shape (`{ settings }`).
+ * De-duplicated: a document identical to the last seeded one is not re-dispatched.
+ * Never throws synchronously — a transport that cannot dispatch surfaces as a
+ * rejected promise the caller logs and ignores (staying on the `appStore`
+ * fallback). Idempotent server-side: replacing with the same content yields no
+ * diff.
+ */
+export function seedSettingsRegion(settings: AppSettings): Promise<void> {
+  const signature = JSON.stringify(settings);
+  if (signature === lastSeededSignature) return Promise.resolve();
+  // Set before dispatching so concurrent callers (the various Settings panels) do
+  // not double-dispatch the same seed.
+  lastSeededSignature = signature;
+  try {
+    return transport()
+      .dispatch({
+        intentId: newIntentId(),
+        kind: "settings.replace",
+        payload: { settings },
+        clientId,
+      })
+      .then((ack: IntentAck) => {
+        if (ack.status === "rejected") {
+          // Let a later change retry the seed rather than latch on a failure.
+          lastSeededSignature = null;
+          throw new Error(ack.error?.message ?? "settings.replace rejected");
+        }
+      })
+      .catch((err) => {
+        lastSeededSignature = null;
+        throw err;
+      });
+  } catch (err) {
+    // A synchronous transport-construction failure (non-Tauri, no socket).
+    lastSeededSignature = null;
+    return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+// ── Faithful-mirror gate ───────────────────────────────────────────────────────
+
+/**
+ * Whether a projected `view` faithfully mirrors `appStore`'s settings document —
+ * the gate deciding whether the UI may render from the projection (true) or must
+ * fall back to `appStore` (false). A deep value comparison of the whole document;
+ * because the projected document maps to {@link AppSettings} one-to-one, a
+ * mirroring view is value-identical to the `appStore` slice, so rendering from it
+ * can never diverge.
+ *
+ * The twin of the monitor render cut's `monitorsViewMirrors` and the agents render
+ * cut's `agentsViewMirrors`.
+ */
+export function settingsViewMirrors(
+  view: SettingsView | undefined,
+  settings: AppSettings
+): boolean {
+  if (!view) return false;
+  return deepEqual(view, settings);
+}
+
+/**
+ * A structural deep-equal for the JSON-ish settings view model (objects, arrays,
+ * and primitives — no functions/dates/maps). Numbers compare with `===`, so an
+ * integer that round-tripped through JSON as a float (`14` vs `14.0`) still
+ * matches. Exported for the bridge's parity tests.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const ao = a as Record<string, unknown>;
+    const bo = b as Record<string, unknown>;
+    const aKeys = Object.keys(ao);
+    const bKeys = Object.keys(bo);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every(
+      (k) => Object.prototype.hasOwnProperty.call(bo, k) && deepEqual(ao[k], bo[k])
+    );
+  }
+  return false;
+}
+
+/** Log a bridge fallback so the appStore-path recovery is visible in the LogViewer. */
+export function logSettingsBridgeFallback(kind: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  frontendLog("settings_bridge", `${kind} fell back to appStore settings: ${message}`);
+}

--- a/src/store/useProjectedSettings.test.tsx
+++ b/src/store/useProjectedSettings.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * `useProjectedSettings` — the Settings screen cut to the projected `settings`
+ * region (#2227 render cut). Drives the hook against an in-memory substrate double
+ * and asserts: flag-off returns the appStore document and dispatches nothing;
+ * flag-on seeds the region (a `settings.replace` mirror) and then renders the
+ * document from the projection, value-identical to appStore; and a region that has
+ * not caught up falls back to the appStore document.
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import { useAppStore } from "@/store/appStore";
+import type { AppSettings } from "@/types/connection";
+
+import {
+  SETTINGS_REGION,
+  setSettingsRenderFromProjectionEnabled,
+  setSettingsTransportForTest,
+  settingsViewMirrors,
+  stopSettingsSubscription,
+} from "./settingsBridge";
+import { useProjectedSettings } from "./useProjectedSettings";
+
+function settings(overrides: Partial<AppSettings> = {}): AppSettings {
+  return {
+    version: "1",
+    externalConnectionFiles: [],
+    powerMonitoringEnabled: true,
+    fileBrowserEnabled: true,
+    ...overrides,
+  };
+}
+
+/** In-memory substrate double: applies `settings.replace` and fans a snapshot. */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  /** When false, `settings.replace` acks but does NOT advance the region. */
+  applyReplace = true;
+  private view: Record<string, unknown> = { version: "1", externalConnectionFiles: [] };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (intent.kind === "settings.replace" && this.applyReplace) {
+      const p = intent.payload as Record<string, unknown>;
+      this.view = (p.settings ?? {}) as Record<string, unknown>;
+      this.version += 1;
+      this.fan();
+    }
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: SETTINGS_REGION, version: this.version }],
+    };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(SETTINGS_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+/** Render the hook into a throwaway component, exposing the latest return value. */
+function renderHook(): { get: () => AppSettings; unmount: () => void } {
+  const container = document.createElement("div");
+  const root: Root = createRoot(container);
+  let latest: AppSettings = settings();
+
+  function Probe() {
+    latest = useProjectedSettings();
+    return null;
+  }
+
+  act(() => root.render(<Probe />));
+  return { get: () => latest, unmount: () => act(() => root.unmount()) };
+}
+
+let transport: FakeTransport;
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setSettingsTransportForTest(transport);
+  useAppStore.setState({ settings: settings() });
+});
+
+afterEach(() => {
+  stopSettingsSubscription();
+  setSettingsTransportForTest(null);
+  setSettingsRenderFromProjectionEnabled(null);
+});
+
+const flush = () => act(async () => await Promise.resolve());
+
+describe("useProjectedSettings", () => {
+  it("flag off: returns the appStore document and dispatches nothing", async () => {
+    setSettingsRenderFromProjectionEnabled(false);
+    useAppStore.setState({ settings: settings({ theme: "light", fontSize: 18 }) });
+
+    const hook = renderHook();
+    await flush();
+
+    expect(hook.get().theme).toBe("light");
+    expect(hook.get().fontSize).toBe(18);
+    expect(transport.dispatched).toHaveLength(0);
+    hook.unmount();
+  });
+
+  it("flag on: seeds the region then renders the document from the projection", async () => {
+    const doc = settings({ theme: "solarized-dark", fontSize: 15, cursorBlink: true });
+    useAppStore.setState({ settings: doc });
+
+    const hook = renderHook();
+    await flush();
+    await flush();
+
+    // The hook seeded appStore's document via settings.replace…
+    expect(transport.dispatched.some((d) => d.kind === "settings.replace")).toBe(true);
+    // …and now renders a value-identical document (sourced from the projection).
+    expect(hook.get()).toEqual(doc);
+    hook.unmount();
+  });
+
+  it("region not caught up: falls back to the appStore document", async () => {
+    transport.applyReplace = false; // the replace acks but never advances the region
+    const doc = settings({ theme: "light", fontFamily: "Fira Code" });
+    useAppStore.setState({ settings: doc });
+
+    const hook = renderHook();
+    await flush();
+    await flush();
+
+    // The projection stays behind, so the gate rejects it and the hook renders the
+    // appStore document verbatim — parity preserved.
+    expect(hook.get()).toEqual(doc);
+    hook.unmount();
+  });
+});
+
+describe("settingsViewMirrors", () => {
+  it("is false for an undefined view", () => {
+    expect(settingsViewMirrors(undefined, settings())).toBe(false);
+  });
+
+  it("is true only when the view deep-equals the appStore document", () => {
+    const a = settings({ theme: "dark", sessionHistoryLimit: 50 });
+    expect(settingsViewMirrors(settings({ theme: "dark", sessionHistoryLimit: 50 }), a)).toBe(true);
+    expect(settingsViewMirrors(settings({ theme: "light", sessionHistoryLimit: 50 }), a)).toBe(
+      false
+    );
+    expect(settingsViewMirrors(settings({ theme: "dark", sessionHistoryLimit: 99 }), a)).toBe(
+      false
+    );
+    // A view that carries an extra key is not a faithful mirror.
+    expect(
+      settingsViewMirrors(settings({ theme: "dark", sessionHistoryLimit: 50, fontSize: 14 }), a)
+    ).toBe(false);
+  });
+});

--- a/src/store/useProjectedSettings.ts
+++ b/src/store/useProjectedSettings.ts
@@ -1,0 +1,95 @@
+/**
+ * `useProjectedSettings` — the Settings screen cut to the projected `settings`
+ * region (#2227 render cut, part of #2153 / #2139).
+ *
+ * The Settings screen renders the persisted `AppSettings` document (theme, fonts,
+ * confirmation prompts, shell integration, editor mappings, …). Through the shadow
+ * step the panels read `appStore.settings` directly. This hook makes them source
+ * that document from the shared `settings` projection region instead — the direct
+ * analog of {@link import("./useProjectedMonitors").useProjectedMonitors} (#2224)
+ * and {@link import("./useProjectedAgents").useProjectedAgents} (#2226).
+ *
+ * # Safety (strangler)
+ *
+ * - **Gated** by {@link settingsRenderFromProjectionEnabled} (on by default). Flag
+ *   off ⇒ the hook returns `appStore`'s settings document verbatim.
+ * - **Faithful-mirror gate.** The projection sources the render only when it
+ *   deep-equals the `appStore` document ({@link settingsViewMirrors}); otherwise
+ *   the hook falls back to `appStore` (never a stale view). While `appStore` stays
+ *   authoritative (the mutation cut is a later step) the region is kept a mirror by
+ *   {@link seedSettingsRegion}, so it is always populated — making the cut
+ *   parity-safe and independent of the mutation flag.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+import { useAppStore } from "@/store/appStore";
+import {
+  currentSettingsView,
+  ensureSettingsSubscribed,
+  logSettingsBridgeFallback,
+  onSettingsView,
+  seedSettingsRegion,
+  settingsRenderFromProjectionEnabled,
+  settingsViewMirrors,
+  type SettingsView,
+} from "@/store/settingsBridge";
+import type { AppSettings } from "@/types/connection";
+
+/**
+ * The effective settings document for rendering: the persisted `AppSettings`
+ * sourced from the projected `settings` region when it faithfully mirrors
+ * `appStore`, otherwise `appStore`'s document verbatim (flag off, region not yet
+ * caught up, or a transport that cannot subscribe).
+ */
+export function useProjectedSettings(): AppSettings {
+  const settings = useAppStore((s) => s.settings);
+
+  // Read the flag once at mount: it flips only via dev tooling, and the
+  // subscription lifecycle is keyed off it below.
+  const [enabled] = useState(() => settingsRenderFromProjectionEnabled());
+
+  const [view, setView] = useState<SettingsView | undefined>(undefined);
+
+  // Subscribe to the shared settings region while enabled; a transport that cannot
+  // subscribe (non-Tauri without a socket) just leaves the UI on the appStore
+  // fallback.
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const unsubscribe = onSettingsView((next) => {
+      if (!cancelled) setView(next);
+    });
+    // `ensureSettingsSubscribed` builds the transport eagerly, so a non-Tauri env
+    // without a socket throws synchronously (not just a rejection) — guard both so
+    // the UI silently stays on the appStore fallback.
+    try {
+      ensureSettingsSubscribed()
+        .then(() => {
+          if (!cancelled) setView(currentSettingsView());
+        })
+        .catch((err) => logSettingsBridgeFallback("subscribe", err));
+    } catch (err) {
+      logSettingsBridgeFallback("subscribe", err);
+    }
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [enabled]);
+
+  const matches = enabled && settingsViewMirrors(view, settings);
+
+  // Keep the region a faithful mirror of appStore's document. Only once a view has
+  // arrived (so we are subscribed) and it is not already a mirror; de-duped inside
+  // `seedSettingsRegion` so a settled document is not re-seeded on every render.
+  useEffect(() => {
+    if (!enabled || matches || view === undefined) return;
+    seedSettingsRegion(settings).catch((err) => logSettingsBridgeFallback("seed", err));
+  }, [enabled, matches, view, settings]);
+
+  return useMemo(() => {
+    if (matches && view) return view;
+    return settings;
+  }, [matches, view, settings]);
+}


### PR DESCRIPTION
Part of #2227 (Phase 5 · Settings domain render cut, part of #2153 / #2139).

The Settings **shadow** (PR #2260) landed a backend-authoritative `SettingsStore` served as the shared `settings` projection region with `settings.*` intents, but nothing in the UI touched it. This is the parity-safe **render cut** of the Settings screen — the direct analog of the monitor (#2224) and agents (#2226) render cuts.

## What changed
- **`src/store/settingsBridge.ts`** — the `settings` projection bridge: subscribes to the shared region, keeps it a faithful mirror of `appStore` via the existing `settings.replace` seed intent (always populated), a deep-equal faithful-mirror gate, and a runtime-flippable render flag **on by default** (`window.__TERMIHUB_SETTINGS_RENDER_FROM_PROJECTION__` / `localStorage["termihub.settingsRenderFromProjection"]`).
- **`src/store/useProjectedSettings.ts`** — the `useProjectedSettings()` hook: returns the projected `AppSettings` document **only when it faithfully mirrors** `appStore`, otherwise `appStore`'s document verbatim (flag off, region not caught up, or a transport that cannot subscribe). Twin of `useProjectedMonitors` / `useProjectedAgents`.
- **Cut the Settings screen readers** (`src/components/Settings/*`) from `useAppStore((s) => s.settings)` to `useProjectedSettings()`: `SettingsPanel` (which prop-feeds General/Appearance/Terminal), `UpdateSettings`, `FrontendPluginGateSettings`, `KeyboardSettings`, `FileTypeSettings`, `ShellIntegrationSettings`, `ExternalFilesSettings`, `SecuritySettings`, `LanguagePackagesSettings`, `SerialPortSettings`, `CustomGrammarsSettings`.

## Scope — bounded slice
`AppSettings` has ~40 render readers across the app. This PR cuts the coherent **Settings screen** slice (the Settings UI). The remaining settings-driven **behavior** readers (Terminal, StatusBar, NetworkTools, FileEditor, etc.) are tracked in the follow-up **#2269**. The `settings.replace` seed intent already existed in the shadow; no backend change was needed. The mutation cut is a later step (this PR does not add `settings.*` intent dispatch).

## Parity — no user-visible change
The faithful-mirror gate guarantees the projected view deep-equals `appStore`'s document whenever it is used, so rendered output is byte-identical to the pre-cut path; any lag or failure falls back to `appStore` verbatim.

## Tests
- `src/store/useProjectedSettings.test.tsx` — flag-off (appStore verbatim, no dispatch), flag-on (seeds then renders value-identical from the projection), region-not-caught-up fallback, plus `settingsViewMirrors` gate cases.
- `src/components/Settings/SerialPortSettings.projection.test.tsx` — a cut reader renders from the projected region and falls back to `appStore` when the region cannot catch up.
- Full `src/store` + `src/components/Settings` suites green (1175 tests); typecheck, prettier, and eslint clean.