### PR TITLE
fix(agent): persist agent state and connections atomically (Closes #2366)

### DIFF
--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -52,6 +52,10 @@ reqwest = { version = "0.12", default-features = false, features = [
 semver = "1"
 sha2 = "0.10"
 hex = "0.4"
+# Atomic config-file writes (temp file in the same dir → rename). Used by the
+# state/connection persistence stores so a torn write can never lose data
+# (#2366).
+tempfile = "3"
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.29", features = ["signal", "process", "term", "poll", "fs"] }
@@ -69,7 +73,6 @@ windows-sys = { version = "0.59", features = [
 
 
 [dev-dependencies]
-tempfile = "3"
 serde_json = { workspace = true }
 # `start_paused` for the coordinated-update ack/timeout tests (#1351): the 10 s
 # window is asserted on virtual time, so the tests are instant and immune to

--- a/agent/src/fs.rs
+++ b/agent/src/fs.rs
@@ -1,0 +1,112 @@
+//! Small filesystem helpers shared across the agent.
+
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use tempfile::NamedTempFile;
+
+/// Atomically write `contents` to `path`.
+///
+/// The bytes are first written to a temporary file in the **same directory** as
+/// `path` (so the final rename stays on one filesystem and is therefore atomic),
+/// flushed to disk, and only then renamed over `path`. A crash, power loss, or
+/// full disk mid-write can leave the temporary file behind but never touches the
+/// destination: `path` always holds either the complete previous contents or the
+/// complete new contents, never a truncated mix.
+///
+/// This protects the agent's config-persistence stores from silent total data
+/// loss on a torn write. A plain [`std::fs::write`] opens the destination with
+/// `O_TRUNC`, truncating it to zero *before* writing — so an interrupted write
+/// leaves invalid JSON that the recovery paths discard, wiping the saved session
+/// state (#2366). Route all production config saves through this helper.
+pub fn write_atomic(path: &Path, contents: &str) -> Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+
+    let mut tmp = NamedTempFile::new_in(parent)
+        .context("failed to create temporary file for atomic write")?;
+    tmp.write_all(contents.as_bytes())
+        .context("failed to write to temporary file")?;
+    // Flush the data to disk before the rename so a crash after the rename can
+    // never expose a temp file whose contents were not durably written.
+    tmp.as_file()
+        .sync_all()
+        .context("failed to flush temporary file to disk")?;
+    tmp.persist(path)
+        .map_err(|e| e.error)
+        .context("failed to persist temporary file over target")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_atomic_writes_new_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.json");
+
+        write_atomic(&path, "{\"hello\":true}").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "{\"hello\":true}");
+    }
+
+    #[test]
+    fn write_atomic_overwrites_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.json");
+
+        write_atomic(&path, "old").unwrap();
+        write_atomic(&path, "new-and-longer").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "new-and-longer");
+    }
+
+    #[test]
+    fn write_atomic_leaves_no_temp_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.json");
+
+        write_atomic(&path, "payload").unwrap();
+
+        let names: Vec<String> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec!["data.json".to_string()], "got {names:?}");
+    }
+
+    /// A failed atomic write must leave the previous good file untouched — this
+    /// is the whole point of the helper (a torn write must never lose saved
+    /// data).
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_failed_write_preserves_existing_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.json");
+        write_atomic(&path, "original").unwrap();
+
+        // Make the directory read-only so a new temp file cannot be created.
+        let restore = std::fs::metadata(dir.path()).unwrap().permissions();
+        let mut ro = restore.clone();
+        ro.set_mode(0o500);
+        std::fs::set_permissions(dir.path(), ro).unwrap();
+
+        let result = write_atomic(&path, "replacement");
+
+        // Restore permissions before asserting so temp-dir cleanup succeeds.
+        std::fs::set_permissions(dir.path(), restore).unwrap();
+
+        assert!(result.is_err(), "write into read-only dir should fail");
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "original",
+            "failed write must preserve the previous file contents"
+        );
+    }
+}

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1,6 +1,7 @@
 mod client_registry;
 mod daemon;
 mod files;
+mod fs;
 mod handler;
 mod io;
 mod monitoring;

