### PR TITLE
fix(serial): parse baud/data-bits connect config as number or numeric string (Closes #2351)

### DIFF
--- a/core/src/backends/serial.rs
+++ b/core/src/backends/serial.rs
@@ -703,6 +703,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn connect_rejects_malformed_baud_rate() {
+        // Regression for #2351: a malformed `baudRate` must surface a config
+        // error, not silently open the port at the 115200 default.
+        let mut serial = Serial::new();
+        let settings = serde_json::json!({
+            "port": "/dev/ttyUSB0",
+            "baudRate": "fast",
+            "dataBits": "8",
+        });
+        let err = serial
+            .connect(settings)
+            .await
+            .expect_err("malformed baud rate must be rejected");
+        assert!(
+            err.to_string().contains("invalid serial configuration"),
+            "expected a config-parse error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_accepts_numeric_baud_rate() {
+        // Regression for #2351: a JSON-number `baudRate`/`dataBits` (the canonical
+        // wire form) must parse through rather than being dropped by `.as_str()`.
+        // An empty port then makes `parse_serial_config` the point of failure,
+        // proving deserialization accepted the numbers instead of erroring earlier.
+        let mut serial = Serial::new();
+        let settings = serde_json::json!({
+            "port": "",
+            "baudRate": 9600,
+            "dataBits": 8,
+        });
+        let err = serial
+            .connect(settings)
+            .await
+            .expect_err("empty port must still fail");
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "numeric framing should parse and fail only on the empty port, got: {err}"
+        );
+    }
+
+    #[tokio::test]
     async fn disconnect_when_not_connected_is_noop() {
         let mut serial = Serial::new();
         serial

--- a/core/src/backends/serial.rs
+++ b/core/src/backends/serial.rs
@@ -345,45 +345,19 @@ impl ConnectionType for Serial {
             return Err(SessionError::AlreadyExists("Already connected".to_string()));
         }
 
-        let port = settings
-            .get("port")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        let baud_rate: u32 = settings
-            .get("baudRate")
-            .and_then(|v| v.as_str())
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(115200);
-        let data_bits: u8 = settings
-            .get("dataBits")
-            .and_then(|v| v.as_str())
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(8);
-        let stop_bits: u8 = settings
-            .get("stopBits")
-            .and_then(|v| v.as_str())
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(1);
-        let parity = settings
-            .get("parity")
-            .and_then(|v| v.as_str())
-            .unwrap_or("none")
-            .to_string();
-        let flow_control = settings
-            .get("flowControl")
-            .and_then(|v| v.as_str())
-            .unwrap_or("none")
-            .to_string();
-
-        let config = SerialConfig {
-            port,
-            baud_rate,
-            data_bits,
-            stop_bits,
-            parity,
-            flow_control,
-        };
+        // Deserialize into the shared typed [`SerialConfig`] rather than pulling
+        // fields out by hand. The numeric framing fields (`baudRate`/`dataBits`/
+        // `stopBits`) accept either a JSON number — stored/agent-forwarded configs
+        // and `docs/remote-protocol.md` carry them that way — or a numeric string,
+        // which the schema form's `Select` widgets emit. A present but non-numeric
+        // value is **rejected here** instead of silently defaulting: the previous
+        // `.as_str().parse().ok().unwrap_or(default)` path dropped a JSON-number
+        // baud/data-bits back to the default before the hardened
+        // [`parse_serial_config`] gate ever saw it, mis-framing the port with no
+        // error (#2351). `parse_serial_config` remains the final validation gate.
+        let config: SerialConfig = serde_json::from_value(settings).map_err(|e| {
+            SessionError::InvalidConfig(format!("invalid serial configuration: {e}"))
+        })?;
         let config = config.expand();
         let parsed = parse_serial_config(&config)?;
 

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -155,12 +155,13 @@ impl Default for ShellConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SerialConfig {
+    #[serde(default)]
     pub port: String,
-    #[serde(default = "default_baud_rate")]
+    #[serde(default = "default_baud_rate", deserialize_with = "de_u32_num_or_str")]
     pub baud_rate: u32,
-    #[serde(default = "default_data_bits")]
+    #[serde(default = "default_data_bits", deserialize_with = "de_u8_num_or_str")]
     pub data_bits: u8,
-    #[serde(default = "default_stop_bits")]
+    #[serde(default = "default_stop_bits", deserialize_with = "de_u8_num_or_str")]
     pub stop_bits: u8,
     #[serde(default = "default_parity")]
     pub parity: String,
@@ -659,6 +660,62 @@ impl DockerConfig {
         }
         self
     }
+}
+
+// --- Flexible numeric deserialization ---
+
+/// A number that may arrive on the wire as a JSON number *or* a numeric string.
+///
+/// termiHub's schema-driven connection form renders the serial framing fields
+/// (baud rate / data bits / stop bits) as `Select` widgets, whose chosen value
+/// is emitted as a **string** (`"115200"`). Stored connection definitions,
+/// agent-forwarded configs, and the `docs/remote-protocol.md` session config
+/// instead carry them as JSON **numbers** (`115200`). Both must deserialize;
+/// anything else — a malformed string, a boolean, a float, an array, an
+/// object — is **rejected** rather than silently coerced to a default, so a
+/// mis-typed framing parameter surfaces a clear error instead of quietly opening
+/// the port at the wrong framing (#2351).
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum NumOrStr {
+    Num(u64),
+    Str(String),
+}
+
+impl NumOrStr {
+    /// Resolve to a `u64`, parsing the string form and rejecting a non-numeric
+    /// value. Shared core of [`de_u32_num_or_str`] and [`de_u8_num_or_str`].
+    fn into_u64<E: serde::de::Error>(self) -> Result<u64, E> {
+        match self {
+            NumOrStr::Num(n) => Ok(n),
+            NumOrStr::Str(s) => s
+                .trim()
+                .parse::<u64>()
+                .map_err(|_| E::custom(format!("expected a number, got string {s:?}"))),
+        }
+    }
+}
+
+/// Deserialize a [`u32`] from a JSON number or a numeric string (see [`NumOrStr`]).
+fn de_u32_num_or_str<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = NumOrStr::deserialize(deserializer)?.into_u64::<D::Error>()?;
+    u32::try_from(value).map_err(|_| {
+        <D::Error as serde::de::Error>::custom(format!("value {value} out of range for u32"))
+    })
+}
+
+/// Deserialize a [`u8`] from a JSON number or a numeric string (see [`NumOrStr`]).
+fn de_u8_num_or_str<'de, D>(deserializer: D) -> Result<u8, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = NumOrStr::deserialize(deserializer)?.into_u64::<D::Error>()?;
+    u8::try_from(value).map_err(|_| {
+        <D::Error as serde::de::Error>::custom(format!("value {value} out of range for u8"))
+    })
 }
 
 // --- Default value functions ---

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -1952,4 +1952,83 @@ mod tests {
         };
         assert_eq!(cfg.connect_timeout(), Duration::from_secs(5));
     }
