### PR TITLE
fix(credential): derive decrypt key from the envelope's stored argon2 params (Closes #2362)

### DIFF
--- a/docs/changes/dev2/fix/2362-envelope-kdf-params.md
+++ b/docs/changes/dev2/fix/2362-envelope-kdf-params.md
@@ -1,0 +1,17 @@
+# Changes
+
+## Security
+
+- **Credential encryption is now crypto-agile**: decrypting a credential vault
+  or an encrypted connection export derives the key from the Argon2 cost
+  parameters stored _in the envelope_, rather than the compiled-in constants.
+  Previously the stored `memoryCost`/`timeCost`/`parallelism`/`algorithm` fields
+  were written but ignored on decrypt, so raising the Argon2 cost to strengthen
+  the KDF — a routine hardening step — would have silently rendered every
+  existing `credentials.enc` file and every previously-exported credential file
+  undecryptable, surfacing as an unrecoverable "wrong password". The stored
+  parameters are validated before use (unknown algorithm rejected; memory/time/
+  parallelism capped) so a corrupt or tampered envelope cannot force an
+  unbounded allocation on unlock. Existing files (written with the current
+  constants) decrypt unchanged; changing the master password transparently
+  re-keys the vault to the current parameters.

--- a/src-tauri/src/credential/crypto.rs
+++ b/src-tauri/src/credential/crypto.rs
@@ -24,6 +24,18 @@ pub const ENVELOPE_VERSION: u32 = 1;
 /// Additional authenticated data: single version byte.
 pub const AAD: &[u8] = &[1];
 
+/// Upper bound on the Argon2 memory cost (KiB) accepted from a stored envelope.
+///
+/// The decrypt path derives from the params carried *in the file*, so a
+/// corrupted or tampered envelope must not be able to force an unbounded
+/// allocation on unlock. 1 GiB is far above any sane setting while still
+/// leaving generous room to strengthen the KDF over time.
+pub const ARGON2_MAX_MEMORY_COST: u32 = 1_048_576;
+/// Upper bound on the Argon2 time cost accepted from a stored envelope.
+pub const ARGON2_MAX_TIME_COST: u32 = 64;
+/// Upper bound on the Argon2 parallelism accepted from a stored envelope.
+pub const ARGON2_MAX_PARALLELISM: u32 = 16;
+
 /// Encrypted envelope format used for on-disk storage and export files.
 ///
 /// Uses camelCase for JSON serialization (new format), but accepts
@@ -51,15 +63,81 @@ pub struct KdfParams {
     pub salt: String,
 }
 
