### PR TITLE
fix(config): harden config structs against silent frontend field drops (Closes #2311)

### DIFF
--- a/src-tauri/src/connection/config.rs
+++ b/src-tauri/src/connection/config.rs
@@ -105,6 +105,17 @@ pub struct TerminalOptions {
     /// precedent rather than duplicating the frontend's nested schema in Rust.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub syntax_highlighting: Option<serde_json::Value>,
+    /// Forward-compatibility catch-all (#2311).
+    ///
+    /// Preserves any field the frontend `TerminalOptions` interface
+    /// (`src/types/terminal.ts`) carries that this struct does not model
+    /// explicitly. Without it, an unmodelled key is silently dropped on the
+    /// save/load round-trip and the user loses that per-connection option on the
+    /// next restart — the exact defect class behind #2261, #2309 and this
+    /// hardening. Unknown keys round-trip verbatim instead. Empty by default, so
+    /// a flattened empty map contributes nothing to the serialized output.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
 // ---------------------------------------------------------------------------
@@ -115,6 +126,12 @@ pub struct TerminalOptions {
 ///
 /// Folders contain children; connections are leaf nodes.
 /// Neither has an `id` — identity is determined by name within the parent.
+// Both variants are intentionally value-carrying persistence nodes: a
+// `Connection` inlines its `ConnectionConfig` and `TerminalOptions` (the latter
+// grew with the #2311 flatten catch-all). Boxing a field to shrink the enum
+// would add heap indirection to every tree node — an unhelpful trade for a
+// short-lived (de)serialization type — so the size skew is accepted.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum ConnectionTreeNode {
@@ -520,5 +537,206 @@ mod tests {
         assert_eq!(json.get("type").unwrap(), "folder");
         assert_eq!(json.get("name").unwrap(), "Work");
         assert_eq!(json.get("isExpanded").unwrap(), false);
+    }
+
+    // -----------------------------------------------------------------------
+    // #2311 — serde field-drop guard
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn terminal_options_flatten_preserves_unknown_frontend_field() {
+        // A field the backend does not model must round-trip through the
+        // `#[serde(flatten)] extra` catch-all instead of vanishing on save.
+        // Without the catch-all this assertion fails — that is the guard.
+        let json = serde_json::json!({
+            "cursorStyle": "bar",
+            "someFutureOption": { "nested": [1, 2, 3] },
+            "anotherNewFlag": true,
+        });
+
+        let opts: TerminalOptions = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(
+            opts.extra.get("someFutureOption"),
+            json.get("someFutureOption"),
+            "unknown key was not captured by the flatten catch-all",
+        );
+
+        let round_tripped = serde_json::to_value(&opts).unwrap();
+        assert_eq!(
+            round_tripped.get("someFutureOption"),
+            json.get("someFutureOption")
+        );
+        assert_eq!(
+            round_tripped.get("anotherNewFlag"),
+            json.get("anotherNewFlag")
+        );
+        // Modelled fields still work alongside the catch-all.
+        assert_eq!(round_tripped.get("cursorStyle").unwrap(), "bar");
+    }
+
+    #[test]
+    fn terminal_options_empty_extra_keeps_serialized_output_clean() {
+        // An empty catch-all must contribute nothing to the JSON — no stray
+        // "extra" key, no empty object.
+        let opts = TerminalOptions {
+            cursor_style: Some("block".to_string()),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&opts).unwrap();
+        assert!(json.get("extra").is_none(), "flatten leaked an `extra` key");
+        let obj = json.as_object().unwrap();
+        assert_eq!(obj.len(), 1, "unexpected keys: {obj:?}");
+        assert_eq!(obj.get("cursorStyle").unwrap(), "block");
+    }
+
+    // ---- Frontend/backend drift guard (approach (b), for the non-flatten
+    // ---- container structs `SavedConnection` and `ConnectionConfig`) --------
+
+    /// Extract the top-level field names of a TypeScript `export interface`.
+    ///
+    /// Only depth-1 members are returned; JSDoc/`//` comments, blank lines and
+    /// nested object types are skipped. Trailing `?` (optional) is stripped.
+    fn extract_ts_interface_fields(
+        src: &str,
+        interface: &str,
+    ) -> std::collections::BTreeSet<String> {
+        let header = format!("export interface {interface} {{");
+        let mut lines = src.lines();
+        let mut found = false;
+        for line in lines.by_ref() {
+            if line.contains(&header) {
+                found = true;
+                break;
+            }
+        }
+        assert!(found, "interface `{interface}` not found in source");
+
+        let mut fields = std::collections::BTreeSet::new();
+        let mut depth = 1i32; // the opening brace was on the header line
+        for line in lines {
+            let trimmed = line.trim();
+            let is_comment = trimmed.is_empty()
+                || trimmed.starts_with("//")
+                || trimmed.starts_with("/*")
+                || trimmed.starts_with('*');
+            if depth == 1 && !is_comment {
+                if let Some(name) = parse_ts_field_name(trimmed) {
+                    fields.insert(name);
+                }
+            }
+            depth += line.matches('{').count() as i32;
+            depth -= line.matches('}').count() as i32;
+            if depth <= 0 {
+                break;
+            }
+        }
+        fields
+    }
+
+    /// Parse a leading `name:` / `name?:` identifier from a TS member line.
+    fn parse_ts_field_name(line: &str) -> Option<String> {
+        let end = line
+            .char_indices()
+            .find(|(_, c)| !(c.is_ascii_alphanumeric() || *c == '_' || *c == '$'))
+            .map(|(i, _)| i)
+            .unwrap_or(line.len());
+        if end == 0 {
+            return None;
+        }
+        let rest = line[end..].trim_start();
+        if rest.starts_with('?') || rest.starts_with(':') {
+            Some(line[..end].to_string())
+        } else {
+            None
+        }
+    }
+
+    /// Fail when the frontend interface carries a field the backend neither
+    /// models nor knowingly excludes — the silent-drop defect (#2311).
+    fn assert_no_silent_drop(ts_src: &str, interface: &str, modelled: &[&str], known_gap: &[&str]) {
+        let ts = extract_ts_interface_fields(ts_src, interface);
+        assert!(!ts.is_empty(), "no fields parsed for `{interface}`");
+        let modelled: std::collections::BTreeSet<String> =
+            modelled.iter().map(|s| s.to_string()).collect();
+        let known_gap: std::collections::BTreeSet<String> =
+            known_gap.iter().map(|s| s.to_string()).collect();
+        let dropped: Vec<&String> = ts
+            .iter()
+            .filter(|f| !modelled.contains(*f) && !known_gap.contains(*f))
+            .collect();
+        assert!(
+            dropped.is_empty(),
+            "frontend `{interface}` has field(s) the backend silently drops: {dropped:?}. \
+             Add a matching backend field (or `#[serde(flatten)] extra` catch-all), or record \
+             it in the known-gap list with a tracking issue.",
+        );
+    }
+
+    // These const lists mirror the serialized (camelCase) keys of the Rust
+    // structs. Update them when a field is added/removed so the drift test
+    // stays a faithful mirror.
+    const CONNECTION_CONFIG_BACKEND_FIELDS: &[&str] = &["type", "config"];
+    const SAVED_CONNECTION_BACKEND_FIELDS: &[&str] = &[
+        "id",
+        "name",
+        "config",
+        "folderId",
+        "terminalOptions",
+        "sourceFile",
+    ];
+
+    #[test]
+    fn connection_config_no_silent_frontend_field_drop() {
+        // `ConnectionConfig.settings` is opaque JSON (`serde_json::Value`) that
+        // already preserves everything under `config`; only the two top-level
+        // keys need to stay in parity with the frontend.
+        let ts = include_str!("../../../src/types/terminal.ts");
+        assert_no_silent_drop(
+            ts,
+            "ConnectionConfig",
+            CONNECTION_CONFIG_BACKEND_FIELDS,
+            &[],
+        );
+    }
+
+    #[test]
+    fn saved_connection_no_silent_frontend_field_drop() {
+        let ts = include_str!("../../../src/types/connection.ts");
+        // KNOWN GAP: the frontend `SavedConnection.icon` (src/types/connection.ts)
+        // has no backend field, so it is dropped on `save_connection`. Recorded
+        // here rather than silently ignored — tracked by a follow-up to #2311.
+        assert_no_silent_drop(
+            ts,
+            "SavedConnection",
+            SAVED_CONNECTION_BACKEND_FIELDS,
+            &["icon"],
+        );
+    }
+
+    #[test]
+    fn drift_guard_flags_an_unmodelled_field() {
+        // Proves the guard's red path: a synthetic interface with a field the
+        // backend does not model is reported.
+        let ts = "export interface Sample {\n  known: string;\n  brandNew?: number;\n}\n";
+        // The catch-all is expected to panic; silence its backtrace so the test
+        // log stays clean, then restore the previous hook.
+        let prev = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let result = std::panic::catch_unwind(|| {
+            assert_no_silent_drop(ts, "Sample", &["known"], &[]);
+        });
+        std::panic::set_hook(prev);
+        assert!(
+            result.is_err(),
+            "drift guard failed to flag the unmodelled `brandNew` field",
+        );
+    }
+
+    #[test]
+    fn ts_field_extractor_ignores_comments_and_nested_blocks() {
+        let ts = "export interface Sample {\n  /** doc */\n  a: string;\n  // note\n  b?: { x: number };\n  c: string;\n}\n";
+        let fields = extract_ts_interface_fields(ts, "Sample");
+        let got: Vec<&str> = fields.iter().map(String::as_str).collect();
+        assert_eq!(got, vec!["a", "b", "c"]);
     }
 }

--- a/src-tauri/src/connection/settings.rs
+++ b/src-tauri/src/connection/settings.rs
@@ -322,6 +322,17 @@ pub struct AppSettings {
     /// imported workflow can never add an entry.
     #[serde(default)]
     pub workflow_local_process_allowlist: Vec<String>,
+    /// Forward-compatibility catch-all (#2311).
+    ///
+    /// Preserves any field the frontend `AppSettings` interface
+    /// (`src/types/connection.ts`) carries that this struct does not model
+    /// explicitly. Without it, an unmodelled key is silently dropped when
+    /// settings are saved and the user loses that setting on the next restart —
+    /// the exact defect class behind #2261 (`confirmCloseAttachedTab` etc.) and
+    /// #2309. Unknown keys round-trip verbatim instead. Empty by default, so a
+    /// flattened empty map contributes nothing to the serialized output.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
 impl Default for AppSettings {
@@ -378,6 +389,7 @@ impl Default for AppSettings {
             syntax_highlighting: None,
             workflow_local_process_enabled: false,
             workflow_local_process_allowlist: Vec::new(),
+            extra: serde_json::Map::new(),
         }
     }
 }
@@ -1348,5 +1360,47 @@ mod tests {
         assert!(legacy.warn_large_port_scan);
         assert!(legacy.warn_large_ping_sweep);
         assert!(legacy.screen_reader_mode.is_none());
+    }
+
+    #[test]
+    fn app_settings_flatten_preserves_unknown_frontend_field() {
+        // #2311: a field the backend does not model must round-trip through the
+        // `#[serde(flatten)] extra` catch-all instead of being silently dropped
+        // on save — the exact failure mode of #2261/#2309. Without the catch-all
+        // this assertion fails, which is what makes it a guard.
+        let json = serde_json::json!({
+            "version": "1",
+            "externalConnectionFiles": [],
+            "theme": "dark",
+            "someFutureSetting": { "a": 1, "b": [true, false] },
+            "anotherNewToggle": true,
+        });
+
+        let settings: AppSettings = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(
+            settings.extra.get("someFutureSetting"),
+            json.get("someFutureSetting"),
+            "unknown key was not captured by the flatten catch-all",
+        );
+
+        let round_tripped = serde_json::to_value(&settings).unwrap();
+        assert_eq!(
+            round_tripped.get("someFutureSetting"),
+            json.get("someFutureSetting")
+        );
+        assert_eq!(
+            round_tripped.get("anotherNewToggle"),
+            json.get("anotherNewToggle")
+        );
+        // A modelled field still deserializes correctly alongside the catch-all.
+        assert_eq!(settings.theme.as_deref(), Some("dark"));
+    }
+
+    #[test]
+    fn app_settings_empty_extra_keeps_serialized_output_clean() {
+        // An empty catch-all must not leak an `extra` key into the JSON.
+        let settings = AppSettings::default();
+        let json = serde_json::to_value(&settings).unwrap();
+        assert!(json.get("extra").is_none(), "flatten leaked an `extra` key");
     }
 }


### PR DESCRIPTION
## What & why

The same defect class has hit three times: a typed backend struct that mirrors a frontend TypeScript interface silently **drops** any field it does not explicitly model, because it deserializes at the IPC boundary with `#[serde(default, rename_all="camelCase")]` and no catch-all — so an unmodelled key vanishes on save and the user loses that setting on restart (#2261 `AppSettings`, #2309 `TerminalOptions`).

Closes #2311.

## Approach — (a) flatten catch-all + (b) drift test, combined

Both candidate approaches were evaluated; each is applied where it fits best.

**(a) `#[serde(flatten)] extra` catch-all** on the two IPC-boundary *settings-mirror* structs that actually got hit and are the exact recurrence pattern (a large TS interface mirrored field-by-field):

- `AppSettings` (`connection/settings.rs`)
- `TerminalOptions` (`connection/config.rs`)

Any field the frontend adds now round-trips verbatim instead of being dropped — **no data loss, no future backend change required**. The map is empty by default, so a flattened empty map contributes nothing to the serialized output (verified by test). Blast radius is trivial: all construction sites use `..Default::default()` (`TerminalOptions` derives `Default`; `AppSettings` has a manual `Default` that gained one line).

**(b) drift test** for the two *container* structs where flatten is the wrong tool:

- `ConnectionConfig` — `settings` is already opaque `serde_json::Value`, so it captures everything under `config`; it is immune to drift and only its two top-level keys need parity.
- `SavedConnection` — has ~44 full-literal construction sites (several in `*_projection` domains) and no `Default`, so a flatten field would be an invasive refactor touching unrelated code. Instead, a test reads the frontend TS interface (`include_str!`) and fails loudly if the frontend carries a field the backend neither models nor knowingly excludes.

This directly satisfies the issue's *Done when*: a newly-added frontend field is either **preserved** (flatten round-trip) or **fails a CI test** — no silent drop.

## Real drop found by the new guard

The drift test immediately surfaced a live instance: the frontend `SavedConnection.icon` (`src/types/connection.ts`) has no backend field, so it is dropped by `save_connection`. It is recorded as a documented known-gap so CI stays green, and tracked by follow-up #2316 to persist it properly (it needs an explicit field, not flatten, for the reason above).

## Tests

- `terminal_options_flatten_preserves_unknown_frontend_field` / `app_settings_flatten_preserves_unknown_frontend_field` — unknown key round-trips through the catch-all (would fail without the fix).
- `*_empty_extra_keeps_serialized_output_clean` — empty catch-all leaks no `extra` key.
- `saved_connection_no_silent_frontend_field_drop` / `connection_config_no_silent_frontend_field_drop` — TS-vs-backend drift guard.
- `drift_guard_flags_an_unmodelled_field` — proves the guard's red path (a synthetic unmodelled field is reported).
- `ts_field_extractor_ignores_comments_and_nested_blocks` — TS parser sanity.

All in the standard `cargo test` lane. `cargo test -p termihub --lib connection::` → 188 passed; `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, and `cargo build` all clean.

Note: clippy `large_enum_variant` fired on `ConnectionTreeNode` once `TerminalOptions` grew; resolved with a justified `#[allow]` (boxing would add heap indirection to every tree node for a short-lived (de)serialization type).

## Changelog

No changelog fragment — internal hardening with no user-visible feature change (the two previously-lost settings from #2261/#2309 are already fixed by their explicit fields).