+
+    // --- SerialConfig flexible numeric deserialization (#2351) ---
+
+    #[test]
+    fn serial_config_deserializes_numeric_framing_fields() {
+        // The canonical wire form: JSON numbers (stored/agent-forwarded configs,
+        // docs/remote-protocol.md). These must be honoured, never dropped to a
+        // default.
+        let cfg: SerialConfig = serde_json::from_value(serde_json::json!({
+            "port": "/dev/ttyUSB0",
+            "baudRate": 9600,
+            "dataBits": 7,
+            "stopBits": 2,
+            "parity": "even",
+            "flowControl": "hardware",
+        }))
+        .expect("numeric framing fields should deserialize");
+        assert_eq!(cfg.baud_rate, 9600);
+        assert_eq!(cfg.data_bits, 7);
+        assert_eq!(cfg.stop_bits, 2);
+    }
+
+    #[test]
+    fn serial_config_deserializes_string_framing_fields() {
+        // The schema form's `Select` widgets emit numeric strings; these must
+        // still parse to the same values.
+        let cfg: SerialConfig = serde_json::from_value(serde_json::json!({
+            "port": "/dev/ttyUSB0",
+            "baudRate": "9600",
+            "dataBits": "7",
+            "stopBits": "2",
+        }))
+        .expect("string framing fields should deserialize");
+        assert_eq!(cfg.baud_rate, 9600);
+        assert_eq!(cfg.data_bits, 7);
+        assert_eq!(cfg.stop_bits, 2);
+    }
+
+    #[test]
+    fn serial_config_absent_framing_fields_use_defaults() {
+        let cfg: SerialConfig = serde_json::from_value(serde_json::json!({
+            "port": "/dev/ttyUSB0",
+        }))
+        .expect("absent framing fields should fall back to defaults");
+        assert_eq!(cfg.baud_rate, default_baud_rate());
+        assert_eq!(cfg.data_bits, default_data_bits());
+        assert_eq!(cfg.stop_bits, default_stop_bits());
+    }
+
+    #[test]
+    fn serial_config_rejects_malformed_baud_string() {
+        // Regression for #2351: a malformed value must error, not silently
+        // default to 115200.
+        let result: Result<SerialConfig, _> = serde_json::from_value(serde_json::json!({
+            "port": "/dev/ttyUSB0",
+            "baudRate": "fast",
+        }));
+        assert!(result.is_err(), "malformed baud string must be rejected");
+    }
+
+    #[test]
+    fn serial_config_rejects_non_numeric_baud_type() {
+        // A boolean (or any non-number, non-numeric-string) must error.
+        let result: Result<SerialConfig, _> = serde_json::from_value(serde_json::json!({
+            "port": "/dev/ttyUSB0",
+            "baudRate": true,
+        }));
+        assert!(result.is_err(), "boolean baud rate must be rejected");
+    }
+
+    #[test]
+    fn serial_config_rejects_out_of_range_data_bits() {
+        // 999 does not fit in a u8; must error rather than wrap or default.
+        let result: Result<SerialConfig, _> = serde_json::from_value(serde_json::json!({
+            "port": "/dev/ttyUSB0",
+            "dataBits": 999,
+        }));
+        assert!(result.is_err(), "out-of-range data bits must be rejected");
+    }
 }

