### PR TITLE
fix(backend): harden validate_docker_config against whitespace-only and malformed values (Closes #2371)

### DIFF
--- a/core/src/session/docker.rs
+++ b/core/src/session/docker.rs
@@ -11,35 +11,56 @@ use crate::errors::SessionError;
 
 /// Validate a [`DockerConfig`] before session creation.
 ///
-/// Checks that the image is non-empty, all environment variable keys are
-/// non-empty, and all volume mount paths (host and container) are non-empty.
+/// Checks that the image is non-blank, every environment variable key is
+/// non-blank and free of `=`, and every volume mount path (host and container)
+/// is non-blank.
+///
+/// This is the last no-I/O gate before a session is created — the desktop
+/// `connect()` path does not run the schema validator — so, like
+/// [`validate_ssh_config`](crate::session::ssh::validate_ssh_config) and
+/// [`parse_serial_config`](crate::session::serial::parse_serial_config) (#2349),
+/// it **rejects** malformed values rather than letting them through to fail deep
+/// in the runtime:
+/// - Blank (whitespace-only) values are treated as empty: an image of `"   "`
+///   would otherwise reach `create_image` and fail mid-pull with a confusing
+///   `Failed to pull image '   '` instead of a clear up-front error.
+/// - An env-var key containing `=` is rejected because the backend builds each
+///   variable as `format!("{key}={value}")`; a key like `FOO=BAR` would be split
+///   by the daemon at the first `=`, silently corrupting the container's
+///   environment.
 ///
 /// # Errors
 ///
 /// Returns [`SessionError::InvalidConfig`] with a descriptive message if
 /// validation fails.
 pub fn validate_docker_config(config: &DockerConfig) -> Result<(), SessionError> {
-    if config.image.is_empty() {
+    if config.image.trim().is_empty() {
         return Err(SessionError::InvalidConfig(
             "Docker image must not be empty".to_string(),
         ));
     }
 
     for env_var in &config.env_vars {
-        if env_var.key.is_empty() {
+        if env_var.key.trim().is_empty() {
             return Err(SessionError::InvalidConfig(
                 "Environment variable key must not be empty".to_string(),
             ));
         }
+        if env_var.key.contains('=') {
+            return Err(SessionError::InvalidConfig(format!(
+                "Environment variable key must not contain '=': {:?}",
+                env_var.key
+            )));
+        }
     }
 
     for volume in &config.volumes {
-        if volume.host_path.is_empty() {
+        if volume.host_path.trim().is_empty() {
             return Err(SessionError::InvalidConfig(
                 "Volume host path must not be empty".to_string(),
             ));
         }
-        if volume.container_path.is_empty() {
+        if volume.container_path.trim().is_empty() {
             return Err(SessionError::InvalidConfig(
                 "Volume container path must not be empty".to_string(),
             ));

--- a/core/src/session/docker.rs
+++ b/core/src/session/docker.rs
@@ -140,4 +140,116 @@ mod tests {
             "unexpected error: {err}"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Whitespace-only / malformed values must be REJECTED, not silently
+    // accepted (#2371 — the #2349 class). The sibling `validate_ssh_config`
+    // already holds host/username/key_path to `.trim().is_empty()`; Docker
+    // must match, and env-var keys must never carry a `=` (it corrupts the
+    // `KEY=VALUE` env string built in backends::docker).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn validate_docker_config_whitespace_only_image() {
+        let config = DockerConfig {
+            image: "   ".to_string(),
+            ..Default::default()
+        };
+        let err = validate_docker_config(&config).unwrap_err();
+        assert!(
+            err.to_string().contains("Docker image must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_docker_config_whitespace_only_env_var_key() {
+        let config = DockerConfig {
+            image: "alpine".to_string(),
+            env_vars: vec![EnvVar {
+                key: "   ".to_string(),
+                value: "val".to_string(),
+            }],
+            ..Default::default()
+        };
+        let err = validate_docker_config(&config).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Environment variable key must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_docker_config_env_var_key_with_equals() {
+        let config = DockerConfig {
+            image: "alpine".to_string(),
+            env_vars: vec![EnvVar {
+                key: "FOO=BAR".to_string(),
+                value: "val".to_string(),
+            }],
+            ..Default::default()
+        };
+        let err = validate_docker_config(&config).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Environment variable key must not contain '='"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_docker_config_whitespace_only_volume_host_path() {
+        let config = DockerConfig {
+            image: "alpine".to_string(),
+            volumes: vec![VolumeMount {
+                host_path: "   ".to_string(),
+                container_path: "/data".to_string(),
+                read_only: false,
+            }],
+            ..Default::default()
+        };
+        let err = validate_docker_config(&config).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Volume host path must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_docker_config_whitespace_only_volume_container_path() {
+        let config = DockerConfig {
+            image: "alpine".to_string(),
+            volumes: vec![VolumeMount {
+                host_path: "/host".to_string(),
+                container_path: "   ".to_string(),
+                read_only: false,
+            }],
+            ..Default::default()
+        };
+        let err = validate_docker_config(&config).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Volume container path must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_docker_config_accepts_normal_env_key_with_underscore() {
+        // Regression guard: the `=` check must not reject ordinary keys.
+        let config = DockerConfig {
+            image: "alpine".to_string(),
+            env_vars: vec![EnvVar {
+                key: "MY_VAR_1".to_string(),
+                value: "some=value=with=equals".to_string(),
+            }],
+            ..Default::default()
+        };
+        assert!(
+            validate_docker_config(&config).is_ok(),
+            "a normal key with an '=' in the VALUE must still be accepted"
+        );
+    }
 }

--- a/docs/changes/dev2/fix/2371-docker-config-whitespace-validation.md
+++ b/docs/changes/dev2/fix/2371-docker-config-whitespace-validation.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Docker connection validation now rejects malformed configs up front with a
+  clear error instead of letting them fail deep in the container runtime: a
+  whitespace-only image, env-var key, or volume path is treated as empty, and an
+  environment-variable key containing `=` (which would silently corrupt the
+  container's environment) is rejected. Brings Docker validation to the same bar
+  as SSH and serial (#2371).


### PR DESCRIPTION
## Summary

`validate_docker_config` (`core/src/session/docker.rs`) is the last no-I/O gate before a Docker session is created — the desktop `connect()` path does not run the schema validator, and it is called at `core/src/backends/docker/mod.rs:625`, right before `config.image` reaches `create_image` and env vars are formatted `KEY=VALUE` (`mod.rs:664`).

It used `String::is_empty()` for every check, so it **silently accepted invalid values** — the same class of bug that bit `parse_serial_config` (#2349) and that the sibling `validate_ssh_config` already guards against with `.trim().is_empty()`.

This PR brings Docker validation to that same bar:

- Whitespace-only `image` / env-var key / volume `host_path` / `container_path` are now rejected (via `trim().is_empty()`). Previously e.g. an image of `"   "` passed and failed mid-pull with a confusing `Failed to pull image '   '`.
- An env-var key containing `=` is rejected. Env vars are built with `format!("{}={}", ev.key, ev.value)`, so a key like `FOO=BAR` would be split by the daemon at the first `=`, silently corrupting the container's environment. An env-var name can never contain `=`.

No previously-working config is rejected — every newly-rejected value was already broken downstream.

## Testing (TDD — test commit precedes fix commit)

- Added 6 unit tests in `core/src/session/docker.rs` (5 rejection cases + a positive guard that a normal key with `=` only in the *value* is still accepted).
- `cargo test -p termihub-core --lib session::docker` — 11 passed.
- `cargo test -p termihub-core --lib session` — 120 passed.
- `cargo fmt --all -- --check`, `cargo clippy -p termihub-core --all-targets --all-features -- -D warnings` — clean.

Closes #2371