### PR TITLE
fix(backend): preserve nested symlinks when copying local directories (Closes #2346)

### DIFF
--- a/docs/changes/dev2/fix/2346-copy-dir-symlink.md
+++ b/docs/changes/dev2/fix/2346-copy-dir-symlink.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Local file browser: copying a directory whose tree contains a symlink
+  pointing at a directory no longer fails with a "source path is neither a
+  regular file …" error that left a partial, half-copied result behind. Nested
+  symlinks are now preserved as symlinks (pointing at their original target)
+  instead of being followed (#2346).

--- a/src-tauri/src/files/local.rs
+++ b/src-tauri/src/files/local.rs
@@ -49,6 +49,13 @@ pub fn copy_file(src: &str, dest: &str, is_directory: bool) -> Result<(), Termin
 }
 
 /// Recursively copy a directory and all its contents.
+///
+/// Symlinks are checked **before** the directory case (`entry.file_type()` does
+/// not follow links) and are recreated as symlinks pointing at their original
+/// target rather than being followed. This avoids two problems: `std::fs::copy`
+/// erroring on a symlink-to-directory (which previously aborted the whole copy
+/// and left a partial tree behind), and unbounded recursion should a link form
+/// a loop back into the tree.
 fn copy_dir_recursive(src: &std::path::Path, dest: &std::path::Path) -> Result<(), TerminalError> {
     std::fs::create_dir_all(dest)?;
     for entry in std::fs::read_dir(src)? {
@@ -56,10 +63,38 @@ fn copy_dir_recursive(src: &std::path::Path, dest: &std::path::Path) -> Result<(
         let file_type = entry.file_type()?;
         let src_path = entry.path();
         let dest_path = dest.join(entry.file_name());
-        if file_type.is_dir() {
+        if file_type.is_symlink() {
+            copy_symlink(&src_path, &dest_path)?;
+        } else if file_type.is_dir() {
             copy_dir_recursive(&src_path, &dest_path)?;
         } else {
             std::fs::copy(&src_path, &dest_path)?;
+        }
+    }
+    Ok(())
+}
+
+/// Recreate a symlink at `dest` pointing at the same target as the one at `src`.
+///
+/// The link is copied verbatim (its target is not followed or resolved), so a
+/// broken or relative link is preserved as-is. On Windows the file/dir variant
+/// is chosen from the resolved target's kind, defaulting to a file symlink when
+/// the target cannot be stat'd (e.g. a broken link).
+fn copy_symlink(src: &std::path::Path, dest: &std::path::Path) -> Result<(), TerminalError> {
+    let target = std::fs::read_link(src)?;
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(&target, dest)?;
+    }
+    #[cfg(windows)]
+    {
+        // Follows the link to learn whether the target is a directory; a broken
+        // link (metadata fails) falls back to a file symlink.
+        let target_is_dir = std::fs::metadata(src).map(|m| m.is_dir()).unwrap_or(false);
+        if target_is_dir {
+            std::os::windows::fs::symlink_dir(&target, dest)?;
+        } else {
+            std::os::windows::fs::symlink_file(&target, dest)?;
         }
     }
     Ok(())

--- a/src-tauri/src/files/local.rs
+++ b/src-tauri/src/files/local.rs
@@ -199,6 +199,52 @@ mod tests {
         assert!(src.is_dir());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn copy_directory_preserves_nested_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src_dir");
+        std::fs::create_dir_all(src.join("realsub")).unwrap();
+        std::fs::write(src.join("a.txt"), "hi").unwrap();
+        std::fs::write(src.join("realsub/b.txt"), "nested").unwrap();
+
+        // A symlink pointing at a directory, and one pointing at a file. The
+        // symlink-to-dir is the regression trigger: `entry.file_type()` reports
+        // it as a symlink (not a dir), so the old code fell through to
+        // `std::fs::copy`, which follows the link, finds a directory, and errors
+        // ("source path is neither a regular file …"), aborting the whole copy.
+        symlink(src.join("realsub"), src.join("link_to_dir")).unwrap();
+        symlink(src.join("a.txt"), src.join("link_to_file")).unwrap();
+
+        let dest = dir.path().join("dest_dir");
+        copy_file(src.to_str().unwrap(), dest.to_str().unwrap(), true).unwrap();
+
+        // Real entries are copied.
+        assert_eq!(std::fs::read_to_string(dest.join("a.txt")).unwrap(), "hi");
+        assert_eq!(
+            std::fs::read_to_string(dest.join("realsub/b.txt")).unwrap(),
+            "nested"
+        );
+
+        // Both symlinks are preserved AS symlinks (not dereferenced), pointing
+        // at their original targets.
+        let dir_link = dest.join("link_to_dir");
+        assert!(
+            std::fs::symlink_metadata(&dir_link).unwrap().is_symlink(),
+            "link_to_dir should be preserved as a symlink"
+        );
+        assert_eq!(std::fs::read_link(&dir_link).unwrap(), src.join("realsub"));
+
+        let file_link = dest.join("link_to_file");
+        assert!(
+            std::fs::symlink_metadata(&file_link).unwrap().is_symlink(),
+            "link_to_file should be preserved as a symlink"
+        );
+        assert_eq!(std::fs::read_link(&file_link).unwrap(), src.join("a.txt"));
+    }
+
     #[test]
     fn copy_file_creates_parent_dirs() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Problem

The desktop local file browser's recursive directory copy (`copy_dir_recursive` in `src-tauri/src/files/local.rs`) aborted with an error whenever the source tree contained a **symlink pointing to a directory**, leaving a **partial, half-copied** destination behind.

`copy_dir_recursive` classified each child with `entry.file_type()`, which does not follow symlinks, so a symlink-to-dir failed the `is_dir()` check and fell through to `std::fs::copy(...)`. `std::fs::copy` then followed the link, found a directory as its source, and errored:

```
InvalidInput: "the source path is neither a regular file nor a symlink to a regular file"
```

The error propagated mid-iteration, so the copy stopped partway — a data-integrity hazard for a safety-critical app. A symlink-to-**file** was silently dereferenced (copied as a regular file), losing the link.

## Fix

`copy_dir_recursive` now checks `file_type.is_symlink()` **before** `is_dir()` and recreates symlink entries as symlinks pointing at their original target, via a new `copy_symlink` helper. This:

- fixes the symlink-to-directory abort + partial copy,
- preserves nested symlinks as links instead of dereferencing them,
- removes any risk of unbounded recursion from a symlink loop (links are never followed into).

The helper is platform-gated: `std::os::unix::fs::symlink` on unix; `symlink_dir`/`symlink_file` on Windows (chosen from the resolved target, defaulting to a file symlink for a broken link).

## Testing

- New unix-gated regression test `copy_directory_preserves_nested_symlinks` — copies a directory containing a symlink-to-dir and a symlink-to-file; asserts the copy succeeds, real entries are copied, and both symlinks are preserved as links pointing at their original targets. Confirmed **red** before the fix (exact `InvalidInput` error) and **green** after.
- `cargo test -p termihub --lib files` (98 passed) and `-p termihub-core --lib files` (37 passed).
- `cargo fmt --all -- --check` and `cargo clippy -p termihub --all-targets --all-features -- -D warnings` clean.

Closes #2346