### PR TITLE
feat(sftp): render the file browser from the projected region (Part of #2228)

### DIFF
--- a/src-tauri/src/file_browser_projection/projection.rs
+++ b/src-tauri/src/file_browser_projection/projection.rs
@@ -70,7 +70,7 @@ use serde_json::Value;
 use tauri::{AppHandle, Manager};
 
 use crate::file_browser_projection::store::{
-    Clipboard, ClientView, FileBrowserKind, FileBrowserStore, FileEntry,
+    ClientView, Clipboard, FileBrowserKind, FileBrowserStore, FileEntry,
 };
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
 

--- a/src-tauri/src/file_browser_projection/projection.rs
+++ b/src-tauri/src/file_browser_projection/projection.rs
@@ -38,6 +38,13 @@
 //! | `fileBrowser.loadFailed`    | `{ pane, error? }`                     | clear loading, record the error, keep last listing  |
 //! | `fileBrowser.reset`         | `{ pane }`                             | reset the pane to the idle baseline (`/`, empty)    |
 //! | `fileBrowser.setClipboard`  | `{ clipboard }` (`null` clears)        | set / clear the copy-cut clipboard                  |
+//! | `fileBrowser.replace`       | `{ mode?, local?, sftp?, session?, clipboard? }` | overwrite the whole client view (render-cut mirror) |
+//!
+//! `fileBrowser.replace` is the whole-slice seed the frontend render cut (#2228)
+//! uses to keep the client's region a faithful copy of `appStore`'s file-browser
+//! UI-state slice while `appStore` stays authoritative — the analog of the
+//! connections bridge's `connection.replace`. The per-transition intents above
+//! drive the store for the (later) mutation cut.
 //!
 //! `pane` is the concrete browser being acted on (`local` / `sftp` / `session`);
 //! `mode` is which pane is *active* and additionally accepts `"none"`. The
@@ -63,7 +70,7 @@ use serde_json::Value;
 use tauri::{AppHandle, Manager};
 
 use crate::file_browser_projection::store::{
-    Clipboard, FileBrowserKind, FileBrowserStore, FileEntry,
+    Clipboard, ClientView, FileBrowserKind, FileBrowserStore, FileEntry,
 };
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
 
@@ -139,11 +146,19 @@ pub fn register_file_browser_intents(registry: &mut HandlerRegistry, app_handle:
         Ok(publish_file_browser(projector, &store, &intent.client_id))
     });
 
-    let handle = app_handle;
+    let handle = app_handle.clone();
     registry.route("fileBrowser.setClipboard", move |intent, projector| {
         let store = store_of(&handle)?;
         let clipboard = parse_clipboard(intent)?;
         store.set_clipboard(&intent.client_id, clipboard);
+        Ok(publish_file_browser(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle;
+    registry.route("fileBrowser.replace", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let view = parse_view(intent)?;
+        store.replace(&intent.client_id, view);
         Ok(publish_file_browser(projector, &store, &intent.client_id))
     });
 }
@@ -195,6 +210,16 @@ fn parse_entries(intent: &Intent) -> Result<Vec<FileEntry>, (String, String)> {
         .ok_or_else(|| ("bad_payload".to_string(), "missing 'entries'".to_string()))?;
     serde_json::from_value(value.clone())
         .map_err(|e| ("bad_payload".to_string(), format!("invalid 'entries': {e}")))
+}
+
+/// Parse a `fileBrowser.replace` payload into a whole-client [`ClientView`] — the
+/// render-cut mirror's snapshot of `appStore`'s file-browser slice (`{ mode,
+/// local, sftp, session, clipboard }`, the shape of the region view model). Any
+/// field absent defaults to the idle baseline; a present-but-malformed field is a
+/// `bad_payload` rejection that advances nothing.
+fn parse_view(intent: &Intent) -> Result<ClientView, (String, String)> {
+    serde_json::from_value(intent.payload.clone())
+        .map_err(|e| ("bad_payload".to_string(), format!("invalid view: {e}")))
 }
 
 /// Parse the `clipboard` field into an optional [`Clipboard`]; a missing or

--- a/src-tauri/src/file_browser_projection/projection_tests.rs
+++ b/src-tauri/src/file_browser_projection/projection_tests.rs
@@ -309,7 +309,11 @@ fn a_replace_seed_produces_one_diff_that_converges_on_the_whole_view() {
     let diffs = sink.diffs();
     assert_eq!(diffs.len(), 1, "the whole-slice seed is one coalesced diff");
     cache.apply(&diffs[0]);
-    assert_eq!(cache.view, store.snapshot("A"), "cache converges on authority");
+    assert_eq!(
+        cache.view,
+        store.snapshot("A"),
+        "cache converges on authority"
+    );
     assert_eq!(cache.view["mode"], json!("sftp"));
     assert_eq!(cache.view["local"]["entries"][0]["name"], json!("a"));
     assert_eq!(cache.view["sftp"]["path"], json!("/var"));
@@ -328,7 +332,11 @@ fn a_replace_seed_produces_one_diff_that_converges_on_the_whole_view() {
         }),
     ));
     assert_eq!(ack2.status, IntentStatus::Accepted);
-    assert_eq!(ack2.produced, Some(vec![]), "an identical re-seed is a no-op");
+    assert_eq!(
+        ack2.produced,
+        Some(vec![]),
+        "an identical re-seed is a no-op"
+    );
     assert_eq!(sink.diffs().len(), 1, "no second diff");
 }
 

--- a/src-tauri/src/file_browser_projection/projection_tests.rs
+++ b/src-tauri/src/file_browser_projection/projection_tests.rs
@@ -18,7 +18,9 @@ use std::sync::{Arc, Mutex};
 
 use serde_json::{json, Value};
 
-use super::{optional_str, parse_clipboard, parse_entries, parse_mode, parse_pane, required_str};
+use super::{
+    optional_str, parse_clipboard, parse_entries, parse_mode, parse_pane, parse_view, required_str,
+};
 use crate::file_browser_projection::projection::{file_browser_region, publish_file_browser};
 use crate::file_browser_projection::store::FileBrowserStore;
 use crate::projection::{
@@ -68,9 +70,15 @@ fn registry_for(store: Arc<FileBrowserStore>) -> HandlerRegistry {
         Ok(publish_file_browser(projector, &s, &intent.client_id))
     });
 
-    let s = store;
+    let s = store.clone();
     registry.route("fileBrowser.setClipboard", move |intent, projector| {
         s.set_clipboard(&intent.client_id, parse_clipboard(intent)?);
+        Ok(publish_file_browser(projector, &s, &intent.client_id))
+    });
+
+    let s = store;
+    registry.route("fileBrowser.replace", move |intent, projector| {
+        s.replace(&intent.client_id, parse_view(intent)?);
         Ok(publish_file_browser(projector, &s, &intent.client_id))
     });
 
