### PR TITLE
feat(sftp): cut transfer-queue mutations to transfer.* intents

### DIFF
--- a/src/store/appStore.transfersMutationCut.test.ts
+++ b/src/store/appStore.transfersMutationCut.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Transfers mutation cut (#2229, part of #2139 and #2153) — cut-vs-local parity.
+ *
+ * The mutation cut routes each Transfer Queue action through a granular
+ * `transfer.*` intent so the backend `TransferStore` becomes authoritative, while
+ * the local `appStore` reducer path stays in place as the render source and the
+ * resilience / rollback fallback (the reducer removal is a later step). This is
+ * the final Phase-5 domain: with it merged every Phase-5 domain is fully cut over
+ * (shadow + render + mutation).
+ *
+ * These tests prove the cut is parity-safe end to end: with the flag **on**, the
+ * intents dispatched by the actions — applied by a faithful in-memory port of the
+ * Rust store (mirroring `transfers_projection/store.rs`, itself a twin of the
+ * shared `@/types/transfer` fold helpers) — reproduce the exact `appStore`
+ * transfer-queue slice (`transferQueue` + `transferQueueMinimized`) for every
+ * action and its fan-out. With the flag **off**, no intents are dispatched and the
+ * local slice is byte-identical — the instant rollback path the flip relies on.
+ *
+ * Timekeeping: `updatedAt` on a fold is stamped with `now`. Both the `appStore`
+ * reducer and this in-memory port read `Date.now()`, and `mirrorTransferIntent`
+ * dispatches synchronously in the same action tick, so a frozen fake clock gives
+ * both the same `now` — the region entries are value-identical to `appStore`'s.
+ *
+ * JSON semantics: a `TransferEntry` carries optional fields (`path` / `error` /
+ * `attempt` / `maxAttempts`) that `appStore` may hold as explicit `undefined`
+ * keys, whereas the region round-trips through JSON (serde) and drops them. The
+ * region view here is JSON-normalised to model that wire behaviour, and `toEqual`
+ * treats an absent key and an explicit `undefined` as equal — so a dropped
+ * optional key never reads as a parity failure.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve("persisted-id")),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(() => Promise.resolve()),
+  sftpListDir: vi.fn(() => Promise.resolve([])),
+  sftpRealpath: vi.fn(() => Promise.resolve("/home/alice")),
+  sftpCancelTransfer: vi.fn(() => Promise.resolve()),
+  claimSession: vi.fn(() => Promise.resolve(null)),
+  releaseSession: vi.fn(() => Promise.resolve(true)),
+  listSessionOwners: vi.fn(() => Promise.resolve({})),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+}));
+
+import { useAppStore } from "./appStore";
+import { setTransferIntentsEnabled, setTransferTransportForTest } from "./transfersBridge";
+import type { TransferProgress, TransferSnapshot } from "@/services/api";
+import {
+  type TransferEntry,
+  type TransferSeed,
+  isTerminalTransferState,
+  transferEntryFromProgress,
+  transferEntryFromSeed,
+  transferEntryFromSnapshot,
+} from "@/types/transfer";
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+
+// ── Fixtures (twins of appStore.transferQueue.test.ts) ─────────────────────────
+
+function seed(overrides: Partial<TransferSeed> = {}): TransferSeed {
+  return {
+    id: "t1",
+    sessionId: "sess-a",
+    direction: "download",
+    name: "file.txt",
+    path: "/remote/file.txt",
+    totalBytes: 100,
+    ...overrides,
+  };
+}
+
+function progress(overrides: Partial<TransferProgress> = {}): TransferProgress {
+  return {
+    transferId: "t1",
+    sessionId: "sess-a",
+    direction: "download",
+    fileName: "file.txt",
+    transferred: 0,
+    total: 100,
+    phase: "transferring",
+    ...overrides,
+  };
+}
+
+function snapshot(overrides: Partial<TransferSnapshot> = {}): TransferSnapshot {
+  return {
+    transferId: "t1",
+    sessionId: "sess-a",
+    direction: "download",
+    fileName: "file.txt",
+    path: "/remote/file.txt",
+    state: "completed",
+    settled: true,
+    transferred: 100,
+    total: 100,
+    speed: 0,
+    attempt: 0,
+    maxAttempts: 3,
+    ...overrides,
+  };
+}
+
+// ── In-memory Rust-store double ────────────────────────────────────────────────
+
+interface RegionView {
+  queue: Record<string, TransferEntry>;
+  minimized: boolean;
+}
+
+/**
+ * A substrate double that applies the granular `transfer.*` intents with the same
+ * semantics as the Rust `TransferStore` (`transfers_projection/store.rs`), so a
+ * run of the real `appStore` actions (which mirror those intents) reconstructs the
+ * region view the Transfer Queue panel would render. Only `transfer.replace` (the
+ * render-cut mirror) is intentionally not applied — the mutation cut drives the
+ * region through the per-transition intents.
+ *
+ * The fold helpers are the shared `@/types/transfer` twins the Rust store and the
+ * `appStore` reducers both use, applied here with `Date.now()` — a frozen fake
+ * clock gives the same `now` as the reducer, so the entries match value-for-value.
+ */
+class TransferStoreTransport implements Transport {
+  dispatched: Intent[] = [];
+  private queue: Record<string, TransferEntry> = {};
+  private minimized = false;
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    this.apply(intent);
+    this.version += 1;
+    this.fan();
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: "transfers", version: this.version }],
+    };
+  }
+
+  private apply(intent: Intent): void {
+    const p = intent.payload as Record<string, unknown>;
+    const now = Date.now();
+    switch (intent.kind) {
+      case "transfer.seed": {
+        const s = p.seed as TransferSeed;
+        // Idempotent: never overwrite a row an event already advanced.
+        if (this.queue[s.id]) break;
+        this.queue[s.id] = transferEntryFromSeed(s, now);
+        break;
+      }
+      case "transfer.progress": {
+        const prog = p.progress as TransferProgress;
+        const prev = this.queue[prog.transferId];
+        const entry = transferEntryFromProgress(prog, prev, now);
+        this.queue[entry.id] = entry;
+        break;
+      }
+      case "transfer.reconcile": {
+        const snaps = p.snapshots as TransferSnapshot[];
+        for (const snap of snaps) {
+          if (!snap.settled || !isTerminalTransferState(snap.state)) continue;
+          const prev = this.queue[snap.transferId];
+          if (!prev) continue;
+          if (isTerminalTransferState(prev.state)) continue;
+          this.queue[snap.transferId] = transferEntryFromSnapshot(snap, prev, now);
+        }
+        break;
+      }
+      case "transfer.remove": {
+        delete this.queue[p.id as string];
+        break;
+      }
+      case "transfer.clearCompleted": {
+        this.queue = Object.fromEntries(
+          Object.entries(this.queue).filter(([, e]) => e.state !== "completed")
+        );
+        break;
+      }
+      case "transfer.setMinimized": {
+        this.minimized = p.minimized as boolean;
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  /**
+   * The reconstructed region view, twin of the store snapshot. JSON-normalised to
+   * model the serde round-trip that drops explicit `undefined` optional keys.
+   */
+  regionView(): RegionView {
+    return JSON.parse(JSON.stringify({ queue: this.queue, minimized: this.minimized }));
+  }
+
+  kinds(): string[] {
+    return this.dispatched.map((i) => i.kind);
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: this.regionView() };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot("transfers");
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+let transport: TransferStoreTransport;
+
+/** Assert the region the intents reconstruct equals the local appStore slice. */
+function expectParity() {
+  const state = useAppStore.getState();
+  const region = transport.regionView();
+  expect(region.queue).toEqual(state.transferQueue);
+  expect(region.minimized).toEqual(state.transferQueueMinimized);
+}
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+  transport = new TransferStoreTransport();
+  setTransferTransportForTest(transport);
+  setTransferIntentsEnabled(true);
+});
+
+afterEach(() => {
+  setTransferTransportForTest(null);
+  setTransferIntentsEnabled(null);
+  vi.useRealTimers();
+});
+
+describe("transfers mutation cut — cut-vs-local parity (flag on)", () => {
+  it("seedTransferQueue enqueues a queued row in the region", () => {
+    useAppStore.getState().seedTransferQueue(seed());
+
+    expect(transport.kinds()).toEqual(["transfer.seed"]);
+    expectParity();
+    expect(transport.regionView().queue["t1"].state).toBe("queued");
+  });
+
+  it("seedTransferQueue is idempotent — a second seed does not overwrite the row", () => {
+    useAppStore.getState().seedTransferQueue(seed());
+    useAppStore
+      .getState()
+      .applyTransferProgressToQueue(progress({ transferred: 50, state: "active" }));
+    // Re-seeding the same id must not clobber the further-along row.
+    useAppStore.getState().seedTransferQueue(seed());
+
+    expectParity();
+    expect(transport.regionView().queue["t1"].transferred).toBe(50);
+  });
+
+  it("applyTransferProgressToQueue folds a progress event into the region", () => {
+    useAppStore.getState().seedTransferQueue(seed());
+    useAppStore
+      .getState()
+      .applyTransferProgressToQueue(progress({ transferred: 40, state: "active" }));
+
+    expect(transport.kinds()).toEqual(["transfer.seed", "transfer.progress"]);
+    expectParity();
+    const row = transport.regionView().queue["t1"];
+    expect(row.state).toBe("active");
+    expect(row.transferred).toBe(40);
+    expect(row.percent).toBe(40);
+  });
+
+  it("applyTransferProgressToQueue upserts a row with no prior seed", () => {
+    useAppStore
+      .getState()
+      .applyTransferProgressToQueue(progress({ transferred: 100, state: "completed" }));
+
+    expect(transport.kinds()).toEqual(["transfer.progress"]);
+    expectParity();
+    expect(transport.regionView().queue["t1"].state).toBe("completed");
+    expect(transport.regionView().queue["t1"].percent).toBe(100);
+  });
+
+  it("computed throughput across two progress events stays in parity", () => {
+    useAppStore
+      .getState()
+      .applyTransferProgressToQueue(progress({ transferred: 10, state: "active", speed: 0 }));
+    vi.advanceTimersByTime(1000);
+    useAppStore
+      .getState()
+      .applyTransferProgressToQueue(progress({ transferred: 60, state: "active", speed: 0 }));
+
+    expectParity();
+    // 50 bytes over 1000ms → 50 B/s, computed identically both sides.
+    expect(transport.regionView().queue["t1"].speedBytesPerSec).toBe(50);
+  });
+
+  it("applyTransferProgressToQueue does NOT dispatch for a session owned by another window", () => {
+    // A session the backend map assigns to a different window is suppressed by
+    // the reducer; the mutation cut must not advance the shared region past it.
+    useAppStore.setState({
+      sessionOwners: { "sess-a": "other-window" },
+      windowLabel: "main",
+    });
+
+    useAppStore
+      .getState()
+      .applyTransferProgressToQueue(progress({ transferred: 40, state: "active" }));
+
+    expect(transport.kinds()).toEqual([]);
+    expectParity();
+    expect(transport.regionView().queue).toEqual({});
+  });
+
+  it("reconcileTransferQueue settles a stuck row from a terminal snapshot", () => {
+    useAppStore.getState().seedTransferQueue(seed());
+    useAppStore
+      .getState()
+      .applyTransferProgressToQueue(progress({ transferred: 60, state: "active" }));
+
+    useAppStore.getState().reconcileTransferQueue([snapshot({ state: "completed" })]);
+
+    expect(transport.kinds()).toEqual(["transfer.seed", "transfer.progress", "transfer.reconcile"]);
+    expectParity();
+    expect(transport.regionView().queue["t1"].state).toBe("completed");
+  });
+
+  it("reconcileTransferQueue never resurrects a removed row", () => {
+    useAppStore.getState().seedTransferQueue(seed());
+    useAppStore.getState().removeTransfer("t1");
+
+    useAppStore.getState().reconcileTransferQueue([snapshot({ state: "completed" })]);
+
+    expectParity();
+    expect(transport.regionView().queue["t1"]).toBeUndefined();
+  });
+
+  it("removeTransfer drops the row from the region", () => {
+    useAppStore.getState().seedTransferQueue(seed({ id: "t1" }));
+    useAppStore.getState().seedTransferQueue(seed({ id: "t2" }));
+
+    useAppStore.getState().removeTransfer("t1");
+
+    expect(transport.kinds()).toEqual(["transfer.seed", "transfer.seed", "transfer.remove"]);
+    expectParity();
+    expect(Object.keys(transport.regionView().queue)).toEqual(["t2"]);
+  });
+
+  it("clearCompleted removes only completed rows in the region", () => {
+    useAppStore.getState().seedTransferQueue(seed({ id: "done" }));
+    useAppStore
+      .getState()
+      .applyTransferProgressToQueue(
+        progress({ transferId: "done", transferred: 100, state: "completed" })
+      );
+    useAppStore.getState().seedTransferQueue(seed({ id: "live" }));
+    useAppStore
+      .getState()
+      .applyTransferProgressToQueue(
+        progress({ transferId: "live", transferred: 20, state: "active" })
+      );
+
+    useAppStore.getState().clearCompleted();
+
+    expect(transport.kinds()).toContain("transfer.clearCompleted");
+    expectParity();
+    const keys = Object.keys(transport.regionView().queue);
+    expect(keys).toEqual(["live"]);
+  });
+
+  it("setTransferQueueMinimized mirrors the panel flag", () => {
+    useAppStore.getState().setTransferQueueMinimized(true);
+
+    expect(transport.kinds()).toEqual(["transfer.setMinimized"]);
+    expectParity();
+    expect(transport.regionView().minimized).toBe(true);
+
+    useAppStore.getState().setTransferQueueMinimized(false);
+    expectParity();
+    expect(transport.regionView().minimized).toBe(false);
+  });
+
+  it("a full lifecycle fan-out reconstructs the exact slice", () => {
+    const s = useAppStore.getState();
+    s.seedTransferQueue(seed({ id: "a" }));
+    s.seedTransferQueue(seed({ id: "b" }));
+    s.applyTransferProgressToQueue(progress({ transferId: "a", transferred: 50, state: "active" }));
+    s.applyTransferProgressToQueue(
+      progress({ transferId: "b", transferred: 100, state: "completed" })
+    );
+    s.setTransferQueueMinimized(true);
+    s.clearCompleted();
+    s.removeTransfer("a");
+
+    expectParity();
+    expect(transport.regionView().queue).toEqual({});
+    expect(transport.regionView().minimized).toBe(true);
+  });
+});
+
+describe("transfers mutation cut — flag off is the local-only rollback path", () => {
+  beforeEach(() => {
+    setTransferIntentsEnabled(false);
+  });
+
+  it("dispatches nothing when the flag is off", () => {
+    const s = useAppStore.getState();
+    s.seedTransferQueue(seed());
+    s.applyTransferProgressToQueue(progress({ transferred: 50, state: "active" }));
+    s.reconcileTransferQueue([snapshot({ state: "completed" })]);
+    s.setTransferQueueMinimized(true);
+    s.clearCompleted();
+    s.removeTransfer("t1");
+
+    expect(transport.dispatched).toEqual([]);
+    // The local slice still mutates exactly as before the cut.
+    expect(useAppStore.getState().transferQueueMinimized).toBe(true);
+    expect(useAppStore.getState().transferQueue).toEqual({});
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -288,6 +288,7 @@ import { mirrorMonitorIntent } from "@/store/systemMonitorBridge";
 import { mirrorAgentIntent } from "@/store/agentsBridge";
 import { mirrorConnectionIntent } from "@/store/connectionsBridge";
 import { mirrorFileBrowserIntent } from "@/store/fileBrowsersBridge";
+import { mirrorTransferIntent } from "@/store/transfersBridge";
 import { mirrorSettingsIntent } from "@/store/settingsBridge";
 import { mirrorBroadcastIntent } from "@/store/broadcastBridge";
 import {
@@ -6007,22 +6008,33 @@ export const useAppStore = create<AppState>((set, get, store) => {
         return { transferQueue: { ...state.transferQueue, [id]: { ...existing, ...patch } } };
       }),
 
-    removeTransfer: (id: string) =>
+    removeTransfer: (id: string) => {
       set((state) => {
         if (!(id in state.transferQueue)) return {};
         return { transferQueue: omitKey(state.transferQueue, id) };
-      }),
+      });
+      // Mutation cut (#2229): mirror the removal into the authoritative store.
+      // `transfer.remove` is idempotent server-side, so a removal of a row that
+      // was never present is a harmless no-op in both slices (parity holds).
+      mirrorTransferIntent("transfer.remove", { id });
+    },
 
-    clearCompleted: () =>
+    clearCompleted: () => {
       set((state) => ({
         transferQueue: Object.fromEntries(
           Object.entries(state.transferQueue).filter(([, t]) => t.state !== "completed")
         ),
-      })),
+      }));
+      mirrorTransferIntent("transfer.clearCompleted", {});
+    },
 
-    setTransferQueueMinimized: (minimized: boolean) => set({ transferQueueMinimized: minimized }),
+    setTransferQueueMinimized: (minimized: boolean) => {
+      set({ transferQueueMinimized: minimized });
+      mirrorTransferIntent("transfer.setMinimized", { minimized });
+    },
 
-    applyTransferProgressToQueue: (progress: TransferProgress) =>
+    applyTransferProgressToQueue: (progress: TransferProgress) => {
+      let applied = false;
       set((state) => {
         // Ignore transfers whose session was handed to another window (#1951) so
         // a moved-away queue row is not re-adopted from a broadcast event.
@@ -6031,10 +6043,17 @@ export const useAppStore = create<AppState>((set, get, store) => {
         if (!windowOwnsTransferSession(state, progress.sessionId)) return {};
         const prev = state.transferQueue[progress.transferId];
         const entry = transferEntryFromProgress(progress, prev, Date.now());
+        applied = true;
         return { transferQueue: { ...state.transferQueue, [entry.id]: entry } };
-      }),
+      });
+      // Only mirror when the local reducer actually folded the event: the
+      // window-ownership gates (#1951 / #1964) are frontend presentation the
+      // backend store does not model, so dispatching for a released/unowned
+      // session would advance the shared region past this window's slice.
+      if (applied) mirrorTransferIntent("transfer.progress", { progress });
+    },
 
-    seedTransferQueue: (seed: TransferSeed) =>
+    seedTransferQueue: (seed: TransferSeed) => {
       set((state) => {
         // Idempotent: never overwrite a row an event already advanced (#1632).
         if (seed.id in state.transferQueue) return {};
@@ -6048,9 +6067,14 @@ export const useAppStore = create<AppState>((set, get, store) => {
           transferQueue: { ...state.transferQueue, [entry.id]: entry },
           releasedTransferSessions,
         };
-      }),
+      });
+      // Mutation cut (#2229): mirror the seed. `transfer.seed` is idempotent
+      // server-side (it never overwrites an already-advanced row), so it stays a
+      // no-op in the region exactly when it is a no-op in `appStore`.
+      mirrorTransferIntent("transfer.seed", { seed });
+    },
 
