### PR TITLE
refactor(sftp): drive the transfer subsystem through a core SftpTransferChannel (Closes #2236)

### DIFF
--- a/core/src/backends/ssh/file_browser.rs
+++ b/core/src/backends/ssh/file_browser.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 
+use russh_sftp::client::fs::File;
 use russh_sftp::client::SftpSession;
 use tokio::io::AsyncReadExt;
 use tokio::sync::Mutex;
@@ -84,22 +85,25 @@ impl SftpFileBrowser {
     }
 
     /// Open a **dedicated** SFTP channel on a fresh channel off the same
-    /// authenticated SSH connection.
+    /// authenticated SSH connection, wrapped in an [`SftpTransferChannel`].
     ///
-    /// Used by the cancellable transfer subsystem (#1245): the returned session
-    /// owns its own channel, so a chunked copy can run on it without holding this
-    /// browser's lock — keeping directory listing / navigation live on the
-    /// browsing channel during a transfer. Pushed into core so the desktop
-    /// `SftpSession` no longer forks it (#2104, issue-body item 1).
-    pub async fn open_dedicated_channel(&self) -> Result<SftpSession, FileError> {
+    /// Used by the cancellable transfer subsystem (#1245): the returned channel
+    /// owns its own SSH channel, so a chunked copy can run on it without holding
+    /// this browser's lock — keeping directory listing / navigation live on the
+    /// browsing channel during a transfer. Returning the [`SftpTransferChannel`]
+    /// wrapper (rather than the raw russh session) keeps the russh-sftp types
+    /// encapsulated in core, so the desktop transfer subsystem drives the core
+    /// API rather than russh directly (#2104 item 1, #2236 item 2).
+    pub async fn open_dedicated_channel(&self) -> Result<SftpTransferChannel, FileError> {
         Self::ensure_connected(&self.state, &self.config).await?;
         let guard = self.state.lock().await;
         let state = guard
             .as_ref()
             .ok_or_else(|| FileError::OperationFailed("SFTP not connected".to_string()))?;
-        sftp::open_sftp_subsystem(&state.session)
+        let sftp = sftp::open_sftp_subsystem(&state.session)
             .await
-            .map_err(|e| FileError::OperationFailed(e.to_string()))
+            .map_err(|e| FileError::OperationFailed(e.to_string()))?;
+        Ok(SftpTransferChannel { sftp })
     }
 
     /// Best-effort size (in bytes) of a remote file via SFTP `stat`.
@@ -151,6 +155,56 @@ impl SftpFileBrowser {
         });
 
         Ok(())
+    }
+}
+
+/// A dedicated SFTP channel for a single background file transfer (#1245, #2236).
+///
+/// Wraps a russh SFTP session bound to its **own** SSH channel, so a chunked,
+/// cancellable copy runs on it without holding the browsing session's lock —
+/// keeping directory listing / navigation live during a transfer. Obtained via
+/// [`SftpFileBrowser::open_dedicated_channel`].
+///
+/// Keeping the raw russh-sftp types encapsulated behind this wrapper means the
+/// desktop transfer subsystem streams through the core API (`open_read` /
+/// `create_write` / `remove_file`) rather than manipulating `russh_sftp` types
+/// directly (#2236 item 2). The returned file handles implement
+/// [`AsyncRead`](tokio::io::AsyncRead) / [`AsyncWrite`](tokio::io::AsyncWrite),
+/// so the caller drives the chunked copy loop without naming a russh type.
+pub struct SftpTransferChannel {
+    sftp: SftpSession,
+}
+
+impl SftpTransferChannel {
+    /// Open an existing remote file for streaming reads (the download source).
+    ///
+    /// The returned handle implements [`AsyncRead`](tokio::io::AsyncRead), so the
+    /// caller reads it in chunks without touching russh directly.
+    pub async fn open_read(&self, path: &str) -> Result<File, FileError> {
+        self.sftp
+            .open(path)
+            .await
+            .map_err(|e| FileError::OperationFailed(format!("open remote file failed: {e}")))
+    }
+
+    /// Create (truncating) a remote file for streaming writes (the upload
+    /// destination).
+    ///
+    /// The returned handle implements [`AsyncWrite`](tokio::io::AsyncWrite), so
+    /// the caller writes it in chunks without touching russh directly.
+    pub async fn create_write(&self, path: &str) -> Result<File, FileError> {
+        self.sftp
+            .create(path)
+            .await
+            .map_err(|e| FileError::OperationFailed(format!("create remote file failed: {e}")))
+    }
+
+    /// Remove a remote file — used to clean up a partial upload on cancel/error.
+    pub async fn remove_file(&self, path: &str) -> Result<(), FileError> {
+        self.sftp
+            .remove_file(path)
+            .await
+            .map_err(|e| FileError::OperationFailed(format!("remove remote file failed: {e}")))
     }
 }
 
