### PR TITLE
fix(ui): make redos detection deterministic

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.76.1",
     "react-resizable-panels": "^4.11.2",
+    "scslre": "^0.3.0",
     "shiki": "^4.1.0",
     "sonner": "^2.0.7",
     "ulid": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       react-resizable-panels:
         specifier: ^4.11.2
         version: 4.11.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      scslre:
+        specifier: ^0.3.0
+        version: 0.3.0
       shiki:
         specifier: ^4.1.0
         version: 4.1.0
@@ -2954,6 +2957,10 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
+  refa@0.12.1:
+    resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -2962,6 +2969,10 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  regexp-ast-analysis@0.7.1:
+    resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   remove-accents@0.5.0:
     resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
@@ -3003,6 +3014,10 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  scslre@0.3.0:
+    resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
+    engines: {node: ^14.0.0 || >=16.0.0}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -6120,6 +6135,10 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  refa@0.12.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
@@ -6129,6 +6148,11 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
+  regexp-ast-analysis@0.7.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      refa: 0.12.1
 
   remove-accents@0.5.0: {}
 
@@ -6187,6 +6211,12 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  scslre@0.3.0:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      refa: 0.12.1
+      regexp-ast-analysis: 0.7.1
 
   semver@6.3.1: {}
 

--- a/src/services/regexSafety.test.ts
+++ b/src/services/regexSafety.test.ts
@@ -3,7 +3,7 @@ import {
   MAX_PATTERN_LENGTH,
   buildRuleSource,
   hasNestedQuantifier,
-  exceedsAdversarialBudget,
+  hasSuperLinearBacktracking,
   validateHighlightPattern,
 } from "./regexSafety";
 
@@ -54,31 +54,32 @@ describe("hasNestedQuantifier", () => {
   });
 });
 