@@ -270,6 +278,58 @@ fn a_full_browsing_session_advances_monotonically_and_converges() {
     assert_eq!(cache.view["local"]["entries"], json!([]));
     assert_eq!(cache.view["clipboard"]["operation"], json!("copy"));
     assert_eq!(cache.view["mode"], json!("local"));
+}
+
+#[test]
+fn a_replace_seed_produces_one_diff_that_converges_on_the_whole_view() {
+    let store = Arc::new(FileBrowserStore::new());
+    let region = file_browser_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(&region, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    // The render-cut mirror seeds the whole slice in a single intent.
+    let ack = dispatcher.dispatch(intent(
+        "fileBrowser.replace",
+        "A",
+        json!({
+            "mode": "sftp",
+            "local": { "path": "/home", "entries": [entry_json("a", false)], "loading": false, "error": null },
+            "sftp": { "path": "/var", "entries": [entry_json("log", true)], "loading": true, "error": null },
+            "session": { "path": "/", "entries": [], "loading": false, "error": null },
+            "clipboard": null,
+        }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "the whole-slice seed is one coalesced diff");
+    cache.apply(&diffs[0]);
+    assert_eq!(cache.view, store.snapshot("A"), "cache converges on authority");
+    assert_eq!(cache.view["mode"], json!("sftp"));
+    assert_eq!(cache.view["local"]["entries"][0]["name"], json!("a"));
+    assert_eq!(cache.view["sftp"]["path"], json!("/var"));
+    assert_eq!(cache.view["sftp"]["loading"], json!(true));
+
+    // Re-seeding with identical content is idempotent — no second diff.
+    let ack2 = dispatcher.dispatch(intent(
+        "fileBrowser.replace",
+        "A",
+        json!({
+            "mode": "sftp",
+            "local": { "path": "/home", "entries": [entry_json("a", false)], "loading": false, "error": null },
+            "sftp": { "path": "/var", "entries": [entry_json("log", true)], "loading": true, "error": null },
+            "session": { "path": "/", "entries": [], "loading": false, "error": null },
+            "clipboard": null,
+        }),
+    ));
+    assert_eq!(ack2.status, IntentStatus::Accepted);
+    assert_eq!(ack2.produced, Some(vec![]), "an identical re-seed is a no-op");
+    assert_eq!(sink.diffs().len(), 1, "no second diff");
 }
 
 #[test]

--- a/src-tauri/src/file_browser_projection/store.rs
+++ b/src-tauri/src/file_browser_projection/store.rs
@@ -147,6 +147,93 @@ impl Pane {
     }
 }
 
+/// The idle-baseline root path a pane defaults to (mirrors [`Pane::default`]).
+fn root_path() -> String {
+    "/".to_string()
+}
+
+/// The active-pane field of a whole-client [`ClientView`] seed, mirroring the
+/// frontend `fileBrowserMode` string (`"none"` is the absence of an active pane).
+/// Deserialize-only twin of the `mode` string [`ClientState::to_view`] emits.
+#[derive(Deserialize, Clone, Copy, Debug, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ModeView {
+    /// No browser pane active (frontend `"none"`).
+    #[default]
+    None,
+    Local,
+    Sftp,
+    Session,
+}
+
+impl ModeView {
+    fn to_kind(self) -> Option<FileBrowserKind> {
+        match self {
+            ModeView::None => None,
+            ModeView::Local => Some(FileBrowserKind::Local),
+            ModeView::Sftp => Some(FileBrowserKind::Sftp),
+            ModeView::Session => Some(FileBrowserKind::Session),
+        }
+    }
+}
+
+/// One pane of a whole-client [`ClientView`] seed — a deserialize-only twin of
+/// the `{ path, entries, loading, error }` object [`Pane::to_view`] emits.
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct PaneView {
+    #[serde(default = "root_path")]
+    pub path: String,
+    #[serde(default)]
+    pub entries: Vec<FileEntry>,
+    #[serde(default)]
+    pub loading: bool,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+impl Default for PaneView {
+    fn default() -> Self {
+        Self {
+            path: root_path(),
+            entries: Vec::new(),
+            loading: false,
+            error: None,
+        }
+    }
+}
+
+impl PaneView {
+    fn into_pane(self) -> Pane {
+        Pane {
+            path: self.path,
+            entries: self.entries,
+            loading: self.loading,
+            error: self.error,
+        }
+    }
+}
+
+/// A caller-supplied whole-client browser view for the render-cut seed
+/// (`fileBrowser.replace`) — the deserialize-only twin of the `{ mode, local,
+/// sftp, session, clipboard }` view model [`ClientState::to_view`] emits. Any
+/// field absent defaults to the idle baseline, so a seed that clears the view is
+/// expressible; a present-but-malformed field is a `bad_payload` rejection.
+#[derive(Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientView {
+    #[serde(default)]
+    pub mode: ModeView,
+    #[serde(default)]
+    pub local: PaneView,
+    #[serde(default)]
+    pub sftp: PaneView,
+    #[serde(default)]
+    pub session: PaneView,
+    #[serde(default)]
+    pub clipboard: Option<Clipboard>,
+}
+
 /// One client's file-browser view.
 #[derive(Clone, Debug, Default)]
 struct ClientState {
@@ -301,6 +388,24 @@ impl FileBrowserStore {
     pub fn set_clipboard(&self, client_id: &str, clipboard: Option<Clipboard>) {
         let mut clients = self.lock();
         clients.entry(client_id.to_string()).or_default().clipboard = clipboard;
+    }
+
+    /// `fileBrowser.replace` — overwrite a client's whole browser view (active
+    /// pane, the three panes, clipboard) with a caller-supplied snapshot. The
+    /// frontend render-cut mirror (#2228) uses this whole-slice seed to keep the
+    /// client's `file-browser@<clientId>` region a faithful copy of `appStore`'s
+    /// file-browser UI-state slice while `appStore` stays authoritative (the
+    /// mutation cut is a later step) — the analog of the connections bridge's
+    /// `connection.replace` / agents bridge's `agent.replace` seed. Idempotent
+    /// server-side: replacing with identical content yields no diff.
+    pub fn replace(&self, client_id: &str, view: ClientView) {
+        let mut clients = self.lock();
+        let state = clients.entry(client_id.to_string()).or_default();
+        state.mode = view.mode.to_kind();
+        state.local = view.local.into_pane();
+        state.sftp = view.sftp.into_pane();
+        state.session = view.session.into_pane();
+        state.clipboard = view.clipboard;
     }
 
     /// Read a pane's `(path, entry_count, loading)` (test/diagnostics helper).

--- a/src-tauri/src/file_browser_projection/store_tests.rs
+++ b/src-tauri/src/file_browser_projection/store_tests.rs
@@ -189,7 +189,12 @@ fn replace_overwrites_the_whole_view_from_a_seed() {
     let store = FileBrowserStore::new();
     // Pre-existing state that the whole-slice seed must overwrite, not merge.
     store.set_mode(C, Some(FileBrowserKind::Session));
-    store.load_succeeded(C, FileBrowserKind::Session, "/old", vec![entry("stale", false)]);
+    store.load_succeeded(
+        C,
+        FileBrowserKind::Session,
+        "/old",
+        vec![entry("stale", false)],
+    );
 
     let view: ClientView = serde_json::from_value(json!({
         "mode": "sftp",

--- a/src-tauri/src/file_browser_projection/store_tests.rs
+++ b/src-tauri/src/file_browser_projection/store_tests.rs
@@ -185,6 +185,79 @@ fn the_three_panes_are_independent() {
 }
 
 #[test]
+fn replace_overwrites_the_whole_view_from_a_seed() {
+    let store = FileBrowserStore::new();
+    // Pre-existing state that the whole-slice seed must overwrite, not merge.
+    store.set_mode(C, Some(FileBrowserKind::Session));
+    store.load_succeeded(C, FileBrowserKind::Session, "/old", vec![entry("stale", false)]);
+
+    let view: ClientView = serde_json::from_value(json!({
+        "mode": "sftp",
+        "local": { "path": "/home", "entries": [], "loading": false, "error": null },
+        "sftp": {
+            "path": "/var",
+            "entries": [{ "name": "log", "path": "/var/log", "isDirectory": true, "size": 0 }],
+            "loading": true,
+            "error": null,
+        },
+        "session": { "path": "/", "entries": [], "loading": false, "error": "gone" },
+        "clipboard": null,
+    }))
+    .unwrap();
+    store.replace(C, view);
+
+    let out = store.snapshot(C);
+    assert_eq!(out["mode"], json!("sftp"));
+    assert_eq!(out["sftp"]["path"], json!("/var"));
+    assert_eq!(out["sftp"]["loading"], json!(true));
+    assert_eq!(out["sftp"]["entries"][0]["name"], json!("log"));
+    assert_eq!(out["session"]["error"], json!("gone"));
+    // The prior session listing is gone — replace overwrites, never merges.
+    assert_eq!(out["session"]["path"], json!("/"));
+    assert_eq!(out["session"]["entries"], json!([]));
+    assert_eq!(out["local"]["path"], json!("/home"));
+}
+
+#[test]
+fn replace_round_trips_the_snapshot_shape() {
+    // Seeding with a prior snapshot reproduces it exactly (idempotent mirror).
+    let store = FileBrowserStore::new();
+    store.set_mode(C, Some(FileBrowserKind::Local));
+    store.load_succeeded(C, FileBrowserKind::Local, "/l", vec![entry("a", true)]);
+    store.set_clipboard(
+        C,
+        Some(Clipboard {
+            entries: vec![entry("a", true)],
+            operation: ClipboardOperation::Cut,
+            source_mode: FileBrowserKind::Local,
+            source_path: "/l".to_string(),
+            sftp_session_id: None,
+            terminal_session_id: None,
+        }),
+    );
+    let snapshot = store.snapshot(C);
+
+    let fresh = FileBrowserStore::new();
+    let view: ClientView = serde_json::from_value(snapshot.clone()).unwrap();
+    fresh.replace(C, view);
+    assert_eq!(fresh.snapshot(C), snapshot);
+}
+
+#[test]
+fn replace_defaults_absent_fields_to_the_idle_baseline() {
+    let store = FileBrowserStore::new();
+    store.set_mode(C, Some(FileBrowserKind::Sftp));
+    // An empty payload clears the whole view back to baseline.
+    let view: ClientView = serde_json::from_value(json!({})).unwrap();
+    store.replace(C, view);
+    let out = store.snapshot(C);
+    assert_eq!(out["mode"], json!("none"));
+    assert_eq!(out["local"]["path"], json!("/"));
+    assert_eq!(out["sftp"]["path"], json!("/"));
+    assert_eq!(out["clipboard"], Value::Null);
+}
+
+#[test]
 fn browser_state_is_isolated_per_client() {
     let store = FileBrowserStore::new();
     store.set_mode("a", Some(FileBrowserKind::Sftp));

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -38,6 +38,7 @@ import {
 } from "lucide-react";
 import { useAppStore, getActiveTab } from "@/store/appStore";
 import { useProjectedSettings } from "@/store/useProjectedSettings";
+import { useProjectedFileBrowsers } from "@/store/useProjectedFileBrowsers";
 import { Button, Tooltip, Progress, Input, toast } from "@/components/ui";
 import { useFileBrowser } from "@/hooks/useFileBrowser";
 import { onVscodeEditComplete } from "@/services/events";
@@ -914,7 +915,9 @@ export function FileBrowser() {
   const transfers = useAppStore((s) => s.transfers);
   const cancelTransfer = useAppStore((s) => s.cancelTransfer);
   const vscodeAvailable = useAppStore((s) => s.vscodeAvailable);
-  const fileClipboard = useAppStore((s) => s.fileClipboard);
+  // Render cut (#2228): the copy-cut clipboard is sourced from the projected
+  // client-scoped file-browser region (mirror-gated, falls back to appStore).
+  const fileClipboard = useProjectedFileBrowsers().clipboard;
   const quickShareServer = useAppStore((s) => s.quickShareServer);
   const setSidebarView = useAppStore((s) => s.setSidebarView);
   const [newDirName, setNewDirName] = useState<string | null>(null);

--- a/src/hooks/useFileBrowser.test.ts
+++ b/src/hooks/useFileBrowser.test.ts
@@ -101,6 +101,7 @@ vi.mock("./useSessionFileSystem", () => ({
 }));
 
 import { useAppStore } from "@/store/appStore";
+import type { FileEntry } from "@/types/connection";
 import { useFileBrowser } from "./useFileBrowser";
 
 // Test the routing logic by calling the hook with the store in different modes.
@@ -179,8 +180,16 @@ describe("useFileBrowser hook (mode routing)", () => {
     expect(result!.isConnected).toBe(false);
   });
 
+  // After the #2228 render cut the per-pane render fields (listing, cwd, loading,
+  // error) are sourced from the projected file-browser region — which, with no
+  // transport in this unit env, falls back to `appStore` verbatim. So the mode
+  // routing is asserted against the `appStore` per-mode slice; the file *actions*
+  // and `isConnected` still come from the per-mode hooks (mocked above).
+  const listing = (name: string) =>
+    [{ name, path: `/${name}`, isDirectory: false }] as unknown as FileEntry[];
+
   it('returns mode "local" with local file entries', () => {
-    useAppStore.setState({ fileBrowserMode: "local" });
+    useAppStore.setState({ fileBrowserMode: "local", localFileEntries: listing("local-file.txt") });
     let result: ReturnType<typeof useFileBrowser> | undefined;
 
     act(() => {
@@ -189,10 +198,12 @@ describe("useFileBrowser hook (mode routing)", () => {
 
     expect(result!.mode).toBe("local");
     expect(result!.fileEntries[0].name).toBe("local-file.txt");
+    // The actions/isConnected still come from the per-mode hook.
+    expect(result!.isConnected).toBe(true);
   });
 
   it('returns mode "sftp" with SFTP file entries', () => {
-    useAppStore.setState({ fileBrowserMode: "sftp" });
+    useAppStore.setState({ fileBrowserMode: "sftp", fileEntries: listing("sftp-file.txt") });
     let result: ReturnType<typeof useFileBrowser> | undefined;
 
     act(() => {
@@ -201,10 +212,14 @@ describe("useFileBrowser hook (mode routing)", () => {
 
     expect(result!.mode).toBe("sftp");
     expect(result!.fileEntries[0].name).toBe("sftp-file.txt");
+    expect(result!.isConnected).toBe(true);
   });
 
   it('returns mode "session" with session file entries', () => {
-    useAppStore.setState({ fileBrowserMode: "session" });
+    useAppStore.setState({
+      fileBrowserMode: "session",
+      sessionFileEntries: listing("session-file.txt"),
+    });
     let result: ReturnType<typeof useFileBrowser> | undefined;
 
     act(() => {
@@ -213,5 +228,6 @@ describe("useFileBrowser hook (mode routing)", () => {
 
     expect(result!.mode).toBe("session");
     expect(result!.fileEntries[0].name).toBe("session-file.txt");
+    expect(result!.isConnected).toBe(true);
   });
 });

--- a/src/hooks/useFileBrowser.ts
+++ b/src/hooks/useFileBrowser.ts
@@ -1,28 +1,53 @@
-import { useAppStore } from "@/store/appStore";
 import { useFileSystem } from "./useFileSystem";
 import { useLocalFileSystem } from "./useLocalFileSystem";
 import { useSessionFileSystem } from "./useSessionFileSystem";
+import { useProjectedFileBrowsers } from "@/store/useProjectedFileBrowsers";
+import type { FileBrowserPaneView } from "@/store/fileBrowsersBridge";
+
+/**
+ * The per-pane UI-state fields a browser renders, sourced from the projected
+ * `file-browser@<clientId>` region (#2228 render cut): the pane's listing, cwd,
+ * and list-operation loading/error. The active/connected status and the file
+ * *actions* still come from the per-mode hook — only these render reads are cut.
+ */
+function paneRenderState(pane: FileBrowserPaneView) {
+  return {
+    fileEntries: pane.entries,
+    currentPath: pane.path,
+    isLoading: pane.loading,
+    error: pane.error,
+  };
+}
 
 /**
  * Unified file browser hook that delegates to local, SFTP, or session mode.
  * All hooks are always called to satisfy Rules of Hooks.
+ *
+ * The active pane and each pane's per-render UI state (listing, cwd, loading,
+ * error) are sourced from the projected client-scoped `file-browser` region via
+ * {@link useProjectedFileBrowsers} — the parity-safe render cut (#2228). The region
+ * faithfully mirrors `appStore` (and falls back to it when it does not), so the
+ * output is value-identical to the pre-cut path. The file *actions* and the
+ * session-model `isConnected` flag still come from the per-mode hooks, which keep
+ * reading `appStore` directly (the mutation cut and the SFTP session model, #2236,
+ * are out of scope here).
  */
 export function useFileBrowser() {
-  const fileBrowserMode = useAppStore((s) => s.fileBrowserMode);
+  const projected = useProjectedFileBrowsers();
   const sftp = useFileSystem();
   const local = useLocalFileSystem();
   const session = useSessionFileSystem();
 
-  if (fileBrowserMode === "local") {
-    return { ...local, mode: "local" as const };
+  if (projected.mode === "local") {
+    return { ...local, ...paneRenderState(projected.local), mode: "local" as const };
   }
 
-  if (fileBrowserMode === "sftp") {
-    return { ...sftp, mode: "sftp" as const };
+  if (projected.mode === "sftp") {
+    return { ...sftp, ...paneRenderState(projected.sftp), mode: "sftp" as const };
   }
 
-  if (fileBrowserMode === "session") {
-    return { ...session, mode: "session" as const };
+  if (projected.mode === "session") {
+    return { ...session, ...paneRenderState(projected.session), mode: "session" as const };
   }
 
   // "none" mode — return disconnected defaults

--- a/src/store/fileBrowsersBridge.test.ts
+++ b/src/store/fileBrowsersBridge.test.ts
@@ -1,0 +1,198 @@
+/**
+ * File-browsers projection bridge (#2228) — the render-cut flag, the
+ * faithful-mirror gate, and the `fileBrowser.replace` whole-slice seed round-trip.
+ * Drives the bridge against an in-memory substrate double that applies
+ * `fileBrowser.replace` and fans a snapshot, without a backend.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import type { FileEntry } from "@/types/connection";
+
+import {
+  currentFileBrowsersView,
+  EMPTY_FILE_BROWSERS_VIEW,
+  ensureFileBrowsersSubscribed,
+  FILE_BROWSERS_REGION,
+  fileBrowsersRenderFromProjectionEnabled,
+  fileBrowsersViewMirrors,
+  onFileBrowsersView,
+  seedFileBrowsersRegion,
+  setFileBrowsersRenderFromProjectionEnabled,
+  setFileBrowsersTransportForTest,
+  stopFileBrowsersSubscription,
+  type FileBrowsersView,
+} from "./fileBrowsersBridge";
+
+function entry(name: string, isDirectory = false): FileEntry {
+  return {
+    name,
+    path: `/${name}`,
+    isDirectory,
+    size: 0,
+    modified: "",
+    permissions: null,
+    writable: null,
+    isSymlink: false,
+    symlinkTarget: null,
+  };
+}
+
+function view(over: Partial<FileBrowsersView> = {}): FileBrowsersView {
+  return {
+    mode: "local",
+    local: { path: "/home", entries: [entry("a")], loading: false, error: null },
+    sftp: { path: "/var", entries: [entry("log", true)], loading: true, error: null },
+    session: { path: "/", entries: [], loading: false, error: "gone" },
+    clipboard: null,
+    ...over,
+  };
+}
+
+/** An in-memory substrate double: holds one file-browsers view, applies a
+ * `fileBrowser.replace` by overwriting it, and fans a fresh snapshot to subscribers. */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  private stored: FileBrowsersView = { ...EMPTY_FILE_BROWSERS_VIEW };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (intent.kind === "fileBrowser.replace") {
+      this.stored = intent.payload as unknown as FileBrowsersView;
+      this.version += 1;
+      this.fan();
+      return {
+        intentId: intent.intentId,
+        status: "accepted",
+        produced: [{ region: FILE_BROWSERS_REGION, version: this.version }],
+      };
+    }
+    return { intentId: intent.intentId, status: "accepted", produced: [] };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.stored) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(FILE_BROWSERS_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+let transport: FakeTransport;
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setFileBrowsersTransportForTest(transport);
+});
+
+afterEach(() => {
+  stopFileBrowsersSubscription();
+  setFileBrowsersTransportForTest(null);
+  setFileBrowsersRenderFromProjectionEnabled(null);
+});
+
+describe("fileBrowsersRenderFromProjectionEnabled flag", () => {
+  it("defaults on and honours the programmatic override", () => {
+    expect(fileBrowsersRenderFromProjectionEnabled()).toBe(true);
+    setFileBrowsersRenderFromProjectionEnabled(false);
+    expect(fileBrowsersRenderFromProjectionEnabled()).toBe(false);
+    setFileBrowsersRenderFromProjectionEnabled(true);
+    expect(fileBrowsersRenderFromProjectionEnabled()).toBe(true);
+    setFileBrowsersRenderFromProjectionEnabled(null);
+    expect(fileBrowsersRenderFromProjectionEnabled()).toBe(true);
+  });
+});
+
+describe("fileBrowsersViewMirrors gate", () => {
+  it("is false for an undefined view", () => {
+    expect(fileBrowsersViewMirrors(undefined, view())).toBe(false);
+  });
+
+  it("mirrors when the whole view matches by value", () => {
+    expect(fileBrowsersViewMirrors(view(), view())).toBe(true);
+  });
+
+  it("rejects on any field divergence", () => {
+    expect(fileBrowsersViewMirrors(view({ mode: "sftp" }), view())).toBe(false);
+    expect(
+      fileBrowsersViewMirrors(
+        view({ local: { path: "/x", entries: [], loading: false, error: null } }),
+        view()
+      )
+    ).toBe(false);
+    // A different listing under the same pane path is not a mirror.
+    expect(
+      fileBrowsersViewMirrors(
+        view({
+          sftp: { path: "/var", entries: [entry("other", true)], loading: true, error: null },
+        }),
+        view()
+      )
+    ).toBe(false);
+    // A divergent clipboard is not a mirror.
+    expect(
+      fileBrowsersViewMirrors(
+        view({
+          clipboard: {
+            entries: [entry("c")],
+            operation: "copy",
+            sourceMode: "local",
+            sourcePath: "/home",
+            sftpSessionId: null,
+          },
+        }),
+        view()
+      )
+    ).toBe(false);
+  });
+});
+
+describe("seedFileBrowsersRegion (fileBrowser.replace mirror)", () => {
+  it("dispatches a fileBrowser.replace and fans the mirrored view", async () => {
+    const received: FileBrowsersView[] = [];
+    onFileBrowsersView((v) => received.push(v));
+    await ensureFileBrowsersSubscribed();
+
+    const v = view();
+    await seedFileBrowsersRegion(v);
+
+    const replace = transport.dispatched.filter((d) => d.kind === "fileBrowser.replace");
+    expect(replace).toHaveLength(1);
+    expect(currentFileBrowsersView()).toEqual(v);
+    expect(received[received.length - 1]).toEqual(v);
+  });
+
+  it("de-duplicates an identical seed", async () => {
+    await ensureFileBrowsersSubscribed();
+    const v = view();
+    await seedFileBrowsersRegion(v);
+    await seedFileBrowsersRegion(v);
+    expect(transport.dispatched.filter((d) => d.kind === "fileBrowser.replace")).toHaveLength(1);
+  });
+});

--- a/src/store/fileBrowsersBridge.ts
+++ b/src/store/fileBrowsersBridge.ts
@@ -1,0 +1,382 @@
+/**
+ * File-browsers projection bridge — Phase 5 render cut of the File-browsers
+ * domain (#2228, part of #2139 and #2153).
+ *
+ * The File-browsers **shadow** (PR #2272) landed a backend-authoritative,
+ * client-scoped
+ * [`FileBrowserStore`](../../src-tauri/src/file_browser_projection/store.rs)
+ * served as the `file-browser@<clientId>` projection region, with `fileBrowser.*`
+ * intents, but nothing in the UI touched it. This step makes the file-browser
+ * panel ({@link import("../components/Sidebar/FileBrowser").FileBrowser}, via
+ * {@link import("../hooks/useFileBrowser").useFileBrowser}) source its per-pane
+ * UI state — the active pane, each pane's cwd / listing / loading / error, and the
+ * copy-cut clipboard — from that region: the parity-safe render cut (the direct
+ * analog of the client-scoped broadcast render cut
+ * {@link import("./broadcastBridge")}, #2242, and the connections render cut
+ * {@link import("./connectionsBridge")}, #2225).
+ *
+ * # Client-scoped region
+ *
+ * An open file browser — its active pane, each pane's cwd / listing, and the
+ * clipboard — is a property of the *viewing client's* pane, not shared
+ * infrastructure (Open Design Decision #4 / #6). So, like the client-scoped
+ * `broadcast` and `layout` regions, the region is `file-browser@<clientId>` — a
+ * stable per-session client identity — and dispatched intents carry the same id.
+ *
+ * # Scope — the browser *view*, not the SFTP session model (#2236)
+ *
+ * This bridge mirrors only the **browser view**: which pane is active, each pane's
+ * cwd / listing / list-operation loading+error, and the clipboard. It deliberately
+ * leaves the backend SFTP/session model on `appStore` — the SFTP connect status
+ * (`sftpStatus`), the live session ids (`sftpSessionId` / `sessionFileBrowserId`,
+ * which gate `isConnected`), and transfers stay `appStore` reads. The SFTP pane's
+ * `loading`/`error` mirrored here are the frontend's own derived list flags
+ * (`sftpStatus`-derived + `sftpError`), carried through the region verbatim so the
+ * render is a pure parity swap; the session model itself (#2236) is untouched.
+ *
+ * # Strangler safety — flag-gated, on by default, faithful-mirror gate
+ *
+ * The `appStore` file-browser slice is still authoritative (the mutation cut is a
+ * later step). To keep the render cut parity-safe **independent of any mutation
+ * flag**, the region is kept a faithful copy of `appStore` by
+ * {@link seedFileBrowsersRegion} (a `fileBrowser.replace` whole-slice mirror, the
+ * analog of the broadcast bridge's `broadcast.replace` seed), and the UI renders
+ * from the region **only when it faithfully mirrors** `appStore`
+ * ({@link fileBrowsersViewMirrors}); otherwise it falls back to `appStore`
+ * verbatim. Because the gate guarantees the projected view deep-equals `appStore`'s
+ * slice, the rendered output is value-identical to the pre-cut path.
+ *
+ * Gated by {@link fileBrowsersRenderFromProjectionEnabled} — **on by default**.
+ * Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_FILE_BROWSERS_RENDER_FROM_PROJECTION__` or
+ * `localStorage["termihub.fileBrowsersRenderFromProjection"]` (set `"false"` to
+ * render straight from `appStore`).
+ */
+
+import {
+  createTransport,
+  newClientId,
+  newIntentId,
+  ProjectionClient,
+  type IntentAck,
+  type Transport,
+} from "@/services/transport";
+import type { FileClipboard } from "@/store/appStore";
+import type { FileEntry } from "@/types/connection";
+import { frontendLog } from "@/utils/frontendLog";
+
+/** The active file-browser pane (twin of the Rust `mode` string; `"none"` is no
+ * open browser). Mirrors the frontend `fileBrowserMode`. */
+export type FileBrowserMode = "none" | "local" | "sftp" | "session";
+
+/** One browser pane's view: the directory it shows, its listing, and the
+ * in-flight/error status of a directory list. Twin of the Rust `Pane::to_view`. */
+export interface FileBrowserPaneView {
+  path: string;
+  entries: FileEntry[];
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * The `file-browser@<clientId>` region view model — a twin of the Rust store
+ * snapshot: the active pane, the three panes (local / sftp / session), and the
+ * copy-cut clipboard. Each field matches the `appStore` slice one-to-one, so the
+ * render cut is a pure parity swap.
+ */
+export interface FileBrowsersView {
+  mode: FileBrowserMode;
+  local: FileBrowserPaneView;
+  sftp: FileBrowserPaneView;
+  session: FileBrowserPaneView;
+  clipboard: FileClipboard | null;
+}
+
+/** The idle baseline a pane reports before its first listing (twin of `Pane::default`). */
+export const EMPTY_PANE_VIEW: FileBrowserPaneView = {
+  path: "/",
+  entries: [],
+  loading: false,
+  error: null,
+};
+
+/** The idle baseline a fresh region reports (twin of the empty store snapshot). */
+export const EMPTY_FILE_BROWSERS_VIEW: FileBrowsersView = {
+  mode: "none",
+  local: EMPTY_PANE_VIEW,
+  sftp: EMPTY_PANE_VIEW,
+  session: EMPTY_PANE_VIEW,
+  clipboard: null,
+};
+
+// ── Render-cut feature flag (runtime-flippable, on by default) ─────────────────
+
+let renderFlagOverride: boolean | null = null;
+
+interface FileBrowsersRenderFlagWindow {
+  __TERMIHUB_FILE_BROWSERS_RENDER_FROM_PROJECTION__?: boolean;
+  localStorage?: Storage;
+}
+
+/**
+ * Programmatic override for the render-cut flag (tests, and a runtime toggle).
+ * `null` clears the override and falls back to the window/localStorage signal,
+ * then to the default (on).
+ */
+export function setFileBrowsersRenderFromProjectionEnabled(value: boolean | null): void {
+  renderFlagOverride = value;
+}
+
+/**
+ * Whether the file-browser panel renders its per-pane UI state from the projected
+ * `file-browser@<clientId>` region instead of reading `appStore`'s file-browser
+ * slice directly.
+ *
+ * **On by default** — the render cut is parity-safe: the UI renders from the
+ * region only when it faithfully mirrors `appStore` ({@link fileBrowsersViewMirrors}),
+ * and otherwise falls back to `appStore` verbatim, so the output is value-identical
+ * to the pre-cut path. Independent of the (later) mutation cut: the region is kept
+ * a mirror of `appStore` by {@link seedFileBrowsersRegion}, so it is always
+ * populated. Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_FILE_BROWSERS_RENDER_FROM_PROJECTION__` or
+ * `localStorage["termihub.fileBrowsersRenderFromProjection"]`.
+ */
+export function fileBrowsersRenderFromProjectionEnabled(): boolean {
+  if (renderFlagOverride !== null) return renderFlagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as FileBrowsersRenderFlagWindow;
+      if (typeof w.__TERMIHUB_FILE_BROWSERS_RENDER_FROM_PROJECTION__ === "boolean") {
+        return w.__TERMIHUB_FILE_BROWSERS_RENDER_FROM_PROJECTION__;
+      }
+      const ls = w.localStorage?.getItem("termihub.fileBrowsersRenderFromProjection");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return true;
+}
+
+// ── Transport + client-scoped region client (lazy, mirrors the broadcast slice) ─
+
+let transportInstance: Transport | null = null;
+let regionClient: ProjectionClient | null = null;
+let startPromise: Promise<ProjectionClient> | null = null;
+
+// A stable per-session client identity. The region is `file-browser@<clientId>` and
+// dispatched intents carry the same id, so this checkout mutates and subscribes to
+// its own file-browser region (mirroring the client-scoped broadcast bridge).
+const clientId = newClientId();
+
+/** The client-scoped projection region id for this session's file browsers. */
+export const FILE_BROWSERS_REGION = `file-browser@${clientId}`;
+
+/** Inject a transport for tests; `null` restores the lazily-created real one and
+ * drops any active subscription / seed dedup. */
+export function setFileBrowsersTransportForTest(t: Transport | null): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  transportInstance = t;
+  lastView = EMPTY_FILE_BROWSERS_VIEW;
+  lastSeededSignature = null;
+}
+
+function transport(): Transport {
+  if (!transportInstance) {
+    transportInstance = createTransport();
+  }
+  return transportInstance;
+}
+
+// ── View fan-out (one subscription, many consuming hooks) ──────────────────────
+
+/** A change listener for the projected `file-browser` view. */
+export type FileBrowsersViewListener = (view: FileBrowsersView) => void;
+
+const viewListeners = new Set<FileBrowsersViewListener>();
+let lastView: FileBrowsersView = EMPTY_FILE_BROWSERS_VIEW;
+
+/**
+ * Register a listener, invoked with the projected view on every diff. Returns an
+ * unsubscribe. The region client is started on first use.
+ */
+export function onFileBrowsersView(listener: FileBrowsersViewListener): () => void {
+  viewListeners.add(listener);
+  return () => viewListeners.delete(listener);
+}
+
+/** Normalize a possibly-partial pane view into a full {@link FileBrowserPaneView}. */
+function normalizePane(pane: Partial<FileBrowserPaneView> | undefined): FileBrowserPaneView {
+  return {
+    path: pane?.path ?? "/",
+    entries: pane?.entries ?? [],
+    loading: pane?.loading ?? false,
+    error: pane?.error ?? null,
+  };
+}
+
+/** Normalize a possibly-partial projected view into a full {@link FileBrowsersView}. */
+function normalizeView(view: Partial<FileBrowsersView> | undefined): FileBrowsersView {
+  return {
+    mode: view?.mode ?? "none",
+    local: normalizePane(view?.local),
+    sftp: normalizePane(view?.sftp),
+    session: normalizePane(view?.session),
+    clipboard: view?.clipboard ?? null,
+  };
+}
+
+/**
+ * Ensure the `file-browser@<clientId>` region client is subscribed so projected
+ * diffs are received and fanned out to the {@link onFileBrowsersView} listeners.
+ * Idempotent and de-duplicated across concurrent callers; a transport/subscribe
+ * failure is logged and rethrown so the caller can fall back to `appStore`.
+ */
+export function ensureFileBrowsersSubscribed(): Promise<ProjectionClient> {
+  if (regionClient) return Promise.resolve(regionClient);
+  if (!startPromise) {
+    const client = new ProjectionClient(transport(), FILE_BROWSERS_REGION);
+    client.onChange((state) => {
+      lastView = normalizeView(state.view as Partial<FileBrowsersView> | undefined);
+      for (const listener of viewListeners) {
+        try {
+          listener(lastView);
+        } catch (err) {
+          logFileBrowsersBridgeFallback("reconcile", err);
+        }
+      }
+    });
+    startPromise = client
+      .start()
+      .then(() => {
+        regionClient = client;
+        return client;
+      })
+      .catch((err) => {
+        startPromise = null;
+        logFileBrowsersBridgeFallback("subscribe", err);
+        throw err;
+      });
+  }
+  return startPromise;
+}
+
+/** Drop the region subscription (tests / re-init). */
+export function stopFileBrowsersSubscription(): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  lastView = EMPTY_FILE_BROWSERS_VIEW;
+  lastSeededSignature = null;
+}
+
+/** The last view fanned out (for a hook that subscribes after the first diff). */
+export function currentFileBrowsersView(): FileBrowsersView {
+  return lastView;
+}
+
+// ── Seed: keep the region a faithful mirror of appStore (fileBrowser.replace) ───
+
+let lastSeededSignature: string | null = null;
+
+/**
+ * Seed the region with `appStore`'s whole file-browser slice via a
+ * `fileBrowser.replace` intent, so the projection tracks `appStore`'s current
+ * state while `appStore` stays authoritative (the render-side counterpart of the
+ * broadcast bridge seed). De-duplicated: a slice identical to the last seeded one
+ * is not re-dispatched. Never throws synchronously — a transport that cannot
+ * dispatch surfaces as a rejected promise the caller logs and ignores (staying on
+ * the `appStore` fallback). Idempotent server-side: replacing with the same
+ * content yields no diff.
+ */
+export function seedFileBrowsersRegion(view: FileBrowsersView): Promise<void> {
+  const signature = JSON.stringify(view);
+  if (signature === lastSeededSignature) return Promise.resolve();
+  // Set before dispatching so concurrent callers do not double-dispatch the seed.
+  lastSeededSignature = signature;
+  try {
+    return transport()
+      .dispatch({
+        intentId: newIntentId(),
+        kind: "fileBrowser.replace",
+        payload: {
+          mode: view.mode,
+          local: view.local,
+          sftp: view.sftp,
+          session: view.session,
+          clipboard: view.clipboard,
+        },
+        clientId,
+      })
+      .then((ack: IntentAck) => {
+        if (ack.status === "rejected") {
+          // Let a later change retry the seed rather than latch on a failure.
+          lastSeededSignature = null;
+          throw new Error(ack.error?.message ?? "fileBrowser.replace rejected");
+        }
+      })
+      .catch((err) => {
+        lastSeededSignature = null;
+        throw err;
+      });
+  } catch (err) {
+    // A synchronous transport-construction failure (non-Tauri, no socket).
+    lastSeededSignature = null;
+    return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+// ── Faithful-mirror gate ───────────────────────────────────────────────────────
+
+/**
+ * Whether a projected `view` faithfully mirrors `appStore`'s file-browser slice —
+ * the gate deciding whether the UI may render from the projection (true) or must
+ * fall back to `appStore` (false). A deep value comparison of the active pane, the
+ * three panes and the clipboard; because the projected records match the frontend
+ * shapes one-to-one, a mirroring view is value-identical to the `appStore` slice,
+ * so rendering from it can never diverge. The twin of the broadcast render cut's
+ * `broadcastViewMirrors`.
+ */
+export function fileBrowsersViewMirrors(
+  view: FileBrowsersView | undefined,
+  slice: FileBrowsersView
+): boolean {
+  if (!view) return false;
+  return deepEqual(view, slice);
+}
+
+/**
+ * A structural deep-equal for the JSON-ish file-browsers view model (objects,
+ * arrays, and primitives — no functions/dates/maps). Numbers compare with `===`,
+ * so an integer that round-tripped through JSON as a float (`22` vs `22.0`) still
+ * matches. Exported for the bridge's parity tests.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const ao = a as Record<string, unknown>;
+    const bo = b as Record<string, unknown>;
+    const aKeys = Object.keys(ao);
+    const bKeys = Object.keys(bo);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every(
+      (k) => Object.prototype.hasOwnProperty.call(bo, k) && deepEqual(ao[k], bo[k])
+    );
+  }
+  return false;
+}
+
+/** Log a bridge fallback so the appStore-path recovery is visible in the LogViewer. */
+export function logFileBrowsersBridgeFallback(kind: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  frontendLog("file_browsers_bridge", `${kind} fell back to appStore file browsers: ${message}`);
+}

--- a/src/store/useProjectedFileBrowsers.test.tsx
+++ b/src/store/useProjectedFileBrowsers.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * `useProjectedFileBrowsers` — the file-browser panel cut to the projected
+ * client-scoped `file-browser@<clientId>` region (#2228 render cut). Drives the
+ * hook against an in-memory substrate double and asserts: flag-off returns the
+ * appStore slice and dispatches nothing; flag-on seeds the region (a
+ * `fileBrowser.replace` mirror) and then renders the slice from the projection,
+ * value-identical to appStore; and a region that has not caught up falls back to
+ * the appStore slice.
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import { useAppStore } from "@/store/appStore";
+import type { FileEntry } from "@/types/connection";
+
+import {
+  EMPTY_FILE_BROWSERS_VIEW,
+  FILE_BROWSERS_REGION,
+  setFileBrowsersRenderFromProjectionEnabled,
+  setFileBrowsersTransportForTest,
+  stopFileBrowsersSubscription,
+  type FileBrowsersView,
+} from "./fileBrowsersBridge";
+import { useProjectedFileBrowsers } from "./useProjectedFileBrowsers";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  getSettings: vi.fn(() =>
+    Promise.resolve({ version: "1", externalConnectionFiles: [], powerMonitoringEnabled: true })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn(() => vi.fn()) }));
+
+function entry(name: string, isDirectory = false): FileEntry {
+  return {
+    name,
+    path: `/${name}`,
+    isDirectory,
+    size: 0,
+    modified: "",
+    permissions: null,
+    writable: null,
+    isSymlink: false,
+    symlinkTarget: null,
+  };
+}
+
+/** Seed appStore with a local-mode browsing state (the fields the hook reads). */
+function seedAppStore(over: Record<string, unknown> = {}): void {
+  useAppStore.setState({
+    fileBrowserMode: "local",
+    localFileEntries: [entry("a")],
+    localCurrentPath: "/home",
+    localFileLoading: false,
+    localFileError: null,
+    fileEntries: [],
+    currentPath: "/",
+    sftpStatus: "idle",
+    sftpError: null,
+    sessionFileEntries: [],
+    sessionCurrentPath: "/",
+    sessionFileLoading: false,
+    sessionFileError: null,
+    fileClipboard: null,
+    ...over,
+  });
+}
+
+/** In-memory substrate double: applies `fileBrowser.replace` and fans a snapshot. */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  /** When false, `fileBrowser.replace` acks but does NOT advance the region. */
+  applyReplace = true;
+  private stored: FileBrowsersView = { ...EMPTY_FILE_BROWSERS_VIEW };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (intent.kind === "fileBrowser.replace" && this.applyReplace) {
+      this.stored = intent.payload as unknown as FileBrowsersView;
+      this.version += 1;
+      this.fan();
+    }
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: FILE_BROWSERS_REGION, version: this.version }],
+    };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.stored) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(FILE_BROWSERS_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+/** Render the hook into a throwaway component, exposing the latest return value. */
+function renderHook(): { get: () => FileBrowsersView; unmount: () => void } {
+  const container = document.createElement("div");
+  const root: Root = createRoot(container);
+  let latest: FileBrowsersView = { ...EMPTY_FILE_BROWSERS_VIEW };
+
+  function Probe() {
+    latest = useProjectedFileBrowsers();
+    return null;
+  }
+
+  act(() => root.render(<Probe />));
+  return { get: () => latest, unmount: () => act(() => root.unmount()) };
+}
+
+let transport: FakeTransport;
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setFileBrowsersTransportForTest(transport);
+  seedAppStore();
+});
+
+afterEach(() => {
+  stopFileBrowsersSubscription();
+  setFileBrowsersTransportForTest(null);
+  setFileBrowsersRenderFromProjectionEnabled(null);
+});
+
+const flush = () => act(async () => await Promise.resolve());
+
+describe("useProjectedFileBrowsers", () => {
+  it("flag off: returns the appStore slice and dispatches nothing", async () => {
+    setFileBrowsersRenderFromProjectionEnabled(false);
+
+    const hook = renderHook();
+    await flush();
+
+    expect(hook.get().mode).toBe("local");
+    expect(hook.get().local.path).toBe("/home");
+    expect(hook.get().local.entries).toEqual([entry("a")]);
+    expect(transport.dispatched).toHaveLength(0);
+    hook.unmount();
+  });
+
+  it("flag on: seeds the region then renders the slice from the projection", async () => {
+    const hook = renderHook();
+    await flush();
+    await flush();
+
+    // The hook seeded appStore's slice via fileBrowser.replace…
+    expect(transport.dispatched.some((d) => d.kind === "fileBrowser.replace")).toBe(true);
+    // …and now renders a value-identical slice (sourced from the projection).
+    expect(hook.get().mode).toBe("local");
+    expect(hook.get().local.path).toBe("/home");
+    expect(hook.get().local.entries).toEqual([entry("a")]);
+    hook.unmount();
+  });
+
+  it("region not caught up: falls back to the appStore slice", async () => {
+    transport.applyReplace = false; // the replace acks but never advances the region
+
+    const hook = renderHook();
+    await flush();
+    await flush();
+
+    // The projection stays empty, so the gate rejects it and the hook renders the
+    // appStore slice verbatim — parity preserved.
+    expect(hook.get().mode).toBe("local");
+    expect(hook.get().local.path).toBe("/home");
+    expect(hook.get().local.entries).toEqual([entry("a")]);
+    hook.unmount();
+  });
+});

--- a/src/store/useProjectedFileBrowsers.ts
+++ b/src/store/useProjectedFileBrowsers.ts
@@ -1,0 +1,165 @@
+/**
+ * `useProjectedFileBrowsers` — the file-browser panel cut to the projected
+ * client-scoped `file-browser@<clientId>` region (#2228 render cut, part of #2139
+ * and #2153).
+ *
+ * The file-browser panel renders per-pane UI state: the active pane, each pane's
+ * cwd / listing / loading / error, and the copy-cut clipboard. Through the shadow
+ * step it reads `appStore`'s file-browser slice (`fileBrowserMode`, the per-mode
+ * `*FileEntries` / `*CurrentPath` / `*FileLoading` / `*FileError`, `fileClipboard`)
+ * directly. This hook makes it source that slice from the client-scoped
+ * `file-browser@<clientId>` projection region instead — the direct analog of
+ * {@link import("./useProjectedBroadcast").useProjectedBroadcast} (#2242) and
+ * {@link import("./useProjectedConnections").useProjectedConnections} (#2225).
+ *
+ * # Scope — the browser *view*, not the SFTP session model (#2236)
+ *
+ * The projected view mirrors only the browser *view*: the active pane, each pane's
+ * cwd / listing / list-operation loading+error, and the clipboard. The backend
+ * SFTP/session model — the SFTP connect status, the live session ids that gate
+ * `isConnected`, and transfers — stays an `appStore` read in the per-mode hooks;
+ * this hook does not touch it. The SFTP pane's `loading`/`error` mirrored here are
+ * the frontend's own derived list flags (`sftpStatus`-derived + `sftpError`),
+ * carried through the region verbatim so the render is a pure parity swap.
+ *
+ * # Safety (strangler)
+ *
+ * - **Gated** by {@link fileBrowsersRenderFromProjectionEnabled} (on by default).
+ *   Flag off ⇒ the hook returns `appStore`'s slice verbatim.
+ * - **Faithful-mirror gate.** The projection sources the render only when it
+ *   deep-equals the `appStore` slice ({@link fileBrowsersViewMirrors}); otherwise
+ *   the hook falls back to `appStore` (never a stale view). While `appStore` stays
+ *   authoritative (the mutation cut is a later step) the region is kept a mirror by
+ *   {@link seedFileBrowsersRegion}, so it is always populated — making the cut
+ *   parity-safe and independent of the mutation flag.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+import { useAppStore } from "@/store/appStore";
+import {
+  currentFileBrowsersView,
+  ensureFileBrowsersSubscribed,
+  fileBrowsersRenderFromProjectionEnabled,
+  fileBrowsersViewMirrors,
+  logFileBrowsersBridgeFallback,
+  onFileBrowsersView,
+  seedFileBrowsersRegion,
+  type FileBrowsersView,
+} from "@/store/fileBrowsersBridge";
+
+/**
+ * The effective file-browsers slice for rendering: the active pane, the three
+ * panes (local / sftp / session) and the clipboard, sourced from the projected
+ * `file-browser@<clientId>` region when it faithfully mirrors `appStore`, otherwise
+ * `appStore`'s slice verbatim (flag off, region not yet caught up, or a transport
+ * that cannot subscribe).
+ */
+export function useProjectedFileBrowsers(): FileBrowsersView {
+  const mode = useAppStore((s) => s.fileBrowserMode);
+
+  const localEntries = useAppStore((s) => s.localFileEntries);
+  const localPath = useAppStore((s) => s.localCurrentPath);
+  const localLoading = useAppStore((s) => s.localFileLoading);
+  const localError = useAppStore((s) => s.localFileError);
+
+  const sftpEntries = useAppStore((s) => s.fileEntries);
+  const sftpPath = useAppStore((s) => s.currentPath);
+  const sftpStatus = useAppStore((s) => s.sftpStatus);
+  const sftpError = useAppStore((s) => s.sftpError);
+
+  const sessionEntries = useAppStore((s) => s.sessionFileEntries);
+  const sessionPath = useAppStore((s) => s.sessionCurrentPath);
+  const sessionLoading = useAppStore((s) => s.sessionFileLoading);
+  const sessionError = useAppStore((s) => s.sessionFileError);
+
+  const clipboard = useAppStore((s) => s.fileClipboard);
+
+  // The `appStore`-shaped slice, matching the Rust region view model one-to-one.
+  // The SFTP pane's `loading` mirrors `useFileSystem`'s derived flag exactly.
+  const slice = useMemo<FileBrowsersView>(
+    () => ({
+      mode,
+      local: { path: localPath, entries: localEntries, loading: localLoading, error: localError },
+      sftp: {
+        path: sftpPath,
+        entries: sftpEntries,
+        loading: sftpStatus === "connecting" || sftpStatus === "listing",
+        error: sftpError,
+      },
+      session: {
+        path: sessionPath,
+        entries: sessionEntries,
+        loading: sessionLoading,
+        error: sessionError,
+      },
+      clipboard,
+    }),
+    [
+      mode,
+      localPath,
+      localEntries,
+      localLoading,
+      localError,
+      sftpPath,
+      sftpEntries,
+      sftpStatus,
+      sftpError,
+      sessionPath,
+      sessionEntries,
+      sessionLoading,
+      sessionError,
+      clipboard,
+    ]
+  );
+
+  // Read the flag once at mount: it flips only via dev tooling, and the
+  // subscription lifecycle is keyed off it below.
+  const [enabled] = useState(() => fileBrowsersRenderFromProjectionEnabled());
+
+  const [view, setView] = useState<FileBrowsersView | undefined>(undefined);
+
+  // Subscribe to the client-scoped file-browsers region while enabled; a transport
+  // that cannot subscribe (non-Tauri without a socket) just leaves the UI on the
+  // appStore fallback.
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const unsubscribe = onFileBrowsersView((next) => {
+      if (!cancelled) setView(next);
+    });
+    // `ensureFileBrowsersSubscribed` builds the transport eagerly, so a non-Tauri
+    // env without a socket throws synchronously (not just a rejection) — guard both
+    // so the UI silently stays on the appStore fallback.
+    try {
+      ensureFileBrowsersSubscribed()
+        .then(() => {
+          if (!cancelled) setView(currentFileBrowsersView());
+        })
+        .catch((err) => logFileBrowsersBridgeFallback("subscribe", err));
+    } catch (err) {
+      logFileBrowsersBridgeFallback("subscribe", err);
+    }
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [enabled]);
+
+  const matches = enabled && fileBrowsersViewMirrors(view, slice);
+
+  // Keep the region a faithful mirror of appStore's slice. Only once a view has
+  // arrived (so we are subscribed) and it is not already a mirror; de-duped inside
+  // `seedFileBrowsersRegion` so a settled slice is not re-seeded on every render.
+  useEffect(() => {
+    if (!enabled || matches || view === undefined) return;
+    seedFileBrowsersRegion(slice).catch((err) =>
+      logFileBrowsersBridgeFallback("seed", err)
+    );
+  }, [enabled, matches, view, slice]);
+
+  return useMemo(() => {
+    if (matches && view) return view;
+    return slice;
+  }, [matches, view, slice]);
+}

--- a/src/store/useProjectedFileBrowsers.ts
+++ b/src/store/useProjectedFileBrowsers.ts
@@ -153,9 +153,7 @@ export function useProjectedFileBrowsers(): FileBrowsersView {
   // `seedFileBrowsersRegion` so a settled slice is not re-seeded on every render.
   useEffect(() => {
     if (!enabled || matches || view === undefined) return;
-    seedFileBrowsersRegion(slice).catch((err) =>
-      logFileBrowsersBridgeFallback("seed", err)
-    );
+    seedFileBrowsersRegion(slice).catch((err) => logFileBrowsersBridgeFallback("seed", err));
   }, [enabled, matches, view, slice]);
 
   return useMemo(() => {


### PR DESCRIPTION
Part of #2228 (Phase 5 · File browsers), following the proven per-domain render-cut pattern (Agents #2252 / Connections #2264 / Broadcast #2242).

## What

The File-browsers **shadow** (PR #2272) landed a backend-authoritative, client-scoped `FileBrowserStore` served as the `file-browser@<clientId>` region with `fileBrowser.*` intents, but nothing in the UI touched it. This is the **render cut**: the file-browser panel now sources its per-pane UI state from that region — parity-safe, flag-gated, instantly revertible.

### Backend — one minimal seed intent

The shadow exposed only granular per-transition intents, so this adds the whole-slice seed the render cut needs (the analog of `connection.replace` / `broadcast.replace`):

- `FileBrowserStore::replace(client_id, ClientView)` + a `fileBrowser.replace` route that overwrites a client's whole browser view (active pane, the three panes, clipboard) from a snapshot. Idempotent server-side.

### Frontend — the render cut

- `fileBrowsersBridge.ts` — a client-scoped (`file-browser@<clientId>`) bridge: a runtime-flippable render flag (**on by default**), a `fileBrowser.replace` mirror seed that keeps the region a faithful copy of `appStore`, and a deep-equal faithful-mirror gate.
- `useProjectedFileBrowsers()` — returns the projected view when it faithfully mirrors `appStore`, else `appStore`'s slice verbatim.
- `useFileBrowser` cut to source the active pane + each pane's cwd/listing/loading/error from the hook; `FileBrowser.tsx` sources the copy-cut clipboard from it. The file **actions** and the session-model `isConnected` flag stay `appStore` reads.

### Out of scope

The SFTP/session **session model** (#2236) — connect status, live session ids, transfers — is untouched. The mutation cut and reducer removal are later steps.

## Parity / no user-visible change

The gate guarantees the projected view deep-equals `appStore`'s slice before the UI renders from it; otherwise it falls back to `appStore` verbatim. So the rendered output is value-identical to the pre-cut path. Revert at runtime via `window.__TERMIHUB_FILE_BROWSERS_RENDER_FROM_PROJECTION__ = false` or `localStorage["termihub.fileBrowsersRenderFromProjection"] = "false"`.

## Tests

- Rust: `FileBrowserStore::replace` overwrite / snapshot round-trip / defaulting, and a `fileBrowser.replace` projection test (one coalesced diff, converges, idempotent re-seed). All 23 module tests pass.
- Frontend: bridge (flag, mirror gate, seed round-trip + dedup) and hook (flag-off appStore slice + no dispatch, flag-on projection render, region-not-caught-up fallback); the `useFileBrowser` routing test updated to the cut. Full suite green (4992 passed).
- `cargo clippy`/`fmt`, `tsc`, `eslint`, `prettier --check` all clean.