### PR TITLE
test(system): fix flaky restart roundtrip test (Closes #2359)

### DIFF
--- a/tests/system/termihub_harness/bridge.py
+++ b/tests/system/termihub_harness/bridge.py
@@ -87,7 +87,19 @@ class _Connection:
         self._next_id += 1
         future: asyncio.Future = self._loop.create_future()
         self._pending[request_id] = future
-        await self._ws.send(encode_request(request_id, command))
+        try:
+            await self._ws.send(encode_request(request_id, command))
+        except websockets.exceptions.ConnectionClosed as exc:
+            # The app closed the socket between our `_closed` check and this
+            # send — e.g. it was killed/restarted mid-flight. A clean close
+            # arrives as ConnectionClosedOK; surface it as the same BridgeError
+            # a drop produces (the reader's `_fail_all` sets it for in-flight
+            # requests) rather than leaking the raw websockets exception, which
+            # otherwise races the reader and made this window flaky (#2359).
+            self._pending.pop(request_id, None)
+            raise BridgeError(
+                command.get("action", ""), "bridge connection closed"
+            ) from exc
         try:
             return await asyncio.wait_for(future, timeout)
         except asyncio.TimeoutError as exc:


### PR DESCRIPTION
## What

Fixes the intermittent failure of `tests/system/tests/test_roundtrip.py::test_sequential_connections_survive_restart` with `websockets.exceptions.ConnectionClosedOK: received 1000 (OK); then sent 1000 (OK)`.

## Root cause

In the harness bridge server (`termihub_harness/bridge.py`), `_Connection.send` had a race between its `if self._closed:` guard and `await self._ws.send(...)`. When the fake app is killed/restarted (the sequential-restart step), it closes the socket cleanly (1000 OK). The reader's `finally`/`_fail_all` — which sets `_closed` and converts in-flight requests to `BridgeError` — has not necessarily run yet, so `ws.send` raises `ConnectionClosedOK` (a subclass of `ConnectionClosed`). That raw websockets exception propagated through `run_coroutine_threadsafe` into the test, so the `with pytest.raises(BridgeError): driver_a.read_terminal()` assertion saw a `ConnectionClosedOK` instead and failed. Purely timing-dependent, hence flaky.

## Fix

Wrap the `ws.send` call and translate any `ConnectionClosed` (clean 1000 or error) during send into the same `BridgeError("bridge connection closed")` that the reader's `_fail_all` already produces for in-flight drops. This is correct-by-construction and deterministic — no `sleep`, no weakening of the assertion. The test still verifies survival across restart: the old transport reliably fails fast with `BridgeError`, and a fresh `FakeApp` connects and is driven (`"second"` read back).

## Verification

Ran locally (fake-app tests need no Docker/built app):

- `test_sequential_connections_survive_restart` x8 repeats: all pass.
- Full `tests/test_roundtrip.py`: 19 passed.

Note: this harness/machinery test lane is Docker/harness-gated and is **not** run in per-PR CI, so a green per-PR run does not exercise it — verified via the local pytest runs above.

Test-only harness change → no changelog fragment.

Closes #2359