-describe("exceedsAdversarialBudget", () => {
-  it("returns true for a catastrophic overlapping-alternation pattern", () => {
-    // (a|a)+ is not a nested-quantifier shape but backtracks exponentially.
-    expect(exceedsAdversarialBudget("(a|a)+$", "g")).toBe(true);
+describe("hasSuperLinearBacktracking", () => {
+  it("flags overlapping-alternation ReDoS the structural check misses", () => {
+    // (a|a)+ is not a nested-quantifier shape but backtracks super-linearly.
+    // Detection is static (automaton-based), so it never depends on machine speed.
+    expect(hasSuperLinearBacktracking("(a|a)+$", "g")).toBe(true);
+    expect(hasSuperLinearBacktracking("(a|ab)+$", "g")).toBe(true);
+    expect(hasSuperLinearBacktracking("(x+x+)+y", "g")).toBe(true);
   });
 
   it("returns false for a normal linear pattern", () => {
-    expect(exceedsAdversarialBudget("\\berror\\b", "g")).toBe(false);
-    expect(exceedsAdversarialBudget("(?:https?)://\\S+", "g")).toBe(false);
+    expect(hasSuperLinearBacktracking("\\berror\\b", "g")).toBe(false);
+    expect(hasSuperLinearBacktracking("(?:https?)://\\S+", "g")).toBe(false);
+    expect(hasSuperLinearBacktracking("(a|b)+", "g")).toBe(false);
+    expect(hasSuperLinearBacktracking("\\b(?:TODO|FIXME)\\b", "g")).toBe(false);
   });
 
-  it("uses the injected clock to decide (deterministic budget check)", () => {
-    let t = 0;
-    // Clock jumps 100ms on the first read after start -> over a 30ms budget.
-    const fakeNow = (): number => {
-      const v = t;
-      t += 100;
-      return v;
-    };
-    expect(exceedsAdversarialBudget("abc", "g", 30, fakeNow)).toBe(true);
+  it("is deterministic across repeated calls (no timing dependence)", () => {
+    // The same verdict every time, regardless of how fast the machine runs it.
+    for (let i = 0; i < 5; i++) {
+      expect(hasSuperLinearBacktracking("(a|a)+$", "g")).toBe(true);
+      expect(hasSuperLinearBacktracking("\\berror\\b", "g")).toBe(false);
+    }
   });
 
-  it("stays under budget when the injected clock does not advance", () => {
-    const frozenNow = (): number => 5;
-    expect(exceedsAdversarialBudget("abc", "g", 30, frozenNow)).toBe(false);
+  it("defers (returns false) for an uncompilable source", () => {
+    expect(hasSuperLinearBacktracking("(unclosed", "g")).toBe(false);
   });
 });
 
@@ -119,9 +120,18 @@ describe("validateHighlightPattern", () => {
     if (!result.valid) expect(result.reason).toMatch(/backtracking|nested/i);
   });
 
-  it("rejects an overlapping-alternation ReDoS pattern via the empirical backstop", () => {
+  it("rejects an overlapping-alternation ReDoS pattern via static analysis", () => {
+    // Deterministic: caught by scslre's automaton analysis, not a wall-clock
+    // threshold, so the verdict does not depend on runner speed (#2262).
     const result = validateHighlightPattern("(a|a)+$");
     expect(result.valid).toBe(false);
-    if (!result.valid) expect(result.reason).toMatch(/backtracking|redos|slow/i);
+    if (!result.valid) expect(result.reason).toMatch(/backtracking|redos/i);
+  });
+
+  it("gives the same verdict on repeated runs (no timing flake)", () => {
+    for (let i = 0; i < 5; i++) {
+      expect(validateHighlightPattern("(a|a)+$").valid).toBe(false);
+      expect(validateHighlightPattern("\\b(?:TODO|FIXME)\\b").valid).toBe(true);
+    }
   });
 });

--- a/src/services/regexSafety.ts
+++ b/src/services/regexSafety.ts
@@ -7,7 +7,9 @@
  * render loop and can freeze the terminal, so user input is validated *before*
  * it is ever saved or applied.
  *
- * The validation is layered defence:
+ * The validation is layered defence, and every layer is **deterministic** — the
+ * verdict depends only on the pattern's structure, never on wall-clock time, so it
+ * cannot flake with runner speed:
  *   1. **Length cap** — patterns over {@link MAX_PATTERN_LENGTH} chars are rejected
  *      outright (long sources are both hard to reason about and a cheap DoS vector).
  *   2. **Compile check** — the pattern (with the same wrapping the engine applies)
@@ -15,24 +17,22 @@
  *   3. **Structural check** — deterministic detection of nested unbounded
  *      quantifiers (the `(a+)+` / `(a*)*` star-height-2 shapes that drive the vast
  *      majority of ReDoS), rejected instantly without ever executing the pattern.
- *   4. **Empirical backstop** — the compiled pattern is run against a small battery
- *      of adversarial inputs with a wall-clock budget; anything that blows the
- *      budget (e.g. overlapping-alternation shapes the structural check misses) is
- *      rejected. The separation between a safe pattern (microseconds) and a
- *      catastrophic one (many milliseconds and up) is many orders of magnitude, so
- *      this stays deterministic in practice.
+ *   4. **Static super-linear analysis** — the compiled pattern is analysed by
+ *      {@link https://github.com/RunDevelopment/scslre | scslre}, a finite-automaton
+ *      ReDoS analyzer, which statically detects the overlapping-alternation and
+ *      ambiguity shapes the structural check misses (e.g. `(a|a)+$`). It never runs
+ *      the pattern, so — unlike the wall-clock backstop it replaced (#2262) — the
+ *      result is identical on a slow or a fast machine.
  *
  * The engine additionally caps per-line length and self-disables a rule that
  * exceeds a per-line time budget at runtime (see `findMatchesGuarded`), but this
  * save-time gate is the primary protection: a bad pattern should never reach the
  * engine in the first place.
  */
+import { analyse } from "scslre";
 
 /** Maximum accepted pattern source length, in characters. */
 export const MAX_PATTERN_LENGTH = 500;
-
-/** Wall-clock budget (ms) for the empirical adversarial run across all probes. */
-export const ADVERSARIAL_BUDGET_MS = 30;
 
 /** Options describing how the pattern will be compiled by the engine. */
 export interface PatternValidationOptions {
@@ -169,66 +169,33 @@ export function hasNestedQuantifier(source: string): boolean {
 }
 
 /**
- * Runs a compiled pattern against a battery of adversarial inputs and reports
- * whether the total wall-clock time exceeds `budgetMs`. Catches ReDoS shapes the
- * structural check misses (e.g. overlapping alternation `(a|a)+`).
+ * Statically detects patterns with super-linear (polynomial or exponential)
+ * worst-case matching — the ReDoS shapes the structural {@link hasNestedQuantifier}
+ * check misses, most notably overlapping alternation such as `(a|a)+$`.
  *
- * The probes are built from characters that appear in the pattern so that the
- * pattern actually engages with them, each a long run followed by a
- * non-matching sentinel that forces maximal backtracking.
+ * Delegates to {@link https://github.com/RunDevelopment/scslre | scslre}, which
+ * builds a finite automaton from the pattern and reports whether any repetition is
+ * ambiguous enough to backtrack super-linearly. This is a pure structural analysis:
+ * the pattern is **never executed**, so the verdict is deterministic regardless of
+ * machine speed (the reason this replaced the old wall-clock backstop — #2262).
+ *
+ * Returns `false` (defers to the caller) when the pattern cannot be compiled or the
+ * analyzer throws — compile errors are surfaced separately by the caller.
  */
-export function exceedsAdversarialBudget(
-  source: string,
-  flags: string,
-  budgetMs = ADVERSARIAL_BUDGET_MS,
-  nowFn: () => number = defaultNow
-): boolean {
+export function hasSuperLinearBacktracking(source: string, flags: string): boolean {
   let regex: RegExp;
   try {
     regex = new RegExp(source, flags);
   } catch {
     return false; // compile errors are handled elsewhere
   }
-
-  const probes = buildAdversarialInputs(source);
-  const start = nowFn();
-  for (const input of probes) {
-    regex.lastIndex = 0;
-    // A single exec cannot be interrupted; the input lengths are chosen so a
-    // catastrophic pattern clearly overruns the budget while a safe one stays in
-    // the microsecond range.
-    regex.test(input);
-    if (nowFn() - start > budgetMs) return true;
+  try {
+    return analyse(regex).reports.length > 0;
+  } catch {
+    // A pattern the analyzer cannot model is treated as "not proven dangerous"
+    // here; the structural check and length cap remain in force.
+    return false;
   }
-  return false;
-}
-
-/** Characters worth stress-testing, seeded from the pattern's own literals. */
-function adversarialAlphabet(source: string): string[] {
-  const chars = new Set<string>();
-  for (const ch of source) {
-    if (/[a-zA-Z0-9]/.test(ch)) chars.add(ch);
-  }
-  // Always include a couple of generic characters so `.`/class-only patterns are
-  // still exercised.
-  chars.add("a");
-  chars.add("0");
-  return [...chars].slice(0, 4);
-}
-
-/** Adversarial inputs: long single-char runs plus a failing sentinel. */
-function buildAdversarialInputs(source: string): string[] {
-  const inputs: string[] = [];
-  // ~20 repeats is deliberately modest: an exponential pattern still overruns the
-  // budget by an order of magnitude (hundreds of ms) yet the worst-case single
-  // exec stays bounded (~2^20 steps), so the validator never hangs. A linear
-  // pattern stays sub-millisecond.
-  const runLength = 20;
-  for (const ch of adversarialAlphabet(source)) {
-    inputs.push(ch.repeat(runLength) + "!");
-    inputs.push(ch.repeat(runLength) + " ");
-  }
-  return inputs;
 }
 
 /**
@@ -237,7 +204,8 @@ function buildAdversarialInputs(source: string): string[] {
  * with a user-facing message otherwise.
  *
  * Checks, in order: non-empty, length cap, compiles, no nested unbounded
- * quantifiers, and not empirically catastrophic on adversarial input.
+ * quantifiers, and no statically-detected super-linear backtracking. Every check
+ * is deterministic — the result never depends on how fast the machine is.
  */
 export function validateHighlightPattern(
   pattern: string,
@@ -268,10 +236,10 @@ export function validateHighlightPattern(
     };
   }
 
-  if (exceedsAdversarialBudget(source, flags)) {
+  if (hasSuperLinearBacktracking(source, flags)) {
     return {
       valid: false,
-      reason: "Pattern is too slow on adversarial input (possible ReDoS).",
+      reason: "Pattern may cause catastrophic backtracking (possible ReDoS).",
     };
   }
 
@@ -284,10 +252,4 @@ function describeError(err: unknown): string {
     return err.message.replace(/^Invalid regular expression:[^:]*:\s*/, "");
   }
   return String(err);
-}
-
-function defaultNow(): number {
-  return typeof performance !== "undefined" && typeof performance.now === "function"
-    ? performance.now()
-    : Date.now();
 }


### PR DESCRIPTION
## Summary

The regexSafety ReDoS "empirical backstop" decided whether a highlight pattern was dangerous by **running it and measuring wall-clock time** against a 30 ms budget. On a fast CI runner the pathological regex finished under the threshold, so an overlapping-alternation pattern like `(a|a)+$` was judged *safe* — intermittently failing `validateHighlightPattern > rejects an overlapping-alternation ReDoS pattern` on `Run Tests (windows-latest)` with `expected true to be false`.

This replaces the timing-based backstop with **static structural analysis**, so the verdict is deterministic regardless of runner speed.

## Approach

- Added [`scslre`](https://github.com/RunDevelopment/scslre) — a synchronous, pure-JS super-linear-regex analyzer (the engine behind `eslint-plugin-regexp`'s `no-super-linear-backtracking`). Per the repo's "prefer libraries over custom code" rule, this beats hand-rolling ambiguity analysis. It is browser-safe (no Node builtins, verified to bundle via `pnpm build`) and synchronous, which the on-keystroke `useMemo` call site in `CustomRuleEditor` requires.
- Replaced `exceedsAdversarialBudget` (wall-clock probe) with `hasSuperLinearBacktracking`, which builds a finite automaton from the pattern and reports super-linear backtracking **without ever executing it**.
- Kept the existing `hasNestedQuantifier` structural check as a fast pre-filter — it also covers unanchored `(a*)*` / `(\d+)+` shapes that scslre's reject-based analysis skips. Every remaining layer (length cap, compile, nested-quantifier, static analysis) is now deterministic.

## Security behavior preserved

- Still **rejected**: `(a|a)+$`, `(a|ab)+$`, `(x+x+)+y`, `(a+)+$`, `(a*)*`, `(\d+)+`, `((ab)+)+`.
- Still **accepted**: `\berror\b`, `(?:https?)://\S+`, `(?:https?|ftp)://\S+`, `(a|b)+`, `\b(?:TODO|FIXME)\b`.

The guard is not weakened — the analyzer errs conservative (rejects genuinely ambiguous patterns), which is the safe direction for a save-time security gate.

## Testing

- Rewrote the timing/injected-clock unit tests into deterministic static-analysis tests; added explicit "same verdict on repeated runs" checks at both the unit and `validateHighlightPattern` level.
- `pnpm test` — full suite green (5006 tests); `regexSafety.test.ts` run repeatedly with identical results (no timing branch left).
- `pnpm build`, `pnpm run lint`, `prettier --check` all clean.

Closes #2262