### PR TITLE
fix(agent): apply deferred update on daemon-backed session natural exit (Closes #2381)

### DIFF
--- a/agent/src/daemon/client.rs
+++ b/agent/src/daemon/client.rs
@@ -5,8 +5,10 @@
 //! methods for write_input, resize, attach, detach, and close. Used by both
 //! `ShellBackend` and `DockerBackend`.
 
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use base64::Engine;
@@ -23,6 +25,37 @@ use crate::protocol::messages::JsonRpcNotification;
 /// Like the connect timeout, this is generous so a daemon that is slow to
 /// finish startup and send `MSG_READY` under CI load is not dropped prematurely.
 const READY_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Future returned by an [`ExitHook`].
+pub type ExitHookFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+/// Callback invoked once when the daemon reader detects the backend has exited
+/// on its own — an `MSG_EXITED` frame, a clean EOF, or a transport read error.
+///
+/// The [`SessionManager`](crate::session::manager::SessionManager) installs one
+/// via [`DaemonClient::set_exit_hook`] so a naturally-exiting daemon-backed
+/// session promptly runs its deferred self-update auto-apply, mirroring the
+/// in-process output-forwarder path (#2378/#2381). The reader awaits the
+/// returned future, so the hook may do async work (e.g. lock the session map).
+pub type ExitHook = Arc<dyn Fn() -> ExitHookFuture + Send + Sync>;
+
+/// Shared, set-once slot holding a session's [`ExitHook`].
+///
+/// Shared between the [`DaemonClient`] and its background reader task(s) so the
+/// hook can be installed *after* [`DaemonClient::connect`] has already spawned
+/// the reader, and so a reader respawned on reattach still observes it. Empty
+/// when no hook was installed (e.g. a manager not built through
+/// [`SessionManager::into_arc`](crate::session::manager::SessionManager::into_arc),
+/// or a client used in isolation), in which case the reader simply skips it.
+type ExitHookSlot = Arc<OnceLock<ExitHook>>;
+
+/// Run the installed exit hook, if any. Called by the reader once its backend
+/// has exited on its own.
+async fn run_exit_hook(slot: &ExitHookSlot) {
+    if let Some(hook) = slot.get() {
+        hook().await;
+    }
+}
 
 /// Cloneable handle to the daemon's write half.
 ///
@@ -49,6 +82,9 @@ pub struct DaemonClient {
     notification_tx: NotificationSender,
     /// Pending oneshot channel for a query_buffer response.
     pending_buffer_reply: Arc<Mutex<Option<tokio::sync::oneshot::Sender<Vec<u8>>>>>,
+    /// Hook the reader runs when this session's backend exits on its own,
+    /// installed via [`set_exit_hook`](Self::set_exit_hook) (#2381).
+    on_exit: ExitHookSlot,
 }
 
 impl DaemonClient {
@@ -65,12 +101,14 @@ impl DaemonClient {
     ) -> Result<Self, anyhow::Error> {
         let pending_buffer_reply: Arc<Mutex<Option<tokio::sync::oneshot::Sender<Vec<u8>>>>> =
             Arc::new(Mutex::new(None));
+        let on_exit: ExitHookSlot = Arc::new(OnceLock::new());
 
         let (writer, reader_task, alive) = connect_and_start_reader(
             &endpoint,
             &session_id,
             notification_tx.clone(),
             pending_buffer_reply.clone(),
+            on_exit.clone(),
         )
         .await?;
 
@@ -82,7 +120,22 @@ impl DaemonClient {
             alive,
             notification_tx,
             pending_buffer_reply,
+            on_exit,
         })
+    }
+
+    /// Install the callback the reader runs when this session's backend exits on
+    /// its own (an `MSG_EXITED` frame or EOF/read error on the transport).
+    ///
+    /// Set-once — a second call is ignored. Wired by the
+    /// [`SessionManager`](crate::session::manager::SessionManager) so a natural
+    /// last-session exit promptly triggers the deferred self-update auto-apply,
+    /// matching the in-process output-forwarder path (#2381). Safe to call after
+    /// [`connect`](Self::connect): the reader reads the slot only once the
+    /// backend has actually exited, and the shared slot is also observed by a
+    /// reader respawned on [`attach`](Self::attach).
+    pub fn set_exit_hook(&self, hook: ExitHook) {
+        let _ = self.on_exit.set(hook);
     }
 
     /// Request the current ring buffer contents from the daemon without reconnecting.
@@ -157,6 +210,7 @@ impl DaemonClient {
             &self.session_id,
             self.notification_tx.clone(),
             self.pending_buffer_reply.clone(),
+            self.on_exit.clone(),
         )
         .await?;
 
@@ -284,6 +338,7 @@ async fn connect_and_start_reader(
     session_id: &str,
     notification_tx: NotificationSender,
     pending_buffer_reply: Arc<Mutex<Option<tokio::sync::oneshot::Sender<Vec<u8>>>>>,
+    on_exit: ExitHookSlot,
 ) -> Result<(BoxedWriter, tokio::task::JoinHandle<()>, Arc<AtomicBool>), anyhow::Error> {
     let (mut reader, writer) = transport::connect(endpoint).await?;
 
@@ -350,6 +405,7 @@ async fn connect_and_start_reader(
             &tx,
             &alive_clone,
             pending_buffer_reply,
+            on_exit,
         )
         .await;
     });
