### PR TITLE
feat(agent): feed AgentsStore server-side from status + CRUD streams (Closes #2388)

### DIFF
--- a/src-tauri/src/agents_projection/projection.rs
+++ b/src-tauri/src/agents_projection/projection.rs
@@ -64,6 +64,7 @@ use tauri::{AppHandle, Manager};
 use crate::agents_projection::store::{
     AgentConnectionState, AgentDefinition, AgentEntry, AgentFolder, AgentSession, AgentsStore,
 };
+use crate::commands::projection::ProjectionState;
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
 
 /// The projection region id for the agents domain (shared, per Open Design
@@ -80,6 +81,43 @@ pub fn publish_agents(projector: &Projector, store: &AgentsStore) -> Vec<Produce
             version,
         }],
         None => Vec::new(),
+    }
+}
+
+/// Fold an agent transition into the managed [`AgentsStore`] **server-side** and
+/// fan the resulting `agents` region diff out to every subscriber (#2388,
+/// prerequisite for #2226).
+///
+/// This is the server-authority counterpart to [`register_agent_intents`]: the
+/// same store transitions the frontend currently mirrors via `agent.*` intents
+/// are applied here **at the source** — the instant the backend produces the
+/// outcome (a connection-state change emitted by the agent manager, or a
+/// definition/folder/session CRUD result returned by an agent RPC command) — so
+/// the store is fed server-side, with no client round-trip required for it to be
+/// correct. It is **additive**: the existing Tauri event emission / RPC return
+/// and the client `agent.*` mirror stay in place, and the render-cut seed
+/// (`agent.replace` on the frontend) keeps the region a faithful mirror of
+/// `appStore`, so this changes no user-facing behavior. Removing the now-redundant
+/// client re-dispatch is the later #2226 render/mutation inversion.
+///
+/// Best-effort and non-fatal: if the store or the projection state is not managed
+/// (e.g. a headless unit-test app that never ran `setup()`), the fold is skipped
+/// rather than erroring — the client mirror still drives the region. The `apply`
+/// closure runs to completion synchronously before the publish, so the store lock
+/// is never held across an await. The per-agent transitions are themselves no-ops
+/// for an unknown agent id (entry creation stays client-side, carrying the UI
+/// fields the backend command does not receive — the analog of the
+/// system-monitor bridge's client-owned `monitor.open`).
+pub fn fold_agent_transition<R: tauri::Runtime>(
+    app_handle: &AppHandle<R>,
+    apply: impl FnOnce(&AgentsStore),
+) {
+    let Some(store) = app_handle.try_state::<Arc<AgentsStore>>() else {
+        return;
+    };
+    apply(store.inner().as_ref());
+    if let Some(projection) = app_handle.try_state::<ProjectionState>() {
+        publish_agents(&projection.projector, store.inner().as_ref());
     }
 }
 

--- a/src-tauri/src/agents_projection/projection_tests.rs
+++ b/src-tauri/src/agents_projection/projection_tests.rs
@@ -15,9 +15,13 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use serde_json::{json, Value};
+use tauri::Manager;
 
