### PR TITLE
feat(sftp): cut file-browser actions to fileBrowser.* intents

### DIFF
--- a/src/store/appStore.fileBrowsersMutationCut.test.ts
+++ b/src/store/appStore.fileBrowsersMutationCut.test.ts
@@ -1,0 +1,446 @@
+/**
+ * File-browsers mutation cut (#2228, part of #2139 and #2153) — cut-vs-local
+ * parity.
+ *
+ * The mutation cut routes each file-browser UI-state action through a granular
+ * `fileBrowser.*` intent so the client-scoped backend `FileBrowserStore` becomes
+ * authoritative, while the local `appStore` reducer path stays in place as the
+ * render source and the resilience / rollback fallback (the reducer removal is a
+ * later step).
+ *
+ * These tests prove the cut is parity-safe end to end: with the flag **on**, the
+ * intents dispatched by the actions — applied by a faithful in-memory port of the
+ * Rust store (mirroring `file_browser_projection/store.rs`) — reproduce the exact
+ * `appStore` file-browser view (the active pane, the three panes and the
+ * clipboard, in the same shape `useProjectedFileBrowsers` renders) for every
+ * action and its fan-out. With the flag **off**, no intents are dispatched and the
+ * local slice is byte-identical — the instant rollback path the flip relies on.
+ *
+ * # Scope (#2236)
+ *
+ * The SFTP list operations (`navigateSftp` / `refreshSftp`) mirror only the
+ * browser *view* fields (path / listing / list flags); the SFTP session model
+ * (`sftpStatus`, session ids) and the connect / disconnect / session-death pane
+ * resets stay `appStore`-driven and out of this cut, carried into the region by
+ * the render-cut `fileBrowser.replace` mirror instead.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  sessionListFiles: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  getConnectionTypes: vi.fn(() => Promise.resolve([])),
+}));
+
+import { useAppStore, type FileClipboard } from "./appStore";
+import { localListDir, sessionListFiles, sftpListDir } from "@/services/api";
+import {
+  FILE_BROWSERS_REGION,
+  setFileBrowsersIntentsEnabled,
+  setFileBrowsersTransportForTest,
+  type FileBrowsersView,
+} from "./fileBrowsersBridge";
+import type { FileEntry } from "@/types/connection";
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+
+function entry(name: string, isDirectory = false): FileEntry {
+  return {
+    name,
+    path: `/${name}`,
+    isDirectory,
+    size: 0,
+    modified: "",
+    permissions: null,
+    writable: null,
+    isSymlink: false,
+    symlinkTarget: null,
+  };
+}
+
+interface Pane {
+  path: string;
+  entries: FileEntry[];
+  loading: boolean;
+  error: string | null;
+}
+
+function emptyPane(): Pane {
+  return { path: "/", entries: [], loading: false, error: null };
+}
+
+/**
+ * An in-memory substrate double that applies the granular `fileBrowser.*` intents
+ * with the same semantics as the Rust `FileBrowserStore`, so a run of the real
+ * `appStore` actions (which mirror those intents) reconstructs the region view the
+ * file-browser panel would render. Only `fileBrowser.replace` (the render-cut
+ * mirror) is intentionally not applied here — the mutation cut drives the region
+ * through the per-transition intents.
+ */
+class FileBrowserStoreTransport implements Transport {
+  dispatched: Intent[] = [];
+  private mode = "none";
+  private local = emptyPane();
+  private sftp = emptyPane();
+  private session = emptyPane();
+  private clipboard: FileClipboard | null = null;
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    this.apply(intent);
+    this.version += 1;
+    this.fan();
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: FILE_BROWSERS_REGION, version: this.version }],
+    };
+  }
+
+  private paneOf(name: string): Pane {
+    if (name === "local") return this.local;
+    if (name === "sftp") return this.sftp;
+    return this.session;
+  }
+
+  private apply(intent: Intent): void {
+    const p = intent.payload as Record<string, unknown>;
+    switch (intent.kind) {
+      case "fileBrowser.setMode": {
+        this.mode = p.mode as string;
+        break;
+      }
+      case "fileBrowser.loadStarted": {
+        const pane = this.paneOf(p.pane as string);
+        pane.loading = true;
+        pane.error = null;
+        break;
+      }
+      case "fileBrowser.loadSucceeded": {
+        const pane = this.paneOf(p.pane as string);
+        pane.path = p.path as string;
+        pane.entries = structuredClone(p.entries as FileEntry[]);
+        pane.loading = false;
+        pane.error = null;
+        break;
+      }
+      case "fileBrowser.loadFailed": {
+        const pane = this.paneOf(p.pane as string);
+        pane.loading = false;
+        pane.error = (p.error as string | undefined) ?? null;
+        break;
+      }
+      case "fileBrowser.setClipboard": {
+        this.clipboard = (p.clipboard as FileClipboard | null) ?? null;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  /** The reconstructed region view, twin of the store snapshot. */
+  regionView(): FileBrowsersView {
+    return structuredClone({
+      mode: this.mode as FileBrowsersView["mode"],
+      local: this.local,
+      sftp: this.sftp,
+      session: this.session,
+      clipboard: this.clipboard,
+    });
+  }
+
+  kinds(): string[] {
+    return this.dispatched.map((i) => i.kind);
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: this.regionView() };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(FILE_BROWSERS_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+let transport: FileBrowserStoreTransport;
+
+/**
+ * The `appStore` file-browser view in the region's shape, mirroring
+ * `useProjectedFileBrowsers` exactly (including the SFTP pane's `sftpStatus`-derived
+ * `loading`), so the region the intents reconstruct can be asserted equal to it.
+ */
+function sliceOf(): FileBrowsersView {
+  const s = useAppStore.getState();
+  return {
+    mode: s.fileBrowserMode,
+    local: {
+      path: s.localCurrentPath,
+      entries: s.localFileEntries,
+      loading: s.localFileLoading,
+      error: s.localFileError,
+    },
+    sftp: {
+      path: s.currentPath,
+      entries: s.fileEntries,
+      loading: s.sftpStatus === "connecting" || s.sftpStatus === "listing",
+      error: s.sftpError,
+    },
+    session: {
+      path: s.sessionCurrentPath,
+      entries: s.sessionFileEntries,
+      loading: s.sessionFileLoading,
+      error: s.sessionFileError,
+    },
+    clipboard: s.fileClipboard,
+  };
+}
+
+/** Assert the region the intents reconstruct equals the local appStore view. */
+function expectParity() {
+  expect(transport.regionView()).toEqual(sliceOf());
+}
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  vi.clearAllMocks();
+  transport = new FileBrowserStoreTransport();
+  setFileBrowsersTransportForTest(transport);
+  setFileBrowsersIntentsEnabled(true);
+});
+
+afterEach(() => {
+  setFileBrowsersTransportForTest(null);
+  setFileBrowsersIntentsEnabled(null);
+});
+
+describe("file-browsers mutation cut — cut-vs-local parity (flag on)", () => {
+  it("setFileBrowserMode reproduces the active pane", () => {
+    useAppStore.getState().setFileBrowserMode("local");
+    expect(transport.kinds()).toEqual(["fileBrowser.setMode"]);
+    expectParity();
+    expect(transport.regionView().mode).toBe("local");
+
+    useAppStore.getState().setFileBrowserMode("none");
+    expectParity();
+    expect(transport.regionView().mode).toBe("none");
+  });
+
+  it("navigateLocal commits the pane path + listing", async () => {
+    vi.mocked(localListDir).mockResolvedValue([entry("a"), entry("dir", true)]);
+
+    await useAppStore.getState().navigateLocal("/home/user");
+
+    expect(transport.kinds()).toEqual(["fileBrowser.loadStarted", "fileBrowser.loadSucceeded"]);
+    expectParity();
+    const view = transport.regionView();
+    expect(view.local.path).toBe("/home/user");
+    expect(view.local.entries.map((e) => e.name)).toEqual(["a", "dir"]);
+    expect(view.local.loading).toBe(false);
+  });
+
+  it("navigateLocal records the pane error on failure", async () => {
+    vi.mocked(localListDir).mockRejectedValue(new Error("nope"));
+
+    await useAppStore.getState().navigateLocal("/root");
+
+    expect(transport.kinds()).toEqual(["fileBrowser.loadStarted", "fileBrowser.loadFailed"]);
+    expectParity();
+    expect(transport.regionView().local.error).toBe("nope");
+    expect(transport.regionView().local.loading).toBe(false);
+  });
+
+  it("refreshLocal re-lists the current local path", async () => {
+    vi.mocked(localListDir).mockResolvedValue([entry("x")]);
+    await useAppStore.getState().navigateLocal("/tmp");
+    vi.mocked(localListDir).mockResolvedValue([entry("x"), entry("y")]);
+
+    await useAppStore.getState().refreshLocal();
+
+    expectParity();
+    expect(transport.regionView().local.path).toBe("/tmp");
+    expect(transport.regionView().local.entries.map((e) => e.name)).toEqual(["x", "y"]);
+  });
+
+  it("navigateSession commits the session pane path + listing", async () => {
+    vi.mocked(sessionListFiles).mockResolvedValue([entry("s")]);
+
+    await useAppStore.getState().navigateSession("sess-1", "/srv");
+
+    expect(transport.kinds()).toEqual(["fileBrowser.loadStarted", "fileBrowser.loadSucceeded"]);
+    expectParity();
+    expect(transport.regionView().session.path).toBe("/srv");
+    expect(transport.regionView().session.entries.map((e) => e.name)).toEqual(["s"]);
+  });
+
+  it("navigateSession records the session pane error on failure", async () => {
+    vi.mocked(sessionListFiles).mockRejectedValue(new Error("denied"));
+
+    await useAppStore.getState().navigateSession("sess-1", "/srv");
+
+    expectParity();
+    expect(transport.regionView().session.error).toBe("denied");
+  });
+
+  it("refreshSession re-lists the current session path", async () => {
+    useAppStore.setState({ sessionFileBrowserId: "sess-1", sessionCurrentPath: "/srv" });
+    vi.mocked(sessionListFiles).mockResolvedValue([entry("s"), entry("t")]);
+
+    await useAppStore.getState().refreshSession();
+
+    expect(transport.kinds()).toEqual(["fileBrowser.loadStarted", "fileBrowser.loadSucceeded"]);
+    expectParity();
+    expect(transport.regionView().session.entries.map((e) => e.name)).toEqual(["s", "t"]);
+  });
+
+  it("navigateSftp commits the sftp pane path + listing (view fields only)", async () => {
+    useAppStore.setState({ sftpSessionId: "sftp-1" });
+    vi.mocked(sftpListDir).mockResolvedValue([entry("f")]);
+
+    await useAppStore.getState().navigateSftp("/var/log");
+
+    expect(transport.kinds()).toEqual(["fileBrowser.loadStarted", "fileBrowser.loadSucceeded"]);
+    expectParity();
+    expect(transport.regionView().sftp.path).toBe("/var/log");
+    expect(transport.regionView().sftp.entries.map((e) => e.name)).toEqual(["f"]);
+    expect(transport.regionView().sftp.loading).toBe(false);
+  });
+
+  it("navigateSftp records the sftp pane error on a non-fatal failure", async () => {
+    useAppStore.setState({ sftpSessionId: "sftp-1" });
+    vi.mocked(sftpListDir).mockRejectedValue(new Error("boom"));
+
+    await useAppStore.getState().navigateSftp("/var/log");
+
+    expect(transport.kinds()).toEqual(["fileBrowser.loadStarted", "fileBrowser.loadFailed"]);
+    expectParity();
+    expect(transport.regionView().sftp.error).toBe("boom");
+    expect(transport.regionView().sftp.loading).toBe(false);
+  });
+
+  it("refreshSftp re-lists the current sftp path", async () => {
+    useAppStore.setState({ sftpSessionId: "sftp-1", currentPath: "/etc" });
+    vi.mocked(sftpListDir).mockResolvedValue([entry("hosts")]);
+
+    await useAppStore.getState().refreshSftp();
+
+    expectParity();
+    expect(transport.regionView().sftp.path).toBe("/etc");
+    expect(transport.regionView().sftp.entries.map((e) => e.name)).toEqual(["hosts"]);
+  });
+
+  it("setFileClipboard sets then clears the clipboard", () => {
+    const clipboard: FileClipboard = {
+      entries: [entry("c")],
+      operation: "copy",
+      sourceMode: "local",
+      sourcePath: "/home",
+      sftpSessionId: null,
+    };
+
+    useAppStore.getState().setFileClipboard(clipboard);
+    expect(transport.kinds()).toEqual(["fileBrowser.setClipboard"]);
+    expectParity();
+    expect(transport.regionView().clipboard).toEqual(clipboard);
+
+    useAppStore.getState().setFileClipboard(null);
+    expectParity();
+    expect(transport.regionView().clipboard).toBeNull();
+  });
+
+  it("a full browser lifecycle stays in parity across every step", async () => {
+    vi.mocked(localListDir).mockResolvedValue([entry("a")]);
+    vi.mocked(sessionListFiles).mockResolvedValue([entry("s")]);
+
+    useAppStore.getState().setFileBrowserMode("local");
+    expectParity();
+    await useAppStore.getState().navigateLocal("/home");
+    expectParity();
+    useAppStore.getState().setFileBrowserMode("session");
+    expectParity();
+    await useAppStore.getState().navigateSession("sess-1", "/srv");
+    expectParity();
+    useAppStore.getState().setFileClipboard({
+      entries: [entry("a")],
+      operation: "cut",
+      sourceMode: "local",
+      sourcePath: "/home",
+      sftpSessionId: null,
+    });
+    expectParity();
+    useAppStore.getState().setFileClipboard(null);
+    expectParity();
+    useAppStore.getState().setFileBrowserMode("none");
+    expectParity();
+  });
+});
+
+describe("file-browsers mutation cut — flag off (rollback path)", () => {
+  beforeEach(() => setFileBrowsersIntentsEnabled(false));
+
+  it("dispatches no intents and drives the slice locally", async () => {
+    vi.mocked(localListDir).mockResolvedValue([entry("a")]);
+
+    useAppStore.getState().setFileBrowserMode("local");
+    await useAppStore.getState().navigateLocal("/home");
+    useAppStore.getState().setFileClipboard({
+      entries: [entry("a")],
+      operation: "copy",
+      sourceMode: "local",
+      sourcePath: "/home",
+      sftpSessionId: null,
+    });
+
+    // No mirror reached the region — the pre-cut local path is intact.
+    expect(transport.dispatched).toHaveLength(0);
+    // The local slice still behaves exactly as before the cut.
+    expect(useAppStore.getState().fileBrowserMode).toBe("local");
+    expect(useAppStore.getState().localCurrentPath).toBe("/home");
+    expect(useAppStore.getState().localFileEntries.map((e) => e.name)).toEqual(["a"]);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -287,6 +287,7 @@ import {
 import { mirrorMonitorIntent } from "@/store/systemMonitorBridge";
 import { mirrorAgentIntent } from "@/store/agentsBridge";
 import { mirrorConnectionIntent } from "@/store/connectionsBridge";
+import { mirrorFileBrowserIntent } from "@/store/fileBrowsersBridge";
 import { mirrorSettingsIntent } from "@/store/settingsBridge";
 import { mirrorBroadcastIntent } from "@/store/broadcastBridge";
 import {
@@ -6097,6 +6098,10 @@ export const useAppStore = create<AppState>((set, get, store) => {
       if (!sessionId) return;
       const seq = ++_sftpListSeq;
       set({ sftpStatus: "listing", sftpError: null });
+      // Browser-view mirror (#2228): the SFTP list flags map to the pane's
+      // loadStarted/loadSucceeded/loadFailed; the session model (sftpStatus,
+      // session ids) stays appStore-driven (#2236).
+      mirrorFileBrowserIntent("fileBrowser.loadStarted", { pane: "sftp" });
       try {
         const entries = await sftpListDir(sessionId, path);
         // Ignore a stale response: a newer navigate/refresh superseded this one.
@@ -6105,6 +6110,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
           return;
         }
         set({ fileEntries: entries, currentPath: path, sftpStatus: "connected" });
+        mirrorFileBrowserIntent("fileBrowser.loadSucceeded", { pane: "sftp", path, entries });
       } catch (err) {
         if (seq !== _sftpListSeq) return;
         const message = err instanceof Error ? err.message : String(err);
@@ -6127,6 +6133,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
               }
             : {}),
         }));
+        mirrorFileBrowserIntent("fileBrowser.loadFailed", { pane: "sftp", error: message });
       }
     },
 
@@ -6135,6 +6142,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
       if (!sftpSessionId) return;
       const seq = ++_sftpListSeq;
       set({ sftpStatus: "listing", sftpError: null });
+      mirrorFileBrowserIntent("fileBrowser.loadStarted", { pane: "sftp" });
       try {
         const entries = await sftpListDir(sftpSessionId, currentPath);
         // Ignore a stale response: a newer navigate/refresh superseded this one.
@@ -6143,6 +6151,11 @@ export const useAppStore = create<AppState>((set, get, store) => {
           return;
         }
         set({ fileEntries: entries, sftpStatus: "connected" });
+        mirrorFileBrowserIntent("fileBrowser.loadSucceeded", {
+          pane: "sftp",
+          path: currentPath,
+          entries,
+        });
       } catch (err) {
         if (seq !== _sftpListSeq) return;
         const message = err instanceof Error ? err.message : String(err);
@@ -6165,6 +6178,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
               }
             : {}),
         }));
