### PR TITLE
fix(config): persist per-connection terminalOptions dropped on save (Closes #2309)

### DIFF
--- a/docs/changes/dev3/fix/2309-terminaloptions-dropped-fields.md
+++ b/docs/changes/dev3/fix/2309-terminaloptions-dropped-fields.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Per-connection terminal options no longer vanish after saving. The
+  `logToFile` / `logTimestamps` (#1960), `lineHeight`, and per-connection
+  `syntaxHighlighting` (#1696) settings were silently discarded when a
+  connection was saved, because the backend's `TerminalOptions` struct did not
+  model them — so they were gone on the next app restart. The backend now
+  persists all four (Closes #2309).

--- a/src-tauri/src/connection/config.rs
+++ b/src-tauri/src/connection/config.rs
@@ -447,6 +447,52 @@ mod tests {
     }
 
     #[test]
+    fn terminal_options_round_trip_preserves_all_frontend_fields() {
+        // Regression for #2309: the frontend `TerminalOptions` (src/types/terminal.ts)
+        // carries fields the Rust struct must not drop on the save/load round-trip —
+        // otherwise a user's per-connection log-to-file (#1960), line-height and
+        // syntax-highlighting (#1696) overrides silently vanish on the next restart.
+        let json = serde_json::json!({
+            "horizontalScrolling": true,
+            "color": "#123456",
+            "fontFamily": "Fira Code",
+            "fontSize": 14,
+            "lineHeight": 1.25,
+            "scrollbackBuffer": 5000,
+            "cursorStyle": "bar",
+            "cursorBlink": true,
+            "lineEnding": "crlf",
+            "logToFile": true,
+            "logTimestamps": true,
+            "syntaxHighlighting": {
+                "override": "custom",
+                "additionalRules": [{ "name": "TODO", "enabled": true }]
+            }
+        });
+
+        // Deserialize into the Rust struct, then serialize back — this mirrors what
+        // happens when the connection is persisted and reloaded.
+        let opts: TerminalOptions = serde_json::from_value(json.clone()).unwrap();
+        let round_tripped = serde_json::to_value(&opts).unwrap();
+
+        for key in [
+            "lineHeight",
+            "logToFile",
+            "logTimestamps",
+            "syntaxHighlighting",
+        ] {
+            assert_eq!(
+                round_tripped.get(key),
+                json.get(key),
+                "field {key} was dropped or altered during the round-trip",
+            );
+        }
+        // The already-modelled fields must survive too.
+        assert_eq!(round_tripped.get("cursorStyle"), json.get("cursorStyle"));
+        assert_eq!(round_tripped.get("lineEnding"), json.get("lineEnding"));
+    }
+
+    #[test]
     fn folder_json_shape_has_type_tag() {
         let node = ConnectionTreeNode::Folder {
             name: "Work".to_string(),

--- a/src-tauri/src/connection/config.rs
+++ b/src-tauri/src/connection/config.rs
@@ -88,6 +88,23 @@ pub struct TerminalOptions {
     /// Per-connection line-ending override ("cr", "lf", or "crlf").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_ending: Option<String>,
+    /// Per-connection terminal line-height multiplier (may be fractional).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_height: Option<f64>,
+    /// When `true`, this connection's session output is logged to a file on
+    /// connect (#1960).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log_to_file: Option<bool>,
+    /// When logging to a file, prefix each line with a timestamp (#1960).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log_timestamps: Option<bool>,
+    /// Per-connection syntax-highlighting override (epic #1696).
+    ///
+    /// Stored opaquely as JSON — the backend never introspects it, so it
+    /// follows the [`crate::terminal::backend::ConnectionConfig::settings`]
+    /// precedent rather than duplicating the frontend's nested schema in Rust.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub syntax_highlighting: Option<serde_json::Value>,
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Saving a connection silently dropped four `terminalOptions` fields, so the settings were lost on the next app restart — the same class of data-loss bug as #2261.

The frontend `TerminalOptions` (`src/types/terminal.ts`) declares `lineHeight`, `logToFile` (#1960), `logTimestamps` (#1960) and `syntaxHighlighting` (#1696), all set/read for individual connections. The backend `TerminalOptions` struct (`src-tauri/src/connection/config.rs`) did not model them and had no `#[serde(flatten)]` catch-all, so `save_connection(connection: SavedConnection)` discarded them at the deserialize boundary before persisting to `connections.json`.

## Fix

Add the four fields to the Rust struct with matching serde attributes (`camelCase`, `skip_serializing_if = "Option::is_none"`):

- `line_height: Option<f64>`
- `log_to_file: Option<bool>`
- `log_timestamps: Option<bool>`
- `syntax_highlighting: Option<serde_json::Value>` — stored opaquely, following the existing `ConnectionConfig.settings` precedent (the backend never introspects it, so its nested frontend schema is not duplicated in Rust).

## Testing

- TDD: added `terminal_options_round_trip_preserves_all_frontend_fields` (committed first, verified red before the fix), which deserializes a full frontend `terminalOptions` blob and asserts all four fields survive the serialize round-trip.
- `cargo test -p termihub --lib connection` — 238 passed.
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.

User-facing; change fragment added under `docs/changes/dev3/fix/`.

Closes #2309