@@ -364,6 +420,7 @@ async fn reader_loop(
     notification_tx: &NotificationSender,
     alive: &AtomicBool,
     pending_buffer_reply: Arc<Mutex<Option<tokio::sync::oneshot::Sender<Vec<u8>>>>>,
+    on_exit: ExitHookSlot,
 ) {
     loop {
         match protocol::read_frame_async(&mut reader).await {
@@ -397,6 +454,10 @@ async fn reader_loop(
                         }),
                     );
                     let _ = notification_tx.send(notification);
+                    // Natural-exit deferred-update hook (#2381): if this was the
+                    // last active session, apply any staged self-update now,
+                    // matching the explicit-close and in-process paths.
+                    run_exit_hook(&on_exit).await;
                     return;
                 }
                 MSG_ERROR => {
@@ -424,11 +485,13 @@ async fn reader_loop(
                 // Daemon closed the connection (EOF)
                 info!("Daemon connection closed for session {session_id}");
                 alive.store(false, Ordering::SeqCst);
+                run_exit_hook(&on_exit).await;
                 return;
             }
             Err(e) => {
                 error!("Frame read error for session {session_id}: {e}");
                 alive.store(false, Ordering::SeqCst);
+                run_exit_hook(&on_exit).await;
                 return;
             }
         }
