### PR TITLE
refactor(store): extract zoom slice from appStore (part of #2300)

### DIFF
--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -160,6 +160,7 @@ import { createEmbeddedServersSlice, EmbeddedServersSlice } from "./slices/embed
 import { createMacrosSlice, MacrosSlice } from "./slices/macrosSlice";
 import { createPluginsSlice, PluginsSlice } from "./slices/pluginsSlice";
 import { createSessionHistorySlice, SessionHistorySlice } from "./slices/sessionHistorySlice";
+import { createZoomSlice, ZoomSlice } from "./slices/zoomSlice";
 
 export type { MacroPlaybackState, PlayMacroOptions } from "./slices/macrosSlice";
 import {
@@ -456,7 +457,13 @@ export interface AgentUpdatePending {
 const AGENT_UPDATE_RECONNECT_BUFFER_SECS = 3;
 
 export interface AppState
-  extends TunnelSlice, EmbeddedServersSlice, MacrosSlice, PluginsSlice, SessionHistorySlice {
+  extends
+    TunnelSlice,
+    EmbeddedServersSlice,
+    MacrosSlice,
+    PluginsSlice,
+    SessionHistorySlice,
+    ZoomSlice {
   // Connection type registry (loaded from backend at startup)
   connectionTypes: ConnectionTypeInfo[];
 
@@ -888,11 +895,8 @@ export interface AppState
   chordPending: string | null;
   setChordPending: (pending: string | null) => void;
 
-  // Zoom (runtime-only, not persisted) — scale factor for webview zoom
-  zoomLevel: number;
-  zoomIn: () => void;
-  zoomOut: () => void;
-  zoomReset: () => void;
+  // Zoom (runtime-only) — scale factor + in/out/reset provided by ZoomSlice
+  // (extracted under #2077 via #2300).
 
   // Terminal search (runtime-only)
   terminalSearchVisible: Record<string, boolean>;
@@ -2891,6 +2895,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
     ...createMacrosSlice(set, get, store),
     ...createPluginsSlice(set, get, store),
     ...createSessionHistorySlice(set, get, store),
+    ...createZoomSlice(set, get, store),
 
     // Connection type registry — updated by loadFromBackend()
     connectionTypes: [],
@@ -5004,13 +5009,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
     chordPending: null,
     setChordPending: (pending) => set({ chordPending: pending }),
 
-    // Zoom (runtime-only, not persisted) — scale factor for webview zoom
-    zoomLevel: 1.0,
-    zoomIn: () =>
-      set((s) => ({ zoomLevel: Math.min(parseFloat((s.zoomLevel * 1.1).toFixed(2)), 3.0) })),
-    zoomOut: () =>
-      set((s) => ({ zoomLevel: Math.max(parseFloat((s.zoomLevel / 1.1).toFixed(2)), 0.5) })),
-    zoomReset: () => set({ zoomLevel: 1.0 }),
+    // Zoom (runtime-only) — scale factor + in/out/reset provided by
+    // createZoomSlice (extracted under #2077 via #2300).
 
     // Terminal search (runtime-only)
     terminalSearchVisible: {},

--- a/src/store/slices/zoomSlice.ts
+++ b/src/store/slices/zoomSlice.ts
@@ -1,0 +1,34 @@
+import { StateCreator } from "zustand";
+
+import type { AppState } from "../appStore";
+
+/**
+ * Webview zoom domain slice (extracted under #2077 via #2300): the runtime-only
+ * (never persisted) webview scale factor plus the in/out/reset actions that
+ * drive it. Extracted verbatim from the monolithic root store as a
+ * behavior-preserving Zustand slice — every action still receives the shared
+ * `set`/`get` typed against the full {@link AppState}, so the public store shape
+ * and behavior are unchanged. Mirrors the SSH tunnel slice (#2077) and the
+ * embedded-server / macros / plugins / session-history slices
+ * (#2113/#2114/#2115/#2299).
+ */
+
+export interface ZoomSlice {
+  /** Runtime-only webview scale factor (1.0 = 100%), not persisted. */
+  zoomLevel: number;
+  /** Increase the webview zoom by 10%, capped at 3.0. */
+  zoomIn: () => void;
+  /** Decrease the webview zoom by ~10%, floored at 0.5. */
+  zoomOut: () => void;
+  /** Reset the webview zoom back to 1.0. */
+  zoomReset: () => void;
+}
+
+export const createZoomSlice: StateCreator<AppState, [], [], ZoomSlice> = (set) => ({
+  zoomLevel: 1.0,
+  zoomIn: () =>
+    set((s) => ({ zoomLevel: Math.min(parseFloat((s.zoomLevel * 1.1).toFixed(2)), 3.0) })),
+  zoomOut: () =>
+    set((s) => ({ zoomLevel: Math.max(parseFloat((s.zoomLevel / 1.1).toFixed(2)), 0.5) })),
+  zoomReset: () => set({ zoomLevel: 1.0 }),
+});


### PR DESCRIPTION
## Summary

Continues the Zustand domain-slice extraction from `appStore.ts` (~8.8k lines). Extracts the **webview zoom** domain — the smallest, most-isolated runtime-only candidate on the issue's list — into `src/store/slices/zoomSlice.ts`, mirroring the tunnel / embedded-servers / macros / plugins / session-history slices established under #2077.

Moved:
- `zoomLevel` (runtime-only scale factor, never persisted)
- `zoomIn` / `zoomOut` / `zoomReset`

## Why zoom (not terminal search)

The branch was pre-named for terminal search, but zoom is cleaner: terminal-search state (`terminalSearchVisible`) is entangled with the tab-close cleanup path (`omitKey` on tab close in three places), so extracting it now would touch that unrelated logic. Zoom has a single consumer (`useWebviewZoom.ts`) and no cleanup entanglement — a clean one-domain slice. Terminal search stays on the issue's candidate list for a follow-up slice.

## No API change

The public store API is byte-identical: `useAppStore((s) => s.zoomLevel)` selectors and `get().zoomIn()` etc. keep working unchanged. The only consumers (`useWebviewZoom.ts`, `appStore.test.ts`) are untouched. Every action still receives the shared `set`/`get` typed against the full `AppState` via the `StateCreator<AppState, [], [], ZoomSlice>` factory.

## Verification

- `pnpm test` — 5037 tests pass (552 files), including the existing zoom tests in `appStore.test.ts`
- `pnpm run lint` — clean
- `pnpm exec prettier --check` — clean
- `pnpm build` — succeeds

Part of #2300
Part of #2077