### PR TITLE
fix(config): persist SavedConnection.icon through the backend (Closes #2316)

### DIFF
--- a/docs/changes/dev3/fix/2316-persist-connection-icon.md
+++ b/docs/changes/dev3/fix/2316-persist-connection-icon.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- A connection's chosen icon no longer disappears after saving. The frontend
+  `SavedConnection.icon` field had no matching backend field, so the icon was
+  silently dropped when a connection was saved and lost on the next app restart.
+  The backend now models `icon` on both the in-memory `SavedConnection` and the
+  on-disk connection tree node, persisting the user's icon choice across
+  restarts (Closes #2316).

--- a/src-tauri/src/commands/spawn.rs
+++ b/src-tauri/src/commands/spawn.rs
@@ -788,6 +788,7 @@ mod tests {
         settings: serde_json::Value,
     ) -> SavedConnection {
         SavedConnection {
+            icon: None,
             id: id.to_string(),
             name: name.to_string(),
             config: ConnectionConfig {

--- a/src-tauri/src/connection/config.rs
+++ b/src-tauri/src/connection/config.rs
@@ -151,6 +151,13 @@ pub enum ConnectionTreeNode {
         config: ConnectionConfig,
         #[serde(skip_serializing_if = "Option::is_none")]
         terminal_options: Option<TerminalOptions>,
+        /// Optional per-connection icon identifier chosen in the UI.
+        ///
+        /// Mirrors the frontend `SavedConnection.icon`
+        /// (`src/types/connection.ts`). Persisted on disk so the user's icon
+        /// choice survives a save/load round-trip (#2316).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        icon: Option<String>,
     },
 }
 
@@ -245,6 +252,13 @@ pub struct SavedConnection {
     pub folder_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub terminal_options: Option<TerminalOptions>,
+    /// Optional per-connection icon identifier chosen in the UI.
+    ///
+    /// Mirrors the frontend `SavedConnection.icon` (`src/types/connection.ts`).
+    /// Without this field the user's icon choice was silently dropped on
+    /// `save_connection` and lost on the next restart (#2316).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
     /// Runtime-only: which external file this connection was loaded from.
     /// `None` = main connections.json, `Some(path)` = external file.
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -305,6 +319,7 @@ mod tests {
             name: "Work".to_string(),
             is_expanded: true,
             children: vec![ConnectionTreeNode::Connection {
+                icon: None,
                 name: "My SSH".to_string(),
                 config: make_ssh_config(),
                 terminal_options: None,
@@ -329,6 +344,7 @@ mod tests {
     #[test]
     fn connection_tree_node_connection_serde_round_trip() {
         let node = ConnectionTreeNode::Connection {
+            icon: None,
             name: "Local Shell".to_string(),
             config: make_local_config(),
             terminal_options: Some(TerminalOptions {
@@ -343,10 +359,12 @@ mod tests {
                 name,
                 config,
                 terminal_options,
+                icon,
             } => {
                 assert_eq!(name, "Local Shell");
                 assert_eq!(config.type_id, "local");
                 assert!(terminal_options.is_some());
+                assert!(icon.is_none());
             }
             _ => panic!("Expected Connection"),
         }
@@ -361,12 +379,14 @@ mod tests {
                     name: "Work".to_string(),
                     is_expanded: true,
                     children: vec![ConnectionTreeNode::Connection {
+                        icon: None,
                         name: "Prod SSH".to_string(),
                         config: make_ssh_config(),
                         terminal_options: None,
                     }],
                 },
                 ConnectionTreeNode::Connection {
+                    icon: None,
                     name: "Local".to_string(),
                     config: make_local_config(),
                     terminal_options: None,
@@ -465,6 +485,7 @@ mod tests {
     #[test]
     fn serde_produces_correct_json_shape() {
         let node = ConnectionTreeNode::Connection {
+            icon: None,
             name: "Test".to_string(),
             config: make_local_config(),
             terminal_options: Some(TerminalOptions {
@@ -682,6 +703,7 @@ mod tests {
         "config",
         "folderId",
         "terminalOptions",
+        "icon",
         "sourceFile",
     ];
 
@@ -702,15 +724,69 @@ mod tests {
     #[test]
     fn saved_connection_no_silent_frontend_field_drop() {
         let ts = include_str!("../../../src/types/connection.ts");
-        // KNOWN GAP: the frontend `SavedConnection.icon` (src/types/connection.ts)
-        // has no backend field, so it is dropped on `save_connection`. Recorded
-        // here rather than silently ignored — tracked by a follow-up to #2311.
-        assert_no_silent_drop(
-            ts,
-            "SavedConnection",
-            SAVED_CONNECTION_BACKEND_FIELDS,
-            &["icon"],
+        // No known gaps: every frontend `SavedConnection` field is now modelled
+        // by the backend (the `icon` gap tracked by #2311 was closed in #2316).
+        assert_no_silent_drop(ts, "SavedConnection", SAVED_CONNECTION_BACKEND_FIELDS, &[]);
+    }
+
+    #[test]
+    fn saved_connection_icon_round_trips_through_serde() {
+        // Regression for #2316: the frontend `SavedConnection.icon`
+        // (src/types/connection.ts) must survive the save/load round-trip
+        // instead of being silently dropped and lost on the next restart.
+        let json = serde_json::json!({
+            "id": "Work/My SSH",
+            "name": "My SSH",
+            "config": { "type": "ssh", "config": { "host": "example.com" } },
+            "folderId": "Work",
+            "icon": "server"
+        });
+        let conn: SavedConnection = serde_json::from_value(json).unwrap();
+        assert_eq!(conn.icon.as_deref(), Some("server"));
+
+        let round_tripped = serde_json::to_value(&conn).unwrap();
+        assert_eq!(round_tripped.get("icon").unwrap(), "server");
+    }
+
+    #[test]
+    fn saved_connection_without_icon_stays_clean() {
+        // A connection with no icon must not emit a stray `icon` key.
+        let conn = SavedConnection {
+            id: "Local".to_string(),
+            name: "Local".to_string(),
+            config: make_local_config(),
+            folder_id: None,
+            terminal_options: None,
+            icon: None,
+            source_file: None,
+        };
+        let json = serde_json::to_value(&conn).unwrap();
+        assert!(
+            json.get("icon").is_none(),
+            "icon: None leaked an `icon` key into the serialized output",
         );
+    }
+
+    #[test]
+    fn connection_tree_node_connection_icon_round_trips() {
+        // The on-disk `ConnectionTreeNode::Connection` variant must carry `icon`
+        // so it persists to disk, not just in memory (#2316).
+        let node = ConnectionTreeNode::Connection {
+            name: "My SSH".to_string(),
+            config: make_ssh_config(),
+            terminal_options: None,
+            icon: Some("server".to_string()),
+        };
+        let json = serde_json::to_value(&node).unwrap();
+        assert_eq!(json.get("icon").unwrap(), "server");
+
+        let deserialized: ConnectionTreeNode = serde_json::from_value(json).unwrap();
+        match deserialized {
+            ConnectionTreeNode::Connection { icon, .. } => {
+                assert_eq!(icon.as_deref(), Some("server"));
+            }
+            _ => panic!("Expected Connection"),
+        }
     }
 
     #[test]

--- a/src-tauri/src/connection/jump_host_resolver.rs
+++ b/src-tauri/src/connection/jump_host_resolver.rs
@@ -279,6 +279,7 @@ mod tests {
 
     fn conn(id: &str, name: &str, type_id: &str, settings: Value) -> SavedConnection {
         SavedConnection {
+            icon: None,
             id: id.to_string(),
             name: name.to_string(),
             config: ConnectionConfig {

--- a/src-tauri/src/connection/manager.rs
+++ b/src-tauri/src/connection/manager.rs
@@ -1236,6 +1236,7 @@ mod tests {
             settings["savePassword"] = serde_json::Value::Bool(sp);
         }
         SavedConnection {
+            icon: None,
             id: id.to_string(),
             name: "SSH".to_string(),
             config: ConnectionConfig {
@@ -1290,6 +1291,7 @@ mod tests {
 
     fn make_serial_conn(id: &str) -> SavedConnection {
         SavedConnection {
+            icon: None,
             id: id.to_string(),
             name: "Serial".to_string(),
             config: ConnectionConfig {
@@ -1304,6 +1306,7 @@ mod tests {
 
     fn make_local_conn(id: &str) -> SavedConnection {
         SavedConnection {
+            icon: None,
             id: id.to_string(),
             name: "Local".to_string(),
             config: ConnectionConfig {
@@ -1658,6 +1661,7 @@ mod tests {
 
         // Helper: make a connection with a distinct name (ID is computed from name)
         let make_conn = |name: &str| SavedConnection {
+            icon: None,
             id: format!("conn-{}", name),
             name: name.to_string(),
             config: ConnectionConfig {
@@ -1712,6 +1716,7 @@ mod tests {
         let cred_store = Arc::new(MockStore::new());
 
         let make_conn = |name: &str| SavedConnection {
+            icon: None,
             id: name.to_string(),
             name: name.to_string(),
             config: ConnectionConfig {
@@ -1761,6 +1766,7 @@ mod tests {
         let cred_store = Arc::new(MockStore::new());
 
         let make_conn = |name: &str| SavedConnection {
+            icon: None,
             id: name.to_string(),
             name: name.to_string(),
             config: ConnectionConfig {
@@ -1806,6 +1812,7 @@ mod tests {
         let cred_store = Arc::new(MockStore::new());
 
         let make_conn = |name: &str| SavedConnection {
+            icon: None,
             id: name.to_string(),
             name: name.to_string(),
             config: ConnectionConfig {
@@ -1864,6 +1871,7 @@ mod tests {
         let cred_store = Arc::new(MockStore::new());
 
         let make_conn = |name: &str| SavedConnection {
+            icon: None,
             id: name.to_string(),
             name: name.to_string(),
             config: ConnectionConfig {
@@ -1919,6 +1927,7 @@ mod tests {
         let cred_store = Arc::new(MockStore::new());
 
         let make_conn = |name: &str| SavedConnection {
+            icon: None,
             id: name.to_string(),
             name: name.to_string(),
             config: ConnectionConfig {

--- a/src-tauri/src/connection/storage.rs
+++ b/src-tauri/src/connection/storage.rs
@@ -299,6 +299,7 @@ mod tests {
         let store = ConnectionStore {
             version: "2".to_string(),
             children: vec![ConnectionTreeNode::Connection {
+                icon: None,
                 name: "Test".to_string(),
                 config: crate::terminal::backend::ConnectionConfig {
                     type_id: "local".to_string(),
@@ -329,6 +330,7 @@ mod tests {
                 name: "Work".to_string(),
                 is_expanded: true,
                 children: vec![ConnectionTreeNode::Connection {
+                    icon: None,
                     name: "SSH".to_string(),
                     config: crate::terminal::backend::ConnectionConfig {
                         type_id: "ssh".to_string(),
@@ -428,6 +430,7 @@ mod tests {
 
         let flat = FlatConnectionStore {
             connections: vec![SavedConnection {
+                icon: None,
                 id: "Work/SSH".to_string(),
                 name: "SSH".to_string(),
                 config: crate::terminal::backend::ConnectionConfig {

--- a/src-tauri/src/connection/tree.rs
+++ b/src-tauri/src/connection/tree.rs
@@ -58,6 +58,7 @@ pub fn flatten_tree(
                 name,
                 config,
                 terminal_options,
+                icon,
             } => {
                 let conn_id = compute_connection_id(parent_path, name);
                 connections.push(SavedConnection {
@@ -66,6 +67,7 @@ pub fn flatten_tree(
                     config: config.clone(),
                     folder_id: parent_folder_id.clone(),
                     terminal_options: terminal_options.clone(),
+                    icon: icon.clone(),
                     source_file: None,
                 });
             }
@@ -115,6 +117,7 @@ fn build_tree_for_parent(
                 name: conn.name.clone(),
                 config: conn.config.clone(),
                 terminal_options: conn.terminal_options.clone(),
+                icon: conn.icon.clone(),
             });
         }
     }
@@ -327,11 +330,13 @@ mod tests {
     fn flatten_root_connections_only() {
         let tree = vec![
             ConnectionTreeNode::Connection {
+                icon: None,
                 name: "Local".to_string(),
                 config: make_local_config(),
                 terminal_options: None,
             },
             ConnectionTreeNode::Connection {
+                icon: None,
                 name: "SSH".to_string(),
                 config: make_ssh_config(),
                 terminal_options: None,
@@ -355,11 +360,13 @@ mod tests {
             is_expanded: true,
             children: vec![
                 ConnectionTreeNode::Connection {
+                    icon: None,
                     name: "Prod".to_string(),
                     config: make_ssh_config(),
                     terminal_options: None,
                 },
                 ConnectionTreeNode::Connection {
+                    icon: None,
                     name: "Dev".to_string(),
                     config: make_ssh_config(),
                     terminal_options: None,
@@ -389,6 +396,7 @@ mod tests {
                 name: "Sub Folder".to_string(),
                 is_expanded: false,
                 children: vec![ConnectionTreeNode::Connection {
+                    icon: None,
                     name: "Deep SSH".to_string(),
                     config: make_ssh_config(),
                     terminal_options: None,
@@ -414,6 +422,7 @@ mod tests {
     #[test]
     fn flatten_handles_slash_in_name() {
         let tree = vec![ConnectionTreeNode::Connection {
+            icon: None,
             name: "A/B".to_string(),
             config: make_local_config(),
             terminal_options: None,
@@ -435,9 +444,51 @@ mod tests {
     }
 
     #[test]
+    fn connection_icon_survives_save_load_round_trip() {
+        // Regression for #2316: a connection's `icon` must survive the full
+        // persistence path — flat store -> build_tree -> JSON (on disk) ->
+        // parse -> flatten_tree -> flat store — with no data loss.
+        let conns = vec![SavedConnection {
+            id: "Work/My SSH".to_string(),
+            name: "My SSH".to_string(),
+            config: make_ssh_config(),
+            folder_id: Some("Work".to_string()),
+            terminal_options: None,
+            icon: Some("server".to_string()),
+            source_file: None,
+        }];
+        let folders = vec![ConnectionFolder {
+            id: "Work".to_string(),
+            name: "Work".to_string(),
+            parent_id: None,
+            is_expanded: true,
+        }];
+
+        // Save: flat -> nested tree -> JSON on disk.
+        let tree = build_tree(&conns, &folders);
+        let json = serde_json::to_string(&tree).expect("serialize tree");
+        assert!(
+            json.contains("\"icon\":\"server\""),
+            "icon was not written to the on-disk JSON: {json}",
+        );
+
+        // Load: JSON -> nested tree -> flat store.
+        let parsed: Vec<ConnectionTreeNode> =
+            serde_json::from_str(&json).expect("deserialize tree");
+        let (loaded, _folders) = flatten_tree(&parsed, None);
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(
+            loaded[0].icon.as_deref(),
+            Some("server"),
+            "icon was lost on the save/load round-trip",
+        );
+    }
+
+    #[test]
     fn build_tree_root_connections() {
         let conns = vec![
             SavedConnection {
+                icon: None,
                 id: "Local".to_string(),
                 name: "Local".to_string(),
                 config: make_local_config(),
@@ -446,6 +497,7 @@ mod tests {
                 source_file: None,
             },
             SavedConnection {
+                icon: None,
                 id: "SSH".to_string(),
                 name: "SSH".to_string(),
                 config: make_ssh_config(),
@@ -475,6 +527,7 @@ mod tests {
         }];
         let conns = vec![
             SavedConnection {
+                icon: None,
                 id: "Work/Prod".to_string(),
                 name: "Prod".to_string(),
                 config: make_ssh_config(),
@@ -483,6 +536,7 @@ mod tests {
                 source_file: None,
             },
             SavedConnection {
+                icon: None,
                 id: "Root Conn".to_string(),
                 name: "Root Conn".to_string(),
                 config: make_local_config(),
@@ -525,12 +579,14 @@ mod tests {
                         name: "Dev".to_string(),
                         is_expanded: false,
                         children: vec![ConnectionTreeNode::Connection {
+                            icon: None,
                             name: "Dev SSH".to_string(),
                             config: make_ssh_config(),
                             terminal_options: None,
                         }],
                     },
                     ConnectionTreeNode::Connection {
+                        icon: None,
                         name: "Prod SSH".to_string(),
                         config: make_ssh_config(),
                         terminal_options: None,
@@ -538,6 +594,7 @@ mod tests {
                 ],
             },
             ConnectionTreeNode::Connection {
+                icon: None,
                 name: "Local".to_string(),
                 config: make_local_config(),
                 terminal_options: None,
@@ -578,6 +635,7 @@ mod tests {
     fn dedup_no_duplicates() {
         let mut conns = vec![
             SavedConnection {
+                icon: None,
                 id: "A".to_string(),
                 name: "A".to_string(),
                 config: make_local_config(),
@@ -586,6 +644,7 @@ mod tests {
                 source_file: None,
             },
             SavedConnection {
+                icon: None,
                 id: "B".to_string(),
                 name: "B".to_string(),
                 config: make_local_config(),
@@ -605,6 +664,7 @@ mod tests {
     fn dedup_same_name_connections_in_root() {
         let mut conns = vec![
             SavedConnection {
+                icon: None,
                 id: "SSH".to_string(),
                 name: "SSH".to_string(),
                 config: make_ssh_config(),
@@ -613,6 +673,7 @@ mod tests {
                 source_file: None,
             },
             SavedConnection {
+                icon: None,
                 id: "SSH".to_string(),
                 name: "SSH".to_string(),
                 config: make_ssh_config(),
@@ -632,6 +693,7 @@ mod tests {
     fn dedup_three_same_name() {
         let mut conns = vec![
             SavedConnection {
+                icon: None,
                 id: "X".to_string(),
                 name: "X".to_string(),
                 config: make_local_config(),
@@ -640,6 +702,7 @@ mod tests {
                 source_file: None,
             },
             SavedConnection {
+                icon: None,
                 id: "X".to_string(),
                 name: "X".to_string(),
                 config: make_local_config(),
@@ -648,6 +711,7 @@ mod tests {
                 source_file: None,
             },
             SavedConnection {
+                icon: None,
                 id: "X".to_string(),
                 name: "X".to_string(),
                 config: make_local_config(),
@@ -668,6 +732,7 @@ mod tests {
     fn dedup_skips_existing_suffix() {
         let mut conns = vec![
             SavedConnection {
+                icon: None,
                 id: "A".to_string(),
                 name: "A".to_string(),
                 config: make_local_config(),
@@ -676,6 +741,7 @@ mod tests {
                 source_file: None,
             },
             SavedConnection {
+                icon: None,
                 id: "A (1)".to_string(),
                 name: "A (1)".to_string(),
                 config: make_local_config(),
@@ -684,6 +750,7 @@ mod tests {
                 source_file: None,
             },
             SavedConnection {
+                icon: None,
                 id: "A".to_string(),
                 name: "A".to_string(),
                 config: make_local_config(),
@@ -719,6 +786,7 @@ mod tests {
         ];
         let mut conns = vec![
             SavedConnection {
+                icon: None,
                 id: "F1/SSH".to_string(),
                 name: "SSH".to_string(),
                 config: make_ssh_config(),
@@ -727,6 +795,7 @@ mod tests {
                 source_file: None,
             },
             SavedConnection {
+                icon: None,
                 id: "F2/SSH".to_string(),
                 name: "SSH".to_string(),
                 config: make_ssh_config(),
@@ -751,6 +820,7 @@ mod tests {
             is_expanded: true,
         }];
         let mut conns = vec![SavedConnection {
+            icon: None,
             id: "Work".to_string(),
             name: "Work".to_string(),
             config: make_local_config(),
@@ -808,6 +878,7 @@ mod tests {
         let mut conns = vec![
             // Existing connection in folder
             SavedConnection {
+                icon: None,
                 id: "TestDir/Zsh".to_string(),
                 name: "Zsh".to_string(),
                 config: make_local_config(),
@@ -817,6 +888,7 @@ mod tests {
             },
             // Moved connection: ID recomputed to match new folder
             SavedConnection {
+                icon: None,
                 id: "TestDir/Zsh".to_string(),
                 name: "Zsh".to_string(),
                 config: make_local_config(),
@@ -850,6 +922,7 @@ mod tests {
         let mut conns = vec![
             // Existing root connection
             SavedConnection {
+                icon: None,
                 id: "SSH".to_string(),
                 name: "SSH".to_string(),
                 config: make_ssh_config(),
@@ -859,6 +932,7 @@ mod tests {
             },
             // Connection reparented from deleted folder to root
             SavedConnection {
+                icon: None,
                 id: "SSH".to_string(),
                 name: "SSH".to_string(),
                 config: make_ssh_config(),
@@ -923,11 +997,13 @@ mod tests {
                 is_expanded: true,
                 children: vec![
                     ConnectionTreeNode::Connection {
+                        icon: None,
                         name: "C1".to_string(),
                         config: make_local_config(),
                         terminal_options: None,
                     },
                     ConnectionTreeNode::Connection {
+                        icon: None,
                         name: "C2".to_string(),
                         config: make_local_config(),
                         terminal_options: None,
@@ -935,6 +1011,7 @@ mod tests {
                 ],
             },
             ConnectionTreeNode::Connection {
+                icon: None,
                 name: "C3".to_string(),
                 config: make_local_config(),
                 terminal_options: None,

--- a/src-tauri/src/connections_projection/projection_tests.rs
+++ b/src-tauri/src/connections_projection/projection_tests.rs
@@ -30,6 +30,7 @@ use crate::terminal::backend::ConnectionConfig;
 
 fn connection(id: &str, name: &str, folder_id: Option<&str>) -> SavedConnection {
     SavedConnection {
+        icon: None,
         id: id.to_string(),
         name: name.to_string(),
         config: ConnectionConfig {

--- a/src-tauri/src/connections_projection/store_tests.rs
+++ b/src-tauri/src/connections_projection/store_tests.rs
@@ -15,6 +15,7 @@ use super::ConnectionsStore;
 /// A deterministic saved connection, optionally inside a folder.
 fn connection(id: &str, name: &str, folder_id: Option<&str>) -> SavedConnection {
     SavedConnection {
+        icon: None,
         id: id.to_string(),
         name: name.to_string(),
         config: ConnectionConfig {


### PR DESCRIPTION
## Summary

The frontend `SavedConnection` interface declares an optional `icon?: string`, but the backend modelled no matching field anywhere in the connection path. `save_connection` deserialized the frontend object into the Rust `SavedConnection` struct, so `icon` was **silently dropped on save** and the user's per-connection icon choice was lost on the next restart. This was the live instance of the serde field-drop defect class recorded as a known-gap in the #2311 drift test.

## Changes

- Add `icon: Option<String>` to the in-memory `SavedConnection` struct (`src-tauri/src/connection/config.rs`) with `#[serde(default, skip_serializing_if = "Option::is_none")]` and `camelCase` — mirroring how #2261/#2309 added their fields.
- Add the same `icon` field to the on-disk `ConnectionTreeNode::Connection` variant, and thread it through the `tree.rs` `flatten_tree` / `build_tree` conversions so it persists to disk and survives the full save/load round-trip.
- Update all struct-literal / match construction sites accordingly (`tree.rs`, `manager.rs`, `storage.rs`, `jump_host_resolver.rs`, `spawn.rs`, and the two `connections_projection` test helpers — one-line `icon: None,` additions).
- **Remove `"icon"` from the `known_gap` allowlist** in `saved_connection_no_silent_frontend_field_drop`, and add `"icon"` to `SAVED_CONNECTION_BACKEND_FIELDS`, so the drift test now genuinely enforces frontend/backend parity for this field instead of excusing it.
- Add regression tests: serde round-trips for the struct and the on-disk variant, a "no stray key when `None`" guard, and a full flat → `build_tree` → JSON → `flatten_tree` save/load round-trip asserting the icon survives.

## Testing

- `cargo test -p termihub --lib connection` — 250 passed (incl. the drift test now passing with no `icon` exclusion, and the new round-trip tests).
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `cargo build` — succeeds.

Closes #2316