### PR TITLE
fix(workspace): write persistence files atomically to prevent torn-write data loss (Closes #2318)

### DIFF
--- a/docs/changes/dev2/fix/2318-atomic-workspace-writes.md
+++ b/docs/changes/dev2/fix/2318-atomic-workspace-writes.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Workspace persistence now writes its files atomically (temp file + rename)
+  instead of truncating them in place. Previously an interrupted save — a crash,
+  power loss, or full disk mid-write — could leave `workspaces.json` or
+  `last-session.json` truncated; on the next launch the corrupt file was
+  discarded, silently wiping every saved workspace and the restored session. An
+  atomic replace guarantees the file always holds either the complete previous
+  contents or the complete new contents, so an interrupted save never loses
+  existing data (#2318).

--- a/src-tauri/src/workspace/atomic.rs
+++ b/src-tauri/src/workspace/atomic.rs
@@ -1,0 +1,113 @@
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use tempfile::NamedTempFile;
+
+/// Atomically write `contents` to `path`.
+///
+/// The bytes are first written to a temporary file in the **same directory** as
+/// `path` (so the final rename stays on one filesystem and is therefore atomic),
+/// flushed to disk, and only then renamed over `path`. A crash, power loss, or
+/// full disk mid-write can leave the temporary file behind but never touches the
+/// destination: `path` always holds either the complete previous contents or the
+/// complete new contents, never a truncated mix.
+///
+/// This protects the workspace persistence stores from silent total data loss on
+/// a torn write. A plain [`std::fs::write`] opens the destination with
+/// `O_TRUNC`, truncating it to zero *before* writing — so an interrupted write
+/// leaves invalid JSON that the recovery paths discard, wiping every saved
+/// workspace / the restored session (#2318).
+pub(crate) fn write_atomic(path: &Path, contents: &str) -> Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+
+    let mut tmp = NamedTempFile::new_in(parent)
+        .context("Failed to create temporary file for atomic write")?;
+    tmp.write_all(contents.as_bytes())
+        .context("Failed to write to temporary file")?;
+    // Flush the data to disk before the rename so a crash after the rename can
+    // never expose a temp file whose contents were not durably written.
+    tmp.as_file()
+        .sync_all()
+        .context("Failed to flush temporary file to disk")?;
+    tmp.persist(path)
+        .map_err(|e| e.error)
+        .context("Failed to persist temporary file over target")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn writes_new_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.json");
+
+        write_atomic(&path, "{\"hello\":true}").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "{\"hello\":true}");
+    }
+
+    #[test]
+    fn overwrites_existing_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.json");
+
+        write_atomic(&path, "old").unwrap();
+        write_atomic(&path, "new-and-longer").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new-and-longer");
+    }
+
+    #[test]
+    fn leaves_no_temp_artifacts() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.json");
+
+        write_atomic(&path, "payload").unwrap();
+
+        let names: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec!["data.json".to_string()], "got {names:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_write_preserves_existing_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.json");
+        write_atomic(&path, "original").unwrap();
+
+        let restore = std::fs::metadata(dir.path()).unwrap().permissions();
+        let mut ro = restore.clone();
+        ro.set_mode(0o500);
+        std::fs::set_permissions(dir.path(), ro).unwrap();
+
+        // Skip under root, which can create files regardless of directory mode.
+        let probe = dir.path().join(".probe");
+        if std::fs::write(&probe, b"x").is_ok() {
+            let _ = std::fs::remove_file(&probe);
+            std::fs::set_permissions(dir.path(), restore).unwrap();
+            return;
+        }
+
+        let result = write_atomic(&path, "replacement");
+        std::fs::set_permissions(dir.path(), restore).unwrap();
+
+        assert!(result.is_err(), "write into a read-only dir must fail");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "original",
+            "a failed atomic write must leave the previous file intact"
+        );
+    }
+}

--- a/src-tauri/src/workspace/last_session.rs
+++ b/src-tauri/src/workspace/last_session.rs
@@ -213,6 +213,53 @@ mod tests {
         assert!(storage.clear().is_ok());
     }
 