@@ -515,8 +578,17 @@ mod tests {
         let tx = notification_tx.clone();
         let pbr_clone = pending_buffer_reply.clone();
 
+        let on_exit: ExitHookSlot = Arc::new(OnceLock::new());
         let reader_task = tokio::spawn(async move {
-            reader_loop(reader, &session_id_owned, &tx, &alive_clone, pbr_clone).await;
+            reader_loop(
+                reader,
+                &session_id_owned,
+                &tx,
+                &alive_clone,
+                pbr_clone,
+                on_exit,
+            )
+            .await;
         });
 
         let writer_arc: Arc<Mutex<Option<BoxedWriter>>> = Arc::new(Mutex::new(Some(writer)));
@@ -544,5 +616,85 @@ mod tests {
         assert_eq!(reply, b"buffered output");
 
         reader_task.abort();
+    }
+
+    /// Build an [`ExitHook`] that flips the returned flag when run, so a test can
+    /// assert the reader reached back into its owner on a natural exit (#2381).
+    fn recording_exit_hook() -> (ExitHookSlot, Arc<AtomicBool>) {
+        let ran = Arc::new(AtomicBool::new(false));
+        let ran_for_hook = ran.clone();
+        let hook: ExitHook = Arc::new(move || {
+            let ran = ran_for_hook.clone();
+            Box::pin(async move {
+                ran.store(true, Ordering::SeqCst);
+            }) as ExitHookFuture
+        });
+        let slot: ExitHookSlot = Arc::new(OnceLock::new());
+        let _ = slot.set(hook);
+        (slot, ran)
+    }
+
+    /// The reader must run the installed exit hook when the daemon reports the
+    /// backend exited on its own via `MSG_EXITED` (#2381).
+    #[tokio::test]
+    async fn reader_loop_runs_exit_hook_on_msg_exited() {
+        let (client_sock, mut server_sock) = tokio::io::duplex(64 * 1024);
+        // The daemon side signals a natural backend exit, then closes.
+        tokio::spawn(async move {
+            protocol::write_frame_async(&mut server_sock, MSG_EXITED, &[])
+                .await
+                .unwrap();
+        });
+
+        let reader: BoxedReader = Box::new(client_sock);
+        let (on_exit, ran) = recording_exit_hook();
+        let alive = Arc::new(AtomicBool::new(true));
+        let pbr = Arc::new(Mutex::new(None));
+
+        reader_loop(
+            reader,
+            "sess",
+            &make_notification_tx(),
+            &alive,
+            pbr,
+            on_exit,
+        )
+        .await;
+
+        assert!(!alive.load(Ordering::SeqCst), "backend marked dead on exit");
+        assert!(
+            ran.load(Ordering::SeqCst),
+            "exit hook must run when the daemon sends MSG_EXITED"
+        );
+    }
+
+    /// The reader must also run the exit hook when the daemon connection reaches
+    /// EOF (the daemon vanished without a clean `MSG_EXITED`) (#2381).
+    #[tokio::test]
+    async fn reader_loop_runs_exit_hook_on_eof() {
+        let (client_sock, server_sock) = tokio::io::duplex(64 * 1024);
+        // Drop the server end immediately → the client reader observes EOF.
+        drop(server_sock);
+
+        let reader: BoxedReader = Box::new(client_sock);
+        let (on_exit, ran) = recording_exit_hook();
+        let alive = Arc::new(AtomicBool::new(true));
+        let pbr = Arc::new(Mutex::new(None));
+
+        reader_loop(
+            reader,
+            "sess",
+            &make_notification_tx(),
+            &alive,
+            pbr,
+            on_exit,
+        )
+        .await;
+
+        assert!(!alive.load(Ordering::SeqCst), "backend marked dead on EOF");
+        assert!(
+            ran.load(Ordering::SeqCst),
+            "exit hook must run when the daemon connection reaches EOF"
+        );
     }
 }

--- a/agent/src/session/manager.rs
+++ b/agent/src/session/manager.rs
@@ -24,7 +24,7 @@ use crate::transport::JsonRpcOutputSink;
 use termihub_core::connection::{ConnectionTypeRegistry, OutputReceiver};
 use termihub_core::session::traits::OutputSink;
 