-    reconcileTransferQueue: (snapshots: TransferSnapshot[]) =>
+    reconcileTransferQueue: (snapshots: TransferSnapshot[]) => {
       set((state) => {
         const now = Date.now();
         let next: Record<string, TransferEntry> | null = null;
@@ -6071,7 +6095,12 @@ export const useAppStore = create<AppState>((set, get, store) => {
           next[snap.transferId] = transferEntryFromSnapshot(snap, prev, now);
         }
         return next ? { transferQueue: next } : {};
-      }),
+      });
+      // Mutation cut (#2229): mirror the reconcile. `transfer.reconcile` applies
+      // the same conservative terminal-only settle over an already-mirrored
+      // region, so it settles exactly the rows the local reducer did.
+      mirrorTransferIntent("transfer.reconcile", { snapshots });
+    },
 
     retrySftp: async () => {
       const config = useAppStore.getState().sftpLastConfig;

--- a/src/store/transfersBridge.ts
+++ b/src/store/transfersBridge.ts
@@ -133,6 +133,65 @@ export function transferRenderFromProjectionEnabled(): boolean {
   return true;
 }
 
+// ── Mutation-cut feature flag (runtime-flippable, on by default) ───────────────
+
+let mutationFlagOverride: boolean | null = null;
+
+interface TransferMutationFlagWindow {
+  __TERMIHUB_TRANSFER_INTENTS__?: boolean;
+  localStorage?: Storage;
+}
+
+/**
+ * Programmatic override for the mutation-cut flag (tests, and a runtime toggle).
+ * `null` clears the override and falls back to the window/localStorage signal,
+ * then to the default (on).
+ */
+export function setTransferIntentsEnabled(value: boolean | null): void {
+  mutationFlagOverride = value;
+}
+
+/**
+ * Whether the Transfer Queue mutations (seed/progress/reconcile a queue row,
+ * remove a row, clear completed, collapse/expand the panel) dispatch granular
+ * `transfer.*` intents so the backend
+ * {@link import("../../src-tauri/src/transfers_projection/store").TransferStore} is
+ * authoritative — instead of only the render-cut {@link seedTransfersRegion}
+ * `transfer.replace` mirror driving the region.
+ *
+ * **On by default** (#2229 mutation cut, the final Phase-5 domain). When on, each
+ * queue action mirrors its transition through a `transfer.*` intent (via
+ * {@link mirrorTransferIntent}), and the render-cut hook
+ * ({@link import("./useProjectedTransfers").useProjectedTransfers}) reflects the
+ * region back into the UI. The local `appStore` reducer path stays in place as the
+ * render source and as a resilience / rollback fallback — any dispatch failure is
+ * logged and the local mutation continues, so a backend hiccup can never break the
+ * transfer queue (the reducer removal is a later step). When off, `appStore` drives
+ * the slice purely locally (the pre-cut path). The flip was taken on the automated
+ * parity tests plus the instant local fallback, mirroring the connections mutation
+ * cut (#2225). Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_TRANSFER_INTENTS__` or
+ * `localStorage["termihub.transferIntents"]` (set `"false"` to restore the pre-cut
+ * local-mutation path; `"true"` to force on).
+ */
+export function transferIntentsEnabled(): boolean {
+  if (mutationFlagOverride !== null) return mutationFlagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as TransferMutationFlagWindow;
+      if (typeof w.__TERMIHUB_TRANSFER_INTENTS__ === "boolean") {
+        return w.__TERMIHUB_TRANSFER_INTENTS__;
+      }
+      const ls = w.localStorage?.getItem("termihub.transferIntents");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return true;
+}
+
 // ── Transport + shared region client (lazy, mirrors the connections slice) ─────
 
 let transportInstance: Transport | null = null;
@@ -275,6 +334,57 @@ export function seedTransfersRegion(
     // A synchronous transport-construction failure (non-Tauri, no socket).
     lastSeededSignature = null;
     return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+  }
+}
+
+// ── Mutation cut: granular transfer.* intent dispatch ─────────────────────────
+
+/**
+ * The granular `transfer.*` intent kinds the mutation cut dispatches (twins of the
+ * Rust routes). Excludes `transfer.replace`, which is the render-cut whole-slice
+ * mirror ({@link seedTransfersRegion}); the mutation cut drives the region through
+ * these per-transition intents instead so the store becomes authoritative.
+ */
+export type TransferIntentKind =
+  | "transfer.seed"
+  | "transfer.progress"
+  | "transfer.reconcile"
+  | "transfer.remove"
+  | "transfer.clearCompleted"
+  | "transfer.setMinimized";
+
+/** Dispatch a granular `transfer.*` intent, resolving with the ack (parity tests). */
+export function dispatchTransferIntent(
+  kind: TransferIntentKind,
+  payload: Record<string, unknown>
+): Promise<IntentAck> {
+  return transport().dispatch({ intentId: newIntentId(), kind, payload, clientId });
+}
+
+/**
+ * Fire a granular `transfer.*` intent to keep the backend store authoritative,
+ * swallowing and logging any failure so the local `appStore` mutation path is
+ * never disrupted by a bridge hiccup (the resilience fallback). A no-op when the
+ * mutation cut is disabled ({@link transferIntentsEnabled} off — the rollback
+ * path). Never throws — a synchronous transport-construction failure (non-Tauri,
+ * no socket) is caught and logged, leaving the UI on the local slice. The twin of
+ * the connections bridge's {@link import("./connectionsBridge").mirrorConnectionIntent}.
+ */
+export function mirrorTransferIntent(
+  kind: TransferIntentKind,
+  payload: Record<string, unknown>
+): void {
+  if (!transferIntentsEnabled()) return;
+  try {
+    void dispatchTransferIntent(kind, payload)
+      .then((ack) => {
+        if (ack.status === "rejected") {
+          logTransferBridgeFallback(kind, new Error(ack.error?.message ?? "rejected"));
+        }
+      })
+      .catch((err) => logTransferBridgeFallback(kind, err));
+  } catch (err) {
+    logTransferBridgeFallback(kind, err);
   }
 }
 


