### PR TITLE
fix(ui): clean up section-resize listeners and body styles on unmount (Closes #2361)

### DIFF
--- a/docs/changes/dev3/fix/2361-section-resize-unmount-cleanup.md
+++ b/docs/changes/dev3/fix/2361-section-resize-unmount-cleanup.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Fixed a sidebar bug where hiding the sidebar (or otherwise rebuilding its
+  section list) while dragging a section-resize handle left the mouse listeners
+  attached and the whole window stuck with a resize cursor and text selection
+  disabled until the next interaction. ([#2361](https://github.com/armaxri/termiHub/issues/2361))

--- a/src/hooks/useSectionResize.test.ts
+++ b/src/hooks/useSectionResize.test.ts
@@ -257,6 +257,57 @@ describe("useSectionResize", () => {
       });
     });
 
+    it("removes document listeners and resets body styles when unmounted mid-drag", () => {
+      let result: ReturnType<typeof useSectionResize> | undefined;
+
+      act(() => {
+        root.render(
+          createElement(ResizeHarness, { initialCount: 2, onResult: (r) => (result = r) })
+        );
+      });
+
+      const above = document.createElement("div");
+      const below = document.createElement("div");
+      Object.defineProperty(above, "getBoundingClientRect", { value: () => ({ height: 100 }) });
+      Object.defineProperty(below, "getBoundingClientRect", { value: () => ({ height: 100 }) });
+      result!.sectionRefs.current[0] = above;
+      result!.sectionRefs.current[1] = below;
+
+      // Start a drag — this attaches document listeners and sets body styles.
+      act(() => {
+        result!.handleProps(0).onMouseDown({
+          clientY: 100,
+          preventDefault: vi.fn(),
+        } as unknown as React.MouseEvent);
+      });
+      expect(document.body.style.cursor).toBe("ns-resize");
+      expect(document.body.style.userSelect).toBe("none");
+
+      const removeSpy = vi.spyOn(document, "removeEventListener");
+
+      // Unmount WITHOUT firing mouseup — simulates the sidebar being hidden or
+      // its section list rebuilt while a resize drag is still in progress.
+      act(() => root.unmount());
+
+      // Both document-level drag listeners must be removed on unmount.
+      const removed = removeSpy.mock.calls.map((c) => c[0]);
+      expect(removed).toContain("mousemove");
+      expect(removed).toContain("mouseup");
+
+      // Body styles must not be left stuck app-wide.
+      expect(document.body.style.cursor).toBe("");
+      expect(document.body.style.userSelect).toBe("");
+
+      // A later mousemove must not reach the (now-unmounted) hook.
+      const before = result!.flexValues;
+      act(() => {
+        document.dispatchEvent(new MouseEvent("mousemove", { clientY: 300 }));
+      });
+      expect(result!.flexValues).toEqual(before);
+
+      removeSpy.mockRestore();
+    });
+
     it("releases listeners and resets isResizing on mouseup", () => {
       let result: ReturnType<typeof useSectionResize> | undefined;
 

--- a/src/hooks/useSectionResize.ts
+++ b/src/hooks/useSectionResize.ts
@@ -119,6 +119,25 @@ export function useSectionResize(expandedCount: number): UseSectionResizeResult 
     [startResize]
   );
 
+  // Cleanup on unmount: if the component unmounts mid-drag (before `mouseup`
+  // fires — e.g. the sidebar is hidden or its section list rebuilt via a
+  // keyboard shortcut), the document-level listeners would otherwise leak and
+  // keep calling `setFlexValues` on an unmounted hook, and `document.body`
+  // would stay stuck with `user-select: none` and a `ns-resize` cursor
+  // app-wide. Mirror `useSidebarResize`'s cleanup here, and additionally clear
+  // the stuck body styles when a drag was active.
+  useEffect(() => {
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+      if (resizeRef.current) {
+        resizeRef.current = null;
+        document.body.style.userSelect = "";
+        document.body.style.cursor = "";
+      }
+    };
+  }, [handleMouseMove, handleMouseUp]);
+
   // Normalise the returned array to always be exactly `expandedCount` long,
   // defaulting any missing slot to an even `1`. `flexValues` state lags
   // `expandedCount` for one render whenever the section count grows (the reset


### PR DESCRIPTION
## Summary

`useSectionResize` (used by the Sidebar's `ConnectionList`) attaches `mousemove`/`mouseup` listeners to `document` and sets `document.body` styles (`user-select: none`, `cursor: ns-resize`) when a section-resize drag starts, cleaning them up only in `handleMouseUp`. It had **no unmount cleanup**, so if the owning component unmounts mid-drag (sidebar hidden, section list rebuilt, view switched — all reachable via keyboard shortcuts while dragging):

- the `document` listeners leak and keep calling `setFlexValues` on an unmounted hook, and
- `document.body` is left stuck with disabled text selection and a `ns-resize` cursor **app-wide**.

The sibling hook `useSidebarResize` already had exactly this cleanup effect; `useSectionResize` was simply missing it.

## Fix

Added an unmount cleanup `useEffect` (mirroring `useSidebarResize`) that removes the `document` listeners, and additionally clears the stuck body styles when a drag was active.

## Test

TDD: added a regression test (`useSectionResize.test.ts`) that starts a drag, unmounts **without** firing `mouseup`, and asserts both `document` listeners are removed and the body styles reset. Verified red before the fix, green after.

## Verification

- `pnpm test src/hooks/useSectionResize.test.ts src/hooks/useSectionResize.test.tsx` — 14 passed
- `pnpm run lint` — clean
- `pnpm exec prettier --check` — clean
- `pnpm build` — passes

Closes #2361