### PR TITLE
fix(terminal): detect RIS full-reset (ESC c) as a screen clear (Closes #2335)

### DIFF
--- a/core/src/output/screen_clear.rs
+++ b/core/src/output/screen_clear.rs
@@ -163,4 +163,35 @@ mod tests {
         assert!(!d.feed(b"world"));
         assert!(d.feed(b"\x1b[2J"));
     }
+
+    #[test]
+    fn detects_ris_full_reset() {
+        // ESC c (RIS) resets the terminal, clearing the visible screen.
+        assert!(feed_once(b"\x1bc"));
+    }
+
+    #[test]
+    fn detects_ris_embedded_in_data() {
+        assert!(feed_once(b"before \x1bc after"));
+    }
+
+    #[test]
+    fn detects_ris_split_across_chunks() {
+        let mut d = ScreenClearDetector::new();
+        assert!(!d.feed(b"\x1b"));
+        assert!(d.feed(b"c"));
+    }
+
+    #[test]
+    fn no_match_on_esc_with_intermediate() {
+        // ESC ( B designates the ASCII charset — an ESC sequence with an
+        // intermediate byte, not a reset. It must not count as a clear.
+        assert!(!feed_once(b"\x1b(B"));
+    }
+
+    #[test]
+    fn no_match_on_plain_lowercase_c() {
+        // A bare 'c' with no preceding ESC is ordinary output, not RIS.
+        assert!(!feed_once(b"c"));
+    }
 }

--- a/core/src/output/screen_clear.rs
+++ b/core/src/output/screen_clear.rs
@@ -7,8 +7,12 @@ use vte::{Params, Parser, Perform};
 ///
 /// - `CSI 2 J` — erase entire display
 /// - `CSI 3 J` — erase display + scrollback (xterm extension)
+/// - `ESC c` — RIS (Reset to Initial State): resets the terminal, which
+///   clears the visible screen and homes the cursor
 ///
-/// Other `CSI n J` variants (`0`, `1`, default) are not treated as a clear.
+/// Other `CSI n J` variants (`0`, `1`, default) are not treated as a clear,
+/// and `ESC` sequences carrying intermediate bytes (e.g. charset designation
+/// `ESC ( B`) are not RIS and are ignored.
 pub struct ScreenClearDetector {
     parser: Parser,
 }
@@ -50,6 +54,15 @@ impl Perform for Hit {
             .and_then(|p| p.first().copied())
             .unwrap_or(0);
         if n == 2 || n == 3 {
+            self.0 = true;
+        }
+    }
+
+    fn esc_dispatch(&mut self, intermediates: &[u8], ignore: bool, byte: u8) {
+        // RIS (Reset to Initial State) is `ESC c` with no intermediate bytes.
+        // An ESC sequence with intermediates (e.g. `ESC ( B`, charset
+        // designation) or one vte flagged to ignore is not a reset.
+        if !ignore && intermediates.is_empty() && byte == b'c' {
             self.0 = true;
         }
     }

--- a/docs/changes/dev3/fix/2335-screen-clear-ris.md
+++ b/docs/changes/dev3/fix/2335-screen-clear-ris.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Clean-startup output buffering now recognizes the RIS full-reset sequence
+  (`ESC c`) as a screen clear. Previously only `CSI 2 J` / `CSI 3 J` were
+  detected, so a connection with an initial command and "wait for screen clear"
+  enabled would hang for the full 5-second timeout — then dump the raw startup
+  banner — whenever the program or device cleared the screen via RIS (common on
+  serial/telnet embedded-device menus and emitted by `reset` / `tput reset`).


### PR DESCRIPTION
## Summary

`ScreenClearDetector` (`core/src/output/screen_clear.rs`) only implemented vte's `csi_dispatch`, so it detected `CSI 2 J` / `CSI 3 J` but **missed the RIS full-reset sequence `ESC c`** (`0x1B 0x63`). RIS ("Reset to Initial State") resets the terminal — clearing the visible screen and homing the cursor — and is a legitimate, common screen clear.

## Why it matters

`SessionManager::run_output_reader` uses the detector on the `wait_for_clear` clean-startup path: when an initial command is configured with `wait_for_clear == true`, all output is buffered until a screen clear is detected, so the user sees a clean UI instead of the login banner + command echo. If the program/device clears via RIS instead of `CSI 2 J` — common on serial/telnet embedded-device menus, and emitted by `reset` / `tput reset` — the clear was never detected. The reader then blocked for the full 5-second `CLEAR_WAIT_TIMEOUT` and finally dumped the raw buffered banner, defeating the feature.

## Change

- Implement `Perform::esc_dispatch` so a bare `ESC c` (no intermediates, not `ignore`) reports a screen clear. Purely additive — existing `CSI 2J`/`CSI 3J` behavior is unchanged.
- Parser state is retained across `feed` calls, so RIS is detected even when split across chunk boundaries.
- Updated the detector's doc comment.

## Tests (TDD — test commit precedes fix commit)

New regression tests in `screen_clear.rs`: RIS standalone, embedded in data, and split across `feed` chunks; plus negatives that `ESC ( B` (charset designation, has an intermediate) and a bare `c` are NOT treated as clears. All were red before the fix.

## Verification

- `cargo test -p termihub-core --lib output` — 55 passed (23 in `screen_clear`)
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p termihub-core --all-targets --all-features -- -D warnings` — clean

Closes #2335