### PR TITLE
fix(ui): keep simplifyTree sizes aligned when flattening nested splits (Closes #2355)

### DIFF
--- a/docs/changes/dev3/fix/2355-simplifytree-stale-sizes.md
+++ b/docs/changes/dev3/fix/2355-simplifytree-stale-sizes.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Split-view: closing or moving a panel no longer mis-sizes the remaining panes
+  when the layout had same-direction nested splits. `simplifyTree` hoists a
+  nested split's panes into its parent, but was keeping the parent's original
+  (now too-short) `sizes` array, so the hoisted panes rendered with wrong widths
+  and the sizes stopped summing to 100%. The nested split's size slot is now
+  subdivided among its hoisted panes proportionally, keeping `sizes` aligned with
+  the panes and summing to 100% (#2355).

--- a/src/utils/panelTree.test.ts
+++ b/src/utils/panelTree.test.ts
@@ -223,6 +223,81 @@ describe("simplifyTree", () => {
     const result = simplifyTree(split);
     expect(result).toBe(leaf);
   });
+
+  it("keeps sizes length in sync with children when flattening", () => {
+    const leaf1 = makeLeaf("leaf-1");
+    const leaf2 = makeLeaf("leaf-2");
+    const leaf3 = makeLeaf("leaf-3");
+    const inner = makeSplit("inner", "horizontal", [leaf2, leaf3]);
+    inner.sizes = [50, 50];
+    const outer = makeSplit("outer", "horizontal", [leaf1, inner]);
+    outer.sizes = [40, 60];
+
+    const result = simplifyTree(outer) as SplitContainer;
+    expect(result.children).toHaveLength(3);
+    expect(result.sizes).toBeDefined();
+    expect(result.sizes).toHaveLength(3);
+    const total = result.sizes!.reduce((a, b) => a + b, 0);
+    expect(total).toBeCloseTo(100);
+  });
+
+  it("subdivides the flattened slot by the inner proportions", () => {
+    const leaf1 = makeLeaf("leaf-1");
+    const leaf2 = makeLeaf("leaf-2");
+    const leaf3 = makeLeaf("leaf-3");
+    const inner = makeSplit("inner", "horizontal", [leaf2, leaf3]);
+    inner.sizes = [50, 50];
+    const outer = makeSplit("outer", "horizontal", [leaf1, inner]);
+    outer.sizes = [40, 60];
+
+    const result = simplifyTree(outer) as SplitContainer;
+    expect(result.children.map((c) => c.id)).toEqual(["leaf-1", "leaf-2", "leaf-3"]);
+    expect(result.sizes![0]).toBeCloseTo(40);
+    expect(result.sizes![1]).toBeCloseTo(30);
+    expect(result.sizes![2]).toBeCloseTo(30);
+  });
+
+  it("subdivides an uneven flattened slot proportionally", () => {
+    const leaf1 = makeLeaf("leaf-1");
+    const leaf2 = makeLeaf("leaf-2");
+    const leaf3 = makeLeaf("leaf-3");
+    const inner = makeSplit("inner", "vertical", [leaf2, leaf3]);
+    inner.sizes = [75, 25];
+    const outer = makeSplit("outer", "vertical", [leaf1, inner]);
+    outer.sizes = [20, 80];
+
+    const result = simplifyTree(outer) as SplitContainer;
+    expect(result.sizes![0]).toBeCloseTo(20);
+    expect(result.sizes![1]).toBeCloseTo(60); // 80 * 0.75
+    expect(result.sizes![2]).toBeCloseTo(20); // 80 * 0.25
+  });
+
+  it("does not add sizes when the parent split has none", () => {
+    const leaf1 = makeLeaf("leaf-1");
+    const leaf2 = makeLeaf("leaf-2");
+    const leaf3 = makeLeaf("leaf-3");
+    const inner = makeSplit("inner", "horizontal", [leaf2, leaf3]);
+    const outer = makeSplit("outer", "horizontal", [leaf1, inner]);
+
+    const result = simplifyTree(outer) as SplitContainer;
+    expect(result.children).toHaveLength(3);
+    expect(result.sizes).toBeUndefined();
+  });
+
+  it("falls back to equal sizes when the inner split has no sizes", () => {
+    const leaf1 = makeLeaf("leaf-1");
+    const leaf2 = makeLeaf("leaf-2");
+    const leaf3 = makeLeaf("leaf-3");
+    const inner = makeSplit("inner", "horizontal", [leaf2, leaf3]);
+    const outer = makeSplit("outer", "horizontal", [leaf1, inner]);
+    outer.sizes = [50, 50];
+
+    const result = simplifyTree(outer) as SplitContainer;
+    expect(result.sizes).toHaveLength(3);
+    expect(result.sizes![0]).toBeCloseTo(50);
+    expect(result.sizes![1]).toBeCloseTo(25);
+    expect(result.sizes![2]).toBeCloseTo(25);
+  });
 });
 
 describe("edgeToSplit", () => {

--- a/src/utils/panelTree.ts
+++ b/src/utils/panelTree.ts
@@ -199,22 +199,38 @@ export function simplifyTree(root: PanelNode): PanelNode {
   if (root.type === "leaf") return root;
 
   // First simplify children
-  let children = root.children.map(simplifyTree);
+  const simplified = root.children.map(simplifyTree);
 
-  // Flatten children that split in the same direction
+  // Flatten children that split in the same direction. When flattening, the
+  // parent size slot allotted to the nested split is subdivided among its
+  // hoisted grandchildren so `sizes` stays aligned with `children` and keeps
+  // summing to 100 (SplitView reads sizes by child index).
   const flattened: PanelNode[] = [];
-  for (const child of children) {
+  const flattenedSizes: number[] = [];
+  simplified.forEach((child, i) => {
+    const slotSize = root.sizes?.[i] ?? 100 / simplified.length;
     if (child.type === "split" && child.direction === root.direction) {
-      flattened.push(...child.children);
+      const inner =
+        child.sizes && child.sizes.length === child.children.length
+          ? child.sizes
+          : child.children.map(() => 100 / child.children.length);
+      const innerTotal = inner.reduce((a, b) => a + b, 0) || child.children.length;
+      child.children.forEach((grandchild, j) => {
+        flattened.push(grandchild);
+        flattenedSizes.push((slotSize * (inner[j] ?? 0)) / innerTotal);
+      });
     } else {
       flattened.push(child);
+      flattenedSizes.push(slotSize);
     }
-  }
-  children = flattened;
+  });
 
-  if (children.length === 0) return createLeafPanel();
-  if (children.length === 1) return children[0];
-  return { ...root, children };
+  if (flattened.length === 0) return createLeafPanel();
+  if (flattened.length === 1) return flattened[0];
+
+  // Preserve the "no sizes" contract: only attach sizes when the parent had them.
+  const sizes = root.sizes ? normalizeSizes(flattenedSizes) : undefined;
+  return { ...root, children: flattened, ...(sizes ? { sizes } : {}) };
 }
 
 /** Convert a DropEdge to split direction and position, or null for center. */


### PR DESCRIPTION
## What

`simplifyTree` (`src/utils/panelTree.ts`) flattens same-direction nested split containers, hoisting a nested split's panes into the parent and **growing the parent's child count** — but it returned the parent with its original, now-stale `sizes` array. After a flatten, `sizes.length < children.length`.

`SplitView.tsx` renders pane widths from `split.sizes` by child index (L569/L579), so the hoisted panes rendered with `undefined`/wrong sizes and the array stopped summing to 100%. `simplifyTree` runs after nearly every panel close / tab move in `appStore.ts`, so any resized layout that develops same-direction nesting hit this on the next close.

## Fix

When flattening a nested same-direction split, subdivide the parent's size slot for that child among the hoisted grandchildren — proportional to the grandchild's own `sizes` (equal split as fallback) — then `normalizeSizes` so the result sums to 100. The "no sizes" contract is preserved: a parent split with no `sizes` still yields none.

Pure-function change only; no store/backend edits.

## Tests (TDD, red first)

Added to `src/utils/panelTree.test.ts`:
- sizes length stays equal to children length after flattening; sizes sum to ~100
- flattened slot subdivided by inner proportions (even and uneven)
- parent with no sizes yields no sizes
- inner split without sizes falls back to equal subdivision

Verified red before the fix, green after.

## Verification

- `pnpm test src/utils/panelTree.test.ts` — 60 passed
- `pnpm test src/utils/panelTree.fileDrop.test.ts src/store/appStore.layoutBridge.test.ts` — 19 passed
- `pnpm run lint`, `pnpm exec prettier --check`, `pnpm build` — all green

User-facing change fragment: `docs/changes/dev3/fix/2355-simplifytree-stale-sizes.md`.

Closes #2355