### PR TITLE
fix(config): make graft cache ignore idempotent with graft build (Closes #2287)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,5 +94,10 @@ tests/system/test-inventory.json
 core/tests/fixtures/test-plugin/Cargo.lock
 
 # graft's local graph cache — regenerable, not committed (run `graft build`).
-# Anchored to repo root so it does not also ignore .claude/skills/graft/.
-/graft/
+# NOTE: keep this pattern exactly `graft/` (unanchored). `graft build` re-appends
+# this literal line on every run when it's absent; anchoring it to /graft/ makes
+# graft think it's missing and re-append, dirtying the tree each build.
+graft/
+# The unanchored pattern above also matches the *tracked* skill dir at
+# .claude/skills/graft/ — re-admit it so the graft skill stays under version control.
+!.claude/skills/graft/


### PR DESCRIPTION
Follow-up to #2284 (PR #2285).

`graft build` re-appends the literal line `graft/` to `.gitignore` whenever it is absent. The anchored `/graft/` shipped in #2285 did not match that check, so **every build dirtied `.gitignore`** in every checkout, and the re-added unanchored `graft/` shadowed the tracked `.claude/skills/graft/` dir (an agent `git add -A` could commit the bad pattern back).

## Fix
Keep the bare `graft/` graft expects — so it detects its own entry and stops re-appending — then re-admit the tracked skill dir right after:

```gitignore
graft/
!.claude/skills/graft/
```

## Verified
- After this change, running `graft build` on a clean checkout leaves `.gitignore` **unmodified** (tree stays clean).
- Root `graft/` cache still ignored; `.claude/skills/graft/` still tracked.

Config-only, no `src/` changes.

Closes #2287