### PR TITLE
test(ui): fix FileBrowser.test.tsx windows CI timeout flake (Closes #2282)

### DIFF
--- a/src/components/Sidebar/FileBrowser.test.tsx
+++ b/src/components/Sidebar/FileBrowser.test.tsx
@@ -34,10 +34,22 @@ vi.mock("@/services/api", async (importOriginal) => {
 
 const mockedInvoke = vi.mocked(invoke);
 
-/** Flush pending microtasks (Promise callbacks) inside act(). */
+/**
+ * Flush pending microtasks (Promise callbacks) inside act().
+ *
+ * Uses `setImmediate` rather than `setTimeout(…, 0)` so the wait does not depend
+ * on the OS timer subsystem. A `setTimeout` macrotask must wait for a real
+ * wall-clock timer to fire; on a starved Windows CI runner (coarse ~15ms timer
+ * granularity, further delayed under load) that callback can be deferred long
+ * enough to trip the 15s per-test timeout — the intermittent
+ * `FileBrowser.test.tsx` flake tracked in #2282. `setImmediate` instead resolves
+ * on the next event-loop check phase, after microtasks and any due timer
+ * callbacks, without waiting on the wall clock — so the flush stays deterministic
+ * regardless of how loaded the runner is.
+ */
 async function flushAsync() {
   await act(async () => {
-    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setImmediate(r));
   });
 }
 


### PR DESCRIPTION
## Problem

`src/components/Sidebar/FileBrowser.test.tsx` intermittently hit the 15s per-test timeout on `Run Tests (windows-latest)` (green on macOS + Ubuntu), cascading into a spurious file failure. It is a timing/environment flake on the slower Windows runner, not a regression.

## Root cause

Every test in the file synchronises via the `flushAsync` helper, which awaited a real macrotask timer:

```ts
await new Promise((r) => setTimeout(r, 0));
```

That is a wall-clock dependency. On a starved Windows CI worker — coarse (~15ms) OS timer granularity, further delayed under load — the `setTimeout` callback can be deferred long enough to blow the 15s test timeout. The `vitest.config.ts` note even describes these tests as having "no real timers", which is exactly the blind spot: `setTimeout(…, 0)` *is* a real timer.

## Fix

Replace `setTimeout(…, 0)` with `setImmediate` in `flushAsync`. `setImmediate` resolves on the next event-loop check phase — after microtasks and any due timer callbacks — without waiting on the OS timer subsystem, so the flush is deterministic regardless of runner load. Same flush semantics (still an `act`-wrapped macrotask boundary), no wall-clock wait. Test-only change; no production code touched.

Verified locally: all 71 tests pass, repeatedly, slightly faster than before.

## Follow-up

The identical `setTimeout(0)` flush primitive is duplicated across ~12 other test files; a follow-up will propose propagating this deterministic flush (or extracting a shared test util) so the same flake class cannot resurface elsewhere.

Closes #2282