### PR TITLE
refactor(store): extract session-history slice from appStore (part of #2077)

### DIFF
--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -61,16 +61,6 @@ import {
   reloadExternalConnections as apiReloadExternalConnections,
   getRecoveryWarnings,
 } from "@/services/storage";
-import {
-  getSessionHistory,
-  recordSession as apiRecordSession,
-  setHistoryEntryPinned as apiSetHistoryEntryPinned,
-  markHistoryEntryPromoted as apiMarkHistoryEntryPromoted,
-  removeHistoryEntry as apiRemoveHistoryEntry,
-  clearSessionHistory as apiClearSessionHistory,
-} from "@/services/sessionHistoryApi";
-import { SessionHistoryEntry } from "@/types/sessionHistory";
-import { sessionHistoryTitle } from "@/utils/sessionHistoryTitle";
 import { deriveTabStatus, type TabStatusMaps } from "@/utils/tabStatus";
 import {
   sftpOpen,
@@ -169,6 +159,7 @@ import { createTunnelSlice, TunnelSlice } from "./slices/tunnelSlice";
 import { createEmbeddedServersSlice, EmbeddedServersSlice } from "./slices/embedded-serversSlice";
 import { createMacrosSlice, MacrosSlice } from "./slices/macrosSlice";
 import { createPluginsSlice, PluginsSlice } from "./slices/pluginsSlice";
+import { createSessionHistorySlice, SessionHistorySlice } from "./slices/sessionHistorySlice";
 
 export type { MacroPlaybackState, PlayMacroOptions } from "./slices/macrosSlice";
 import {
@@ -428,21 +419,6 @@ function stripPassword(connection: SavedConnection): SavedConnection {
   return connection;
 }
 
-/** Config keys that hold secrets and must never be written to session history. */
-const HISTORY_SECRET_KEYS = ["password", "passphrase", "keyPassphrase"];
-
-/**
- * Return a copy of a connection config with all secret fields removed, for
- * safe storage in the session history (which never holds credentials).
- */
-function stripHistorySecrets(config: ConnectionConfig): ConnectionConfig {
-  const inner = { ...(config.config as Record<string, unknown>) };
-  for (const key of HISTORY_SECRET_KEYS) {
-    delete inner[key];
-  }
-  return { type: config.type, config: inner };
-}
-
 /**
  * A staged/available update reported by a connected agent via its
  * `agent.update_available` notification (#1352). Recorded per agent id so the
@@ -479,7 +455,8 @@ export interface AgentUpdatePending {
  */
 const AGENT_UPDATE_RECONNECT_BUFFER_SECS = 3;
 
-export interface AppState extends TunnelSlice, EmbeddedServersSlice, MacrosSlice, PluginsSlice {
+export interface AppState
+  extends TunnelSlice, EmbeddedServersSlice, MacrosSlice, PluginsSlice, SessionHistorySlice {
   // Connection type registry (loaded from backend at startup)
   connectionTypes: ConnectionTypeInfo[];
 
@@ -983,24 +960,8 @@ export interface AppState extends TunnelSlice, EmbeddedServersSlice, MacrosSlice
   addConnection: (connection: SavedConnection) => void;
   bulkAddConnections: (connections: SavedConnection[]) => void;
 
-  // --- Session history (#1883) ---
-  /** Recorded session history, ordered pinned-first then most-recently-used. */
-  sessionHistory: SessionHistoryEntry[];
-  /** Load session history from the backend. */
-  loadSessionHistory: () => Promise<void>;
-  /**
-   * Record a session open in history (deduplicated + evicted in the backend).
-   * A no-op when `sessionHistoryEnabled` is off. Failures are logged, not thrown.
-   */
-  recordSession: (connectionType: string, config: ConnectionConfig) => Promise<void>;
-  /** Pin or unpin a history entry. */
-  pinHistoryEntry: (dedupKey: string, pinned: boolean) => Promise<void>;
-  /** Mark a history entry as promoted to a saved connection. */
-  markHistoryPromoted: (dedupKey: string) => Promise<void>;
-  /** Remove a single history entry. */
-  removeHistoryEntry: (dedupKey: string) => Promise<void>;
-  /** Clear all session history. */
-  clearSessionHistory: () => Promise<void>;
+  // Session history — data + load/record/pin/promote/remove/clear live in
+  // SessionHistorySlice (#1883, extracted under #2077).
   updateConnection: (connection: SavedConnection) => void;
   deleteConnection: (connectionId: string) => void;
   bulkDeleteConnections: (connectionIds: string[]) => void;
@@ -2929,6 +2890,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
     ...createEmbeddedServersSlice(set, get, store),
     ...createMacrosSlice(set, get, store),
     ...createPluginsSlice(set, get, store),
+    ...createSessionHistorySlice(set, get, store),
 
     // Connection type registry — updated by loadFromBackend()
     connectionTypes: [],
@@ -5437,59 +5399,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
       void applyConnectionReload();
     },
 
-    // --- Session history (#1883) ---
-    sessionHistory: [],
-
-    loadSessionHistory: async () => {
-      try {
-        const entries = await getSessionHistory();
-        set({ sessionHistory: entries });
-      } catch (err) {
-        frontendLog(
-          "session_history",
-          `Failed to load session history: ${err instanceof Error ? err.message : String(err)}`
-        );
-      }
-    },
-
-    recordSession: async (connectionType, config) => {
-      const settings = get().settings;
-      if (settings.sessionHistoryEnabled === false) return;
-      // Privacy: passwords/passphrases are NEVER written to history, regardless
-      // of the connection's savePassword flag (they live in the credential store).
-      const safeConfig = stripHistorySecrets(config);
-      const title = sessionHistoryTitle(connectionType, safeConfig);
-      const limit = settings.sessionHistoryLimit ?? 50;
-      try {
-        const entries = await apiRecordSession(connectionType, safeConfig, title, limit);
-        set({ sessionHistory: entries });
-      } catch (err) {
-        frontendLog(
-          "session_history",
-          `Failed to record session: ${err instanceof Error ? err.message : String(err)}`
-        );
-      }
-    },
-
-    pinHistoryEntry: async (dedupKey, pinned) => {
-      const entries = await apiSetHistoryEntryPinned(dedupKey, pinned);
-      set({ sessionHistory: entries });
-    },
-
-    markHistoryPromoted: async (dedupKey) => {
-      const entries = await apiMarkHistoryEntryPromoted(dedupKey);
-      set({ sessionHistory: entries });
-    },
-
-    removeHistoryEntry: async (dedupKey) => {
-      const entries = await apiRemoveHistoryEntry(dedupKey);
-      set({ sessionHistory: entries });
-    },
-
-    clearSessionHistory: async () => {
-      const entries = await apiClearSessionHistory();
-      set({ sessionHistory: entries });
-    },
+    // Session history (#1883) — data + load/record/pin/promote/remove/clear
+    // provided by createSessionHistorySlice (extracted under #2077).
 
     addConnection: (connection) => {
       set((state) => ({ connections: [...state.connections, connection] }));

--- a/src/store/slices/sessionHistorySlice.ts
+++ b/src/store/slices/sessionHistorySlice.ts
@@ -1,0 +1,119 @@
+import { StateCreator } from "zustand";
+
+import {
+  getSessionHistory,
+  recordSession as apiRecordSession,
+  setHistoryEntryPinned as apiSetHistoryEntryPinned,
+  markHistoryEntryPromoted as apiMarkHistoryEntryPromoted,
+  removeHistoryEntry as apiRemoveHistoryEntry,
+  clearSessionHistory as apiClearSessionHistory,
+} from "@/services/sessionHistoryApi";
+import { ConnectionConfig } from "@/types/terminal";
+import { SessionHistoryEntry } from "@/types/sessionHistory";
+import { frontendLog } from "@/utils/frontendLog";
+import { sessionHistoryTitle } from "@/utils/sessionHistoryTitle";
+
+import type { AppState } from "../appStore";
+
+/**
+ * Recent-session history domain slice (#1883, extracted under #2077): the
+ * recorded-session list plus the load/record/pin/promote/remove/clear actions
+ * that drive it. Extracted verbatim from the monolithic root store as a
+ * behavior-preserving Zustand slice — every action still receives the shared
+ * `set`/`get` typed against the full {@link AppState}, so the public store shape
+ * and behavior are unchanged. Mirrors the SSH tunnel slice (#2077) and the
+ * embedded-server / macros / plugins slices (#2113/#2114/#2115).
+ */
+
+/** Secret fields that must never be written to session history. */
+const HISTORY_SECRET_KEYS = ["password", "passphrase", "keyPassphrase"];
+
+/**
+ * Return a copy of a connection config with all secret fields removed, for
+ * safe storage in the session history (which never holds credentials).
+ */
+function stripHistorySecrets(config: ConnectionConfig): ConnectionConfig {
+  const inner = { ...(config.config as Record<string, unknown>) };
+  for (const key of HISTORY_SECRET_KEYS) {
+    delete inner[key];
+  }
+  return { type: config.type, config: inner };
+}
+
+export interface SessionHistorySlice {
+  /** Recorded session history, ordered pinned-first then most-recently-used. */
+  sessionHistory: SessionHistoryEntry[];
+  /** Load session history from the backend. */
+  loadSessionHistory: () => Promise<void>;
+  /**
+   * Record a session open in history (deduplicated + evicted in the backend).
+   * A no-op when `sessionHistoryEnabled` is off. Failures are logged, not thrown.
+   */
+  recordSession: (connectionType: string, config: ConnectionConfig) => Promise<void>;
+  /** Pin or unpin a history entry. */
+  pinHistoryEntry: (dedupKey: string, pinned: boolean) => Promise<void>;
+  /** Mark a history entry as promoted to a saved connection. */
+  markHistoryPromoted: (dedupKey: string) => Promise<void>;
+  /** Remove a single history entry. */
+  removeHistoryEntry: (dedupKey: string) => Promise<void>;
+  /** Clear all session history. */
+  clearSessionHistory: () => Promise<void>;
+}
+
+export const createSessionHistorySlice: StateCreator<AppState, [], [], SessionHistorySlice> = (
+  set,
+  get
+) => ({
+  sessionHistory: [],
+
+  loadSessionHistory: async () => {
+    try {
+      const entries = await getSessionHistory();
+      set({ sessionHistory: entries });
+    } catch (err) {
+      frontendLog(
+        "session_history",
+        `Failed to load session history: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  },
+
+  recordSession: async (connectionType, config) => {
+    const settings = get().settings;
+    if (settings.sessionHistoryEnabled === false) return;
+    // Privacy: passwords/passphrases are NEVER written to history, regardless
+    // of the connection's savePassword flag (they live in the credential store).
+    const safeConfig = stripHistorySecrets(config);
+    const title = sessionHistoryTitle(connectionType, safeConfig);
+    const limit = settings.sessionHistoryLimit ?? 50;
+    try {
+      const entries = await apiRecordSession(connectionType, safeConfig, title, limit);
+      set({ sessionHistory: entries });
+    } catch (err) {
+      frontendLog(
+        "session_history",
+        `Failed to record session: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  },
+
+  pinHistoryEntry: async (dedupKey, pinned) => {
+    const entries = await apiSetHistoryEntryPinned(dedupKey, pinned);
+    set({ sessionHistory: entries });
+  },
+
+  markHistoryPromoted: async (dedupKey) => {
+    const entries = await apiMarkHistoryEntryPromoted(dedupKey);
+    set({ sessionHistory: entries });
+  },
+
+  removeHistoryEntry: async (dedupKey) => {
+    const entries = await apiRemoveHistoryEntry(dedupKey);
+    set({ sessionHistory: entries });
+  },
+
+  clearSessionHistory: async () => {
+    const entries = await apiClearSessionHistory();
+    set({ sessionHistory: entries });
+  },
+});


### PR DESCRIPTION
## What

Extracts the **recorded-session-history** domain out of the 9k-line `src/store/appStore.ts` monolith into its own behavior-preserving Zustand slice: `src/store/slices/sessionHistorySlice.ts`.

This follows the slice pattern already established under #2077 (tunnel) and #2113/#2114/#2115 (embedded-servers / macros / plugins): a `StateCreator<AppState, [], [], SessionHistorySlice>` factory spread into the root `create()` call, with the slice interface added to `AppState extends …`.

## Scope (one domain, deliberately bounded)

`appStore.ts` is a serialization hotspot, so this PR moves **one** low-risk, self-contained, non-projection domain — not the whole store. The slice owns:

- state: `sessionHistory`
- actions: `loadSessionHistory`, `recordSession`, `pinHistoryEntry`, `markHistoryPromoted`, `removeHistoryEntry`, `clearSessionHistory`
- the private `stripHistorySecrets` helper + `HISTORY_SECRET_KEYS` (used only by `recordSession`), moved alongside it

## Behavior unchanged

- Actions still receive the shared `set`/`get` typed against the full `AppState`, so `get().settings` and cross-domain access work identically.
- The public store API is byte-identical: every call site (`useAppStore((s) => s.sessionHistory)`, `get().recordSession(...)`, `get().loadSessionHistory()`, the `RecentSessionsSidebar` consumers) is untouched — **zero import churn**.
- Now-unused `@/services/sessionHistoryApi` / `@/types/sessionHistory` / `@/utils/sessionHistoryTitle` imports removed from `appStore.ts`.

## Verification

- `pnpm test` — 5037/5037 pass (incl. `appStore.sessionHistory.test.ts`, `RecentSessionsSidebar`)
- `pnpm build` (tsc + vite) — green
- `pnpm run lint` — clean
- `pnpm exec prettier --check` — clean

Refactor with no user-facing change → no changelog fragment.

Remaining domains to slice are tracked in the follow-up issue #2300.

Part of #2077