### PR TITLE
feat(settings): feed the settings projection store server-side (Closes #2386)

### DIFF
--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -9,7 +9,7 @@ use crate::connection::config::{
 };
 use crate::connection::manager::{self, ConnectionManager};
 use crate::connection::recovery::RecoveryWarning;
-use crate::connection::settings::{default_serial_port_scan_prefixes, AppSettings};
+use crate::connection::settings::AppSettings;
 use crate::credential::CredentialManager;
 
 /// Response containing all connections (unified), folders, and agents.
@@ -172,20 +172,22 @@ pub fn import_connections(
 /// the frontend always receives a concrete, editable list.
 #[tauri::command]
 pub fn get_settings(manager: State<'_, ConnectionManager>) -> Result<AppSettings, String> {
-    let mut settings = manager.get_settings();
-    if settings.serial_port_scan_prefixes.is_none() {
-        settings.serial_port_scan_prefixes = Some(default_serial_port_scan_prefixes());
-    }
-    Ok(settings)
+    Ok(manager.get_settings_resolved())
 }
 
 /// Update and persist application settings.
 #[tauri::command]
 pub fn save_settings(
     settings: AppSettings,
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
 ) -> Result<(), String> {
-    manager.save_settings(settings).map_err(|e| e.to_string())
+    manager.save_settings(settings).map_err(|e| e.to_string())?;
+    // Server-authority fold (#2386): reflect the persisted `AppSettings`
+    // document into the shadow `SettingsStore` at the source. Additive; no
+    // user-facing change. (`AppHandle` is Tauri-injected — no JS invoke change.)
+    crate::settings_projection::projection::fold_settings_from_manager(&app);
+    Ok(())
 }
 
 /// Save an external connection file to disk.

--- a/src-tauri/src/connection/manager.rs
+++ b/src-tauri/src/connection/manager.rs
@@ -10,7 +10,7 @@ use super::config::{
     SavedRemoteAgent,
 };
 use super::recovery::RecoveryWarning;
-use super::settings::{AppSettings, SettingsStorage};
+use super::settings::{default_serial_port_scan_prefixes, AppSettings, SettingsStorage};
 use super::storage::ConnectionStorage;
 use super::tree::{
     build_tree, compute_connection_id, compute_folder_id, count_tree_items,
@@ -592,6 +592,23 @@ impl ConnectionManager {
     /// Get the current application settings.
     pub fn get_settings(&self) -> AppSettings {
         self.settings.lock().unwrap().clone()
+    }
+
+    /// Get the current application settings with the serial-port-scan prefixes
+    /// resolved to the concrete built-in default list when they have never been
+    /// saved (`None` in storage).
+    ///
+    /// This is the exact shape the frontend receives from the `get_settings`
+    /// command and, therefore, the shape reflected into the shadow
+    /// [`SettingsStore`](crate::settings_projection::SettingsStore) at startup
+    /// and on every persisted save (#2386). Keeping the resolution in one place
+    /// keeps the command return value and the projection fold from drifting.
+    pub fn get_settings_resolved(&self) -> AppSettings {
+        let mut settings = self.get_settings();
+        if settings.serial_port_scan_prefixes.is_none() {
+            settings.serial_port_scan_prefixes = Some(default_serial_port_scan_prefixes());
+        }
+        settings
     }
 
     /// Update and persist application settings.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -955,12 +955,24 @@ pub fn run() {
                         store.snapshot(),
                     );
                 }
-                // Seed the shared `settings` region with the default settings
-                // document at version 0, so a subscriber attaches to a real region
-                // before the first `settings.*` intent (#2227).
+                // Seed the shared `settings` region from the persisted
+                // `AppSettings` authority (#2386), so the shadow store — and the
+                // region a subscriber attaches to before the first `settings.*`
+                // intent — reflects the real persisted preferences document from
+                // startup rather than the default baseline. Seeding the resolved
+                // document here is the startup counterpart to
+                // `fold_settings_from_manager`, which keeps the store in sync on
+                // every later `save_settings` (#2227).
                 if let Some(store) =
                     app.handle().try_state::<Arc<settings_projection::SettingsStore>>()
                 {
+                    if let Some(manager) = app.handle().try_state::<ConnectionManager>() {
+                        if let Ok(serde_json::Value::Object(doc)) =
+                            serde_json::to_value(manager.get_settings_resolved())
+                        {
+                            store.replace(doc);
+                        }
+                    }
                     projection_state.projector.register_region(
                         settings_projection::projection::SETTINGS_REGION,
                         store.snapshot(),

--- a/src-tauri/src/settings_projection/projection.rs
+++ b/src-tauri/src/settings_projection/projection.rs
@@ -51,6 +51,8 @@ use std::sync::Arc;
 use serde_json::{Map, Value};
 use tauri::{AppHandle, Manager};
 
+use crate::commands::projection::ProjectionState;
+use crate::connection::manager::ConnectionManager;
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
 use crate::settings_projection::store::SettingsStore;
 
@@ -68,6 +70,54 @@ pub fn publish_settings(projector: &Projector, store: &SettingsStore) -> Vec<Pro
             version,
         }],
         None => Vec::new(),
+    }
+}
+
+/// Fold the persisted [`AppSettings`](crate::connection::settings::AppSettings)
+/// document — the real authority behind `get_settings` / `save_settings` — into
+/// the managed [`SettingsStore`] **server-side** and fan the resulting `settings`
+/// region diff out to every subscriber (#2386, prerequisite for #2227).
+///
+/// This is the server-authority counterpart to the `settings.*` intents
+/// [`register_settings_intents`] registers: the whole-document save the frontend
+/// currently mirrors via a `settings.replace` intent is reflected here **at the
+/// source** — the instant a `save_settings` lands in the persisted
+/// [`ConnectionManager`] authority — with no client round-trip required for the
+/// store to be correct.
+///
+/// It reflects the manager's **whole** post-save document (via
+/// [`ConnectionManager::get_settings_resolved`] serialized to its camelCase view
+/// shape + [`SettingsStore::replace`]) rather than a targeted patch. `AppSettings`
+/// is a single opaque document persisted and replaced as a whole, so reflecting
+/// the authoritative resolved document guarantees the region always equals what
+/// was actually persisted (including the resolved serial-port-scan prefixes the
+/// frontend receives). The projector coalesces an unchanged document to no diff,
+/// so a save that changes nothing is a no-op.
+///
+/// It is **additive**: the `settings.*` intents stay in place, and nothing in the
+/// live UI subscribes to the region yet, so this changes no user-facing behavior.
+/// Making the store authoritative (dropping the redundant `appStore` reducer) is
+/// the later #2227 reducer-removal.
+///
+/// Best-effort and non-fatal: if the store or the connection manager is not
+/// managed (e.g. a headless unit-test app that never ran `setup()`), or the
+/// resolved settings do not serialize to a JSON object, the fold is skipped
+/// rather than erroring. The `replace` runs to completion synchronously before
+/// the publish, so the store lock is never held across an await.
+pub fn fold_settings_from_manager<R: tauri::Runtime>(app_handle: &AppHandle<R>) {
+    let Some(store) = app_handle.try_state::<Arc<SettingsStore>>() else {
+        return;
+    };
+    let store: Arc<SettingsStore> = (*store).clone();
+    let Some(manager) = app_handle.try_state::<ConnectionManager>() else {
+        return;
+    };
+    let Ok(Value::Object(doc)) = serde_json::to_value(manager.get_settings_resolved()) else {
+        return;
+    };
+    store.replace(doc);
+    if let Some(projection) = app_handle.try_state::<ProjectionState>() {
+        publish_settings(&projection.projector, &store);
     }
 }
 

