### PR TITLE
feat(sftp): shadow transfers projection region (#2229)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -87,6 +87,12 @@ mod spawn;
 /// [`system_monitor_projection`].
 mod system_monitor_projection;
 mod terminal;
+/// Shadow transfer-queue authority (#2229, Phase 5 of #2139 / #2153): the shared
+/// `transfers` projection region + `transfer.*` intents modeling the `appStore`
+/// Transfer Queue slice (per-transfer queue-row lifecycle + panel-minimized
+/// flag). Registered and served but not yet driving the live UI — a pure shadow
+/// foundation. See [`transfers_projection`].
+mod transfers_projection;
 mod tunnel;
 mod utils;
 /// Multi-window foundation (#1900): window creation/labelling, the
@@ -863,6 +869,20 @@ pub fn run() {
                     &mut registry,
                     app.handle().clone(),
                 );
+                // Shadow TransferStore (#2229, Phase 5): the shared `transfers`
+                // region + `transfer.*` intents modeling the `appStore` Transfer
+                // Queue slice (per-transfer queue-row lifecycle + the
+                // panel-minimized flag), mirroring the frontend `TransferEntry`
+                // folds. Managed authoritative state that serves intents, but
+                // nothing in the live UI subscribes to or renders the region yet —
+                // a pure shadow foundation (later steps cut rendering, then
+                // mutations, over to it). The shared region is seeded below once
+                // the store is managed.
+                app.manage(Arc::new(transfers_projection::TransferStore::new()));
+                transfers_projection::projection::register_transfer_intents(
+                    &mut registry,
+                    app.handle().clone(),
+                );
                 // Test-bridge-only: add the diagnostic region's `diag.*` routes so
                 // the projection-assertion harness (#2164) has a self-contained
                 // region to drive. Never registered in production launches. See
@@ -933,6 +953,17 @@ pub fn run() {
                 {
                     projection_state.projector.register_region(
                         settings_projection::projection::SETTINGS_REGION,
+                        store.snapshot(),
+                    );
+                }
+                // Seed the shared `transfers` region with the (empty) store
+                // baseline at version 0, so a subscriber attaches to a real region
+                // before the first `transfer.*` intent (#2229).
+                if let Some(store) =
+                    app.handle().try_state::<Arc<transfers_projection::TransferStore>>()
+                {
+                    projection_state.projector.register_region(
+                        transfers_projection::projection::TRANSFERS_REGION,
                         store.snapshot(),
                     );
                 }

--- a/src-tauri/src/transfers_projection/mod.rs
+++ b/src-tauri/src/transfers_projection/mod.rs
@@ -1,0 +1,45 @@
+//! Shadow transfer-queue authority — Phase 5 of the stateless-UI migration
+//! (#2229, part of #2153 / #2139).
+//!
+//! Moves the SFTP/FTP transfer-queue UI state the frontend drives in `appStore`
+//! (`transferQueue: Record<transferId, TransferEntry>` + the panel-minimized
+//! flag) into a Rust authority on the projection substrate
+//! ([`crate::projection`]). The store models the per-transfer queue-row lifecycle
+//! — `queued → active → completed | failed | cancelled` (plus `paused`), with
+//! byte progress, derived percent/throughput, error message and retry
+//! attempt/max-attempt counters — mirroring the frontend `TransferEntry` and the
+//! `transferEntryFrom*` folds one-to-one (`src/types/transfer.ts`).
+//!
+//! This is the **queue-panel view**, not the backend transfer engine: the actual
+//! `sftp_download` / `sftp_upload` byte-pump (`src-tauri/src/files/transfer`) and
+//! the per-window ownership scoping of a transfer (#1951 / #1964) stay out of
+//! scope. The store owns only which transfers the queue shows and each row's
+//! derived render state.
+//!
+//! # Shared region — Open Design Decision #4 / #6
+//!
+//! A transfer runs backend-side and its progress/state is a property of the
+//! transfer, not of a viewing client: two clients watching the same queue see the
+//! same bytes, percent and outcome (like SSH tunnels,
+//! [`crate::tunnel::projection`], session-lifecycle,
+//! [`crate::session_projection`], and system-monitors,
+//! [`crate::system_monitor_projection`]). The region is therefore a single
+//! **shared** `transfers` region. The per-window choice of *which* transfers a
+//! given window renders (the #1951 / #1964 ownership scoping) is presentation and
+//! stays a frontend concern under partial projection — the same boundary the
+//! system-monitor shadow drew for the status-bar active tab.
+//!
+//! # Shadow only (#2229)
+//!
+//! Landed as a pure shadow foundation: managed authoritative state that serves
+//! the `transfer.*` intents, but nothing in the live UI subscribes to or
+//! dispatches them yet — `appStore` stays authoritative and nothing user-facing
+//! changes. Later steps cut rendering (the Transfer Queue panel + Open
+//! Connections read the projected `transfers` region), then the mutations, then
+//! remove the `appStore` reducers, keeping them as the parity-safe fallback until
+//! then.
+
+pub mod projection;
+pub mod store;
+
+pub use store::TransferStore;

--- a/src-tauri/src/transfers_projection/projection.rs
+++ b/src-tauri/src/transfers_projection/projection.rs
@@ -1,0 +1,217 @@
+//! Transfer-queue projection: the shared `transfers` region and the
+//! `transfer.*` intents (#2229, Phase 5 of #2139 / #2153).
+//!
+//! Exposes the authoritative [`TransferStore`] as one versioned, multi-subscriber
+//! projection region and turns the transfer-queue transitions the frontend
+//! currently drives into [`Intent`]s — mirroring the SSH-tunnels pilot
+//! ([`crate::tunnel::projection`]) and the system-monitor shadow
+//! ([`crate::system_monitor_projection::projection`]).
+//!
+//! # The `transfers` region
+//!
+//! **Shared** (Open Design Decision #4: infrastructure domains are shared). A
+//! transfer runs backend-side; its progress/state is a property of the transfer,
+//! not of a viewing client, so two clients watching the same queue see the same
+//! row. The view model:
+//!
+//! ```json
+//! { "queue": { "<transferId>": TransferEntry, ... }, "minimized": false }
+//! ```
+//!
+//! # Intents
+//!
+//! | kind                       | payload                    | effect                                       |
+//! | -------------------------- | -------------------------- | -------------------------------------------- |
+//! | `transfer.seed`            | `{ seed }`                 | enqueue a `queued` row (idempotent)          |
+//! | `transfer.progress`        | `{ progress }`             | fold a `transfer-progress` event             |
+//! | `transfer.reconcile`       | `{ snapshots }`            | settle stuck rows from a `transfer_list`     |
+//! | `transfer.remove`          | `{ id }`                   | drop one queue row                           |
+//! | `transfer.clearCompleted`  | `{}`                       | drop every `completed` row                   |
+//! | `transfer.setMinimized`    | `{ minimized }`            | collapse/expand the panel                    |
+//! | `transfer.replace`         | `{ queue, minimized }`     | overwrite the whole slice (render mirror)    |
+//!
+//! `transfer.replace` is the whole-slice seed the (later) frontend render cut
+//! (#2229) uses to keep the shared region a faithful copy of `appStore`'s
+//! transfer-queue slice while `appStore` stays authoritative — the analog of the
+//! system-monitor bridge's `monitor.replace`. The granular `seed` / `progress` /
+//! `reconcile` / `remove` / `clearCompleted` / `setMinimized` transitions drive
+//! the store for the (later) mutation cut.
+//!
+//! # Shadow only (#2229)
+//!
+//! Registered and fully served, but nothing in the live UI subscribes to or
+//! dispatches these intents yet — a pure shadow foundation. Later steps cut
+//! rendering, then the mutations, over to it, keeping the `appStore` reducers as
+//! the parity-safe fallback. Per the substrate contract the result of an intent
+//! is never returned inline — it always arrives as a projection diff on the
+//! `transfers` region.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::Value;
+use tauri::{AppHandle, Manager};
+
+use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
+use crate::transfers_projection::store::{
+    TransferEntry, TransferProgress, TransferSeed, TransferSnapshot, TransferStore,
+};
+
+/// The projection region id for the transfer-queue domain (shared, per Open
+/// Design Decision #4).
+pub const TRANSFERS_REGION: &str = "transfers";
+
+/// Current wall-clock milliseconds — the `now` injected into the queue folds
+/// (`updatedAt`, throughput deltas), matching the frontend `Date.now()`.
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Publish the `transfers` region from the store, fanning a diff out to every
+/// subscriber and returning the advanced region for the intent ack (empty when
+/// the view did not change).
+pub fn publish_transfers(projector: &Projector, store: &TransferStore) -> Vec<ProducedRegion> {
+    match projector.publish(TRANSFERS_REGION, store.snapshot()) {
+        Some(version) => vec![ProducedRegion {
+            region: TRANSFERS_REGION.to_string(),
+            version,
+        }],
+        None => Vec::new(),
+    }
+}
+
+/// Register the `transfer.*` intents on a handler registry.
+///
+/// Each route resolves the managed [`TransferStore`] lazily (so it rejects
+/// gracefully rather than panicking if the store is somehow absent), applies the
+/// transition, and publishes the shared region. All transitions are pure/fast map
+/// edits, so they run inline on the dispatcher's single writer.
+pub fn register_transfer_intents(registry: &mut HandlerRegistry, app_handle: AppHandle) {
+    let handle = app_handle.clone();
+    registry.route("transfer.seed", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let seed = parse_field::<TransferSeed>(intent, "seed")?;
+        store.seed(&seed, now_ms());
+        Ok(publish_transfers(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("transfer.progress", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let progress = parse_field::<TransferProgress>(intent, "progress")?;
+        store.progress(&progress, now_ms());
+        Ok(publish_transfers(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("transfer.reconcile", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let snapshots = parse_field::<Vec<TransferSnapshot>>(intent, "snapshots")?;
+        store.reconcile(&snapshots, now_ms());
+        Ok(publish_transfers(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("transfer.remove", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let id = required_str(intent, "id")?;
+        store.remove(&id);
+        Ok(publish_transfers(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("transfer.clearCompleted", move |_intent, projector| {
+        let store = store_of(&handle)?;
+        store.clear_completed();
+        Ok(publish_transfers(projector, &store))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("transfer.setMinimized", move |intent, projector| {
+        let store = store_of(&handle)?;
+        store.set_minimized(required_bool(intent, "minimized")?);
+        Ok(publish_transfers(projector, &store))
+    });
+
+    let handle = app_handle;
+    registry.route("transfer.replace", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let (queue, minimized) = parse_replace(intent)?;
+        store.replace(queue, minimized);
+        Ok(publish_transfers(projector, &store))
+    });
+}
+
+/// Resolve the managed transfer store, or a rejectable error if absent.
+fn store_of(app_handle: &AppHandle) -> Result<Arc<TransferStore>, (String, String)> {
+    app_handle
+        .try_state::<Arc<TransferStore>>()
+        .map(|state| (*state).clone())
+        .ok_or_else(|| {
+            (
+                "unavailable".to_string(),
+                "transfer store is not initialized".to_string(),
+            )
+        })
+}
+
+/// Deserialize a required object/array field of an intent payload into `T`.
+fn parse_field<T: serde::de::DeserializeOwned>(
+    intent: &Intent,
+    key: &str,
+) -> Result<T, (String, String)> {
+    let value = intent
+        .payload
+        .get(key)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))?;
+    serde_json::from_value(value.clone())
+        .map_err(|e| ("bad_payload".to_string(), format!("invalid '{key}': {e}")))
+}
+
+/// Parse a `transfer.replace` payload into the whole-slice snapshot the render
+/// mirror carries: `{ queue: { <id>: TransferEntry }, minimized: bool }`. A
+/// missing `queue` is an empty map (so a mirror that clears the queue is
+/// expressible) and a missing `minimized` defaults to `false`; a
+/// present-but-malformed field is a `bad_payload` rejection that advances nothing.
+fn parse_replace(
+    intent: &Intent,
+) -> Result<(HashMap<String, TransferEntry>, bool), (String, String)> {
+    let queue = match intent.payload.get("queue") {
+        None | Some(Value::Null) => HashMap::new(),
+        Some(value) => serde_json::from_value(value.clone())
+            .map_err(|e| ("bad_payload".to_string(), format!("invalid 'queue': {e}")))?,
+    };
+    let minimized = intent
+        .payload
+        .get("minimized")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    Ok((queue, minimized))
+}
+
+/// Extract a required string field from an intent payload.
+fn required_str(intent: &Intent, key: &str) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// Extract a required bool field from an intent payload.
+fn required_bool(intent: &Intent, key: &str) -> Result<bool, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_bool)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+#[cfg(test)]
+#[path = "projection_tests.rs"]
+mod tests;

--- a/src-tauri/src/transfers_projection/projection_tests.rs
+++ b/src-tauri/src/transfers_projection/projection_tests.rs
@@ -1,0 +1,442 @@
+//! Projection-contract tests for the shared `transfers` region (#2229), reusing
+//! the substrate harness (#2164): an in-memory [`ProjectionSink`] and a client
+//! cache that applies diffs. The routes here drive a real [`TransferStore`]
+//! directly (the production `register_transfer_intents` resolves the same store
+//! from the Tauri `AppHandle`; that thin wiring is integration-verified via a
+//! local `./scripts/dev.sh` run) through the identical parse → mutate → publish
+//! path.
+//!
+//! Asserted: subscribe → snapshot (identical to every subscriber), an accepted
+//! intent → exactly one coalesced diff fanned to every subscriber with monotonic
+//! versions, rejection paths advance nothing, a no-op intent advances nothing, a
+//! dead subscriber is reaped, and the client cache converges on the store's
+//! authority across a full transfer lifecycle.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::{json, Value};
+
+use crate::projection::{
+    apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
+    ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
+};
+use crate::transfers_projection::projection::{publish_transfers, TRANSFERS_REGION};
+use crate::transfers_projection::store::{
+    TransferProgress, TransferSeed, TransferSnapshot, TransferStore,
+};
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+/// A fixed `now` so folds are deterministic in tests.
+const NOW: u64 = 10_000;
+
+/// A store with a couple of transfers already in the queue, so a subscriber sees
+/// a populated baseline.
+fn seeded_store() -> Arc<TransferStore> {
+    let store = Arc::new(TransferStore::new());
+    store.seed(&seed("t1"), NOW);
+    store.seed(&seed("t2"), NOW);
+    store.progress(&progress_active("t2", 500), NOW);
+    store
+}
+
+fn seed(id: &str) -> TransferSeed {
+    serde_json::from_value(json!({
+        "id": id,
+        "sessionId": "sess-1",
+        "direction": "download",
+        "name": "data.csv",
+        "path": "/remote/data.csv",
+        "totalBytes": 1000,
+    }))
+    .unwrap()
+}
+
+fn progress_active(id: &str, transferred: u64) -> TransferProgress {
+    serde_json::from_value(json!({
+        "transferId": id,
+        "sessionId": "sess-1",
+        "direction": "download",
+        "fileName": "data.csv",
+        "path": "/remote/data.csv",
+        "transferred": transferred,
+        "total": 1000,
+        "phase": "transferring",
+        "state": "active",
+        "totalBytes": 1000,
+    }))
+    .unwrap()
+}
+
+/// The production `transfer.*` routes, bound to an injected store instead of
+/// resolving one from an `AppHandle` — the exact parse → mutate → publish path
+/// `register_transfer_intents` runs, with a fixed `now` so folds are
+/// deterministic. Each closure mirrors the production route one-to-one so the
+/// test drives real logic, not a stand-in.
+fn registry_for(store: Arc<TransferStore>) -> HandlerRegistry {
+    let mut registry = HandlerRegistry::new();
+
+    let s = store.clone();
+    registry.route("transfer.seed", move |intent, projector| {
+        let seed: TransferSeed = parse_field(intent, "seed")?;
+        s.seed(&seed, NOW);
+        Ok(publish_transfers(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("transfer.progress", move |intent, projector| {
+        let progress: TransferProgress = parse_field(intent, "progress")?;
+        s.progress(&progress, NOW);
+        Ok(publish_transfers(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("transfer.reconcile", move |intent, projector| {
+        let snapshots: Vec<TransferSnapshot> = parse_field(intent, "snapshots")?;
+        s.reconcile(&snapshots, NOW);
+        Ok(publish_transfers(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("transfer.remove", move |intent, projector| {
+        s.remove(&required_str(intent, "id")?);
+        Ok(publish_transfers(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("transfer.clearCompleted", move |_intent, projector| {
+        s.clear_completed();
+        Ok(publish_transfers(projector, &s))
+    });
+    let s = store.clone();
+    registry.route("transfer.setMinimized", move |intent, projector| {
+        let minimized = intent
+            .payload
+            .get("minimized")
+            .and_then(Value::as_bool)
+            .ok_or_else(|| ("bad_payload".to_string(), "missing 'minimized'".to_string()))?;
+        s.set_minimized(minimized);
+        Ok(publish_transfers(projector, &s))
+    });
+    let s = store;
+    registry.route("transfer.replace", move |intent, projector| {
+        let queue = match intent.payload.get("queue") {
+            None | Some(Value::Null) => std::collections::HashMap::new(),
+            Some(value) => serde_json::from_value(value.clone())
+                .map_err(|e| ("bad_payload".to_string(), format!("invalid 'queue': {e}")))?,
+        };
+        let minimized = intent
+            .payload
+            .get("minimized")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        s.replace(queue, minimized);
+        Ok(publish_transfers(projector, &s))
+    });
+
+    registry
+}
+
+/// The route-side `parse_field` — deserialize a required object/array field.
+fn parse_field<T: serde::de::DeserializeOwned>(
+    intent: &Intent,
+    key: &str,
+) -> Result<T, (String, String)> {
+    let value = intent
+        .payload
+        .get(key)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))?;
+    serde_json::from_value(value.clone())
+        .map_err(|e| ("bad_payload".to_string(), format!("invalid '{key}': {e}")))
+}
+
+fn required_str(intent: &Intent, key: &str) -> Result<String, (String, String)> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// An in-memory sink recording delivered frames; can be killed to simulate a
+/// dead subscriber (mirrors the substrate/tunnel/monitor test double).
+struct VecSink {
+    frames: Mutex<Vec<ProjectionFrame>>,
+    alive: AtomicBool,
+}
+
+impl VecSink {
+    fn new() -> Self {
+        Self {
+            frames: Mutex::new(Vec::new()),
+            alive: AtomicBool::new(true),
+        }
+    }
+
+    fn diffs(&self) -> Vec<DiffFrame> {
+        self.frames
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|f| match f {
+                ProjectionFrame::Diff(d) => Some(d.clone()),
+                ProjectionFrame::Snapshot(_) => None,
+            })
+            .collect()
+    }
+}
+
+impl ProjectionSink for VecSink {
+    fn deliver(&self, frame: &ProjectionFrame) -> Result<(), ProjectionError> {
+        if !self.alive.load(Ordering::SeqCst) {
+            return Err(ProjectionError::SinkClosed("killed".into()));
+        }
+        self.frames.lock().unwrap().push(frame.clone());
+        Ok(())
+    }
+}
+
+/// A minimal client cache mirroring the TypeScript `ProjectionClient`.
+struct ClientCache {
+    version: u64,
+    view: Value,
+}
+
+impl ClientCache {
+    fn from_snapshot(s: &SnapshotFrame) -> Self {
+        Self {
+            version: s.version,
+            view: s.view.clone(),
+        }
+    }
+
+    fn apply(&mut self, diff: &DiffFrame) {
+        assert_eq!(diff.base_version, self.version, "diff must fit the cache");
+        apply_ops(&mut self.view, &diff.ops).expect("diff applies cleanly");
+        self.version = diff.version;
+    }
+}
+
+fn intent(kind: &str, payload: Value) -> Intent {
+    Intent {
+        intent_id: format!("01J-{kind}"),
+        kind: kind.to_string(),
+        payload,
+        client_id: "client-1".to_string(),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn subscribe_returns_the_seeded_snapshot_identically_to_every_subscriber() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(TRANSFERS_REGION, store.snapshot());
+
+    let snap_a = projector.subscribe(TRANSFERS_REGION, "sub-a", "A", Arc::new(VecSink::new()));
+    let snap_b = projector.subscribe(TRANSFERS_REGION, "sub-b", "B", Arc::new(VecSink::new()));
+
+    assert_eq!(snap_a.version, 0);
+    assert_eq!(snap_a, snap_b, "a late joiner gets an identical baseline");
+    assert_eq!(snap_a.region, "transfers");
+    assert_eq!(snap_a.view["queue"]["t1"]["state"], json!("queued"));
+    assert_eq!(snap_a.view["queue"]["t2"]["state"], json!("active"));
+    assert_eq!(snap_a.view["minimized"], json!(false));
+}
+
+#[test]
+fn a_transfer_intent_produces_one_diff_fanned_to_two_subscribers() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(TRANSFERS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink_a = Arc::new(VecSink::new());
+    let sink_b = Arc::new(VecSink::new());
+    let snap = projector.subscribe(TRANSFERS_REGION, "sub-a", "A", sink_a.clone());
+    projector.subscribe(TRANSFERS_REGION, "sub-b", "B", sink_b.clone());
+    let mut cache_a = ClientCache::from_snapshot(&snap);
+
+    let ack = dispatcher.dispatch(intent(
+        "transfer.progress",
+        json!({ "progress": progress_payload("t1", "completed", 1000) }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(
+        ack.produced,
+        Some(vec![crate::projection::ProducedRegion {
+            region: TRANSFERS_REGION.to_string(),
+            version: 1,
+        }])
+    );
+
+    let diffs_a = sink_a.diffs();
+    let diffs_b = sink_b.diffs();
+    assert_eq!(diffs_a.len(), 1, "exactly one diff to A");
+    assert_eq!(diffs_b.len(), 1, "exactly one diff to B");
+    assert_eq!(diffs_a[0], diffs_b[0], "identical diff to every subscriber");
+    assert_eq!(diffs_a[0].base_version, 0);
+    assert_eq!(diffs_a[0].version, 1);
+
+    cache_a.apply(&diffs_a[0]);
+    assert_eq!(
+        cache_a.view,
+        store.snapshot(),
+        "cache converges on authority"
+    );
+    assert_eq!(cache_a.view["queue"]["t1"]["state"], json!("completed"));
+    assert_eq!(cache_a.view["queue"]["t1"]["percent"], json!(100));
+}
+
+#[test]
+fn a_full_transfer_lifecycle_advances_monotonically_and_converges() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(TRANSFERS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(TRANSFERS_REGION, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    // t1: queued → active → completed, then clearCompleted drops it. Each
+    // view-changing intent = one diff.
+    for (kind, payload) in [
+        (
+            "transfer.progress",
+            json!({ "progress": progress_payload("t1", "active", 400) }),
+        ),
+        (
+            "transfer.progress",
+            json!({ "progress": progress_payload("t1", "completed", 1000) }),
+        ),
+        ("transfer.setMinimized", json!({ "minimized": true })),
+        ("transfer.clearCompleted", json!({})),
+    ] {
+        let ack = dispatcher.dispatch(intent(kind, payload));
+        assert_eq!(ack.status, IntentStatus::Accepted, "{kind} accepted");
+    }
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 4, "one diff per view-changing intent");
+    for diff in &diffs {
+        cache.apply(diff);
+    }
+    assert_eq!(cache.version, 4);
+    assert_eq!(cache.view, store.snapshot(), "cache converges on authority");
+    assert_eq!(cache.view["queue"].get("t1"), None, "completed row cleared");
+    assert_eq!(cache.view["minimized"], json!(true));
+}
+
+#[test]
+fn replace_mirrors_a_whole_slice_in_one_diff_and_converges() {
+    // The render-cut mirror (#2229): a `transfer.replace` carrying `appStore`'s
+    // whole transfer-queue slice overwrites the region in a single diff.
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(TRANSFERS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(TRANSFERS_REGION, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    // Build the mirror from an independent store (a fresh t3, no t1/t2).
+    let source = Arc::new(TransferStore::new());
+    source.seed(&seed("t3"), NOW);
+    source.progress(&progress_active("t3", 750), NOW);
+    let view = source.snapshot();
+
+    let ack = dispatcher.dispatch(intent(
+        "transfer.replace",
+        json!({ "queue": view["queue"], "minimized": true }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "one coalesced diff for the whole replace");
+    cache.apply(&diffs[0]);
+    assert_eq!(cache.view, store.snapshot(), "region mirrors the source");
+    assert_eq!(cache.view["queue"].get("t1"), None, "prior rows gone");
+    assert_eq!(cache.view["queue"]["t3"]["state"], json!("active"));
+    assert_eq!(cache.view["minimized"], json!(true));
+}
+
+#[test]
+fn an_intent_missing_its_field_is_rejected_without_advancing() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(TRANSFERS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(TRANSFERS_REGION, "sub", "A", sink.clone());
+
+    let ack = dispatcher.dispatch(intent("transfer.seed", json!({ "wrong": "field" })));
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "bad_payload");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(TRANSFERS_REGION), Some(0));
+}
+
+#[test]
+fn a_no_op_intent_advances_nothing() {
+    // `remove` of an unknown id leaves the view unchanged, so the projector
+    // coalesces it to no diff and no version bump.
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(TRANSFERS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(TRANSFERS_REGION, "sub", "A", sink.clone());
+
+    let ack = dispatcher.dispatch(intent("transfer.remove", json!({ "id": "ghost" })));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(ack.produced, Some(vec![]), "no region advanced");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(TRANSFERS_REGION), Some(0));
+}
+
+#[test]
+fn a_dead_subscriber_is_reaped_on_publish() {
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(TRANSFERS_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let live = Arc::new(VecSink::new());
+    let dead = Arc::new(VecSink::new());
+    projector.subscribe(TRANSFERS_REGION, "live", "A", live.clone());
+    projector.subscribe(TRANSFERS_REGION, "dead", "B", dead.clone());
+    assert_eq!(projector.subscriber_count(TRANSFERS_REGION), 2);
+
+    dead.alive.store(false, Ordering::SeqCst);
+    dispatcher.dispatch(intent(
+        "transfer.progress",
+        json!({ "progress": progress_payload("t1", "active", 300) }),
+    ));
+
+    assert_eq!(
+        live.diffs().len(),
+        1,
+        "the live subscriber still gets the diff"
+    );
+    assert_eq!(
+        projector.subscriber_count(TRANSFERS_REGION),
+        1,
+        "the dead subscriber was reaped"
+    );
+}
+
+/// A `transfer-progress` payload as the frontend serialises it (camelCase).
+fn progress_payload(id: &str, state: &str, transferred: u64) -> Value {
+    json!({
+        "transferId": id,
+        "sessionId": "sess-1",
+        "direction": "download",
+        "fileName": "data.csv",
+        "path": "/remote/data.csv",
+        "transferred": transferred,
+        "total": 1000,
+        "phase": "transferring",
+        "state": state,
+        "totalBytes": 1000,
+    })
+}

--- a/src-tauri/src/transfers_projection/store.rs
+++ b/src-tauri/src/transfers_projection/store.rs
@@ -1,0 +1,524 @@
+//! The authoritative, shared transfer-queue state behind the shadow `transfers`
+//! projection region (#2229, Phase 5 of #2139 / #2153).
+//!
+//! Models the Transfer Queue panel slice the frontend currently drives in
+//! `appStore` (`transferQueue: Record<transferId, TransferEntry>` plus the
+//! `transferQueueMinimized` flag): the per-transfer queue-row lifecycle
+//! (`queued → active → completed | failed | cancelled`, plus `paused`), byte
+//! progress, derived percent + throughput, error message and retry
+//! attempt/max-attempt counters. The [`TransferEntry`] record and the
+//! `entry_from_*` folds mirror the frontend `TransferEntry` and the
+//! `transferEntryFrom{Seed,Progress,Snapshot}` helpers one-to-one
+//! (`src/types/transfer.ts`), so the eventual render cut is a pure parity swap.
+//!
+//! # Scope — the queue *view*, not the transfer engine
+//!
+//! This store owns only the **queue-panel view**: which transfers the panel shows
+//! and each row's derived render state. It deliberately does **not** model the
+//! backend transfer engine — the `sftp_download` / `sftp_upload` byte-pump
+//! (`src-tauri/src/files/transfer`) that produces the `transfer-progress` events —
+//! nor the per-window ownership scoping of a transfer (#1951 / #1964), which is
+//! frontend presentation. The store learns of a transfer only through the
+//! `seed` / `progress` / `reconcile` folds the frontend already drives.
+//!
+//! # Shared — Open Design Decision #4 / #6
+//!
+//! A transfer runs backend-side; its progress/state is a property of the
+//! transfer, not of a viewing client, so two clients watching the same queue see
+//! the same row (like SSH tunnels, session-lifecycle and system-monitors). The
+//! store therefore keeps a single map and projects one shared `transfers` region.
+//!
+//! # Shadow only (#2229)
+//!
+//! Managed authoritative state that serves the `transfer.*` intents, but nothing
+//! in the live UI subscribes to or renders the region yet: `appStore` stays
+//! authoritative. Later steps cut rendering, then the mutations, over to it,
+//! keeping the `appStore` reducers as the parity-safe fallback.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map, Value};
+
+/// Direction of a transfer, mirroring the frontend `TransferDirection`.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferDirection {
+    Download,
+    Upload,
+}
+
+/// The connection-type-agnostic state space of a queued transfer, mirroring the
+/// frontend `TransferQueueState` (#1336).
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferQueueState {
+    Queued,
+    Active,
+    Paused,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl TransferQueueState {
+    /// The terminal states — a transfer in one of these will not move on its own
+    /// (mirrors `isTerminalTransferState` / `TERMINAL_TRANSFER_STATES`).
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            TransferQueueState::Completed
+                | TransferQueueState::Failed
+                | TransferQueueState::Cancelled
+        )
+    }
+}
+
+/// The legacy `transfer-progress` lifecycle phase (#1245), mapped to a
+/// [`TransferQueueState`] for events that predate the #1336 `state` field.
+#[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferPhase {
+    Transferring,
+    Done,
+    Cancelled,
+    Error,
+}
+
+impl TransferPhase {
+    /// Mirror of the frontend `stateFromPhase`.
+    fn to_state(self) -> TransferQueueState {
+        match self {
+            TransferPhase::Transferring => TransferQueueState::Active,
+            TransferPhase::Done => TransferQueueState::Completed,
+            TransferPhase::Cancelled => TransferQueueState::Cancelled,
+            TransferPhase::Error => TransferQueueState::Failed,
+        }
+    }
+}
+
+/// A single row in the Transfer Queue panel — the render-ready projection of the
+/// frontend `TransferEntry` (#1337). The optional (`?`) frontend fields
+/// (`path`/`error`/`attempt`/`maxAttempts`) skip serialization when absent and
+/// the always-present `number | null` fields (`totalBytes`/`percent`/
+/// `speedBytesPerSec`) serialize as `null`, so the view model matches the
+/// frontend JSON exactly and the render cut stays a parity swap.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferEntry {
+    /// Stable per-transfer id (the backend `transferId`).
+    pub id: String,
+    /// Owning SFTP/FTP session id (grouping / cancel-all).
+    pub session_id: String,
+    /// Upload or download.
+    pub direction: TransferDirection,
+    /// Display name (file name).
+    pub name: String,
+    /// Remote path, when the backend supplies one (#1531).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// Derived lifecycle state.
+    pub state: TransferQueueState,
+    /// Bytes transferred so far.
+    pub transferred: u64,
+    /// Total bytes, or `null` when the size is unknown (indeterminate).
+    pub total_bytes: Option<u64>,
+    /// Completion percentage (0–100), or `null` when indeterminate.
+    pub percent: Option<u32>,
+    /// Instantaneous throughput in bytes/sec, or `null` when not moving/unknown.
+    pub speed_bytes_per_sec: Option<u64>,
+    /// Human-readable error, only populated for the `failed` state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Current retry attempt (#1336), when reported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attempt: Option<u32>,
+    /// Maximum retry attempts (#1336), when reported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_attempts: Option<u32>,
+    /// Wall-clock ms of the last update (throughput-delta seed).
+    pub updated_at: u64,
+}
+
+/// The minimal description of a transfer known at registration time, before any
+/// `transfer-progress` event — mirrors the frontend `TransferSeed` (#1632).
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferSeed {
+    pub id: String,
+    pub session_id: String,
+    pub direction: TransferDirection,
+    pub name: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub total_bytes: Option<u64>,
+}
+
+/// Payload of a `transfer-progress` event, mirroring the frontend
+/// `TransferProgress`. The #1336 rich fields (`state`/`speed`/`totalBytes`/
+/// `attempt`/`maxAttempts`) are preferred when present; otherwise the legacy
+/// #1245 fields (`phase`/`total`) drive the fold.
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferProgress {
+    pub transfer_id: String,
+    pub session_id: String,
+    pub direction: TransferDirection,
+    pub file_name: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    pub transferred: u64,
+    #[serde(default)]
+    pub total: u64,
+    pub phase: TransferPhase,
+    #[serde(default)]
+    pub message: Option<String>,
+    #[serde(default)]
+    pub state: Option<TransferQueueState>,
+    #[serde(default)]
+    pub speed: Option<u64>,
+    #[serde(default)]
+    pub total_bytes: Option<u64>,
+    #[serde(default)]
+    pub attempt: Option<u32>,
+    #[serde(default)]
+    pub max_attempts: Option<u32>,
+}
+
+/// A snapshot of one queued transfer from `transfer_list`, mirroring the frontend
+/// `TransferSnapshot` — the reconcile backstop (#1645 / #1657).
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferSnapshot {
+    pub transfer_id: String,
+    pub session_id: String,
+    pub direction: TransferDirection,
+    pub file_name: String,
+    #[serde(default)]
+    pub path: Option<String>,
+    pub state: TransferQueueState,
+    /// Whether this is a genuinely settled outcome the reconcile may fold into a
+    /// stuck row (#1657) — stricter than [`TransferQueueState::is_terminal`].
+    pub settled: bool,
+    pub transferred: u64,
+    #[serde(default)]
+    pub total: u64,
+    #[serde(default)]
+    pub speed: u64,
+    #[serde(default)]
+    pub attempt: u32,
+    #[serde(default)]
+    pub max_attempts: u32,
+}
+
+/// Normalize a raw total (`0` = indeterminate) to `Some(total)` / `None`.
+fn total_or_none(total: u64) -> Option<u64> {
+    if total > 0 {
+        Some(total)
+    } else {
+        None
+    }
+}
+
+/// Derive the render percent (mirror of the frontend `percent` derivation):
+/// `100` when completed, else the clamped ratio when the total is known, else
+/// `None`.
+fn derive_percent(
+    state: TransferQueueState,
+    transferred: u64,
+    total_bytes: Option<u64>,
+) -> Option<u32> {
+    if state == TransferQueueState::Completed {
+        return Some(100);
+    }
+    match total_bytes {
+        Some(total) if total > 0 => {
+            let ratio = (transferred as f64 / total as f64) * 100.0;
+            Some(ratio.round().clamp(0.0, 100.0) as u32)
+        }
+        _ => None,
+    }
+}
+
+impl TransferEntry {
+    /// Build a `queued` entry from a [`TransferSeed`] — the pre-event
+    /// registration seed (mirror of `transferEntryFromSeed`). Progress/throughput
+    /// are unknown until the first event folds over the row.
+    fn from_seed(seed: &TransferSeed, now: u64) -> Self {
+        Self {
+            id: seed.id.clone(),
+            session_id: seed.session_id.clone(),
+            direction: seed.direction,
+            name: seed.name.clone(),
+            path: seed.path.clone(),
+            state: TransferQueueState::Queued,
+            transferred: 0,
+            total_bytes: seed.total_bytes.filter(|&t| t > 0),
+            percent: None,
+            speed_bytes_per_sec: None,
+            error: None,
+            attempt: None,
+            max_attempts: None,
+            updated_at: now,
+        }
+    }
+
+    /// Fold a `transfer-progress` event into an entry, deriving state, percent and
+    /// throughput (mirror of `transferEntryFromProgress`). `prev` seeds the
+    /// throughput delta and preserves fields the event omits.
+    fn from_progress(progress: &TransferProgress, prev: Option<&TransferEntry>, now: u64) -> Self {
+        let state = progress.state.unwrap_or_else(|| progress.phase.to_state());
+        let total_bytes = total_or_none(progress.total_bytes.unwrap_or(progress.total));
+        let percent = derive_percent(state, progress.transferred, total_bytes);
+        let speed_bytes_per_sec = Self::derive_speed(progress, prev, now, state);
+
+        Self {
+            id: progress.transfer_id.clone(),
+            session_id: progress.session_id.clone(),
+            direction: progress.direction,
+            name: progress.file_name.clone(),
+            path: progress
+                .path
+                .clone()
+                .or_else(|| prev.and_then(|p| p.path.clone())),
+            state,
+            transferred: progress.transferred,
+            total_bytes,
+            percent,
+            speed_bytes_per_sec,
+            error: if state == TransferQueueState::Failed {
+                Some(
+                    progress
+                        .message
+                        .clone()
+                        .unwrap_or_else(|| "Transfer failed".to_string()),
+                )
+            } else {
+                None
+            },
+            attempt: progress.attempt.or_else(|| prev.and_then(|p| p.attempt)),
+            max_attempts: progress
+                .max_attempts
+                .or_else(|| prev.and_then(|p| p.max_attempts)),
+            updated_at: now,
+        }
+    }
+
+    /// Throughput derivation for a progress fold: backend-measured speed when
+    /// supplied, else the byte/time delta against an `active` `prev`, else `None`
+    /// (mirror of the frontend `speedBytesPerSec` branch).
+    fn derive_speed(
+        progress: &TransferProgress,
+        prev: Option<&TransferEntry>,
+        now: u64,
+        state: TransferQueueState,
+    ) -> Option<u64> {
+        if state != TransferQueueState::Active {
+            return None;
+        }
+        if let Some(speed) = progress.speed {
+            if speed > 0 {
+                return Some(speed);
+            }
+        }
+        let prev = prev?;
+        if prev.state != TransferQueueState::Active {
+            return None;
+        }
+        let delta_bytes = progress.transferred as i64 - prev.transferred as i64;
+        let delta_ms = now as i64 - prev.updated_at as i64;
+        if delta_bytes >= 0 && delta_ms > 0 {
+            Some(((delta_bytes as f64 / delta_ms as f64) * 1000.0).round() as u64)
+        } else {
+            prev.speed_bytes_per_sec
+        }
+    }
+
+    /// Fold a `transfer_list` snapshot into an entry, settling a stuck row to its
+    /// true terminal state (mirror of `transferEntryFromSnapshot`). `prev` is the
+    /// row being settled; its path / retry counters / error are preserved where
+    /// the snapshot does not supply them.
+    fn from_snapshot(snapshot: &TransferSnapshot, prev: Option<&TransferEntry>, now: u64) -> Self {
+        let total_bytes =
+            total_or_none(snapshot.total).or_else(|| prev.and_then(|p| p.total_bytes));
+        let state = snapshot.state;
+        let percent = derive_percent(state, snapshot.transferred, total_bytes);
+
+        Self {
+            id: snapshot.transfer_id.clone(),
+            session_id: snapshot.session_id.clone(),
+            direction: snapshot.direction,
+            name: snapshot.file_name.clone(),
+            path: snapshot
+                .path
+                .clone()
+                .or_else(|| prev.and_then(|p| p.path.clone())),
+            state,
+            transferred: snapshot.transferred,
+            total_bytes,
+            percent,
+            speed_bytes_per_sec: if snapshot.speed > 0 {
+                Some(snapshot.speed)
+            } else {
+                None
+            },
+            error: if state == TransferQueueState::Failed {
+                Some(
+                    prev.and_then(|p| p.error.clone())
+                        .unwrap_or_else(|| "Transfer failed".to_string()),
+                )
+            } else {
+                None
+            },
+            attempt: (snapshot.attempt != 0)
+                .then_some(snapshot.attempt)
+                .or_else(|| prev.and_then(|p| p.attempt)),
+            max_attempts: (snapshot.max_attempts != 0)
+                .then_some(snapshot.max_attempts)
+                .or_else(|| prev.and_then(|p| p.max_attempts)),
+            updated_at: now,
+        }
+    }
+}
+
+/// The private mutable core: the per-transfer queue map plus the panel-minimized
+/// flag. One mutex guards it so intents never interleave — the substrate's
+/// single-writer contract also holds within the store.
+#[derive(Default)]
+struct Inner {
+    queue: HashMap<String, TransferEntry>,
+    minimized: bool,
+}
+
+/// The shadow transfer-queue authority. Owns one [`TransferEntry`] per transfer,
+/// keyed by `transferId`, plus the panel-minimized flag. The single shared
+/// `transfers` region projects this state.
+#[derive(Default)]
+pub struct TransferStore {
+    inner: Mutex<Inner>,
+}
+
+impl TransferStore {
+    /// A store with an empty queue.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The render-ready view model for the whole region:
+    /// `{ "queue": { "<id>": TransferEntry, ... }, "minimized": bool }`.
+    ///
+    /// Pure with respect to queue state (never mutates), so the projector can
+    /// safely diff two consecutive snapshots.
+    pub fn snapshot(&self) -> Value {
+        let inner = self.lock();
+        let mut queue = Map::with_capacity(inner.queue.len());
+        for (id, entry) in &inner.queue {
+            if let Ok(value) = serde_json::to_value(entry) {
+                queue.insert(id.clone(), value);
+            }
+        }
+        json!({ "queue": Value::Object(queue), "minimized": inner.minimized })
+    }
+
+    /// `transfer.seed` — enqueue a `queued` row from a registration snapshot
+    /// (#1632). Idempotent: never overwrites a row an event already advanced
+    /// (mirrors `seedTransferQueue`). The window-ownership `releasedTransferSessions`
+    /// bookkeeping is frontend presentation and out of scope here.
+    pub fn seed(&self, seed: &TransferSeed, now: u64) {
+        let mut inner = self.lock();
+        if inner.queue.contains_key(&seed.id) {
+            return;
+        }
+        inner
+            .queue
+            .insert(seed.id.clone(), TransferEntry::from_seed(seed, now));
+    }
+
+    /// `transfer.progress` — fold a `transfer-progress` event into the queue,
+    /// upserting the row and retaining terminal rows (mirrors
+    /// `applyTransferProgressToQueue`). The window-ownership scoping (#1951 /
+    /// #1964) is frontend presentation and out of scope.
+    pub fn progress(&self, progress: &TransferProgress, now: u64) {
+        let mut inner = self.lock();
+        let prev = inner.queue.get(&progress.transfer_id).cloned();
+        let entry = TransferEntry::from_progress(progress, prev.as_ref(), now);
+        inner.queue.insert(entry.id.clone(), entry);
+    }
+
+    /// `transfer.reconcile` — settle stuck non-terminal rows against a
+    /// `transfer_list` snapshot (mirrors `reconcileTransferQueue`). Only a
+    /// genuinely settled terminal snapshot for an existing, still-live row folds;
+    /// events own live progress, so this never regresses an event-advanced row.
+    pub fn reconcile(&self, snapshots: &[TransferSnapshot], now: u64) {
+        let mut inner = self.lock();
+        for snap in snapshots {
+            if !snap.settled || !snap.state.is_terminal() {
+                continue;
+            }
+            let Some(prev) = inner.queue.get(&snap.transfer_id) else {
+                continue;
+            };
+            if prev.state.is_terminal() {
+                continue;
+            }
+            let settled = TransferEntry::from_snapshot(snap, Some(prev), now);
+            inner.queue.insert(snap.transfer_id.clone(), settled);
+        }
+    }
+
+    /// `transfer.remove` — drop one queue row (mirrors `removeTransfer`).
+    /// Idempotent.
+    pub fn remove(&self, id: &str) {
+        self.lock().queue.remove(id);
+    }
+
+    /// `transfer.clearCompleted` — drop every `completed` row, retaining
+    /// failed/cancelled ones (mirrors `clearCompleted`).
+    pub fn clear_completed(&self) {
+        self.lock()
+            .queue
+            .retain(|_, e| e.state != TransferQueueState::Completed);
+    }
+
+    /// `transfer.setMinimized` — collapse/expand the panel to its status-bar
+    /// indicator (mirrors `setTransferQueueMinimized`).
+    pub fn set_minimized(&self, minimized: bool) {
+        self.lock().minimized = minimized;
+    }
+
+    /// `transfer.replace` — overwrite the whole queue map and minimized flag with
+    /// a caller-supplied snapshot. Used by the frontend render-cut mirror (#2229)
+    /// to keep the shared region a faithful copy of `appStore`'s transfer-queue
+    /// slice while `appStore` remains authoritative (the mutation cut is a later
+    /// step) — the analog of the system-monitor bridge's `monitor.replace` seed.
+    /// Idempotent server-side: replacing with identical content yields no diff.
+    pub fn replace(&self, queue: HashMap<String, TransferEntry>, minimized: bool) {
+        let mut inner = self.lock();
+        inner.queue = queue;
+        inner.minimized = minimized;
+    }
+
+    /// Read one queue row (test / diagnostics helper).
+    #[cfg(test)]
+    pub fn get(&self, id: &str) -> Option<TransferEntry> {
+        self.lock().queue.get(id).cloned()
+    }
+
+    /// Read the number of queue rows (test / diagnostics helper).
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.lock().queue.len()
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Inner> {
+        // Short critical sections only; a poisoned lock means another thread
+        // panicked mid-mutation (a bug) — recover rather than cascade.
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+#[cfg(test)]
+#[path = "store_tests.rs"]
+mod tests;

--- a/src-tauri/src/transfers_projection/store_tests.rs
+++ b/src-tauri/src/transfers_projection/store_tests.rs
@@ -1,0 +1,360 @@
+//! Unit tests for the shadow [`TransferStore`] transitions and folds (#2229).
+//!
+//! Drives the store directly and asserts on the typed [`TransferEntry`] records,
+//! covering the `queued → active → completed | failed | cancelled` lifecycle, the
+//! derived percent/throughput folds (mirroring `src/types/transfer.ts`), the
+//! reconcile backstop, and the whole-slice `replace` mirror.
+
+use std::collections::HashMap;
+
+use serde_json::json;
+
+use super::{
+    TransferDirection, TransferProgress, TransferQueueState, TransferSeed, TransferSnapshot,
+    TransferStore,
+};
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+fn seed(id: &str) -> TransferSeed {
+    TransferSeed {
+        id: id.to_string(),
+        session_id: "sess-1".to_string(),
+        direction: TransferDirection::Download,
+        name: "data.csv".to_string(),
+        path: Some("/remote/data.csv".to_string()),
+        total_bytes: Some(1000),
+    }
+}
+
+/// A `transfer-progress` event using the rich #1336 fields.
+fn progress(id: &str, state: TransferQueueState, transferred: u64) -> TransferProgress {
+    TransferProgress {
+        transfer_id: id.to_string(),
+        session_id: "sess-1".to_string(),
+        direction: TransferDirection::Download,
+        file_name: "data.csv".to_string(),
+        path: Some("/remote/data.csv".to_string()),
+        transferred,
+        total: 1000,
+        phase: super::TransferPhase::Transferring,
+        message: None,
+        state: Some(state),
+        speed: None,
+        total_bytes: Some(1000),
+        attempt: None,
+        max_attempts: None,
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn a_fresh_store_snapshots_empty() {
+    let store = TransferStore::new();
+    assert_eq!(store.snapshot(), json!({ "queue": {}, "minimized": false }));
+}
+
+#[test]
+fn seed_creates_a_queued_row() {
+    let store = TransferStore::new();
+    store.seed(&seed("t1"), 1_000);
+
+    let entry = store.get("t1").expect("row exists");
+    assert_eq!(entry.state, TransferQueueState::Queued);
+    assert_eq!(entry.transferred, 0);
+    assert_eq!(entry.total_bytes, Some(1000));
+    assert_eq!(entry.percent, None);
+    assert_eq!(entry.speed_bytes_per_sec, None);
+    assert_eq!(entry.path.as_deref(), Some("/remote/data.csv"));
+    assert_eq!(entry.updated_at, 1_000);
+}
+
+#[test]
+fn seed_is_idempotent_and_never_overwrites_an_advanced_row() {
+    let store = TransferStore::new();
+    store.seed(&seed("t1"), 1_000);
+    store.progress(&progress("t1", TransferQueueState::Active, 500), 2_000);
+
+    // A late seed for the same id must not clobber the active row back to queued.
+    store.seed(&seed("t1"), 3_000);
+    let entry = store.get("t1").unwrap();
+    assert_eq!(entry.state, TransferQueueState::Active);
+    assert_eq!(entry.transferred, 500);
+}
+
+#[test]
+fn progress_upserts_and_derives_percent() {
+    let store = TransferStore::new();
+    store.progress(&progress("t1", TransferQueueState::Active, 250), 1_000);
+
+    let entry = store.get("t1").unwrap();
+    assert_eq!(entry.state, TransferQueueState::Active);
+    assert_eq!(entry.percent, Some(25));
+    assert_eq!(entry.total_bytes, Some(1000));
+}
+
+#[test]
+fn progress_derives_throughput_from_the_byte_time_delta() {
+    let store = TransferStore::new();
+    // First active sample at t=1000ms, 100 bytes.
+    store.progress(&progress("t1", TransferQueueState::Active, 100), 1_000);
+    // Second at t=2000ms, 1100 bytes → 1000 bytes / 1000 ms = 1000 B/s.
+    let mut p = progress("t1", TransferQueueState::Active, 1_100);
+    p.total = 4000;
+    p.total_bytes = Some(4000);
+    store.progress(&p, 2_000);
+
+    let entry = store.get("t1").unwrap();
+    assert_eq!(entry.speed_bytes_per_sec, Some(1000));
+}
+
+#[test]
+fn progress_prefers_backend_measured_speed() {
+    let store = TransferStore::new();
+    let mut p = progress("t1", TransferQueueState::Active, 500);
+    p.speed = Some(4242);
+    store.progress(&p, 1_000);
+
+    assert_eq!(store.get("t1").unwrap().speed_bytes_per_sec, Some(4242));
+}
+
+#[test]
+fn completed_forces_percent_100_and_clears_speed() {
+    let store = TransferStore::new();
+    store.progress(&progress("t1", TransferQueueState::Active, 900), 1_000);
+    store.progress(&progress("t1", TransferQueueState::Completed, 1_000), 2_000);
+
+    let entry = store.get("t1").unwrap();
+    assert_eq!(entry.state, TransferQueueState::Completed);
+    assert_eq!(entry.percent, Some(100));
+    assert_eq!(entry.speed_bytes_per_sec, None);
+}
+
+#[test]
+fn failed_records_the_error_message() {
+    let store = TransferStore::new();
+    let mut p = progress("t1", TransferQueueState::Failed, 300);
+    p.message = Some("connection reset".to_string());
+    store.progress(&p, 1_000);
+
+    let entry = store.get("t1").unwrap();
+    assert_eq!(entry.state, TransferQueueState::Failed);
+    assert_eq!(entry.error.as_deref(), Some("connection reset"));
+}
+
+#[test]
+fn failed_without_a_message_uses_the_default() {
+    let store = TransferStore::new();
+    store.progress(&progress("t1", TransferQueueState::Failed, 300), 1_000);
+    assert_eq!(
+        store.get("t1").unwrap().error.as_deref(),
+        Some("Transfer failed")
+    );
+}
+
+#[test]
+fn legacy_phase_drives_state_when_rich_state_is_absent() {
+    let store = TransferStore::new();
+    let mut p = progress("t1", TransferQueueState::Active, 400);
+    p.state = None;
+    p.phase = super::TransferPhase::Done;
+    store.progress(&p, 1_000);
+
+    let entry = store.get("t1").unwrap();
+    assert_eq!(entry.state, TransferQueueState::Completed);
+    assert_eq!(entry.percent, Some(100));
+}
+
+#[test]
+fn progress_carries_retry_counters_and_preserves_them_across_events() {
+    let store = TransferStore::new();
+    let mut p = progress("t1", TransferQueueState::Active, 200);
+    p.attempt = Some(2);
+    p.max_attempts = Some(5);
+    store.progress(&p, 1_000);
+
+    // A later event that omits the counters keeps the previous values.
+    store.progress(&progress("t1", TransferQueueState::Active, 600), 2_000);
+    let entry = store.get("t1").unwrap();
+    assert_eq!(entry.attempt, Some(2));
+    assert_eq!(entry.max_attempts, Some(5));
+}
+
+#[test]
+fn indeterminate_total_yields_null_percent() {
+    let store = TransferStore::new();
+    let mut p = progress("t1", TransferQueueState::Active, 500);
+    p.total = 0;
+    p.total_bytes = None;
+    store.progress(&p, 1_000);
+
+    let entry = store.get("t1").unwrap();
+    assert_eq!(entry.total_bytes, None);
+    assert_eq!(entry.percent, None);
+}
+
+#[test]
+fn remove_drops_a_row_and_is_idempotent() {
+    let store = TransferStore::new();
+    store.seed(&seed("t1"), 1_000);
+    store.remove("t1");
+    assert!(store.get("t1").is_none());
+    store.remove("t1"); // no panic on an absent id
+    store.remove("ghost");
+}
+
+#[test]
+fn clear_completed_drops_only_completed_rows() {
+    let store = TransferStore::new();
+    store.progress(
+        &progress("done", TransferQueueState::Completed, 1_000),
+        1_000,
+    );
+    store.progress(&progress("fail", TransferQueueState::Failed, 300), 1_000);
+    store.progress(&progress("live", TransferQueueState::Active, 500), 1_000);
+
+    store.clear_completed();
+    assert!(store.get("done").is_none(), "completed dropped");
+    assert!(store.get("fail").is_some(), "failed retained");
+    assert!(store.get("live").is_some(), "active retained");
+}
+
+#[test]
+fn set_minimized_toggles_the_panel_flag() {
+    let store = TransferStore::new();
+    assert_eq!(store.snapshot()["minimized"], json!(false));
+    store.set_minimized(true);
+    assert_eq!(store.snapshot()["minimized"], json!(true));
+    store.set_minimized(false);
+    assert_eq!(store.snapshot()["minimized"], json!(false));
+}
+
+fn snapshot_of(id: &str, state: TransferQueueState, settled: bool) -> TransferSnapshot {
+    TransferSnapshot {
+        transfer_id: id.to_string(),
+        session_id: "sess-1".to_string(),
+        direction: TransferDirection::Download,
+        file_name: "data.csv".to_string(),
+        path: None,
+        state,
+        settled,
+        transferred: 1_000,
+        total: 1_000,
+        speed: 0,
+        attempt: 0,
+        max_attempts: 0,
+    }
+}
+
+#[test]
+fn reconcile_settles_a_stuck_row_from_a_settled_terminal_snapshot() {
+    let store = TransferStore::new();
+    // A row stuck `active` because its terminal event was dropped.
+    store.progress(&progress("t1", TransferQueueState::Active, 1_000), 1_000);
+
+    store.reconcile(
+        &[snapshot_of("t1", TransferQueueState::Completed, true)],
+        2_000,
+    );
+    assert_eq!(
+        store.get("t1").unwrap().state,
+        TransferQueueState::Completed
+    );
+}
+
+#[test]
+fn reconcile_ignores_unsettled_and_non_terminal_and_missing_rows() {
+    let store = TransferStore::new();
+    store.progress(&progress("t1", TransferQueueState::Active, 1_000), 1_000);
+
+    // Unsettled terminal snapshot (mid auto-retry) must not settle the row.
+    store.reconcile(
+        &[snapshot_of("t1", TransferQueueState::Failed, false)],
+        2_000,
+    );
+    assert_eq!(store.get("t1").unwrap().state, TransferQueueState::Active);
+
+    // A snapshot for a row the user already removed must not resurrect it.
+    store.reconcile(
+        &[snapshot_of("ghost", TransferQueueState::Completed, true)],
+        2_000,
+    );
+    assert!(store.get("ghost").is_none());
+}
+
+#[test]
+fn reconcile_never_regresses_an_already_terminal_row() {
+    let store = TransferStore::new();
+    store.progress(&progress("t1", TransferQueueState::Completed, 1_000), 1_000);
+    store.reconcile(
+        &[snapshot_of("t1", TransferQueueState::Failed, true)],
+        2_000,
+    );
+    // Already terminal → untouched.
+    assert_eq!(
+        store.get("t1").unwrap().state,
+        TransferQueueState::Completed
+    );
+}
+
+#[test]
+fn replace_overwrites_the_whole_slice() {
+    let store = TransferStore::new();
+    store.seed(&seed("old"), 1_000);
+    store.set_minimized(false);
+
+    // Build a mirror snapshot by driving a second store, then hand its rows back.
+    let source = TransferStore::new();
+    source.progress(&progress("t1", TransferQueueState::Active, 400), 5_000);
+    let view = source.snapshot();
+    let queue: HashMap<String, super::TransferEntry> =
+        serde_json::from_value(view["queue"].clone()).unwrap();
+
+    store.replace(queue, true);
+    assert!(store.get("old").is_none(), "prior rows dropped");
+    assert_eq!(store.get("t1").unwrap().state, TransferQueueState::Active);
+    assert_eq!(store.snapshot(), source_snapshot_minimized(&source));
+}
+
+/// The source snapshot with `minimized: true`, for comparison against a
+/// `replace(_, true)`.
+fn source_snapshot_minimized(source: &TransferStore) -> serde_json::Value {
+    let mut view = source.snapshot();
+    view["minimized"] = json!(true);
+    view
+}
+
+#[test]
+fn replace_with_an_empty_map_clears_everything() {
+    let store = TransferStore::new();
+    store.seed(&seed("t1"), 1_000);
+    store.replace(HashMap::new(), false);
+    assert_eq!(store.len(), 0);
+    assert_eq!(store.snapshot(), json!({ "queue": {}, "minimized": false }));
+}
+
+#[test]
+fn entry_json_omits_absent_optional_fields_but_keeps_nullable_ones() {
+    // Parity with the frontend `TransferEntry` JSON: `path`/`error`/`attempt`/
+    // `maxAttempts` are omitted when absent, while `totalBytes`/`percent`/
+    // `speedBytesPerSec` serialize as `null`.
+    let store = TransferStore::new();
+    let mut p = progress("t1", TransferQueueState::Active, 500);
+    p.path = None;
+    p.total = 0;
+    p.total_bytes = None;
+    store.progress(&p, 1_000);
+
+    let row = &store.snapshot()["queue"]["t1"];
+    assert!(row.get("error").is_none(), "error omitted when absent");
+    assert!(row.get("attempt").is_none(), "attempt omitted when absent");
+    assert!(row.get("path").is_none(), "path omitted when absent");
+    assert_eq!(
+        row["totalBytes"],
+        json!(null),
+        "nullable field present as null"
+    );
+    assert_eq!(row["percent"], json!(null));
+    assert_eq!(row["speedBytesPerSec"], json!(null));
+}


### PR DESCRIPTION
## Summary

Phase 5 **shadow foundation** for the Transfers domain (#2229, part of #2153 / #2139) — the last Phase-5 domain to scaffold. Adds a backend-only Rust authority for the SFTP/FTP **Transfer Queue** slice the frontend drives in `appStore` (`transferQueue: Record<transferId, TransferEntry>` + the `transferQueueMinimized` flag), on the projection substrate.

Backend-only, **zero user-facing change**: the store is registered, seeded and serves intents, but nothing in the live UI subscribes to or dispatches them yet — `appStore` stays authoritative. The diff touches only `src-tauri/` (new `src-tauri/src/transfers_projection/` module + minimal `lib.rs` region registration); no `src/` change.

## What the shadow models

- `TransferEntry` record + the `entry_from_{seed,progress,snapshot}` folds mirror the frontend `TransferEntry` and `transferEntryFrom{Seed,Progress,Snapshot}` helpers (`src/types/transfer.ts`) one-to-one: the `queued → active → completed | failed | cancelled` (plus `paused`) lifecycle, byte progress, derived percent + throughput, error message, and retry attempt/max-attempt counters.
- `transfer.*` intents defined from what `appStore` actually drives: `seed` (idempotent enqueue), `progress` (fold a `transfer-progress` event), `reconcile` (settle stuck rows from a `transfer_list` snapshot), `remove`, `clearCompleted`, `setMinimized`, and `replace` (the whole-slice render-cut mirror seed). `addTransfer`/`updateTransfer` have no callers in the frontend, so they are intentionally not modelled.

## Region scope — **shared** (Open Design Decision #4 / #6)

A transfer runs backend-side and its progress/state is a property of the transfer, not of a viewing client: two clients watching the same queue see the same bytes, percent and outcome — like SSH tunnels, session-lifecycle and system-monitors. So a single **shared** `transfers` region. The per-window choice of *which* transfers a window renders (the #1951 / #1964 ownership scoping) is presentation and stays a frontend concern under partial projection — the same boundary the system-monitor shadow drew.

## Tests

- **Store unit tests** — the lifecycle, derived percent/throughput (incl. backend-measured vs byte/time-delta speed), legacy-phase fallback, retry-counter carry-over, indeterminate totals, reconcile backstop (settled/unsettled/non-terminal/missing/already-terminal), `clearCompleted`, `replace`, and the JSON parity of optional-vs-nullable fields.
- **Projection-contract tests** on the #2164 substrate harness — subscribe→snapshot fan-out, one coalesced diff per view-changing intent with monotonic versions, rejection/no-op advance nothing, dead-subscriber reaping, and client-cache convergence across a full lifecycle + the `replace` mirror.

`cargo test` (28 tests), `cargo clippy -D warnings`, and `cargo fmt --check` all green. No frontend files changed.

Part of #2229