### PR TITLE
refactor(store): extract dialogs slice from appStore (part of #2300)

### DIFF
--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -38,7 +38,6 @@ import {
   LayoutConfig,
   DEFAULT_LAYOUT,
   LAYOUT_PRESETS,
-  RecoveryWarning,
   PersistentRunState,
   PersistentSessionEntry,
   ShellIntegrationSettings,
@@ -162,6 +161,7 @@ import { createSessionHistorySlice, SessionHistorySlice } from "./slices/session
 import { createZoomSlice, ZoomSlice } from "./slices/zoomSlice";
 import { createCommandPaletteSlice, CommandPaletteSlice } from "./slices/commandPaletteSlice";
 import { createHttpMonitorsSlice, HttpMonitorsSlice } from "./slices/httpMonitorsSlice";
+import { createDialogsSlice, DialogsSlice } from "./slices/dialogsSlice";
 
 export type { MacroPlaybackState, PlayMacroOptions } from "./slices/macrosSlice";
 import {
@@ -466,7 +466,8 @@ export interface AppState
     SessionHistorySlice,
     ZoomSlice,
     CommandPaletteSlice,
-    HttpMonitorsSlice {
+    HttpMonitorsSlice,
+    DialogsSlice {
   // Connection type registry (loaded from backend at startup)
   connectionTypes: ConnectionTypeInfo[];
 
@@ -906,27 +907,10 @@ export interface AppState
   sessionHighlighting: Record<string, boolean>;
   setSessionHighlighting: (sessionId: string, enabled: boolean | undefined) => void;
 
-  // Large paste confirmation
-  largePasteDialog: { open: boolean; charCount: number; onConfirm: (() => void) | null };
-  showLargePasteDialog: (charCount: number, onConfirm: () => void) => void;
-  closeLargePasteDialog: () => void;
-
-  // Open-saved-file-in-tab confirmation
-  openSavedFileDialog: { open: boolean; filePath: string };
-  showOpenSavedFileDialog: (filePath: string) => void;
-  closeOpenSavedFileDialog: () => void;
-
-  // Export/Import dialogs
-  exportDialogOpen: boolean;
-  setExportDialogOpen: (open: boolean) => void;
-  importDialogOpen: boolean;
-  importFileContent: string | undefined;
-  setImportDialog: (open: boolean, content?: string) => void;
-
-  // Recovery warnings from corrupt config files
-  recoveryWarnings: RecoveryWarning[];
-  recoveryDialogOpen: boolean;
-  setRecoveryDialogOpen: (open: boolean) => void;
+  // Dialogs — large-paste / open-saved-file / export-import / recovery-warning
+  // open/close flags provided by DialogsSlice (extracted under #2077 via #2300).
+  // loadFromBackend still populates recoveryWarnings/recoveryDialogOpen via the
+  // shared set.
 
   loadFromBackend: () => Promise<void>;
   /**
@@ -2890,6 +2874,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
     ...createZoomSlice(set, get, store),
     ...createCommandPaletteSlice(set, get, store),
     ...createHttpMonitorsSlice(set, get, store),
+    ...createDialogsSlice(set, get, store),
 
     // Connection type registry — updated by loadFromBackend()
     connectionTypes: [],
@@ -5017,29 +5002,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
           : { sessionHighlighting: { ...s.sessionHighlighting, [sessionId]: enabled } }
       ),
 
-    // Large paste confirmation
-    largePasteDialog: { open: false, charCount: 0, onConfirm: null },
-    showLargePasteDialog: (charCount, onConfirm) =>
-      set({ largePasteDialog: { open: true, charCount, onConfirm } }),
-    closeLargePasteDialog: () =>
-      set({ largePasteDialog: { open: false, charCount: 0, onConfirm: null } }),
-
-    // Open-saved-file-in-tab confirmation
-    openSavedFileDialog: { open: false, filePath: "" },
-    showOpenSavedFileDialog: (filePath) => set({ openSavedFileDialog: { open: true, filePath } }),
-    closeOpenSavedFileDialog: () => set({ openSavedFileDialog: { open: false, filePath: "" } }),
-
-    // Export/Import dialogs
-    exportDialogOpen: false,
-    setExportDialogOpen: (open) => set({ exportDialogOpen: open }),
-    importDialogOpen: false,
-    importFileContent: undefined,
-    setImportDialog: (open, content) => set({ importDialogOpen: open, importFileContent: content }),
-
-    // Recovery warnings from corrupt config files
-    recoveryWarnings: [],
-    recoveryDialogOpen: false,
-    setRecoveryDialogOpen: (open) => set({ recoveryDialogOpen: open }),
+    // Dialogs — large-paste / open-saved-file / export-import / recovery-warning
+    // open/close flags provided by createDialogsSlice (extracted under #2077 via
+    // #2300).
 
     updateLayoutConfig: (partial) => {
       const updated = { ...get().layoutConfig, ...partial };

--- a/src/store/slices/dialogsSlice.ts
+++ b/src/store/slices/dialogsSlice.ts
@@ -1,0 +1,71 @@
+import { StateCreator } from "zustand";
+
+import type { RecoveryWarning } from "@/types/connection";
+
+import type { AppState } from "../appStore";
+
+/**
+ * Dialogs domain slice (extracted under #2077 via #2300): the small,
+ * self-contained confirmation/dialog state that is not tied to any
+ * projection-migration domain — the large-paste confirmation, the
+ * open-saved-file-in-tab confirmation, the export/import dialogs, and the
+ * corrupt-config recovery-warnings dialog — together with their open/close
+ * setters. Extracted verbatim from the monolithic root store as a
+ * behavior-preserving Zustand slice: every action still receives the shared
+ * `set` typed against the full {@link AppState}, so the public store shape and
+ * behavior are unchanged. Note that `loadFromBackend` (kept in the root store)
+ * still populates {@link recoveryWarnings}/{@link recoveryDialogOpen} through
+ * that same shared `set`. Mirrors the SSH tunnel slice (#2077) and the
+ * embedded-server / macros / plugins / session-history / zoom / command-palette
+ * / http-monitors slices (#2113/#2114/#2115/#2299/#2300).
+ */
+
+export interface DialogsSlice {
+  // Large paste confirmation
+  largePasteDialog: { open: boolean; charCount: number; onConfirm: (() => void) | null };
+  showLargePasteDialog: (charCount: number, onConfirm: () => void) => void;
+  closeLargePasteDialog: () => void;
+
+  // Open-saved-file-in-tab confirmation
+  openSavedFileDialog: { open: boolean; filePath: string };
+  showOpenSavedFileDialog: (filePath: string) => void;
+  closeOpenSavedFileDialog: () => void;
+
+  // Export/Import dialogs
+  exportDialogOpen: boolean;
+  setExportDialogOpen: (open: boolean) => void;
+  importDialogOpen: boolean;
+  importFileContent: string | undefined;
+  setImportDialog: (open: boolean, content?: string) => void;
+
+  // Recovery warnings from corrupt config files
+  recoveryWarnings: RecoveryWarning[];
+  recoveryDialogOpen: boolean;
+  setRecoveryDialogOpen: (open: boolean) => void;
+}
+
+export const createDialogsSlice: StateCreator<AppState, [], [], DialogsSlice> = (set) => ({
+  // Large paste confirmation
+  largePasteDialog: { open: false, charCount: 0, onConfirm: null },
+  showLargePasteDialog: (charCount, onConfirm) =>
+    set({ largePasteDialog: { open: true, charCount, onConfirm } }),
+  closeLargePasteDialog: () =>
+    set({ largePasteDialog: { open: false, charCount: 0, onConfirm: null } }),
+
+  // Open-saved-file-in-tab confirmation
+  openSavedFileDialog: { open: false, filePath: "" },
+  showOpenSavedFileDialog: (filePath) => set({ openSavedFileDialog: { open: true, filePath } }),
+  closeOpenSavedFileDialog: () => set({ openSavedFileDialog: { open: false, filePath: "" } }),
+
+  // Export/Import dialogs
+  exportDialogOpen: false,
+  setExportDialogOpen: (open) => set({ exportDialogOpen: open }),
+  importDialogOpen: false,
+  importFileContent: undefined,
+  setImportDialog: (open, content) => set({ importDialogOpen: open, importFileContent: content }),
+
+  // Recovery warnings from corrupt config files
+  recoveryWarnings: [],
+  recoveryDialogOpen: false,
+  setRecoveryDialogOpen: (open) => set({ recoveryDialogOpen: open }),
+});


### PR DESCRIPTION
Continues the appStore slicing effort. Extracts the self-contained dialog open/close state out of the ~8.8k-line monolithic root store into a new `DialogsSlice` at `src/store/slices/dialogsSlice.ts`, following the Zustand domain-slice pattern established in #2077 (`StateCreator<AppState, [], [], DialogsSlice>`, added to `AppState extends …`, spread into `create()`).

## Flags moved (one cohesive dialogs cluster)
- `largePasteDialog` + `showLargePasteDialog` + `closeLargePasteDialog`
- `openSavedFileDialog` + `showOpenSavedFileDialog` + `closeOpenSavedFileDialog`
- `exportDialogOpen` + `setExportDialogOpen`
- `importDialogOpen` + `importFileContent` + `setImportDialog`
- `recoveryWarnings` + `recoveryDialogOpen` + `setRecoveryDialogOpen`

All are runtime-only open/close flags with no `omitKey`/persist/session-cleanup entanglement — verified with graft. `loadFromBackend` stays in the root store and still populates `recoveryWarnings`/`recoveryDialogOpen` through the shared `set` (typed against the full `AppState`), so its behavior is unchanged. Removed the now-unused `RecoveryWarning` type import from `appStore.ts`.

## Nothing left behind from this cluster
Every export/import + misc-dialog candidate named in the issue was clean and extracted. (`terminal-search` and `remote-desktop-resolutions` remain excluded — both use `omitKey` on cleanup, out of scope.)

## Verification
- Public store API byte-identical — no call-site changes; selectors/actions unchanged.
- `pnpm test` — 5037 passed (552 files)
- `pnpm run lint` — clean
- `pnpm exec prettier --check "src/**/*.{ts,tsx,css}"` — clean
- `pnpm build` — green

Part of #2300
Part of #2077