### PR TITLE
fix(tunnel): bind port 0 and read back the bound port in forwarder tests (Closes #2280)

### DIFF
--- a/core/src/tunnel/dynamic_forward.rs
+++ b/core/src/tunnel/dynamic_forward.rs
@@ -29,6 +29,11 @@ use super::local_forward::ForwarderStats;
 pub struct DynamicForwarder {
     task_handle: Option<tokio::task::JoinHandle<()>>,
     stats: Arc<ForwarderStats>,
+    /// The address the listener actually bound. When `config.local_port` is `0`
+    /// the OS assigns an ephemeral port; this reads it back so callers (and
+    /// tests) can connect to the real port instead of racily re-binding a probed
+    /// one (#2280).
+    local_addr: std::net::SocketAddr,
     /// Fires when the accept loop exits, so the tunnel supervisor can observe
     /// forwarder death and drive the tunnel to `Error` (#1243, GAP 2).
     death: Option<tokio::sync::oneshot::Receiver<()>>,
@@ -67,6 +72,7 @@ impl DynamicForwarder {
         let std_listener = std::net::TcpListener::bind(&addr)?;
         std_listener.set_nonblocking(true)?;
         let listener = tokio::net::TcpListener::from_std(std_listener)?;
+        let local_addr = listener.local_addr()?;
 
         let stats = Arc::new(ForwarderStats::new());
         let stats_clone = Arc::clone(&stats);
@@ -81,8 +87,18 @@ impl DynamicForwarder {
         Ok(Self {
             task_handle: Some(task_handle),
             stats,
+            local_addr,
             death: Some(death_rx),
         })
+    }
+
+    /// The address the SOCKS listener actually bound.
+    ///
+    /// Equals `config.local_host:config.local_port` for a fixed request; when
+    /// port `0` was requested the OS picked an ephemeral port and this returns
+    /// the real one (#2280).
+    pub fn local_addr(&self) -> std::net::SocketAddr {
+        self.local_addr
     }
 
     /// Get current tunnel statistics.
@@ -271,18 +287,14 @@ mod tests {
     use super::super::config::DynamicForwardConfig;
     use super::*;
 
-    fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .expect("bind ephemeral")
-            .local_addr()
-            .expect("local addr")
-            .port()
-    }
-
-    fn config_for(port: u16) -> DynamicForwardConfig {
+    /// A config that binds an ephemeral loopback port. Passing port `0` lets the
+    /// OS assign a free port the forwarder keeps, so the test reads the real port
+    /// back via [`DynamicForwarder::local_addr`] instead of racily re-binding a
+    /// probed one (#2280).
+    fn ephemeral_config() -> DynamicForwardConfig {
         DynamicForwardConfig {
             local_host: "127.0.0.1".to_string(),
-            local_port: port,
+            local_port: 0,
         }
     }
 
@@ -291,11 +303,10 @@ mod tests {
     async fn start_and_connect(
         opener: EchoChannelOpener,
     ) -> (DynamicForwarder, TcpStream, Arc<Mutex<Vec<(String, u16)>>>) {
-        let port = free_port();
         let targets = opener.targets_handle();
-        let forwarder = DynamicForwarder::start_with_opener(&config_for(port), opener)
+        let forwarder = DynamicForwarder::start_with_opener(&ephemeral_config(), opener)
             .expect("start forwarder");
-        let client = TcpStream::connect(("127.0.0.1", port))
+        let client = TcpStream::connect(forwarder.local_addr())
             .await
             .expect("connect to socks proxy");
         (forwarder, client, targets)
@@ -478,11 +489,11 @@ mod tests {
 
     #[tokio::test]
     async fn teardown_closes_the_listener() {
-        let port = free_port();
         let forwarder =
-            DynamicForwarder::start_with_opener(&config_for(port), EchoChannelOpener::new())
+            DynamicForwarder::start_with_opener(&ephemeral_config(), EchoChannelOpener::new())
                 .expect("start forwarder");
-        TcpStream::connect(("127.0.0.1", port))
+        let addr = forwarder.local_addr();
+        TcpStream::connect(addr)
             .await
             .expect("connect while active");
 
@@ -490,7 +501,7 @@ mod tests {
 
         let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
         loop {
-            match TcpStream::connect(("127.0.0.1", port)).await {
+            match TcpStream::connect(addr).await {
                 Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => break,
                 _ if tokio::time::Instant::now() >= deadline => {
                     panic!("listener still accepting after teardown");

--- a/core/src/tunnel/local_forward.rs
+++ b/core/src/tunnel/local_forward.rs
@@ -22,6 +22,11 @@ use super::config::{LocalForwardConfig, TunnelStats};
 pub struct LocalForwarder {
     task_handle: Option<tokio::task::JoinHandle<()>>,
     stats: Arc<ForwarderStats>,
+    /// The address the listener actually bound. When `config.local_port` is `0`
+    /// the OS assigns an ephemeral port; this reads it back so callers (and
+    /// tests) can connect to the real port instead of racily re-binding a probed
+    /// one (#2280).
+    local_addr: std::net::SocketAddr,
     /// Fires when the accept loop exits (bind lost / listener error), so the
     /// tunnel supervisor can observe forwarder death and drive the tunnel to
     /// `Error` instead of leaving it green-forever (#1243, GAP 2). Taken once by
@@ -106,6 +111,7 @@ impl LocalForwarder {
         let std_listener = std::net::TcpListener::bind(&addr)?;
         std_listener.set_nonblocking(true)?;
         let listener = tokio::net::TcpListener::from_std(std_listener)?;
+        let local_addr = listener.local_addr()?;
 
         let stats = Arc::new(ForwarderStats::new());
         let stats_clone = Arc::clone(&stats);
@@ -126,8 +132,18 @@ impl LocalForwarder {
         Ok(Self {
             task_handle: Some(task_handle),
             stats,
+            local_addr,
             death: Some(death_rx),
         })
+    }
+
+    /// The address the listener actually bound.
+    ///
+    /// Equals `config.local_host:config.local_port` for a fixed request; when
+    /// port `0` was requested the OS picked an ephemeral port and this returns
+    /// the real one (#2280).
+    pub fn local_addr(&self) -> std::net::SocketAddr {
+        self.local_addr
     }
 
     /// Take the forwarder-death receiver (once) for the tunnel supervisor.
@@ -222,20 +238,14 @@ mod tests {
     use super::super::config::LocalForwardConfig;
     use super::*;
 
-    /// Reserve an ephemeral loopback port, then release it so the forwarder can
-    /// bind it. A small TOCTOU window exists but is harmless for a unit test.
-    fn free_port() -> u16 {
-        std::net::TcpListener::bind("127.0.0.1:0")
-            .expect("bind ephemeral")
-            .local_addr()
-            .expect("local addr")
-            .port()
-    }
-
-    fn config_for(port: u16) -> LocalForwardConfig {
+    /// A config that binds an ephemeral loopback port. Passing port `0` lets the
+    /// OS assign a free port the forwarder keeps, so the test reads the real port
+    /// back via [`LocalForwarder::local_addr`] instead of racily re-binding a
+    /// probed one (#2280).
+    fn ephemeral_config() -> LocalForwardConfig {
         LocalForwardConfig {
             local_host: "127.0.0.1".to_string(),
-            local_port: port,
+            local_port: 0,
             remote_host: "db.internal".to_string(),
             remote_port: 5432,
         }
@@ -261,13 +271,12 @@ mod tests {
 
     #[tokio::test]
     async fn relays_bytes_bidirectionally_and_records_stats() {
-        let port = free_port();
         let opener = EchoChannelOpener::new();
         let targets = opener.targets_handle();
-        let forwarder =
-            LocalForwarder::start_with_opener(&config_for(port), opener).expect("start forwarder");
+        let forwarder = LocalForwarder::start_with_opener(&ephemeral_config(), opener)
+            .expect("start forwarder");
 
-        let mut client = TcpStream::connect(("127.0.0.1", port))
+        let mut client = TcpStream::connect(forwarder.local_addr())
             .await
             .expect("connect to local forward");
         client.write_all(b"hello world").await.expect("write");
@@ -294,13 +303,13 @@ mod tests {
 
     #[tokio::test]
     async fn teardown_closes_the_listener() {
-        let port = free_port();
         let forwarder =
-            LocalForwarder::start_with_opener(&config_for(port), EchoChannelOpener::new())
+            LocalForwarder::start_with_opener(&ephemeral_config(), EchoChannelOpener::new())
                 .expect("start forwarder");
+        let addr = forwarder.local_addr();
 
         // Sanity: the port accepts while running.
-        TcpStream::connect(("127.0.0.1", port))
+        TcpStream::connect(addr)
             .await
             .expect("connect while active");
 
@@ -309,7 +318,7 @@ mod tests {
         // The listener should stop accepting shortly after teardown.
         let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
         loop {
-            match TcpStream::connect(("127.0.0.1", port)).await {
+            match TcpStream::connect(addr).await {
                 Err(e) if e.kind() == io::ErrorKind::ConnectionRefused => break,
                 _ if tokio::time::Instant::now() >= deadline => {
                     panic!("listener still accepting after teardown");
@@ -321,12 +330,11 @@ mod tests {
 
     #[tokio::test]
     async fn channel_open_failure_counts_connection_but_relays_nothing() {
-        let port = free_port();
         let forwarder =
-            LocalForwarder::start_with_opener(&config_for(port), EchoChannelOpener::failing())
+            LocalForwarder::start_with_opener(&ephemeral_config(), EchoChannelOpener::failing())
                 .expect("start forwarder");
 
-        let mut client = TcpStream::connect(("127.0.0.1", port))
+        let mut client = TcpStream::connect(forwarder.local_addr())
             .await
             .expect("connect to local forward");
         // The relay bails out when the channel fails to open, so the connection

--- a/core/src/tunnel/remote_forward.rs
+++ b/core/src/tunnel/remote_forward.rs
@@ -220,12 +220,11 @@ mod tests {
         addr
     }
 
-    fn free_local_addr() -> String {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
-        let addr = listener.local_addr().expect("addr");
-        // Drop the listener so the port is free (nothing listening -> refused).
-        addr.to_string()
-    }
+    /// A loopback address that can never be connected to. Port `0` is not a
+    /// connectable target, so `TcpStream::connect` fails immediately on every
+    /// platform — deterministic, with no bind-then-drop probe that could race a
+    /// busy CI runner (#2280).
+    const UNREACHABLE_LOCAL_ADDR: &str = "127.0.0.1:0";
 
     #[tokio::test]
     async fn relays_channel_to_local_target_and_records_stats() {
@@ -261,14 +260,13 @@ mod tests {
 
     #[tokio::test]
     async fn relay_to_unreachable_local_target_is_a_no_op() {
-        let addr = free_local_addr(); // nothing is listening here
         let stats = Arc::new(ForwarderStats::new());
         let (channel_stream, _peer) = tokio::io::duplex(1024);
 
         // Should return promptly without panicking and without recording bytes.
         tokio::time::timeout(
             Duration::from_secs(3),
-            relay_to_local(channel_stream, &addr, &stats),
+            relay_to_local(channel_stream, UNREACHABLE_LOCAL_ADDR, &stats),
         )
         .await
         .expect("relay returns on connect failure");


### PR DESCRIPTION
## Problem

The tunnel forwarder unit tests picked a port via a bind-then-drop `free_port()` probe, then let the forwarder re-bind it — a TOCTOU race that intermittently failed with `Address already in use` on busy CI runners. Observed live while working #2223 on `core::tunnel::dynamic_forward::tests::channel_open_failure_replies_general_failure`. Same class of bug as #2223, different subsystem.

## Fix

Expose the actual bound address so tests never re-bind a probed port:

- `DynamicForwarder` and `LocalForwarder` now read `listener.local_addr()` back into a public `local_addr()` accessor. This is the read-back the issue calls for: when `local_port == 0` the OS assigns an ephemeral port the forwarder keeps, and callers/tests read the real one back.
- Their tests bind port `0` (`ephemeral_config()`) and connect to `forwarder.local_addr()` instead of a racily re-bound `free_port()`. Tests still exercise a real client connection through the forwarder; listener teardown is unchanged.
- `remote_forward` does not re-bind a listener (the SSH server binds), so it never had the `AddrInUse` race — but its `free_local_addr()` bind-then-drop probe for the unreachable-target test is replaced with a fixed `127.0.0.1:0` target, which `TcpStream::connect` rejects immediately and deterministically on every platform, with no probe.

The racy probe is gone from all three modules.

## Verification

- `cargo test -p termihub-core --lib --features ssh tunnel::` — 20 passed, run 6× with no flake.
- `cargo fmt --all -- --check` clean; `cargo clippy -p termihub-core --all-targets --features ssh -- -D warnings` clean.

Closes #2280