+    /// Regression (#2318): the last-session file is rewritten on every layout
+    /// change, so a torn write is especially likely. A save that cannot durably
+    /// complete must fail without destroying the previously-saved session. The
+    /// old truncate-in-place `fs::write` overwrites the existing file here (red);
+    /// the atomic temp+rename write leaves it untouched.
+    #[cfg(unix)]
+    #[test]
+    fn failed_save_preserves_previous_session() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let storage = create_test_storage(&dir);
+
+        storage.save(&sample_session()).unwrap();
+        let before = fs::read_to_string(&storage.file_path).unwrap();
+
+        let restore = fs::metadata(dir.path()).unwrap().permissions();
+        let mut ro = restore.clone();
+        ro.set_mode(0o500);
+        fs::set_permissions(dir.path(), ro).unwrap();
+
+        // Root can write regardless of mode — skip in that case.
+        let probe = dir.path().join(".probe");
+        if fs::write(&probe, b"x").is_ok() {
+            let _ = fs::remove_file(&probe);
+            fs::set_permissions(dir.path(), restore).unwrap();
+            return;
+        }
+
+        let mut updated = sample_session();
+        updated.version = "2".to_string();
+        let result = storage.save(&updated);
+
+        fs::set_permissions(dir.path(), restore).unwrap();
+
+        assert!(
+            result.is_err(),
+            "a save that cannot durably complete must report an error"
+        );
+        let after = fs::read_to_string(&storage.file_path).unwrap();
+        assert_eq!(
+            before, after,
+            "a failed save must leave the previous session fully intact"
+        );
+        serde_json::from_str::<LastSession>(&after).expect("preserved session still parses");
+    }
+
     #[test]
     fn deserialize_without_active_group_index_defaults_to_zero() {
         let json = r#"{"version":"1","tabGroups":[]}"#;

--- a/src-tauri/src/workspace/last_session.rs
+++ b/src-tauri/src/workspace/last_session.rs
@@ -5,6 +5,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
 
+use super::atomic::write_atomic;
 use super::config::{WorkspaceTabGroupDef, WorkspaceWindowDef};
 use crate::utils::config_paths::resolve_config_dir;
 
@@ -83,11 +84,16 @@ impl LastSessionStorage {
     }
 
     /// Save the last session to disk (pretty-printed JSON).
+    ///
+    /// The write is atomic (temp file in the same directory + rename). This file
+    /// is rewritten on every layout change, so a torn write is especially likely;
+    /// an atomic replace guarantees the previous session survives an interrupted
+    /// save instead of being silently discarded on next startup (#2318).
     pub fn save(&self, session: &LastSession) -> Result<()> {
         let data =
             serde_json::to_string_pretty(session).context("Failed to serialize last session")?;
 
-        fs::write(&self.file_path, data).context("Failed to write last-session file")?;
+        write_atomic(&self.file_path, &data).context("Failed to write last-session file")?;
 
         Ok(())
     }

--- a/src-tauri/src/workspace/mod.rs
+++ b/src-tauri/src/workspace/mod.rs
@@ -1,3 +1,4 @@
+mod atomic;
 pub mod config;
 pub mod last_session;
 pub mod manager;

--- a/src-tauri/src/workspace/storage.rs
+++ b/src-tauri/src/workspace/storage.rs
@@ -143,4 +143,78 @@ mod tests {
         let backup = storage.file_path.with_extension("json.bak");
         assert!(backup.exists());
     }
+
+    /// A successful atomic save must leave only the target file behind — no
+    /// leftover temporary write artifacts in the config directory.
+    #[test]
+    fn save_leaves_no_stray_files() {
+        let dir = TempDir::new().unwrap();
+        let storage = create_test_storage(&dir);
+
+        storage.save(&WorkspaceStore::default()).unwrap();
+
+        let names: Vec<String> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec![FILE_NAME.to_string()],
+            "atomic save must leave only the target file, got {names:?}"
+        );
+    }
+
+    /// Regression (#2318): a save that cannot durably complete must fail
+    /// **without** clobbering the previously-saved store. The old truncate-in-place
+    /// `fs::write` succeeds here by overwriting the existing file, so this fails
+    /// red on it; the atomic temp+rename write cannot create its temp file in a
+    /// read-only directory and therefore leaves the prior file untouched.
+    #[cfg(unix)]
+    #[test]
+    fn failed_save_preserves_previous_store() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let storage = create_test_storage(&dir);
+
+        // Seed a good, complete store and capture its exact on-disk bytes.
+        storage.save(&WorkspaceStore::default()).unwrap();
+        let before = fs::read_to_string(&storage.file_path).unwrap();
+
+        // Make the directory read-only so no new (temp) file can be created in it.
+        let restore = fs::metadata(dir.path()).unwrap().permissions();
+        let mut ro = restore.clone();
+        ro.set_mode(0o500);
+        fs::set_permissions(dir.path(), ro).unwrap();
+
+        // A privileged/root process can create files regardless of mode — skip.
+        let probe = dir.path().join(".probe");
+        if fs::write(&probe, b"x").is_ok() {
+            let _ = fs::remove_file(&probe);
+            fs::set_permissions(dir.path(), restore).unwrap();
+            return;
+        }
+
+        let updated = WorkspaceStore {
+            version: "2".to_string(),
+            workspaces: Vec::new(),
+        };
+        let result = storage.save(&updated);
+
+        // Restore permissions before asserting so TempDir can clean up.
+        fs::set_permissions(dir.path(), restore).unwrap();
+
+        assert!(
+            result.is_err(),
+            "a save that cannot durably complete must report an error"
+        );
+        let after = fs::read_to_string(&storage.file_path).unwrap();
+        assert_eq!(
+            before, after,
+            "a failed save must leave the previous store fully intact"
+        );
+        // And the preserved file must still be valid JSON.
+        serde_json::from_str::<WorkspaceStore>(&after).expect("preserved store still parses");
+    }
 }