-/// Derive a 256-bit key from a password and salt using Argon2id.
-pub fn derive_key(password: &str, salt: &[u8]) -> Result<[u8; 32]> {
-    let params = argon2::Params::new(
-        ARGON2_MEMORY_COST,
-        ARGON2_TIME_COST,
-        ARGON2_PARALLELISM,
-        Some(32),
-    )
-    .map_err(|e| anyhow::anyhow!("Invalid Argon2 parameters: {e}"))?;
+/// Argon2id cost parameters used to derive a key.
+///
+/// These are persisted in every [`EncryptedEnvelope`] so the KDF can be
+/// strengthened over time without breaking existing data: the decrypt side
+/// derives from *the params the file was written with*, read back via
+/// [`from_kdf`](Self::from_kdf), not from the compiled-in constants. Without
+/// this, raising [`ARGON2_MEMORY_COST`]/[`ARGON2_TIME_COST`] would silently
+/// render every existing vault and export undecryptable (#2362).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Argon2Cost {
+    /// Memory cost in KiB.
+    pub memory_cost: u32,
+    /// Iteration count.
+    pub time_cost: u32,
+    /// Parallelism degree.
+    pub parallelism: u32,
+}
+
+impl Argon2Cost {
+    /// The current compiled-in cost parameters used for all new encryptions.
+    pub const fn current() -> Self {
+        Self {
+            memory_cost: ARGON2_MEMORY_COST,
+            time_cost: ARGON2_TIME_COST,
+            parallelism: ARGON2_PARALLELISM,
+        }
+    }
+
+    /// Read and validate the cost parameters from a stored envelope's KDF block.
+    ///
+    /// Rejects an unrecognised `algorithm` and any value outside the accepted
+    /// bounds, so a corrupt or tampered envelope cannot select a foreign KDF or
+    /// force an unbounded allocation on unlock.
+    pub fn from_kdf(kdf: &KdfParams) -> Result<Self> {
+        if !kdf.algorithm.eq_ignore_ascii_case("argon2id") {
+            anyhow::bail!("Unsupported KDF algorithm: {}", kdf.algorithm);
+        }
+        let cost = Self {
+            memory_cost: kdf.memory_cost,
+            time_cost: kdf.time_cost,
+            parallelism: kdf.parallelism,
+        };
+        cost.validate()?;
+        Ok(cost)
+    }
+
+    /// Ensure the parameters are non-zero and within the accepted ceilings.
+    fn validate(&self) -> Result<()> {
+        if self.memory_cost == 0 || self.memory_cost > ARGON2_MAX_MEMORY_COST {
+            anyhow::bail!(
+                "Argon2 memory cost out of range: {} (allowed 1..={ARGON2_MAX_MEMORY_COST})",
+                self.memory_cost
+            );
+        }
+        if self.time_cost == 0 || self.time_cost > ARGON2_MAX_TIME_COST {
+            anyhow::bail!(
+                "Argon2 time cost out of range: {} (allowed 1..={ARGON2_MAX_TIME_COST})",
+                self.time_cost
+            );
+        }
+        if self.parallelism == 0 || self.parallelism > ARGON2_MAX_PARALLELISM {
+            anyhow::bail!(
+                "Argon2 parallelism out of range: {} (allowed 1..={ARGON2_MAX_PARALLELISM})",
+                self.parallelism
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Derive a 256-bit key from a password and salt using Argon2id with the
+/// given [`Argon2Cost`].
+pub fn derive_key_with_cost(password: &str, salt: &[u8], cost: &Argon2Cost) -> Result<[u8; 32]> {
+    let params = argon2::Params::new(cost.memory_cost, cost.time_cost, cost.parallelism, Some(32))
+        .map_err(|e| anyhow::anyhow!("Invalid Argon2 parameters: {e}"))?;
     let argon2 = Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
 
     let mut key = [0u8; 32];
@@ -69,16 +147,30 @@ pub fn derive_key(password: &str, salt: &[u8]) -> Result<[u8; 32]> {
     Ok(key)
 }
 
-/// Encrypt plaintext bytes with a password using Argon2id + AES-256-GCM.
+/// Derive a 256-bit key from a password and salt using Argon2id with the
+/// current compiled-in cost parameters.
+pub fn derive_key(password: &str, salt: &[u8]) -> Result<[u8; 32]> {
+    derive_key_with_cost(password, salt, &Argon2Cost::current())
+}
+
+/// Encrypt plaintext bytes with a password using Argon2id + AES-256-GCM,
+/// deriving the key with the given [`Argon2Cost`].
 ///
-/// Generates a fresh random salt and nonce, derives an encryption key from
-/// the password, then returns the sealed ciphertext inside an
-/// [`EncryptedEnvelope`].
-pub fn encrypt_with_password(password: &str, plaintext: &[u8]) -> Result<EncryptedEnvelope> {
+/// Generates a fresh random salt and nonce, records the cost parameters in the
+/// envelope so decryption can reproduce the key, and returns the sealed
+/// ciphertext. Prefer [`encrypt_with_password`] unless you specifically need to
+/// pin non-default cost parameters.
+pub fn encrypt_with_cost(
+    password: &str,
+    plaintext: &[u8],
+    cost: &Argon2Cost,
+) -> Result<EncryptedEnvelope> {
+    cost.validate()?;
+
     let mut salt = vec![0u8; SALT_LEN];
     OsRng.fill_bytes(&mut salt);
 
-    let key = derive_key(password, &salt)?;
+    let key = derive_key_with_cost(password, &salt, cost)?;
 
     let mut nonce_bytes = [0u8; NONCE_LEN];
     OsRng.fill_bytes(&mut nonce_bytes);
@@ -99,13 +191,22 @@ pub fn encrypt_with_password(password: &str, plaintext: &[u8]) -> Result<Encrypt
         kdf: KdfParams {
             algorithm: "argon2id".to_string(),
             salt: BASE64.encode(&salt),
-            memory_cost: ARGON2_MEMORY_COST,
-            time_cost: ARGON2_TIME_COST,
-            parallelism: ARGON2_PARALLELISM,
+            memory_cost: cost.memory_cost,
+            time_cost: cost.time_cost,
+            parallelism: cost.parallelism,
         },
         nonce: BASE64.encode(nonce_bytes),
         data: BASE64.encode(&ciphertext),
     })
+}
+
+/// Encrypt plaintext bytes with a password using Argon2id + AES-256-GCM.
+///
+/// Generates a fresh random salt and nonce, derives an encryption key from
+/// the password with the current compiled-in cost parameters, then returns the
+/// sealed ciphertext inside an [`EncryptedEnvelope`].
+pub fn encrypt_with_password(password: &str, plaintext: &[u8]) -> Result<EncryptedEnvelope> {
+    encrypt_with_cost(password, plaintext, &Argon2Cost::current())
 }
 
 /// Decrypt an [`EncryptedEnvelope`] using the given password.
@@ -146,7 +247,12 @@ pub fn decrypt_with_password(password: &str, envelope: &EncryptedEnvelope) -> Re
         );
     }
 
-    let key = derive_key(password, &salt)?;
+    // Derive the key from the cost parameters carried *in the envelope*, not the
+    // compiled-in constants — this is what lets the KDF be strengthened without
+    // orphaning existing data. The params are validated first so a tampered file
+    // cannot select a foreign KDF or force an unbounded allocation (#2362).
+    let cost = Argon2Cost::from_kdf(&envelope.kdf)?;
+    let key = derive_key_with_cost(password, &salt, &cost)?;
 
     let cipher = Aes256Gcm::new_from_slice(&key).context("Failed to create cipher")?;
     let nonce = Nonce::from_slice(&nonce_bytes);
@@ -269,6 +375,57 @@ mod tests {
             .to_string()
             .to_lowercase()
             .contains("salt"));
+    }
+
+    #[test]
+    fn decrypt_uses_envelope_kdf_params_not_compiled_constants() {
+        // A file sealed with Argon2 params different from the compiled-in
+        // constants — as a hardened future build, or another build, would
+        // write — must still decrypt with the correct password. Decryption
+        // derives the key from the envelope's stored params, not `ARGON2_*`
+        // (#2362); before the fix this failed with a wrong-password error.
+        let password = "test-password";
+        let plaintext = b"secret data";
+        let cost = Argon2Cost {
+            memory_cost: ARGON2_MEMORY_COST,
+            time_cost: ARGON2_TIME_COST + 2,
+            parallelism: ARGON2_PARALLELISM,
+        };
+        let envelope = encrypt_with_cost(password, plaintext, &cost).unwrap();
+        assert_eq!(envelope.kdf.time_cost, ARGON2_TIME_COST + 2);
+
+        let decrypted = decrypt_with_password(password, &envelope).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn decrypt_rejects_out_of_range_kdf_params() {
+        // Honoring file-supplied params must not let a tampered envelope force an
+        // unbounded allocation on unlock (#2362).
+        let mut envelope = encrypt_with_password("pw", b"data").unwrap();
+        envelope.kdf.memory_cost = ARGON2_MAX_MEMORY_COST + 1;
+
+        let result = decrypt_with_password("pw", &envelope);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .to_lowercase()
+            .contains("memory cost"));
+    }
+
+    #[test]
+    fn decrypt_rejects_unknown_kdf_algorithm() {
+        let mut envelope = encrypt_with_password("pw", b"data").unwrap();
+        envelope.kdf.algorithm = "scrypt".to_string();
+
+        let result = decrypt_with_password("pw", &envelope);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .to_lowercase()
+            .contains("algorithm"));
     }
 
     #[test]