-use crate::agents_projection::projection::{publish_agents, AGENTS_REGION};
-use crate::agents_projection::store::{AgentDefinition, AgentFolder, AgentSession, AgentsStore};
+use crate::agents_projection::projection::{fold_agent_transition, publish_agents, AGENTS_REGION};
+use crate::agents_projection::store::{
+    AgentConnectionState, AgentDefinition, AgentFolder, AgentSession, AgentsStore,
+};
+use crate::commands::projection::ProjectionState;
 use crate::projection::{
     apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
     ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
@@ -459,4 +463,246 @@ fn replace_mirrors_a_whole_snapshot_in_one_diff_and_converges() {
     assert_eq!(cache.view["agents"].as_array().unwrap().len(), 1);
     assert_eq!(cache.view["agents"][0]["name"], json!("Only"));
     assert!(store.get("a2").is_none(), "replace dropped the prior agent");
+}
+
+// ── Server-authority fold (#2388, prerequisite for #2226) ─────────────────────
+//
+// These drive the *production* `fold_agent_transition` end to end against a
+// `tauri::test::mock_app()` with the same managed state `lib.rs::setup()` wires:
+// an `Arc<AgentsStore>` and a `ProjectionState`. They prove the store is fed
+// **server-side** — the instant the agent manager emits a state change or an
+// agent-RPC command returns a CRUD outcome — with no `agent.*` client dispatch,
+// and that the fold reproduces the client route's store transition exactly
+// (parity) and stays idempotent alongside the still-present client mirror.
+
+/// A definition RPC record → the store shape it folds into.
+fn definition(id: &str, folder: Option<&str>) -> AgentDefinition {
+    AgentDefinition {
+        id: id.to_string(),
+        name: format!("def-{id}"),
+        session_type: "shell".to_string(),
+        config: json!({ "shell": "bash" }),
+        persistent: false,
+        folder_id: folder.map(str::to_string),
+        terminal_options: None,
+        icon: None,
+        source_file: None,
+    }
+}
+
+fn folder(id: &str) -> AgentFolder {
+    AgentFolder {
+        id: id.to_string(),
+        name: format!("folder-{id}"),
+        parent_id: None,
+        is_expanded: true,
+    }
+}
+
+fn session(id: &str) -> AgentSession {
+    AgentSession {
+        session_id: id.to_string(),
+        title: format!("session {id}"),
+        session_type: "shell".to_string(),
+        status: "running".to_string(),
+        attached: true,
+        definition_id: None,
+    }
+}
+
+/// A live connection-status transition folded server-side (the `agent-state-change`
+/// emission point) updates the shared store and fans the `agents` region diff out
+/// — without any client `agent.status` dispatch.
+#[test]
+fn server_side_status_fold_updates_store_and_region_without_client_dispatch() {
+    let app = tauri::test::mock_app();
+
+    // The agent entry is created client-side (it carries the UI config/settings the
+    // backend does not receive); the server folds the live status into it.
+    let store = Arc::new(AgentsStore::new());
+    store.add("a1", "One", json!({ "host": "h1" }), json!({}));
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(AGENTS_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    let snap = projection
+        .projector
+        .subscribe(AGENTS_REGION, "sub", "C", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+    app.manage(projection);
+
+    // Server folds the transition at the source — no `agent.status` intent runs.
+    fold_agent_transition(app.handle(), |s| {
+        s.set_status("a1", AgentConnectionState::Connected, None)
+    });
+
+    // The store is authoritative server-side.
+    assert_eq!(
+        store.get("a1").map(|a| a.connection_state),
+        Some(AgentConnectionState::Connected)
+    );
+
+    // Exactly one region diff fanned out; the client cache converges with no round-trip.
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "one diff from the server-side fold");
+    cache.apply(&diffs[0]);
+    assert_eq!(
+        cache.view["agents"][0]["connectionState"],
+        json!("connected")
+    );
+}
+
+/// The server-side status fold reproduces the client `agent.status` route's store
+/// transition exactly — identical snapshots, so the (additive) client mirror and
+/// the fold never drift and `set_status` is idempotent across both.
+#[test]
+fn server_side_status_fold_matches_the_client_agent_status_route() {
+    // (a) Server-side fold: the store method the fold applies at the source.
+    let server = seeded_store();
+    server.set_status(
+        "a1",
+        AgentConnectionState::Reconnecting,
+        Some("boom".into()),
+    );
+
+    // (b) Client route: the `agent.status` intent through the production registry.
+    let client = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(AGENTS_REGION, client.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(client.clone())));
+    let ack = dispatcher.dispatch(intent(
+        "agent.status",
+        json!({ "id": "a1", "state": "reconnecting", "error": "boom" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    assert_eq!(
+        server.snapshot(),
+        client.snapshot(),
+        "the server fold reproduces the client route's transition exactly"
+    );
+}
+
+/// A definition CRUD outcome folded server-side upserts into the shared store and
+/// publishes the region diff, and re-folding the identical outcome is a no-op (no
+/// double count when the additive client `agent.saveDefinition` mirror also runs).
+#[test]
+fn server_side_definition_fold_upserts_and_is_idempotent() {
+    let app = tauri::test::mock_app();
+    let store = Arc::new(AgentsStore::new());
+    store.add("a1", "One", json!({ "host": "h1" }), json!({}));
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(AGENTS_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    let snap = projection
+        .projector
+        .subscribe(AGENTS_REGION, "sub", "C", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+    app.manage(projection);
+
+    // Server folds a `save_agent_definition` outcome at the source.
+    fold_agent_transition(app.handle(), |s| {
+        s.save_definition("a1", definition("d1", None))
+    });
+    // The (still-present) client `agent.saveDefinition` mirror folds the same id.
+    fold_agent_transition(app.handle(), |s| {
+        s.save_definition("a1", definition("d1", None))
+    });
+
+    assert_eq!(
+        store.definitions_of("a1").len(),
+        1,
+        "upsert — no double count across the fold and the client mirror"
+    );
+    // One diff (the first fold); the identical second fold advances nothing.
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "the idempotent re-fold produced no diff");
+    cache.apply(&diffs[0]);
+    assert_eq!(cache.view["definitions"]["a1"][0]["id"], json!("d1"));
+}
+
+/// A `create_agent_folder` outcome folded server-side adds the folder and — because
+/// `create_folder` upserts by id — running the identical fold again (the additive
+/// client `agent.createFolder` mirror) neither duplicates the folder nor emits a
+/// second diff.
+#[test]
+fn server_side_create_folder_fold_converges_without_duplicate() {
+    let app = tauri::test::mock_app();
+    let store = Arc::new(AgentsStore::new());
+    store.add("a1", "One", json!({ "host": "h1" }), json!({}));
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(AGENTS_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    projection
+        .projector
+        .subscribe(AGENTS_REGION, "sub", "C", sink.clone());
+    app.manage(projection);
+
+    fold_agent_transition(app.handle(), |s| s.create_folder("a1", folder("f1")));
+    fold_agent_transition(app.handle(), |s| s.create_folder("a1", folder("f1")));
+
+    assert_eq!(
+        store.folders_of("a1").len(),
+        1,
+        "the folder is not duplicated"
+    );
+    assert_eq!(
+        sink.diffs().len(),
+        1,
+        "only the first fold advanced the region"
+    );
+}
+
+/// A `close_agent_session` outcome folded server-side drops the session from the
+/// shared store and publishes the region diff.
+#[test]
+fn server_side_close_session_fold_drops_the_session() {
+    let app = tauri::test::mock_app();
+    let store = Arc::new(AgentsStore::new());
+    store.add("a1", "One", json!({ "host": "h1" }), json!({}));
+    store.set_sessions("a1", vec![session("s1"), session("s2")]);
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(AGENTS_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    projection
+        .projector
+        .subscribe(AGENTS_REGION, "sub", "C", sink.clone());
+    app.manage(projection);
+
+    fold_agent_transition(app.handle(), |s| s.remove_session("a1", "s1"));
+
+    let remaining: Vec<String> = store.snapshot()["sessions"]["a1"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["sessionId"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(remaining, vec!["s2".to_string()]);
+    assert_eq!(sink.diffs().len(), 1);
+}
+
+/// The fold is a best-effort no-op when no store / projection state is managed
+/// (e.g. a headless harness that never ran `setup()`) — it must not panic.
+#[test]
+fn server_side_fold_is_a_noop_without_managed_state() {
+    let app = tauri::test::mock_app();
+    // Nothing managed — reaching the assert without panicking is the contract.
+    fold_agent_transition(app.handle(), |s| {
+        s.set_status("a1", AgentConnectionState::Connected, None)
+    });
 }

--- a/src-tauri/src/agents_projection/store.rs
+++ b/src-tauri/src/agents_projection/store.rs
@@ -332,6 +332,51 @@ impl AgentsStore {
         }
     }
 
+    /// Replace one agent's live-session list with a server-produced snapshot (the
+    /// `list_agent_sessions` RPC outcome, #2388). Distinct from [`Self::refresh`],
+    /// which replaces sessions/definitions/folders together; this sets only the
+    /// sessions slice so folding a `list_agent_sessions` result does not clobber
+    /// the saved definitions/folders. A no-op for an unknown id. Idempotent, so
+    /// running it alongside the additive client `agent.refresh` mirror converges
+    /// without drift.
+    pub fn set_sessions(&self, id: &str, sessions: Vec<AgentSession>) {
+        let mut inner = self.lock();
+        if inner.agent_mut(id).is_some() {
+            inner.sessions.insert(id.to_string(), sessions);
+        }
+    }
+
+    /// Remove one live session from an agent by session id (the
+    /// `close_agent_session` RPC outcome, #2388). A no-op if the agent or session
+    /// is unknown; idempotent.
+    pub fn remove_session(&self, id: &str, session_id: &str) {
+        let mut inner = self.lock();
+        if let Some(list) = inner.sessions.get_mut(id) {
+            list.retain(|s| s.session_id != session_id);
+        }
+    }
+
+    /// Replace one agent's saved-definition list with a server-produced snapshot
+    /// (the `list_agent_definitions` / `list_agent_connections` RPC outcome,
+    /// #2388). Sets only the definitions slice (see [`Self::set_sessions`]). A
+    /// no-op for an unknown id; idempotent.
+    pub fn set_definitions(&self, id: &str, definitions: Vec<AgentDefinition>) {
+        let mut inner = self.lock();
+        if inner.agent_mut(id).is_some() {
+            inner.definitions.insert(id.to_string(), definitions);
+        }
+    }
+
+    /// Replace one agent's folder list with a server-produced snapshot (the
+    /// `list_agent_connections` RPC outcome, #2388). Sets only the folders slice
+    /// (see [`Self::set_sessions`]). A no-op for an unknown id; idempotent.
+    pub fn set_folders(&self, id: &str, folders: Vec<AgentFolder>) {
+        let mut inner = self.lock();
+        if inner.agent_mut(id).is_some() {
+            inner.folders.insert(id.to_string(), folders);
+        }
+    }
+
     // ── Definition CRUD (on-agent connection definitions) ─────────────────────
 
     /// `agent.saveDefinition` — upsert a saved definition on an agent
@@ -369,18 +414,24 @@ impl AgentsStore {
 
     // ── Folder CRUD ───────────────────────────────────────────────────────────
 
-    /// `agent.createFolder` — append a folder to an agent (`createAgentFolder`).
-    /// A no-op for an unknown agent id.
+    /// `agent.createFolder` — add a folder to an agent (`createAgentFolder`).
+    /// Upsert by id: replace any existing folder with the same id, else append. A
+    /// no-op for an unknown agent id.
+    ///
+    /// Upsert (rather than a bare append) keeps the transition idempotent so the
+    /// server-side fold of the `create_agent_folder` RPC outcome (#2388) and the
+    /// additive client `agent.createFolder` mirror — both carrying the same
+    /// server-assigned folder id — converge on one entry instead of duplicating
+    /// it. Folder ids are unique, so legitimate creates never collide and see no
+    /// behavior change.
     pub fn create_folder(&self, id: &str, folder: AgentFolder) {
         let mut inner = self.lock();
         if inner.agent_mut(id).is_none() {
             return;
         }
-        inner
-            .folders
-            .entry(id.to_string())
-            .or_default()
-            .push(folder);
+        let list = inner.folders.entry(id.to_string()).or_default();
+        list.retain(|f| f.id != folder.id);
+        list.push(folder);
     }
 
     /// `agent.updateFolder` — replace an existing folder by id

--- a/src-tauri/src/agents_projection/store_tests.rs
+++ b/src-tauri/src/agents_projection/store_tests.rs
@@ -286,6 +286,131 @@ fn update_folder_replaces_by_id() {
 }
 
 #[test]
+fn create_folder_upserts_by_id_so_it_is_idempotent() {
+    // The server-side fold of the `create_agent_folder` RPC outcome (#2388) and
+    // the additive client `agent.createFolder` mirror both apply `create_folder`
+    // with the same server-assigned id; upsert-by-id must converge on one entry.
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+
+    store.create_folder("a1", folder("f1"));
+    store.create_folder("a1", folder("f1"));
+    assert_eq!(
+        store.folders_of("a1").len(),
+        1,
+        "duplicate id does not append"
+    );
+
+    // A distinct id still appends.
+    store.create_folder("a1", folder("f2"));
+    assert_eq!(store.folders_of("a1").len(), 2);
+
+    // Re-creating with the same id replaces (last-write-wins).
+    let mut renamed = folder("f1");
+    renamed.name = "renamed".to_string();
+    store.create_folder("a1", renamed);
+    let f1 = store
+        .folders_of("a1")
+        .into_iter()
+        .find(|f| f.id == "f1")
+        .unwrap();
+    assert_eq!(f1.name, "renamed");
+    assert_eq!(store.folders_of("a1").len(), 2, "still no duplicate");
+}
+
+#[test]
+fn set_sessions_replaces_only_the_sessions_slice() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.refresh(
+        "a1",
+        vec![session("s1")],
+        vec![definition("d1", None)],
+        vec![folder("f1")],
+    );
+
+    store.set_sessions("a1", vec![session("s2"), session("s3")]);
+
+    let view = store.snapshot();
+    let ids: Vec<&str> = view["sessions"]["a1"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["sessionId"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids, vec!["s2", "s3"], "sessions replaced");
+    // Definitions and folders are untouched (distinct from `refresh`).
+    assert_eq!(store.definitions_of("a1").len(), 1);
+    assert_eq!(store.folders_of("a1").len(), 1);
+}
+
+#[test]
+fn remove_session_drops_one_session_by_id_and_is_idempotent() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.set_sessions("a1", vec![session("s1"), session("s2")]);
+
+    store.remove_session("a1", "s1");
+    let remaining: Vec<String> = store.snapshot()["sessions"]["a1"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["sessionId"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(remaining, vec!["s2".to_string()]);
+
+    // Removing again / an unknown id is a no-op.
+    store.remove_session("a1", "s1");
+    store.remove_session("a1", "ghost");
+    assert_eq!(
+        store.snapshot()["sessions"]["a1"].as_array().unwrap().len(),
+        1
+    );
+}
+
+#[test]
+fn set_definitions_and_set_folders_replace_only_their_slice() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.refresh(
+        "a1",
+        vec![session("s1")],
+        vec![definition("d1", None)],
+        vec![folder("f1")],
+    );
+
+    store.set_definitions("a1", vec![definition("d2", None), definition("d3", None)]);
+    store.set_folders("a1", vec![folder("f2")]);
+
+    let def_ids: Vec<String> = store
+        .definitions_of("a1")
+        .into_iter()
+        .map(|d| d.id)
+        .collect();
+    assert_eq!(def_ids, vec!["d2".to_string(), "d3".to_string()]);
+    let folder_ids: Vec<String> = store.folders_of("a1").into_iter().map(|f| f.id).collect();
+    assert_eq!(folder_ids, vec!["f2".to_string()]);
+    // The live-session slice is untouched.
+    assert_eq!(
+        store.snapshot()["sessions"]["a1"].as_array().unwrap().len(),
+        1
+    );
+}
+
+#[test]
+fn per_slice_setters_on_an_unknown_agent_are_no_ops() {
+    let store = AgentsStore::new();
+    store.set_sessions("ghost", vec![session("s1")]);
+    store.set_definitions("ghost", vec![definition("d1", None)]);
+    store.set_folders("ghost", vec![folder("f1")]);
+    store.remove_session("ghost", "s1");
+    assert_eq!(
+        store.snapshot(),
+        json!({ "agents": [], "sessions": {}, "definitions": {}, "folders": {} })
+    );
+}
+
+#[test]
 fn transitions_on_an_unknown_agent_are_no_ops() {
     let store = AgentsStore::new();
     // None of these should panic or create an agent / sub-state.

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -4,6 +4,11 @@ use serde_json::Value;
 use tauri::State;
 use tracing::{debug, info, warn};
 
+use crate::agents_projection::projection::fold_agent_transition;
+use crate::agents_projection::store::{
+    AgentDefinition as StoreAgentDefinition, AgentFolder as StoreAgentFolder,
+    AgentSession as StoreAgentSession,
+};
 use crate::connection::config::AgentSettings;
 use crate::connection::manager::ConnectionManager;
 use crate::session::manager::SessionManager;
@@ -15,6 +20,54 @@ use crate::terminal::agent_manager::{
 };
 use crate::terminal::agent_setup::{AgentSetupConfig, AgentSetupResult, RemoteArchInfo};
 use crate::terminal::backend::{RemoteAgentConfig, UpdateStrategy};
+
+// ── Server-authority projection folds (#2388) ────────────────────────────────
+//
+// The definition/folder/session CRUD commands below fold their RPC outcome into
+// the shared `AgentsStore` **at the source** (see `fold_agent_transition`), so the
+// `agents` projection region is fed server-side rather than only by the client
+// `agent.*` mirror. Additive: every command still returns its value to the
+// frontend unchanged, and the transitions are idempotent so running alongside the
+// (still-present) client mirror converges without drift. The `Info` wire types
+// and the store types share the same camelCase shape one-to-one; these helpers
+// convert without a serde round-trip.
+
+/// Convert an agent definition RPC value into the store's definition shape.
+fn to_store_definition(info: &AgentDefinitionInfo) -> StoreAgentDefinition {
+    StoreAgentDefinition {
+        id: info.id.clone(),
+        name: info.name.clone(),
+        session_type: info.session_type.clone(),
+        config: info.config.clone(),
+        persistent: info.persistent,
+        folder_id: info.folder_id.clone(),
+        terminal_options: info.terminal_options.clone(),
+        icon: info.icon.clone(),
+        source_file: info.source_file.clone(),
+    }
+}
+
+/// Convert an agent folder RPC value into the store's folder shape.
+fn to_store_folder(info: &AgentFolderInfo) -> StoreAgentFolder {
+    StoreAgentFolder {
+        id: info.id.clone(),
+        name: info.name.clone(),
+        parent_id: info.parent_id.clone(),
+        is_expanded: info.is_expanded,
+    }
+}
+
+/// Convert an agent session RPC value into the store's session shape.
+fn to_store_session(info: &AgentSessionInfo) -> StoreAgentSession {
+    StoreAgentSession {
+        session_id: info.session_id.clone(),
+        title: info.title.clone(),
+        session_type: info.session_type.clone(),
+        status: info.status.clone(),
+        attached: info.attached,
+        definition_id: info.definition_id.clone(),
+    }
+}
 
 /// Connect to a remote agent via SSH.
 ///
@@ -294,17 +347,26 @@ pub async fn request_agent_update(
 pub async fn close_agent_session(
     agent_id: String,
     session_id: String,
+    app_handle: tauri::AppHandle,
     agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<(), String> {
     info!(agent_id, session_id, "Closing session on remote agent");
     let manager = agent_manager.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
-        manager
-            .close_session(&agent_id, &session_id)
-            .map_err(|e| e.to_string())
+    let aid = agent_id.clone();
+    let sid = session_id.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        manager.close_session(&aid, &sid).map_err(|e| e.to_string())
     })
     .await
-    .unwrap_or_else(|e| Err(e.to_string()))
+    .unwrap_or_else(|e| Err(e.to_string()));
+    // Server-authority fold (#2388): drop the closed session from the shared store
+    // at the source.
+    if result.is_ok() {
+        fold_agent_transition(&app_handle, |store| {
+            store.remove_session(&agent_id, &session_id);
+        });
+    }
+    result
 }
 
 /// List sessions on a remote agent.
@@ -313,15 +375,24 @@ pub async fn close_agent_session(
 #[tauri::command]
 pub async fn list_agent_sessions(
     agent_id: String,
+    app_handle: tauri::AppHandle,
     agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<Vec<AgentSessionInfo>, String> {
     debug!(agent_id, "Listing agent sessions");
     let manager = agent_manager.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
-        manager.list_sessions(&agent_id).map_err(|e| e.to_string())
+    let aid = agent_id.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        manager.list_sessions(&aid).map_err(|e| e.to_string())
     })
     .await
-    .unwrap_or_else(|e| Err(e.to_string()))
+    .unwrap_or_else(|e| Err(e.to_string()));
+    // Server-authority fold (#2388): mirror the live-session snapshot into the
+    // shared store at the source.
+    if let Ok(sessions) = &result {
+        let stored = sessions.iter().map(to_store_session).collect();
+        fold_agent_transition(&app_handle, |store| store.set_sessions(&agent_id, stored));
+    }
+    result
 }
 
 /// List saved session definitions on a remote agent.
@@ -330,17 +401,26 @@ pub async fn list_agent_sessions(
 #[tauri::command]
 pub async fn list_agent_definitions(
     agent_id: String,
+    app_handle: tauri::AppHandle,
     agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<Vec<AgentDefinitionInfo>, String> {
     debug!(agent_id, "Listing agent definitions");
     let manager = agent_manager.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
-        manager
-            .list_definitions(&agent_id)
-            .map_err(|e| e.to_string())
+    let aid = agent_id.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        manager.list_definitions(&aid).map_err(|e| e.to_string())
     })
     .await
-    .unwrap_or_else(|e| Err(e.to_string()))
+    .unwrap_or_else(|e| Err(e.to_string()));
+    // Server-authority fold (#2388): mirror the saved-definition snapshot into the
+    // shared store at the source.
+    if let Ok(definitions) = &result {
+        let stored = definitions.iter().map(to_store_definition).collect();
+        fold_agent_transition(&app_handle, |store| {
+            store.set_definitions(&agent_id, stored)
+        });
+    }
+    result
 }
 
 /// Save a session definition on a remote agent.
@@ -350,17 +430,28 @@ pub async fn list_agent_definitions(
 pub async fn save_agent_definition(
     agent_id: String,
     definition: Value,
+    app_handle: tauri::AppHandle,
     agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<AgentDefinitionInfo, String> {
     debug!(agent_id, "Saving agent definition");
     let manager = agent_manager.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
+    let aid = agent_id.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
         manager
-            .save_definition(&agent_id, definition)
+            .save_definition(&aid, definition)
             .map_err(|e| e.to_string())
     })
     .await
-    .unwrap_or_else(|e| Err(e.to_string()))
+    .unwrap_or_else(|e| Err(e.to_string()));
+    // Server-authority fold (#2388): upsert the saved definition into the shared
+    // store at the source.
+    if let Ok(info) = &result {
+        let stored = to_store_definition(info);
+        fold_agent_transition(&app_handle, |store| {
+            store.save_definition(&agent_id, stored)
+        });
+    }
+    result
 }
 
 /// Delete a session definition on a remote agent.
@@ -370,17 +461,28 @@ pub async fn save_agent_definition(
 pub async fn delete_agent_definition(
     agent_id: String,
     definition_id: String,
+    app_handle: tauri::AppHandle,
     agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<(), String> {
     info!(agent_id, definition_id, "Deleting agent definition");
     let manager = agent_manager.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
+    let aid = agent_id.clone();
+    let did = definition_id.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
         manager
-            .delete_definition(&agent_id, &definition_id)
+            .delete_definition(&aid, &did)
             .map_err(|e| e.to_string())
     })
     .await
-    .unwrap_or_else(|e| Err(e.to_string()))
+    .unwrap_or_else(|e| Err(e.to_string()));
+    // Server-authority fold (#2388): drop the deleted definition from the shared
+    // store at the source.
+    if result.is_ok() {
+        fold_agent_transition(&app_handle, |store| {
+            store.delete_definition(&agent_id, &definition_id);
+        });
+    }
+    result
 }
 
 /// List saved connections and folders on a remote agent.
@@ -389,17 +491,31 @@ pub async fn delete_agent_definition(
 #[tauri::command]
 pub async fn list_agent_connections(
     agent_id: String,
+    app_handle: tauri::AppHandle,
     agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<AgentConnectionsData, String> {
     debug!(agent_id, "Listing agent connections and folders");
     let manager = agent_manager.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
+    let aid = agent_id.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
         manager
-            .list_connections_and_folders(&agent_id)
+            .list_connections_and_folders(&aid)
             .map_err(|e| e.to_string())
     })
     .await
-    .unwrap_or_else(|e| Err(e.to_string()))
+    .unwrap_or_else(|e| Err(e.to_string()));
+    // Server-authority fold (#2388): mirror the saved connections + folders
+    // snapshot into the shared store at the source (definitions and folders slices
+    // only; the live-session slice is left to `list_agent_sessions`).
+    if let Ok(data) = &result {
+        let definitions = data.connections.iter().map(to_store_definition).collect();
+        let folders = data.folders.iter().map(to_store_folder).collect();
+        fold_agent_transition(&app_handle, |store| {
+            store.set_definitions(&agent_id, definitions);
+            store.set_folders(&agent_id, folders);
+        });
+    }
+    result
 }
 
 /// Update a saved connection definition on a remote agent.
@@ -409,17 +525,28 @@ pub async fn list_agent_connections(
 pub async fn update_agent_definition(
     agent_id: String,
     params: Value,
+    app_handle: tauri::AppHandle,
     agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<AgentDefinitionInfo, String> {
     debug!(agent_id, "Updating agent definition");
     let manager = agent_manager.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
+    let aid = agent_id.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
         manager
-            .update_definition(&agent_id, params)
+            .update_definition(&aid, params)
             .map_err(|e| e.to_string())
     })
     .await
-    .unwrap_or_else(|e| Err(e.to_string()))
+    .unwrap_or_else(|e| Err(e.to_string()));
+    // Server-authority fold (#2388): replace the updated definition in the shared
+    // store at the source.
+    if let Ok(info) = &result {
+        let stored = to_store_definition(info);
+        fold_agent_transition(&app_handle, |store| {
+            store.update_definition(&agent_id, stored)
+        });
+    }
+    result
 }
 
 /// Create a folder on a remote agent.
@@ -430,17 +557,26 @@ pub async fn create_agent_folder(
     agent_id: String,
     name: String,
     parent_id: Option<String>,
+    app_handle: tauri::AppHandle,
     agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<AgentFolderInfo, String> {
     debug!(agent_id, %name, "Creating agent folder");
     let manager = agent_manager.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
+    let aid = agent_id.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
         manager
-            .create_folder(&agent_id, &name, parent_id.as_deref())
+            .create_folder(&aid, &name, parent_id.as_deref())
             .map_err(|e| e.to_string())
     })
     .await
-    .unwrap_or_else(|e| Err(e.to_string()))
+    .unwrap_or_else(|e| Err(e.to_string()));
+    // Server-authority fold (#2388): add the new folder to the shared store at the
+    // source (upsert by id, so the additive client mirror does not duplicate it).
+    if let Ok(info) = &result {
+        let stored = to_store_folder(info);
+        fold_agent_transition(&app_handle, |store| store.create_folder(&agent_id, stored));
+    }
+    result
 }
 
 /// Update a folder on a remote agent.
@@ -450,17 +586,26 @@ pub async fn create_agent_folder(
 pub async fn update_agent_folder(
     agent_id: String,
     params: Value,
+    app_handle: tauri::AppHandle,
     agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<AgentFolderInfo, String> {
     debug!(agent_id, "Updating agent folder");
     let manager = agent_manager.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
+    let aid = agent_id.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
         manager
-            .update_folder(&agent_id, params)
+            .update_folder(&aid, params)
             .map_err(|e| e.to_string())
     })
     .await
-    .unwrap_or_else(|e| Err(e.to_string()))
+    .unwrap_or_else(|e| Err(e.to_string()));
+    // Server-authority fold (#2388): replace the updated folder in the shared store
+    // at the source.
+    if let Ok(info) = &result {
+        let stored = to_store_folder(info);
+        fold_agent_transition(&app_handle, |store| store.update_folder(&agent_id, stored));
+    }
+    result
 }
 
 /// Delete a folder on a remote agent.
@@ -470,17 +615,27 @@ pub async fn update_agent_folder(
 pub async fn delete_agent_folder(
     agent_id: String,
     folder_id: String,
+    app_handle: tauri::AppHandle,
     agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<(), String> {
     info!(agent_id, folder_id, "Deleting agent folder");
     let manager = agent_manager.inner().clone();
-    tauri::async_runtime::spawn_blocking(move || {
-        manager
-            .delete_folder(&agent_id, &folder_id)
-            .map_err(|e| e.to_string())
+    let aid = agent_id.clone();
+    let fid = folder_id.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        manager.delete_folder(&aid, &fid).map_err(|e| e.to_string())
     })
     .await
-    .unwrap_or_else(|e| Err(e.to_string()))
+    .unwrap_or_else(|e| Err(e.to_string()));
+    // Server-authority fold (#2388): drop the deleted folder from the shared store
+    // at the source (reparenting its child definitions to the root, as the store's
+    // `delete_folder` does).
+    if result.is_ok() {
+        fold_agent_transition(&app_handle, |store| {
+            store.delete_folder(&agent_id, &folder_id);
+        });
+    }
+    result
 }
 
 /// Detect the remote host's architecture before the setup dialog opens.

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -22,6 +22,8 @@ use tracing::{error, info, warn};
 use termihub_core::backends::ssh::handler::SshSession;
 use termihub_core::monitoring::{MonitoringSender, SystemStats};
 
+use crate::agents_projection::projection::fold_agent_transition;
+use crate::agents_projection::store::AgentConnectionState;
 use crate::connection::config::AgentSettings;
 use crate::terminal::agent_deploy::ConnectedHost;
 use crate::terminal::agent_forward::DesktopAgentForward;
@@ -1596,6 +1598,21 @@ async fn read_handshake_line(
     }
 }
 
+/// Map an `agent-state-change` wire string to the store's connection-state enum.
+///
+/// The four states the agent manager emits are the camelCase variants of
+/// [`AgentConnectionState`]; an unrecognised string yields `None` so the fold is
+/// skipped rather than forcing a state.
+fn parse_agent_connection_state(state: &str) -> Option<AgentConnectionState> {
+    match state {
+        "disconnected" => Some(AgentConnectionState::Disconnected),
+        "connecting" => Some(AgentConnectionState::Connecting),
+        "connected" => Some(AgentConnectionState::Connected),
+        "reconnecting" => Some(AgentConnectionState::Reconnecting),
+        _ => None,
+    }
+}
+
 /// Emit an agent state change event with an optional error description.
 fn emit_agent_state_with_error(
     app_handle: &AppHandle,
@@ -1603,6 +1620,20 @@ fn emit_agent_state_with_error(
     state: &str,
     error: Option<&str>,
 ) {
+    // Server-authority fold (#2388): reflect the connection-state transition into
+    // the shared `AgentsStore` at the source — this function is the single choke
+    // point every `connecting`/`connected`/`disconnected`/`reconnecting` emission
+    // flows through. Additive: the Tauri event below and the client `agent.status`
+    // mirror stay in place, so no user-facing behavior changes. The store's
+    // `set_status` tracks `lastError` with the same rules the frontend's
+    // `setAgentConnectionState` applies (record on `disconnected`, clear on
+    // `connecting`/`connected`), so the fold and the client mirror agree.
+    if let Some(connection_state) = parse_agent_connection_state(state) {
+        let error_owned = error.map(|s| s.to_string());
+        fold_agent_transition(app_handle, move |store| {
+            store.set_status(agent_id, connection_state, error_owned);
+        });
+    }
     let _ = app_handle.emit(
         "agent-state-change",
         RemoteStateChangeEvent {


### PR DESCRIPTION
## What

Makes the shadow `AgentsStore` (the `agents` projection region) **server-authoritative at the source**: both the live connection-status stream and the definition/folder/session CRUD outcomes are folded into the store **server-side, the instant they are produced**, instead of relying solely on the client-dispatched `agent.*` mirror.

Prerequisite for #2226 (Phase 5 Agents reducer-removal). Today `AgentsStore` is fed only by the client `agent.*` mirror; two server streams produce the authoritative agent state but neither touches the store, so removing the appStore reducers (making the store authoritative) would be a **lossy** inversion. This PR feeds the store from the source so #2226 can invert the data flow with no data-loss risk. Mirrors the merged monitoring template (#2376 / PR #2379), across **two** streams.

## Changes

- **New `fold_agent_transition`** (`agents_projection/projection.rs`): resolves the managed `AgentsStore` + `ProjectionState` from the `AppHandle`, applies a transition, and publishes the `agents` region diff. Generic over the runtime (so it drives under `mock_app()`), best-effort (skips when state is unmanaged), never holds the store lock across an await.
- **Live-status stream** (`terminal/agent_manager.rs`): the connection-state transition is folded at `emit_agent_state_with_error` — the single choke point every `connecting`/`connected`/`disconnected`/`reconnecting` emission flows through — via the store's `set_status` (same `lastError` rules the frontend's `setAgentConnectionState` applies).
- **CRUD stream** (`commands/agent.rs`): the `list`/`save`/`update`/`delete` definition, `list_connections`, folder CRUD, `list`/`close` session RPC outcomes are folded at the source. `AppHandle` is Tauri-injected — **no change to the JS invoke surface**.
- **Store support** (`agents_projection/store.rs`): per-slice setters (`set_sessions` / `set_definitions` / `set_folders`) + `remove_session` so a single list/close outcome reflects without clobbering the other slices (unlike `refresh`); `create_folder` now **upserts by id** so the server fold and the additive client `agent.createFolder` mirror (same server-assigned id) converge on one entry instead of duplicating it.
- **Tests**: drive the production folds end-to-end against `tauri::test::mock_app()` — a status / definition / folder / close transition updates the store and fans the region diff out **with no client dispatch**; **parity** — the server status fold reproduces the client `agent.status` route's store transition exactly; idempotent re-folds advance nothing (no double count alongside the still-present mirror); a no-op when unmanaged. Plus store-level unit tests for the new methods.

## Additive / no user-facing change

- The existing Tauri event emission / RPC return **and** the client `agent.*` mirror stay in place; the render-cut seed (`agent.replace`) keeps the region a faithful mirror of `appStore`, so the UI is unchanged. Entry **creation** stays client-side (it carries the UI config/settings the backend command does not receive — the analog of the monitor bridge's client-owned `monitor.open`); the fold updates existing entries and is a safe no-op otherwise. The render/mutation inversion (dropping the redundant client re-dispatch) is the later #2226 step; `appStore.ts` is intentionally untouched here.
- Backend-only, no user-facing behavior change → no changelog fragment.

## Verification

- `cargo test -p termihub --lib agents_projection` — 34 pass (11 new)
- `cargo fmt -p termihub -- --check` clean; `cargo clippy -p termihub --all-targets --all-features -- -D warnings` clean
- The CRUD folds are pure in-process store mutations applied to the RPC return value (no new agent-RPC/integration behavior), so they are fully covered by the `mock_app()` unit tests; no integration lane needed.

Closes #2388
Part of #2226
Part of #2139