### PR TITLE
test(agent): make deferred self-update reconnect tolerant of peer reset (Closes #2333)

### DIFF
--- a/agent/tests/self_update_integration.rs
+++ b/agent/tests/self_update_integration.rs
@@ -340,8 +340,20 @@ impl Client {
         let id = self.next_id;
         self.next_id += 1;
         let req = json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
-        writeln!(self.writer, "{req}").expect("write request");
-        self.writer.flush().expect("flush");
+        // The write races the peer just as the reads below do: during the
+        // deferred idle→apply→re-exec cycle the agent swaps its binary and
+        // re-execs, so a socket that `TcpStream::connect` just accepted against
+        // the outgoing listener can be reset before this request lands
+        // (`ConnectionReset`/`BrokenPipe`, #2333). Treat a failed write/flush as
+        // a dead connection — return `Null` rather than panicking — so the
+        // `connect` retry loop simply tries again on a fresh socket, exactly as
+        // the read path already does.
+        if writeln!(self.writer, "{req}")
+            .and_then(|()| self.writer.flush())
+            .is_err()
+        {
+            return Value::Null;
+        }
 
         loop {
             let mut line = String::new();


### PR DESCRIPTION
## Summary

Fixes the flaky `agent/tests/self_update_integration.rs` test `deferred_strategy_auto_applies_on_idle_and_comes_back`, which intermittently panicked on CI at the RPC write:

```
write request: Os { code: 104, kind: ConnectionReset, message: "Connection reset by peer" }
```

## Root cause

The test's `Client::rpc` write (`writeln!(...).expect("write request")` / `flush().expect("flush")`) was an unguarded `expect`. During the deferred **idle -> apply -> re-exec** cycle, the live agent atomically swaps its own binary and `execve`s, tearing down the outgoing listener and its connections. In `Client::connect`'s retry loop, a `TcpStream::connect` can be accepted against that outgoing listener a moment before it closes, so the very next `writeln!` races the peer close and surfaces `ConnectionReset` (or `BrokenPipe`).

The **read** path already anticipated exactly this — it returns `Value::Null` on a read error so the connect retry loop simply tries again on a fresh socket. The write path did not, so the same expected restart signal panicked instead of retrying.

## Fix

Give the write/flush the same treatment as the read path: a failed `writeln!`/`flush` returns `Value::Null` (a dead connection) instead of panicking. The `connect` retry loop then reconnects on a fresh socket once the re-execed agent's new listener is up. No blanket sleep; the retry loop provides the determinism.

The old connection resetting mid-re-exec is the **expected** restart signal (the agent re-binds the same port with a new listener), not a product bug — the agent is not dropping data on a live session here, it is intentionally re-execing on idle. The test still meaningfully verifies the deferred update: binary inode swap, staged verified binary, successful reconnect + non-empty version on the swapped-in binary, and cleared `pending_update`.

## Verification

- Ran the specific test **10/10 times** locally, all pass (previously flaky).
- `cargo fmt --all -- --check`, `cargo clippy -p termihub-agent --tests --all-features -- -D warnings`, and the integration test compile all clean.

Test-only change; no changelog fragment.

Closes #2333