@@ -406,5 +460,14 @@ mod tests {
     fn sftp_file_browser_implements_advanced_ops() {
         fn _assert_impl<T: SftpAdvancedOps>() {}
         _assert_impl::<SftpFileBrowser>();
+    }
+
+    /// The dedicated transfer channel must be `Send` so the desktop transfer
+    /// subsystem can move it into a background copy task
+    /// (`tauri::async_runtime::spawn`), holding it across `.await` points while a
+    /// chunked copy runs on its own channel (#1245, #2236).
+    #[test]
+    fn sftp_transfer_channel_is_send() {
+        _assert_send::<SftpTransferChannel>();
     }
 }

--- a/core/src/backends/ssh/mod.rs
+++ b/core/src/backends/ssh/mod.rs
@@ -23,7 +23,7 @@ pub use self::exec::{
     exec_probe_indicates_capability, probe_exec_capability, ssh_exec_with_stdin, SshExecOutput,
     EXEC_PROBE_MARKER,
 };
-pub use self::file_browser::{SftpAdvancedOps, SftpFileBrowser};
+pub use self::file_browser::{SftpAdvancedOps, SftpFileBrowser, SftpTransferChannel};
 
 use std::io::Read;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1,6 +1,8 @@
 use serde::Serialize;
 use tauri::{Emitter, Manager, State};
-use termihub_core::backends::ssh::{parse_ssh_settings, SftpAdvancedOps, SftpFileBrowser};
+use termihub_core::backends::ssh::{
+    parse_ssh_settings, SftpAdvancedOps, SftpFileBrowser, SftpTransferChannel,
+};
 use termihub_core::files::FileBrowser;
 use tracing::{debug, info};
 
@@ -108,14 +110,14 @@ pub async fn sftp_check_writable(
         .map_err(sftp_op_error)
 }
 