--- a/src-tauri/src/settings_projection/projection_tests.rs
+++ b/src-tauri/src/settings_projection/projection_tests.rs
@@ -17,11 +17,17 @@ use std::sync::{Arc, Mutex};
 
 use serde_json::{json, Map, Value};
 
+use tauri::Manager;
+
+use crate::commands::projection::ProjectionState;
+use crate::connection::manager::ConnectionManager;
 use crate::projection::{
     apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
     ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
 };
-use crate::settings_projection::projection::{publish_settings, SETTINGS_REGION};
+use crate::settings_projection::projection::{
+    fold_settings_from_manager, publish_settings, SETTINGS_REGION,
+};
 use crate::settings_projection::store::SettingsStore;
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -280,6 +286,134 @@ fn a_no_op_intent_advances_nothing() {
     assert_eq!(ack.produced, Some(vec![]), "no region advanced");
     assert_eq!(sink.diffs().len(), 0);
     assert_eq!(projector.region_version(SETTINGS_REGION), Some(0));
+}
+
+// ── Server-authority fold (#2386, prerequisite for #2227) ─────────────────────
+//
+// These drive the *production* `fold_settings_from_manager` end to end against a
+// `tauri::test::mock_app()` carrying the same managed state `lib.rs::setup()`
+// wires: a real `ConnectionManager` (backed by a temp dir), an
+// `Arc<SettingsStore>`, and a `ProjectionState`. They prove the store is fed
+// **server-side** — the instant a `save_settings` lands in the persisted manager
+// authority — with no `settings.*` client dispatch, and that the store reflects
+// the manager's *resolved* `AppSettings` document (serial-port-scan prefixes and
+// all), not the default baseline.
+
+/// A `ConnectionManager` backed by a fresh temp dir with a null credential store.
+/// Returns the manager and the `TempDir` guard (kept alive for the test's span).
+fn test_manager() -> (ConnectionManager, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let manager =
+        ConnectionManager::new_for_test(dir.path(), Arc::new(crate::credential::NullStore))
+            .unwrap();
+    (manager, dir)
+}
+
+/// Wire a mock app with the managed state `setup()` builds for the settings
+/// region: the manager, the store, and a `ProjectionState` whose `settings`
+/// region is registered and has one `VecSink` subscribed. Returns the app, the
+/// store, the sink, and the subscribe-time client cache.
+#[allow(clippy::type_complexity)]
+fn wire_app(
+    manager: ConnectionManager,
+) -> (
+    tauri::App<tauri::test::MockRuntime>,
+    Arc<SettingsStore>,
+    Arc<VecSink>,
+    ClientCache,
+) {
+    let app = tauri::test::mock_app();
+    app.manage(manager);
+
+    let store = Arc::new(SettingsStore::new());
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(SETTINGS_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    let snap = projection
+        .projector
+        .subscribe(SETTINGS_REGION, "sub", "C", sink.clone());
+    let cache = ClientCache::from_snapshot(&snap);
+    app.manage(projection);
+
+    (app, store, sink, cache)
+}
+
+/// A backend-produced whole-document `save_settings` folded server-side replaces
+/// the document in the shared store and fans exactly one `settings` region diff
+/// out — with no `settings.*` client dispatch. The store reflects the persisted
+/// authority, proving the fold feeds the store at the source.
+#[test]
+fn server_side_settings_save_folds_into_store_and_region_without_client_dispatch() {
+    let (manager, _dir) = test_manager();
+    let (app, store, sink, mut cache) = wire_app(manager);
+
+    // Persist a whole-document save through the real manager authority.
+    let manager = app.state::<ConnectionManager>();
+    let mut settings = manager.get_settings();
+    settings.theme = Some("light".to_string());
+    settings.font_size = Some(20);
+    manager
+        .save_settings(settings)
+        .expect("manager persists the settings");
+
+    // No `settings.*` intent is dispatched — the fold feeds the store at the
+    // source, from the persisted authority.
+    fold_settings_from_manager(app.handle());
+
+    // The store is authoritative server-side and carries the saved document.
+    assert_eq!(store.get("theme"), Some(json!("light")));
+    assert_eq!(store.get("fontSize"), Some(json!(20)));
+
+    // Exactly one region diff fanned out; the client cache converges on the store
+    // (which equals the manager's resolved snapshot) with no round-trip.
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "one diff from the server-side fold");
+    cache.apply(&diffs[0]);
+    assert_eq!(cache.view, store.snapshot(), "cache converges on authority");
+    assert_eq!(cache.view["theme"], json!("light"));
+    assert_eq!(cache.view["fontSize"], json!(20));
+}
+
+/// The fold reflects the manager's **resolved** document, not its raw storage:
+/// `serial_port_scan_prefixes` is `None` in storage after a plain save, but the
+/// fold reflects the concrete built-in default list the frontend receives from
+/// `get_settings` — proving `get_settings_resolved` is the single source shared
+/// by the command and the fold.
+#[test]
+fn server_side_fold_reflects_the_resolved_settings_document() {
+    let (manager, _dir) = test_manager();
+    let (app, store, sink, _cache) = wire_app(manager);
+
+    let manager = app.state::<ConnectionManager>();
+    // A plain save leaves `serial_port_scan_prefixes` unset in storage.
+    let settings = manager.get_settings();
+    assert!(settings.serial_port_scan_prefixes.is_none());
+    manager.save_settings(settings).unwrap();
+
+    fold_settings_from_manager(app.handle());
+
+    // The store carries the resolved (non-empty) prefixes, not `null`/absent.
+    let prefixes = store
+        .get("serialPortScanPrefixes")
+        .expect("prefixes present");
+    assert!(
+        prefixes.as_array().map(|a| !a.is_empty()).unwrap_or(false),
+        "the fold reflects the resolved default prefix list, got {prefixes:?}"
+    );
+    assert_eq!(sink.diffs().len(), 1, "one diff from the server-side fold");
+}
+
+/// The fold is a best-effort no-op when the required state is not managed (e.g. a
+/// headless harness that never ran `setup()`) — it must not panic.
+#[test]
+fn server_side_fold_is_a_noop_without_managed_state() {
+    let app = tauri::test::mock_app();
+    // Nothing managed — reaching the assert without panicking is the contract.
+    fold_settings_from_manager(app.handle());
 }
 
 #[test]