--- a/src-tauri/src/credential/master_password.rs
+++ b/src-tauri/src/credential/master_password.rs
@@ -13,8 +13,8 @@ use rand::RngCore;
 use zeroize::Zeroize;
 
 use super::crypto::{
-    derive_key, EncryptedEnvelope, KdfParams, AAD, ARGON2_MEMORY_COST, ARGON2_PARALLELISM,
-    ARGON2_TIME_COST, ENVELOPE_VERSION, NONCE_LEN, SALT_LEN,
+    derive_key, derive_key_with_cost, Argon2Cost, EncryptedEnvelope, KdfParams, AAD,
+    ENVELOPE_VERSION, NONCE_LEN, SALT_LEN,
 };
 use super::types::{CredentialKey, CredentialStoreStatus};
 use super::CredentialStore;
@@ -59,6 +59,11 @@ pub struct MasterPasswordStore {
     salt: RwLock<Option<Vec<u8>>>,
     credentials: RwLock<Option<HashMap<String, String>>>,
     derived_key: RwLock<Option<Vec<u8>>>,
+    /// The Argon2 cost parameters the in-memory key was derived with. A vault
+    /// keeps the params it was written with, so `derived_key` and the params
+    /// persisted on the next save always agree even if the compiled-in
+    /// constants change under an existing vault (#2362).
+    kdf_cost: RwLock<Option<Argon2Cost>>,
 }
 
 impl MasterPasswordStore {
@@ -73,6 +78,7 @@ impl MasterPasswordStore {
             salt: RwLock::new(None),
             credentials: RwLock::new(None),
             derived_key: RwLock::new(None),
+            kdf_cost: RwLock::new(None),
         }
     }
 
