### PR TITLE
feat(sftp): shadow file-browser view store + projection region

### DIFF
--- a/src-tauri/src/file_browser_projection/mod.rs
+++ b/src-tauri/src/file_browser_projection/mod.rs
@@ -1,0 +1,40 @@
+//! Shadow file-browser view authority — Phase 5 of the stateless-UI migration
+//! (#2228, part of #2153 / #2139).
+//!
+//! Moves the file-browser **UI state** the frontend drives in `appStore.ts` —
+//! the three browser panes (**local**, **sftp**, **session**), each with its
+//! current directory and listing; which pane is active (`fileBrowserMode`); and
+//! the copy/cut clipboard (`fileClipboard`) — into a Rust authority on the
+//! projection substrate ([`crate::projection`]).
+//!
+//! This is the **browser view**, not the SFTP/session *session* model: the live
+//! `sftpSessions` map, the SFTP transport connect status, the connected host and
+//! transfers stay out of scope (governed by the pending `SftpManager` vs
+//! `SessionManager` decision, #2236). The store owns only which directory each
+//! pane shows, its listing, the in-flight/error status of a *directory list*,
+//! the active pane, and the clipboard. See [`store`] for the scope boundary.
+//!
+//! # Client-scoped region — Open Design Decision #4 / #6
+//!
+//! An open file browser is a property of the *viewing client's* pane, not shared
+//! infrastructure: the underlying filesystem / SFTP backend is shared, but the
+//! browser's cwd, listing, active pane and clipboard belong to the one client
+//! looking at it. Like the client-scoped `layout` ([`crate::layout::projection`]),
+//! `broadcast` ([`crate::broadcast_projection`]) and `workflow-run`
+//! ([`crate::workflow_projection`]) regions — and unlike the shared
+//! `session-lifecycle` region — the region is **client-scoped**
+//! (`file-browser@<clientId>`).
+//!
+//! # Shadow only (#2228)
+//!
+//! Landed as a pure shadow foundation: managed authoritative state that serves
+//! the `fileBrowser.*` intents, but nothing in the live UI subscribes to or
+//! dispatches them yet — `appStore` stays authoritative and nothing user-facing
+//! changes. Later steps cut rendering (the panels read the projected region),
+//! then the mutations (browser actions dispatch `fileBrowser.*`), then remove the
+//! `appStore` reducers, keeping them as the parity-safe fallback until then.
+
+pub mod projection;
+pub mod store;
+
+pub use store::FileBrowserStore;