-/// Open a dedicated SFTP channel off `browser` and (for downloads) stat the
-/// remote size. Both are awaited directly on the async core browser — no
-/// `spawn_blocking` / `block_in_place` bridging is needed. Returns the dedicated
-/// session plus the known total size (`0` = indeterminate).
+/// Open a dedicated [`SftpTransferChannel`] off `browser` and (for downloads)
+/// stat the remote size. Both are awaited directly on the async core browser —
+/// no `spawn_blocking` / `block_in_place` bridging is needed. Returns the
+/// dedicated channel plus the known total size (`0` = indeterminate).
 async fn open_transfer_channel(
     browser: std::sync::Arc<SftpFileBrowser>,
     remote_path: Option<String>,
-) -> Result<(russh_sftp::client::SftpSession, u64), TerminalError> {
+) -> Result<(SftpTransferChannel, u64), TerminalError> {
     let dedicated = browser
         .open_dedicated_channel()
         .await

--- a/src-tauri/src/files/transfer/mod.rs
+++ b/src-tauri/src/files/transfer/mod.rs
@@ -23,9 +23,9 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use russh_sftp::client::SftpSession as RusshSftp;
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
+use termihub_core::backends::ssh::SftpTransferChannel;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -291,13 +291,13 @@ enum CopyOutcome {
 
 /// Run a download (remote → local) on a dedicated SFTP channel.
 ///
-/// `sftp` is a freshly-opened SFTP session bound to its own channel, so this
-/// copy never touches the browsing session's `Mutex`. On cancel the partial
-/// local file is removed; on error a terminal `error` event is emitted. In all
-/// terminal cases the registry entry is dropped.
+/// `channel` is a freshly-opened dedicated [`SftpTransferChannel`] bound to its
+/// own SSH channel, so this copy never touches the browsing session's `Mutex`.
+/// On cancel the partial local file is removed; on error a terminal `error`
+/// event is emitted. In all terminal cases the registry entry is dropped.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_download(
-    sftp: RusshSftp,
+    channel: SftpTransferChannel,
     remote_path: String,
     local_path: String,
     ctx: TransferContext,
@@ -305,7 +305,7 @@ pub async fn run_download(
     registry: TransferRegistry,
     sink: ProgressSink,
 ) {
-    let outcome = download_inner(&sftp, &remote_path, &local_path, &ctx, &token, &sink).await;
+    let outcome = download_inner(&channel, &remote_path, &local_path, &ctx, &token, &sink).await;
     finish_transfer(outcome, &ctx, &registry, &sink, || {
         // Cleanup: remove the partial local file (best-effort).
         let _ = std::fs::remove_file(&local_path);
@@ -313,15 +313,15 @@ pub async fn run_download(
 }
 
 async fn download_inner(
-    sftp: &RusshSftp,
+    channel: &SftpTransferChannel,
     remote_path: &str,
     local_path: &str,
     ctx: &TransferContext,
     token: &CancellationToken,
     sink: &ProgressSink,
 ) -> Result<CopyOutcome, TerminalError> {
-    let mut remote = sftp
-        .open(remote_path)
+    let mut remote = channel
+        .open_read(remote_path)
         .await
         .map_err(|e| TerminalError::SshError(format!("open remote file: {e}")))?;
     let mut local = tokio::fs::File::create(local_path)
@@ -334,7 +334,7 @@ async fn download_inner(
 /// partial remote file is removed; on error a terminal `error` event is emitted.
 #[allow(clippy::too_many_arguments)]
 pub async fn run_upload(
-    sftp: RusshSftp,
+    channel: SftpTransferChannel,
     local_path: String,
     remote_path: String,
     ctx: TransferContext,
@@ -342,21 +342,21 @@ pub async fn run_upload(
     registry: TransferRegistry,
     sink: ProgressSink,
 ) {
-    let outcome = upload_inner(&sftp, &local_path, &remote_path, &ctx, &token, &sink).await;
-    let sftp_for_cleanup = sftp;
+    let outcome = upload_inner(&channel, &local_path, &remote_path, &ctx, &token, &sink).await;
+    let channel_for_cleanup = channel;
     let remote_for_cleanup = remote_path.clone();
     // Remove the partial remote file on cancel/error (best-effort).
     let cleanup_needed = matches!(outcome, Ok(CopyOutcome::Cancelled { .. }) | Err(_));
     finish_transfer(outcome, &ctx, &registry, &sink, || {});
     if cleanup_needed {
-        if let Err(e) = sftp_for_cleanup.remove_file(&remote_for_cleanup).await {
+        if let Err(e) = channel_for_cleanup.remove_file(&remote_for_cleanup).await {
             debug!(error = %e, "could not remove partial remote upload (best-effort)");
         }
     }
 }
 
 async fn upload_inner(
-    sftp: &RusshSftp,
+    channel: &SftpTransferChannel,
     local_path: &str,
     remote_path: &str,
     ctx: &TransferContext,
@@ -366,8 +366,8 @@ async fn upload_inner(
     let mut local = tokio::fs::File::open(local_path)
         .await
         .map_err(|e| TerminalError::SshError(format!("open local file: {e}")))?;
-    let mut remote = sftp
-        .create(remote_path)
+    let mut remote = channel
+        .create_write(remote_path)
         .await
         .map_err(|e| TerminalError::SshError(format!("create remote file: {e}")))?;
     copy_chunked(&mut local, &mut remote, ctx, token, sink).await

--- a/src-tauri/tests/sftp_transfer.rs
+++ b/src-tauri/tests/sftp_transfer.rs
@@ -21,7 +21,7 @@ use std::net::TcpStream;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use termihub_core::backends::ssh::{SftpAdvancedOps, SftpFileBrowser};
+use termihub_core::backends::ssh::{SftpAdvancedOps, SftpFileBrowser, SftpTransferChannel};
 use termihub_core::config::SshConfig;
 use termihub_core::files::FileBrowser;
 use termihub_lib::files::sftp::{SftpManager, Writability};
@@ -154,9 +154,9 @@ async fn connect() -> (SftpManager, Arc<SftpFileBrowser>) {
     (manager, session)
 }
 
-/// Open a dedicated SFTP channel off `session` (mirrors the command layer),
-/// awaited directly on the async core browser.
-async fn open_dedicated(session: Arc<SftpFileBrowser>) -> russh_sftp::client::SftpSession {
+/// Open a dedicated [`SftpTransferChannel`] off `session` (mirrors the command
+/// layer), awaited directly on the async core browser.
+async fn open_dedicated(session: Arc<SftpFileBrowser>) -> SftpTransferChannel {
     session
         .open_dedicated_channel()
         .await


### PR DESCRIPTION
Migrates the desktop SFTP **transfer subsystem** onto the core async browser path, completing the code-level remainder of #2236 that #2255/#2239 had not yet covered.

## What #2236 asked for, and what was already done
#2236 is a follow-up to #2104 with four scope items. Establishing the actual remaining work first:

| Scope item | State on `develop` before this PR |
| --- | --- |
| 1. Migrate the `sftp_*` command layer onto the async `FileBrowser` path | **Already done** (#2255/#2239) — `src-tauri/src/commands/files.rs` drives `Arc<SftpFileBrowser>` directly with `.await`. |
| 3. Retire the `block_in_place` sync-adapter `SftpSession`/`SftpManager` | **Already done** — the sync adapter is gone; `SftpManager` is now a thin async registry of `Arc<SftpFileBrowser>`. |
| 2. Migrate the **transfer subsystem** onto the core path | **This PR.** |
| 4. Reconcile the two session models into one file-browsing entry point | **Deferred** to #2307 (needs a frontend cut; out of scope for a backend-only change). |

## This change (item 2)
The transfer subsystem was the last place the desktop layer manipulated `russh_sftp` types directly: `commands/files.rs` and `files/transfer/mod.rs` passed a raw `russh_sftp::client::SftpSession` around for the dedicated per-transfer channel (#1245).

- New core `SftpTransferChannel` (`core/src/backends/ssh/file_browser.rs`) wraps the dedicated russh SFTP session and exposes `open_read` / `create_write` / `remove_file`, returning handles that implement `AsyncRead`/`AsyncWrite`.
- `SftpFileBrowser::open_dedicated_channel` now returns the wrapper instead of the raw russh session.
- The desktop transfer copy loops (`run_download`/`run_upload`) and `open_transfer_channel` drive the wrapper; the transfer subsystem no longer names any `russh_sftp` type.
- The dedicated per-transfer channel (#1245) and the eager fail-loudly `sftp_open` contract are unchanged. Streaming/chunked/cancellable copy logic is byte-for-byte identical — the change is pure encapsulation of the transport type.

Note: `FileBrowser`/`SftpAdvancedOps` themselves cannot host the transfer path (they have no streaming/dedicated-channel primitives), so the faithful "core path" for transfers is this dedicated core-owned channel type.

## Testing
- `cargo build`, `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` — all clean.
- New core unit test `sftp_transfer_channel_is_send` (guards the `Send` bound the background copy task relies on).
- Desktop `files::` lib tests — 88 passed.
- `sftp_transfer` **integration tests run locally against the live sftp-stress container** (this checkout is Docker-isolated): all 3 pass (cancel-mid-transfer cleanup, browsing-stays-live-during-transfer, writability probe). Per-PR CI does not run these, so they were verified locally.

## Follow-up
- #2307 — converge the standalone `SftpManager` UUID session model onto `ConnectionType::file_browser()` (scope item 4; needs frontend coordination).

Closes #2236