@@ -97,6 +103,10 @@ impl MasterPasswordStore {
         {
             let mut key_guard = self.derived_key.write().expect("derived_key lock poisoned");
             *key_guard = Some(key.to_vec());
+        }
+        {
+            let mut cost_guard = self.kdf_cost.write().expect("kdf_cost lock poisoned");
+            *cost_guard = Some(Argon2Cost::current());
         }
         {
             let mut creds_guard = self.credentials.write().expect("credentials lock poisoned");
@@ -163,7 +173,12 @@ impl MasterPasswordStore {
             )));
         }
 
-        let key = derive_key(password, &salt)
+        // Derive from the cost parameters carried *in the file*, not the
+        // compiled-in constants, so an existing vault stays decryptable even
+        // after the KDF is strengthened. The params are validated first (#2362).
+        let cost = Argon2Cost::from_kdf(&envelope.kdf)
+            .map_err(|e| UnlockFailure::Corrupted(format!("invalid KDF params: {e}")))?;
+        let key = derive_key_with_cost(password, &salt, &cost)
             .map_err(|e| UnlockFailure::Corrupted(format!("key derivation failed: {e}")))?;
 
         let cipher = Aes256Gcm::new_from_slice(&key)
@@ -190,6 +205,10 @@ impl MasterPasswordStore {
         {
             let mut key_guard = self.derived_key.write().expect("derived_key lock poisoned");
             *key_guard = Some(key.to_vec());
+        }
+        {
+            let mut cost_guard = self.kdf_cost.write().expect("kdf_cost lock poisoned");
+            *cost_guard = Some(cost);
         }
         {
             let mut creds_guard = self.credentials.write().expect("credentials lock poisoned");
@@ -229,6 +248,9 @@ impl MasterPasswordStore {
         if let Ok(mut salt_guard) = self.salt.write() {
             *salt_guard = None;
         }
+        if let Ok(mut cost_guard) = self.kdf_cost.write() {
+            *cost_guard = None;
+        }
     }
 
     /// Returns `true` if the store is currently unlocked.
@@ -249,7 +271,14 @@ impl MasterPasswordStore {
                 .clone()
                 .context("Store is locked — cannot change password")?
         };
-        let current_key = derive_key(current_password, &current_salt)?;
+        // Re-derive with the cost params the current key was derived with — the
+        // vault may carry non-default params — so the verification compares
+        // like with like (#2362).
+        let current_cost = {
+            let cost_guard = self.kdf_cost.read().expect("kdf_cost lock poisoned");
+            cost_guard.context("Store is locked — cannot change password")?
+        };
+        let current_key = derive_key_with_cost(current_password, &current_salt, &current_cost)?;
         {
             let key_guard = self.derived_key.read().expect("derived_key lock poisoned");
             let stored_key = key_guard
@@ -260,7 +289,9 @@ impl MasterPasswordStore {
             }
         }
 
-        // Generate a new salt and derive a new key.
+        // Generate a new salt and derive a new key. Re-keying adopts the current
+        // compiled-in cost, so changing the master password transparently
+        // upgrades the vault to any strengthened KDF parameters.
         let mut new_salt = vec![0u8; SALT_LEN];
         OsRng.fill_bytes(&mut new_salt);
         let new_key = derive_key(new_password, &new_salt)?;
@@ -275,6 +306,10 @@ impl MasterPasswordStore {
                 old_key.zeroize();
             }
             *key_guard = Some(new_key.to_vec());
+        }
+        {
+            let mut cost_guard = self.kdf_cost.write().expect("kdf_cost lock poisoned");
+            *cost_guard = Some(Argon2Cost::current());
         }
 
         self.save_to_disk()
@@ -297,6 +332,10 @@ impl MasterPasswordStore {
         let key = {
             let key_guard = self.derived_key.read().expect("derived_key lock poisoned");
             key_guard.clone().context("Cannot save — store is locked")?
+        };
+        let cost = {
+            let cost_guard = self.kdf_cost.read().expect("kdf_cost lock poisoned");
+            cost_guard.context("Cannot save — store is locked")?
         };
         let creds = {
             let creds_guard = self.credentials.read().expect("credentials lock poisoned");
@@ -328,9 +367,9 @@ impl MasterPasswordStore {
             kdf: KdfParams {
                 algorithm: "argon2id".to_string(),
                 salt: BASE64.encode(&salt),
-                memory_cost: ARGON2_MEMORY_COST,
-                time_cost: ARGON2_TIME_COST,
-                parallelism: ARGON2_PARALLELISM,
+                memory_cost: cost.memory_cost,
+                time_cost: cost.time_cost,
+                parallelism: cost.parallelism,
             },
             nonce: BASE64.encode(nonce_bytes),
             data: BASE64.encode(&ciphertext),
@@ -676,6 +715,46 @@ mod tests {
 
         assert_eq!(store.get(&pw_key).unwrap(), None);
         assert_eq!(store.get(&kp_key).unwrap(), None);
+    }
+
+    #[test]
+    fn unlock_uses_stored_kdf_params_and_round_trips() {
+        use crate::credential::crypto::{
+            encrypt_with_cost, Argon2Cost, ARGON2_MEMORY_COST, ARGON2_PARALLELISM, ARGON2_TIME_COST,
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let store = make_store(dir.path());
+
+        // Seal a vault (empty credential map) with Argon2 params different from
+        // the compiled-in constants — as a build with a strengthened KDF would
+        // write. Unlock must derive from these stored params, not `ARGON2_*`
+        // (#2362); before the fix this failed with a wrong-password error.
+        let cost = Argon2Cost {
+            memory_cost: ARGON2_MEMORY_COST,
+            time_cost: ARGON2_TIME_COST + 2,
+            parallelism: ARGON2_PARALLELISM,
+        };
+        let empty: HashMap<String, String> = HashMap::new();
+        let plaintext = serde_json::to_vec(&empty).unwrap();
+        let envelope = encrypt_with_cost("pw", &plaintext, &cost).unwrap();
+        fs::write(
+            &store.file_path,
+            serde_json::to_string_pretty(&envelope).unwrap(),
+        )
+        .unwrap();
+
+        store.unlock("pw").unwrap();
+        assert!(store.is_unlocked());
+
+        // A subsequent save must keep the vault's params consistent: the file
+        // stays decryptable across a lock/unlock cycle rather than being
+        // silently re-sealed with params that mismatch the key.
+        let key = CredentialKey::new("conn-1", CredentialType::Password);
+        store.set(&key, "secret").unwrap();
+        store.lock();
+        store.unlock("pw").unwrap();
+        assert_eq!(store.get(&key).unwrap(), Some("secret".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The encrypted-credential envelope is self-describing: `EncryptedEnvelope.kdf` persists `algorithm`, `memory_cost`, `time_cost`, and `parallelism` alongside the ciphertext so the KDF can be strengthened over time without breaking existing data. But **both decrypt paths ignored those params and hard-coded the compiled-in Argon2 constants**:

- `crypto.rs::decrypt_with_password` (used by encrypted connection export/import)
- `master_password.rs::unlock_classified` (the on-disk vault)

Both called `derive_key(password, &salt)`, which always uses `ARGON2_MEMORY_COST` / `ARGON2_TIME_COST` / `ARGON2_PARALLELISM`. The stored params were decorative.

### Impact

Today every envelope carries the current constants, so it works. The trap is latent:

1. **On-disk vault** — the moment anyone raises the Argon2 cost (a routine, expected hardening step, especially pre-1.0), `derive_key` produces a different key than the one the existing vault was sealed with. Every existing vault then fails to unlock **with the correct password**; the AEAD tag mismatch surfaces as `WrongPassword`. To the user this is **silent, unrecoverable loss** of all stored credentials.
2. **Encrypted export/import** — `import_encrypted_json` decrypts the same envelope. This is an explicitly portable, cross-version format (`version: "2"`), so a file exported by a build with different Argon2 constants fails to decrypt despite the correct password.

## Fix

Derive the decryption key from the KDF params carried **in the envelope**, validated first, while encryption keeps using the current constants.

- New `Argon2Cost` type: `current()` for encryption, `from_kdf()` reads + validates the stored params (rejects a non-`argon2id` algorithm; caps memory/time/parallelism to sane ceilings so a tampered file cannot force an unbounded allocation on unlock — no new DoS vector when honoring file-supplied params).
- `decrypt_with_password` and `unlock_classified` now derive from the envelope's params.
- The master-password store records the cost its in-memory key was derived with, so the key and the params written on the next save always agree even if the compiled constants change under an existing vault. A master-password change transparently re-keys to the current params.

**Fully backward compatible**: existing files store the current constants, so the identical key is derived and every current `credentials.enc` / export decrypts unchanged. No on-disk format change (fields already present).

## Tests (TDD, red before green)

- `crypto`: an envelope sealed with non-default-but-valid Argon2 params decrypts with the correct password; out-of-range params and unknown algorithms are rejected.
- `master_password`: a vault sealed with non-default params unlocks via `MasterPasswordStore::unlock`, and a subsequent `set` → lock → unlock round-trips (proving save keeps the key/params consistent).
- Full existing credential suite (118 tests) passes; `cargo fmt`, workspace `clippy -D warnings`, and build are green.

Closes #2362