### PR TITLE
feat(session): add session-path vscode_open_remote to complete step-A sftp parity (Part of #2307)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2237,6 +2237,25 @@ Raspberry Pi). See PR #1508 (#1329).
 8. Confirm the sudo password is never visible in the LogViewer (elevated-save DEBUG
    lines name the host/path only) and never written to workspace/tab state.
 
+### Open remote file in VS Code over the session path (#2307)
+
+Verifies the session/`ConnectionType`-scoped `session_vscode_open_remote`
+command drives the same download → edit (`--wait`) → re-upload flow as the
+standalone `vscode_open_remote`. Both now share the `open_remote_in_vscode`
+helper, differing only in how they resolve the core `SftpFileBrowser`; the
+shared flow is already exercised by the guided-manual harness test
+`test_open_in_vscode_sftp` (`tests/system/tests/test_external_app.py`), and the
+session resolver's error shapes by `session_sftp_ops_error_*` unit tests. This
+manual pass covers the session route end-to-end and is exercisable once the
+frontend cut (#2313, step B) routes SSH remote-edit through the session path.
+
+1. On a remote SSH/SFTP connection with the VS Code CLI (`code`) available,
+   browse to a remote file, right-click → **Open in VS Code**.
+2. Confirm VS Code opens the downloaded file; edit and save it, then close the
+   VS Code tab.
+3. Confirm the change is re-uploaded to the host (`cat` it in a shell) and
+   termiHub is still running (no crash — regression #828).
+
 ### File editor SFTP-only read-only fallback (#1330)
 
 Verifies the graceful fallback for a read-only file on an SFTP-only / relayed

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -515,7 +515,24 @@ pub async fn vscode_open_remote(
 ) -> Result<(), TerminalError> {
     // Clone the session browser Arc before spawning the background task.
     let browser = manager.get_session(&session_id)?;
+    open_remote_in_vscode(browser, remote_path, app_handle).await
+}
 
+/// Download `remote_path` from `browser` to a temp file, open it in VS Code with
+/// `--wait`, and re-upload on close, emitting a `vscode-edit-complete` event.
+///
+/// Shared by the standalone `SftpManager` path ([`vscode_open_remote`]) and the
+/// session/`ConnectionType` path
+/// ([`session_vscode_open_remote`](crate::commands::session::session_vscode_open_remote))
+/// so both drive the identical download → edit → re-upload flow on the one core
+/// [`SftpFileBrowser`], differing only in how they resolve the browser handle
+/// (part of the #2307 SFTP-session convergence). The initial download is awaited
+/// here; the `--wait` + re-upload run in a spawned background task.
+pub(crate) async fn open_remote_in_vscode(
+    browser: std::sync::Arc<SftpFileBrowser>,
+    remote_path: String,
+    app_handle: tauri::AppHandle,
+) -> Result<(), TerminalError> {
     // Extract the filename from the remote path
     let filename = std::path::Path::new(&remote_path)
         .file_name()

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -532,6 +532,29 @@ pub async fn session_upload(
     Ok(transfer_id)
 }
 
+/// Open a remote file in VS Code over a session's SFTP connection: download,
+/// open with `--wait`, re-upload on close.
+///
+/// Session-path mirror of the standalone `vscode_open_remote` — the one
+/// `sftp_*`-only command #2312 left without a session equivalent — so an SSH tab
+/// can edit a remote file in VS Code straight from its `ConnectionType` session,
+/// with no separate `SftpManager` session. Resolves the owned
+/// `Arc<SftpFileBrowser>` from the session path and reuses the exact shared
+/// download → edit → re-upload flow. Only succeeds for an SFTP-backed session;
+/// other backends return a "not supported" error. Completes the step-A backend
+/// parity of the #2307 convergence.
+#[tauri::command]
+pub async fn session_vscode_open_remote(
+    session_id: String,
+    remote_path: String,
+    manager: State<'_, SessionManager>,
+    app_handle: tauri::AppHandle,
+) -> Result<(), TerminalError> {
+    debug!(session_id, remote_path, "Session SFTP open in VS Code");
+    let browser = manager.sftp_transfer_browser(&session_id).await?;
+    crate::commands::files::open_remote_in_vscode(browser, remote_path, app_handle).await
+}
+
 // --- Session-based monitoring commands ---
 
 /// Capabilities of an active session exposed to the frontend.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1301,6 +1301,7 @@ pub fn run() {
             commands::session::session_has_exec_capability,
             commands::session::session_download,
             commands::session::session_upload,
+            commands::session::session_vscode_open_remote,
             // Session-based monitoring
             commands::session::session_get_capabilities,
             commands::session::session_monitoring_open,


### PR DESCRIPTION
## Summary

Adds `session_vscode_open_remote`, the **last** standalone `sftp_*` command that had no session/`ConnectionType` mirror after #2312 (PR #2315) landed the rest of the step-A backend SFTP parity for the #2307 convergence.

Without it, routing the SSH file browser through the session path (step B, #2313) would break **Open remote file in VS Code**: `vscode_open_remote` resolves its browser via `SftpManager::get_session`, which only knows UUID-keyed standalone sessions.

## What changed

- **`commands/files.rs`** — extract the download → edit (`--wait`) → re-upload flow out of `vscode_open_remote` into a shared `pub(crate) open_remote_in_vscode(Arc<SftpFileBrowser>, …)` helper (pure extract-method; the body is unchanged). `vscode_open_remote` now resolves its browser and delegates.
- **`commands/session.rs`** — add `session_vscode_open_remote`, which resolves the owned `Arc<SftpFileBrowser>` from the session path via `SessionManager::sftp_transfer_browser` (added in #2312) and reuses the shared helper. Only succeeds for an SFTP-backed session; other backends get the existing "not supported" error.
- **`lib.rs`** — register the command.
- **`docs/testing.md`** — manual pass for the session route.

Additive only: `SftpManager` / `sftp_*` are untouched (retired in step C, #2314). No frontend change (the frontend cut is step B, #2313) — same additive backend-only pattern #2312 used.

## Backend SFTP parity is now complete

Every standalone `sftp_*` command has a session-path equivalent: `list_dir`/`stat`/`realpath`/`check_writable`/`mkdir`/`delete`/`rename`/`elevated write`/`exec-cap`/`download`/`upload` (via #2312), read/write file content via the byte-based `session_read_file`/`session_write_file`, `cancel_transfer` is shared, and now **VS Code remote edit**. This unblocks the step-B frontend cut (#2313) as a pure frontend swap with no remaining backend gaps.

## Testing

- `cargo build` / `cargo clippy --all-targets --all-features -D warnings` / `cargo fmt --check` — clean.
- `cargo test -p termihub --lib session::` — 131 passed; the `session_sftp_ops_error_when_browser_not_sftp_backed` / `…_session_unknown` tests cover the resolver `session_vscode_open_remote` depends on.
- The extracted `open_remote_in_vscode` flow is a behavior-preserving refactor already exercised end-to-end by the `test_open_in_vscode_sftp` guided-manual harness test (`tests/system/tests/test_external_app.py`) via the standalone path.

## Scope note

Titled **Part of #2307**, not "Closes" — #2307 is the convergence tracker and closes only when step C (#2314) removes `SftpManager`. This PR completes the step-A backend parity that #2312 (step A) left one command short of.

Part of #2307. Completes step-A parity from #2312 (PR #2315). Unblocks #2313.
