### PR TITLE
refactor(store): extract command-palette slice from appStore (part of #2300)

### DIFF
--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -161,6 +161,7 @@ import { createMacrosSlice, MacrosSlice } from "./slices/macrosSlice";
 import { createPluginsSlice, PluginsSlice } from "./slices/pluginsSlice";
 import { createSessionHistorySlice, SessionHistorySlice } from "./slices/sessionHistorySlice";
 import { createZoomSlice, ZoomSlice } from "./slices/zoomSlice";
+import { createCommandPaletteSlice, CommandPaletteSlice } from "./slices/commandPaletteSlice";
 
 export type { MacroPlaybackState, PlayMacroOptions } from "./slices/macrosSlice";
 import {
@@ -463,7 +464,8 @@ export interface AppState
     MacrosSlice,
     PluginsSlice,
     SessionHistorySlice,
-    ZoomSlice {
+    ZoomSlice,
+    CommandPaletteSlice {
   // Connection type registry (loaded from backend at startup)
   connectionTypes: ConnectionTypeInfo[];
 
@@ -872,18 +874,9 @@ export interface AppState
   applyLayoutPreset: (preset: "default" | "focus" | "zen") => void;
   toggleActivityBarView: (view: SidebarView) => void;
 
-  // Shortcuts overlay
-  shortcutsOverlayOpen: boolean;
-  setShortcutsOverlayOpen: (open: boolean) => void;
-
-  // Command palette (Cmd/Ctrl+P) — fuzzy-find commands + saved connections
-  commandPaletteOpen: boolean;
-  setCommandPaletteOpen: (open: boolean) => void;
-
-  // Standalone overlay views (updates, about) — opened from the settings menu
-  overlayView: "updates" | "about" | null;
-  openOverlayView: (view: "updates" | "about") => void;
-  closeOverlayView: () => void;
+  // Shortcuts overlay + command palette + standalone overlay views (updates,
+  // about) — runtime-only open/close flags provided by CommandPaletteSlice
+  // (extracted under #2077 via #2300).
 
   // Panel zoom overlay (runtime-only) — temporarily expand the active terminal tab to full view
   zoomedTabId: string | null;
@@ -2896,6 +2889,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
     ...createPluginsSlice(set, get, store),
     ...createSessionHistorySlice(set, get, store),
     ...createZoomSlice(set, get, store),
+    ...createCommandPaletteSlice(set, get, store),
 
     // Connection type registry — updated by loadFromBackend()
     connectionTypes: [],
@@ -4977,17 +4971,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
 
     setLayoutDialogOpen: (open) => set({ layoutDialogOpen: open }),
 
-    // Shortcuts overlay
-    shortcutsOverlayOpen: false,
-    setShortcutsOverlayOpen: (open) => set({ shortcutsOverlayOpen: open }),
-
-    commandPaletteOpen: false,
-    setCommandPaletteOpen: (open) => set({ commandPaletteOpen: open }),
-
-    // Standalone overlay views
-    overlayView: null,
-    openOverlayView: (view) => set({ overlayView: view }),
-    closeOverlayView: () => set({ overlayView: null }),
+    // Shortcuts overlay + command palette + standalone overlay views provided
+    // by createCommandPaletteSlice (extracted under #2077 via #2300).
 
     // Panel zoom overlay
     zoomedTabId: null,

--- a/src/store/slices/commandPaletteSlice.ts
+++ b/src/store/slices/commandPaletteSlice.ts
@@ -1,0 +1,49 @@
+import { StateCreator } from "zustand";
+
+import type { AppState } from "../appStore";
+
+/**
+ * Command palette / overlay-views domain slice (extracted under #2077 via
+ * #2300): the runtime-only (never persisted) open/closed flags for the
+ * keyboard-shortcuts overlay, the Cmd/Ctrl+P command palette, and the
+ * standalone overlay views (updates / about), plus the setters that drive them.
+ * Extracted verbatim from the monolithic root store as a behavior-preserving
+ * Zustand slice — every action still receives the shared `set`/`get` typed
+ * against the full {@link AppState}, so the public store shape and behavior are
+ * unchanged. Mirrors the SSH tunnel slice (#2077) and the embedded-server /
+ * macros / plugins / session-history / zoom slices
+ * (#2113/#2114/#2115/#2299/#2300).
+ */
+
+export interface CommandPaletteSlice {
+  /** Whether the keyboard-shortcuts overlay is open (runtime-only). */
+  shortcutsOverlayOpen: boolean;
+  /** Open or close the keyboard-shortcuts overlay. */
+  setShortcutsOverlayOpen: (open: boolean) => void;
+
+  /** Whether the Cmd/Ctrl+P command palette is open (runtime-only). */
+  commandPaletteOpen: boolean;
+  /** Open or close the command palette. */
+  setCommandPaletteOpen: (open: boolean) => void;
+
+  /** The active standalone overlay view (updates / about), or null when none. */
+  overlayView: "updates" | "about" | null;
+  /** Open a standalone overlay view. */
+  openOverlayView: (view: "updates" | "about") => void;
+  /** Close the active standalone overlay view. */
+  closeOverlayView: () => void;
+}
+
+export const createCommandPaletteSlice: StateCreator<AppState, [], [], CommandPaletteSlice> = (
+  set
+) => ({
+  shortcutsOverlayOpen: false,
+  setShortcutsOverlayOpen: (open) => set({ shortcutsOverlayOpen: open }),
+
+  commandPaletteOpen: false,
+  setCommandPaletteOpen: (open) => set({ commandPaletteOpen: open }),
+
+  overlayView: null,
+  openOverlayView: (view) => set({ overlayView: view }),
+  closeOverlayView: () => set({ overlayView: null }),
+});


### PR DESCRIPTION
Continues the Zustand domain-slice extraction from `src/store/appStore.ts` established in #2077, extracting the **command palette / overlay views** domain.

## What moved
New `src/store/slices/commandPaletteSlice.ts` (`CommandPaletteSlice`) holds the runtime-only (never persisted) overlay flags and their setters, extracted verbatim:

- `shortcutsOverlayOpen` / `setShortcutsOverlayOpen`
- `commandPaletteOpen` / `setCommandPaletteOpen`
- `overlayView` / `openOverlayView` / `closeOverlayView`

Wired in exactly like the existing slices: import added, `AppState extends … CommandPaletteSlice`, factory spread into `create()`, and the inline interface + action blocks removed from `appStore.ts`.

## Isolation
`graft grep` confirmed these symbols appear only in the interface + create block of `appStore.ts` — no persist/partialize, reset, or cross-domain references. Pure `set` calls, no entanglement with the deferred projection-migration domains. The nearby panel-zoom overlay (`zoomedTabId`, `toggleZoomActiveTab`) was deliberately left in place — it touches the active terminal tab and belongs to the tab domain.

## Public API unchanged
The store shape and behavior are byte-identical — every action still receives the shared `set`/`get` typed against the full `AppState`, so all `useAppStore((s) => s.x)` selectors and `get().action()` call sites are unchanged. No call-site churn.

## Verification
- `pnpm test` — 5037 passed (552 files)
- `pnpm run lint` — clean
- `pnpm exec prettier --check "src/**/*.{ts,tsx,css}"` — clean
- `pnpm build` — success

Part of #2300
Part of #2077