### PR TITLE
feat(backend): feed the transfers projection store server-side (Closes #2387)

### DIFF
--- a/src-tauri/src/files/transfer/mod.rs
+++ b/src-tauri/src/files/transfer/mod.rs
@@ -176,6 +176,23 @@ pub type ProgressSink = Arc<dyn Fn(&TransferProgress) + Send + Sync>;
 /// copy).
 pub fn app_progress_sink(app: AppHandle) -> ProgressSink {
     Arc::new(move |progress: &TransferProgress| {
+        // Server-authority fold (#2387, prerequisite for #2229): reflect every
+        // backend-produced transfer transition / progress sample into the shared
+        // `TransferStore` at the source — the instant the copy loop / FTP
+        // scheduler produces it — and fan the `transfers` region diff out.
+        // `app_progress_sink` is the single choke point every `transfer-progress`
+        // event flows through for both the legacy SFTP and rich FTP paths, so
+        // folding here feeds the store the whole register → queue → progress →
+        // pause → resume → finish → cancel lifecycle. Additive: the Tauri event
+        // below still fires and the frontend mirror is untouched, so no
+        // user-facing behavior changes; the fold serializes the event to the same
+        // camelCase JSON the frontend receives, so the store transition matches
+        // the client `transfer.progress` route exactly. Best-effort: skipped when
+        // the store/projection is unmanaged (e.g. a collector-sink integration
+        // test) or the event does not serialize.
+        if let Ok(value) = serde_json::to_value(progress) {
+            crate::transfers_projection::projection::fold_transfer_progress(&app, &value);
+        }
         if let Err(e) = app.emit(TRANSFER_PROGRESS_EVENT, progress) {
             warn!(error = %e, "failed to emit transfer-progress");
         }

--- a/src-tauri/src/transfers_projection/projection.rs
+++ b/src-tauri/src/transfers_projection/projection.rs
@@ -53,6 +53,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde_json::Value;
 use tauri::{AppHandle, Manager};
 
+use crate::commands::projection::ProjectionState;
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
 use crate::transfers_projection::store::{
     TransferEntry, TransferProgress, TransferSeed, TransferSnapshot, TransferStore,
@@ -81,6 +82,48 @@ pub fn publish_transfers(projector: &Projector, store: &TransferStore) -> Vec<Pr
             version,
         }],
         None => Vec::new(),
+    }
+}
+
+/// Fold a backend-produced `transfer-progress` event into the managed
+/// [`TransferStore`] **server-side** and fan the resulting `transfers` region
+/// diff out to every subscriber (#2387, prerequisite for #2229).
+///
+/// This is the server-authority counterpart to the `transfer.progress` intent
+/// [`register_transfer_intents`] registers: the same store transition the
+/// frontend currently mirrors via `transfer.*` intents is applied here **at the
+/// source** — the instant the transfer engine (the SFTP copy loop / the FTP
+/// scheduler executor) produces a lifecycle transition or progress sample and
+/// hands it to [`crate::files::transfer::app_progress_sink`]. Every backend
+/// `transfer-progress` event carries the rich `state` field
+/// (`queued`/`active`/`paused`/`completed`/`failed`/`cancelled`), so folding the
+/// event stream reflects the full register → queue → progress → pause → resume →
+/// finish → cancel lifecycle into the store without any client round-trip.
+///
+/// `progress` is the event serialized exactly as the frontend receives it
+/// (camelCase JSON); it is parsed into the store's [`TransferProgress`] via the
+/// identical `serde_json::from_value` path the client `transfer.progress` route
+/// runs, so the server fold reproduces the client route's store transition
+/// exactly (parity). It is **additive**: the Tauri `transfer-progress` emission
+/// stays in place and the render-cut mirror (`transfer.replace`, a later #2229
+/// step) keeps the region a faithful copy of `appStore`, so this changes no
+/// user-facing behavior.
+///
+/// Best-effort and non-fatal: if the store or the projection state is not managed
+/// (e.g. a headless unit-test app that never ran `setup()`), or the event does
+/// not parse, the fold is skipped rather than erroring. The store transition runs
+/// to completion synchronously before the publish, so the store lock is never
+/// held across an await.
+pub fn fold_transfer_progress<R: tauri::Runtime>(app_handle: &AppHandle<R>, progress: &Value) {
+    let Some(store) = app_handle.try_state::<Arc<TransferStore>>() else {
+        return;
+    };
+    let Ok(parsed) = serde_json::from_value::<TransferProgress>(progress.clone()) else {
+        return;
+    };
+    store.progress(&parsed, now_ms());
+    if let Some(projection) = app_handle.try_state::<ProjectionState>() {
+        publish_transfers(&projection.projector, store.inner().as_ref());
     }
 }
 

--- a/src-tauri/src/transfers_projection/projection_tests.rs
+++ b/src-tauri/src/transfers_projection/projection_tests.rs
@@ -16,14 +16,18 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use serde_json::{json, Value};
+use tauri::Manager;
 
+use crate::commands::projection::ProjectionState;
 use crate::projection::{
     apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
     ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
 };
-use crate::transfers_projection::projection::{publish_transfers, TRANSFERS_REGION};
+use crate::transfers_projection::projection::{
+    fold_transfer_progress, publish_transfers, TRANSFERS_REGION,
+};
 use crate::transfers_projection::store::{
-    TransferProgress, TransferSeed, TransferSnapshot, TransferStore,
+    TransferProgress, TransferQueueState, TransferSeed, TransferSnapshot, TransferStore,
 };
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -439,4 +443,121 @@ fn progress_payload(id: &str, state: &str, transferred: u64) -> Value {
         "state": state,
         "totalBytes": 1000,
     })