--- a/agent/src/session/definitions.rs
+++ b/agent/src/session/definitions.rs
@@ -500,9 +500,11 @@ impl ConnectionStore {
         }
         match serde_json::to_string_pretty(&storage) {
             Ok(json) => {
-                if let Err(e) = std::fs::write(&self.file_path, json) {
+                // Atomic write (temp + rename) so a crash mid-write can never
+                // truncate connections.json and lose saved connections (#2366).
+                if let Err(e) = crate::fs::write_atomic(&self.file_path, &json) {
                     warn!(
-                        "Failed to write connections to {}: {}",
+                        "Failed to write connections to {}: {:#}",
                         self.file_path.display(),
                         e
                     );

--- a/agent/src/state/persistence.rs
+++ b/agent/src/state/persistence.rs
@@ -414,6 +414,59 @@ mod tests {
         assert!(loaded.update.pending_update.is_none());
     }
 
+    /// A save that fails part-way (here: the parent directory is read-only, so a
+    /// new temp file cannot be created) must leave the **previous** good
+    /// `state.json` untouched — never a truncated or empty file. This is the
+    /// whole point of an atomic write: a torn write must never lose the persisted
+    /// session-recovery state. Regression test for #2366.
+    #[cfg(unix)]
+    #[test]
+    fn failed_save_preserves_previous_state() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("cfg");
+        std::fs::create_dir(&dir).unwrap();
+        let path = dir.join("state.json");
+
+        // Persist a good state first.
+        let mut original = AgentState::default();
+        original
+            .sessions
+            .insert("keep".to_string(), make_session("local", Some("/tmp/keep.sock")));
+        original.save_to(&path);
+        assert_eq!(AgentState::load_from(&path).sessions.len(), 1);
+
+        // Make the parent directory read-only so the save cannot complete.
+        let mut ro = std::fs::metadata(&dir).unwrap().permissions();
+        ro.set_mode(0o500);
+        std::fs::set_permissions(&dir, ro).unwrap();
+
+        // Attempt to save a DIFFERENT state; the write must fail internally
+        // without panicking and without clobbering the file on disk.
+        let mut changed = AgentState::default();
+        changed
+            .sessions
+            .insert("gone".to_string(), make_session("serial", None));
+        changed.save_to(&path);
+
+        // Restore write permission so we can read the file and so temp-dir
+        // cleanup succeeds.
+        let mut rw = std::fs::metadata(&dir).unwrap().permissions();
+        rw.set_mode(0o700);
+        std::fs::set_permissions(&dir, rw).unwrap();
+
+        // The on-disk file must still hold the ORIGINAL state, intact.
+        let recovered = AgentState::load_from(&path);
+        assert_eq!(
+            recovered.sessions.len(),
+            1,
+            "a failed save clobbered state.json — torn write lost data"
+        );
+        assert!(recovered.sessions.contains_key("keep"));
+        assert!(!recovered.sessions.contains_key("gone"));
+    }
+
     #[test]
     fn add_and_remove_session() {
         let tmp = TempDir::new().unwrap();

--- a/agent/src/state/persistence.rs
+++ b/agent/src/state/persistence.rs
@@ -4,7 +4,7 @@
 //! can reconnect to surviving daemon processes on startup.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
@@ -101,7 +101,7 @@ impl AgentState {
     }
 
     /// Save state to a specific path.
-    pub fn save_to(&self, path: &PathBuf) {
+    pub fn save_to(&self, path: &Path) {
         if let Some(parent) = path.parent() {
             if let Err(e) = std::fs::create_dir_all(parent) {
                 warn!(
@@ -114,8 +114,10 @@ impl AgentState {
         }
         match serde_json::to_string_pretty(self) {
             Ok(json) => {
-                if let Err(e) = std::fs::write(path, json) {
-                    warn!("Failed to write agent state to {}: {}", path.display(), e);
+                // Atomic write (temp + rename) so a crash mid-write can never
+                // truncate state.json and lose the persisted session state (#2366).
+                if let Err(e) = crate::fs::write_atomic(path, &json) {
+                    warn!("Failed to write agent state to {}: {:#}", path.display(), e);
                 }
             }
             Err(e) => {
@@ -431,9 +433,10 @@ mod tests {
 
         // Persist a good state first.
         let mut original = AgentState::default();
-        original
-            .sessions
-            .insert("keep".to_string(), make_session("local", Some("/tmp/keep.sock")));
+        original.sessions.insert(
+            "keep".to_string(),
+            make_session("local", Some("/tmp/keep.sock")),
+        );
         original.save_to(&path);
         assert_eq!(AgentState::load_from(&path).sessions.len(), 1);
 

--- a/docs/changes/dev2/fix/2366-agent-atomic-state-write.md
+++ b/docs/changes/dev2/fix/2366-agent-atomic-state-write.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Agent: the remote agent now writes its `state.json` (session-recovery state) and `connections.json` (saved connections) atomically, so a crash, power loss, or full disk mid-write can no longer truncate these files and silently wipe persisted sessions or saved connections on restart (#2366).


### PR DESCRIPTION
## What & why

The remote **agent** persisted `state.json` (session-recovery state) and `connections.json` (saved connections) with a plain `std::fs::write`, which is **not** atomic. `std::fs::write` opens the destination with `O_TRUNC`, truncating it to zero **before** writing — so a crash, power loss, or full disk mid-write leaves a truncated / empty JSON file. On next startup the load path cannot parse it and **falls back to empty**, silently wiping the persisted state.

`AgentState::save_to` is called on every session add/remove and every self-update state change (many callers in `agent/src/session/manager.rs`), so the window is not rare.

This is the same systemic torn-write bug class already fixed in the **desktop** (`src-tauri`) crate via `write_atomic` (#2318 / #2320). The agent is a separate codebase and still had it.

## Change

- New `agent/src/fs.rs::write_atomic` — writes to a temp file in the **same directory**, `sync_all`s it, then `rename`s over the destination. On failure the destination is left untouched (complete-old-or-complete-new, never truncated).
- Routed both agent config saves (`AgentState::save_to`, `ConnectionStore::save_to_disk`) through it.
- Promoted `tempfile` from a dev-dependency to a regular dependency (already in the tree).

No `.unwrap()`/`.expect()` in production code; the helper returns `anyhow::Result` and the call sites `warn!` on failure (same as before).

## Tests (TDD — red before green)

- `state::persistence::tests::failed_save_preserves_previous_state` (`#[cfg(unix)]`) — mirrors the desktop `failed_save_preserves_previous_state` shape: a save that fails (read-only parent dir) must leave the **previous** good `state.json` intact. Verified red on the old `std::fs::write` code (it clobbered the file), green after the fix.
- `fs::tests::*` — the atomic helper's own unit tests (new file, overwrite, no leftover temp artifacts, failed-write-preserves-existing).

Verification: `cargo test -p termihub-agent` (420 passed), `cargo fmt --all --check`, `cargo clippy -p termihub-agent --all-targets --all-features -- -D warnings`, `cargo build -p termihub-agent` all green locally.

Closes #2366