### PR TITLE
fix(credential): fsync before rename for crash-durable envelope writes (Closes #2324)

### DIFF
--- a/docs/changes/dev2/fix/2324-credential-fsync.md
+++ b/docs/changes/dev2/fix/2324-credential-fsync.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- The encrypted credential store (`credentials.enc`) now writes durably: the
+  envelope is flushed to disk (`sync_all`) before the atomic rename, so a crash or
+  power loss right after the rename can no longer leave a zero-length or
+  partially-written credentials file behind on reboot. The store now saves through
+  the same shared atomic-write helper as the other config stores; on Unix the
+  credentials file is also created owner-only (mode 0600) rather than
+  world-readable (#2324).

--- a/src-tauri/src/credential/master_password.rs
+++ b/src-tauri/src/credential/master_password.rs
@@ -18,6 +18,7 @@ use super::crypto::{
 };
 use super::types::{CredentialKey, CredentialStoreStatus};
 use super::CredentialStore;
+use crate::utils::fs::write_atomic;
 
 /// Why an unlock attempt failed.
 ///
@@ -338,12 +339,16 @@ impl MasterPasswordStore {
         let json =
             serde_json::to_string_pretty(&envelope).context("Failed to serialize envelope")?;
 
-        // Atomic write: write to a temp file, then rename.
-        let tmp_path = self.file_path.with_extension("enc.tmp");
-        fs::write(&tmp_path, json.as_bytes())
-            .context("Failed to write temporary credentials file")?;
-        fs::rename(&tmp_path, &self.file_path)
-            .context("Failed to rename temporary credentials file")?;
+        // Atomic, durable write via the shared helper: it writes to a temp file
+        // in the same directory, `sync_all()`s it to disk, then renames over the
+        // target. The fsync *before* the rename is what makes this crash-safe —
+        // it guarantees the envelope's contents are durable before the rename is
+        // observable, so a crash or power loss right after the rename can never
+        // leave a zero-length or partially-written credentials file behind
+        // (#2324). The previous bespoke temp+rename here skipped the fsync. The
+        // helper's temp file is mode 0600 on Unix, so the credentials file is no
+        // longer world-readable — a strict improvement for secret material.
+        write_atomic(&self.file_path, &json).context("Failed to write credentials file")?;
 
         Ok(())
     }
@@ -708,6 +713,58 @@ mod tests {
         store.remove(&key).unwrap();
         let raw = fs::read_to_string(&store.file_path).unwrap();
         assert!(serde_json::from_str::<EncryptedEnvelope>(&raw).is_ok());
+    }
+
+    /// A save must leave the credentials file complete and no temporary sibling
+    /// behind. `write_atomic` writes to a randomly-named temp file, fsyncs it,
+    /// then renames it over the target (#2324) — so after any write the store
+    /// directory holds exactly the one envelope file, fully-formed JSON, and no
+    /// `.tmp` artifact from an interrupted or half-flushed write.
+    #[test]
+    fn save_leaves_complete_file_and_no_temp_artifact() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = make_store(dir.path());
+        store.setup("pw").unwrap();
+
+        let key = CredentialKey::new("conn-1", CredentialType::Password);
+        store.set(&key, "secret").unwrap();
+
+        // The envelope on disk is complete, valid JSON after the write.
+        let raw = fs::read_to_string(&store.file_path).unwrap();
+        assert!(serde_json::from_str::<EncryptedEnvelope>(&raw).is_ok());
+
+        // Only the envelope file exists — no leftover temp sibling.
+        let names: Vec<String> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["credentials.enc".to_string()],
+            "expected only the envelope file, got {names:?}"
+        );
+    }
+
+    /// On Unix the credentials file must not be world- or group-readable: it holds
+    /// encrypted secrets, and `write_atomic`'s temp file is created mode 0600 and
+    /// keeps those perms through the rename (#2324).
+    #[cfg(unix)]
+    #[test]
+    fn saved_file_is_owner_only_readable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = make_store(dir.path());
+        store.setup("pw").unwrap();
+
+        let mode = fs::metadata(&store.file_path).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o077,
+            0,
+            "credentials file must not be group/other readable, got mode {:o}",
+            mode & 0o777
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The master-password credential store (`src-tauri/src/credential/master_password.rs`) wrote its encrypted envelope via a bespoke temp-file + `rename`, which is safe against *truncation* but **not** against a crash between the write and the rename: without an `fsync`, a crash or power loss right after the rename could leave the rename durable while the file *contents* were not yet flushed — a zero-length or partial credentials envelope after reboot.

This routes the store's `save_to_disk` through the shared `utils::fs::write_atomic` helper (added in #2323), which does temp -> `sync_all` -> atomic `rename`. This is the single audited write path already used by every other config store (connections, settings, workspaces, WoL, HTTP monitors).

## Changes

- Replace the bespoke `fs::write(tmp)` + `fs::rename` in `save_to_disk` with `write_atomic(&self.file_path, &json)`.
- Regression tests:
  - a save leaves a complete envelope on disk and **no** `.tmp` artifact;
  - (Unix) the saved credentials file is **not** group/other-readable.

## Permissions note

The previous path used `fs::write`, producing a `0644` (umask-default), world-readable credentials file. `write_atomic` creates its temp file via `tempfile` at mode `0600` and preserves it through the rename, so the credentials file is now **owner-only** on Unix — a strict improvement for secret material, and no behavior any test relied on.

## Verification

- `cargo test -p termihub --lib credential` — 114 passed (incl. the two new tests)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo build` — ok

Closes #2324