### PR TITLE
feat(backend): fold monitoring stats/status into SystemMonitorStore server-side (Closes #2376)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -20,6 +20,7 @@ use crate::session::line_ending::LineEnding;
 use crate::session::manager::{
     PersistentSessionSummary, SessionInfo, SessionLogStatus, SessionManager,
 };
+use crate::system_monitor_projection::projection::fold_monitor_transition;
 use crate::utils::errors::TerminalError;
 use crate::utils::fs::file_name_of;
 use crate::utils::shell_detect;
@@ -569,19 +570,43 @@ pub async fn session_monitoring_open(
     manager: State<'_, SessionManager>,
 ) -> Result<(), TerminalError> {
     info!(session_id, interval_ms = ?interval_ms, "Starting session monitoring");
-    manager
-        .start_session_monitoring(&session_id, interval_ms, app_handle)
+    // Server-authority fold (#2376): reflect the connect outcome into the shared
+    // `SystemMonitorStore` at the source. Additive — the client `monitor.opened`
+    // / `monitor.openFailed` mirror stays in place, so no user-facing change. The
+    // entry itself is created client-side (`monitor.open`, which carries the UI
+    // `host` label the command does not have); making the server own entry
+    // creation is the remaining #2224 inversion step.
+    match manager
+        .start_session_monitoring(&session_id, interval_ms, app_handle.clone())
         .await
+    {
+        Ok(()) => {
+            fold_monitor_transition(&app_handle, |store| store.opened(&session_id));
+            Ok(())
+        }
+        Err(e) => {
+            fold_monitor_transition(&app_handle, |store| {
+                store.open_failed(&session_id, Some(e.to_string()));
+            });
+            Err(e)
+        }
+    }
 }
 
 /// Stop session-based monitoring.
 #[tauri::command]
 pub async fn session_monitoring_close(
     session_id: String,
+    app_handle: tauri::AppHandle,
     manager: State<'_, SessionManager>,
 ) -> Result<(), TerminalError> {
     info!(session_id, "Stopping session monitoring");
-    manager.stop_session_monitoring(&session_id).await
+    let result = manager.stop_session_monitoring(&session_id).await;
+    // Server-authority fold (#2376): drop the entry from the shared store at the
+    // source (retaining the stats cache, as the store's `close` does). Additive —
+    // the client `monitor.close` mirror stays in place.
+    fold_monitor_transition(&app_handle, |store| store.close(&session_id));
+    result
 }
 
 /// Pause or resume a session monitor's collection loop (#1233).
@@ -589,12 +614,18 @@ pub async fn session_monitoring_close(
 pub async fn session_monitoring_set_paused(
     session_id: String,
     paused: bool,
+    app_handle: tauri::AppHandle,
     manager: State<'_, SessionManager>,
 ) -> Result<(), TerminalError> {
     info!(session_id, paused, "Setting session monitoring paused");
     manager
         .set_session_monitoring_paused(&session_id, paused)
-        .await
+        .await?;
+    // Server-authority fold (#2376): mirror the pause/resume into the shared store
+    // at the source (additive; the collector loop also emits the authoritative
+    // `Paused`/`Live` status, folded by the push task).
+    fold_monitor_transition(&app_handle, |store| store.set_paused(&session_id, paused));
+    Ok(())
 }
 
 /// Change a session monitor's refresh interval (#1233).
@@ -602,6 +633,7 @@ pub async fn session_monitoring_set_paused(
 pub async fn session_monitoring_set_interval(
     session_id: String,
     interval_ms: u64,
+    app_handle: tauri::AppHandle,
     manager: State<'_, SessionManager>,
 ) -> Result<(), TerminalError> {
     info!(
@@ -610,17 +642,29 @@ pub async fn session_monitoring_set_interval(
     );
     manager
         .set_session_monitoring_interval(&session_id, interval_ms)
-        .await
+        .await?;
+    // Server-authority fold (#2376): mirror the new cadence into the shared store
+    // at the source (additive).
+    fold_monitor_transition(&app_handle, |store| {
+        store.set_interval(&session_id, interval_ms)
+    });
+    Ok(())
 }
 
 /// Cancel a session monitor's in-flight connect / collect (#1233).
 #[tauri::command]
 pub async fn session_monitoring_cancel(
     session_id: String,
+    app_handle: tauri::AppHandle,
     manager: State<'_, SessionManager>,
 ) -> Result<(), TerminalError> {
     info!(session_id, "Cancelling session monitoring connect");
-    manager.cancel_session_monitoring(&session_id).await
+    let result = manager.cancel_session_monitoring(&session_id).await;
+    // Server-authority fold (#2376): a cancel tears the monitor down (the frontend
+    // `cancelMonitoring` disconnects), so drop the entry from the shared store at
+    // the source. Additive — the client teardown's `monitor.close` mirror stays.
+    fold_monitor_transition(&app_handle, |store| store.close(&session_id));
+    result
 }
 
 // --- Session output logging commands (#1960) ---

--- a/src-tauri/src/session/monitoring_controller.rs
+++ b/src-tauri/src/session/monitoring_controller.rs
@@ -27,6 +27,7 @@ use tracing::{info, warn};
 
 use termihub_core::monitoring::{MonitorStatus, MonitorStatusReceiver};
 
+use crate::system_monitor_projection::projection::fold_monitor_transition;
 use crate::utils::errors::TerminalError;
 
 use super::manager::{SessionEntry, SessionMonitoringStatsEvent, SessionMonitoringStatusEvent};
@@ -117,6 +118,15 @@ impl<'a> MonitoringController<'a> {
                     stats = stats_rx.recv() => {
                         match stats {
                             Some(stats) => {
+                                // Server-authority fold (#2376): update the shared
+                                // `SystemMonitorStore` at the source — the instant
+                                // the collector loop produces the sample — and fan
+                                // the region diff out. Additive: the Tauri event
+                                // below and the client `monitor.stats` mirror stay
+                                // in place, so no user-facing behavior changes.
+                                fold_monitor_transition(&app_handle, |store| {
+                                    store.stats(&sid, stats.clone());
+                                });
                                 let event = SessionMonitoringStatsEvent {
                                     session_id: sid.clone(),
                                     stats,
@@ -132,6 +142,13 @@ impl<'a> MonitoringController<'a> {
                     status = recv_optional(&mut status_rx) => {
                         match status {
                             Some(status) => {
+                                // Server-authority fold (#2376): mirror the
+                                // collector-produced status transition into the
+                                // shared store at the source (additive; see the
+                                // stats arm above).
+                                fold_monitor_transition(&app_handle, |store| {
+                                    store.set_status(&sid, status);
+                                });
                                 let event = SessionMonitoringStatusEvent {
                                     session_id: sid.clone(),
                                     status,

--- a/src-tauri/src/system_monitor_projection/projection.rs
+++ b/src-tauri/src/system_monitor_projection/projection.rs
@@ -53,6 +53,7 @@ use tauri::{AppHandle, Manager};
 
 use termihub_core::monitoring::{MonitorStatus, SystemStats};
 
+use crate::commands::projection::ProjectionState;
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
 use crate::system_monitor_projection::store::{MonitorEntry, SystemMonitorStore};
 
@@ -70,6 +71,40 @@ pub fn publish_monitors(projector: &Projector, store: &SystemMonitorStore) -> Ve
             version,
         }],
         None => Vec::new(),
+    }
+}
+
+/// Fold a monitoring transition into the managed [`SystemMonitorStore`]
+/// **server-side** and fan the resulting `system-monitors` region diff out to
+/// every subscriber (#2376, prerequisite for #2224).
+///
+/// This is the server-authority counterpart to [`register_monitor_intents`]: the
+/// same store transitions the frontend currently mirrors via `monitor.*` intents
+/// are applied here **at the source** — the instant the session collector loop
+/// produces a stats sample / status change, or the session monitoring lifecycle
+/// (connect / disconnect / pause / interval) advances — so the store is fed
+/// server-side, with no client round-trip required for it to be correct. It is
+/// **additive**: the existing Tauri event emission and the client `monitor.*`
+/// mirror stay in place, and the render-cut seed (`seedMonitorsRegion` on the
+/// frontend) keeps the region a faithful mirror of `appStore`, so this changes no
+/// user-facing behavior. Removing the now-redundant client re-dispatch is the
+/// later #2224 render/mutation inversion.
+///
+/// Best-effort and non-fatal: if the store or the projection state is not managed
+/// (e.g. a headless unit-test app that never ran `setup()`), the fold is skipped
+/// rather than erroring — the client mirror still drives the region. The `apply`
+/// closure runs to completion synchronously before the publish, so the store lock
+/// is never held across an await.
+pub fn fold_monitor_transition<R: tauri::Runtime>(
+    app_handle: &AppHandle<R>,
+    apply: impl FnOnce(&SystemMonitorStore),
+) {
+    let Some(store) = app_handle.try_state::<Arc<SystemMonitorStore>>() else {
+        return;
+    };
+    apply(store.inner().as_ref());
+    if let Some(projection) = app_handle.try_state::<ProjectionState>() {
+        publish_monitors(&projection.projector, store.inner().as_ref());
     }
 }
 

--- a/src-tauri/src/system_monitor_projection/projection_tests.rs
+++ b/src-tauri/src/system_monitor_projection/projection_tests.rs
@@ -16,14 +16,18 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use serde_json::{json, Value};
+use tauri::Manager;
 
 use termihub_core::monitoring::SystemStats;
 
+use crate::commands::projection::ProjectionState;
 use crate::projection::{
     apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
     ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
 };
-use crate::system_monitor_projection::projection::{publish_monitors, SYSTEM_MONITORS_REGION};
+use crate::system_monitor_projection::projection::{
+    fold_monitor_transition, publish_monitors, SYSTEM_MONITORS_REGION,
+};
 use crate::system_monitor_projection::store::SystemMonitorStore;
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -436,4 +440,163 @@ fn a_dead_subscriber_is_reaped_on_publish() {
         1,
         "the dead subscriber was reaped"
     );
+}
+
+// ── Server-authority fold (#2376, prerequisite for #2224) ─────────────────────
+//
+// These drive the *production* `fold_monitor_transition` end to end against a
+// `tauri::test::mock_app()` with the same managed state `lib.rs::setup()` wires:
+// an `Arc<SystemMonitorStore>` and a `ProjectionState`. They prove the store is
+// fed **server-side** — the instant the collector loop / lifecycle produces a
+// transition — with no `monitor.*` client dispatch, and that the fold reproduces
+// the client route's store transition exactly (parity, no double count).
+
+/// A collector-produced stats sample folded server-side updates the shared store
+/// and fans the `system-monitors` region diff out — without any client dispatch.
+#[test]
+fn server_side_stats_fold_updates_store_and_region_without_client_dispatch() {
+    let app = tauri::test::mock_app();
+
+    // The entry is created client-side (`monitor.open`, which carries the UI host
+    // label); the server folds the collector stream into it.
+    let store = Arc::new(SystemMonitorStore::new());
+    store.open("s1", Some("host-a".to_string()), None);
+    store.opened("s1");
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(SYSTEM_MONITORS_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    let snap = projection
+        .projector
+        .subscribe(SYSTEM_MONITORS_REGION, "sub", "C", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+    app.manage(projection);
+
+    // Server folds a sample at the source — no `monitor.stats` intent is dispatched.
+    let sample = stats("host-a", 42.0);
+    fold_monitor_transition(app.handle(), |s| s.stats("s1", sample.clone()));
+
+    // The store is authoritative server-side.
+    let entry = store.get("s1").expect("entry still present");
+    assert_eq!(
+        entry.sample_count, 1,
+        "server fold incremented the sample count"
+    );
+    assert_eq!(
+        store.cached_stats("s1").map(|s| s.cpu_usage_percent),
+        Some(42.0)
+    );
+
+    // Exactly one region diff fanned out; the client cache converges on the server
+    // truth with no round-trip.
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "one diff from the server-side fold");
+    cache.apply(&diffs[0]);
+    assert_eq!(cache.view["monitors"]["s1"]["sampleCount"], json!(1));
+    assert_eq!(
+        cache.view["monitors"]["s1"]["stats"]["cpuUsagePercent"],
+        json!(42.0)
+    );
+}
+
+/// A collector-produced status transition folded server-side updates the store
+/// and region without any client dispatch.
+#[test]
+fn server_side_status_fold_updates_store_and_region() {
+    use termihub_core::monitoring::MonitorStatus;
+
+    let app = tauri::test::mock_app();
+    let store = Arc::new(SystemMonitorStore::new());
+    store.open("s1", Some("host-a".to_string()), None);
+    store.opened("s1");
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(SYSTEM_MONITORS_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    let snap = projection
+        .projector
+        .subscribe(SYSTEM_MONITORS_REGION, "sub", "C", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+    app.manage(projection);
+
+    fold_monitor_transition(app.handle(), |s| s.set_status("s1", MonitorStatus::Stale));
+
+    assert_eq!(
+        store.get("s1").and_then(|e| e.status),
+        Some(MonitorStatus::Stale)
+    );
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1);
+    cache.apply(&diffs[0]);
+    assert_eq!(cache.view["monitors"]["s1"]["status"], json!("stale"));
+}
+
+/// The server-side stats fold reproduces the client `monitor.stats` route's store
+/// transition exactly — identical snapshots, so there is no drift or double count
+/// when the fold and the (still-present, additive) client mirror both run.
+#[test]
+fn server_side_stats_fold_matches_the_client_monitor_stats_route() {
+    let sample = stats("host-a", 42.0);
+
+    // (a) Server-side fold: the store method the fold applies at the source.
+    let server = seeded_store();
+    server.opened("s1");
+    server.stats("s1", sample.clone());
+
+    // (b) Client route: the `monitor.stats` intent through the production registry.
+    let client = seeded_store();
+    client.opened("s1");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SYSTEM_MONITORS_REGION, client.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(client.clone())));
+    let ack = dispatcher.dispatch(intent(
+        "monitor.stats",
+        json!({ "key": "s1", "stats": serde_json::to_value(&sample).unwrap() }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    assert_eq!(
+        server.snapshot(),
+        client.snapshot(),
+        "the server fold reproduces the client route's transition exactly"
+    );
+}
+
+/// A server-side close fold drops the entry from the shared store (the disconnect
+/// / cancel lifecycle edge), publishing the region diff.
+#[test]
+fn server_side_close_fold_drops_the_entry() {
+    let app = tauri::test::mock_app();
+    let store = Arc::new(SystemMonitorStore::new());
+    store.open("s1", Some("host-a".to_string()), None);
+    store.opened("s1");
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(SYSTEM_MONITORS_REGION, store.snapshot());
+    app.manage(projection);
+
+    fold_monitor_transition(app.handle(), |s| s.close("s1"));
+
+    assert!(
+        store.get("s1").is_none(),
+        "close dropped the entry server-side"
+    );
+}
+
+/// The fold is a best-effort no-op when no store / projection state is managed
+/// (e.g. a headless harness that never ran `setup()`) — it must not panic.
+#[test]
+fn server_side_fold_is_a_noop_without_managed_state() {
+    let app = tauri::test::mock_app();
+    // Nothing managed — reaching the assert without panicking is the contract.
+    fold_monitor_transition(app.handle(), |s| s.stats("s1", stats("h", 1.0)));
 }


### PR DESCRIPTION
## What

Makes the shared `SystemMonitorStore` (the `system-monitors` projection region) **server-authoritative at the source**: monitoring stats/status and the connect/disconnect/pause/interval lifecycle are folded into the store **server-side, the instant they are produced**, instead of relying solely on client-dispatched `monitor.*` intents.

Prerequisite for #2224 (Phase 5 Monitors migration): today the collector loop produces the authoritative monitoring data server-side and emits it straight to the frontend as Tauri events, and `SystemMonitorStore` is only ever fed by client `monitor.*` re-dispatch. Removing the appStore reducers (making the store authoritative) is a **lossy** inversion while the store is never fed from the data source. This PR feeds it from the source so #2224 can invert the data flow with no data-loss risk.

## Changes

- **New `fold_monitor_transition`** (`system_monitor_projection/projection.rs`): resolves the managed store + projector from the `AppHandle`, applies a transition, and publishes the region diff. Best-effort (skips if state is unmanaged); never holds the store lock across an await.
- **Push task** (`session/monitoring_controller.rs`): each collector-produced **stats** sample and **status** change is folded the instant it is produced.
- **Session monitoring commands** (`commands/session.rs`): connect outcome (`opened` / `openFailed`), disconnect/cancel (`close`), `setPaused`, `setInterval`. (`AppHandle` is Tauri-injected — no change to the JS invoke surface.)
- **Tests**: drive the production fold end-to-end against `tauri::test::mock_app()` — a stats sample / status change updates the store and fans the region diff out **with no client dispatch** (server-authoritative); a close fold drops the entry; a no-op when unmanaged; and **parity** — the server fold reproduces the client `monitor.stats` route's store transition exactly.

## Additive / no user-facing change

- The existing Tauri event emission **and** the client `monitor.*` mirror stay in place.
- The frontend render-cut seed (`seedMonitorsRegion`, an absolute `monitor.replace`) keeps the region a faithful mirror of `appStore`, so it self-heals any transient divergence — the UI is unchanged. The render/mutation inversion (dropping the redundant client re-dispatch) is the **later #2224 step**; `appStore.ts` / `useProjectedMonitors.ts` are intentionally untouched here.
- Backend-only, no user-facing behavior change → no changelog fragment.

## Scope note (for #2224)

Entry **creation** (`monitor.open`) still originates client-side because it carries the UI-only `host` label the backend command does not receive. Threading `host` to `session_monitoring_open` so the server can own `open` (and then removing the client stats/status re-dispatch) is the remaining #2224 inversion work.

## Verification

- `cargo test -p termihub --lib system_monitor_projection` — 25 pass (5 new)
- `cargo test -p termihub --lib session` — 208 pass
- `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean

Closes #2376
Part of #2224
Part of #2139