-use crate::daemon::client::{DaemonClient, DaemonWriterHandle};
+use crate::daemon::client::{DaemonClient, DaemonWriterHandle, ExitHook, ExitHookFuture};
 use crate::daemon::transport::{endpoint_alive, session_endpoint};
 use crate::state::persistence::{AgentState, PendingUpdate, PersistedSession};
 use crate::update::{
@@ -590,6 +590,15 @@ impl SessionManager {
             )
             .await;
 
+        // Install the natural-exit deferred-update hook on the daemon client so a
+        // self-terminating daemon-backed session promptly applies a staged
+        // self-update, mirroring the in-process output-forwarder path (#2381).
+        if let Ok(SessionBackend::Daemon(ref client)) = result {
+            if let Some(hook) = self.deferred_update_exit_hook() {
+                client.set_exit_hook(hook);
+            }
+        }
+
         // A daemon that never launched leaves no one to talk to the relay, so
         // don't leave the socket dangling.
         if result.is_err() && ssh_auth_sock.is_some() {
@@ -755,6 +764,33 @@ impl SessionManager {
         }
     }
 
+    /// Build the natural-exit hook a daemon-backed session installs on its
+    /// [`DaemonClient`].
+    ///
+    /// When the daemon reports its backend exited on its own (`MSG_EXITED`/EOF),
+    /// the client runs this hook, which reaches back through the [`Weak`] self
+    /// reference and runs the shared [`apply_deferred_update_if_idle`] helper —
+    /// so a naturally-exiting last daemon-backed session promptly applies a
+    /// staged self-update, matching the in-process output-forwarder path
+    /// (#2378/#2381).
+    ///
+    /// Returns `None` when the manager was not wrapped through
+    /// [`into_arc`](Self::into_arc) (e.g. some unit tests); the daemon client
+    /// then installs no hook and read-path reconciliation still settles the
+    /// session — exactly as the in-process forwarder skips its hook on an empty
+    /// [`Weak`].
+    fn deferred_update_exit_hook(&self) -> Option<ExitHook> {
+        let weak = self.self_ref.get().cloned()?;
+        Some(Arc::new(move || {
+            let weak = weak.clone();
+            Box::pin(async move {
+                if let Some(manager) = weak.upgrade() {
+                    manager.apply_deferred_update_if_idle().await;
+                }
+            }) as ExitHookFuture
+        }))
+    }
+
     /// Detach all sessions without closing them.
     ///
     /// Called when a TCP client disconnects so sessions remain alive
@@ -846,6 +882,12 @@ impl SessionManager {
 
             match DaemonClient::connect(id.clone(), endpoint, self.notification_tx.clone()).await {
                 Ok(client) => {
+                    // A recovered daemon session must also promptly apply a
+                    // staged self-update when it later exits on its own (#2381).
+                    if let Some(hook) = self.deferred_update_exit_hook() {
+                        client.set_exit_hook(hook);
+                    }
+
                     let created_at = chrono::DateTime::parse_from_rfc3339(&session.created_at)
                         .map(|dt| dt.with_timezone(&Utc))
                         .unwrap_or_else(|_| Utc::now());
@@ -1893,6 +1935,94 @@ mod tests {
             assert!(
                 mgr.pending_update_for_test().await.is_none(),
                 "a successful apply clears pending_update"
+            );
+        }
+
+        // ── Daemon-backed natural-exit deferred-apply (issue #2381) ──────
+
+        /// Build an `into_arc` manager with a recording applier so the daemon
+        /// exit hook (which reaches back through the `Weak` self-reference) can be
+        /// exercised end to end.
+        fn arc_manager_with_recording_applier(
+        ) -> (Arc<SessionManager>, AppliedLog, tempfile::TempDir) {
+            let tmp = tempfile::tempdir().unwrap();
+            let state_path = tmp.path().join("state.json");
+            let applied: AppliedLog = Arc::new(StdMutex::new(Vec::new()));
+            let mgr = SessionManager::with_test_deps(
+                test_notification_tx(),
+                test_registry(),
+                Arc::new(SystemDaemonLauncher),
+                state_path,
+                Arc::new(RecordingApplier {
+                    applied: applied.clone(),
+                }),
+            )
+            .into_arc();
+            (mgr, applied, tmp)
+        }
+
+        #[tokio::test]
+        async fn daemon_exit_hook_applies_pending_update_when_idle() {
+            // The daemon-backed twin of the in-process forwarder test: when the
+            // last daemon-backed session exits on its own, the client runs the
+            // installed exit hook, which must drive the deferred apply through the
+            // manager's `Weak` self-reference (#2381).
+            let (mgr, applied, _tmp) = arc_manager_with_recording_applier();
+            mgr.seed_pending_update_for_test(fake_pending("/tmp/new-agent"))
+                .await;
+
+            // No running sessions → the manager is idle. Running the hook the
+            // daemon client would install must apply the staged update once.
+            let hook = mgr
+                .deferred_update_exit_hook()
+                .expect("an into_arc manager installs a daemon exit hook");
+            hook().await;
+
+            {
+                let log = applied.lock().unwrap();
+                assert_eq!(log.len(), 1, "update applies exactly once when idle");
+                assert_eq!(log[0].binary_path, "/tmp/new-agent");
+            }
+            assert!(
+                mgr.pending_update_for_test().await.is_none(),
+                "a successful daemon-exit apply clears pending_update"
+            );
+        }
+
+        #[tokio::test]
+        async fn daemon_exit_hook_defers_while_a_session_still_runs() {
+            // A daemon-backed session exiting while another session is still
+            // running must NOT apply the staged update — the agent is still busy.
+            let (mgr, applied, _tmp) = arc_manager_with_recording_applier();
+            mgr.create_stub_session("stub", "still-running".to_string(), serde_json::json!({}))
+                .await
+                .unwrap();
+            mgr.seed_pending_update_for_test(fake_pending("/tmp/new-agent"))
+                .await;
+
+            let hook = mgr.deferred_update_exit_hook().expect("hook present");
+            hook().await;
+
+            assert!(
+                applied.lock().unwrap().is_empty(),
+                "update must not apply while a session is still running"
+            );
+            assert!(
+                mgr.pending_update_for_test().await.is_some(),
+                "the pending update is retained until the agent is idle"
+            );
+        }
+
+        #[tokio::test]
+        async fn deferred_update_exit_hook_absent_without_into_arc() {
+            // A manager not built through `into_arc` has no self-reference, so no
+            // daemon exit hook is installed — read-path reconciliation still
+            // settles the session, exactly as the in-process forwarder skips its
+            // hook on an empty `Weak`.
+            let (mgr, _applied, _tmp) = manager_with_recording_applier();
+            assert!(
+                mgr.deferred_update_exit_hook().is_none(),
+                "no self-reference ⇒ no daemon exit hook"
             );
         }
     }

--- a/docs/changes/dev1/fix/2381-daemon-exit-deferred-update.md
+++ b/docs/changes/dev1/fix/2381-daemon-exit-deferred-update.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- Agent: a staged self-update now auto-applies promptly when the **last
+  daemon-backed (persistent) session exits on its own**, not only when it is
+  explicitly closed or on the next reconciliation/self-update poll. #2378 wired
+  this natural-exit hook for in-process sessions; daemon-backed sessions detect
+  their exit inside the daemon client (`MSG_EXITED`/EOF), which previously had no
+  way to reach back into the session manager. The daemon client now runs an
+  installed exit hook on a natural exit, invoking the same shared
+  `apply_deferred_update_if_idle()` helper — so a staged update lands the moment
+  the agent goes idle regardless of how the last session ended (#2381).


### PR DESCRIPTION
## Summary

Follow-up to #2378 (PR #2380). #2378 wired the deferred agent self-update auto-apply — "reached zero active sessions → apply the staged pending update" — into the **in-process output-forwarder** natural-exit path, but **daemon-backed (persistent) sessions were not covered promptly**. A daemon-backed session's exit is detected inside `DaemonClient` (`MSG_EXITED`/EOF), which had no callback into `SessionManager`, so a staged update only applied on the next read-path reconciliation (`list()`/`active_count()`), an explicit `close()`, or the next self-update poll — not at the exit.

## Changes

- `DaemonClient` gains a set-once **exit-hook slot** (`Arc<OnceLock<ExitHook>>`) shared with its background reader. The reader runs the hook when the backend exits on its own — `MSG_EXITED`, a clean EOF, or a transport read error — right after flipping the liveness flag. The slot is shared, so a reader respawned on `attach()` still observes it.
- `SessionManager` installs a hook on every daemon client it creates (both the spawn path in `spawn_daemon_backend` and the recovery path in `recover_sessions`) via `DaemonClient::set_exit_hook`. The hook is built from the **same `Weak<SessionManager>` self-reference** the in-process forwarder uses (`into_arc`), and runs the **shared `apply_deferred_update_if_idle()` helper** — no apply logic is duplicated.
- When the manager was not built through `into_arc` (some unit tests), the hook is absent; the daemon client installs nothing and read-path reconciliation still settles the session — exactly as the in-process forwarder skips its hook on an empty `Weak`.
- Explicit `close()`/`detach()` abort the reader task before it reads EOF, so the hook does not double-fire there; `close()` already runs the shared helper.

## Tests

- `reader_loop_runs_exit_hook_on_msg_exited` / `reader_loop_runs_exit_hook_on_eof` (daemon client): the reader reaches back into its owner on a natural exit.
- `daemon_exit_hook_applies_pending_update_when_idle` (manager): the installed hook applies a staged update exactly once and clears it when the agent is idle.
- `daemon_exit_hook_defers_while_a_session_still_runs`: no apply while another session is still running.
- `deferred_update_exit_hook_absent_without_into_arc`: no self-reference ⇒ no daemon exit hook.

`cargo build -p termihub-agent`, `cargo test -p termihub-agent`, `cargo fmt --all --check`, and `cargo clippy -p termihub-agent --all-targets --all-features -D warnings` all pass.

Closes #2381