--- a/src-tauri/src/workspace/storage.rs
+++ b/src-tauri/src/workspace/storage.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use tauri::AppHandle;
 
+use super::atomic::write_atomic;
 use super::config::WorkspaceStore;
 use crate::connection::recovery::{RecoveryResult, RecoveryWarning};
 use crate::utils::config_paths::resolve_config_dir;
@@ -78,10 +79,14 @@ impl WorkspaceStorage {
     }
 
     /// Save the workspace store to disk (pretty-printed JSON).
+    ///
+    /// The write is atomic (temp file in the same directory + rename), so an
+    /// interrupted save can never truncate the existing store and lose every
+    /// saved workspace (#2318).
     pub fn save(&self, store: &WorkspaceStore) -> Result<()> {
         let data = serde_json::to_string_pretty(store).context("Failed to serialize workspaces")?;
 
-        fs::write(&self.file_path, data).context("Failed to write workspaces file")?;
+        write_atomic(&self.file_path, &data).context("Failed to write workspaces file")?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Workspace persistence wrote its JSON stores with a non-atomic `fs::write`, which truncates the destination file **before** writing. An interrupted write (crash, power loss, full disk) left the file truncated/invalid, and on the next launch the recovery paths silently discarded it — wiping **all saved workspaces** (`workspaces.json`) and the **restored session layout** (`last-session.json`, which is rewritten on every layout change, so especially exposed). For a ventilator-grade app this is real data loss.

This routes both saves through a new atomic `write_atomic` helper: serialize to a temp file in the **same directory**, `sync_all`, then `rename` over the target. The destination always holds either the complete previous contents or the complete new contents — never a truncated mix. Uses the already-present `tempfile` crate (`NamedTempFile::persist`) per the repo's prefer-libraries standard.

## Changes

- New `src-tauri/src/workspace/atomic.rs` with `write_atomic` (temp-in-same-dir + fsync + rename).
- `WorkspaceStorage::save` and `LastSessionStorage::save` now use it.

## Testing (TDD — red before green)

- Regression tests in `storage.rs` and `last_session.rs` (unix, root-skipped): a save that cannot durably complete returns `Err` and leaves the previously-saved file fully intact. Both fail red against the old truncate-in-place write.
- Helper unit tests: new-file write, overwrite, no stray temp artifacts, and failed-write-preserves-existing.
- `cargo test -p termihub --lib workspace` (62 passed), `cargo fmt --all --check`, `cargo clippy -p termihub --all-targets --all-features -D warnings`, `cargo build` all clean.

Closes #2318
