### PR TITLE
feat(sftp): render transfer queue from the projected transfers region

### DIFF
--- a/src/components/TransferQueue/TransferQueue.projection.test.tsx
+++ b/src/components/TransferQueue/TransferQueue.projection.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * TransferQueue render cut (#2229) — the panel reads its rows + minimized flag
+ * from the projected `transfers` region via {@link useProjectedTransfers}. Drives
+ * the real component against an in-memory substrate double and asserts: it renders
+ * the rows sourced from the projection (and seeds it from appStore), and it falls
+ * back to the appStore slice verbatim when the region has not caught up — parity
+ * preserved either way.
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TooltipProvider } from "@/components/ui";
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import { useAppStore } from "@/store/appStore";
+import {
+  setTransferRenderFromProjectionEnabled,
+  setTransferTransportForTest,
+  stopTransfersSubscription,
+  TRANSFERS_REGION,
+} from "@/store/transfersBridge";
+import type { TransferEntry } from "@/types/transfer";
+
+import { TransferQueue } from "./TransferQueue";
+import { TransferQueueIndicator } from "./TransferQueueIndicator";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  getSettings: vi.fn(() =>
+    Promise.resolve({ version: "1", externalConnectionFiles: [], powerMonitoringEnabled: true })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn(() => vi.fn()) }));
+
+function entry(id: string, overrides: Partial<TransferEntry> = {}): TransferEntry {
+  return {
+    id,
+    sessionId: "sess-a",
+    direction: "download",
+    name: `file-${id}.bin`,
+    path: `/pub/file-${id}.bin`,
+    state: "active",
+    transferred: 40,
+    totalBytes: 100,
+    percent: 40,
+    speedBytesPerSec: 2048,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function queueOf(...rows: TransferEntry[]): Record<string, TransferEntry> {
+  return Object.fromEntries(rows.map((r) => [r.id, r]));
+}
+
+/** In-memory substrate double: applies `transfer.replace` and fans a snapshot. */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  /** When false, `transfer.replace` acks but does NOT advance the region. */
+  applyReplace = true;
+  private view: Record<string, unknown> = { queue: {}, minimized: false };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (intent.kind === "transfer.replace" && this.applyReplace) {
+      const p = intent.payload as Record<string, unknown>;
+      this.view = JSON.parse(
+        JSON.stringify({ queue: p.queue ?? {}, minimized: p.minimized ?? false })
+      );
+      this.version += 1;
+      this.fan();
+    }
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: TRANSFERS_REGION, version: this.version }],
+    };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(TRANSFERS_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+let transport: FakeTransport;
+let container: HTMLDivElement;
+let root: Root;
+
+const flush = () => act(async () => await Promise.resolve());
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setTransferTransportForTest(transport);
+  useAppStore.setState({ transferQueue: {}, transferQueueMinimized: false });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  stopTransfersSubscription();
+  setTransferTransportForTest(null);
+  setTransferRenderFromProjectionEnabled(null);
+  useAppStore.setState({ transferQueue: {}, transferQueueMinimized: false });
+});
+
+function renderQueue() {
+  act(() => {
+    root.render(
+      <TooltipProvider>
+        <TransferQueue />
+      </TooltipProvider>
+    );
+  });
+}
+
+describe("TransferQueue render cut (#2229)", () => {
+  it("renders the queue rows sourced from the projection and seeds it from appStore", async () => {
+    const queue = queueOf(entry("aaa"), entry("bbb", { state: "queued" }));
+    useAppStore.setState({ transferQueue: queue });
+
+    renderQueue();
+    await flush();
+    await flush();
+    renderQueue();
+
+    // The panel is populated and shows both rows.
+    expect(container.querySelector('[data-testid="transfer-queue"]')).not.toBeNull();
+    expect(container.textContent).toContain("file-aaa.bin");
+    expect(container.textContent).toContain("file-bbb.bin");
+    // …and the region was seeded to mirror appStore.
+    expect(transport.dispatched.some((d) => d.kind === "transfer.replace")).toBe(true);
+  });
+
+  it("falls back to the appStore slice when the region has not caught up (parity)", async () => {
+    transport.applyReplace = false; // the replace acks but never advances the region
+    const queue = queueOf(entry("ccc"));
+    useAppStore.setState({ transferQueue: queue });
+
+    renderQueue();
+    await flush();
+    await flush();
+    renderQueue();
+
+    // The projection stayed empty; the panel still renders the appStore row verbatim.
+    expect(container.textContent).toContain("file-ccc.bin");
+  });
+});
+
+describe("TransferQueueIndicator render cut (#2229)", () => {
+  it("renders the minimized indicator from the projected slice", async () => {
+    const queue = queueOf(entry("aaa"));
+    useAppStore.setState({ transferQueue: queue, transferQueueMinimized: true });
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <TransferQueueIndicator />
+        </TooltipProvider>
+      );
+    });
+    await flush();
+    await flush();
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <TransferQueueIndicator />
+        </TooltipProvider>
+      );
+    });
+
+    const indicator = container.querySelector('[data-testid="transfer-queue-indicator"]');
+    expect(indicator).not.toBeNull();
+    expect(indicator?.textContent).toContain("1 transferring");
+  });
+});

