### PR TITLE
feat(session): expose SFTP advanced ops + transfers via the session path (Closes #2312)

### DIFF
--- a/core/src/backends/ssh/file_browser.rs
+++ b/core/src/backends/ssh/file_browser.rs
@@ -3,6 +3,7 @@
 //! Opens a dedicated SSH session for SFTP operations using russh-sftp.
 //! All operations are fully async — no `spawn_blocking` needed.
 
+use std::any::Any;
 use std::sync::Arc;
 
 use russh_sftp::client::fs::File;
@@ -41,6 +42,17 @@ struct SftpState {
 /// path and the desktop file-browser/transfer command layer, whose `SftpSession`
 /// wraps one of these (#2104). It reaches jump-host targets through their pooled
 /// gateway via [`connect_target`] (#939).
+///
+/// `Clone` shares the underlying connection: the lazily-opened [`SftpState`] lives
+/// behind an `Arc<Mutex<…>>`, so a clone points at the **same** authenticated SFTP
+/// session rather than opening a new one. This lets a session-scoped caller lift an
+/// *owned* handle out from under the sessions lock (via
+/// [`FileBrowser::as_any`](crate::files::FileBrowser::as_any) →
+/// `downcast_ref::<SftpFileBrowser>()` → `.clone()`) and move it into a background
+/// transfer task, exactly as the desktop `SftpManager` hands out
+/// `Arc<SftpFileBrowser>` (#2312). The shared `state` keeps the connection alive as
+/// long as either the session or an in-flight transfer holds a clone.
+#[derive(Clone)]
 pub struct SftpFileBrowser {
     config: SshConfig,
     state: Arc<Mutex<Option<SftpState>>>,
@@ -337,6 +349,15 @@ impl FileBrowser for SftpFileBrowser {
             .await
             .map_err(|e| FileError::OperationFailed(format!("stat failed: {e}")))
     }
+
+    /// Expose the concrete browser so a session-scoped caller holding only a
+    /// `&dyn FileBrowser` can `downcast_ref::<SftpFileBrowser>()` and reach the
+    /// SFTP advanced ops ([`SftpAdvancedOps`]), the exec-capability probe, and the
+    /// owned transfer handle — none of which fit on the shared [`FileBrowser`]
+    /// trait (#2312).
+    fn as_any(&self) -> Option<&dyn Any> {
+        Some(self)
+    }
 }
 
 /// Advanced SFTP capabilities that complement [`FileBrowser`].
@@ -469,5 +490,45 @@ mod tests {
     #[test]
     fn sftp_transfer_channel_is_send() {
         _assert_send::<SftpTransferChannel>();
+    }
+
+    /// A minimal `SshConfig` for constructing a browser without connecting.
+    fn test_config() -> SshConfig {
+        SshConfig {
+            host: "127.0.0.1".to_string(),
+            port: 22,
+            username: "tester".to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// Cloning an `SftpFileBrowser` shares the same lazily-opened SFTP session
+    /// (the `state` `Arc`), so an owned clone lifted out from under a session lock
+    /// drives the *same* authenticated connection rather than opening a new one
+    /// (#2312).
+    #[test]
+    fn clone_shares_the_underlying_connection_state() {
+        let browser = SftpFileBrowser::new(test_config());
+        let cloned = browser.clone();
+        assert!(
+            Arc::ptr_eq(&browser.state, &cloned.state),
+            "a clone must share the same connection state Arc"
+        );
+    }
+
+    /// `as_any` returns the concrete browser so a `&dyn FileBrowser` can be
+    /// downcast to `SftpFileBrowser` to reach the SFTP advanced ops / transfer
+    /// handle from the session path (#2312).
+    #[test]
+    fn as_any_downcasts_back_to_the_concrete_browser() {
+        let browser = SftpFileBrowser::new(test_config());
+        let dynamic: &dyn FileBrowser = &browser;
+        let recovered = dynamic
+            .as_any()
+            .and_then(|any| any.downcast_ref::<SftpFileBrowser>());
+        assert!(
+            recovered.is_some(),
+            "as_any must expose the concrete SftpFileBrowser for downcasting"
+        );
     }
 }

--- a/core/src/files/browser.rs
+++ b/core/src/files/browser.rs
@@ -6,6 +6,8 @@
 //! desktop remote proxy). It is also the agent's file backend — the former,
 //! near-duplicate `FileBackend` trait was retired in favour of it (#2104).
 
+use std::any::Any;
+
 use crate::errors::FileError;
 use crate::files::FileEntry;
 
@@ -43,6 +45,22 @@ pub trait FileBrowser: Send {
 
     /// Create a directory (and any missing parent directories) at the given path.
     async fn mkdir(&self, path: &str) -> Result<(), FileError>;
+
+    /// Optional downcast hook to the concrete browser type behind this
+    /// `&dyn FileBrowser`.
+    ///
+    /// The shared capability surface is deliberately uniform, but a
+    /// session-scoped caller that holds only a `&dyn FileBrowser` sometimes needs
+    /// the backend-specific advanced operations that cannot live on this trait —
+    /// for SSH, the SFTP advanced ops (`realpath` / `check_writable` /
+    /// privilege-elevated write) and the owned transfer handle exposed by
+    /// [`SftpFileBrowser`](crate::backends::ssh::SftpFileBrowser). Backends that
+    /// offer such capabilities override this to return `Some(self)`, letting the
+    /// caller `downcast_ref` to the concrete type; the default returns `None`, so
+    /// no other backend is affected (#2312).
+    fn as_any(&self) -> Option<&dyn Any> {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/core/tests/sftp_stress.rs
+++ b/core/tests/sftp_stress.rs
@@ -25,7 +25,8 @@ mod common;
 
 use common::{port_sftp_stress, require_docker};
 use serial_test::serial;
-use termihub_core::backends::ssh::Ssh;
+use termihub_core::backends::ssh::{SftpAdvancedOps, SftpFileBrowser, Ssh};
+use termihub_core::config::SshConfig;
 use termihub_core::connection::ConnectionType;
 
 /// Connect to the SFTP stress container and return an Ssh instance
@@ -450,5 +451,99 @@ async fn sftp_stress_16_permission_000_directory() {
     assert!(
         result.is_err(),
         "SFTP-STRESS-16: Permission 000 directory should return access denied error"
+    );
+}
+
+// ── SFTP-STRESS-17: session-path advanced-ops parity (#2312) ─────────
+//
+// The #2307 step-A convergence lets a session-scoped `&dyn FileBrowser` reach the
+// SFTP advanced ops via the new `FileBrowser::as_any` downcast bridge. This test
+// proves that bridge end-to-end AND that the results match the standalone
+// `sftp_*` path (a directly-constructed `SftpFileBrowser`), so the session path
+// is a faithful mirror rather than a divergent second implementation.
+
+/// Build the standalone-path browser for the stress container (mirrors how the
+/// desktop `SftpManager::open_session` constructs one from an `SshConfig`).
+fn standalone_browser() -> SftpFileBrowser {
+    SftpFileBrowser::new(SshConfig {
+        host: "127.0.0.1".to_string(),
+        port: port_sftp_stress(),
+        username: "testuser".to_string(),
+        auth_method: "password".to_string(),
+        password: Some("testpass".to_string()),
+        ..Default::default()
+    })
+}
+
+#[tokio::test]
+#[serial(sftp_stress)]
+async fn sftp_stress_17_session_path_advanced_ops_parity() {
+    require_docker!(port_sftp_stress());
+
+    // Session/ConnectionType path: reach the advanced ops through the `&dyn
+    // FileBrowser` the session holds, via the new `as_any` downcast (#2312).
+    let ssh = connect_sftp().await;
+    let dynamic = ssh
+        .file_browser()
+        .expect("file browser should be available");
+    let via_session = dynamic
+        .as_any()
+        .and_then(|any| any.downcast_ref::<SftpFileBrowser>())
+        .expect("SSH session's FileBrowser must downcast to SftpFileBrowser (#2312)");
+
+    // Standalone `sftp_*` path.
+    let standalone = standalone_browser();
+
+    // realpath(".") → home dir; both paths must agree and yield an absolute path.
+    let session_home = via_session
+        .realpath(".")
+        .await
+        .expect("session realpath should succeed");
+    let standalone_home = standalone
+        .realpath(".")
+        .await
+        .expect("standalone realpath should succeed");
+    assert_eq!(
+        session_home, standalone_home,
+        "session-path realpath must match the standalone path"
+    );
+    assert!(
+        session_home.starts_with('/'),
+        "realpath must be absolute, got {session_home:?}"
+    );
+
+    // check_writable on a known fixture file → both paths must return the same
+    // verdict (the probe is non-destructive: WRITE-open only, no truncate).
+    let probe_path = "/home/testuser/sftp-test/large-files/1mb.bin";
+    let session_verdict = via_session
+        .check_writable(probe_path)
+        .await
+        .expect("session check_writable should succeed");
+    let standalone_verdict = standalone
+        .check_writable(probe_path)
+        .await
+        .expect("standalone check_writable should succeed");
+    assert_eq!(
+        session_verdict, standalone_verdict,
+        "session-path writability verdict must match the standalone path"
+    );
+
+    // has_exec_capability (inherent, reached through the same downcast): a normal
+    // SSH+shell container exposes an exec channel on both paths.
+    let session_exec = via_session
+        .has_exec_capability()
+        .await
+        .expect("session has_exec_capability should succeed");
+    let standalone_exec = standalone
+        .has_exec_capability()
+        .await
+        .expect("standalone has_exec_capability should succeed");
+    assert_eq!(
+        session_exec, standalone_exec,
+        "session-path exec-capability must match the standalone path"
+    );
+    assert!(
+        session_exec,
+        "the sftp-stress container is a normal SSH host, so exec must be available"
     );
 }

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -114,7 +114,7 @@ pub async fn sftp_check_writable(
 /// stat the remote size. Both are awaited directly on the async core browser —
 /// no `spawn_blocking` / `block_in_place` bridging is needed. Returns the
 /// dedicated channel plus the known total size (`0` = indeterminate).
-async fn open_transfer_channel(
+pub(crate) async fn open_transfer_channel(
     browser: std::sync::Arc<SftpFileBrowser>,
     remote_path: Option<String>,
 ) -> Result<(SftpTransferChannel, u64), TerminalError> {

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -12,12 +12,16 @@ use tracing::{debug, info};
 use termihub_core::connection::ConnectionTypeInfo;
 use termihub_core::files::FileEntry;
 
+use crate::commands::files::open_transfer_channel;
 use crate::connection::manager::ConnectionManager;
+use crate::files::sftp::{ElevatedWriteResult, Writability};
+use crate::files::transfer::{self, TransferContext, TransferDirection, TransferRegistry};
 use crate::session::line_ending::LineEnding;
 use crate::session::manager::{
     PersistentSessionSummary, SessionInfo, SessionLogStatus, SessionManager,
 };
 use crate::utils::errors::TerminalError;
+use crate::utils::fs::file_name_of;
 use crate::utils::shell_detect;
 use crate::window::WindowManager;
 
@@ -337,6 +341,194 @@ pub async fn session_mkdir(
 ) -> Result<(), TerminalError> {
     debug!(session_id, path, "Session mkdir");
     manager.mkdir_file(&session_id, &path).await
+}
+
+// --- Session-scoped SFTP advanced operations & transfers (#2312) ---
+//
+// Session-path mirrors of the standalone `sftp_*` commands, routed through the
+// session's `ConnectionType` file browser rather than a separate `SftpManager`
+// session. They only succeed for an SFTP-backed (SSH) session; other backends
+// return a "not supported" error. Part of the #2307 convergence (step A):
+// additive, so the standalone `sftp_*` path keeps working unchanged.
+
+/// Resolve a remote path to its canonical absolute form via a session's SFTP
+/// realpath.
+///
+/// Passing `"."` yields the session's home directory, avoiding a `/home/<user>`
+/// guess (mirror of `sftp_realpath`, #2312).
+#[tauri::command]
+pub async fn session_realpath(
+    session_id: String,
+    path: String,
+    manager: State<'_, SessionManager>,
+) -> Result<String, TerminalError> {
+    debug!(session_id, path, "Session SFTP realpath");
+    manager.session_realpath(&session_id, &path).await
+}
+
+/// Authoritatively check whether a remote file is writable by the connecting
+/// user, via a non-destructive SFTP write-open probe on a session (mirror of
+/// `sftp_check_writable`, #2312).
+#[tauri::command]
+pub async fn session_check_writable(
+    session_id: String,
+    remote_path: String,
+    manager: State<'_, SessionManager>,
+) -> Result<Writability, TerminalError> {
+    debug!(session_id, "Session SFTP check writable");
+    manager
+        .session_check_writable(&session_id, &remote_path)
+        .await
+}
+
+/// Write a string to a remote file with `sudo`-elevated privileges over a
+/// session's SFTP connection.
+///
+/// Returns a typed [`ElevatedWriteResult`] (`success` / `incorrectPassword` /
+/// `other`) rather than erroring on an authorization failure, so the caller can
+/// re-prompt. The temp upload is always cleaned up and the password is never
+/// logged (mirror of `sftp_write_file_content_elevated`, #2312).
+#[tauri::command]
+pub async fn session_write_file_elevated(
+    session_id: String,
+    remote_path: String,
+    content: String,
+    sudo_password: String,
+    manager: State<'_, SessionManager>,
+) -> Result<ElevatedWriteResult, TerminalError> {
+    // Do not log `sudo_password`.
+    debug!(session_id, remote_path, "Session SFTP elevated write");
+    manager
+        .session_write_file_elevated(&session_id, &remote_path, &content, &sudo_password)
+        .await
+}
+
+/// Report whether a session's SFTP connection can open an exec channel (i.e. run
+/// remote commands such as `sudo`).
+///
+/// Returns `true` for a normal SSH+shell connection and `false` for an
+/// SFTP-only / relayed connection, letting the editor know whether elevated
+/// writes are possible (mirror of `sftp_has_exec_capability`, #2312).
+#[tauri::command]
+pub async fn session_has_exec_capability(
+    session_id: String,
+    manager: State<'_, SessionManager>,
+) -> Result<bool, TerminalError> {
+    manager.session_has_exec_capability(&session_id).await
+}
+
+/// Start a download (remote → local) over a session's SFTP connection.
+///
+/// Registers a `transfer_id`, runs a chunked copy on a **dedicated** SFTP
+/// channel in the background, and returns the id immediately — the copy does not
+/// hold the session lock, so listing / navigating the same session stays live
+/// during the transfer (#1245). Progress and completion are reported via
+/// `transfer-progress` events (mirror of `sftp_download`, #2312).
+#[tauri::command]
+pub async fn session_download(
+    session_id: String,
+    remote_path: String,
+    local_path: String,
+    manager: State<'_, SessionManager>,
+    registry: State<'_, TransferRegistry>,
+    app_handle: tauri::AppHandle,
+) -> Result<String, TerminalError> {
+    debug!(session_id, remote_path, local_path, "Session SFTP download");
+    let browser = manager.sftp_transfer_browser(&session_id).await?;
+    let (dedicated, total) = open_transfer_channel(browser, Some(remote_path.clone())).await?;
+
+    let transfer_id = uuid::Uuid::new_v4().to_string();
+    let file_name = file_name_of(&remote_path);
+    let token = registry.register(
+        &transfer_id,
+        &session_id,
+        TransferDirection::Download,
+        &file_name,
+        &remote_path,
+        total,
+    );
+    let ctx = TransferContext {
+        transfer_id: transfer_id.clone(),
+        session_id,
+        direction: TransferDirection::Download,
+        file_name,
+        path: remote_path.clone(),
+        total,
+    };
+    let registry = (*registry).clone();
+    let sink = transfer::app_progress_sink(app_handle);
+    tauri::async_runtime::spawn(async move {
+        transfer::run_download(
+            dedicated,
+            remote_path,
+            local_path,
+            ctx,
+            token,
+            registry,
+            sink,
+        )
+        .await;
+    });
+    Ok(transfer_id)
+}
+
+/// Start an upload (local → remote) over a session's SFTP connection.
+///
+/// Registers a `transfer_id`, runs a chunked copy on a dedicated SFTP channel in
+/// the background, and returns the id immediately (#1245). Mirrors
+/// [`session_download`] and the standalone `sftp_upload` (#2312).
+#[tauri::command]
+pub async fn session_upload(
+    session_id: String,
+    local_path: String,
+    remote_path: String,
+    manager: State<'_, SessionManager>,
+    registry: State<'_, TransferRegistry>,
+    app_handle: tauri::AppHandle,
+) -> Result<String, TerminalError> {
+    debug!(session_id, local_path, remote_path, "Session SFTP upload");
+    let browser = manager.sftp_transfer_browser(&session_id).await?;
+    let (dedicated, _total) = open_transfer_channel(browser, None).await?;
+
+    // Local files are cheap to stat, so we can report a real total for uploads.
+    let total = tokio::fs::metadata(&local_path)
+        .await
+        .map(|m| m.len())
+        .unwrap_or(0);
+
+    let transfer_id = uuid::Uuid::new_v4().to_string();
+    let file_name = file_name_of(&remote_path);
+    let token = registry.register(
+        &transfer_id,
+        &session_id,
+        TransferDirection::Upload,
+        &file_name,
+        &remote_path,
+        total,
+    );
+    let ctx = TransferContext {
+        transfer_id: transfer_id.clone(),
+        session_id,
+        direction: TransferDirection::Upload,
+        file_name,
+        path: remote_path.clone(),
+        total,
+    };
+    let registry = (*registry).clone();
+    let sink = transfer::app_progress_sink(app_handle);
+    tauri::async_runtime::spawn(async move {
+        transfer::run_upload(
+            dedicated,
+            local_path,
+            remote_path,
+            ctx,
+            token,
+            registry,
+            sink,
+        )
+        .await;
+    });
+    Ok(transfer_id)
 }
 
 // --- Session-based monitoring commands ---

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1294,6 +1294,13 @@ pub fn run() {
             commands::session::session_delete_file,
             commands::session::session_rename_file,
             commands::session::session_mkdir,
+            // Session-scoped SFTP advanced ops & transfers (#2312)
+            commands::session::session_realpath,
+            commands::session::session_check_writable,
+            commands::session::session_write_file_elevated,
+            commands::session::session_has_exec_capability,
+            commands::session::session_download,
+            commands::session::session_upload,
             // Session-based monitoring
             commands::session::session_get_capabilities,
             commands::session::session_monitoring_open,

--- a/src-tauri/src/session/file_ops.rs
+++ b/src-tauri/src/session/file_ops.rs
@@ -8,11 +8,14 @@
 //! lock is held across the browser `await`, as before.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
+use termihub_core::backends::ssh::{SftpAdvancedOps, SftpFileBrowser};
 use termihub_core::files::{FileBrowser, FileEntry};
 
+use crate::files::sftp::{sftp_op_error, ElevatedWriteResult, Writability};
 use crate::utils::errors::TerminalError;
 
 use super::manager::SessionEntry;
@@ -139,5 +142,97 @@ impl<'a> FileOps<'a> {
             .mkdir(path)
             .await
             .map_err(|e| TerminalError::RemoteError(e.to_string()))
+    }
+
+    /// Resolve an **owned** [`Arc<SftpFileBrowser>`] for a session, so a caller
+    /// can drop the sessions lock before driving a (potentially slow) SFTP
+    /// operation or move the handle into a background transfer task.
+    ///
+    /// The session's file browser is stored borrowed inside the connection under
+    /// the sessions lock; the base [`FileBrowser`] capability exposes none of the
+    /// SFTP advanced ops or transfer handles. This downcasts the browser to the
+    /// concrete [`SftpFileBrowser`] via [`FileBrowser::as_any`] and clones it —
+    /// the clone shares the same underlying SFTP connection (its `state` lives
+    /// behind an `Arc`), mirroring how the desktop `SftpManager` hands out
+    /// `Arc<SftpFileBrowser>` (#2312). The lock is released as soon as this
+    /// returns.
+    ///
+    /// Fails with [`TerminalError::RemoteError`] when the session has no file
+    /// browser or its browser is not SFTP-backed (e.g. a local/docker/FTP
+    /// session), preserving the "not supported" shape of the surrounding facade.
+    pub(super) async fn sftp_browser(
+        &self,
+        session_id: &str,
+    ) -> Result<Arc<SftpFileBrowser>, TerminalError> {
+        let sessions = self.sessions.lock().await;
+        let browser = Self::browser(&sessions, session_id)?;
+        let sftp = browser
+            .as_any()
+            .and_then(|any| any.downcast_ref::<SftpFileBrowser>())
+            .ok_or_else(|| {
+                TerminalError::RemoteError(
+                    "Session file browser does not support SFTP advanced operations".to_string(),
+                )
+            })?;
+        Ok(Arc::new(sftp.clone()))
+    }
+
+    /// Resolve a remote path to its canonical absolute form via SFTP realpath.
+    ///
+    /// Session-path mirror of the standalone `sftp_realpath` command; errors are
+    /// mapped with [`sftp_op_error`] so the messages match the standalone path.
+    pub(super) async fn realpath(
+        &self,
+        session_id: &str,
+        path: &str,
+    ) -> Result<String, TerminalError> {
+        let sftp = self.sftp_browser(session_id).await?;
+        sftp.realpath(path).await.map_err(sftp_op_error)
+    }
+
+    /// Authoritatively probe whether a remote file is writable by the connecting
+    /// user, via the non-destructive SFTP write-open probe.
+    ///
+    /// Session-path mirror of the standalone `sftp_check_writable` command.
+    pub(super) async fn check_writable(
+        &self,
+        session_id: &str,
+        remote_path: &str,
+    ) -> Result<Writability, TerminalError> {
+        let sftp = self.sftp_browser(session_id).await?;
+        sftp.check_writable(remote_path)
+            .await
+            .map_err(sftp_op_error)
+    }
+
+    /// Write `content` to `remote_path` with `sudo`-elevated privileges.
+    ///
+    /// Session-path mirror of the standalone `sftp_write_file_content_elevated`
+    /// command; returns a typed [`ElevatedWriteResult`] rather than erroring on an
+    /// authorization failure so the caller can re-prompt.
+    pub(super) async fn write_file_elevated(
+        &self,
+        session_id: &str,
+        remote_path: &str,
+        content: &str,
+        sudo_password: &str,
+    ) -> Result<ElevatedWriteResult, TerminalError> {
+        let sftp = self.sftp_browser(session_id).await?;
+        sftp.write_file_content_elevated(remote_path, content, sudo_password)
+            .await
+            .map_err(sftp_op_error)
+    }
+
+    /// Report whether the session's SFTP connection can open an exec channel
+    /// (i.e. run remote commands such as `sudo`).
+    ///
+    /// Session-path mirror of the standalone `sftp_has_exec_capability` command:
+    /// a dropped / SFTP-only connection maps to `false` rather than erroring.
+    pub(super) async fn has_exec_capability(
+        &self,
+        session_id: &str,
+    ) -> Result<bool, TerminalError> {
+        let sftp = self.sftp_browser(session_id).await?;
+        Ok(sftp.has_exec_capability().await.unwrap_or(false))
     }
 }

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -15,6 +15,7 @@ use tokio_util::sync::CancellationToken;
 
 use serde::Serialize;
 use tauri::Emitter;
+use termihub_core::backends::ssh::SftpFileBrowser;
 use termihub_core::buffer::{RingBuffer, DEFAULT_BUFFER_CAPACITY};
 use termihub_core::connection::{
     Capabilities, ConnectionType, ConnectionTypeInfo, ConnectionTypeRegistry,
@@ -26,6 +27,7 @@ use termihub_core::output::screen_clear::ScreenClearDetector;
 use termihub_core::output::session_log::{SessionLogConfig, SessionLogger};
 use tracing::{error, info, warn};
 
+use crate::files::sftp::{ElevatedWriteResult, Writability};
 use crate::terminal::agent_manager::AgentRpcClient;
 use crate::utils::errors::TerminalError;
 
@@ -873,6 +875,72 @@ impl SessionManager {
     /// Create a directory via a session's file browser capability.
     pub async fn mkdir_file(&self, session_id: &str, path: &str) -> Result<(), TerminalError> {
         self.file_ops().mkdir(session_id, path).await
+    }
+
+    // --- Session-scoped SFTP advanced operations & transfers (#2312) ---
+    //
+    // These reach the SSH-specific SFTP capabilities that do not fit on the shared
+    // `FileBrowser` trait (realpath / writability probe / elevated write / exec
+    // probe) and hand out an owned transfer handle, so a session-backed SSH
+    // connection can drive the same advanced ops and cancellable transfers the
+    // standalone `sftp_*` path offers. They only succeed for an SFTP-backed
+    // session; other backends get a "not supported" `RemoteError`.
+
+    /// Resolve a remote path to its canonical absolute form via a session's SFTP
+    /// realpath (session-path mirror of `sftp_realpath`, #2312).
+    pub async fn session_realpath(
+        &self,
+        session_id: &str,
+        path: &str,
+    ) -> Result<String, TerminalError> {
+        self.file_ops().realpath(session_id, path).await
+    }
+
+    /// Authoritatively probe whether a remote file is writable by the connecting
+    /// user via a session's SFTP write-open probe (session-path mirror of
+    /// `sftp_check_writable`, #2312).
+    pub async fn session_check_writable(
+        &self,
+        session_id: &str,
+        remote_path: &str,
+    ) -> Result<Writability, TerminalError> {
+        self.file_ops()
+            .check_writable(session_id, remote_path)
+            .await
+    }
+
+    /// Write `content` to `remote_path` with `sudo`-elevated privileges over a
+    /// session's SFTP connection (session-path mirror of
+    /// `sftp_write_file_content_elevated`, #2312).
+    pub async fn session_write_file_elevated(
+        &self,
+        session_id: &str,
+        remote_path: &str,
+        content: &str,
+        sudo_password: &str,
+    ) -> Result<ElevatedWriteResult, TerminalError> {
+        self.file_ops()
+            .write_file_elevated(session_id, remote_path, content, sudo_password)
+            .await
+    }
+
+    /// Report whether a session's SFTP connection can open an exec channel
+    /// (session-path mirror of `sftp_has_exec_capability`, #2312).
+    pub async fn session_has_exec_capability(
+        &self,
+        session_id: &str,
+    ) -> Result<bool, TerminalError> {
+        self.file_ops().has_exec_capability(session_id).await
+    }
+
+    /// Resolve an owned [`Arc<SftpFileBrowser>`] for a session so a cancellable
+    /// background transfer can own its channel independently of the sessions lock
+    /// (#1245/#2312). See [`FileOps::sftp_browser`](super::file_ops).
+    pub async fn sftp_transfer_browser(
+        &self,
+        session_id: &str,
+    ) -> Result<Arc<SftpFileBrowser>, TerminalError> {
+        self.file_ops().sftp_browser(session_id).await
     }
 
     /// Get the list of available connection types from the registry.
@@ -3177,6 +3245,68 @@ mod tests {
         let manager = SessionManager::new(ConnectionTypeRegistry::new(), Arc::new(NullAgent));
         let err = manager.read_file("ghost", "/").await.unwrap_err();
         assert!(matches!(err, TerminalError::SessionNotFound(_)));
+    }
+
+    /// The session-scoped SFTP advanced ops (#2312) refuse a session whose file
+    /// browser is not SFTP-backed: the `MockFileBrowser` uses the default
+    /// `FileBrowser::as_any` (returns `None`), so the downcast to
+    /// `SftpFileBrowser` fails and every entry point returns the "not supported"
+    /// `RemoteError` rather than misbehaving.
+    #[tokio::test]
+    async fn session_sftp_ops_error_when_browser_not_sftp_backed() {
+        let manager = SessionManager::new(ConnectionTypeRegistry::new(), Arc::new(NullAgent));
+        manager
+            .insert_test_session(
+                "fs-nonsftp",
+                Box::new(FileConnection {
+                    browser: MockFileBrowser {
+                        listed: Arc::new(std::sync::Mutex::new(Vec::new())),
+                    },
+                }),
+            )
+            .await;
+
+        let assert_not_supported = |res: Result<String, TerminalError>| match res {
+            Err(TerminalError::RemoteError(msg)) => {
+                assert!(
+                    msg.contains("does not support SFTP advanced operations"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected RemoteError, got {other:?}"),
+        };
+
+        assert_not_supported(manager.session_realpath("fs-nonsftp", ".").await);
+        // The transfer-handle resolver rejects the same way. `SftpFileBrowser` is
+        // not `Debug`, so assert on the error without formatting the Ok value.
+        match manager.sftp_transfer_browser("fs-nonsftp").await {
+            Err(TerminalError::RemoteError(msg)) => {
+                assert!(msg.contains("does not support SFTP advanced operations"))
+            }
+            Err(other) => panic!("expected RemoteError, got {other:?}"),
+            Ok(_) => panic!("expected RemoteError for a non-SFTP session, got Ok"),
+        }
+        // has_exec_capability also rejects a non-SFTP session (it cannot silently
+        // report `false` — that verdict only applies to a real SFTP connection).
+        assert!(matches!(
+            manager.session_has_exec_capability("fs-nonsftp").await,
+            Err(TerminalError::RemoteError(_))
+        ));
+    }
+
+    /// The session-scoped SFTP ops surface `SessionNotFound` for an unknown
+    /// session, exactly like the rest of the file-ops facade (#2312).
+    #[tokio::test]
+    async fn session_sftp_ops_error_when_session_unknown() {
+        let manager = SessionManager::new(ConnectionTypeRegistry::new(), Arc::new(NullAgent));
+        assert!(matches!(
+            manager.session_realpath("ghost", ".").await,
+            Err(TerminalError::SessionNotFound(_))
+        ));
+        assert!(matches!(
+            manager.sftp_transfer_browser("ghost").await,
+            Err(TerminalError::SessionNotFound(_))
+        ));
     }
 
     // ── MonitoringController facade tests (#2110) ─────────────────────


### PR DESCRIPTION
## Summary

SFTP convergence **step A** (backend-only, additive) of the #2307 A→B→C split: expose the SSH-specific SFTP advanced ops and cancellable transfers through the session/`ConnectionType` path, so a session-backed SSH connection offers the same surface the standalone `sftp_*` commands do. Nothing is removed — the standalone `SftpManager`/`sftp_*` path keeps working unchanged (step C removes it later).

## What changed

**Core bridge (`termihub-core`)**
- `FileBrowser` trait gains an optional `as_any(&self) -> Option<&dyn Any>` downcast hook. Default returns `None` (no other backend affected); `SftpFileBrowser` overrides it to return `Some(self)`. This lets a session-scoped `&dyn FileBrowser` reach the advanced ops that live on `SftpAdvancedOps` + the concrete `SftpFileBrowser` (`realpath`, `check_writable`, `write_file_content_elevated`, `has_exec_capability`).
- `SftpFileBrowser` derives `Clone`. Its lazily-opened session lives behind an `Arc<Mutex<…>>`, so a clone **shares the same authenticated connection** — the owned-handle mechanism that lets a transfer survive a spawned background task, mirroring how `SftpManager` hands out `Arc<SftpFileBrowser>`.

**Desktop session path (`termihub`)**
- The session `FileOps` facade resolves an owned `Arc<SftpFileBrowser>` (downcast + clone), releasing the sessions lock before each SFTP round-trip.
- `SessionManager` exposes delegating methods, and **six new commands** mirror their standalone counterparts: `session_realpath`, `session_check_writable`, `session_write_file_elevated`, `session_has_exec_capability`, `session_download`, `session_upload`. Transfers preserve the eager fail-loudly-open contract and the #1245 dedicated per-transfer channel by reusing the existing transfer machinery. A non-SFTP session gets a "not supported" `RemoteError`.

## Testing

- **Unit** (core): `Clone` shares the connection-state `Arc`; `as_any` downcasts back to `SftpFileBrowser`.
- **Unit** (desktop): the session SFTP ops reject a non-SFTP session with the "not supported" `RemoteError` and surface `SessionNotFound` for an unknown session.
- **Docker-SFTP integration parity** (`sftp_stress_17`): drives the new `as_any` downcast end-to-end against the `sftp-stress` container and asserts the session path returns the same `realpath`, writability verdict, and exec-capability as a standalone `SftpFileBrowser`. Ran locally (dev2-isolated Docker): full `sftp_stress` suite 17/17 pass.
- `cargo test -p termihub-core --all-features --lib` (1354 pass), `cargo test -p termihub --lib` (session/files), `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -D warnings` all green.

## Notes

- Backend-only and not yet wired to the frontend (step B), so no changelog fragment.
- Item 2 (owned transfer handle) was achieved additively via `#[derive(Clone)]` + downcast — it did **not** require touching connection/session storage internals or any forbidden zone.

Part of #2307
Closes #2312

🤖 Generated with [Claude Code](https://claude.com/claude-code)