### PR TITLE
fix(ui): unlisten only the local mid-init listener on destroy race (Closes #2365)

### DIFF
--- a/src/services/events.test.ts
+++ b/src/services/events.test.ts
@@ -758,6 +758,53 @@ describe("events service", () => {
       // The callback must have been called exactly once — not doubled
       expect(outputCb).toHaveBeenCalledTimes(1);
     });
+
+    it("cleans up a partially-initialized listener without dereferencing nulled fields when destroy races mid-init", async () => {
+      // Regression: destroy() runs while doInit() is suspended *after* the output
+      // listener resolved (this.unlistenOutput already set) but *before* the exit
+      // listener resolves. destroy() nulls this.unlistenOutput, so the stale
+      // doInit's generation-mismatch cleanup must NOT call the nulled instance
+      // field (that threw a TypeError and rejected the init promise). It must
+      // instead unlisten the listener it itself just registered so it cannot leak.
+      const unlistenOutput = vi.fn();
+      const unlistenExit = vi.fn();
+
+      let resolveExit!: (value: () => void) => void;
+      const deferredExit = new Promise<() => void>((r) => (resolveExit = r));
+
+      let callCount = 0;
+      mockedListen.mockImplementation(() => {
+        callCount++;
+        // #1 output: resolves immediately so this.unlistenOutput gets set.
+        if (callCount === 1) return Promise.resolve(unlistenOutput);
+        // #2 exit: stays pending so init suspends inside doInit's second await.
+        if (callCount === 2) return deferredExit;
+        return Promise.resolve(vi.fn());
+      });
+
+      const initPromise = dispatcher.init();
+
+      // Let the output listen() resolve: doInit is now suspended awaiting the
+      // exit listen(), with this.unlistenOutput already assigned.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Unmount races in: destroy() bumps the generation and nulls the fields
+      // it has (including this.unlistenOutput).
+      dispatcher.destroy();
+
+      // The exit listener finally resolves — the stale init must clean up
+      // gracefully rather than throw on the nulled this.unlistenOutput.
+      resolveExit(unlistenExit);
+
+      await expect(initPromise).resolves.toBeUndefined();
+
+      // destroy() unlistened the already-registered output listener exactly once.
+      expect(unlistenOutput).toHaveBeenCalledTimes(1);
+      // The mid-init exit listener the stale doInit registered was cleaned up
+      // (exactly once) rather than leaking as a duplicate.
+      expect(unlistenExit).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("onCredentialStoreLocked", () => {

--- a/src/services/events.ts
+++ b/src/services/events.ts
@@ -259,9 +259,12 @@ export class TerminalOutputDispatcher {
     });
 
     if (gen !== this.initGeneration) {
+      // A generation mismatch means destroy() has run; it already unlistened
+      // (and nulled) every listener this invocation had assigned to `this.*`.
+      // Only the listener we just registered above is still live and untracked,
+      // so unlisten that local one — never the nulled instance fields, which
+      // would throw (or, after a fresh init(), tear down the new listener).
       unlistenExit();
-      this.unlistenOutput();
-      this.unlistenOutput = null;
       return;
     }
     this.unlistenExit = unlistenExit;
@@ -278,11 +281,9 @@ export class TerminalOutputDispatcher {
     );
 
     if (gen !== this.initGeneration) {
+      // See the note above: destroy() already cleaned up the earlier listeners;
+      // unlisten only the one this invocation just registered.
       unlistenRemoteState();
-      this.unlistenOutput();
-      this.unlistenOutput = null;
-      this.unlistenExit();
-      this.unlistenExit = null;
       return;
     }
     this.unlistenRemoteState = unlistenRemoteState;
@@ -299,13 +300,9 @@ export class TerminalOutputDispatcher {
     );
 
     if (gen !== this.initGeneration) {
+      // See the note above: destroy() already cleaned up the earlier listeners;
+      // unlisten only the one this invocation just registered.
       unlistenAgentState();
-      this.unlistenOutput();
-      this.unlistenOutput = null;
-      this.unlistenExit();
-      this.unlistenExit = null;
-      this.unlistenRemoteState();
-      this.unlistenRemoteState = null;
       return;
     }
     this.unlistenAgentState = unlistenAgentState;


### PR DESCRIPTION
## What

Fixes a subscription-lifecycle bug in `TerminalOutputDispatcher` (`src/services/events.ts`). `doInit()` registers the four global terminal Tauri listeners one `await listen()` at a time, guarding a React-StrictMode mount → unmount → remount race with a generation counter.

The generation-mismatch cleanup blocks were wrong: on mismatch they tore down the **instance fields** (`this.unlistenOutput()` etc.). A mismatch can only happen because `destroy()` ran — and `destroy()` has already nulled those fields — so the cleanup dereferenced `null`:

```
TypeError: this.unlistenOutput is not a function
    at TerminalOutputDispatcher.doInit (src/services/events.ts)
```

That rejected the `init()` promise; and if a newer `init()` had re-set the fields, the stale cleanup instead unlistened the **fresh** listener (silent terminal-output loss) — defeating the StrictMode safety the counter exists to provide.

Only the listener the block itself just registered (the local `unlisten*`) is still untracked and needs cleanup; every earlier listener was already unlistened by `destroy()`. Each cleanup block now unlistens just that local one and returns, never touching the instance fields.

## Test

`test(ui): add regression test …` (committed first) suspends `doInit()` after the output listener resolves, runs `destroy()`, then resolves the exit listener, and asserts `init()` resolves without throwing and each listener is unlistened exactly once. Red before the fix (the TypeError above), green after.

## Verification

- `pnpm test src/services/events.test.ts` — 46 passed
- `pnpm test src/components/Terminal` — 284 passed
- `pnpm run lint`, `pnpm exec prettier --check` — clean
- `pnpm build` — succeeds

No user-facing behavior change (`destroy()` is not wired into production teardown today), so no change fragment — this is an internal correctness/robustness fix in the event subscription lifecycle.

Closes #2365