### PR TITLE
feat(connection): feed the connections projection store server-side (Closes #2389)

### DIFF
--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use serde::Serialize;
-use tauri::State;
+use tauri::{AppHandle, State};
 use tracing::{debug, info};
 
 use crate::connection::config::{
@@ -68,12 +68,17 @@ pub fn load_connections_and_folders(
 #[tauri::command]
 pub fn save_connection(
     connection: SavedConnection,
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
 ) -> Result<String, String> {
     debug!(id = %connection.id, name = %connection.name, "Saving connection");
-    manager
+    let persisted_id = manager
         .save_connection_routed(connection)
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    // Server-authority fold (#2389): reflect the persisted tree into the shadow
+    // `ConnectionsStore` at the source. Additive; no user-facing change.
+    crate::connections_projection::projection::fold_connections_from_manager(&app);
+    Ok(persisted_id)
 }
 
 /// Delete a connection by ID, optionally from an external file.
@@ -81,12 +86,15 @@ pub fn save_connection(
 pub fn delete_connection(
     id: String,
     source_file: Option<String>,
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
 ) -> Result<(), String> {
     info!(id, ?source_file, "Deleting connection");
     manager
         .delete_connection_routed(&id, source_file.as_deref())
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    crate::connections_projection::projection::fold_connections_from_manager(&app);
+    Ok(())
 }
 
 /// Move a connection between storage files (main <-> external).
@@ -95,6 +103,7 @@ pub fn move_connection_to_file(
     connection_id: String,
     current_source: Option<String>,
     target_source: Option<String>,
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
 ) -> Result<SavedConnection, String> {
     info!(
@@ -103,24 +112,39 @@ pub fn move_connection_to_file(
         ?target_source,
         "Moving connection to file"
     );
-    manager
+    let moved = manager
         .move_connection_to_file(&connection_id, current_source.as_deref(), target_source)
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    // A move into/out of the main store changes the persisted tree; an
+    // external↔external move leaves it untouched and coalesces to no diff.
+    crate::connections_projection::projection::fold_connections_from_manager(&app);
+    Ok(moved)
 }
 
 /// Save (add or update) a folder.
 #[tauri::command]
 pub fn save_folder(
     folder: ConnectionFolder,
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
 ) -> Result<(), String> {
-    manager.save_folder(folder).map_err(|e| e.to_string())
+    manager.save_folder(folder).map_err(|e| e.to_string())?;
+    // Covers `addFolder` and the `toggleFolder`-persist edge (the frontend
+    // persists a folder's `isExpanded` flip via `save_folder`).
+    crate::connections_projection::projection::fold_connections_from_manager(&app);
+    Ok(())
 }
 
 /// Delete a folder by ID.
 #[tauri::command]
-pub fn delete_folder(id: String, manager: State<'_, ConnectionManager>) -> Result<(), String> {
-    manager.delete_folder(&id).map_err(|e| e.to_string())
+pub fn delete_folder(
+    id: String,
+    app: AppHandle,
+    manager: State<'_, ConnectionManager>,
+) -> Result<(), String> {
+    manager.delete_folder(&id).map_err(|e| e.to_string())?;
+    crate::connections_projection::projection::fold_connections_from_manager(&app);
+    Ok(())
 }
 
 /// Export all connections as a JSON string.
@@ -133,9 +157,12 @@ pub fn export_connections(manager: State<'_, ConnectionManager>) -> Result<Strin
 #[tauri::command]
 pub fn import_connections(
     json: String,
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
 ) -> Result<usize, String> {
-    manager.import_json(&json).map_err(|e| e.to_string())
+    let count = manager.import_json(&json).map_err(|e| e.to_string())?;
+    crate::connections_projection::projection::fold_connections_from_manager(&app);
+    Ok(count)
 }
 
 /// Get the current application settings.
@@ -250,15 +277,18 @@ pub fn preview_import(json: String) -> Result<ImportPreview, String> {
 pub fn import_connections_with_credentials(
     json: String,
     import_password: Option<String>,
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
 ) -> Result<ImportResult, String> {
     info!(
         "Importing connections (with_credentials={})",
         import_password.is_some()
     );
-    manager
+    let result = manager
         .import_encrypted_json(&json, import_password.as_deref())
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    crate::connections_projection::projection::fold_connections_from_manager(&app);
+    Ok(result)
 }
 
 /// Drain and return any recovery warnings collected during app startup.

--- a/src-tauri/src/connections_projection/projection.rs
+++ b/src-tauri/src/connections_projection/projection.rs
@@ -54,7 +54,9 @@ use std::sync::Arc;
 use serde_json::Value;
 use tauri::{AppHandle, Manager};
 
+use crate::commands::projection::ProjectionState;
 use crate::connection::config::{ConnectionFolder, SavedConnection};
+use crate::connection::manager::ConnectionManager;
 use crate::connections_projection::store::ConnectionsStore;
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
 
@@ -72,6 +74,60 @@ pub fn publish_connections(projector: &Projector, store: &ConnectionsStore) -> V
             version,
         }],
         None => Vec::new(),
+    }
+}
+
+/// Fold the [`ConnectionManager`]'s authoritative saved-connection / folder tree
+/// into the managed [`ConnectionsStore`] **server-side** and fan the resulting
+/// `connections` region diff out to every subscriber (#2389, prerequisite for
+/// #2225).
+///
+/// This is the server-authority counterpart to the `connection.*` intents
+/// [`register_connection_intents`] registers: the same store transitions the
+/// frontend currently mirrors via `connection.*` intents are reflected here **at
+/// the source** — the instant a saved-connection / folder mutation
+/// (`save_connection` / `delete_connection` / `move_connection_to_file` /
+/// `save_folder` / `delete_folder` / import) lands in the persisted
+/// [`ConnectionManager`] authority — with no client round-trip required for the
+/// store to be correct.
+///
+/// It reflects the manager's **whole** post-mutation tree (via
+/// [`ConnectionManager::get_all`] + [`ConnectionsStore::replace`]) rather than
+/// replaying one fine-grained store op per call. This is deliberate: the manager
+/// is a *coarse* authority — a single `save_connection` may recompute the
+/// path-based id, deduplicate sibling names, re-home children, and migrate
+/// credentials — so replaying the intent-level ops (`add` / `update` / …) against
+/// the store would drift from the persisted truth. Reflecting the manager's
+/// authoritative snapshot guarantees the region always equals what was actually
+/// persisted. The projector coalesces an unchanged snapshot to no diff, so a
+/// mutation that leaves the main tree untouched (e.g. an external-file-only save)
+/// is a no-op.
+///
+/// It is **additive**: the per-transition `connection.*` intents and the
+/// render-cut `connection.replace` mirror stay in place, and nothing in the live
+/// UI subscribes to the region yet, so this changes no user-facing behavior.
+/// Dropping the now-redundant client re-dispatch is the later #2225
+/// render/mutation inversion.
+///
+/// Best-effort and non-fatal: if the store, the connection manager, or the
+/// projection state is not managed (e.g. a headless unit-test app that never ran
+/// `setup()`), or the disk reload inside `get_all` fails, the fold is skipped
+/// rather than erroring. The `replace` runs to completion synchronously before
+/// the publish, so the store lock is never held across an await.
+pub fn fold_connections_from_manager<R: tauri::Runtime>(app_handle: &AppHandle<R>) {
+    let Some(store) = app_handle.try_state::<Arc<ConnectionsStore>>() else {
+        return;
+    };
+    let store: Arc<ConnectionsStore> = (*store).clone();
+    let Some(manager) = app_handle.try_state::<ConnectionManager>() else {
+        return;
+    };
+    let Ok(flat) = manager.get_all() else {
+        return;
+    };
+    store.replace(flat.folders, flat.connections);
+    if let Some(projection) = app_handle.try_state::<ProjectionState>() {
+        publish_connections(&projection.projector, &store);
     }
 }
 

--- a/src-tauri/src/connections_projection/projection_tests.rs
+++ b/src-tauri/src/connections_projection/projection_tests.rs
@@ -16,9 +16,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use serde_json::{json, Value};
+use tauri::Manager;
 
+use crate::commands::projection::ProjectionState;
 use crate::connection::config::{ConnectionFolder, SavedConnection};
-use crate::connections_projection::projection::{publish_connections, CONNECTIONS_REGION};
+use crate::connection::manager::ConnectionManager;
+use crate::connections_projection::projection::{
+    fold_connections_from_manager, publish_connections, CONNECTIONS_REGION,
+};
 use crate::connections_projection::store::ConnectionsStore;
 use crate::projection::{
     apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
@@ -438,6 +443,171 @@ fn a_no_op_intent_advances_nothing() {
     assert_eq!(ack.produced, Some(vec![]), "no region advanced");
     assert_eq!(sink.diffs().len(), 0);
     assert_eq!(projector.region_version(CONNECTIONS_REGION), Some(0));
+}
+
+// ── Server-authority fold (#2389, prerequisite for #2225) ─────────────────────
+//
+// These drive the *production* `fold_connections_from_manager` end to end against
+// a `tauri::test::mock_app()` carrying the same managed state `lib.rs::setup()`
+// wires: a real `ConnectionManager` (backed by a temp dir), an
+// `Arc<ConnectionsStore>`, and a `ProjectionState`. They prove the store is fed
+// **server-side** — the instant a saved-connection / folder mutation lands in the
+// persisted manager authority — with no `connection.*` client dispatch, and that
+// the store reflects the manager's *authoritative* post-mutation tree (recomputed
+// ids and all), not a naive replay of the intent-level ops.
+
+/// A `ConnectionManager` backed by a fresh temp dir with a null credential store.
+/// Returns the manager and the `TempDir` guard (kept alive for the test's span).
+fn test_manager() -> (ConnectionManager, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let manager =
+        ConnectionManager::new_for_test(dir.path(), Arc::new(crate::credential::NullStore))
+            .unwrap();
+    (manager, dir)
+}
+
+/// Wire a mock app with the managed state `setup()` builds for the connections
+/// region: the manager, the store, and a `ProjectionState` whose `connections`
+/// region is registered and has one `VecSink` subscribed. Returns the app, the
+/// store, the sink, and the subscribe-time client cache.
+#[allow(clippy::type_complexity)]
+fn wire_app(
+    manager: ConnectionManager,
+) -> (
+    tauri::App<tauri::test::MockRuntime>,
+    Arc<ConnectionsStore>,
+    Arc<VecSink>,
+    ClientCache,
+) {
+    let app = tauri::test::mock_app();
+    app.manage(manager);
+
+    let store = Arc::new(ConnectionsStore::new());
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(CONNECTIONS_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    let snap = projection
+        .projector
+        .subscribe(CONNECTIONS_REGION, "sub", "C", sink.clone());
+    let cache = ClientCache::from_snapshot(&snap);
+    app.manage(projection);
+
+    (app, store, sink, cache)
+}
+
+/// A backend-produced saved-connection mutation folded server-side upserts the row
+/// in the shared store and fans exactly one `connections` region diff out — with
+/// no `connection.*` client dispatch. The store reflects the manager's
+/// **recomputed** path-based id, proving the fold reflects the persisted authority
+/// rather than replaying the caller's optimistic id.
+#[test]
+fn server_side_manager_mutation_folds_into_store_and_region_without_client_dispatch() {
+    let (manager, _dir) = test_manager();
+    let (app, store, sink, mut cache) = wire_app(manager);
+
+    // The manager recomputes the id from folder + name, so a connection saved
+    // with an optimistic `conn-<ts>` id persists under a path-based id.
+    let mut incoming = connection("conn-1700000000", "MyHost", None);
+    incoming.config.settings = json!({ "host": "example.com", "port": 22 });
+    let persisted_id = app
+        .state::<ConnectionManager>()
+        .save_connection(incoming)
+        .expect("manager persists the connection");
+    assert_ne!(
+        persisted_id, "conn-1700000000",
+        "the manager recomputes the id from folder + name"
+    );
+
+    // No `connection.*` intent is dispatched — the fold feeds the store at the
+    // source, from the persisted authority.
+    fold_connections_from_manager(app.handle());
+
+    // The store is authoritative server-side and carries the *recomputed* id.
+    assert!(
+        store.connection(&persisted_id).is_some(),
+        "store carries the manager's recomputed id"
+    );
+    assert!(
+        store.connection("conn-1700000000").is_none(),
+        "store does not carry the optimistic pre-persist id"
+    );
+
+    // Exactly one region diff fanned out; the client cache converges on the store
+    // (which equals the manager's authoritative snapshot) with no round-trip.
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "one diff from the server-side fold");
+    cache.apply(&diffs[0]);
+    assert_eq!(cache.view, store.snapshot(), "cache converges on authority");
+    assert_eq!(
+        cache.view["connections"][0]["id"],
+        json!(persisted_id),
+        "the region reflects the persisted id"
+    );
+}
+
+/// The fold reflects the manager's whole authoritative tree across a
+/// folder/connection lifecycle: add folder → add a connection under it → delete
+/// the folder (the manager re-homes the child to root). The store mirrors the
+/// manager's `get_all()` at each source mutation, with one diff per step.
+#[test]
+fn server_side_fold_reflects_folder_and_connection_lifecycle() {
+    let (manager, _dir) = test_manager();
+    let (app, store, sink, _cache) = wire_app(manager);
+    let manager = app.state::<ConnectionManager>();
+
+    manager
+        .save_folder(folder("Work", "Work", None, true))
+        .unwrap();
+    fold_connections_from_manager(app.handle());
+
+    let mut child = connection("Work/Child", "Child", Some("Work"));
+    child.config.settings = json!({ "host": "h", "port": 22 });
+    manager.save_connection(child).unwrap();
+    fold_connections_from_manager(app.handle());
+    assert_eq!(store.folder_count(), 1);
+    assert_eq!(store.connection_count(), 1);
+
+    // Deleting the folder re-homes the child to root (manager authority).
+    manager.delete_folder("Work").unwrap();
+    fold_connections_from_manager(app.handle());
+    assert_eq!(store.folder_count(), 0, "folder removed server-side");
+    assert_eq!(store.connection_count(), 1, "child retained, re-homed");
+
+    // The store equals the manager's authoritative tree at every step.
+    let flat = app.state::<ConnectionManager>().get_all().unwrap();
+    assert_eq!(
+        store.snapshot(),
+        json!({
+            "folders": serde_json::to_value(&flat.folders).unwrap(),
+            "connections": serde_json::to_value(&flat.connections).unwrap(),
+        }),
+        "store mirrors the manager authority"
+    );
+    assert!(
+        store
+            .snapshot()
+            .get("connections")
+            .and_then(|c| c.get(0))
+            .and_then(|c| c.get("folderId"))
+            .map(Value::is_null)
+            .unwrap_or(false),
+        "the re-homed child sits at root"
+    );
+
+    assert_eq!(sink.diffs().len(), 3, "one diff per source mutation");
+}
+
+/// The fold is a best-effort no-op when the required state is not managed (e.g. a
+/// headless harness that never ran `setup()`) — it must not panic.
+#[test]
+fn server_side_fold_is_a_noop_without_managed_state() {
+    let app = tauri::test::mock_app();
+    // Nothing managed — reaching the assert without panicking is the contract.
+    fold_connections_from_manager(app.handle());
 }
 
 #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -934,12 +934,22 @@ pub fn run() {
                         store.snapshot(),
                     );
                 }
-                // Seed the shared `connections` region with the (empty) store
-                // baseline at version 0, so a subscriber attaches to a real region
-                // before the first `connection.*` intent (#2225).
+                // Seed the shared `connections` region from the persisted
+                // `ConnectionManager` authority (#2389), so the shadow store — and
+                // the region a subscriber attaches to before the first
+                // `connection.*` intent — reflects the real saved-connection /
+                // folder tree from startup rather than an empty baseline. The
+                // manager is the coarse authority: seeding its whole snapshot here
+                // is the startup counterpart to `fold_connections_from_manager`,
+                // which keeps the store in sync on every later mutation (#2225).
                 if let Some(store) =
                     app.handle().try_state::<Arc<connections_projection::ConnectionsStore>>()
                 {
+                    if let Some(manager) = app.handle().try_state::<ConnectionManager>() {
+                        if let Ok(flat) = manager.get_all() {
+                            store.replace(flat.folders, flat.connections);
+                        }
+                    }
                     projection_state.projector.register_region(
                         connections_projection::projection::CONNECTIONS_REGION,
                         store.snapshot(),


### PR DESCRIPTION
## What

Makes the shared \`ConnectionsStore\` (the \`connections\` projection region) **server-authoritative at the source**: every backend-produced saved-connection / folder mutation is reflected into the store from the persisted \`ConnectionManager\` authority the instant it lands, instead of relying solely on client-dispatched \`connection.*\` intents.

Prerequisite for #2225 (Phase 5 Connections reducer-removal). Audit (from #2389): \`ConnectionsStore\` was written **only** by frontend \`connection.*\` intents and seeded empty in \`lib.rs\` — its docstring's "wraps the existing Rust authority" was only *type reuse*, never fed from the real authority (\`ConnectionManager\` + persisted config). Removing the appStore reducers (making the store authoritative) would be a **lossy** inversion while the store is never fed from the data source. This PR feeds it from the source so #2225 can invert the data flow with no data-loss risk. Closest analogs: Monitors #2376 (PR #2379), Transfers #2387 (PR #2391).

## Changes

- **New \`fold_connections_from_manager\`** (\`connections_projection/projection.rs\`): resolves the managed \`ConnectionsStore\` + \`ConnectionManager\` + \`ProjectionState\` from the \`AppHandle\`, reflects the manager's **whole authoritative post-mutation tree** into the store (\`get_all\` → \`replace\`), and publishes the \`connections\` region diff. Best-effort (skips if any of the three is unmanaged, or the disk reload fails); never holds the store lock across an await.
- **Fold at the source** (\`commands/connection.rs\`): each command that mutates the persisted saved-connection / folder tree — \`save_connection\`, \`delete_connection\`, \`move_connection_to_file\`, \`save_folder\` (also the \`toggleFolder\`-persist edge), \`delete_folder\`, \`import_connections\`, \`import_connections_with_credentials\` — folds after the manager mutation succeeds. (\`AppHandle\` is Tauri-injected — no change to the JS invoke surface.)
- **Startup seed** (\`lib.rs\`): the \`connections\` region is now seeded from the persisted manager tree instead of an empty baseline, so a subscriber attaching before the first mutation sees the real saved-connection tree.
- **Tests** (\`projection_tests.rs\`): drive the production fold end to end against \`tauri::test::mock_app()\` with a real \`ConnectionManager\` — a persisted mutation feeds the store and fans one region diff out **with no client dispatch**; the store reflects the manager's **recomputed** path-based id (not the caller's optimistic id); a folder/connection lifecycle mirrors the manager authority (delete-folder re-homes the child to root); a no-op when unmanaged.

## Why reflect the whole tree, not per-op folds

Unlike Transfers/Monitors (which fold a single event via one store method), the \`ConnectionManager\` is a **coarse** authority: one \`save_connection\` may recompute the path-based id, deduplicate sibling names, re-home children, and migrate credentials. Replaying the intent-level ops (\`add\`/\`update\`/…) against the store would drift from the persisted truth, so the fold reflects the manager's authoritative snapshot (\`get_all\` → \`replace\`). The projector coalesces an unchanged snapshot to no diff, so a mutation that leaves the main tree untouched (e.g. an external-file-only save) is a no-op.

## Additive / no user-facing change

- The per-transition \`connection.*\` intents and the render-cut \`connection.replace\` mirror stay in place; \`appStore.ts\` and the frontend mirror are intentionally untouched.
- Nothing in the live UI subscribes to the \`connections\` region yet. The render/mutation inversion (dropping the redundant client re-dispatch, making the store authoritative) is the **later #2225 step**.
- Backend-only, no user-facing behavior change → no changelog fragment.

## Scope note (for #2225)

The store reflects the **main** persisted store (the tree the listed manager mutations affect). Connections merged in from **external** connection files are a read-only overlay not modeled here — filed as a follow-up so #2225's render cut can decide whether the region needs them.

## Verification

- \`cargo test --lib connections_projection\` — 29 pass (3 new)
- \`cargo test --lib connection::\` — 195 pass
- \`cargo build\`, \`cargo fmt --check\`, \`cargo clippy --all-targets --all-features\` — clean

Closes #2389