--- a/docs/changes/dev2/fix/2351-serial-connect-typed-config.md
+++ b/docs/changes/dev2/fix/2351-serial-connect-typed-config.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- Serial connections now accept a `baudRate`/`dataBits`/`stopBits` given as a
+  JSON number (the canonical wire form used by stored connection definitions,
+  agent-forwarded configs, and the remote protocol) instead of silently
+  dropping it back to a default. Previously the connect path read these fields
+  as strings only, so a numeric value failed extraction and quietly opened the
+  port at the default framing — bypassing the validation added in #2349. A
+  present-but-malformed value (a non-numeric string, a boolean, or an
+  out-of-range number) is now rejected with a clear configuration error rather
+  than defaulted. Values chosen through the connection editor are unaffected.


### PR DESCRIPTION
## Summary

`connect()` in `core/src/backends/serial.rs` read `baudRate`/`dataBits`/`stopBits` from the connect settings via `.as_str()` only. A value that arrives as a JSON **number** (or a malformed string) therefore failed extraction and **silently fell back to a default** — bypassing the hardened `parse_serial_config` gate added in #2349 for exactly this class of silent misframing, one layer earlier.

## Canonical wire format (pinned)

The canonical representation for the serial framing fields is a **JSON number**. All three sources of truth already agree:

- **Backend struct** `SerialConfig` (`core/src/config/mod.rs`): `baud_rate: u32`, `data_bits: u8`, `stop_bits: u8`.
- **Frontend** stored connection config (`AgentNode.settings.test.tsx`, `mockData.ts`): `baudRate: 115200` (number).
- **`docs/remote-protocol.md`** serial session config: `"baud_rate": 115200`, `"data_bits": 8` (number).

The only place a **string** appears is the schema-driven connection form: its `Select` widgets emit the chosen option as a string (`"115200"`). That is a rendering-layer quirk, not the wire format — so both representations legitimately reach `connect()`. There was **no disagreement to reconcile** between the frontend type, backend struct, and the protocol doc; all already state the number form, so no frontend/doc change was needed.

## Change

- `connect()` now deserializes the shared typed `SerialConfig` via `serde_json::from_value` instead of pulling fields out by hand, then routes through the unchanged `parse_serial_config` gate.
- `SerialConfig`'s numeric framing fields (`baud_rate`/`data_bits`/`stop_bits`) gained a flexible deserializer (`de_u32_num_or_str` / `de_u8_num_or_str`) that accepts **either a JSON number or a numeric string** and **rejects** anything else — a malformed string, a boolean, a float, an out-of-range number — with a clear error. Absent fields still fall back to their `#[serde(default)]`. `port` gained `#[serde(default)]` so a missing port is reported by `parse_serial_config` ("must not be empty") rather than an opaque serde error.

Net effect: a mis-typed `baudRate`/`dataBits` now surfaces a clear configuration error instead of quietly opening the port at the wrong framing, and a JSON-number config (the canonical form) parses correctly instead of being dropped to a default.

## Tests

- `core/src/config/mod.rs`: number form parses, numeric-string form parses, absent → defaults, malformed string rejected, non-numeric type (bool) rejected, out-of-range `dataBits` rejected.
- `core/src/backends/serial.rs`: `connect()` rejects a malformed `baudRate` with a config error, and accepts a numeric `baudRate` (failing only later on the empty port, proving the number was parsed not dropped).

Committed test-first, then implementation.

## Verification

`cargo test -p termihub-core --lib --features serial` (690 pass), `cargo test -p termihub --lib` (only the unrelated real-SSH SFTP integration test `agent_deploy_sftp_upload_round_trips_over_real_ssh` fails, environmental — needs a clean ssh-password container), `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features -D warnings`, `cargo build` — all green. No TypeScript touched.

Closes #2351