--- a/src/components/TransferQueue/TransferQueue.tsx
+++ b/src/components/TransferQueue/TransferQueue.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { ArrowDownUp, Minus } from "lucide-react";
 import { Button, Tooltip, toast } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedTransfers } from "@/store/useProjectedTransfers";
 import { frontendLog } from "@/utils/frontendLog";
 import { transferPause, transferResume, transferCancel, transferRetry } from "@/services/api";
 import { isTerminalTransferState, type TransferEntry } from "@/types/transfer";
@@ -31,8 +32,9 @@ function summarize(entries: TransferEntry[]): string {
  * surfaced by the status-bar `TransferQueueIndicator` instead.
  */
 export function TransferQueue() {
-  const transferQueue = useAppStore((s) => s.transferQueue);
-  const minimized = useAppStore((s) => s.transferQueueMinimized);
+  // Render from the projected `transfers` region (parity-safe: it mirrors
+  // `appStore` and falls back to it verbatim — #2229 render cut).
+  const { queue: transferQueue, minimized } = useProjectedTransfers();
   const removeTransfer = useAppStore((s) => s.removeTransfer);
   const clearCompleted = useAppStore((s) => s.clearCompleted);
   const setMinimized = useAppStore((s) => s.setTransferQueueMinimized);

--- a/src/components/TransferQueue/TransferQueueIndicator.tsx
+++ b/src/components/TransferQueue/TransferQueueIndicator.tsx
@@ -1,6 +1,7 @@
 import { ArrowDownUp } from "lucide-react";
 import { Tooltip } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedTransfers } from "@/store/useProjectedTransfers";
 import { isTerminalTransferState } from "@/types/transfer";
 
 /**
@@ -11,8 +12,9 @@ import { isTerminalTransferState } from "@/types/transfer";
  * total when all rows are terminal) and re-expands the panel on click.
  */
 export function TransferQueueIndicator() {
-  const transferQueue = useAppStore((s) => s.transferQueue);
-  const minimized = useAppStore((s) => s.transferQueueMinimized);
+  // Render from the projected `transfers` region (parity-safe: it mirrors
+  // `appStore` and falls back to it verbatim — #2229 render cut).
+  const { queue: transferQueue, minimized } = useProjectedTransfers();
   const setMinimized = useAppStore((s) => s.setTransferQueueMinimized);
 
   const entries = Object.values(transferQueue);

--- a/src/store/transfersBridge.test.ts
+++ b/src/store/transfersBridge.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import type { TransferEntry } from "@/types/transfer";
+
+import {
+  currentTransfersView,
+  deepEqual,
+  ensureTransfersSubscribed,
+  onTransfersView,
+  seedTransfersRegion,
+  setTransferRenderFromProjectionEnabled,
+  setTransferTransportForTest,
+  stopTransfersSubscription,
+  transferRenderFromProjectionEnabled,
+  TRANSFERS_REGION,
+  transfersViewMirrors,
+  type TransfersView,
+} from "./transfersBridge";
+
+/** A deterministic queue row, keyed by id. */
+function entry(id: string, overrides: Partial<TransferEntry> = {}): TransferEntry {
+  return {
+    id,
+    sessionId: "sess-a",
+    direction: "download",
+    name: `file-${id}`,
+    state: "active",
+    transferred: 40,
+    totalBytes: 100,
+    percent: 40,
+    speedBytesPerSec: 2048,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+/** A `{ [id]: entry }` map from a list of rows. */
+function queueOf(...rows: TransferEntry[]): Record<string, TransferEntry> {
+  return Object.fromEntries(rows.map((r) => [r.id, r]));
+}
+
+/**
+ * An in-memory substrate double: holds one `transfers` view, applies a
+ * `transfer.replace` intent by overwriting the view from its payload (keyed to the
+ * Rust snapshot shape `queue`/`minimized`), and fans a fresh snapshot to every
+ * subscriber — so the seed round-trip and multi-subscriber fan-out are exercised
+ * without a backend. `structuredClone` mirrors the JSON round-trip's drop of
+ * `undefined`-valued optional keys is emulated via {@link stripUndefined}.
+ */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  private view: Record<string, unknown> = { queue: {}, minimized: false };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (intent.kind === "transfer.replace") {
+      const p = intent.payload as Record<string, unknown>;
+      // Round-trip through JSON to drop undefined-valued keys, exactly as the real
+      // transport + Rust store do.
+      this.view = JSON.parse(
+        JSON.stringify({ queue: p.queue ?? {}, minimized: p.minimized ?? false })
+      );
+      this.version += 1;
+      this.fan();
+      return {
+        intentId: intent.intentId,
+        status: "accepted",
+        produced: [{ region: TRANSFERS_REGION, version: this.version }],
+      };
+    }
+    return { intentId: intent.intentId, status: "accepted", produced: [] };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(TRANSFERS_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+let transport: FakeTransport;
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setTransferTransportForTest(transport);
+});
+
+afterEach(() => {
+  stopTransfersSubscription();
+  setTransferTransportForTest(null);
+  setTransferRenderFromProjectionEnabled(null);
+});
+
+describe("transferRenderFromProjectionEnabled flag", () => {
+  it("defaults on and honours the programmatic override", () => {
+    expect(transferRenderFromProjectionEnabled()).toBe(true);
+    setTransferRenderFromProjectionEnabled(false);
+    expect(transferRenderFromProjectionEnabled()).toBe(false);
+    setTransferRenderFromProjectionEnabled(true);
+    expect(transferRenderFromProjectionEnabled()).toBe(true);
+    setTransferRenderFromProjectionEnabled(null);
+    expect(transferRenderFromProjectionEnabled()).toBe(true);
+  });
+});
+
+describe("deepEqual", () => {
+  it("treats an integer and its float round-trip as equal", () => {
+    expect(deepEqual(22, 22.0)).toBe(true);
+    expect(deepEqual({ a: [1, 2] }, { a: [1, 2] })).toBe(true);
+  });
+
+  it("treats an absent optional key and an explicit undefined as equal (JSON semantics)", () => {
+    // `appStore` may hold `path: undefined`; the region drops it on serialization.
+    expect(deepEqual({ id: "t1", path: undefined }, { id: "t1" })).toBe(true);
+    expect(deepEqual({ id: "t1" }, { id: "t1", attempt: undefined })).toBe(true);
+  });
+
+  it("distinguishes differing values, key sets, and null", () => {
+    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
+    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+    expect(deepEqual(null, {})).toBe(false);
+    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+  });
+});
+
+describe("transfersViewMirrors", () => {
+  const queue = queueOf(entry("t1"));
+
+  it("is false for an undefined view", () => {
+    expect(transfersViewMirrors(undefined, queue, false)).toBe(false);
+  });
+
+  it("is true when the view value-matches the appStore slice", () => {
+    const view: TransfersView = { queue: structuredClone(queue), minimized: false };
+    expect(transfersViewMirrors(view, queue, false)).toBe(true);
+  });
+
+  it("is true across a dropped undefined optional key", () => {
+    // appStore row carries `path: undefined`; the projected row omits the key.
+    const withUndef = queueOf(entry("t1", { path: undefined }));
+    const projected = JSON.parse(JSON.stringify(withUndef)) as Record<string, TransferEntry>;
+    expect(transfersViewMirrors({ queue: projected, minimized: false }, withUndef, false)).toBe(
+      true
+    );
+  });
+
+  it("is false when the minimized flag diverges", () => {
+    const view: TransfersView = { queue: structuredClone(queue), minimized: true };
+    expect(transfersViewMirrors(view, queue, false)).toBe(false);
+  });
+
+  it("is false when a row's progress diverges", () => {
+    const view: TransfersView = {
+      queue: queueOf(entry("t1", { transferred: 99, percent: 99 })),
+      minimized: false,
+    };
+    expect(transfersViewMirrors(view, queue, false)).toBe(false);
+  });
+});
+
+describe("seedTransfersRegion", () => {
+  it("dispatches transfer.replace carrying the whole slice, keyed to the Rust shape", async () => {
+    const queue = queueOf(entry("t1"));
+    await seedTransfersRegion(queue, true);
+    expect(transport.dispatched).toHaveLength(1);
+    expect(transport.dispatched[0]).toMatchObject({
+      kind: "transfer.replace",
+      payload: { queue, minimized: true },
+    });
+  });
+
+  it("de-dupes an identical slice but re-seeds after a change", async () => {
+    const queue = queueOf(entry("t1"));
+    await seedTransfersRegion(queue, false);
+    await seedTransfersRegion(queue, false);
+    expect(transport.dispatched).toHaveLength(1);
+
+    await seedTransfersRegion(queue, true); // minimized flipped
+    expect(transport.dispatched).toHaveLength(2);
+  });
+});
+
+describe("seed round-trip → the region mirrors appStore", () => {
+  it("makes the projected view a faithful mirror of the seeded slice", async () => {
+    const received: TransfersView[] = [];
+    const unsubscribe = onTransfersView((v) => received.push(v));
+    await ensureTransfersSubscribed();
+
+    const queue = queueOf(entry("t1"), entry("t2", { state: "queued" }));
+    await seedTransfersRegion(queue, false);
+
+    // The region now carries the seeded slice and the gate accepts it.
+    expect(transfersViewMirrors(currentTransfersView(), queue, false)).toBe(true);
+    expect(received[received.length - 1]).toEqual({ queue, minimized: false });
+    unsubscribe();
+  });
+});

--- a/src/store/transfersBridge.ts
+++ b/src/store/transfersBridge.ts
@@ -1,0 +1,341 @@
+/**
+ * Transfers projection bridge — Phase 5 render cut of the Transfer-Queue domain
+ * (#2229, part of #2139 and #2153).
+ *
+ * The Transfers **shadow** (PR #2275) landed a backend-authoritative
+ * [`TransferStore`](../../src-tauri/src/transfers_projection/store.rs) served as
+ * the shared `transfers` projection region, with `transfer.*` intents, but
+ * nothing in the UI touched it. This step makes the **Transfer Queue panel**
+ * ({@link import("../components/TransferQueue/TransferQueue").TransferQueue} and
+ * its status-bar {@link import("../components/TransferQueue/TransferQueueIndicator").TransferQueueIndicator})
+ * source the queue rows + minimized flag from that region — the parity-safe
+ * render cut (the direct analog of the connections render cut
+ * {@link import("./connectionsBridge")}, #2225, and the agents render cut
+ * {@link import("./agentsBridge")}, #2226).
+ *
+ * # Strangler safety — flag-gated, on by default, faithful-mirror gate
+ *
+ * The `appStore` transfer-queue slice (`transferQueue` / `transferQueueMinimized`)
+ * is still authoritative (the mutation cut is a later step). To keep the render
+ * cut parity-safe **independent of any mutation flag**, the region is kept a
+ * faithful copy of `appStore` by {@link seedTransfersRegion} (a `transfer.replace`
+ * mirror, the analog of the connections bridge's `connection.replace` seed), and
+ * the UI renders from the region **only when it faithfully mirrors** `appStore`
+ * ({@link transfersViewMirrors}); otherwise it falls back to `appStore` verbatim.
+ * Because the gate guarantees the projected view deep-equals `appStore`'s slice,
+ * the rendered output is byte-identical to the pre-cut path.
+ *
+ * Gated by {@link transferRenderFromProjectionEnabled} — **on by default**.
+ * Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_TRANSFER_RENDER_FROM_PROJECTION__` or
+ * `localStorage["termihub.transferRenderFromProjection"]` (set `"false"` to
+ * render straight from `appStore`).
+ */
+
+import {
+  createTransport,
+  newClientId,
+  newIntentId,
+  ProjectionClient,
+  type IntentAck,
+  type Transport,
+} from "@/services/transport";
+import type { TransferEntry } from "@/types/transfer";
+import { frontendLog } from "@/utils/frontendLog";
+
+/** The projection region id for the transfer-queue domain (twin of the Rust
+ * `TRANSFERS_REGION` const). Shared (Open Design Decision #4). */
+export const TRANSFERS_REGION = "transfers";
+
+/**
+ * The projected transfers view model, in `appStore` terms — a twin of the Rust
+ * store snapshot: the per-transfer queue map keyed by `transferId`, plus the
+ * panel-minimized flag. The projected records match the frontend
+ * {@link TransferEntry} shape one-to-one, so the render cut is a pure parity swap.
+ */
+export interface TransfersView {
+  queue: Record<string, TransferEntry>;
+  minimized: boolean;
+}
+
+/** The empty view a fresh region reports (twin of the empty store snapshot). */
+const EMPTY_VIEW: TransfersView = {
+  queue: {},
+  minimized: false,
+};
+
+/**
+ * The raw region view model as the Rust store serialises it, keyed
+ * `queue`/`minimized` (see `TransferStore::snapshot`). The keys already match the
+ * `appStore`-mapped {@link TransfersView}, so mapping is a defaulting pass
+ * ({@link toView}).
+ */
+interface TransfersRegionSnapshot {
+  queue?: Record<string, TransferEntry>;
+  minimized?: boolean;
+}
+
+/** Translate the raw region snapshot into the `appStore`-named view. */
+function toView(raw: TransfersRegionSnapshot): TransfersView {
+  return {
+    queue: raw.queue ?? {},
+    minimized: raw.minimized ?? false,
+  };
+}
+
+// ── Render-cut feature flag (runtime-flippable, on by default) ─────────────────
+
+let renderFlagOverride: boolean | null = null;
+
+interface TransferRenderFlagWindow {
+  __TERMIHUB_TRANSFER_RENDER_FROM_PROJECTION__?: boolean;
+  localStorage?: Storage;
+}
+
+/**
+ * Programmatic override for the render-cut flag (tests, and a runtime toggle).
+ * `null` clears the override and falls back to the window/localStorage signal,
+ * then to the default (on).
+ */
+export function setTransferRenderFromProjectionEnabled(value: boolean | null): void {
+  renderFlagOverride = value;
+}
+
+/**
+ * Whether the Transfer Queue panel renders the queue rows + minimized flag from
+ * the projected `transfers` region instead of reading `appStore`'s transfer-queue
+ * slice directly.
+ *
+ * **On by default** — the render cut is parity-safe: the UI renders from the
+ * region only when it faithfully mirrors `appStore` ({@link transfersViewMirrors}),
+ * and otherwise falls back to `appStore` verbatim, so the output is byte-identical
+ * to the pre-cut path. Independent of the (later) mutation cut: the region is kept
+ * a mirror of `appStore` by {@link seedTransfersRegion}, so it is always populated.
+ * Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_TRANSFER_RENDER_FROM_PROJECTION__` or
+ * `localStorage["termihub.transferRenderFromProjection"]`.
+ */
+export function transferRenderFromProjectionEnabled(): boolean {
+  if (renderFlagOverride !== null) return renderFlagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as TransferRenderFlagWindow;
+      if (typeof w.__TERMIHUB_TRANSFER_RENDER_FROM_PROJECTION__ === "boolean") {
+        return w.__TERMIHUB_TRANSFER_RENDER_FROM_PROJECTION__;
+      }
+      const ls = w.localStorage?.getItem("termihub.transferRenderFromProjection");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return true;
+}
+
+// ── Transport + shared region client (lazy, mirrors the connections slice) ─────
+
+let transportInstance: Transport | null = null;
+let regionClient: ProjectionClient | null = null;
+let startPromise: Promise<ProjectionClient> | null = null;
+
+// A stable per-session client identity for dispatched intents (fan-out / audit
+// only; the shared region's diff reaches every subscriber regardless of who
+// dispatched it).
+const clientId = newClientId();
+
+/** Inject a transport for tests; `null` restores the lazily-created real one and
+ * drops any active subscription / seed dedup. */
+export function setTransferTransportForTest(t: Transport | null): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  transportInstance = t;
+  lastView = EMPTY_VIEW;
+  lastSeededSignature = null;
+}
+
+function transport(): Transport {
+  if (!transportInstance) {
+    transportInstance = createTransport();
+  }
+  return transportInstance;
+}
+
+// ── View fan-out (one subscription, many consuming hooks) ──────────────────────
+
+/** A change listener for the projected `transfers` view. */
+export type TransfersViewListener = (view: TransfersView) => void;
+
+const viewListeners = new Set<TransfersViewListener>();
+let lastView: TransfersView = EMPTY_VIEW;
+
+/**
+ * Register a listener, invoked with the projected view on every diff. Returns an
+ * unsubscribe. The region client is started on first use.
+ */
+export function onTransfersView(listener: TransfersViewListener): () => void {
+  viewListeners.add(listener);
+  return () => viewListeners.delete(listener);
+}
+
+/**
+ * Ensure the shared `transfers` region client is subscribed so projected diffs
+ * are received and fanned out to the {@link onTransfersView} listeners.
+ * Idempotent and de-duplicated across concurrent callers; a transport/subscribe
+ * failure is logged and rethrown so the caller can fall back to `appStore`.
+ */
+export function ensureTransfersSubscribed(): Promise<ProjectionClient> {
+  if (regionClient) return Promise.resolve(regionClient);
+  if (!startPromise) {
+    const client = new ProjectionClient(transport(), TRANSFERS_REGION);
+    client.onChange((state) => {
+      lastView = toView((state.view ?? {}) as TransfersRegionSnapshot);
+      for (const listener of viewListeners) {
+        try {
+          listener(lastView);
+        } catch (err) {
+          logTransferBridgeFallback("reconcile", err);
+        }
+      }
+    });
+    startPromise = client
+      .start()
+      .then(() => {
+        regionClient = client;
+        return client;
+      })
+      .catch((err) => {
+        startPromise = null;
+        logTransferBridgeFallback("subscribe", err);
+        throw err;
+      });
+  }
+  return startPromise;
+}
+
+/** Drop the region subscription (tests / re-init). */
+export function stopTransfersSubscription(): void {
+  regionClient?.stop();
+  regionClient = null;
+  startPromise = null;
+  lastView = EMPTY_VIEW;
+  lastSeededSignature = null;
+}
+
+/** The last view fanned out (for a hook that subscribes after the first diff). */
+export function currentTransfersView(): TransfersView {
+  return lastView;
+}
+
+// ── Seed: keep the region a faithful mirror of appStore (transfer.replace) ─────
+
+let lastSeededSignature: string | null = null;
+
+/**
+ * Seed the shared region with `appStore`'s whole transfer-queue slice via a
+ * `transfer.replace` intent, so the projection tracks `appStore`'s current state
+ * while `appStore` stays authoritative (the render-side counterpart to the
+ * granular mutation intents). The payload is keyed to the Rust snapshot shape
+ * (`queue`/`minimized`). De-duplicated: a slice identical to the last seeded one
+ * is not re-dispatched. Never throws synchronously — a transport that cannot
+ * dispatch surfaces as a rejected promise the caller logs and ignores (staying on
+ * the `appStore` fallback). Idempotent server-side: replacing with the same
+ * content yields no diff.
+ */
+export function seedTransfersRegion(
+  queue: Record<string, TransferEntry>,
+  minimized: boolean
+): Promise<void> {
+  const payload = { queue, minimized };
+  const signature = JSON.stringify(payload);
+  if (signature === lastSeededSignature) return Promise.resolve();
+  // Set before dispatching so concurrent callers do not double-dispatch the seed.
+  lastSeededSignature = signature;
+  try {
+    return transport()
+      .dispatch({
+        intentId: newIntentId(),
+        kind: "transfer.replace",
+        payload,
+        clientId,
+      })
+      .then((ack: IntentAck) => {
+        if (ack.status === "rejected") {
+          // Let a later change retry the seed rather than latch on a failure.
+          lastSeededSignature = null;
+          throw new Error(ack.error?.message ?? "transfer.replace rejected");
+        }
+      })
+      .catch((err) => {
+        lastSeededSignature = null;
+        throw err;
+      });
+  } catch (err) {
+    // A synchronous transport-construction failure (non-Tauri, no socket).
+    lastSeededSignature = null;
+    return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+// ── Faithful-mirror gate ───────────────────────────────────────────────────────
+
+/**
+ * Whether a projected `view` faithfully mirrors `appStore`'s transfer-queue slice
+ * — the gate deciding whether the UI may render from the projection (true) or
+ * must fall back to `appStore` (false). A deep value comparison of the queue map
+ * plus the minimized flag; because the projected records match the frontend shape
+ * one-to-one, a mirroring view is value-identical to the `appStore` slice, so
+ * rendering from it can never diverge.
+ *
+ * The twin of the connections render cut's `connectionsViewMirrors`.
+ */
+export function transfersViewMirrors(
+  view: TransfersView | undefined,
+  queue: Record<string, TransferEntry>,
+  minimized: boolean
+): boolean {
+  if (!view) return false;
+  return view.minimized === minimized && deepEqual(view.queue, queue);
+}
+
+/**
+ * A structural deep-equal for the JSON-ish transfers view model (objects, arrays,
+ * and primitives — no functions/dates/maps). Numbers compare with `===`, so an
+ * integer that round-tripped through JSON as a float (`22` vs `22.0`) still
+ * matches.
+ *
+ * **JSON semantics for `undefined`:** a {@link TransferEntry} carries optional
+ * fields (`path` / `error` / `attempt` / `maxAttempts`) that `appStore` may hold
+ * as explicit `undefined`-valued keys, whereas the region round-trips through JSON
+ * and drops them. An absent key and an explicit `undefined` therefore denote the
+ * same value, so keys carrying `undefined` are ignored on both sides — otherwise a
+ * faithful mirror would be rejected purely over a dropped optional key. Exported
+ * for the bridge's parity tests.
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const ao = a as Record<string, unknown>;
+    const bo = b as Record<string, unknown>;
+    const aKeys = Object.keys(ao).filter((k) => ao[k] !== undefined);
+    const bKeys = Object.keys(bo).filter((k) => bo[k] !== undefined);
+    if (aKeys.length !== bKeys.length) return false;
+    return aKeys.every(
+      (k) => Object.prototype.hasOwnProperty.call(bo, k) && deepEqual(ao[k], bo[k])
+    );
+  }
+  return false;
+}
+
+/** Log a bridge fallback so the appStore-path recovery is visible in the LogViewer. */
+export function logTransferBridgeFallback(kind: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  frontendLog("transfer_bridge", `${kind} fell back to appStore transfers: ${message}`);
+}

--- a/src/store/useProjectedTransfers.test.tsx
+++ b/src/store/useProjectedTransfers.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * `useProjectedTransfers` — the Transfer Queue panel cut to the projected
+ * `transfers` region (#2229 render cut). Drives the hook against an in-memory
+ * substrate double and asserts: flag-off returns the appStore slice and dispatches
+ * nothing; flag-on seeds the region (a `transfer.replace` mirror) and then renders
+ * the slice from the projection, value-identical to appStore; and a region that
+ * has not caught up falls back to the appStore slice.
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import { useAppStore } from "@/store/appStore";
+import type { TransferEntry } from "@/types/transfer";
+
+import {
+  setTransferRenderFromProjectionEnabled,
+  setTransferTransportForTest,
+  stopTransfersSubscription,
+  TRANSFERS_REGION,
+  type TransfersView,
+} from "./transfersBridge";
+import { useProjectedTransfers } from "./useProjectedTransfers";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  getSettings: vi.fn(() =>
+    Promise.resolve({ version: "1", externalConnectionFiles: [], powerMonitoringEnabled: true })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn(() => vi.fn()) }));
+
+function entry(id: string, overrides: Partial<TransferEntry> = {}): TransferEntry {
+  return {
+    id,
+    sessionId: "sess-a",
+    direction: "download",
+    name: `file-${id}`,
+    state: "active",
+    transferred: 40,
+    totalBytes: 100,
+    percent: 40,
+    speedBytesPerSec: 2048,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function queueOf(...rows: TransferEntry[]): Record<string, TransferEntry> {
+  return Object.fromEntries(rows.map((r) => [r.id, r]));
+}
+
+/** In-memory substrate double: applies `transfer.replace` and fans a snapshot. */
+class FakeTransport implements Transport {
+  dispatched: Intent[] = [];
+  /** When false, `transfer.replace` acks but does NOT advance the region. */
+  applyReplace = true;
+  private view: Record<string, unknown> = { queue: {}, minimized: false };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (intent.kind === "transfer.replace" && this.applyReplace) {
+      const p = intent.payload as Record<string, unknown>;
+      this.view = JSON.parse(
+        JSON.stringify({ queue: p.queue ?? {}, minimized: p.minimized ?? false })
+      );
+      this.version += 1;
+      this.fan();
+    }
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: TRANSFERS_REGION, version: this.version }],
+    };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(TRANSFERS_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+/** Render the hook into a throwaway component, exposing the latest return value. */
+function renderHook(): { get: () => TransfersView; unmount: () => void } {
+  const container = document.createElement("div");
+  const root: Root = createRoot(container);
+  let latest: TransfersView = { queue: {}, minimized: false };
+
+  function Probe() {
+    latest = useProjectedTransfers();
+    return null;
+  }
+
+  act(() => root.render(<Probe />));
+  return { get: () => latest, unmount: () => act(() => root.unmount()) };
+}
+
+let transport: FakeTransport;
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setTransferTransportForTest(transport);
+  useAppStore.setState({ transferQueue: {}, transferQueueMinimized: false });
+});
+
+afterEach(() => {
+  stopTransfersSubscription();
+  setTransferTransportForTest(null);
+  setTransferRenderFromProjectionEnabled(null);
+  useAppStore.setState({ transferQueue: {}, transferQueueMinimized: false });
+});
+
+const flush = () => act(async () => await Promise.resolve());
+
+describe("useProjectedTransfers", () => {
+  it("flag off: returns the appStore slice and dispatches nothing", async () => {
+    setTransferRenderFromProjectionEnabled(false);
+    const queue = queueOf(entry("t1"));
+    useAppStore.setState({ transferQueue: queue, transferQueueMinimized: true });
+
+    const hook = renderHook();
+    await flush();
+
+    expect(hook.get().queue).toEqual(queue);
+    expect(hook.get().minimized).toBe(true);
+    expect(transport.dispatched).toHaveLength(0);
+    hook.unmount();
+  });
+
+  it("flag on: seeds the region then renders the slice from the projection", async () => {
+    const queue = queueOf(entry("t1"), entry("t2", { state: "queued" }));
+    useAppStore.setState({ transferQueue: queue, transferQueueMinimized: false });
+
+    const hook = renderHook();
+    await flush();
+    await flush();
+
+    // The hook seeded appStore's slice via transfer.replace…
+    expect(transport.dispatched.some((d) => d.kind === "transfer.replace")).toBe(true);
+    // …and now renders a value-identical slice (sourced from the projection).
+    expect(hook.get().queue).toEqual(queue);
+    expect(hook.get().minimized).toBe(false);
+    hook.unmount();
+  });
+
+  it("region not caught up: falls back to the appStore slice", async () => {
+    transport.applyReplace = false; // the replace acks but never advances the region
+    const queue = queueOf(entry("solo", { path: undefined }));
+    useAppStore.setState({ transferQueue: queue, transferQueueMinimized: false });
+
+    const hook = renderHook();
+    await flush();
+    await flush();
+
+    // The projection stays empty, so the gate rejects it and the hook renders the
+    // appStore slice verbatim — parity preserved.
+    expect(hook.get().queue).toEqual(queue);
+    expect(hook.get().minimized).toBe(false);
+    hook.unmount();
+  });
+});

--- a/src/store/useProjectedTransfers.ts
+++ b/src/store/useProjectedTransfers.ts
@@ -1,0 +1,95 @@
+/**
+ * `useProjectedTransfers` — the Transfer Queue panel cut to the projected
+ * `transfers` region (#2229 render cut, part of #2139 and #2153).
+ *
+ * The Transfer Queue panel renders the per-transfer queue map plus the
+ * panel-minimized flag. Through the shadow step it reads `appStore`'s
+ * transfer-queue slice (`transferQueue` / `transferQueueMinimized`) directly. This
+ * hook makes it source that slice from the shared `transfers` projection region
+ * instead — the direct analog of {@link import("./useProjectedConnections").useProjectedConnections}
+ * (#2225) and {@link import("./useProjectedAgents").useProjectedAgents} (#2226).
+ *
+ * # Safety (strangler)
+ *
+ * - **Gated** by {@link transferRenderFromProjectionEnabled} (on by default).
+ *   Flag off ⇒ the hook returns `appStore`'s slice verbatim.
+ * - **Faithful-mirror gate.** The projection sources the render only when it
+ *   deep-equals the `appStore` slice ({@link transfersViewMirrors}); otherwise the
+ *   hook falls back to `appStore` (never a stale view). While `appStore` stays
+ *   authoritative (the mutation cut is a later step) the region is kept a mirror by
+ *   {@link seedTransfersRegion}, so it is always populated — making the cut
+ *   parity-safe and independent of the mutation flag.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+
+import { useAppStore } from "@/store/appStore";
+import {
+  currentTransfersView,
+  ensureTransfersSubscribed,
+  logTransferBridgeFallback,
+  onTransfersView,
+  seedTransfersRegion,
+  transferRenderFromProjectionEnabled,
+  transfersViewMirrors,
+  type TransfersView,
+} from "@/store/transfersBridge";
+
+/**
+ * The effective transfers slice for rendering: the per-transfer queue map plus
+ * the panel-minimized flag, sourced from the projected `transfers` region when it
+ * faithfully mirrors `appStore`, otherwise `appStore`'s slice verbatim (flag off,
+ * region not yet caught up, or a transport that cannot subscribe).
+ */
+export function useProjectedTransfers(): TransfersView {
+  const queue = useAppStore((s) => s.transferQueue);
+  const minimized = useAppStore((s) => s.transferQueueMinimized);
+
+  // Read the flag once at mount: it flips only via dev tooling, and the
+  // subscription lifecycle is keyed off it below.
+  const [enabled] = useState(() => transferRenderFromProjectionEnabled());
+
+  const [view, setView] = useState<TransfersView | undefined>(undefined);
+
+  // Subscribe to the shared transfers region while enabled; a transport that
+  // cannot subscribe (non-Tauri without a socket) just leaves the UI on the
+  // appStore fallback.
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const unsubscribe = onTransfersView((next) => {
+      if (!cancelled) setView(next);
+    });
+    // `ensureTransfersSubscribed` builds the transport eagerly, so a non-Tauri
+    // env without a socket throws synchronously (not just a rejection) — guard both
+    // so the UI silently stays on the appStore fallback.
+    try {
+      ensureTransfersSubscribed()
+        .then(() => {
+          if (!cancelled) setView(currentTransfersView());
+        })
+        .catch((err) => logTransferBridgeFallback("subscribe", err));
+    } catch (err) {
+      logTransferBridgeFallback("subscribe", err);
+    }
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [enabled]);
+
+  const matches = enabled && transfersViewMirrors(view, queue, minimized);
+
+  // Keep the region a faithful mirror of appStore's slice. Only once a view has
+  // arrived (so we are subscribed) and it is not already a mirror; de-duped inside
+  // `seedTransfersRegion` so a settled slice is not re-seeded on every render.
+  useEffect(() => {
+    if (!enabled || matches || view === undefined) return;
+    seedTransfersRegion(queue, minimized).catch((err) => logTransferBridgeFallback("seed", err));
+  }, [enabled, matches, view, queue, minimized]);
+
+  return useMemo(() => {
+    if (matches && view) return view;
+    return { queue, minimized };
+  }, [matches, view, queue, minimized]);
+}


### PR DESCRIPTION
## What

Render cut of the **Transfers** domain (Phase 5, Part of #2229 / #2139 / #2153): the Transfer Queue panel now sources its rows + minimized flag from the shared `transfers` projection region instead of reading `appStore`'s `transferQueue` / `transferQueueMinimized` directly. **Frontend-only** — reuses the `transfer.replace` seed intent the shadow (PR #2275) already landed; no Rust change.

Follows the proven per-domain template (Connections #2225, Agents #2226, Files #2274):

- **`transfersBridge.ts`** — subscribes to the `transfers` region, keeps it a faithful mirror of `appStore` via a `transfer.replace` whole-slice seed, a deep-equal faithful-mirror gate (`transfersViewMirrors`), and a render flag on by default with instant runtime revert (`__TERMIHUB_TRANSFER_RENDER_FROM_PROJECTION__` / `localStorage["termihub.transferRenderFromProjection"]`).
- **`useProjectedTransfers.ts`** — returns the projected slice when it faithfully mirrors `appStore`, else `appStore` verbatim (flag off, region not caught up, or no transport).
- **`TransferQueue.tsx` / `TransferQueueIndicator.tsx`** — reads cut to the hook. `appStore` fields and reducers stay in place (reducer removal is a later step); mutation actions still dispatch through `appStore`.

## Parity note

`TransferEntry` carries optional fields (`path` / `error` / `attempt` / `maxAttempts`) that `appStore` may hold as explicit `undefined`-valued keys but the JSON transport drops. The bridge's `deepEqual` therefore uses JSON semantics (absent key ≡ `undefined` value), so a faithful mirror is not rejected over a dropped optional key — otherwise the panel would never actually render from the projection.

## No user-visible change

The panel renders from the region only when it deep-equals `appStore`; otherwise it falls back to `appStore` verbatim. Output is byte-identical to the pre-cut path.

## Tests

- `transfersBridge.test.ts` — flag default/override, `deepEqual` (incl. undefined/JSON semantics), `transfersViewMirrors`, seed dedup, seed round-trip mirror.
- `useProjectedTransfers.test.tsx` — flag off (appStore, no dispatch), flag on (seeds then renders from projection), region-not-caught-up fallback.
- `TransferQueue.projection.test.tsx` — the real panel + indicator rendering from the projection, and the mirror-fallback parity path.

Frontend suite green; prettier + eslint + tsc clean.

Part of #2229