+}
+
+// ── Server-authority fold (#2387, prerequisite for #2229) ─────────────────────
+//
+// These drive the *production* `fold_transfer_progress` end to end against a
+// `tauri::test::mock_app()` with the same managed state `lib.rs::setup()` wires:
+// an `Arc<TransferStore>` and a `ProjectionState`. They prove the store is fed
+// **server-side** — the instant the transfer engine produces a
+// register/queue/progress/pause/finish/cancel `transfer-progress` event and
+// hands it to `app_progress_sink` — with no `transfer.*` client dispatch, and
+// that the fold reproduces the client `transfer.progress` route's store
+// transition exactly (parity, no double count).
+
+/// A backend-produced progress event folded server-side upserts the row in the
+/// shared store and fans the `transfers` region diff out — without any client
+/// dispatch. The full lifecycle is captured because every backend event carries
+/// the rich `state` field.
+#[test]
+fn server_side_progress_fold_updates_store_and_region_without_client_dispatch() {
+    let app = tauri::test::mock_app();
+
+    let store = Arc::new(TransferStore::new());
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(TRANSFERS_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    let snap = projection
+        .projector
+        .subscribe(TRANSFERS_REGION, "sub", "C", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+    app.manage(projection);
+
+    // The engine emits an `active` progress sample at the source — no
+    // `transfer.progress` intent is dispatched.
+    fold_transfer_progress(app.handle(), &progress_payload("t1", "active", 400));
+
+    // The store is authoritative server-side.
+    let entry = store.get("t1").expect("row created by the server fold");
+    assert_eq!(entry.state, TransferQueueState::Active);
+    assert_eq!(entry.transferred, 400);
+    assert_eq!(entry.percent, Some(40));
+
+    // Exactly one region diff fanned out; the client cache converges on the
+    // server truth with no round-trip.
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "one diff from the server-side fold");
+    cache.apply(&diffs[0]);
+    assert_eq!(cache.view["queue"]["t1"]["state"], json!("active"));
+    assert_eq!(cache.view["queue"]["t1"]["transferred"], json!(400));
+    assert_eq!(cache.view, store.snapshot(), "cache converges on authority");
+}
+
+/// A terminal `completed` event folded server-side settles the row (percent
+/// 100), publishing the region diff — the finish edge of the lifecycle.
+#[test]
+fn server_side_terminal_fold_settles_the_row() {
+    let app = tauri::test::mock_app();
+    let store = Arc::new(TransferStore::new());
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(TRANSFERS_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    projection
+        .projector
+        .subscribe(TRANSFERS_REGION, "sub", "C", sink.clone());
+    app.manage(projection);
+
+    fold_transfer_progress(app.handle(), &progress_payload("t1", "active", 400));
+    fold_transfer_progress(app.handle(), &progress_payload("t1", "completed", 1000));
+
+    let entry = store.get("t1").expect("row retained after completion");
+    assert_eq!(entry.state, TransferQueueState::Completed);
+    assert_eq!(entry.percent, Some(100));
+    assert_eq!(sink.diffs().len(), 2, "one diff per folded event");
+}
+
+/// The server-side progress fold reproduces the client `transfer.progress`
+/// route's store transition exactly — identical snapshots, so there is no drift
+/// or double count when the fold and the (still-present, additive) client mirror
+/// both run the same event.
+#[test]
+fn server_side_progress_fold_matches_the_client_transfer_progress_route() {
+    let event = progress_payload("t1", "active", 400);
+
+    // (a) Server-side fold: the store method the fold applies at the source.
+    let server = Arc::new(TransferStore::new());
+    server.progress(&serde_json::from_value(event.clone()).unwrap(), NOW);
+
+    // (b) Client route: the `transfer.progress` intent through the production
+    // registry wiring (mirrored by `registry_for`).
+    let client = Arc::new(TransferStore::new());
+    let projector = Arc::new(Projector::new());
+    projector.register_region(TRANSFERS_REGION, client.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(client.clone())));
+    let ack = dispatcher.dispatch(intent("transfer.progress", json!({ "progress": event })));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    assert_eq!(
+        server.snapshot(),
+        client.snapshot(),
+        "the server fold reproduces the client route's transition exactly"
+    );
+}
+
+/// The fold is a best-effort no-op when no store / projection state is managed
+/// (e.g. a headless harness that never ran `setup()`) — it must not panic.
+#[test]
+fn server_side_fold_is_a_noop_without_managed_state() {
+    let app = tauri::test::mock_app();
+    // Nothing managed — reaching the assert without panicking is the contract.
+    fold_transfer_progress(app.handle(), &progress_payload("t1", "active", 1));
 }


### PR DESCRIPTION
## What

Makes the shared `TransferStore` (the `transfers` projection region) **server-authoritative at the source**: every backend-produced transfer lifecycle transition and progress sample is folded into the store **the instant the transfer engine produces it**, instead of relying solely on client-dispatched `transfer.*` intents.

Prerequisite for #2229 (Phase 5 Transfers migration): today the SFTP copy loop and the FTP scheduler executor produce the authoritative progress/lifecycle and emit it straight to the frontend as `transfer-progress` events, and `TransferStore` is only ever fed by a client `transfer.*` re-dispatch. Removing the appStore reducers (making the store authoritative) is a **lossy** inversion while the store is never fed from the data source. This PR feeds it from the source so #2229 can invert the data flow with no data-loss risk. Closest analog: Monitors #2376 (PR #2379).

## Changes

- **New `fold_transfer_progress`** (`transfers_projection/projection.rs`): resolves the managed store + projector from the `AppHandle`, parses the event via the **identical `serde_json::from_value` path the client `transfer.progress` route runs**, applies the fold, and publishes the region diff. Best-effort (skips if the store/projection is unmanaged or the event does not parse); never holds the store lock across an await.
- **Fold at the source** (`files/transfer/mod.rs::app_progress_sink`): the **single choke point** every `transfer-progress` event flows through for **both** the legacy SFTP and rich FTP paths. Each event carries the rich `state` field (`queued`/`active`/`paused`/`completed`/`failed`/`cancelled`), so folding the stream reflects the whole **register → queue → progress → pause → resume → finish → cancel** lifecycle into the store server-side. (`AppHandle` is Tauri-injected — no change to the JS invoke surface.)
- **Tests**: drive the production fold end-to-end against `tauri::test::mock_app()` — a progress sample updates the store and fans the region diff out **with no client dispatch** (server-authoritative); a terminal `completed` event settles the row; a no-op when unmanaged; and **parity** — the server fold reproduces the client `transfer.progress` route's store transition exactly.

## Additive / no user-facing change

- The existing Tauri `transfer-progress` event emission stays in place; `appStore.ts` and the frontend mirror are intentionally untouched.
- The render/mutation inversion (dropping the redundant client re-dispatch, making the store authoritative) is the **later #2229 step**.
- Backend-only, no user-facing behavior change → no changelog fragment.

## Scope note (for #2229)

The panel-only operations that have no backend data source — `remove`, `clearCompleted`, `setMinimized`, and the `reconcile` polling backstop — stay client-side (the analog of #2376 leaving `monitor.open`'s UI `host` label client-side). Feeding the live engine stream at the source is what #2229 needs to invert the data flow non-lossily.

## Verification

- `cargo test -p termihub --lib transfers_projection` — 32 pass (4 new)
- `cargo test -p termihub --lib transfer` — 90 pass
- `cargo fmt --all -- --check` clean; `cargo clippy -p termihub --all-targets -- -D warnings` clean, and clean with `--features ftp`

Closes #2387
Part of #2229
Part of #2139