### PR TITLE
fix(network): reject invalid port 0 in port scanner (Closes #2343)

### DIFF
--- a/core/src/network/port_scan.rs
+++ b/core/src/network/port_scan.rs
@@ -333,6 +333,31 @@ mod tests {
         assert!(parse_port_spec("").is_err());
     }
 
+    #[test]
+    fn parse_rejects_single_port_zero() {
+        // Port 0 is IANA-reserved and can never host a listening TCP service.
+        assert!(matches!(
+            parse_port_spec("0"),
+            Err(NetworkError::InvalidParameter(_))
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_range_starting_at_zero() {
+        assert!(matches!(
+            parse_port_spec("0-100"),
+            Err(NetworkError::InvalidParameter(_))
+        ));
+    }
+
+    #[test]
+    fn parse_accepts_boundary_ports() {
+        // The valid TCP port boundaries (1 and 65535) must still parse.
+        assert_eq!(parse_port_spec("1").unwrap(), vec![1]);
+        assert_eq!(parse_port_spec("65535").unwrap(), vec![65535]);
+        assert_eq!(parse_port_spec("1-3").unwrap(), vec![1, 2, 3]);
+    }
+
     // ── parse_target_spec ────────────────────────────────────────────────────
 
     #[test]

--- a/core/src/network/port_scan.rs
+++ b/core/src/network/port_scan.rs
@@ -247,6 +247,9 @@ pub fn parse_target_spec(spec: &str) -> Result<Vec<String>, NetworkError> {
 /// - Comma-separated: `"22,80,443"`
 /// - Range: `"8000-8080"`
 /// - Mixed: `"22,80,8000-8080,443"`
+///
+/// Every port must be within the valid TCP range `1..=65535`; port `0` is
+/// IANA-reserved and rejected with [`NetworkError::InvalidParameter`].
 pub fn parse_port_spec(spec: &str) -> Result<Vec<u16>, NetworkError> {
     let mut ports = Vec::new();
 
@@ -270,11 +273,21 @@ pub fn parse_port_spec(spec: &str) -> Result<Vec<u16>, NetworkError> {
                     "port range {start}-{end}: start must be <= end"
                 )));
             }
+            if start == 0 {
+                return Err(NetworkError::InvalidParameter(format!(
+                    "port range {start}-{end}: port must be between 1 and 65535"
+                )));
+            }
             ports.extend(start..=end);
         } else {
             let port: u16 = part
                 .parse()
                 .map_err(|_| NetworkError::InvalidParameter(format!("invalid port: '{part}'")))?;
+            if port == 0 {
+                return Err(NetworkError::InvalidParameter(
+                    "port 0 is reserved: port must be between 1 and 65535".into(),
+                ));
+            }
             ports.push(port);
         }
     }

--- a/docs/changes/dev3/fix/2343-reject-port-zero.md
+++ b/docs/changes/dev3/fix/2343-reject-port-zero.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Port Scanner now rejects port `0` with a clear validation error instead of
+  silently probing it. Port 0 is IANA-reserved and can never host a listening
+  TCP service, so `"0"` or a range like `"0-100"` now returns a "port must be
+  between 1 and 65535" error rather than issuing a meaningless probe (#2343).


### PR DESCRIPTION
## What

`parse_port_spec` (`core/src/network/port_scan.rs`) accepted port **0** — both as a single port (`"0"`) and as the low bound of a range (`"0-100"`). TCP port 0 is IANA-reserved and can never host a listening service, so the scanner issued a meaningless probe (`connect` to `host:0`) reported as Closed/Filtered instead of returning a clear validation error.

The Port Scanner panel's port field is free text validated only for non-emptiness, so `parse_port_spec` is the sole gate on port validity. The other boundaries were already handled (`u16` rejects >65535, reversed ranges error, empty spec errors); `0` was the remaining gap.

## Change

- Reject port `0` in both the single-port and range low-bound paths with a clear `InvalidParameter` error ("port must be between 1 and 65535").
- Documented the valid `1..=65535` range on `parse_port_spec`.

## Tests (TDD)

Added regression tests (committed red before the fix): `parse_rejects_single_port_zero`, `parse_rejects_range_starting_at_zero`, and `parse_accepts_boundary_ports` (confirms 1 / 65535 / `1-3` still parse).

## Verification

- `cargo test -p termihub-core --lib network::port_scan` — 26 passed.
- `cargo clippy -p termihub-core --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.

Closes #2343