+        mirrorFileBrowserIntent("fileBrowser.loadFailed", { pane: "sftp", error: message });
       }
     },
 
@@ -7263,6 +7277,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
         normalizedPath = normalizedPath + "/";
       }
       set({ localFileLoading: true, localFileError: null });
+      mirrorFileBrowserIntent("fileBrowser.loadStarted", { pane: "local" });
       try {
         const entries = await localListDir(normalizedPath);
         set({
@@ -7270,25 +7285,34 @@ export const useAppStore = create<AppState>((set, get, store) => {
           localCurrentPath: normalizedPath,
           localFileLoading: false,
         });
-      } catch (err) {
-        set({
-          localFileLoading: false,
-          localFileError: err instanceof Error ? err.message : String(err),
+        mirrorFileBrowserIntent("fileBrowser.loadSucceeded", {
+          pane: "local",
+          path: normalizedPath,
+          entries,
         });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        set({ localFileLoading: false, localFileError: message });
+        mirrorFileBrowserIntent("fileBrowser.loadFailed", { pane: "local", error: message });
       }
     },
 
     refreshLocal: async () => {
       const { localCurrentPath } = useAppStore.getState();
       set({ localFileLoading: true, localFileError: null });
+      mirrorFileBrowserIntent("fileBrowser.loadStarted", { pane: "local" });
       try {
         const entries = await localListDir(localCurrentPath);
         set({ localFileEntries: entries, localFileLoading: false });
-      } catch (err) {
-        set({
-          localFileLoading: false,
-          localFileError: err instanceof Error ? err.message : String(err),
+        mirrorFileBrowserIntent("fileBrowser.loadSucceeded", {
+          pane: "local",
+          path: localCurrentPath,
+          entries,
         });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        set({ localFileLoading: false, localFileError: message });
+        mirrorFileBrowserIntent("fileBrowser.loadFailed", { pane: "local", error: message });
       }
     },
 
@@ -7302,6 +7326,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
 
     navigateSession: async (sessionId: string, path: string) => {
       set({ sessionFileLoading: true, sessionFileError: null });
+      mirrorFileBrowserIntent("fileBrowser.loadStarted", { pane: "session" });
       try {
         const entries = await sessionListFiles(sessionId, path);
         set({
@@ -7309,11 +7334,15 @@ export const useAppStore = create<AppState>((set, get, store) => {
           sessionCurrentPath: path,
           sessionFileLoading: false,
         });
-      } catch (err) {
-        set({
-          sessionFileLoading: false,
-          sessionFileError: err instanceof Error ? err.message : String(err),
+        mirrorFileBrowserIntent("fileBrowser.loadSucceeded", {
+          pane: "session",
+          path,
+          entries,
         });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        set({ sessionFileLoading: false, sessionFileError: message });
+        mirrorFileBrowserIntent("fileBrowser.loadFailed", { pane: "session", error: message });
       }
     },
 
@@ -7321,24 +7350,35 @@ export const useAppStore = create<AppState>((set, get, store) => {
       const { sessionFileBrowserId, sessionCurrentPath } = useAppStore.getState();
       if (!sessionFileBrowserId) return;
       set({ sessionFileLoading: true, sessionFileError: null });
+      mirrorFileBrowserIntent("fileBrowser.loadStarted", { pane: "session" });
       try {
         const entries = await sessionListFiles(sessionFileBrowserId, sessionCurrentPath);
         set({ sessionFileEntries: entries, sessionFileLoading: false });
-      } catch (err) {
-        set({
-          sessionFileLoading: false,
-          sessionFileError: err instanceof Error ? err.message : String(err),
+        mirrorFileBrowserIntent("fileBrowser.loadSucceeded", {
+          pane: "session",
+          path: sessionCurrentPath,
+          entries,
         });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        set({ sessionFileLoading: false, sessionFileError: message });
+        mirrorFileBrowserIntent("fileBrowser.loadFailed", { pane: "session", error: message });
       }
     },
 
     // File browser mode
     fileBrowserMode: "none",
-    setFileBrowserMode: (mode) => set({ fileBrowserMode: mode }),
+    setFileBrowserMode: (mode) => {
+      set({ fileBrowserMode: mode });
+      mirrorFileBrowserIntent("fileBrowser.setMode", { mode });
+    },
 
     // File clipboard (copy/cut)
     fileClipboard: null,
-    setFileClipboard: (clipboard) => set({ fileClipboard: clipboard }),
+    setFileClipboard: (clipboard) => {
+      set({ fileClipboard: clipboard });
+      mirrorFileBrowserIntent("fileBrowser.setClipboard", { clipboard });
+    },
 
     // VS Code availability
     vscodeAvailable: false,

--- a/src/store/fileBrowsersBridge.ts
+++ b/src/store/fileBrowsersBridge.ts
@@ -159,6 +159,74 @@ export function fileBrowsersRenderFromProjectionEnabled(): boolean {
   return true;
 }
 
+// ── Mutation-cut feature flag (runtime-flippable, on by default) ───────────────
+
+let mutationFlagOverride: boolean | null = null;
+
+interface FileBrowsersMutationFlagWindow {
+  __TERMIHUB_FILE_BROWSERS_INTENTS__?: boolean;
+  localStorage?: Storage;
+}
+
+/**
+ * Programmatic override for the mutation-cut flag (tests, and a runtime toggle).
+ * `null` clears the override and falls back to the window/localStorage signal,
+ * then to the default (on).
+ */
+export function setFileBrowsersIntentsEnabled(value: boolean | null): void {
+  mutationFlagOverride = value;
+}
+
+/**
+ * Whether the file-browser UI-state actions (set the active pane, a pane's
+ * directory-list start / success / failure, and the copy-cut clipboard) dispatch
+ * granular `fileBrowser.*` intents so the client-scoped backend
+ * {@link import("../../src-tauri/src/file_browser_projection/store").FileBrowserStore}
+ * is authoritative — instead of only the render-cut {@link seedFileBrowsersRegion}
+ * `fileBrowser.replace` whole-slice mirror driving the region.
+ *
+ * **On by default** (#2228 mutation cut). When on, each action mirrors its
+ * transition through a `fileBrowser.*` intent (via {@link mirrorFileBrowserIntent}),
+ * and the render-cut hook
+ * ({@link import("./useProjectedFileBrowsers").useProjectedFileBrowsers}) reflects
+ * the region back into the UI. The local `appStore` reducer path stays in place as
+ * the render source and as a resilience / rollback fallback — any dispatch failure
+ * is logged and the local mutation continues, so a backend hiccup can never break
+ * the file browser (the reducer removal is a later step). When off, `appStore`
+ * drives the slice purely locally (the pre-cut path). The flip was taken on the
+ * automated parity tests plus the instant local fallback, mirroring the
+ * connections (#2225) and agents (#2226) mutation cuts.
+ *
+ * Scope note (#2236): the SFTP list operations (`navigateSftp` / `refreshSftp`)
+ * mirror only the browser *view* fields (path / listing / list flags); the SFTP
+ * *session* model (connect status, live session ids, transfers) and the
+ * connect / disconnect / session-death pane resets stay `appStore`-driven and are
+ * carried into the region by the render-cut `fileBrowser.replace` mirror, pending
+ * the entry-point/session-model decision (#2236).
+ *
+ * Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_FILE_BROWSERS_INTENTS__` or
+ * `localStorage["termihub.fileBrowsersIntents"]` (set `"false"` to restore the
+ * pre-cut local-mutation path; `"true"` to force on).
+ */
+export function fileBrowsersIntentsEnabled(): boolean {
+  if (mutationFlagOverride !== null) return mutationFlagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as FileBrowsersMutationFlagWindow;
+      if (typeof w.__TERMIHUB_FILE_BROWSERS_INTENTS__ === "boolean") {
+        return w.__TERMIHUB_FILE_BROWSERS_INTENTS__;
+      }
+      const ls = w.localStorage?.getItem("termihub.fileBrowsersIntents");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return true;
+}
+
 // ── Transport + client-scoped region client (lazy, mirrors the broadcast slice) ─
 
 let transportInstance: Transport | null = null;
@@ -326,6 +394,65 @@ export function seedFileBrowsersRegion(view: FileBrowsersView): Promise<void> {
     // A synchronous transport-construction failure (non-Tauri, no socket).
     lastSeededSignature = null;
     return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+// ── Mutation cut: granular fileBrowser.* intent dispatch ──────────────────────
+
+/**
+ * The concrete browser pane a `fileBrowser.*` load/reset intent targets. Unlike
+ * {@link FileBrowserMode}, `"none"` is not a pane — it is the *absence* of an
+ * active pane, expressed only through `fileBrowser.setMode`.
+ */
+export type FileBrowserPane = "local" | "sftp" | "session";
+
+/**
+ * The granular `fileBrowser.*` intent kinds the mutation cut dispatches (twins of
+ * the Rust routes). Excludes `fileBrowser.replace`, which is the render-cut
+ * whole-slice mirror ({@link seedFileBrowsersRegion}); the mutation cut drives the
+ * region through these per-transition intents instead so the store becomes
+ * authoritative.
+ */
+export type FileBrowserIntentKind =
+  | "fileBrowser.setMode"
+  | "fileBrowser.loadStarted"
+  | "fileBrowser.loadSucceeded"
+  | "fileBrowser.loadFailed"
+  | "fileBrowser.setClipboard";
+
+/** Dispatch a granular `fileBrowser.*` intent, resolving with the ack (parity tests). */
+export function dispatchFileBrowserIntent(
+  kind: FileBrowserIntentKind,
+  payload: Record<string, unknown>
+): Promise<IntentAck> {
+  return transport().dispatch({ intentId: newIntentId(), kind, payload, clientId });
+}
+
+/**
+ * Fire a granular `fileBrowser.*` intent to keep the client's backend store
+ * authoritative, swallowing and logging any failure so the local `appStore`
+ * mutation path is never disrupted by a bridge hiccup (the resilience fallback). A
+ * no-op when the mutation cut is disabled ({@link fileBrowsersIntentsEnabled} off —
+ * the rollback path). Never throws — a synchronous transport-construction failure
+ * (non-Tauri, no socket) is caught and logged, leaving the UI on the local slice.
+ * The twin of the connections bridge's
+ * {@link import("./connectionsBridge").mirrorConnectionIntent}.
+ */
+export function mirrorFileBrowserIntent(
+  kind: FileBrowserIntentKind,
+  payload: Record<string, unknown>
+): void {
+  if (!fileBrowsersIntentsEnabled()) return;
+  try {
+    void dispatchFileBrowserIntent(kind, payload)
+      .then((ack) => {
+        if (ack.status === "rejected") {
+          logFileBrowsersBridgeFallback(kind, new Error(ack.error?.message ?? "rejected"));
+        }
+      })
+      .catch((err) => logFileBrowsersBridgeFallback(kind, err));
+  } catch (err) {
+    logFileBrowsersBridgeFallback(kind, err);
   }
 }
 


### PR DESCRIPTION
## Mutation cut — File browsers domain (Phase 5)

Third step of the File-browsers domain migration (#2228), after the shadow (#2272) and render cut (#2274). Routes the file-browser UI-state actions through the granular `fileBrowser.*` intents so the client-scoped backend `FileBrowserStore` becomes authoritative — the direct analog of the connections (#2225) and agents (#2226) mutation cuts. **Frontend-only** (the `fileBrowser.*` intents already exist from the shadow).

### What changed
- **`fileBrowsersBridge.ts`** — a `fileBrowsersIntentsEnabled` mutation-cut flag (default **on**; `window.__TERMIHUB_FILE_BROWSERS_INTENTS__` / `localStorage["termihub.fileBrowsersIntents"]` / `setFileBrowsersIntentsEnabled` override for instant revert), plus `dispatchFileBrowserIntent` / `mirrorFileBrowserIntent` (swallow+log on failure — the resilience fallback).
- **`appStore.ts`** — the file-browser actions mirror their transition through a `fileBrowser.*` intent:
  - `setFileBrowserMode` → `fileBrowser.setMode`
  - `navigateLocal` / `refreshLocal`, `navigateSession` / `refreshSession`, `navigateSftp` / `refreshSftp` → `fileBrowser.loadStarted` / `loadSucceeded` / `loadFailed`
  - `setFileClipboard` → `fileBrowser.setClipboard`
- The local `appStore` reducers stay in place as the render source and the **resilience / rollback fallback** — reducer removal is the later step (this PR stays open for it).

### Scope — stays out of #2236
The SFTP list ops mirror only the browser **view** fields (path / listing / list flags). The SFTP **session** model (`sftpStatus`, live session ids, transfers) and the connect / disconnect / session-death pane resets stay `appStore`-driven and out of this cut — they self-heal into the region via the render-cut `fileBrowser.replace` mirror, pending the entry-point/session-model decision (#2236).

### Tests (ship on-by-default, per proceed-on-tests)
`appStore.fileBrowsersMutationCut.test.ts` — cut-vs-local parity: a faithful in-memory port of the Rust `FileBrowserStore` applies the dispatched intents and asserts the reconstructed region equals the `appStore` file-browser view (in the shape `useProjectedFileBrowsers` renders, including the SFTP `sftpStatus`-derived `loading`) for every action + fan-out, plus a **flag-off zero-dispatch** rollback test. GUI parity rests on these tests + the retained local fallback.

### Verification
- Frontend suite green (5005 tests), `tsc` + `vite build` clean, ESLint clean, `prettier --check` clean. No Rust changed.

Part of #2228