### PR TITLE
fix(agent): reassemble ssh monitoring output before decoding utf8 (Closes #2370)

### DIFF
--- a/agent/src/monitoring/collector.rs
+++ b/agent/src/monitoring/collector.rs
@@ -243,15 +243,15 @@ impl StatsCollector for SshCollector {
 ///
 /// SSH frames carry arbitrary byte slices whose boundaries are set by the
 /// channel window, not by character boundaries, so a multi-byte UTF-8 sequence
-/// can straddle two frames. Each frame is decoded on its own here.
+/// can straddle two frames. The bytes are concatenated before decoding so a
+/// boundary-split character is never lost; [`String::from_utf8_lossy`] then
+/// tolerates any genuinely invalid bytes rather than discarding a whole frame.
 fn decode_stdout(frames: &[Vec<u8>]) -> String {
-    let mut output = String::new();
+    let mut bytes = Vec::with_capacity(frames.iter().map(Vec::len).sum());
     for frame in frames {
-        if let Ok(s) = std::str::from_utf8(frame) {
-            output.push_str(s);
-        }
+        bytes.extend_from_slice(frame);
     }
-    output
+    String::from_utf8_lossy(&bytes).into_owned()
 }
 
 #[cfg(test)]

--- a/agent/src/monitoring/collector.rs
+++ b/agent/src/monitoring/collector.rs
@@ -190,20 +190,19 @@ impl SshCollector {
                     .await
                     .context("SSH exec failed")?;
 
-                let mut output = String::new();
+                // Collect the raw stdout frames; a multi-byte UTF-8 character
+                // can straddle two frames, so decoding is deferred until every
+                // frame has been received (see [`decode_stdout`]).
+                let mut frames: Vec<Vec<u8>> = Vec::new();
                 loop {
                     match channel.wait().await {
-                        Some(ChannelMsg::Data { ref data }) => {
-                            if let Ok(s) = std::str::from_utf8(data) {
-                                output.push_str(s);
-                            }
-                        }
+                        Some(ChannelMsg::Data { ref data }) => frames.push(data.to_vec()),
                         Some(ChannelMsg::ExitStatus { .. }) => {}
                         Some(ChannelMsg::Eof) | None => break,
                         _ => {}
                     }
                 }
-                Ok::<String, anyhow::Error>(output)
+                Ok::<String, anyhow::Error>(decode_stdout(&frames))
             })
         })
     }
@@ -239,9 +238,47 @@ impl StatsCollector for SshCollector {
     }
 }
 
+/// Reassemble SSH stdout, delivered as a sequence of `ChannelMsg::Data` byte
+/// frames, into a single string.
+///
+/// SSH frames carry arbitrary byte slices whose boundaries are set by the
+/// channel window, not by character boundaries, so a multi-byte UTF-8 sequence
+/// can straddle two frames. Each frame is decoded on its own here.
+fn decode_stdout(frames: &[Vec<u8>]) -> String {
+    let mut output = String::new();
+    for frame in frames {
+        if let Ok(s) = std::str::from_utf8(frame) {
+            output.push_str(s);
+        }
+    }
+    output
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn decode_stdout_reassembles_utf8_split_across_frames() {
+        // "é" is 0xC3 0xA9; split it across two Data frames, as SSH may deliver
+        // it when the character straddles a channel-window boundary.
+        let frames = vec![vec![b'c', b'a', b'f', 0xC3], vec![0xA9, b'\n']];
+        assert_eq!(decode_stdout(&frames), "café\n");
+    }
+
+    #[test]
+    fn decode_stdout_handles_empty_and_ascii() {
+        assert_eq!(decode_stdout(&[]), "");
+        assert_eq!(decode_stdout(&[b"hostname\n".to_vec()]), "hostname\n");
+    }
+
+    #[test]
+    fn decode_stdout_is_lossy_on_invalid_bytes() {
+        // A lone continuation byte is never valid UTF-8; it becomes U+FFFD
+        // while the surrounding bytes survive, rather than dropping the frame.
+        let frames = vec![vec![b'a', 0xFF, b'b']];
+        assert_eq!(decode_stdout(&frames), "a\u{FFFD}b");
+    }
 
     #[test]
     fn local_collector_returns_valid_stats() {

--- a/docs/changes/dev3/fix/2370-ssh-monitor-utf8-frames.md
+++ b/docs/changes/dev3/fix/2370-ssh-monitor-utf8-frames.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Remote SSH host monitoring no longer silently drops output when a multi-byte
+  UTF-8 character straddles two SSH data frames. The agent's monitoring
+  collector decoded each `ChannelMsg::Data` frame independently, so a frame that
+  ended mid-character was not valid UTF-8 on its own and the entire frame was
+  discarded — corrupting or truncating the stats sample (a failed monitoring
+  cycle, or garbled hostname/OS fields) with no error surfaced. The raw frames
+  are now concatenated before decoding, and any genuinely invalid bytes are
+  decoded lossily rather than dropping a whole frame (#2370).


### PR DESCRIPTION
## Summary

Fixes a silent data-loss bug in the agent's SSH monitoring collector.

`SshCollector::exec` (`agent/src/monitoring/collector.rs`) decoded each SSH
`ChannelMsg::Data` frame independently with `std::str::from_utf8`, and the
`if let Ok(s)` **silently discarded the entire frame** whenever it wasn't valid
UTF-8 in isolation. SSH frame boundaries are set by the channel window, not by
character boundaries, so a multi-byte UTF-8 character (e.g. an internationalized
hostname, or any locale-influenced field in the several-KB monitoring output)
that straddles two frames caused a whole frame to be dropped — producing a
failed monitoring cycle (`parse_stats` sees too few lines) or garbled stats,
with no error logged.

## Fix

The raw stdout frames are now concatenated before decoding, and the combined
bytes are decoded once with `String::from_utf8_lossy` — so a boundary-split
character is never lost, and genuinely invalid bytes become U+FFFD rather than
discarding a whole frame. The concatenate-and-decode step is factored into a
small pure `decode_stdout` helper so it can be unit-tested with frames split
mid-character.

## Testing (TDD)

- `test(agent)` commit adds the regression tests (red before the fix): a
  multi-byte character split across two frames, plus empty/ASCII and
  invalid-byte (lossy) cases.
- `fix(agent)` commit makes them pass.
- `cargo test -p termihub-agent` — all 423+ lib tests pass.
- `cargo fmt --all -- --check` and `cargo clippy -p termihub-agent --all-targets --all-features -- -D warnings` clean.

Closes #2370