### PR DESCRIPTION
## Summary

The **mutation cut** for the Transfers domain — the **final domain migration step** of the Phase-5 stateless-UI port (#2229, part of #2139 / #2153). The Transfers shadow (#2275) and render cut (#2277) already landed; this routes the Transfer Queue *actions* to the backend `transfer.*` intents so the `TransferStore` becomes authoritative, with the local reducers retained as the render source + rollback fallback.

Frontend-only — the `transfer.*` intents already exist from the shadow.

## What changed

- **`transfersBridge.ts`**: adds the mutation-cut layer mirroring the connections cut (#2225):
  - `transferIntentsEnabled()` flag **defaulting ON**, overridable at runtime for instant revert via `window.__TERMIHUB_TRANSFER_INTENTS__` / `localStorage["termihub.transferIntents"]` / `setTransferIntentsEnabled()`.
  - `dispatchTransferIntent` / `mirrorTransferIntent` helpers — fire-and-log, never throw, no-op when the flag is off.
- **`appStore.ts`**: the six Transfer Queue actions now mirror their transition through a `transfer.*` intent while the local reducer still runs:
  - `seedTransferQueue` → `transfer.seed`
  - `applyTransferProgressToQueue` → `transfer.progress` (mirrored **only when the reducer actually folds** — the window-ownership gates #1951/#1964 are frontend-only, so a released/unowned session must not advance the shared region)
  - `reconcileTransferQueue` → `transfer.reconcile`
  - `removeTransfer` → `transfer.remove`
  - `clearCompleted` → `transfer.clearCompleted`
  - `setTransferQueueMinimized` → `transfer.setMinimized`
  - (`addTransfer`/`updateTransfer` are test-only, have no intent twin in the store, and are left local.)

## Resilience / rollback

The local `appStore` reducers stay in place as the render source and the resilience/rollback fallback — any dispatch failure is logged and the local mutation continues, so a backend hiccup can never break the transfer queue. The reducer removal is the later, post-testing step. Flip the flag off (`localStorage["termihub.transferIntents"] = "false"`) for the instant pre-cut path.

## Tests

`appStore.transfersMutationCut.test.ts` — cut-vs-local parity, ships on-by-default:

- A faithful in-memory port of the Rust `TransferStore` applies the dispatched intents and asserts the reconstructed region equals the `appStore` transfer-queue slice for every action and its fan-out (seed idempotency, progress upsert, computed throughput across events, reconcile settle/no-resurrect, remove, clearCompleted, minimize, full lifecycle).
- Ownership-gate test: a progress event for a session owned by another window dispatches **nothing** and stays in parity.
- Flag-off zero-dispatch test (the rollback path).
- JSON `undefined`-vs-absent-key semantics (the render cut flagged these) are handled: the region view is JSON-normalised and compared with `toEqual`.

Timekeeping: a frozen fake clock gives the reducer and the port the same `now`, so `updatedAt` matches value-for-value.

GUI parity rests on the parity tests + the retained local fallback, per the maintainer's proceed-on-tests decision (same as every other domain).

## Verification

- Full `src/store` vitest suite: 909 passed.
- `tsc --noEmit`, `prettier --check`, `eslint` clean on touched files. No Rust changed.

**With this merged, every Phase-5 domain is fully cut over (shadow + render + mutation) — the redesign's cut-over is complete; only the post-testing reducer removals remain.**

Part of #2229 (kept open for the reducer-removal step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)