### PR DESCRIPTION
## What

Makes the shared `SettingsStore` (the `settings` projection region) **server-authoritative at the source**: the persisted `AppSettings` document is reflected into the store from the `ConnectionManager` authority the instant a `save_settings` lands, and the region is seeded from the persisted document at startup — instead of relying solely on client-dispatched `settings.*` intents and a default baseline.

Prerequisite for #2227 (Phase 5 Settings reducer-removal). Audit (from #2386): `SettingsStore` was written **only** by frontend `settings.*` intents and seeded with the *default* document in `lib.rs`. The real authority (`AppSettings`) is persisted in Rust but the store was never fed from it, so removing the `appStore` reducers (making the store authoritative) would be a **lossy** inversion. This PR feeds it from the source so #2227 can invert the data flow with no data-loss risk. Closest analog: Connections #2389 (PR #2393); also Transfers #2387 (PR #2391), Monitors #2376 (PR #2379).

## Changes

- **New `fold_settings_from_manager`** (`settings_projection/projection.rs`): resolves the managed `SettingsStore` + `ConnectionManager` + `ProjectionState` from the `AppHandle`, serializes the manager's resolved `AppSettings` (camelCase view shape) into the store (`replace`), and publishes the `settings` region diff. Best-effort (skips if any required state is unmanaged, or the doc does not serialize to an object); never holds the store lock across an await.
- **Fold at the source** (`commands/connection.rs`): `save_settings` folds after the manager persists. (`AppHandle` is Tauri-injected — no change to the JS invoke surface.)
- **Single resolver** (`connection/manager.rs`): new `get_settings_resolved()` returns the settings with the serial-port-scan prefixes expanded to the built-in default list when unset — the exact shape the frontend already receives from `get_settings`. `get_settings` command and the fold/seed both use it, so the command return value and the projection can't drift.
- **Startup seed** (`lib.rs`): the `settings` region is now seeded from the persisted `AppSettings` document instead of the default baseline, so a subscriber attaching before the first mutation sees the real persisted preferences.
- **Tests** (`projection_tests.rs`): drive the production fold end to end against `tauri::test::mock_app()` with a real `ConnectionManager` — a persisted save feeds the store and fans one region diff out **with no client dispatch**; the store reflects the manager's **resolved** document (serial-port-scan prefixes present though unset in storage); a no-op when unmanaged.

## Why reflect the whole document

`AppSettings` is a single opaque document loaded and saved as a whole (`get_settings` / `save_settings`), so the fold reflects the manager's authoritative resolved document (`get_settings_resolved` → `replace`) rather than a targeted patch — guaranteeing the region always equals what was persisted. The projector coalesces an unchanged document to no diff, so a save that changes nothing is a no-op.

## Additive / no user-facing change

- The `settings.*` intents stay in place; `appStore.ts` and the frontend mirror are intentionally untouched.
- Nothing in the live UI subscribes to the `settings` region yet. The reducer-removal (making the store authoritative) is the **later #2227 step**.
- Backend-only, no user-facing behavior change → no changelog fragment.

## Verification

- `cargo test --lib settings_projection` — 15 pass (3 new)
- `cargo test --lib connection::` — 195 pass
- `cargo build`, `cargo fmt --check`, `cargo clippy --all-targets --all-features` — clean
- `pnpm exec prettier --check` over `src/**` + `docs/**/*.md` — clean (pre-existing unrelated `lucide-tags.json` warning only)

Closes #2386