### PR TITLE
fix(credential): delete sudo password from os keychain on connection delete (Closes #2305)

### DIFF
--- a/docs/changes/dev3/fix/2305-keychain-sudo-orphan.md
+++ b/docs/changes/dev3/fix/2305-keychain-sudo-orphan.md
@@ -1,0 +1,7 @@
+### Security
+
+- OS keychain credential store: deleting a connection now also removes its
+  stored **sudo password** from the native OS credential store (macOS Keychain,
+  Windows Credential Manager, Linux Secret Service). Previously only the password
+  and key passphrase were removed, leaving the sudo password orphaned in the OS
+  store with no way to clean it up from the app (#2305).

--- a/src-tauri/src/credential/os_keychain.rs
+++ b/src-tauri/src/credential/os_keychain.rs
@@ -12,12 +12,6 @@ use super::CredentialStore;
 /// a unique keychain entry.
 const SERVICE_NAME: &str = "termiHub";
 
-/// All credential types termiHub stores. Used by
-/// [`OsKeychainStore::remove_all_for_connection`] because OS credential stores
-/// cannot be portably enumerated through the `keyring` crate.
-const ALL_CREDENTIAL_TYPES: [CredentialType; 2] =
-    [CredentialType::Password, CredentialType::KeyPassphrase];
-
 /// Credential store backed by the native OS credential store via the
 /// [`keyring`](https://crates.io/crates/keyring) crate.
 ///
@@ -101,7 +95,9 @@ impl CredentialStore for OsKeychainStore {
     fn remove_all_for_connection(&self, connection_id: &str) -> Result<()> {
         // OS credential stores cannot be enumerated portably through `keyring`,
         // so we delete every known credential type for the connection instead.
-        for credential_type in ALL_CREDENTIAL_TYPES {
+        // The list is `CredentialType::ALL` so it cannot drift out of date when
+        // a new variant is added and leave a secret orphaned here (#2305).
+        for credential_type in CredentialType::ALL {
             let key = CredentialKey::new(connection_id, credential_type);
             self.remove(&key)?;
         }

--- a/src-tauri/src/credential/os_keychain.rs
+++ b/src-tauri/src/credential/os_keychain.rs
@@ -214,6 +214,29 @@ mod tests {
     }
 
     #[test]
+    fn remove_all_for_connection_removes_sudo_password() {
+        // Regression (#2305): deleting a connection must also delete its stored
+        // sudo password. The OS store cannot be enumerated, so it deletes a
+        // fixed list of credential types — that list previously omitted
+        // SudoPassword, leaving the secret orphaned in the OS keychain forever.
+        let _guard = with_mock();
+        let store = OsKeychainStore::new();
+        let pw = CredentialKey::new("conn-sudo", CredentialType::Password);
+        let kp = CredentialKey::new("conn-sudo", CredentialType::KeyPassphrase);
+        let sudo = CredentialKey::new("conn-sudo", CredentialType::SudoPassword);
+
+        store.set(&pw, "pass").unwrap();
+        store.set(&kp, "phrase").unwrap();
+        store.set(&sudo, "elevated-secret").unwrap();
+
+        store.remove_all_for_connection("conn-sudo").unwrap();
+
+        assert_eq!(store.get(&pw).unwrap(), None);
+        assert_eq!(store.get(&kp).unwrap(), None);
+        assert_eq!(store.get(&sudo).unwrap(), None);
+    }
+
+    #[test]
     fn status_is_always_unlocked() {
         let _guard = with_mock();
         let store = OsKeychainStore::new();

--- a/src-tauri/src/credential/types.rs
+++ b/src-tauri/src/credential/types.rs
@@ -23,6 +23,23 @@ impl fmt::Display for CredentialType {
     }
 }
 
+impl CredentialType {
+    /// Every credential type termiHub can store, in a single authoritative list.
+    ///
+    /// Backends that cannot enumerate their contents (the OS keychain — the
+    /// native stores expose no portable listing API) must iterate this list to
+    /// act on *all* of a connection's secrets, e.g. deleting them when the
+    /// connection is removed. Keeping the list here — rather than duplicated at
+    /// each such call site — stops it from silently drifting out of date when a
+    /// new variant is added; the `all_lists_every_credential_type` guard test
+    /// forces every new variant to be added here.
+    pub const ALL: [CredentialType; 3] = [
+        CredentialType::Password,
+        CredentialType::KeyPassphrase,
+        CredentialType::SudoPassword,
+    ];
+}
+
 /// Identifies a specific credential by connection and type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CredentialKey {
@@ -141,6 +158,29 @@ mod tests {
     #[test]
     fn credential_type_display_password() {
         assert_eq!(CredentialType::Password.to_string(), "password");
+    }
+
+    #[test]
+    fn all_lists_every_credential_type() {
+        // Compile guard: this exhaustive match fails to compile when a new
+        // `CredentialType` variant is added, forcing it to be listed in
+        // `CredentialType::ALL` too. Stores that cannot enumerate their contents
+        // (the OS keychain) rely on ALL being complete to delete every secret
+        // for a connection (#2305).
+        for ct in CredentialType::ALL {
+            match ct {
+                CredentialType::Password
+                | CredentialType::KeyPassphrase
+                | CredentialType::SudoPassword => {}
+            }
+        }
+        assert_eq!(CredentialType::ALL.len(), 3);
+        // No duplicates.
+        for (i, a) in CredentialType::ALL.iter().enumerate() {
+            for b in &CredentialType::ALL[i + 1..] {
+                assert_ne!(a, b, "duplicate credential type in ALL");
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Problem

In the OS keychain credential backend, deleting a connection did **not** remove its stored **sudo password** — it was silently orphaned in the native OS credential store (macOS Keychain / Windows Credential Manager / Linux Secret Service) with no way to clean it up from the app.

`OsKeychainStore::remove_all_for_connection` deletes a fixed list of credential types (the native stores cannot be enumerated portably through `keyring`). That list was hardcoded to `[Password, KeyPassphrase]` and never updated when `SudoPassword` was added to the credential model, despite its doc comment claiming it deletes "every known credential type". Deleting a connection (`connection/manager.rs` → `remove_all_for_connection`) therefore left the sudo password behind.

`MasterPasswordStore` was unaffected (it deletes by key prefix and already cleared all three types).

## Fix

- Introduce a single authoritative `CredentialType::ALL` list in `credential/types.rs`, so the set of types cannot drift out of date at each call site.
- `OsKeychainStore::remove_all_for_connection` now iterates `CredentialType::ALL` (all three types, including `SudoPassword`).
- Added a compile-guard test (`all_lists_every_credential_type`): an exhaustive match forces any future `CredentialType` variant to be added to `ALL`, so this class of leak cannot recur.

## Testing (TDD)

- Regression test `remove_all_for_connection_removes_sudo_password` (committed first) fails before the fix (`Some("elevated-secret")` survives deletion) and passes after.
- `cargo test -p termihub --lib credential` — 112 passed, 0 failed.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- Uses the `keyring` mock backend already used by the other OS-keychain tests.

Found during a proactive review of the credential subsystem (coordinator-authorized).

Closes #2305