### PR TITLE
refactor(store): extract http monitors slice from appStore (part of #2300)

### DIFF
--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -24,7 +24,6 @@ import {
   SessionCloseConfirmRequest,
   BroadcastScope,
 } from "@/types/terminal";
-import type { HttpMonitorState } from "@/types/network";
 import {
   SavedConnection,
   ConnectionFolder,
@@ -162,6 +161,7 @@ import { createPluginsSlice, PluginsSlice } from "./slices/pluginsSlice";
 import { createSessionHistorySlice, SessionHistorySlice } from "./slices/sessionHistorySlice";
 import { createZoomSlice, ZoomSlice } from "./slices/zoomSlice";
 import { createCommandPaletteSlice, CommandPaletteSlice } from "./slices/commandPaletteSlice";
+import { createHttpMonitorsSlice, HttpMonitorsSlice } from "./slices/httpMonitorsSlice";
 
 export type { MacroPlaybackState, PlayMacroOptions } from "./slices/macrosSlice";
 import {
@@ -465,7 +465,8 @@ export interface AppState
     PluginsSlice,
     SessionHistorySlice,
     ZoomSlice,
-    CommandPaletteSlice {
+    CommandPaletteSlice,
+    HttpMonitorsSlice {
   // Connection type registry (loaded from backend at startup)
   connectionTypes: ConnectionTypeInfo[];
 
@@ -651,8 +652,6 @@ export interface AppState
     prefillHost?: string,
     connectionId?: string
   ) => void;
-  httpMonitors: HttpMonitorState[];
-  setHttpMonitors: (monitors: HttpMonitorState[]) => void;
   /**
    * Open (or focus) an editor tab for a file.
    *
@@ -2890,6 +2889,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
     ...createSessionHistorySlice(set, get, store),
     ...createZoomSlice(set, get, store),
     ...createCommandPaletteSlice(set, get, store),
+    ...createHttpMonitorsSlice(set, get, store),
 
     // Connection type registry — updated by loadFromBackend()
     connectionTypes: [],
@@ -2897,9 +2897,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
     // Platform default shell — updated by loadFromBackend()
     defaultShell: "bash",
 
-    // Network monitors (populated by NetworkToolsSidebar on open)
-    httpMonitors: [],
-    setHttpMonitors: (monitors) => set({ httpMonitors: monitors }),
+    // Network monitors (httpMonitors + setHttpMonitors) provided by
+    // createHttpMonitorsSlice (extracted under #2077 via #2300).
 
     // Sidebar
     sidebarView: "connections",

--- a/src/store/slices/httpMonitorsSlice.ts
+++ b/src/store/slices/httpMonitorsSlice.ts
@@ -1,0 +1,31 @@
+import { StateCreator } from "zustand";
+
+import type { AppState } from "../appStore";
+import type { HttpMonitorState } from "@/types/network";
+
+/**
+ * HTTP monitors domain slice (extracted under #2077 via #2300): the list of
+ * running network HTTP monitors that the Network Tools sidebar keeps in sync
+ * as the single source of truth, plus its replace-all setter. Extracted
+ * verbatim from the monolithic root store as a behavior-preserving Zustand
+ * slice — the setter still receives the shared `set` typed against the full
+ * {@link AppState}, so the public store shape and behavior are unchanged. The
+ * tab-opening `openNetworkDiagnosticTab` action deliberately stays in the tab
+ * domain. Mirrors the SSH tunnel slice (#2077) and the embedded-server /
+ * macros / plugins / session-history / zoom / command-palette slices
+ * (#2113/#2114/#2115/#2299/#2300).
+ */
+
+export interface HttpMonitorsSlice {
+  /** Running network HTTP monitors (populated by NetworkToolsSidebar on open). */
+  httpMonitors: HttpMonitorState[];
+  /** Replace the full list of HTTP monitors. */
+  setHttpMonitors: (monitors: HttpMonitorState[]) => void;
+}
+
+export const createHttpMonitorsSlice: StateCreator<AppState, [], [], HttpMonitorsSlice> = (
+  set
+) => ({
+  httpMonitors: [],
+  setHttpMonitors: (monitors) => set({ httpMonitors: monitors }),
+});


### PR DESCRIPTION
Extracts the **HTTP monitors** domain out of the monolithic `appStore.ts` into a dedicated Zustand slice, following the domain-slice pattern established by the tunnel / embedded-servers / macros / plugins / session-history / zoom / command-palette slices.

## What moved
- `httpMonitors: HttpMonitorState[]` state
- `setHttpMonitors` replace-all setter

into `src/store/slices/httpMonitorsSlice.ts` (`createHttpMonitorsSlice`), wired via `AppState extends HttpMonitorsSlice`, the `...createHttpMonitorsSlice(set, get, store)` factory spread, and the import block. The now-unused `HttpMonitorState` type import was removed from `appStore.ts`.

The tab-opening `openNetworkDiagnosticTab` action deliberately **stays** in the tab domain (per the issue note).

## Guarantees
- Public store API is byte-identical — `useAppStore((s) => s.httpMonitors)` / `s.setHttpMonitors` selectors unchanged. No call-site churn.
- No deferred projection-migration state touched.

## Verification
- `pnpm test` — 5037 passed (552 files)
- `pnpm run lint` — clean
- `pnpm exec prettier --check "src/**/*.{ts,tsx,css}"` — clean
- `pnpm build` — succeeds

Part of #2300
Part of #2077