### PR TITLE
fix(agent): negotiate protocol_version instead of echoing agent version (Closes #2339)

### DIFF
--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 use base64::Engine;
 use jsonrpsee::core::server::RpcModule;
 use jsonrpsee::types::ErrorObjectOwned;
+use semver::Version as SemverVersion;
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
 use tracing::{debug, warn};
@@ -301,6 +302,24 @@ fn invalid_params(context: &str, e: impl std::fmt::Display) -> ErrorObjectOwned 
     )
 }
 
+/// Negotiate the protocol version the agent will speak with a client.
+///
+/// Both sides must share the same MAJOR version — a breaking change bumps MAJOR,
+/// so a mismatch is incompatible and yields `None`. The negotiated version is
+/// the *lower* of the two: the highest version both sides understand, per
+/// `docs/remote-protocol.md` ("the agent selects the highest compatible version
+/// it supports, matching major, up to its minor"). Versions are parsed with the
+/// maintained [`semver`] crate. Returns the canonical `MAJOR.MINOR.PATCH`
+/// string, or `None` when either version is unparseable or their majors differ.
+fn negotiate_protocol_version(requested: &str, agent: &str) -> Option<String> {
+    let req = SemverVersion::parse(requested.trim()).ok()?;
+    let ag = SemverVersion::parse(agent.trim()).ok()?;
+    if req.major != ag.major {
+        return None;
+    }
+    Some(req.min(ag).to_string())
+}
+
 fn map_file_error(e: FileError) -> ErrorObjectOwned {
     match e {
         FileError::NotFound(msg) => rpc_err(errors::FILE_NOT_FOUND, msg),
@@ -464,21 +483,22 @@ fn register_initialize(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::R
             .parse()
             .map_err(|e| invalid_params("initialize", e))?;
 
-        let major = p
-            .protocol_version
-            .split('.')
-            .next()
-            .and_then(|s| s.parse::<u32>().ok());
-
-        if major != Some(0) {
-            return Err(rpc_err(
-                errors::VERSION_NOT_SUPPORTED,
-                format!(
-                    "Unsupported protocol version: {} (agent supports 0.x)",
-                    p.protocol_version
-                ),
-            ));
-        }
+        // Negotiate the version both sides will speak: the highest version the
+        // agent supports that does not exceed the client's request, sharing the
+        // agent's major (docs/remote-protocol.md → Version Negotiation). An
+        // incompatible major (or an unparseable version) is rejected.
+        let negotiated_version =
+            negotiate_protocol_version(&p.protocol_version, AGENT_PROTOCOL_VERSION).ok_or_else(
+                || {
+                    rpc_err(
+                        errors::VERSION_NOT_SUPPORTED,
+                        format!(
+                            "Unsupported protocol version: {} (agent supports {})",
+                            p.protocol_version, AGENT_PROTOCOL_VERSION
+                        ),
+                    )
+                },
+            )?;
 
         let (session_manager, connection_store, buffer_size, client_id) = {
             let mut s = ctx.lock().await;
@@ -540,7 +560,7 @@ fn register_initialize(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::R
 
         Ok::<_, ErrorObjectOwned>(
             serde_json::to_value(InitializeResult {
-                protocol_version: AGENT_PROTOCOL_VERSION.to_string(),
+                protocol_version: negotiated_version,
                 agent_version: env!("CARGO_PKG_VERSION").to_string(),
                 client_id,
                 capabilities: Capabilities {
@@ -2202,6 +2222,41 @@ mod tests {
         let handler = make_handler();
         let result = dispatch(&handler, "initialize", json!({}), 1).await;
         assert_eq!(result["error"]["code"], errors::INVALID_PARAMS);
+    }
+
+    #[test]
+    fn negotiate_protocol_version_picks_the_lower_compatible() {
+        // Older client → negotiate down to the client's version.
+        assert_eq!(
+            negotiate_protocol_version("0.3.0", "0.7.0").as_deref(),
+            Some("0.3.0")
+        );
+        // Newer client → cap at the agent's version.
+        assert_eq!(
+            negotiate_protocol_version("0.99.0", "0.7.0").as_deref(),
+            Some("0.7.0")
+        );
+        // Equal → that version.
+        assert_eq!(
+            negotiate_protocol_version("0.7.0", "0.7.0").as_deref(),
+            Some("0.7.0")
+        );
+        // Patch-level negotiation still applies within the same minor.
+        assert_eq!(
+            negotiate_protocol_version("0.7.3", "0.7.5").as_deref(),
+            Some("0.7.3")
+        );
+    }
+
+    #[test]
+    fn negotiate_protocol_version_rejects_incompatible_or_malformed() {
+        // Different major → incompatible.
+        assert_eq!(negotiate_protocol_version("1.0.0", "0.7.0"), None);
+        // Unparseable requests (semver requires a full MAJOR.MINOR.PATCH).
+        assert_eq!(negotiate_protocol_version("", "0.7.0"), None);
+        assert_eq!(negotiate_protocol_version("abc", "0.7.0"), None);
+        assert_eq!(negotiate_protocol_version("0.x.0", "0.7.0"), None);
+        assert_eq!(negotiate_protocol_version("0.3", "0.7.0"), None);
     }
 
     #[tokio::test]

--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -2144,7 +2144,7 @@ mod tests {
 
     fn init_params() -> Value {
         json!({
-            "protocolVersion": "0.1.0",
+            "protocolVersion": AGENT_PROTOCOL_VERSION,
             "client": "test",
             "clientVersion": "0.1.0"
         })
@@ -2202,6 +2202,53 @@ mod tests {
         let handler = make_handler();
         let result = dispatch(&handler, "initialize", json!({}), 1).await;
         assert_eq!(result["error"]["code"], errors::INVALID_PARAMS);
+    }
+
+    #[tokio::test]
+    async fn initialize_negotiates_down_to_older_client_minor() {
+        // A desktop speaking an older minor must get that older version back, not
+        // the agent's newer one: the negotiated version is the highest version
+        // both sides understand (docs/remote-protocol.md → Version Negotiation).
+        let handler = make_handler();
+        let result = dispatch(
+            &handler,
+            "initialize",
+            json!({"protocolVersion": "0.3.0", "client": "test", "clientVersion": "0.1.0"}),
+            1,
+        )
+        .await;
+        assert_eq!(result["result"]["protocol_version"], "0.3.0");
+    }
+
+    #[tokio::test]
+    async fn initialize_caps_newer_client_at_agent_version() {
+        // A desktop newer than the agent is capped at what the agent supports.
+        let handler = make_handler();
+        let result = dispatch(
+            &handler,
+            "initialize",
+            json!({"protocolVersion": "0.99.0", "client": "test", "clientVersion": "0.1.0"}),
+            1,
+        )
+        .await;
+        assert_eq!(result["result"]["protocol_version"], AGENT_PROTOCOL_VERSION);
+    }
+
+    #[tokio::test]
+    async fn initialize_returns_agent_version_for_equal_request() {
+        let handler = make_handler();
+        let result = dispatch(
+            &handler,
+            "initialize",
+            json!({
+                "protocolVersion": AGENT_PROTOCOL_VERSION,
+                "client": "test",
+                "clientVersion": "0.1.0"
+            }),
+            1,
+        )
+        .await;
+        assert_eq!(result["result"]["protocol_version"], AGENT_PROTOCOL_VERSION);
     }
 
     // ── ConnectionRegistry integration ─────────────────────────────

--- a/docs/changes/dev3/fix/2339-negotiate-protocol-version.md
+++ b/docs/changes/dev3/fix/2339-negotiate-protocol-version.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- The remote agent now **negotiates** the protocol version during `initialize`
+  instead of always echoing its own. It returns the lower of the desktop's
+  requested version and its own supported version (within a shared major),
+  matching the negotiation contract in `docs/remote-protocol.md`. Previously the
+  agent unconditionally reported its own version (e.g. `0.7.0`) even when the
+  desktop requested an older one, so the protocol version shown for a connected
+  agent could be wrong. Incompatible major versions are still rejected with
+  `-32002 Version not supported` (#2339).


### PR DESCRIPTION
## What

The agent's `initialize` handler ignored the version-negotiation contract in `docs/remote-protocol.md`: it validated only the client's **major** version, then unconditionally returned its own `AGENT_PROTOCOL_VERSION` (`0.7.0`) as the negotiated `protocol_version`.

Per the spec — *"the agent selects the highest compatible version it supports (matching major, up to its minor)"* and the worked example (desktop requests `0.2.0`, agent responds `0.2.0`) — the agent must return the **lower** of the two versions within a shared major.

This is live today: the desktop (`build_initialize_params`) sends `protocolVersion: "0.3.0"`, so every real connection should negotiate to `0.3.0` but instead reported `0.7.0` (which the desktop stores and surfaces in agent info). No control flow currently gates on the value, so this is a contract/correctness bug, not a crash — but the reported protocol version was wrong for all connections, and any future logic trusting the negotiated version would be misled.

Code and doc disagreed; the doc was correct, so the code is fixed to match.

## How

- New `negotiate_protocol_version(requested, agent)` in `agent/src/handler/dispatch.rs`: parses both versions with the already-present maintained `semver` crate, requires a shared major (else `None` → `-32002 Version not supported`), and returns the lower of the two as the negotiated version.
- `register_initialize` now returns the negotiated version in `InitializeResult.protocol_version`.
- Incompatible major (`1.0.0`) and invalid params behaviour unchanged.

## Testing

TDD (test commit precedes fix commit). Added, red before the fix:
- `initialize_negotiates_down_to_older_client_minor` — `0.3.0` request → `0.3.0`.
- `initialize_caps_newer_client_at_agent_version` — `0.99.0` request → agent version.
- `initialize_returns_agent_version_for_equal_request` — equal request → agent version.
- `negotiate_protocol_version_picks_the_lower_compatible` / `..._rejects_incompatible_or_malformed` — pure-function unit coverage.

`cargo test -p termihub-agent --bins` (412 passed), core protocol/errors tests, `cargo fmt --all --check`, `cargo clippy -p termihub-agent --all-targets --all-features -- -D warnings`, and `cargo build -p termihub-agent` all green.

No change to `docs/remote-protocol.md` — the spec already described the correct behaviour. Added a `docs/changes/` fragment since the surfaced protocol version changes.

Closes #2339