### PR TITLE
test(ui): share setImmediate-based flushAsync across tests (Closes #2292)

### DIFF
--- a/src/components/ConnectionEditor/ConnectionEditor.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
+import { flushMacrotask } from "@/test/flushAsync";
 import React from "react";
 import { createRoot, Root } from "react-dom/client";
 import { invoke } from "@tauri-apps/api/core";
@@ -1549,7 +1550,7 @@ describe("ConnectionEditor — Save gating on invalid input (#1357)", () => {
   async function flush() {
     await act(async () => {
       for (let i = 0; i < 6; i++) await Promise.resolve();
-      await new Promise((r) => setTimeout(r, 0));
+      await flushMacrotask();
     });
   }
 

--- a/src/components/DynamicForm/ConnectionSettingsForm.validity.test.tsx
+++ b/src/components/DynamicForm/ConnectionSettingsForm.validity.test.tsx
@@ -7,6 +7,7 @@
  * visible fields count — a required field hidden by `visibleWhen` must not block.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { flushMacrotask } from "@/test/flushAsync";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import type { SettingsSchema } from "@/types/schema";
@@ -21,7 +22,7 @@ let root: Root;
 async function flush() {
   await act(async () => {
     for (let i = 0; i < 5; i++) await Promise.resolve();
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await flushMacrotask();
   });
 }
 

--- a/src/components/Sidebar/FileBrowser.actionfeedback.test.tsx
+++ b/src/components/Sidebar/FileBrowser.actionfeedback.test.tsx
@@ -13,6 +13,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
+import { flushAsync } from "@/test/flushAsync";
 import { createRoot, Root } from "react-dom/client";
 import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "@/store/appStore";
@@ -70,12 +71,6 @@ vi.mock("@/services/api", async (importOriginal) => {
 });
 
 const mockedInvoke = vi.mocked(invoke);
-
-async function flushAsync() {
-  await act(async () => {
-    await new Promise((r) => setTimeout(r, 0));
-  });
-}
 
 let container: HTMLDivElement;
 let root: Root;

--- a/src/components/Sidebar/FileBrowser.inline-input.test.tsx
+++ b/src/components/Sidebar/FileBrowser.inline-input.test.tsx
@@ -9,6 +9,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
+import { flushAsync } from "@/test/flushAsync";
 import { createRoot, Root } from "react-dom/client";
 import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "@/store/appStore";
@@ -41,12 +42,6 @@ vi.mock("@/services/api", async (importOriginal) => {
 });
 
 const mockedInvoke = vi.mocked(invoke);
-
-async function flushAsync() {
-  await act(async () => {
-    await new Promise((r) => setTimeout(r, 0));
-  });
-}
 
 let container: HTMLDivElement;
 let root: Root;

--- a/src/components/Sidebar/FileBrowser.multidelete.test.tsx
+++ b/src/components/Sidebar/FileBrowser.multidelete.test.tsx
@@ -9,6 +9,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
+import { flushAsync } from "@/test/flushAsync";
 import { createRoot, Root } from "react-dom/client";
 import { invoke } from "@tauri-apps/api/core";
 import type { InvokeArgs } from "@tauri-apps/api/core";
@@ -62,12 +63,6 @@ vi.mock("@/services/api", async (importOriginal) => {
 });
 
 const mockedInvoke = vi.mocked(invoke);
-
-async function flushAsync() {
-  await act(async () => {
-    await new Promise((r) => setTimeout(r, 0));
-  });
-}
 
 let container: HTMLDivElement;
 let root: Root;

--- a/src/components/Sidebar/FileBrowser.rename.test.tsx
+++ b/src/components/Sidebar/FileBrowser.rename.test.tsx
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
+import { flushAsync } from "@/test/flushAsync";
 import { createRoot, Root } from "react-dom/client";
 import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "@/store/appStore";
@@ -40,12 +41,6 @@ vi.mock("@/services/api", async (importOriginal) => {
 });
 
 const mockedInvoke = vi.mocked(invoke);
-
-async function flushAsync() {
-  await act(async () => {
-    await new Promise((r) => setTimeout(r, 0));
-  });
-}
 
 let container: HTMLDivElement;
 let root: Root;

--- a/src/components/Sidebar/FileBrowser.test.tsx
+++ b/src/components/Sidebar/FileBrowser.test.tsx
@@ -3,6 +3,7 @@ import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "@/store/appStore";
+import { flushAsync } from "@/test/flushAsync";
 import { FileBrowser, FileMenuItems, MultiSelectMenuItems } from "./FileBrowser";
 import { TooltipProvider } from "@/components/ui";
 import type { TerminalTab, LeafPanel } from "@/types/terminal";
@@ -33,25 +34,6 @@ vi.mock("@/services/api", async (importOriginal) => {
 });
 
 const mockedInvoke = vi.mocked(invoke);
-
-/**
- * Flush pending microtasks (Promise callbacks) inside act().
- *
- * Uses `setImmediate` rather than `setTimeout(…, 0)` so the wait does not depend
- * on the OS timer subsystem. A `setTimeout` macrotask must wait for a real
- * wall-clock timer to fire; on a starved Windows CI runner (coarse ~15ms timer
- * granularity, further delayed under load) that callback can be deferred long
- * enough to trip the 15s per-test timeout — the intermittent
- * `FileBrowser.test.tsx` flake tracked in #2282. `setImmediate` instead resolves
- * on the next event-loop check phase, after microtasks and any due timer
- * callbacks, without waiting on the wall clock — so the flush stays deterministic
- * regardless of how loaded the runner is.
- */
-async function flushAsync() {
-  await act(async () => {
-    await new Promise((r) => setImmediate(r));
-  });
-}
 
 let container: HTMLDivElement;
 let root: Root;

--- a/src/components/Sidebar/FileBrowser.virtualization.test.tsx
+++ b/src/components/Sidebar/FileBrowser.virtualization.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
+import { flushAsync } from "@/test/flushAsync";
 import { createRoot, Root } from "react-dom/client";
 import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "@/store/appStore";
@@ -34,13 +35,6 @@ vi.mock("@/services/api", async (importOriginal) => {
 });
 
 const mockedInvoke = vi.mocked(invoke);
-
-/** Flush pending microtasks (Promise callbacks) inside act(). */
-async function flushAsync() {
-  await act(async () => {
-    await new Promise((r) => setTimeout(r, 0));
-  });
-}
 
 let container: HTMLDivElement;
 let root: Root;

--- a/src/components/Sidebar/FileBrowser.vscode-feedback.test.tsx
+++ b/src/components/Sidebar/FileBrowser.vscode-feedback.test.tsx
@@ -14,6 +14,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
+import { flushAsync } from "@/test/flushAsync";
 import { createRoot, Root } from "react-dom/client";
 import { invoke } from "@tauri-apps/api/core";
 import { useAppStore } from "@/store/appStore";
@@ -74,12 +75,6 @@ vi.mock("@/services/api", async (importOriginal) => {
 });
 
 const mockedInvoke = vi.mocked(invoke);
-
-async function flushAsync() {
-  await act(async () => {
-    await new Promise((r) => setTimeout(r, 0));
-  });
-}
 
 let container: HTMLDivElement;
 let root: Root;

--- a/src/components/Terminal/TerminalSearchBar.test.tsx
+++ b/src/components/Terminal/TerminalSearchBar.test.tsx
@@ -7,6 +7,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
+import { flushAsync as flush } from "@/test/flushAsync";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { withTooltip } from "@/test/tooltip";
@@ -30,12 +31,6 @@ const TAB_ID = "tab-1";
 
 let container: HTMLDivElement;
 let root: Root;
-
-async function flush() {
-  await act(async () => {
-    await new Promise((r) => setTimeout(r, 0));
-  });
-}
 
 function buttonByLabel(label: string): HTMLButtonElement {
   const el = container.querySelector<HTMLButtonElement>(`[aria-label="${label}"]`);

--- a/src/components/UpdateNotification/UpdateNotification.test.tsx
+++ b/src/components/UpdateNotification/UpdateNotification.test.tsx
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
+import { flushAsync as flush } from "@/test/flushAsync";
 import { createRoot, Root } from "react-dom/client";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useAppStore } from "@/store/appStore";
@@ -42,12 +43,6 @@ const mockedOpenUrl = vi.mocked(openUrl);
 
 let container: HTMLDivElement;
 let root: Root;
-
-async function flush() {
-  await act(async () => {
-    await new Promise((r) => setTimeout(r, 0));
-  });
-}
 
 function byTestId(id: string): HTMLButtonElement | null {
   return container.querySelector<HTMLButtonElement>(`[data-testid="${id}"]`);

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { flushMacrotask } from "@/test/flushAsync";
 import { invoke } from "@tauri-apps/api/core";
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -496,7 +497,7 @@ describe("api service", () => {
     // listener (it does so after a dynamic import), then emit `payload`.
     const fireWhenListening = async (payload: unknown) => {
       for (let i = 0; i < 50 && !transferListener; i++) {
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        await flushMacrotask();
       }
       if (!transferListener) throw new Error("transfer listener never registered");
       transferListener({ payload });

--- a/src/store/appStore.layoutBridge.test.ts
+++ b/src/store/appStore.layoutBridge.test.ts
@@ -9,6 +9,7 @@
  * rejected intent falls back to it.
  */
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { flushMacrotask } from "@/test/flushAsync";
 
 import type { LeafPanel, PanelNode } from "@/types/terminal";
 import {
@@ -258,8 +259,8 @@ function seedTree(): PanelNode {
 
 async function flush() {
   // Let the fire-and-forget bridge promise chain settle.
-  await new Promise((r) => setTimeout(r, 0));
-  await new Promise((r) => setTimeout(r, 0));
+  await flushMacrotask();
+  await flushMacrotask();
 }
 
 describe("appStore layout bridge — splitPanel cut (#2151)", () => {

--- a/src/store/appStore.restoreCohortRenderCut.test.ts
+++ b/src/store/appStore.restoreCohortRenderCut.test.ts
@@ -16,6 +16,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { flushMacrotask } from "@/test/flushAsync";
 
 const toastSuccess = vi.fn((_m: unknown, _o?: unknown) => undefined);
 const toastError = vi.fn((_m: unknown, _o?: unknown) => undefined);
@@ -274,7 +275,7 @@ function restoredTabIds(): string[] {
 /** Let the subscribe/dispatch promise chain settle so projection diffs land. */
 async function settleAsync(): Promise<void> {
   for (let i = 0; i < 8; i++) await Promise.resolve();
-  await new Promise((r) => setTimeout(r, 0));
+  await flushMacrotask();
   for (let i = 0; i < 4; i++) await Promise.resolve();
 }
 

--- a/src/store/appStore.sessionBridge.test.ts
+++ b/src/store/appStore.sessionBridge.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushMacrotask as flush } from "@/test/flushAsync";
 
 // Same lightweight service mocks the auto-reconnect suite uses: the loop never
 // calls the backend directly, so these only satisfy module import.
@@ -133,7 +134,6 @@ class FakeTransport implements Transport {
 }
 
 const auto = (tabId: string) => useAppStore.getState().terminalAutoReconnect[tabId];
-const flush = () => new Promise((r) => setTimeout(r, 0));
 
 function makeSshTab(): string {
   return useAppStore.getState().addTab(

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { flushMacrotask as flushPromises } from "@/test/flushAsync";
 
 // Mock service modules before importing the store
 vi.mock("@/services/storage", () => ({
@@ -40,11 +41,6 @@ import { findLeaf, getAllLeaves } from "@/utils/panelTree";
 import * as api from "@/services/api";
 import * as storage from "@/services/storage";
 import type { AgentDefinitionInfo } from "@/services/api";
-
-/** Flush all pending microtasks so `void promise` side-effects settle. */
-function flushPromises(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
 
 describe("appStore", () => {
   beforeEach(() => {

--- a/src/store/useLayoutRenderTree.test.tsx
+++ b/src/store/useLayoutRenderTree.test.tsx
@@ -8,6 +8,7 @@
  * tree rather than render a stale structure.
  */
 import { act } from "react";
+import { flushMacrotask } from "@/test/flushAsync";
 import { createRoot, type Root } from "react-dom/client";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
@@ -146,8 +147,8 @@ async function mount() {
   });
   // Let the async subscribe + seed + onChange settle.
   await act(async () => {
-    await new Promise((r) => setTimeout(r, 0));
-    await new Promise((r) => setTimeout(r, 0));
+    await flushMacrotask();
+    await flushMacrotask();
   });
 }
 

--- a/src/test/flushAsync.ts
+++ b/src/test/flushAsync.ts
@@ -1,0 +1,43 @@
+import { act } from "react";
+
+/**
+ * Resolve on the next event-loop *check* phase via `setImmediate`.
+ *
+ * This is the shared, deterministic replacement for the `await new Promise((r)
+ * => setTimeout(r, 0))` macrotask flush that was previously re-declared in every
+ * component and store test. A `setTimeout(…, 0)` macrotask must wait for a real
+ * wall-clock timer to fire; on a starved Windows CI runner (coarse ~15ms timer
+ * granularity, further delayed under load) that callback can be deferred long
+ * enough to trip the 15s per-test timeout — the intermittent flake first seen in
+ * `FileBrowser.test.tsx` and tracked in #2282. `setImmediate` instead resolves on
+ * the next event-loop check phase, after microtasks and any due timer callbacks,
+ * without waiting on the wall clock — so the flush stays deterministic regardless
+ * of how loaded the runner is.
+ *
+ * Use this directly in non-React tests (store/service). React component tests
+ * that need the flush wrapped in `act()` should use {@link flushAsync}.
+ *
+ * @returns A promise that resolves after the current macrotask completes.
+ */
+export function flushMacrotask(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+/**
+ * Flush pending microtasks (Promise callbacks) and due timer callbacks inside
+ * `act()`.
+ *
+ * The `act()` wrapper keeps React's effect/update scheduling settled so tests do
+ * not log "not wrapped in act(...)" warnings. The underlying wait is the
+ * deterministic {@link flushMacrotask} rather than a wall-clock `setTimeout(…,
+ * 0)`; see that helper for why (#2282).
+ *
+ * @returns A promise that resolves once the flush has settled.
+ */
+export async function flushAsync(): Promise<void> {
+  await act(async () => {
+    await flushMacrotask();
+  });
+}

--- a/src/testbridge/projectionRecorder.test.ts
+++ b/src/testbridge/projectionRecorder.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { flushMacrotask as flush } from "@/test/flushAsync";
 
 import type {
   DiffFrame,
@@ -14,9 +15,6 @@ import type {
 import { ProjectionRecorder } from "./projectionRecorder";
 
 const REGION = "diag.counter";
-
-/** Let a fire-and-forget `ProjectionClient.resync()` settle before asserting. */
-const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 /**
  * A tiny in-memory stand-in for the backend projector, mirroring the substrate's


### PR DESCRIPTION
## Summary

Follow-up to #2282 (PR #2291), which fixed a Windows-CI 15s test-timeout flake in `FileBrowser.test.tsx` by replacing the wall-clock `setTimeout(…, 0)` macrotask flush with a deterministic `setImmediate`-based one. That same primitive was duplicated across the frontend test suite, each copy carrying the identical latent flake.

This PR extracts the primitive into a single shared util and adopts it everywhere the duplicate lived, so the wall-clock-timer flake class can no longer resurface in these files.

## Changes

- **New shared util `src/test/flushAsync.ts`** (mirrors the existing `src/test/tooltip.tsx` shared-helper pattern), exporting:
  - `flushMacrotask()` — the raw deterministic `setImmediate` yield, for non-React store/service tests.
  - `flushAsync()` — the `act()`-wrapped convenience, for React component tests (the canonical #2282 helper).
- **Adopted across 18 test files**, removing each local `setTimeout(…, 0)` flush re-declaration:
  - Components: `FileBrowser.test.tsx` + 6 `FileBrowser.*` siblings, `ConnectionEditor`, `ConnectionSettingsForm.validity`, `TerminalSearchBar`, `UpdateNotification`
  - Store/hook: `appStore.test`, `appStore.layoutBridge`, `appStore.restoreCohortRenderCut`, `appStore.sessionBridge`, `useLayoutRenderTree`
  - Other: `projectionRecorder`, `services/api`
- Files whose local helper name differed (`flush`, `flushPromises`) keep their call sites via an aliased import (`flushMacrotask as flush`), keeping the diff mechanical.

The `setTimeout(…, 0)` flush primitive no longer appears anywhere in the frontend test suite.

## Left local (intentional)

- `src/testbridge/dispatcher.test.ts` uses `setTimeout(() => seq.push("tick"), 0)` to genuinely assert timer *ordering* — not a flush primitive, so it is correctly untouched.

## Verification

- `pnpm test` — full frontend suite green (552 files / 5037 tests).
- `pnpm run lint` and `pnpm exec prettier --check` on touched files — clean.

Test-only change; no changelog fragment.

Closes #2292