--- a/src-tauri/src/file_browser_projection/projection.rs
+++ b/src-tauri/src/file_browser_projection/projection.rs
@@ -1,0 +1,237 @@
+//! File-browser projection: the client-scoped `file-browser@<clientId>` region
+//! and the `fileBrowser.*` intents (#2228, Phase 5 of #2139 / #2153).
+//!
+//! Exposes the authoritative [`FileBrowserStore`] to each attached client as its
+//! own versioned, multi-subscriber projection region and turns the file-browser
+//! view transitions the frontend currently drives into [`Intent`]s — mirroring
+//! the client-scoped `broadcast` ([`crate::broadcast_projection`]) and
+//! `workflow-run` ([`crate::workflow_projection`]) siblings and the reference
+//! substrate registration pattern ([`crate::projection`]).
+//!
+//! # The `file-browser@<clientId>` region
+//!
+//! **Client-scoped** (Open Design Decision #4 / #6: an open file browser — its
+//! cwd, listing, active pane and clipboard — is a property of the viewing
+//! client's pane, not shared infrastructure; the filesystem/SFTP backend is
+//! shared, the *browser view over it* is not). Each client gets its own region,
+//! seeded lazily and mutated via `intent.client_id`. The view model:
+//!
+//! ```json
+//! {
+//!   "mode": "none" | "local" | "sftp" | "session",
+//!   "local":   { "path": "/", "entries": [ …FileEntry ], "loading": false, "error": null },
+//!   "sftp":    { … }, "session": { … },
+//!   "clipboard": null | { "entries": [ …FileEntry ], "operation": "copy" | "cut",
+//!                         "sourceMode": "local" | "sftp" | "session",
+//!                         "sourcePath": "…", "sftpSessionId": "…"?,
+//!                         "terminalSessionId": "…"? }
+//! }
+//! ```
+//!
+//! # Intents
+//!
+//! | kind                        | payload                                | effect                                              |
+//! | --------------------------- | -------------------------------------- | --------------------------------------------------- |
+//! | `fileBrowser.setMode`       | `{ mode }`                             | set the active pane (`local`/`sftp`/`session`/`none`) |
+//! | `fileBrowser.loadStarted`   | `{ pane }`                             | mark the pane loading, clear its error              |
+//! | `fileBrowser.loadSucceeded` | `{ pane, path, entries }`              | commit the pane's path + listing, clear loading     |
+//! | `fileBrowser.loadFailed`    | `{ pane, error? }`                     | clear loading, record the error, keep last listing  |
+//! | `fileBrowser.reset`         | `{ pane }`                             | reset the pane to the idle baseline (`/`, empty)    |
+//! | `fileBrowser.setClipboard`  | `{ clipboard }` (`null` clears)        | set / clear the copy-cut clipboard                  |
+//!
+//! `pane` is the concrete browser being acted on (`local` / `sftp` / `session`);
+//! `mode` is which pane is *active* and additionally accepts `"none"`. The
+//! directory-list side-effects (the actual `localListDir` / `sftpListDir` /
+//! `sessionListFiles` calls) stay frontend orchestration; the store learns of a
+//! list only through these `loadStarted` → `loadSucceeded` / `loadFailed`
+//! intents. The backend SFTP/session *session* model (`sftpSessions`, connect
+//! status, transfers) is out of scope (#2236); see
+//! [`crate::file_browser_projection::store`].
+//!
+//! # Shadow only (#2228)
+//!
+//! Registered and fully served, but nothing in the live UI subscribes to or
+//! dispatches these intents yet — a pure shadow foundation. Later steps cut
+//! rendering, then the mutations, over to it, keeping the `appStore` reducers as
+//! the parity-safe fallback. Per the substrate contract the result of an intent
+//! is never returned inline — it always arrives as a projection diff on the
+//! client's region.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+use crate::file_browser_projection::store::{
+    Clipboard, FileBrowserKind, FileBrowserStore, FileEntry,
+};
+use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
+
+/// The projection region id for a client's file browser
+/// (`file-browser@<clientId>`).
+pub fn file_browser_region(client_id: &str) -> String {
+    format!("file-browser@{client_id}")
+}
+
+/// Publish a client's `file-browser` region from the store, fanning a diff out
+/// to every subscriber and returning the advanced region for the intent ack
+/// (empty when the view did not change).
+pub fn publish_file_browser(
+    projector: &Projector,
+    store: &FileBrowserStore,
+    client_id: &str,
+) -> Vec<ProducedRegion> {
+    let region = file_browser_region(client_id);
+    match projector.publish(&region, store.snapshot(client_id)) {
+        Some(version) => vec![ProducedRegion { region, version }],
+        None => Vec::new(),
+    }
+}
+
+/// Register the `fileBrowser.*` intents on a handler registry.
+///
+/// Each route resolves the managed [`FileBrowserStore`] lazily (so it rejects
+/// gracefully rather than panicking if the store is somehow absent), mutates the
+/// dispatching client's browser view via [`intent.client_id`](Intent::client_id),
+/// and publishes that client's region. All transitions are pure/fast map edits,
+/// so they run inline on the dispatcher's single writer.
+pub fn register_file_browser_intents(registry: &mut HandlerRegistry, app_handle: AppHandle) {
+    let handle = app_handle.clone();
+    registry.route("fileBrowser.setMode", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let mode = parse_mode(intent)?;
+        store.set_mode(&intent.client_id, mode);
+        Ok(publish_file_browser(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("fileBrowser.loadStarted", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let pane = parse_pane(intent)?;
+        store.load_started(&intent.client_id, pane);
+        Ok(publish_file_browser(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("fileBrowser.loadSucceeded", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let pane = parse_pane(intent)?;
+        let path = required_str(intent, "path")?;
+        let entries = parse_entries(intent)?;
+        store.load_succeeded(&intent.client_id, pane, &path, entries);
+        Ok(publish_file_browser(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("fileBrowser.loadFailed", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let pane = parse_pane(intent)?;
+        let error = optional_str(intent, "error");
+        store.load_failed(&intent.client_id, pane, error);
+        Ok(publish_file_browser(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("fileBrowser.reset", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let pane = parse_pane(intent)?;
+        store.reset_pane(&intent.client_id, pane);
+        Ok(publish_file_browser(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle;
+    registry.route("fileBrowser.setClipboard", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let clipboard = parse_clipboard(intent)?;
+        store.set_clipboard(&intent.client_id, clipboard);
+        Ok(publish_file_browser(projector, &store, &intent.client_id))
+    });
+}
+
+/// Resolve the managed file-browser store, or a rejectable error if absent.
+fn store_of(app_handle: &AppHandle) -> Result<Arc<FileBrowserStore>, (String, String)> {
+    app_handle
+        .try_state::<Arc<FileBrowserStore>>()
+        .map(|state| (*state).clone())
+        .ok_or_else(|| {
+            (
+                "unavailable".to_string(),
+                "file-browser store is not initialized".to_string(),
+            )
+        })
+}
+
+/// Parse the active-mode field (`"local"` / `"sftp"` / `"session"` / `"none"`)
+/// into an optional [`FileBrowserKind`] (`"none"` → `None`).
+fn parse_mode(intent: &Intent) -> Result<Option<FileBrowserKind>, (String, String)> {
+    match intent.payload.get("mode").and_then(Value::as_str) {
+        Some("none") => Ok(None),
+        Some("local") => Ok(Some(FileBrowserKind::Local)),
+        Some("sftp") => Ok(Some(FileBrowserKind::Sftp)),
+        Some("session") => Ok(Some(FileBrowserKind::Session)),
+        Some(_) => Err(("bad_payload".to_string(), "invalid 'mode'".to_string())),
+        None => Err(("bad_payload".to_string(), "missing 'mode'".to_string())),
+    }
+}
+
+/// Parse the target-pane field into a concrete [`FileBrowserKind`]. Unlike
+/// `mode`, a pane must be concrete — `"none"` is rejected.
+fn parse_pane(intent: &Intent) -> Result<FileBrowserKind, (String, String)> {
+    match intent.payload.get("pane").and_then(Value::as_str) {
+        Some("local") => Ok(FileBrowserKind::Local),
+        Some("sftp") => Ok(FileBrowserKind::Sftp),
+        Some("session") => Ok(FileBrowserKind::Session),
+        Some(_) => Err(("bad_payload".to_string(), "invalid 'pane'".to_string())),
+        None => Err(("bad_payload".to_string(), "missing 'pane'".to_string())),
+    }
+}
+
+/// Parse the required `entries` array into typed [`FileEntry`]s, rejecting a
+/// missing or malformed listing.
+fn parse_entries(intent: &Intent) -> Result<Vec<FileEntry>, (String, String)> {
+    let value = intent
+        .payload
+        .get("entries")
+        .ok_or_else(|| ("bad_payload".to_string(), "missing 'entries'".to_string()))?;
+    serde_json::from_value(value.clone())
+        .map_err(|e| ("bad_payload".to_string(), format!("invalid 'entries': {e}")))
+}
+
+/// Parse the `clipboard` field into an optional [`Clipboard`]; a missing or
+/// `null` value clears the clipboard.
+fn parse_clipboard(intent: &Intent) -> Result<Option<Clipboard>, (String, String)> {
+    match intent.payload.get("clipboard") {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => serde_json::from_value(value.clone())
+            .map(Some)
+            .map_err(|e| {
+                (
+                    "bad_payload".to_string(),
+                    format!("invalid 'clipboard': {e}"),
+                )
+            }),
+    }
+}
+
+/// Extract a required string field from an intent payload.
+fn required_str(intent: &Intent, key: &str) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// Extract an optional string field (e.g. a failure reason); absent → `None`.
+fn optional_str(intent: &Intent, key: &str) -> Option<String> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+#[path = "projection_tests.rs"]
+mod tests;

--- a/src-tauri/src/file_browser_projection/projection_tests.rs
+++ b/src-tauri/src/file_browser_projection/projection_tests.rs
@@ -1,0 +1,433 @@
+//! Projection-contract tests for the client-scoped `file-browser@<clientId>`
+//! region (#2228), reusing the substrate harness (#2164): an in-memory
+//! [`VecSink`] and a client cache that applies diffs. The routes here drive a
+//! real [`FileBrowserStore`] directly through the **production** parse helpers
+//! ([`super`]), the exact parse → mutate → publish path
+//! `register_file_browser_intents` runs (that thin wiring only differs in
+//! resolving the store from the Tauri `AppHandle`; it is integration-verified via
+//! a local `./scripts/dev.sh` run).
+//!
+//! Asserted: subscribe → snapshot (identical to every subscriber), an accepted
+//! intent → exactly one coalesced diff fanned to every subscriber with monotonic
+//! versions, client-scoped isolation, rejection paths advance nothing, a no-op
+//! intent coalesces to nothing, a dead subscriber is reaped, and the client cache
+//! converges on the store's authority across a full browsing session.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::{json, Value};
+
+use super::{optional_str, parse_clipboard, parse_entries, parse_mode, parse_pane, required_str};
+use crate::file_browser_projection::projection::{file_browser_region, publish_file_browser};
+use crate::file_browser_projection::store::FileBrowserStore;
+use crate::projection::{
+    apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
+    ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
+};
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+/// The production `fileBrowser.*` routes, bound to an injected store instead of
+/// resolving one from an `AppHandle` — the exact parse → mutate → publish path
+/// `register_file_browser_intents` runs, reusing its parse helpers verbatim.
+fn registry_for(store: Arc<FileBrowserStore>) -> HandlerRegistry {
+    let mut registry = HandlerRegistry::new();
+
+    let s = store.clone();
+    registry.route("fileBrowser.setMode", move |intent, projector| {
+        s.set_mode(&intent.client_id, parse_mode(intent)?);
+        Ok(publish_file_browser(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("fileBrowser.loadStarted", move |intent, projector| {
+        s.load_started(&intent.client_id, parse_pane(intent)?);
+        Ok(publish_file_browser(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("fileBrowser.loadSucceeded", move |intent, projector| {
+        let pane = parse_pane(intent)?;
+        let path = required_str(intent, "path")?;
+        let entries = parse_entries(intent)?;
+        s.load_succeeded(&intent.client_id, pane, &path, entries);
+        Ok(publish_file_browser(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("fileBrowser.loadFailed", move |intent, projector| {
+        let pane = parse_pane(intent)?;
+        s.load_failed(&intent.client_id, pane, optional_str(intent, "error"));
+        Ok(publish_file_browser(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("fileBrowser.reset", move |intent, projector| {
+        s.reset_pane(&intent.client_id, parse_pane(intent)?);
+        Ok(publish_file_browser(projector, &s, &intent.client_id))
+    });
+
+    let s = store;
+    registry.route("fileBrowser.setClipboard", move |intent, projector| {
+        s.set_clipboard(&intent.client_id, parse_clipboard(intent)?);
+        Ok(publish_file_browser(projector, &s, &intent.client_id))
+    });
+
+    registry
+}
+
+/// A file-entry payload object (mirrors the frontend `FileEntry` JSON).
+fn entry_json(name: &str, is_directory: bool) -> Value {
+    json!({
+        "name": name,
+        "path": format!("/{name}"),
+        "isDirectory": is_directory,
+        "size": 0,
+        "modified": "",
+        "permissions": null,
+        "writable": null,
+    })
+}
+
+/// An in-memory sink recording delivered frames; can be killed to simulate a
+/// dead subscriber (mirrors the substrate/broadcast/layout test double).
+struct VecSink {
+    frames: Mutex<Vec<ProjectionFrame>>,
+    alive: AtomicBool,
+}
+
+impl VecSink {
+    fn new() -> Self {
+        Self {
+            frames: Mutex::new(Vec::new()),
+            alive: AtomicBool::new(true),
+        }
+    }
+
+    fn diffs(&self) -> Vec<DiffFrame> {
+        self.frames
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|f| match f {
+                ProjectionFrame::Diff(d) => Some(d.clone()),
+                ProjectionFrame::Snapshot(_) => None,
+            })
+            .collect()
+    }
+}
+
+impl ProjectionSink for VecSink {
+    fn deliver(&self, frame: &ProjectionFrame) -> Result<(), ProjectionError> {
+        if !self.alive.load(Ordering::SeqCst) {
+            return Err(ProjectionError::SinkClosed("killed".into()));
+        }
+        self.frames.lock().unwrap().push(frame.clone());
+        Ok(())
+    }
+}
+
+/// A minimal client cache mirroring the TypeScript `ProjectionClient`.
+struct ClientCache {
+    version: u64,
+    view: Value,
+}
+
+impl ClientCache {
+    fn from_snapshot(s: &SnapshotFrame) -> Self {
+        Self {
+            version: s.version,
+            view: s.view.clone(),
+        }
+    }
+
+    fn apply(&mut self, diff: &DiffFrame) {
+        assert_eq!(diff.base_version, self.version, "diff must fit the cache");
+        apply_ops(&mut self.view, &diff.ops).expect("diff applies cleanly");
+        self.version = diff.version;
+    }
+}
+
+fn intent(kind: &str, client: &str, payload: Value) -> Intent {
+    Intent {
+        intent_id: format!("01J-{kind}"),
+        kind: kind.to_string(),
+        payload,
+        client_id: client.to_string(),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn subscribe_returns_the_idle_baseline_identically_to_every_subscriber() {
+    let store = Arc::new(FileBrowserStore::new());
+    let region = file_browser_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+
+    let snap_a = projector.subscribe(&region, "sub-a", "A", Arc::new(VecSink::new()));
+    let snap_b = projector.subscribe(&region, "sub-b", "A", Arc::new(VecSink::new()));
+
+    assert_eq!(snap_a.version, 0);
+    assert_eq!(snap_a, snap_b, "a late joiner gets an identical baseline");
+    assert_eq!(snap_a.region, "file-browser@A");
+    assert_eq!(snap_a.view["mode"], json!("none"));
+    assert_eq!(snap_a.view["local"]["path"], json!("/"));
+    assert_eq!(snap_a.view["clipboard"], Value::Null);
+}
+
+#[test]
+fn a_load_succeeded_intent_produces_one_diff_fanned_to_two_subscribers() {
+    let store = Arc::new(FileBrowserStore::new());
+    let region = file_browser_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink_a = Arc::new(VecSink::new());
+    let sink_b = Arc::new(VecSink::new());
+    let snap = projector.subscribe(&region, "sub-a", "A", sink_a.clone());
+    projector.subscribe(&region, "sub-b", "A", sink_b.clone());
+    let mut cache_a = ClientCache::from_snapshot(&snap);
+
+    let ack = dispatcher.dispatch(intent(
+        "fileBrowser.loadSucceeded",
+        "A",
+        json!({ "pane": "sftp", "path": "/var", "entries": [entry_json("log", true)] }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(
+        ack.produced,
+        Some(vec![crate::projection::ProducedRegion {
+            region: region.clone(),
+            version: 1,
+        }])
+    );
+
+    let diffs_a = sink_a.diffs();
+    let diffs_b = sink_b.diffs();
+    assert_eq!(diffs_a.len(), 1, "exactly one diff to A");
+    assert_eq!(diffs_b.len(), 1, "exactly one diff to B");
+    assert_eq!(diffs_a[0], diffs_b[0], "identical diff to every subscriber");
+
+    cache_a.apply(&diffs_a[0]);
+    assert_eq!(cache_a.view, store.snapshot("A"), "cache converges");
+    assert_eq!(cache_a.view["sftp"]["path"], json!("/var"));
+    assert_eq!(cache_a.view["sftp"]["entries"][0]["name"], json!("log"));
+}
+
+#[test]
+fn a_full_browsing_session_advances_monotonically_and_converges() {
+    let store = Arc::new(FileBrowserStore::new());
+    let region = file_browser_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(&region, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    // setMode(local) → loadStarted → loadSucceeded → copy to clipboard → reset.
+    for (kind, payload) in [
+        ("fileBrowser.setMode", json!({ "mode": "local" })),
+        ("fileBrowser.loadStarted", json!({ "pane": "local" })),
+        (
+            "fileBrowser.loadSucceeded",
+            json!({ "pane": "local", "path": "/home", "entries": [entry_json("a", false)] }),
+        ),
+        (
+            "fileBrowser.setClipboard",
+            json!({ "clipboard": {
+                "entries": [entry_json("a", false)],
+                "operation": "copy",
+                "sourceMode": "local",
+                "sourcePath": "/home",
+                "sftpSessionId": null,
+            }}),
+        ),
+        ("fileBrowser.reset", json!({ "pane": "local" })),
+    ] {
+        let ack = dispatcher.dispatch(intent(kind, "A", payload));
+        assert_eq!(ack.status, IntentStatus::Accepted, "{kind} accepted");
+    }
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 5, "one diff per view-changing intent");
+    for diff in &diffs {
+        cache.apply(diff);
+    }
+    assert_eq!(cache.version, 5);
+    assert_eq!(
+        cache.view,
+        store.snapshot("A"),
+        "cache converges on authority"
+    );
+    // reset returned the pane to baseline; the clipboard copy persisted.
+    assert_eq!(cache.view["local"]["path"], json!("/"));
+    assert_eq!(cache.view["local"]["entries"], json!([]));
+    assert_eq!(cache.view["clipboard"]["operation"], json!("copy"));
+    assert_eq!(cache.view["mode"], json!("local"));
+}
+
+#[test]
+fn browser_state_is_isolated_to_its_client_region() {
+    let store = Arc::new(FileBrowserStore::new());
+    let region_a = file_browser_region("A");
+    let region_b = file_browser_region("B");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region_a, store.snapshot("A"));
+    projector.register_region(&region_b, store.snapshot("B"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink_a = Arc::new(VecSink::new());
+    let sink_b = Arc::new(VecSink::new());
+    projector.subscribe(&region_a, "sa", "A", sink_a.clone());
+    projector.subscribe(&region_b, "sb", "B", sink_b.clone());
+
+    dispatcher.dispatch(intent(
+        "fileBrowser.loadSucceeded",
+        "A",
+        json!({ "pane": "local", "path": "/a", "entries": [] }),
+    ));
+
+    assert_eq!(sink_a.diffs().len(), 1, "A's region advanced");
+    assert_eq!(sink_b.diffs().len(), 0, "B's region untouched");
+    assert_eq!(projector.region_version(&region_b), Some(0));
+}
+
+#[test]
+fn an_intent_with_an_invalid_pane_is_rejected_without_advancing() {
+    let store = Arc::new(FileBrowserStore::new());
+    let region = file_browser_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(&region, "sub", "A", sink.clone());
+
+    // "none" is not a valid concrete pane target for loadStarted.
+    let ack = dispatcher.dispatch(intent(
+        "fileBrowser.loadStarted",
+        "A",
+        json!({ "pane": "none" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "bad_payload");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(&region), Some(0));
+}
+
+#[test]
+fn a_missing_entries_listing_is_rejected_without_advancing() {
+    let store = Arc::new(FileBrowserStore::new());
+    let region = file_browser_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(&region, "sub", "A", sink.clone());
+
+    let ack = dispatcher.dispatch(intent(
+        "fileBrowser.loadSucceeded",
+        "A",
+        json!({ "pane": "local", "path": "/x" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "bad_payload");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(&region), Some(0));
+}
+
+#[test]
+fn a_no_op_set_mode_advances_nothing() {
+    // Re-setting the mode to its current value leaves the view unchanged, so the
+    // projector coalesces it to no diff and no version bump.
+    let store = Arc::new(FileBrowserStore::new());
+    let region = file_browser_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(&region, "sub", "A", sink.clone());
+
+    // The baseline mode is already "none"; setting it to "none" is a no-op.
+    let ack = dispatcher.dispatch(intent(
+        "fileBrowser.setMode",
+        "A",
+        json!({ "mode": "none" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(ack.produced, Some(vec![]), "no region advanced");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(&region), Some(0));
+}
+
+#[test]
+fn a_set_clipboard_then_clear_round_trips_through_the_region() {
+    let store = Arc::new(FileBrowserStore::new());
+    let region = file_browser_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(&region, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    for payload in [
+        json!({ "clipboard": {
+            "entries": [entry_json("d", true)],
+            "operation": "cut",
+            "sourceMode": "session",
+            "sourcePath": "/r",
+            "terminalSessionId": "t-1",
+        }}),
+        json!({ "clipboard": null }),
+    ] {
+        let ack = dispatcher.dispatch(intent("fileBrowser.setClipboard", "A", payload));
+        assert_eq!(ack.status, IntentStatus::Accepted);
+    }
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 2, "set then clear each produced a diff");
+    for diff in &diffs {
+        cache.apply(diff);
+    }
+    assert_eq!(cache.view, store.snapshot("A"), "cache converges");
+    assert_eq!(cache.view["clipboard"], Value::Null);
+}
+
+#[test]
+fn a_dead_subscriber_is_reaped_on_publish() {
+    let store = Arc::new(FileBrowserStore::new());
+    let region = file_browser_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let live = Arc::new(VecSink::new());
+    let dead = Arc::new(VecSink::new());
+    projector.subscribe(&region, "live", "A", live.clone());
+    projector.subscribe(&region, "dead", "A", dead.clone());
+    assert_eq!(projector.subscriber_count(&region), 2);
+
+    dead.alive.store(false, Ordering::SeqCst);
+    dispatcher.dispatch(intent(
+        "fileBrowser.setMode",
+        "A",
+        json!({ "mode": "sftp" }),
+    ));
+
+    assert_eq!(
+        live.diffs().len(),
+        1,
+        "the live subscriber still gets the diff"
+    );
+    assert_eq!(
+        projector.subscriber_count(&region),
+        1,
+        "the dead subscriber was reaped"
+    );
+}

--- a/src-tauri/src/file_browser_projection/store.rs
+++ b/src-tauri/src/file_browser_projection/store.rs
@@ -1,0 +1,328 @@
+//! The authoritative, client-scoped file-browser **view** state behind the
+//! shadow `file-browser@<clientId>` region (#2228, Phase 5 of #2139 / #2153).
+//!
+//! Models the file-browser UI state the frontend currently drives in
+//! `appStore.ts`: the three browser panes a client can open — **local**
+//! (`localFileEntries` / `localCurrentPath`), **sftp** (`fileEntries` /
+//! `currentPath`) and **session** (`sessionFileEntries` / `sessionCurrentPath`)
+//! — which pane is currently active (`fileBrowserMode`), and the copy/cut
+//! clipboard (`fileClipboard`). Each pane tracks the directory it is showing,
+//! its listing, and whether a directory list is in flight / failed.
+//!
+//! # Scope — the browser *view*, not the SFTP session model (#2236)
+//!
+//! This store owns only the **browser view**: which directory each pane shows,
+//! its entry listing, the in-flight/error status of a *directory list*, the
+//! active pane, and the clipboard. It deliberately does **not** model the
+//! backend SFTP/session lifecycle — the live `sftpSessions` map, the SFTP
+//! transport connect status (`sftpStatus`), the connected host, or transfers.
+//! That backend session model is governed by a separate, pending maintainer
+//! decision (`SftpManager` vs `SessionManager`, #2236) and is out of scope here.
+//! The line is clean: "is a directory listing in progress for this pane" is a
+//! browser-view concern; "is the SFTP transport connected" is the session model.
+//! A pane's `loading`/`error` here are the browser's own list-operation flags
+//! (mirroring `localFileLoading`/`localFileError` etc.), not the SFTP session
+//! status.
+//!
+//! # Client-scoped — Open Design Decision #4 / #6
+//!
+//! An open file browser — its current directory, listing, active pane and
+//! clipboard — is a property of the *viewing client's* pane, not shared
+//! infrastructure. The underlying filesystem / SFTP backend is shared, but the
+//! *browser view over it* belongs to the one client looking at it; a second
+//! client browsing the same host has its own cwd, selection and clipboard. So —
+//! like the client-scoped `layout` ([`crate::layout::projection`]), `broadcast`
+//! ([`crate::broadcast_projection`]) and `workflow-run`
+//! ([`crate::workflow_projection`]) regions, and unlike the shared
+//! `session-lifecycle` region — the store keys everything by `clientId` and
+//! projects one `file-browser@<clientId>` region per client.
+//!
+//! # Shadow only (#2228)
+//!
+//! Managed authoritative state that serves the `fileBrowser.*` intents, but
+//! nothing in the live UI subscribes to or renders the region yet: `appStore`
+//! stays authoritative. Later steps cut rendering, then the mutations, over to
+//! it, keeping the `appStore` reducers as the parity-safe fallback.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// The three file-browser panes a client can open, mirroring the frontend
+/// `fileBrowserMode` variants (minus `"none"`, which is the *absence* of an
+/// active pane — see [`ClientState::mode`]). Also the `sourceMode` of a
+/// clipboard entry.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum FileBrowserKind {
+    /// The local-filesystem browser (`localFileEntries` / `localCurrentPath`).
+    Local,
+    /// The SFTP browser (`fileEntries` / `currentPath`).
+    Sftp,
+    /// The remote-session browser (`sessionFileEntries` / `sessionCurrentPath`).
+    Session,
+}
+
+/// A copy/cut clipboard operation, mirroring the frontend
+/// `FileClipboard.operation`.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ClipboardOperation {
+    Copy,
+    Cut,
+}
+
+/// One directory entry, mirroring the frontend `FileEntry` (`connection.ts`).
+///
+/// Carried verbatim as the pane's listing and inside a clipboard; the store
+/// does not interpret the fields beyond passing them through the projected
+/// view, so its shape stays a faithful mirror of the frontend type.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FileEntry {
+    pub name: String,
+    pub path: String,
+    pub is_directory: bool,
+    pub size: u64,
+    #[serde(default)]
+    pub modified: String,
+    #[serde(default)]
+    pub permissions: Option<String>,
+    #[serde(default)]
+    pub writable: Option<bool>,
+    #[serde(default)]
+    pub is_symlink: bool,
+    #[serde(default)]
+    pub symlink_target: Option<String>,
+}
+
+/// The copy/cut clipboard, mirroring the frontend `FileClipboard`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Clipboard {
+    pub entries: Vec<FileEntry>,
+    pub operation: ClipboardOperation,
+    pub source_mode: FileBrowserKind,
+    pub source_path: String,
+    #[serde(default)]
+    pub sftp_session_id: Option<String>,
+    #[serde(default)]
+    pub terminal_session_id: Option<String>,
+}
+
+/// One browser pane's view: the directory it shows, its listing, and the
+/// in-flight/error status of a directory list. Mirrors the per-mode
+/// `*FileEntries` / `*CurrentPath` / `*FileLoading` / `*FileError` slice.
+#[derive(Clone, Debug, PartialEq)]
+struct Pane {
+    path: String,
+    entries: Vec<FileEntry>,
+    loading: bool,
+    error: Option<String>,
+}
+
+impl Default for Pane {
+    /// The idle baseline the frontend seeds each pane with: root path, empty
+    /// listing, not loading, no error.
+    fn default() -> Self {
+        Self {
+            path: "/".to_string(),
+            entries: Vec::new(),
+            loading: false,
+            error: None,
+        }
+    }
+}
+
+impl Pane {
+    fn to_view(&self) -> Value {
+        json!({
+            "path": self.path,
+            "entries": self.entries,
+            "loading": self.loading,
+            "error": self.error,
+        })
+    }
+}
+
+/// One client's file-browser view.
+#[derive(Clone, Debug, Default)]
+struct ClientState {
+    /// The active pane, or `None` when no browser is open (`fileBrowserMode`
+    /// `"none"`).
+    mode: Option<FileBrowserKind>,
+    local: Pane,
+    sftp: Pane,
+    session: Pane,
+    /// The copy/cut clipboard, or `None` when empty.
+    clipboard: Option<Clipboard>,
+}
+
+impl ClientState {
+    #[cfg(test)]
+    fn pane(&self, kind: FileBrowserKind) -> &Pane {
+        match kind {
+            FileBrowserKind::Local => &self.local,
+            FileBrowserKind::Sftp => &self.sftp,
+            FileBrowserKind::Session => &self.session,
+        }
+    }
+
+    fn pane_mut(&mut self, kind: FileBrowserKind) -> &mut Pane {
+        match kind {
+            FileBrowserKind::Local => &mut self.local,
+            FileBrowserKind::Sftp => &mut self.sftp,
+            FileBrowserKind::Session => &mut self.session,
+        }
+    }
+
+    /// The complete render-ready view model for this client's region.
+    fn to_view(&self) -> Value {
+        let mode = match self.mode {
+            None => "none",
+            Some(FileBrowserKind::Local) => "local",
+            Some(FileBrowserKind::Sftp) => "sftp",
+            Some(FileBrowserKind::Session) => "session",
+        };
+        json!({
+            "mode": mode,
+            "local": self.local.to_view(),
+            "sftp": self.sftp.to_view(),
+            "session": self.session.to_view(),
+            "clipboard": self.clipboard,
+        })
+    }
+}
+
+/// The shadow file-browser authority. Owns one [`ClientState`] per attached
+/// client, keyed by `clientId`; an unknown client is seeded lazily on first
+/// touch. Each client projects its own `file-browser@<clientId>` region.
+pub struct FileBrowserStore {
+    clients: Mutex<HashMap<String, ClientState>>,
+}
+
+impl Default for FileBrowserStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FileBrowserStore {
+    /// A store with no clients yet. Regions are seeded lazily per `clientId`.
+    pub fn new() -> Self {
+        Self {
+            clients: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// The current render-ready view model for a client (seeding it if
+    /// unknown): `{ mode, local, sftp, session, clipboard }`.
+    ///
+    /// Pure with respect to browser state (never mutates beyond lazy seeding of
+    /// an empty client), so the projector can safely diff two consecutive
+    /// snapshots.
+    pub fn snapshot(&self, client_id: &str) -> Value {
+        self.lock()
+            .entry(client_id.to_string())
+            .or_default()
+            .to_view()
+    }
+
+    /// `fileBrowser.setMode` — set the active browser pane (mirroring
+    /// `setFileBrowserMode`). `None` is the frontend `"none"` (no browser open).
+    pub fn set_mode(&self, client_id: &str, mode: Option<FileBrowserKind>) {
+        let mut clients = self.lock();
+        clients.entry(client_id.to_string()).or_default().mode = mode;
+    }
+
+    /// `fileBrowser.loadStarted` — a directory list began for a pane: mark it
+    /// loading and clear its error (mirroring the `set({ *Loading: true,
+    /// *Error: null })` at the head of `navigate*` / `refresh*`).
+    pub fn load_started(&self, client_id: &str, pane: FileBrowserKind) {
+        let mut clients = self.lock();
+        let p = clients
+            .entry(client_id.to_string())
+            .or_default()
+            .pane_mut(pane);
+        p.loading = true;
+        p.error = None;
+    }
+
+    /// `fileBrowser.loadSucceeded` — a directory list completed for a pane:
+    /// commit the listing and path and clear loading (mirroring the success
+    /// `set({ *FileEntries, *CurrentPath, *Loading: false })`). This is the
+    /// `setEntries` seam.
+    pub fn load_succeeded(
+        &self,
+        client_id: &str,
+        pane: FileBrowserKind,
+        path: &str,
+        entries: Vec<FileEntry>,
+    ) {
+        let mut clients = self.lock();
+        let p = clients
+            .entry(client_id.to_string())
+            .or_default()
+            .pane_mut(pane);
+        p.path = path.to_string();
+        p.entries = entries;
+        p.loading = false;
+        p.error = None;
+    }
+
+    /// `fileBrowser.loadFailed` — a directory list failed for a pane: clear
+    /// loading and record the error, leaving the last-good path/listing in place
+    /// (mirroring the `catch` `set({ *Loading: false, *Error })`).
+    pub fn load_failed(&self, client_id: &str, pane: FileBrowserKind, error: Option<String>) {
+        let mut clients = self.lock();
+        let p = clients
+            .entry(client_id.to_string())
+            .or_default()
+            .pane_mut(pane);
+        p.loading = false;
+        p.error = error;
+    }
+
+    /// `fileBrowser.reset` — reset a pane to the idle baseline (root path, empty
+    /// listing, not loading, no error), mirroring the `set({ *FileEntries: [],
+    /// *CurrentPath: "/" })` resets on disconnect / tab close.
+    pub fn reset_pane(&self, client_id: &str, pane: FileBrowserKind) {
+        let mut clients = self.lock();
+        *clients
+            .entry(client_id.to_string())
+            .or_default()
+            .pane_mut(pane) = Pane::default();
+    }
+
+    /// `fileBrowser.setClipboard` — set or clear the copy/cut clipboard
+    /// (mirroring `setFileClipboard`).
+    pub fn set_clipboard(&self, client_id: &str, clipboard: Option<Clipboard>) {
+        let mut clients = self.lock();
+        clients.entry(client_id.to_string()).or_default().clipboard = clipboard;
+    }
+
+    /// Read a pane's `(path, entry_count, loading)` (test/diagnostics helper).
+    #[cfg(test)]
+    pub fn pane_state(
+        &self,
+        client_id: &str,
+        pane: FileBrowserKind,
+    ) -> Option<(String, usize, bool)> {
+        self.lock().get(client_id).map(|s| {
+            let p = s.pane(pane);
+            (p.path.clone(), p.entries.len(), p.loading)
+        })
+    }
+
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, ClientState>> {
+        // Short critical sections only; a poisoned lock means another thread
+        // panicked mid-mutation (a bug) — recover rather than cascade.
+        self.clients.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod tests;

--- a/src-tauri/src/file_browser_projection/store_tests.rs
+++ b/src-tauri/src/file_browser_projection/store_tests.rs
@@ -1,0 +1,204 @@
+//! State-machine tests for [`FileBrowserStore`], proving the file-browser view
+//! authority matches the frontend `appStore` reducers: the per-pane load
+//! lifecycle (`loadStarted` → `loadSucceeded` / `loadFailed`), the idle-baseline
+//! reset, the active-mode selection, the copy/cut clipboard, the independence of
+//! the three panes, and the per-client isolation the client-scoped region needs.
+
+use super::*;
+
+const C: &str = "client-1";
+
+/// A minimal directory entry for a listing (the fields the browser distinguishes
+/// on; the rest default).
+fn entry(name: &str, is_directory: bool) -> FileEntry {
+    FileEntry {
+        name: name.to_string(),
+        path: format!("/{name}"),
+        is_directory,
+        size: 0,
+        modified: String::new(),
+        permissions: None,
+        writable: None,
+        is_symlink: false,
+        symlink_target: None,
+    }
+}
+
+#[test]
+fn a_fresh_client_is_the_idle_baseline() {
+    let store = FileBrowserStore::new();
+    let view = store.snapshot(C);
+    assert_eq!(view["mode"], json!("none"));
+    for pane in ["local", "sftp", "session"] {
+        assert_eq!(view[pane]["path"], json!("/"), "{pane} path");
+        assert_eq!(view[pane]["entries"], json!([]), "{pane} entries");
+        assert_eq!(view[pane]["loading"], json!(false), "{pane} loading");
+        assert_eq!(view[pane]["error"], Value::Null, "{pane} error");
+    }
+    assert_eq!(view["clipboard"], Value::Null);
+}
+
+#[test]
+fn set_mode_selects_the_active_pane_and_none_clears_it() {
+    let store = FileBrowserStore::new();
+    store.set_mode(C, Some(FileBrowserKind::Sftp));
+    assert_eq!(store.snapshot(C)["mode"], json!("sftp"));
+    store.set_mode(C, Some(FileBrowserKind::Local));
+    assert_eq!(store.snapshot(C)["mode"], json!("local"));
+    store.set_mode(C, None);
+    assert_eq!(store.snapshot(C)["mode"], json!("none"));
+}
+
+#[test]
+fn load_started_marks_loading_and_clears_a_prior_error() {
+    let store = FileBrowserStore::new();
+    store.load_failed(C, FileBrowserKind::Local, Some("boom".to_string()));
+    assert_eq!(store.snapshot(C)["local"]["error"], json!("boom"));
+
+    store.load_started(C, FileBrowserKind::Local);
+    let view = store.snapshot(C);
+    assert_eq!(view["local"]["loading"], json!(true));
+    assert_eq!(view["local"]["error"], Value::Null);
+}
+
+#[test]
+fn load_succeeded_commits_path_and_listing_and_clears_loading() {
+    let store = FileBrowserStore::new();
+    store.load_started(C, FileBrowserKind::Sftp);
+    store.load_succeeded(
+        C,
+        FileBrowserKind::Sftp,
+        "/var/log",
+        vec![entry("syslog", false), entry("nginx", true)],
+    );
+    let view = store.snapshot(C);
+    assert_eq!(view["sftp"]["path"], json!("/var/log"));
+    assert_eq!(view["sftp"]["loading"], json!(false));
+    assert_eq!(view["sftp"]["error"], Value::Null);
+    assert_eq!(view["sftp"]["entries"][0]["name"], json!("syslog"));
+    assert_eq!(view["sftp"]["entries"][0]["isDirectory"], json!(false));
+    assert_eq!(view["sftp"]["entries"][1]["name"], json!("nginx"));
+    assert_eq!(view["sftp"]["entries"][1]["isDirectory"], json!(true));
+    assert_eq!(
+        store.pane_state(C, FileBrowserKind::Sftp),
+        Some(("/var/log".to_string(), 2, false))
+    );
+}
+
+#[test]
+fn load_failed_keeps_the_last_good_listing_and_records_the_error() {
+    let store = FileBrowserStore::new();
+    store.load_succeeded(C, FileBrowserKind::Local, "/home", vec![entry("a", false)]);
+    // A later failed navigation keeps the prior path/listing (mirrors the catch
+    // branch, which only sets loading:false + error).
+    store.load_started(C, FileBrowserKind::Local);
+    store.load_failed(C, FileBrowserKind::Local, Some("denied".to_string()));
+    let view = store.snapshot(C);
+    assert_eq!(view["local"]["path"], json!("/home"), "path retained");
+    assert_eq!(
+        view["local"]["entries"][0]["name"],
+        json!("a"),
+        "listing retained"
+    );
+    assert_eq!(view["local"]["loading"], json!(false));
+    assert_eq!(view["local"]["error"], json!("denied"));
+}
+
+#[test]
+fn reset_pane_returns_it_to_the_idle_baseline() {
+    let store = FileBrowserStore::new();
+    store.load_succeeded(C, FileBrowserKind::Session, "/tmp", vec![entry("x", false)]);
+    store.load_failed(C, FileBrowserKind::Session, Some("e".to_string()));
+    store.reset_pane(C, FileBrowserKind::Session);
+    let view = store.snapshot(C);
+    assert_eq!(view["session"]["path"], json!("/"));
+    assert_eq!(view["session"]["entries"], json!([]));
+    assert_eq!(view["session"]["loading"], json!(false));
+    assert_eq!(view["session"]["error"], Value::Null);
+}
+
+#[test]
+fn set_clipboard_stores_a_copy_and_null_clears_it() {
+    let store = FileBrowserStore::new();
+    store.set_clipboard(
+        C,
+        Some(Clipboard {
+            entries: vec![entry("f", false)],
+            operation: ClipboardOperation::Copy,
+            source_mode: FileBrowserKind::Sftp,
+            source_path: "/src".to_string(),
+            sftp_session_id: Some("sess-1".to_string()),
+            terminal_session_id: None,
+        }),
+    );
+    let view = store.snapshot(C);
+    assert_eq!(view["clipboard"]["operation"], json!("copy"));
+    assert_eq!(view["clipboard"]["sourceMode"], json!("sftp"));
+    assert_eq!(view["clipboard"]["sourcePath"], json!("/src"));
+    assert_eq!(view["clipboard"]["sftpSessionId"], json!("sess-1"));
+    assert_eq!(view["clipboard"]["terminalSessionId"], Value::Null);
+    assert_eq!(view["clipboard"]["entries"][0]["name"], json!("f"));
+
+    store.set_clipboard(C, None);
+    assert_eq!(store.snapshot(C)["clipboard"], Value::Null);
+}
+
+#[test]
+fn a_cut_clipboard_records_the_cut_operation() {
+    let store = FileBrowserStore::new();
+    store.set_clipboard(
+        C,
+        Some(Clipboard {
+            entries: vec![entry("d", true)],
+            operation: ClipboardOperation::Cut,
+            source_mode: FileBrowserKind::Local,
+            source_path: "/a".to_string(),
+            sftp_session_id: None,
+            terminal_session_id: Some("term-9".to_string()),
+        }),
+    );
+    let view = store.snapshot(C);
+    assert_eq!(view["clipboard"]["operation"], json!("cut"));
+    assert_eq!(view["clipboard"]["sourceMode"], json!("local"));
+    assert_eq!(view["clipboard"]["terminalSessionId"], json!("term-9"));
+    assert_eq!(view["clipboard"]["sftpSessionId"], Value::Null);
+}
+
+#[test]
+fn the_three_panes_are_independent() {
+    let store = FileBrowserStore::new();
+    store.load_succeeded(C, FileBrowserKind::Local, "/l", vec![entry("l", false)]);
+    store.load_succeeded(
+        C,
+        FileBrowserKind::Sftp,
+        "/s",
+        vec![entry("s1", false), entry("s2", false)],
+    );
+    store.load_started(C, FileBrowserKind::Session);
+    let view = store.snapshot(C);
+    // Local committed, sftp committed with two, session still loading at baseline.
+    assert_eq!(view["local"]["path"], json!("/l"));
+    assert_eq!(view["sftp"]["path"], json!("/s"));
+    assert_eq!(view["sftp"]["entries"].as_array().unwrap().len(), 2);
+    assert_eq!(view["session"]["path"], json!("/"));
+    assert_eq!(view["session"]["loading"], json!(true));
+}
+
+#[test]
+fn browser_state_is_isolated_per_client() {
+    let store = FileBrowserStore::new();
+    store.set_mode("a", Some(FileBrowserKind::Sftp));
+    store.load_succeeded("a", FileBrowserKind::Sftp, "/a", vec![entry("a", false)]);
+    store.set_mode("b", Some(FileBrowserKind::Local));
+
+    // Client b is untouched by client a's mutations.
+    let vb = store.snapshot("b");
+    assert_eq!(vb["mode"], json!("local"));
+    assert_eq!(vb["sftp"]["path"], json!("/"));
+    assert_eq!(vb["sftp"]["entries"], json!([]));
+
+    // ...and a keeps its own state.
+    let va = store.snapshot("a");
+    assert_eq!(va["mode"], json!("sftp"));
+    assert_eq!(va["sftp"]["path"], json!("/a"));
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,12 @@ mod connection;
 mod connections_projection;
 mod credential;
 mod embedded_servers;
+/// Shadow file-browser view authority (#2228, Phase 5 of #2139/#2153): the
+/// client-scoped `file-browser@<clientId>` region + `fileBrowser.*` intents
+/// modeling the file-browser UI state (`appStore` browser panes, active mode,
+/// clipboard). Registered and served but not yet driving the live UI — a pure
+/// shadow foundation. See [`file_browser_projection`].
+mod file_browser_projection;
 /// File-system access: local FS, SFTP sessions, and the cancellable transfer
 /// subsystem (public so integration tests can drive `SftpManager` /
 /// `TransferRegistry` directly — issue #1245).
@@ -786,6 +792,27 @@ pub fn run() {
                 // lazily on a client's first `workflow.*` intent.
                 app.manage(Arc::new(workflow_projection::WorkflowRunStore::new()));
                 workflow_projection::projection::register_workflow_intents(
+                    &mut registry,
+                    app.handle().clone(),
+                );
+                // Shadow FileBrowserStore (#2228, Phase 5, part of #2153): the
+                // client-scoped `file-browser@<clientId>` region +
+                // `fileBrowser.*` intents modeling the file-browser UI *view*
+                // state (the local/sftp/session browser panes — each cwd +
+                // listing — the active `fileBrowserMode`, and the copy/cut
+                // `fileClipboard`). Only the browser view: the backend
+                // SFTP/session *session* model (sessions, connect status,
+                // transfers) stays out of scope (#2236). Managed authoritative
+                // state that serves intents, but nothing in the live UI
+                // subscribes to or renders the region yet — a pure shadow
+                // foundation (later steps cut rendering, then the mutations,
+                // over to it, keeping the appStore reducers as the parity-safe
+                // fallback). No client region is seeded here: like layout,
+                // broadcast, and workflow-run, file-browser regions are
+                // client-scoped and created lazily on a client's first
+                // `fileBrowser.*` intent.
+                app.manage(Arc::new(file_browser_projection::FileBrowserStore::new()));
+                file_browser_projection::projection::register_file_browser_intents(
                     &mut registry,
                     app.handle().clone(),
                 );


### PR DESCRIPTION
## Summary

Lands the **Phase 5 File browsers domain shadow** (#2228) — a **backend-only**, zero-user-facing Rust authority modeling the file-browser **UI view state** `appStore.ts` currently drives, following the proven per-domain shadow pattern (broadcast #2254, workflow-run #2256, monitors #2230).

New module `src-tauri/src/file_browser_projection/`:

- **Store** (`FileBrowserStore`) modeling the three browser panes — **local** / **sftp** / **session**, each `{ path, entries, loading, error }` — the active `fileBrowserMode`, and the copy/cut `fileClipboard`.
- **Client-scoped region** `file-browser@<clientId>` + `fileBrowser.*` intents: `setMode`, `loadStarted`, `loadSucceeded` (the setEntries seam), `loadFailed`, `reset`, `setClipboard`.
- ~20-line `lib.rs` region registration (managed store + intent routes). No client region is seeded — like layout/broadcast/workflow-run, regions are created lazily on a client's first intent.

### Region scope — client-scoped (Decision #4 / #6)

An open file browser — its cwd, listing, active pane and clipboard — is a property of the **viewing client's pane**, not shared infrastructure. The underlying filesystem/SFTP backend is shared, but the *browser view over it* belongs to the one client looking at it (a second client browsing the same host has its own cwd/clipboard). Mirrors the client-scoped `layout` / `broadcast` / `workflow-run` regions; contrast the shared `session-lifecycle` region.

### Out of scope — the SFTP/session session model (#2236)

This shadow models the **browser view only**: which directory each pane shows, its listing, the in-flight/error status of a *directory list*, the active pane, and the clipboard. It deliberately does **not** touch the backend SFTP/session lifecycle (`sftpSessions`, connect status, connected host, transfers) — that is the pending `SftpManager`-vs-`SessionManager` maintainer decision (#2236). The boundary is clean: "is a directory listing in progress" is a browser-view concern; "is the SFTP transport connected" is the session model. The appStore file-browser view separates cleanly from that backend model, so no STOP was needed.

## Shadow only — nothing user-facing changed

Registered and fully served, but **nothing in the live UI subscribes to or dispatches** these intents yet; `appStore` stays authoritative. The diff touches only `src-tauri/` — **zero `src/` changes**. Later steps (separate issues) cut rendering, then the mutations, then remove the appStore reducers, keeping them as the parity-safe fallback until then.

## Tests

- **Store unit tests** (`store_tests.rs`) — the per-pane load lifecycle, idle-baseline reset, active-mode selection, copy/cut clipboard, pane independence, per-client isolation.
- **Projection-contract tests** (`projection_tests.rs`, #2164 harness) — subscribe → identical baseline, one coalesced diff fanned to every subscriber with monotonic versions, client-scoped isolation, rejection paths advance nothing, no-op coalesces to nothing, dead-subscriber reaping, and full-session cache convergence. The routes reuse the **production** parse helpers verbatim.

19 new tests green; `cargo clippy -p termihub --lib -- -D warnings` and `cargo fmt --check` clean.

Part of #2228