### PR TITLE
feat(ui): cut settings mutations to settings.* intents (#2227)

### DIFF
--- a/src/store/appStore.settingsMutationCut.test.ts
+++ b/src/store/appStore.settingsMutationCut.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Settings mutation cut (#2227, part of #2139 and #2153) — cut-vs-local parity.
+ *
+ * The mutation cut routes the settings setters through the `settings.*` intents so
+ * the backend `SettingsStore` becomes authoritative, while the local `appStore`
+ * reducer path stays in place as the render source and the resilience / rollback
+ * fallback (the reducer removal is a later step).
+ *
+ * These tests prove the cut is parity-safe end to end: with the flag **on**, the
+ * intents dispatched by the setters — applied by a faithful in-memory port of the
+ * Rust store (mirroring `settings_projection/store.rs`) — reproduce the exact
+ * `appStore` settings document (`settings`) for every setter and its fan-out. They
+ * also assert the **persistence side-effect is untouched** — `saveSettings` /
+ * `save_shell_integration_settings` still fire with the same payload the intent
+ * carries. With the flag **off**, no intents are dispatched and the local document
+ * is byte-identical — the instant rollback path the flip relies on.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  persistAgent: vi.fn(() => Promise.resolve()),
+  removeAgent: vi.fn(() => Promise.resolve()),
+  reorderAgents: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+      updates: { skippedVersion: undefined },
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  saveShellIntegrationSettings: vi.fn(() => Promise.resolve({})),
+  skipUpdateVersion: vi.fn(() => Promise.resolve()),
+  clearSkippedVersion: vi.fn(() => Promise.resolve()),
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  getConnectionTypes: vi.fn(() => Promise.resolve([])),
+}));
+
+import { useAppStore } from "./appStore";
+import { saveSettings } from "@/services/storage";
+import { saveShellIntegrationSettings } from "@/services/api";
+import { setSettingsIntentsEnabled, setSettingsTransportForTest } from "./settingsBridge";
+import type { AppSettings, ShellIntegrationSettings } from "@/types/connection";
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+
+/** The frontend default settings baseline — mirrors `default_settings_document()`
+ * in `settings_projection/store.rs`, used to service `settings.reset`. */
+function defaultSettingsDocument(): AppSettings {
+  return {
+    version: "1",
+    externalConnectionFiles: [],
+    powerMonitoringEnabled: true,
+    fileBrowserEnabled: true,
+    confirmCloseTabOnShortcut: true,
+    confirmCloseLiveSession: true,
+    confirmCloseAttachedTab: true,
+    askOpenSavedFileInTab: true,
+    warnLargePortScan: true,
+    warnLargePingSweep: true,
+  } as AppSettings;
+}
+
+function shellIntegration(registered: boolean): ShellIntegrationSettings {
+  return {
+    entries: [],
+    fallback: "prompt",
+    openInNewWindow: false,
+    registered,
+    linuxFileManagers: {},
+    firstLaunchBannerDismissed: false,
+  } as unknown as ShellIntegrationSettings;
+}
+
+/**
+ * An in-memory substrate double that applies the `settings.*` intents with the same
+ * semantics as the Rust `SettingsStore`, so a run of the real `appStore` setters
+ * (which mirror those intents) reconstructs the settings document the Settings UI
+ * would render. `settings.replace` overwrites the whole document, `settings.patch`
+ * shallow-merges each top-level key, and `settings.reset` restores the default
+ * baseline.
+ */
+class SettingsStoreTransport implements Transport {
+  dispatched: Intent[] = [];
+  private doc: Record<string, unknown> = {};
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  /** Seed the region to a starting document without recording a user intent, so a
+   * relative `settings.patch` has the same base the appStore slice does. */
+  seed(settings: AppSettings): void {
+    this.doc = structuredClone(settings) as unknown as Record<string, unknown>;
+    this.version += 1;
+    this.fan();
+  }
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    this.apply(intent);
+    this.version += 1;
+    this.fan();
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: "settings", version: this.version }],
+    };
+  }
+
+  private apply(intent: Intent): void {
+    const p = intent.payload as Record<string, unknown>;
+    switch (intent.kind) {
+      case "settings.replace": {
+        this.doc = structuredClone(p.settings as Record<string, unknown>);
+        break;
+      }
+      case "settings.patch": {
+        const patch = structuredClone(p as Record<string, unknown>);
+        for (const [key, value] of Object.entries(patch)) {
+          this.doc[key] = value;
+        }
+        break;
+      }
+      case "settings.reset": {
+        this.doc = structuredClone(defaultSettingsDocument()) as unknown as Record<string, unknown>;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  /** The reconstructed settings document, twin of the store snapshot. */
+  regionView(): AppSettings {
+    return structuredClone(this.doc) as unknown as AppSettings;
+  }
+
+  kinds(): string[] {
+    return this.dispatched.map((i) => i.kind);
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: this.regionView() };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot("settings");
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+let transport: SettingsStoreTransport;
+
+/** Assert the document the intents reconstruct equals the local appStore slice. */
+function expectParity() {
+  expect(transport.regionView()).toEqual(useAppStore.getState().settings);
+}
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  vi.clearAllMocks();
+  transport = new SettingsStoreTransport();
+  setSettingsTransportForTest(transport);
+  setSettingsIntentsEnabled(true);
+  // Seed the region to appStore's initial document so a relative patch is in parity.
+  transport.seed(useAppStore.getState().settings);
+});
+
+afterEach(() => {
+  setSettingsTransportForTest(null);
+  setSettingsIntentsEnabled(null);
+});
+
+describe("settings mutation cut — cut-vs-local parity (flag on)", () => {
+  it("updateSettings replaces the whole document in the region", async () => {
+    const next = { ...defaultSettingsDocument(), confirmCloseTabOnShortcut: false };
+
+    await useAppStore.getState().updateSettings(next);
+
+    expect(transport.kinds()).toEqual(["settings.replace"]);
+    expectParity();
+    expect(transport.regionView().confirmCloseTabOnShortcut).toBe(false);
+  });
+
+  it("updateSettings still persists through saveSettings (persistence parity)", async () => {
+    const next = { ...defaultSettingsDocument(), askOpenSavedFileInTab: false };
+
+    await useAppStore.getState().updateSettings(next);
+
+    // The persist side-effect is untouched — it fires with the same document the
+    // settings.replace intent carries.
+    expect(vi.mocked(saveSettings)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(saveSettings)).toHaveBeenCalledWith(next);
+    expect(transport.regionView()).toEqual(next);
+  });
+
+  it("successive updateSettings calls stay in parity", async () => {
+    await useAppStore.getState().updateSettings({
+      ...defaultSettingsDocument(),
+      warnLargePortScan: false,
+    });
+    expectParity();
+    await useAppStore.getState().updateSettings({
+      ...defaultSettingsDocument(),
+      warnLargePortScan: false,
+      warnLargePingSweep: false,
+    });
+    expectParity();
+    expect(transport.kinds()).toEqual(["settings.replace", "settings.replace"]);
+  });
+
+  it("updateShellIntegration patches the shellIntegration field in the region", async () => {
+    const si = shellIntegration(true);
+
+    await useAppStore.getState().updateShellIntegration(si);
+
+    expect(transport.kinds()).toEqual(["settings.patch"]);
+    expectParity();
+    expect(transport.regionView().shellIntegration).toEqual(si);
+    // Persistence parity — the dedicated command still fires with the field value.
+    expect(vi.mocked(saveShellIntegrationSettings)).toHaveBeenCalledWith(si);
+  });
+
+  it("updateShellIntegration rolls the region back on a persist failure", async () => {
+    // Seed a previously-persisted shell-integration value.
+    const prev = shellIntegration(false);
+    useAppStore.setState({
+      settings: { ...useAppStore.getState().settings, shellIntegration: prev },
+      savedSettings: { ...useAppStore.getState().savedSettings, shellIntegration: prev },
+    });
+    transport.seed(useAppStore.getState().settings);
+
+    vi.mocked(saveShellIntegrationSettings).mockRejectedValueOnce(new Error("backend down"));
+
+    await expect(
+      useAppStore.getState().updateShellIntegration(shellIntegration(true))
+    ).rejects.toThrow("backend down");
+
+    // The optimistic patch was reverted in both the appStore slice and the region.
+    expectParity();
+    expect(transport.regionView().shellIntegration).toEqual(prev);
+    expect(transport.kinds()).toEqual(["settings.patch", "settings.patch"]);
+  });
+
+  it("skipUpdate mirrors the refreshed settings as a replace", async () => {
+    useAppStore.setState({
+      updateInfo: { available: true, latestVersion: "9.9.9" } as never,
+    });
+
+    await useAppStore.getState().skipUpdate();
+
+    expectParity();
+    expect(transport.kinds()).toContain("settings.replace");
+  });
+
+  it("clearSkippedUpdateVersion mirrors the refreshed settings as a replace", async () => {
+    await useAppStore.getState().clearSkippedUpdateVersion();
+
+    expectParity();
+    expect(transport.kinds()).toContain("settings.replace");
+  });
+
+  it("settings.reset restores the default baseline in the region", async () => {
+    // Drift the region away from defaults, then reset.
+    await useAppStore.getState().updateSettings({
+      ...defaultSettingsDocument(),
+      confirmCloseLiveSession: false,
+    });
+    expect(transport.regionView().confirmCloseLiveSession).toBe(false);
+
+    await transport.dispatch({
+      intentId: "reset-1",
+      kind: "settings.reset",
+      payload: {},
+      clientId: "test",
+    });
+
+    expect(transport.regionView()).toEqual(defaultSettingsDocument());
+  });
+
+  it("a full settings lifecycle stays in parity across every step", async () => {
+    await useAppStore.getState().updateSettings({
+      ...defaultSettingsDocument(),
+      confirmCloseTabOnShortcut: false,
+    });
+    expectParity();
+    await useAppStore.getState().updateShellIntegration(shellIntegration(true));
+    expectParity();
+    await useAppStore.getState().updateSettings({
+      ...useAppStore.getState().settings,
+      askOpenSavedFileInTab: false,
+    });
+    expectParity();
+  });
+});
+
+describe("settings mutation cut — flag off (rollback path)", () => {
+  beforeEach(() => setSettingsIntentsEnabled(false));
+
+  it("dispatches no intents and drives the slice locally", async () => {
+    const dispatchedBefore = transport.dispatched.length;
+
+    await useAppStore.getState().updateSettings({
+      ...defaultSettingsDocument(),
+      confirmCloseTabOnShortcut: false,
+    });
+    await useAppStore.getState().updateShellIntegration(shellIntegration(true));
+
+    // No mutation intent reached the region — the pre-cut local path is intact.
+    expect(transport.dispatched.length).toBe(dispatchedBefore);
+    // The local slice still behaves exactly as before the cut.
+    expect(useAppStore.getState().settings.confirmCloseTabOnShortcut).toBe(false);
+    expect(useAppStore.getState().settings.shellIntegration).toEqual(shellIntegration(true));
+    // Persistence is unchanged whether or not the cut is enabled.
+    expect(vi.mocked(saveSettings)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(saveShellIntegrationSettings)).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -287,6 +287,7 @@ import {
 import { mirrorMonitorIntent } from "@/store/systemMonitorBridge";
 import { mirrorAgentIntent } from "@/store/agentsBridge";
 import { mirrorConnectionIntent } from "@/store/connectionsBridge";
+import { mirrorSettingsIntent } from "@/store/settingsBridge";
 import { mirrorBroadcastIntent } from "@/store/broadcastBridge";
 import {
   expectProjectedRestoreSettlement,
@@ -5307,6 +5308,10 @@ export const useAppStore = create<AppState>((set, get, store) => {
         const oldSettings = get().settings;
         await persistSettings(newSettings);
         set({ settings: newSettings, savedSettings: newSettings });
+        // Mutation cut (#2227): make the backend SettingsStore authoritative by
+        // mirroring the whole-document save as a settings.replace intent. Persist
+        // above is untouched; the render-cut hook reflects the region back.
+        mirrorSettingsIntent("settings.replace", { settings: newSettings });
 
         // Re-apply when the selection changes or when the active custom theme's
         // colors were edited (the customThemes array reference changes on save).
@@ -5368,11 +5373,16 @@ export const useAppStore = create<AppState>((set, get, store) => {
       const prevSi = get().settings.shellIntegration;
       const optimistic = { ...get().settings, shellIntegration: nextSi };
       set({ settings: optimistic, savedSettings: optimistic });
+      // Mutation cut (#2227): the shell-integration write is a targeted field
+      // patch, so mirror it as a settings.patch (shallow-merge) rather than a
+      // whole-document replace — keeping a concurrent general-settings edit intact.
+      mirrorSettingsIntent("settings.patch", { shellIntegration: nextSi });
       try {
         return await saveShellIntegrationSettings(nextSi);
       } catch (err) {
         const rolledBack = { ...get().settings, shellIntegration: prevSi };
         set({ settings: rolledBack, savedSettings: rolledBack });
+        mirrorSettingsIntent("settings.patch", { shellIntegration: prevSi });
         throw err;
       }
     },
@@ -8847,6 +8857,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
           savedSettings: updatedSettings,
           updateNotificationDismissed: true,
         });
+        mirrorSettingsIntent("settings.replace", { settings: updatedSettings });
       } catch (err) {
         frontendLog("update", `Failed to skip version: ${err}`);
       }
@@ -8856,6 +8867,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
         await apiClearSkippedVersion();
         const updatedSettings = await import("@/services/storage").then((m) => m.getSettings());
         set({ settings: updatedSettings, savedSettings: updatedSettings });
+        mirrorSettingsIntent("settings.replace", { settings: updatedSettings });
       } catch (err) {
         frontendLog("update", `Failed to clear skipped version: ${err}`);
       }

--- a/src/store/settingsBridge.ts
+++ b/src/store/settingsBridge.ts
@@ -109,6 +109,68 @@ export function settingsRenderFromProjectionEnabled(): boolean {
   return true;
 }
 
+// ── Mutation-cut feature flag (runtime-flippable, on by default) ───────────────
+
+let mutationFlagOverride: boolean | null = null;
+
+interface SettingsMutationFlagWindow {
+  __TERMIHUB_SETTINGS_INTENTS__?: boolean;
+  localStorage?: Storage;
+}
+
+/**
+ * Programmatic override for the mutation-cut flag (tests, and a runtime toggle).
+ * `null` clears the override and falls back to the window/localStorage signal,
+ * then to the default (on).
+ */
+export function setSettingsIntentsEnabled(value: boolean | null): void {
+  mutationFlagOverride = value;
+}
+
+/**
+ * Whether the settings mutations (`updateSettings` whole-document save,
+ * `updateShellIntegration`'s targeted field write, and the update-skip
+ * refreshes) dispatch `settings.*` intents so the backend
+ * {@link import("../../src-tauri/src/settings_projection/store").SettingsStore}
+ * becomes authoritative — instead of only the render-cut {@link seedSettingsRegion}
+ * `settings.replace` mirror driving the region.
+ *
+ * **On by default** (#2227 mutation cut). When on, each setter mirrors its
+ * transition through a `settings.*` intent (via {@link mirrorSettingsIntent}) — a
+ * whole-document `settings.replace` for `updateSettings`, a `settings.patch` for
+ * the shell-integration field write — and the render-cut hook
+ * ({@link import("./useProjectedSettings").useProjectedSettings}) reflects the
+ * region back into the Settings UI. The local `appStore` reducer path stays in
+ * place as the render source and as a resilience / rollback fallback — any dispatch
+ * failure is logged and the local mutation continues, so a backend hiccup can never
+ * break the Settings screen (the reducer removal is a later step). The persistence
+ * side-effect (`saveSettings` / `save_shell_integration_settings`) is untouched:
+ * the intent is dispatched alongside it, not in place of it. When off, `appStore`
+ * drives the slice purely locally (the pre-cut path). The flip was taken on the
+ * automated parity tests plus the instant local fallback, mirroring the connections
+ * (#2225) and agents (#2226) mutation cuts. Overridable at runtime for rollback /
+ * tests via `window.__TERMIHUB_SETTINGS_INTENTS__` or
+ * `localStorage["termihub.settingsIntents"]` (set `"false"` to restore the pre-cut
+ * local-mutation path; `"true"` to force on).
+ */
+export function settingsIntentsEnabled(): boolean {
+  if (mutationFlagOverride !== null) return mutationFlagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as SettingsMutationFlagWindow;
+      if (typeof w.__TERMIHUB_SETTINGS_INTENTS__ === "boolean") {
+        return w.__TERMIHUB_SETTINGS_INTENTS__;
+      }
+      const ls = w.localStorage?.getItem("termihub.settingsIntents");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return true;
+}
+
 // ── Transport + shared region client (lazy, mirrors the monitor slice) ─────────
 
 let transportInstance: Transport | null = null;
@@ -250,6 +312,58 @@ export function seedSettingsRegion(settings: AppSettings): Promise<void> {
     // A synchronous transport-construction failure (non-Tauri, no socket).
     lastSeededSignature = null;
     return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+// ── Mutation cut: settings.* intent dispatch ──────────────────────────────────
+
+/**
+ * The `settings.*` intent kinds the mutation cut dispatches (twins of the Rust
+ * routes on the {@link import("../../src-tauri/src/settings_projection/store").SettingsStore}):
+ * `settings.replace` overwrites the whole document (the `updateSettings` /
+ * update-refresh whole-document save), `settings.patch` shallow-merges a partial
+ * document (the shell-integration field write), and `settings.reset` restores the
+ * default baseline. Unlike the connection/agent cuts — where `*.replace` is the
+ * render-cut whole-slice mirror only — the settings document is opaque and edited
+ * by whole-document save, so `settings.replace` is itself the authoritative
+ * mutation for `updateSettings`; {@link seedSettingsRegion} uses the same kind for
+ * the (independent) render-cut mirror.
+ */
+export type SettingsIntentKind = "settings.replace" | "settings.patch" | "settings.reset";
+
+/** Dispatch a `settings.*` intent, resolving with the ack (parity tests). */
+export function dispatchSettingsIntent(
+  kind: SettingsIntentKind,
+  payload: Record<string, unknown>
+): Promise<IntentAck> {
+  return transport().dispatch({ intentId: newIntentId(), kind, payload, clientId });
+}
+
+/**
+ * Fire a `settings.*` intent to keep the backend store authoritative, swallowing
+ * and logging any failure so the local `appStore` mutation path is never disrupted
+ * by a bridge hiccup (the resilience fallback). A no-op when the mutation cut is
+ * disabled ({@link settingsIntentsEnabled} off — the rollback path). Never throws —
+ * a synchronous transport-construction failure (non-Tauri, no socket) is caught and
+ * logged, leaving the UI on the local slice. The twin of the connections bridge's
+ * {@link import("./connectionsBridge").mirrorConnectionIntent} and the agents
+ * bridge's {@link import("./agentsBridge").mirrorAgentIntent}.
+ */
+export function mirrorSettingsIntent(
+  kind: SettingsIntentKind,
+  payload: Record<string, unknown>
+): void {
+  if (!settingsIntentsEnabled()) return;
+  try {
+    void dispatchSettingsIntent(kind, payload)
+      .then((ack) => {
+        if (ack.status === "rejected") {
+          logSettingsBridgeFallback(kind, new Error(ack.error?.message ?? "rejected"));
+        }
+      })
+      .catch((err) => logSettingsBridgeFallback(kind, err));
+  } catch (err) {
+    logSettingsBridgeFallback(kind, err);
   }
 }
 


### PR DESCRIPTION
Part of #2227 (Phase 5 · Settings) — the **mutation cut** of the Settings domain, following the Connections (#2225 / PR #2267) and Agents (#2226) mutation cuts. The Settings shadow (#2260) and render cut (#2270) are already merged.

## What changed

The settings mutations now dispatch `settings.*` intents so the backend `SettingsStore` becomes authoritative; the render-cut mirror reflects the region back into the Settings UI.

- **`updateSettings`** (the whole-document save that every individual setting setter funnels through) → `settings.replace`.
- **`updateShellIntegration`** (a targeted field write) → `settings.patch { shellIntegration }`, and the rollback path patches back on a persist failure.
- **`skipUpdate` / `clearSkippedUpdateVersion`** (update-skip refreshes) → `settings.replace` with the refreshed document.

Because the settings document is opaque and edited by whole-document save, `settings.replace` is itself the authoritative mutation for `updateSettings` — the same intent kind the render cut's `seedSettingsRegion` uses for its (independent) mirror.

## Flag + fallback

- Gated behind **`settingsIntentsEnabled`**, **default ON**, with instant revert via `window.__TERMIHUB_SETTINGS_INTENTS__` / `localStorage["termihub.settingsIntents"]` / `setSettingsIntentsEnabled(...)`.
- The **local `appStore` reducers are retained** as the render source and the resilience / rollback fallback — any dispatch failure is logged and the local mutation continues (removal is the later step, kept open on #2227).
- **Persistence is untouched**: `saveSettings` / `save_shell_integration_settings` still fire with the same payload; the intent is dispatched alongside them, not in place of them.

## Tests (ship on-by-default)

`appStore.settingsMutationCut.test.ts` — a faithful in-memory port of the Rust `SettingsStore` applies the dispatched intents and asserts the reconstructed region deep-equals the `appStore` settings document for every setter and its fan-out (replace, patch + rollback, the update-skip refreshes, and a `settings.reset`), plus **persistence parity** (the persist side-effect still fires with the intent's payload) and a **flag-off zero-dispatch** test.

Per the maintainer proceed-on-tests decision, GUI parity rests on these parity tests plus the retained local fallback.

## Verification
- `pnpm build` (tsc + vite) green; `pnpm run lint` clean; `pnpm exec prettier --check` clean.
- Settings mutation-cut + existing `useProjectedSettings` / serial-port projection tests green.