### PR TITLE
refactor(ui): cut settings-driven behavior readers to useProjectedSettings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import { useWebviewZoom } from "@/hooks/useWebviewZoom";
 import { useReportWindowTabCount } from "@/hooks/useReportWindowTabCount";
 import { useSidebarResize } from "@/hooks/useSidebarResize";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { getCliWorkspace } from "@/services/workspaceApi";
 import { resolveRestoreMode } from "@/utils/restoreMode";
 import { MAIN_WINDOW_LABEL } from "@/types/window";
@@ -61,7 +62,7 @@ function App() {
   useReportWindowTabCount();
   const loadFromBackend = useAppStore((s) => s.loadFromBackend);
   const checkForUpdates = useAppStore((s) => s.checkForUpdates);
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
   const layoutConfig = useAppStore((s) => s.layoutConfig);
   const sidebarCollapsed = useAppStore((s) => s.sidebarCollapsed);
   const { sidebarWidth, handleProps, isResizing } = useSidebarResize(layoutConfig.sidebarPosition);

--- a/src/components/ActivityBar/ActivityBar.tsx
+++ b/src/components/ActivityBar/ActivityBar.tsx
@@ -25,6 +25,7 @@ import * as ContextMenu from "@radix-ui/react-context-menu";
 import { open } from "@tauri-apps/plugin-dialog";
 import { readTextFile } from "@tauri-apps/plugin-fs";
 import { useAppStore, SidebarView } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { useExperimentalFeatures } from "@/hooks/useExperimentalFeatures";
 import { OpenConnectionsModal } from "@/components/OpenConnections/OpenConnectionsModal";
 import { Tooltip } from "@/components/ui";
@@ -95,7 +96,7 @@ export function ActivityBar({ horizontal }: ActivityBarProps) {
   const setExportDialogOpen = useAppStore((s) => s.setExportDialogOpen);
   const setImportDialog = useAppStore((s) => s.setImportDialog);
   const toggleActivityBarView = useAppStore((s) => s.toggleActivityBarView);
-  const showRecentSessions = useAppStore((s) => s.settings.showRecentSessions);
+  const showRecentSessions = useProjectedSettings().showRecentSessions;
   const experimental = useExperimentalFeatures();
 
   const handleExport = useCallback(() => {

--- a/src/components/ConnectionEditor/ConnectionEditor.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import {
   ConnectionConfig,
   ExternalAgentFile,
@@ -209,7 +210,7 @@ export function ConnectionEditor({ tabId, meta, isVisible }: ConnectionEditorPro
   const agentDefinitions = useAppStore((s) => s.agentDefinitions);
   const saveAgentDef = useAppStore((s) => s.saveAgentDef);
   const updateAgentDef = useAppStore((s) => s.updateAgentDef);
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
   const credentialStoreStatus = useAppStore((s) => s.credentialStoreStatus);
   const setEditorDirty = useAppStore((s) => s.setEditorDirty);
   const pendingCloseRequest = useAppStore((s) => s.pendingCloseRequest);

--- a/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
+++ b/src/components/ConnectionEditor/ConnectionTerminalSettings.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { ChevronDown, ChevronUp, Pencil, Plus, Trash2 } from "lucide-react";
-import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { TerminalOptions, LineEnding } from "@/types/terminal";
 import type { ConnectionHighlightingOverride, HighlightRule } from "@/types/syntaxHighlighting";
 import { DEFAULT_LINE_ENDING, LINE_ENDING_OPTIONS, lineEndingLabel } from "@/utils/lineEndings";
@@ -82,7 +82,7 @@ type AdditionalRuleEditorState = { mode: "new" } | { mode: "edit"; id: string } 
  * patterns for this connection but never remove global rules.
  */
 function ConnectionAdditionalRules({ options, onChange }: ConnectionTerminalSettingsProps) {
-  const globalSettings = useAppStore((s) => s.settings);
+  const globalSettings = useProjectedSettings();
   const [editor, setEditor] = useState<AdditionalRuleEditorState>(null);
 
   const rules = options.syntaxHighlighting?.additionalRules ?? [];
@@ -211,7 +211,7 @@ function ConnectionAdditionalRules({ options, onChange }: ConnectionTerminalSett
 }
 
 export function ConnectionTerminalSettings({ options, onChange }: ConnectionTerminalSettingsProps) {
-  const globalSettings = useAppStore((s) => s.settings);
+  const globalSettings = useProjectedSettings();
 
   const globalFontFamily =
     globalSettings.fontFamily || "MesloLGS Nerd Font Mono, Cascadia Code, ...";

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -18,6 +18,7 @@ import { Button, toast } from "@/components/ui";
 import { save } from "@tauri-apps/plugin-dialog";
 import { EditorTabMeta, EditorStatus } from "@/types/terminal";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { resolveLanguage } from "@/utils/languageMapping";
 import { getBasename } from "@/utils/formatters";
 import { suggestedSaveCopyPath } from "@/utils/saveCopyPath";
@@ -144,14 +145,15 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   const setEditorDirty = useAppStore((s) => s.setEditorDirty);
   const setEditorStatus = useAppStore((s) => s.setEditorStatus);
   const setEditorActions = useAppStore((s) => s.setEditorActions);
-  const fileLanguageMappings = useAppStore((s) => s.settings.fileLanguageMappings);
+  const projectedSettings = useProjectedSettings();
+  const fileLanguageMappings = projectedSettings.fileLanguageMappings;
   const pendingCloseRequest = useAppStore((s) => s.pendingCloseRequest);
   const setPendingCloseRequest = useAppStore((s) => s.setPendingCloseRequest);
   const closeTab = useAppStore((s) => s.closeTab);
   const renameTab = useAppStore((s) => s.renameTab);
   // Subscribe to the theme setting so we re-derive the Monaco theme when the
   // user explicitly switches between dark / light / system in the settings.
-  const themeSetting = useAppStore((s) => s.settings.theme);
+  const themeSetting = projectedSettings.theme;
   // Host label (`user@host:port`) of the editor's SFTP session — names the host
   // in the sudo prompt and keys the (optional) credential-store entry. The
   // credential store treats this string as an opaque namespace, and a sudo

--- a/src/components/NetworkTools/PingSweepPanel.tsx
+++ b/src/components/NetworkTools/PingSweepPanel.tsx
@@ -17,6 +17,7 @@ import { validateHost, validateIntRange } from "@/utils/fieldValidation";
 import { countHosts } from "@/utils/scanEstimate";
 import { useNetworkTask, type NetworkTaskContext } from "@/hooks/useNetworkTask";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 
 /** Host count above which the sweep warns before starting. */
 const LARGE_SWEEP_THRESHOLD = 1024;
@@ -53,8 +54,8 @@ export function PingSweepPanel({ prefillHost }: PingSweepPanelProps) {
 
   // Persisted "warn before a large sweep" preference. Defaults to true when
   // unset; the dialog's opt-out flips it off, re-enabled from General settings.
-  const warnLargeSweep = useAppStore((s) => s.settings.warnLargePingSweep);
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
+  const warnLargeSweep = settings.warnLargePingSweep;
   const updateSettings = useAppStore((s) => s.updateSettings);
 
   const hostRef = useAutofocusSelect<HTMLInputElement>();

--- a/src/components/NetworkTools/PortScannerPanel.tsx
+++ b/src/components/NetworkTools/PortScannerPanel.tsx
@@ -17,6 +17,7 @@ import { validateHost, validateIntRange } from "@/utils/fieldValidation";
 import { estimateScanProbes } from "@/utils/scanEstimate";
 import { useNetworkTask, type NetworkTaskContext } from "@/hooks/useNetworkTask";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 
 /** Probe count above which the scanner warns before starting. */
 const LARGE_SCAN_THRESHOLD = 1000;
@@ -47,8 +48,8 @@ export function PortScannerPanel({ prefillHost }: PortScannerPanelProps) {
 
   // Persisted "warn before a large scan" preference. Defaults to true when
   // unset; the dialog's opt-out flips it off, re-enabled from General settings.
-  const warnLargeScan = useAppStore((s) => s.settings.warnLargePortScan);
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
+  const warnLargeScan = settings.warnLargePortScan;
   const updateSettings = useAppStore((s) => s.updateSettings);
 
   const hostRef = useAutofocusSelect<HTMLInputElement>();

--- a/src/components/RecentSessionsSidebar/RecentSessionsSidebar.tsx
+++ b/src/components/RecentSessionsSidebar/RecentSessionsSidebar.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import { Trash2 } from "lucide-react";
 import { writeText as writeClipboard } from "@tauri-apps/plugin-clipboard-manager";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { Button, ConfirmDialog, Input, Tooltip, toast } from "@/components/ui";
 import { useConnectSavedConnection } from "@/hooks/useConnectSavedConnection";
 import { useFlatRovingNav } from "@/hooks/useFlatRovingNav";
@@ -34,7 +35,7 @@ function entryMatches(entry: SessionHistoryEntry, query: string): boolean {
 export function RecentSessionsSidebar() {
   const history = useAppStore((s) => s.sessionHistory);
   const folders = useAppStore((s) => s.folders);
-  const defaultUser = useAppStore((s) => s.settings.defaultUser);
+  const defaultUser = useProjectedSettings().defaultUser;
   const addConnection = useAppStore((s) => s.addConnection);
   const pinHistoryEntry = useAppStore((s) => s.pinHistoryEntry);
   const removeHistoryEntry = useAppStore((s) => s.removeHistoryEntry);

--- a/src/components/ShellIntegrationBanner/ShellIntegrationBanner.tsx
+++ b/src/components/ShellIntegrationBanner/ShellIntegrationBanner.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { FolderOpen } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { frontendLog } from "@/utils/frontendLog";
 import type { ShellIntegrationStatus } from "@/types/connection";
 import { Button, toast } from "@/components/ui";
@@ -17,7 +18,7 @@ import "./ShellIntegrationBanner.css";
  * Modelled on {@link TerminalViewModeBanner}.
  */
 export function ShellIntegrationBanner() {
-  const storedSi = useAppStore((s) => s.settings.shellIntegration);
+  const storedSi = useProjectedSettings().shellIntegration;
   const updateShellIntegration = useAppStore((s) => s.updateShellIntegration);
   const si = storedSi ?? defaultShellIntegrationSettings();
   // The banner can never show once dismissed or registered, so it need not even

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -37,6 +37,7 @@ import {
   ChevronDown,
 } from "lucide-react";
 import { useAppStore, getActiveTab } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { Button, Tooltip, Progress, Input, toast } from "@/components/ui";
 import { useFileBrowser } from "@/hooks/useFileBrowser";
 import { onVscodeEditComplete } from "@/services/events";
@@ -565,7 +566,7 @@ function useFileBrowserSync() {
   const connections = useAppStore((s) => s.connections);
   const remoteAgents = useAppStore((s) => s.remoteAgents);
   const fileBrowserMode = useAppStore((s) => s.fileBrowserMode);
-  const globalFileBrowserEnabled = useAppStore((s) => s.settings.fileBrowserEnabled);
+  const globalFileBrowserEnabled = useProjectedSettings().fileBrowserEnabled;
 
   // Derive mode from active tab
   const activeTab = useAppStore((s) => getActiveTab(s));

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -33,6 +33,7 @@ import {
   X,
 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { useProjectedBroadcast } from "@/store/useProjectedBroadcast";
 import { useLayoutRenderTree } from "@/store/useLayoutRenderTree";
 import { PanelNode, LeafPanel, TerminalTab, DropEdge } from "@/types/terminal";
@@ -633,7 +634,7 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
   const terminalAutoRetryCount = useAppStore((s) => s.terminalAutoRetryCount);
   const terminalWaitingForAgent = useAppStore((s) => s.terminalWaitingForAgent);
   const terminalReattaching = useAppStore((s) => s.terminalReattaching);
-  const rightClickBehavior = useAppStore((s) => s.settings.rightClickBehavior);
+  const rightClickBehavior = useProjectedSettings().rightClickBehavior;
   const useQuickAction =
     rightClickBehavior === "quickAction" || (!rightClickBehavior && isWindows());
 

--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -20,6 +20,7 @@ import {
   Puzzle,
 } from "lucide-react";
 import { useAppStore, getActiveTab, monitorKeyForTab } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { useProjectedMonitors } from "@/store/useProjectedMonitors";
 import { resolveHighlightingConfig } from "@/services/syntaxHighlightingConfig";
 import { frontendLog } from "@/utils/frontendLog";
@@ -324,7 +325,7 @@ function HighlightingIndicator() {
   });
   const tabId = activeTab?.id ?? null;
   const sessionId = activeTab?.sessionId ?? null;
-  const globalConfig = useAppStore((s) => s.settings.syntaxHighlighting);
+  const globalConfig = useProjectedSettings().syntaxHighlighting;
   const perConnection = useAppStore((s) =>
     tabId ? s.tabTerminalOptions[tabId]?.syntaxHighlighting : undefined
   );
@@ -514,7 +515,7 @@ function AgentUpdatesIndicator() {
  * Shows a connection picker when disconnected, and compact stats when connected.
  */
 function MonitoringStatus() {
-  const globalMonitoringEnabled = useAppStore((s) => s.settings.powerMonitoringEnabled);
+  const globalMonitoringEnabled = useProjectedSettings().powerMonitoringEnabled;
   const disconnectMonitoring = useAppStore((s) => s.disconnectMonitoring);
   const setMonitoringPaused = useAppStore((s) => s.setMonitoringPaused);
   const setMonitoringInterval = useAppStore((s) => s.setMonitoringInterval);

--- a/src/components/Terminal/ConfirmDetachTabDialog.tsx
+++ b/src/components/Terminal/ConfirmDetachTabDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ConfirmDialog } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 
 /**
  * One-time notice shown before closing a tab that is attached to a persistent
@@ -21,7 +22,7 @@ export function ConfirmDetachTabDialog() {
   const request = useAppStore((s) => s.pendingAttachedTabCloseConfirm);
   const setRequest = useAppStore((s) => s.setPendingAttachedTabCloseConfirm);
   const closeTab = useAppStore((s) => s.closeTab);
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
   const updateSettings = useAppStore((s) => s.updateSettings);
   // Local, deferred checkbox state — committed only on confirm, discarded on cancel.
   const [dontShow, setDontShow] = useState(false);

--- a/src/components/Terminal/ConfirmSessionCloseDialog.tsx
+++ b/src/components/Terminal/ConfirmSessionCloseDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ConfirmDialog } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { showReopenToast } from "@/utils/reopenTab";
 
 /**
@@ -22,7 +23,7 @@ export function ConfirmSessionCloseDialog() {
   const setRequest = useAppStore((s) => s.setPendingSessionCloseConfirm);
   const closeTab = useAppStore((s) => s.closeTab);
   const removePanel = useAppStore((s) => s.removePanel);
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
   const updateSettings = useAppStore((s) => s.updateSettings);
   // Local, deferred checkbox state — committed only on confirm, discarded on cancel.
   const [dontAsk, setDontAsk] = useState(false);

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -23,6 +23,7 @@ import {
 import { terminalDispatcher } from "@/services/events";
 import { useTerminalRegistry } from "./TerminalRegistry";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { getXtermTheme } from "@/themes";
 import {
   processKeyEvent,
@@ -1520,13 +1521,14 @@ export function Terminal({
   }, [horizontalScrolling, tabId]);
 
   // React to settings changes on live terminals (per-tab overrides take precedence)
-  const theme = useAppStore((s) => s.settings.theme);
-  const fontFamily = useAppStore((s) => s.settings.fontFamily);
-  const fontSize = useAppStore((s) => s.settings.fontSize);
-  const cursorBlink = useAppStore((s) => s.settings.cursorBlink);
-  const cursorStyle = useAppStore((s) => s.settings.cursorStyle);
-  const scrollbackBuffer = useAppStore((s) => s.settings.scrollbackBuffer);
-  const screenReaderMode = useAppStore((s) => s.settings.screenReaderMode);
+  const projectedSettings = useProjectedSettings();
+  const theme = projectedSettings.theme;
+  const fontFamily = projectedSettings.fontFamily;
+  const fontSize = projectedSettings.fontSize;
+  const cursorBlink = projectedSettings.cursorBlink;
+  const cursorStyle = projectedSettings.cursorStyle;
+  const scrollbackBuffer = projectedSettings.scrollbackBuffer;
+  const screenReaderMode = projectedSettings.screenReaderMode;
   const tabTermOpts = useAppStore((s) => s.tabTerminalOptions[tabId]);
 
   useEffect(() => {
@@ -1569,7 +1571,7 @@ export function Terminal({
   // the per-session toggle changes on a live terminal. `applyHighlighting`
   // resolves all three from the store, so re-running it on any of these keeps the
   // engine in sync — including toggling it off live, which drops all decorations.
-  const globalHighlighting = useAppStore((s) => s.settings.syntaxHighlighting);
+  const globalHighlighting = projectedSettings.syntaxHighlighting;
   const sessionHighlightingOverride = useAppStore((s) =>
     existingSessionId ? s.sessionHighlighting[existingSessionId] : undefined
   );
@@ -1588,7 +1590,7 @@ export function Terminal({
 
   // Keep the backend's per-session line ending in sync when the global default
   // or this connection's override changes while the terminal is open.
-  const defaultLineEnding = useAppStore((s) => s.settings.defaultLineEnding);
+  const defaultLineEnding = projectedSettings.defaultLineEnding;
   useEffect(() => {
     const sessionId = sessionIdRef.current;
     if (sessionId) void pushLineEnding(tabId, sessionId);

--- a/src/components/Terminal/TerminalView.tsx
+++ b/src/components/Terminal/TerminalView.tsx
@@ -14,6 +14,7 @@ import {
 import { listen } from "@tauri-apps/api/event";
 import { toast } from "sonner";
 import { useAppStore, getActiveTab } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { useProjectedBroadcast } from "@/store/useProjectedBroadcast";
 import { TerminalTab } from "@/types/terminal";
 import { getAllLeaves } from "@/utils/panelTree";
@@ -263,7 +264,7 @@ export function TerminalView() {
   const setPendingSessionCloseConfirm = useAppStore((s) => s.setPendingSessionCloseConfirm);
   const terminalExitedTabs = useAppStore((s) => s.terminalExitedTabs);
   const terminalSpawnErrors = useAppStore((s) => s.terminalSpawnErrors);
-  const confirmCloseLiveSession = useAppStore((s) => s.settings.confirmCloseLiveSession);
+  const confirmCloseLiveSession = useProjectedSettings().confirmCloseLiveSession;
   const toggleSidebar = useAppStore((s) => s.toggleSidebar);
   const sidebarCollapsed = useAppStore((s) => s.sidebarCollapsed);
   const macroRecording = useAppStore((s) => s.macroRecording);

--- a/src/components/UpdateNotification/UpdateNotification.tsx
+++ b/src/components/UpdateNotification/UpdateNotification.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { X, Shield, RefreshCw } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { Button } from "@/components/ui";
 import { useDesktopVersion } from "@/hooks/useAppInfo";
 import { frontendLog } from "@/utils/frontendLog";
@@ -20,7 +21,7 @@ export function UpdateNotification() {
   const updateNotificationDismissed = useAppStore((s) => s.updateNotificationDismissed);
   const dismissUpdateNotification = useAppStore((s) => s.dismissUpdateNotification);
   const skipUpdate = useAppStore((s) => s.skipUpdate);
-  const settings = useAppStore((s) => s.settings);
+  const settings = useProjectedSettings();
 
   const [showNotes, setShowNotes] = useState(false);
   const runningVersion = useDesktopVersion();

--- a/src/hooks/useExperimentalFeatures.projection.test.tsx
+++ b/src/hooks/useExperimentalFeatures.projection.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * `useExperimentalFeatures` render-cut parity (#2269). Proves a settings-driven
+ * behavior reader sources its value from the projected `settings` region: with the
+ * render flag on and the region a faithful mirror of `appStore`, the hook returns
+ * the projected `experimentalFeaturesEnabled`; when the region cannot catch up it
+ * falls back to `appStore` verbatim, so the value is identical to the pre-cut path.
+ *
+ * Representative of the behavior-reader subset cut in #2269 — every reader now
+ * routes through the same `useProjectedSettings()` hook, so the mirror + fallback
+ * behavior proven here holds for all of them.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import { useAppStore } from "@/store/appStore";
+import type { AppSettings } from "@/types/connection";
+import {
+  SETTINGS_REGION,
+  setSettingsRenderFromProjectionEnabled,
+  setSettingsTransportForTest,
+  stopSettingsSubscription,
+} from "@/store/settingsBridge";
+
+import { useExperimentalFeatures } from "./useExperimentalFeatures";
+
+function settings(overrides: Partial<AppSettings> = {}): AppSettings {
+  return {
+    version: "1",
+    externalConnectionFiles: [],
+    powerMonitoringEnabled: true,
+    fileBrowserEnabled: true,
+    ...overrides,
+  };
+}
+
+/** In-memory substrate double: applies `settings.replace` and fans a snapshot. */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  applyReplace = true;
+  private view: Record<string, unknown> = { version: "1", externalConnectionFiles: [] };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (intent.kind === "settings.replace" && this.applyReplace) {
+      const p = intent.payload as Record<string, unknown>;
+      this.view = (p.settings ?? {}) as Record<string, unknown>;
+      this.version += 1;
+      this.fan();
+    }
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: SETTINGS_REGION, version: this.version }],
+    };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(SETTINGS_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let transport: FakeTransport;
+
+const flush = () => act(async () => await Promise.resolve());
+
+/** Renders the hook's boolean result into the DOM so it can be asserted. */
+function Probe() {
+  const enabled = useExperimentalFeatures();
+  return <span data-testid="value">{String(enabled)}</span>;
+}
+
+function render() {
+  act(() => {
+    root.render(<Probe />);
+  });
+}
+
+function value(): string {
+  return container.querySelector('[data-testid="value"]')?.textContent ?? "";
+}
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  useAppStore.setState(useAppStore.getInitialState());
+  transport = new FakeTransport();
+  setSettingsTransportForTest(transport);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  stopSettingsSubscription();
+  setSettingsTransportForTest(null);
+  setSettingsRenderFromProjectionEnabled(null);
+  vi.clearAllMocks();
+});
+
+describe("useExperimentalFeatures render cut (#2269)", () => {
+  it("returns the value sourced from the projected region", async () => {
+    useAppStore.setState({ settings: settings({ experimentalFeaturesEnabled: true }) });
+
+    render();
+    await flush();
+    await flush();
+
+    // The hook seeded the region and now reads the projected value.
+    expect(transport.dispatched.some((d) => d.kind === "settings.replace")).toBe(true);
+    expect(value()).toBe("true");
+  });
+
+  it("falls back to the appStore value when the region cannot catch up", async () => {
+    transport.applyReplace = false; // acks but never advances the region
+    useAppStore.setState({ settings: settings({ experimentalFeaturesEnabled: true }) });
+
+    render();
+    await flush();
+    await flush();
+
+    // Gate rejects the stale projection → appStore verbatim, parity preserved.
+    expect(value()).toBe("true");
+  });
+
+  it("defaults to false when the setting is unset (parity with the pre-cut read)", async () => {
+    useAppStore.setState({ settings: settings() });
+
+    render();
+    await flush();
+    await flush();
+
+    expect(value()).toBe("false");
+  });
+});

--- a/src/hooks/useExperimentalFeatures.ts
+++ b/src/hooks/useExperimentalFeatures.ts
@@ -1,4 +1,4 @@
-import { useAppStore } from "@/store/appStore";
+import { useProjectedSettings } from "@/store/useProjectedSettings";
 
 /**
  * Returns whether experimental features are enabled.
@@ -11,5 +11,5 @@ import { useAppStore } from "@/store/appStore";
  * if (!experimental) return null;
  */
 export function useExperimentalFeatures(): boolean {
-  return useAppStore((s) => s.settings.experimentalFeaturesEnabled ?? false);
+  return useProjectedSettings().experimentalFeaturesEnabled ?? false;
 }


### PR DESCRIPTION
Follow-up to #2227 (Settings render cut, PR #2270 / Phase 5 #2153).

The render cut of the Settings **screen** (#2227) landed the `settings` projection bridge (`src/store/settingsBridge.ts`) and the `useProjectedSettings()` hook (`src/store/useProjectedSettings.ts`), and cut the Settings panels. The many **settings-driven behavior** readers scattered across the rest of the app were deliberately left on `appStore` and split out into #2269. This PR swaps them.

## What changed
Every settings-driven **React render** reader now sources its value from `useProjectedSettings()` instead of `useAppStore((s) => s.settings…)`:

- `src/App.tsx`
- `src/components/ActivityBar/ActivityBar.tsx` (`showRecentSessions`)
- `src/components/Sidebar/FileBrowser.tsx` (`fileBrowserEnabled`)
- `src/components/SplitView/SplitView.tsx` (`rightClickBehavior`)
- `src/components/StatusBar/StatusBar.tsx` (`syntaxHighlighting`, `powerMonitoringEnabled`)
- `src/components/FileEditor/FileEditor.tsx` (`fileLanguageMappings`, `theme`)
- `src/components/Terminal/Terminal.tsx` (`theme`, `fontFamily`, `fontSize`, `cursorBlink`, `cursorStyle`, `scrollbackBuffer`, `screenReaderMode`, `syntaxHighlighting`, `defaultLineEnding`)
- `src/components/Terminal/TerminalView.tsx` (`confirmCloseLiveSession`)
- `src/components/Terminal/ConfirmSessionCloseDialog.tsx`
- `src/components/Terminal/ConfirmDetachTabDialog.tsx`
- `src/components/ConnectionEditor/ConnectionEditor.tsx`
- `src/components/ConnectionEditor/ConnectionTerminalSettings.tsx` (both readers)
- `src/components/NetworkTools/PingSweepPanel.tsx` (`warnLargePingSweep`)
- `src/components/NetworkTools/PortScannerPanel.tsx` (`warnLargePortScan`)
- `src/components/RecentSessionsSidebar/RecentSessionsSidebar.tsx` (`defaultUser`)
- `src/components/ShellIntegrationBanner/ShellIntegrationBanner.tsx` (`shellIntegration`)
- `src/components/UpdateNotification/UpdateNotification.tsx`
- `src/hooks/useExperimentalFeatures.ts` (`experimentalFeaturesEnabled`)

Where a component read several settings fields (Terminal, FileEditor, PingSweep, PortScanner) the hook is called **once** and the fields are read off its result — one region subscription per component, and each derived primitive stays a local `const` so the existing `useEffect` dependency arrays keep their exact per-field reactivity.

## Files listed in #2269 with no React render reader (left untouched, intentional)
- `src/components/Terminal/TabBar.tsx` — only imperative `useAppStore.getState().settings` reads.
- `src/components/Terminal/Terminal.tsx` `pushLineEnding` — imperative `getState().settings` read.
- `src/components/Plugins/PluginDetailPanel.tsx` — no settings reader at all.

These are `getState()` reads, which #2269 explicitly places out of scope (handled by the mutation cut, not a render hook). All **render** readers are cut, so this closes the issue.

## Reactivity note
The faithful-mirror gate guarantees the projected view deep-equals `appStore`'s document, so every swapped value is value-identical — no user-visible change. Field selectors that previously subscribed to a single primitive now re-derive from the whole document; values are unchanged and effect dependency arrays are preserved, matching the approach already blessed by the Settings-screen cut.

## Tests
- New projection parity test `src/hooks/useExperimentalFeatures.projection.test.tsx` (mirror + appStore fallback), modeled on `SerialPortSettings.projection.test.tsx` — representative of the whole cut since all readers route through the same hook.
- Full frontend suite green (545 files, 4983 tests). `tsc --noEmit`, ESLint, and `prettier --check` clean. No Rust change.

Closes #2269