### PR TITLE
test(sftp): serialize desktop elevated-save Docker tests (Closes #2238)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7730,6 +7730,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.10.9",
  "shlex",
  "ssh2-config",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -212,3 +212,7 @@ proptest = "1"
 # regression test (#2168) without launching the real Wry app.
 tauri = { version = "2", default-features = false, features = ["wry", "compression", "dynamic-acl", "test"] }
 temp-env = "0.3"
+# Serialize the Docker-backed elevated-save tests that share one root-owned
+# fixture file so they no longer clobber each other under parallel `cargo test`
+# (#2238). Same `#[serial(group)]` convention already used in `core/tests`.
+serial_test = "3"

--- a/src-tauri/src/files/sftp.rs
+++ b/src-tauri/src/files/sftp.rs
@@ -180,10 +180,12 @@ mod tests {
     //
     // The three tests share the one root-owned fixture file, so they must not
     // run concurrently against the same container (they clobber each other's
-    // before/after expectations); run them with `--test-threads=1` until the
-    // per-test fixture isolation tracked in #2238 lands.
+    // before/after expectations). They are serialized in-source with
+    // `#[serial(elevated_save)]` (#2238), which keeps them parallel-safe under
+    // the default `cargo test` regardless of the outer `--test-threads` setting.
     use crate::utils::remote_exec::run_remote_command;
     use crate::utils::ssh_auth::connect_and_authenticate;
+    use serial_test::serial;
     use termihub_core::backends::ssh::handler::SshSession;
     use termihub_core::backends::ssh::SftpAdvancedOps;
 
@@ -282,6 +284,7 @@ mod tests {
     /// Correct password → `Success`: the root-owned file is rewritten, its
     /// owner/mode are preserved, and no temp upload leaks.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial(elevated_save)]
     async fn elevated_save_success_rewrites_root_file_over_real_ssh() {
         let port = env_port("TERMIHUB_TEST_SSH_SUDO_PORT", DEFAULT_SSH_SUDO_PORT);
         if !ssh_port_reachable(port) {
@@ -343,6 +346,7 @@ mod tests {
     /// Wrong password → `IncorrectPassword`: the file is untouched and the temp
     /// upload is cleaned up.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial(elevated_save)]
     async fn elevated_save_wrong_password_leaves_file_untouched() {
         let port = env_port("TERMIHUB_TEST_SSH_SUDO_PORT", DEFAULT_SSH_SUDO_PORT);
         if !ssh_port_reachable(port) {
@@ -396,6 +400,7 @@ mod tests {
     /// No sudo installed → `Other`: the file is untouched and the temp upload is
     /// cleaned up.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial(elevated_save)]
     async fn elevated_save_without_sudo_returns_other() {
         let port = env_port("TERMIHUB_TEST_SSH_NOSUDO_PORT", DEFAULT_SSH_NOSUDO_PORT);
         if !ssh_port_reachable(port) {


### PR DESCRIPTION
## Summary

The three Docker-backed elevated-save tests in `src-tauri/src/files/sftp.rs` — `elevated_save_success_rewrites_root_file_over_real_ssh`, `elevated_save_wrong_password_leaves_file_untouched`, and `elevated_save_without_sudo_returns_other` — all read/rewrite the **same** root-owned fixture file (`/etc/termihub-elevated-target.txt`) on the `ssh-sudo` container. Under the default parallel `cargo test`, the success and wrong-password tests clobbered each other's before/after expectations and flaked; they only passed reliably under `--test-threads=1`.

## Fix

Serialize the three tests in-source with `serial_test`'s `#[serial(elevated_save)]`, matching the existing convention already used in `core/tests` (`ssh_advanced.rs` uses `#[serial(ssh_bastion)]`, `network_resilience.rs` uses `#[serial(network_fault)]`). This keeps them parallel-safe under the default `cargo test` without needing `--test-threads=1`, and is cleaner than minting per-test root-owned fixture files (which would need extra in-container sudo setup).

- Added `serial_test = "3"` as a `src-tauri` dev-dependency (it was already a `core` dev-dependency, pinned to the same major).
- Annotated the three tests with `#[serial(elevated_save)]` and updated the module comment that previously told readers to run with `--test-threads=1`.

## Verification

These tests are **Docker-gated and do NOT run in per-PR CI** (Docker fixtures aren't available there), so this stays latent until run locally or in the release lane — per-PR CI green does not exercise them.

Verified locally in this checkout's isolated Docker Compose project (`ssh-sudo` / `ssh-nosudo` fixtures up):

- `cargo test -p termihub --lib elevated_save` under **default parallel** cargo test: all 3 pass, repeated across 4 runs, stable.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p termihub --all-targets --all-features -- -D warnings`: clean.
- `cargo build -p termihub --tests`: compiles.

Test-only change — no changelog fragment.

Closes #2238

## Note on sibling issue

Scoped strictly to the three tests named in #2238. The broader shared-remote-state isolation (#2220) is intentionally left untouched.