### PR TITLE
feat(connections): reflect external-file connections in the server-authoritative region (Closes #2394)

### DIFF
--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -37,28 +37,20 @@ pub fn load_connections_and_folders(
     manager: State<'_, ConnectionManager>,
 ) -> Result<ConnectionData, String> {
     info!("Loading connections and folders");
-    let flat = manager.get_all().map_err(|e| e.to_string())?;
-
-    // Flatten external connections into the main connections list
-    let external_sources = manager.load_external_sources();
-    let mut all_connections = flat.connections;
-    let mut external_errors = Vec::new();
-
-    for source in external_sources {
-        if let Some(err) = source.error {
-            external_errors.push(ExternalFileError {
-                file_path: source.file_path,
-                error: err,
-            });
-        }
-        all_connections.extend(source.connections);
-    }
+    // The unified main + external view (the same one reflected into the shadow
+    // `ConnectionsStore` server-side, #2394), so the command and the projection
+    // region cannot drift.
+    let view = manager.load_unified_view().map_err(|e| e.to_string())?;
 
     Ok(ConnectionData {
-        connections: all_connections,
-        folders: flat.folders,
-        agents: flat.agents,
-        external_errors,
+        connections: view.connections,
+        folders: view.folders,
+        agents: view.agents,
+        external_errors: view
+            .external_errors
+            .into_iter()
+            .map(|(file_path, error)| ExternalFileError { file_path, error })
+            .collect(),
     })
 }
 
@@ -75,8 +67,10 @@ pub fn save_connection(
     let persisted_id = manager
         .save_connection_routed(connection)
         .map_err(|e| e.to_string())?;
-    // Server-authority fold (#2389): reflect the persisted tree into the shadow
-    // `ConnectionsStore` at the source. Additive; no user-facing change.
+    // Server-authority fold (#2389/#2394): reflect the persisted tree — main
+    // store *and* the external-file overlay — into the shadow `ConnectionsStore`
+    // at the source. A save routed to an external file (`sourceFile` set) updates
+    // the region via that overlay. Additive; no user-facing change.
     crate::connections_projection::projection::fold_connections_from_manager(&app);
     Ok(persisted_id)
 }
@@ -115,8 +109,9 @@ pub fn move_connection_to_file(
     let moved = manager
         .move_connection_to_file(&connection_id, current_source.as_deref(), target_source)
         .map_err(|e| e.to_string())?;
-    // A move into/out of the main store changes the persisted tree; an
-    // external↔external move leaves it untouched and coalesces to no diff.
+    // The fold reflects both the main store and the external-file overlay
+    // (#2394), so a move into/out of the main store *and* an external↔external
+    // move (the `sourceFile` changes) are reflected in the region.
     crate::connections_projection::projection::fold_connections_from_manager(&app);
     Ok(moved)
 }
@@ -197,15 +192,23 @@ pub fn save_external_file(
     name: String,
     folders: Vec<ConnectionFolder>,
     connections: Vec<SavedConnection>,
+    app: AppHandle,
     credential_store: State<'_, Arc<CredentialManager>>,
 ) -> Result<(), String> {
     manager::save_external_file(&file_path, &name, folders, connections, &**credential_store)
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    // Server-authority fold (#2394): reflect the external-file overlay (as it is
+    // now on disk) into the shadow `ConnectionsStore` when the saved file is a
+    // currently-enabled external source. The fold resolves the `ConnectionManager`
+    // from `app`. Additive; no user-facing change.
+    crate::connections_projection::projection::fold_connections_from_manager(&app);
+    Ok(())
 }
 
 /// Reload external connection files and return flattened connections.
 #[tauri::command]
 pub fn reload_external_connections(
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
 ) -> Result<Vec<SavedConnection>, String> {
     let sources = manager.load_external_sources();
@@ -213,6 +216,11 @@ pub fn reload_external_connections(
     for source in sources {
         connections.extend(source.connections);
     }
+    // Server-authority fold (#2394): the external overlay just changed on disk /
+    // in the enabled set — reflect the unified main + external tree into the
+    // shadow `ConnectionsStore` so the region stays in sync with the frontend's
+    // `reloadExternalConnections`. Additive; no user-facing change.
+    crate::connections_projection::projection::fold_connections_from_manager(&app);
     Ok(connections)
 }
 

--- a/src-tauri/src/connection/manager.rs
+++ b/src-tauri/src/connection/manager.rs
@@ -97,6 +97,31 @@ pub struct ExternalSource {
     pub error: Option<String>,
 }
 
+/// The unified connections view the frontend `appStore` slice holds: the main
+/// persisted store's folders + agents, and its connections **merged with** every
+/// enabled external file's flattened connections (each external row carrying its
+/// `source_file`).
+///
+/// This is the exact set [`load_connections_and_folders`] returns to the frontend
+/// and, therefore, the set the server-authoritative `connections` projection
+/// region reflects (#2394): folding only the main store left external-file
+/// connections out of the region, so #2225's render cut would have been lossy for
+/// them. Resolving the merge in one place keeps the command return value, the
+/// startup seed, and the projection fold from drifting.
+///
+/// [`load_connections_and_folders`]: crate::commands::connection::load_connections_and_folders
+pub struct UnifiedConnectionView {
+    pub folders: Vec<ConnectionFolder>,
+    /// Main-store connections followed by every enabled external file's
+    /// connections. External rows carry `source_file`; a file that fails to load
+    /// contributes no rows (its failure is reported in `external_errors`).
+    pub connections: Vec<SavedConnection>,
+    pub agents: Vec<SavedRemoteAgent>,
+    /// Per-file load errors as `(file_path, error)`. A file listed here loaded no
+    /// connections; the frontend surfaces these by logging each one.
+    pub external_errors: Vec<(String, String)>,
+}
+
 /// Manages saved connections and folders with file persistence.
 pub struct ConnectionManager {
     store: Mutex<FlatConnectionStore>,
@@ -644,6 +669,35 @@ impl ConnectionManager {
         }
 
         sources
+    }
+
+    /// Build the [`UnifiedConnectionView`] the frontend `appStore` slice holds:
+    /// the main persisted store (via [`get_all`](Self::get_all)) with every
+    /// enabled external file's flattened connections appended (each carrying its
+    /// `source_file`), plus any per-file load errors.
+    ///
+    /// This is the single source of truth for the merged main + external view —
+    /// used by the `load_connections_and_folders` command, the `connections`
+    /// projection startup seed, and `fold_connections_from_manager` — so the
+    /// command return value and the server-authoritative region cannot drift
+    /// (#2394). The append order and error handling mirror the command's previous
+    /// inline flattening exactly.
+    pub fn load_unified_view(&self) -> Result<UnifiedConnectionView> {
+        let flat = self.get_all()?;
+        let mut connections = flat.connections;
+        let mut external_errors = Vec::new();
+        for source in self.load_external_sources() {
+            if let Some(err) = source.error {
+                external_errors.push((source.file_path, err));
+            }
+            connections.extend(source.connections);
+        }
+        Ok(UnifiedConnectionView {
+            folders: flat.folders,
+            connections,
+            agents: flat.agents,
+            external_errors,
+        })
     }
 
     /// Save a connection to its appropriate file based on `source_file`.

--- a/src-tauri/src/connections_projection/projection.rs
+++ b/src-tauri/src/connections_projection/projection.rs
@@ -77,31 +77,40 @@ pub fn publish_connections(projector: &Projector, store: &ConnectionsStore) -> V
     }
 }
 
-/// Fold the [`ConnectionManager`]'s authoritative saved-connection / folder tree
-/// into the managed [`ConnectionsStore`] **server-side** and fan the resulting
-/// `connections` region diff out to every subscriber (#2389, prerequisite for
-/// #2225).
+/// Fold the [`ConnectionManager`]'s authoritative connections tree — the main
+/// persisted store **and** the external-file overlay — into the managed
+/// [`ConnectionsStore`] **server-side** and fan the resulting `connections` region
+/// diff out to every subscriber (#2389/#2394, prerequisite for #2225).
 ///
 /// This is the server-authority counterpart to the `connection.*` intents
 /// [`register_connection_intents`] registers: the same store transitions the
 /// frontend currently mirrors via `connection.*` intents are reflected here **at
 /// the source** — the instant a saved-connection / folder mutation
 /// (`save_connection` / `delete_connection` / `move_connection_to_file` /
-/// `save_folder` / `delete_folder` / import) lands in the persisted
+/// `save_folder` / `delete_folder` / import) or an external-file change
+/// (`reload_external_connections` / `save_external_file`) lands in the persisted
 /// [`ConnectionManager`] authority — with no client round-trip required for the
 /// store to be correct.
 ///
-/// It reflects the manager's **whole** post-mutation tree (via
-/// [`ConnectionManager::get_all`] + [`ConnectionsStore::replace`]) rather than
-/// replaying one fine-grained store op per call. This is deliberate: the manager
-/// is a *coarse* authority — a single `save_connection` may recompute the
+/// It reflects the manager's **whole** post-mutation view via
+/// [`ConnectionManager::load_unified_view`] + [`ConnectionsStore::replace`] rather
+/// than replaying one fine-grained store op per call. This is deliberate: the
+/// manager is a *coarse* authority — a single `save_connection` may recompute the
 /// path-based id, deduplicate sibling names, re-home children, and migrate
 /// credentials — so replaying the intent-level ops (`add` / `update` / …) against
 /// the store would drift from the persisted truth. Reflecting the manager's
 /// authoritative snapshot guarantees the region always equals what was actually
-/// persisted. The projector coalesces an unchanged snapshot to no diff, so a
-/// mutation that leaves the main tree untouched (e.g. an external-file-only save)
-/// is a no-op.
+/// persisted.
+///
+/// The unified view is exactly the set the frontend `appStore` slice holds: the
+/// main store's folders + connections with every **enabled external file**'s
+/// flattened connections appended (each carrying its `source_file`), so #2225's
+/// render cut is non-lossy for external-file connections (#2394). External-file
+/// **load errors** are handled the way the frontend does — a file that fails to
+/// load contributes no rows (the error is not modelled in the region; the
+/// frontend only logs it, it is not part of the `appStore` connections slice).
+/// The projector coalesces an unchanged snapshot to no diff, so a mutation that
+/// leaves the unified tree untouched is a no-op.
 ///
 /// It is **additive**: the per-transition `connection.*` intents and the
 /// render-cut `connection.replace` mirror stay in place, and nothing in the live
@@ -111,9 +120,9 @@ pub fn publish_connections(projector: &Projector, store: &ConnectionsStore) -> V
 ///
 /// Best-effort and non-fatal: if the store, the connection manager, or the
 /// projection state is not managed (e.g. a headless unit-test app that never ran
-/// `setup()`), or the disk reload inside `get_all` fails, the fold is skipped
-/// rather than erroring. The `replace` runs to completion synchronously before
-/// the publish, so the store lock is never held across an await.
+/// `setup()`), or the disk reload inside `load_unified_view` fails, the fold is
+/// skipped rather than erroring. The `replace` runs to completion synchronously
+/// before the publish, so the store lock is never held across an await.
 pub fn fold_connections_from_manager<R: tauri::Runtime>(app_handle: &AppHandle<R>) {
     let Some(store) = app_handle.try_state::<Arc<ConnectionsStore>>() else {
         return;
@@ -122,10 +131,10 @@ pub fn fold_connections_from_manager<R: tauri::Runtime>(app_handle: &AppHandle<R
     let Some(manager) = app_handle.try_state::<ConnectionManager>() else {
         return;
     };
-    let Ok(flat) = manager.get_all() else {
+    let Ok(view) = manager.load_unified_view() else {
         return;
     };
-    store.replace(flat.folders, flat.connections);
+    store.replace(view.folders, view.connections);
     if let Some(projection) = app_handle.try_state::<ProjectionState>() {
         publish_connections(&projection.projector, &store);
     }

--- a/src-tauri/src/connections_projection/projection_tests.rs
+++ b/src-tauri/src/connections_projection/projection_tests.rs
@@ -610,6 +610,217 @@ fn server_side_fold_is_a_noop_without_managed_state() {
     fold_connections_from_manager(app.handle());
 }
 
+// ── External-file overlay reflected in the region (#2394) ─────────────────────
+//
+// The frontend `appStore` connections slice holds the main persisted store **and**
+// the read-only external-file overlay (`reloadExternalConnections` /
+// `load_connections_and_folders` flatten `load_external_sources()` into the list;
+// each external row carries `sourceFile`). These prove the server-side fold
+// reflects that **same unified set** into the region, so #2225's render cut is
+// non-lossy for external-file connections. `fold_connections_from_manager` now
+// reflects `ConnectionManager::load_unified_view` (main + external), not the main
+// store alone.
+
+/// Write `connections` into a fresh enabled external file inside `dir` and point
+/// the manager's settings at it. Returns the file path (kept alive by the caller's
+/// `TempDir`).
+fn enable_external_file(
+    manager: &ConnectionManager,
+    dir: &std::path::Path,
+    file_name: &str,
+    connections: Vec<SavedConnection>,
+) -> String {
+    let path = dir.join(file_name);
+    let path_str = path.to_str().unwrap().to_string();
+    crate::connection::manager::save_external_file(
+        &path_str,
+        "Shared",
+        vec![],
+        connections,
+        &crate::credential::NullStore,
+    )
+    .unwrap();
+    manager
+        .save_settings(crate::connection::settings::AppSettings {
+            external_connection_files: vec![crate::connection::settings::ExternalFileConfig {
+                path: path_str.clone(),
+                enabled: true,
+            }],
+            ..Default::default()
+        })
+        .unwrap();
+    path_str
+}
+
+/// The fold reflects the unified main + external view: a main-store connection and
+/// an enabled external file both land in the `connections` region, the external
+/// row carrying its `sourceFile`. One diff fans out and the client cache converges
+/// on the unified authority — with no `connection.*` client dispatch.
+#[test]
+fn server_side_fold_reflects_external_file_connections_in_the_region() {
+    let (manager, dir) = test_manager();
+
+    // A main-store connection persisted through the manager.
+    manager
+        .save_connection(connection("Main", "Main", None))
+        .expect("manager persists the main connection");
+
+    // An enabled external file carrying one connection on disk.
+    let ext_path = enable_external_file(
+        &manager,
+        dir.path(),
+        "shared.json",
+        vec![connection("Ext", "Ext", None)],
+    );
+
+    let (app, store, sink, mut cache) = wire_app(manager);
+
+    // Fold the unified view server-side — no `connection.*` intent is dispatched.
+    fold_connections_from_manager(app.handle());
+
+    // The region carries BOTH connections; the external one carries its
+    // `sourceFile`, the main one does not.
+    assert_eq!(
+        store.connection_count(),
+        2,
+        "main store + external overlay both reflected in the region"
+    );
+    let conns = store.snapshot()["connections"].as_array().unwrap().clone();
+    let external = conns
+        .iter()
+        .find(|c| c["sourceFile"] == json!(ext_path))
+        .expect("the external connection is present, tagged with its sourceFile");
+    assert_eq!(external["name"], json!("Ext"));
+    assert!(
+        conns
+            .iter()
+            .any(|c| c["name"] == json!("Main") && c["sourceFile"].is_null()),
+        "the main connection is present with no sourceFile"
+    );
+
+    // Exactly one diff fanned out; the client cache converges on the unified tree.
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "one diff from the server-side fold");
+    cache.apply(&diffs[0]);
+    assert_eq!(
+        cache.view,
+        store.snapshot(),
+        "cache converges on the unified (main + external) authority"
+    );
+}
+
+/// A `reload_external_connections`-shaped change (toggling / editing the external
+/// set) re-reflects the overlay: enabling a second external file and re-folding
+/// adds its connection to the region.
+#[test]
+fn server_side_fold_repicks_up_external_changes() {
+    let (manager, dir) = test_manager();
+    let ext_path = enable_external_file(
+        &manager,
+        dir.path(),
+        "one.json",
+        vec![connection("One", "One", None)],
+    );
+
+    let (app, store, sink, _cache) = wire_app(manager);
+    fold_connections_from_manager(app.handle());
+    assert_eq!(
+        store.connection_count(),
+        1,
+        "one external connection reflected"
+    );
+
+    // Enable a *second* external file (mirrors editing the enabled set, then the
+    // frontend's `reloadExternalConnections`, which now folds server-side).
+    let dir2 = tempfile::tempdir().unwrap();
+    let ext_path_2 = dir2.path().join("two.json");
+    let ext_path_2_str = ext_path_2.to_str().unwrap().to_string();
+    crate::connection::manager::save_external_file(
+        &ext_path_2_str,
+        "Two",
+        vec![],
+        vec![connection("Two", "Two", None)],
+        &crate::credential::NullStore,
+    )
+    .unwrap();
+    app.state::<ConnectionManager>()
+        .save_settings(crate::connection::settings::AppSettings {
+            external_connection_files: vec![
+                crate::connection::settings::ExternalFileConfig {
+                    path: ext_path.clone(),
+                    enabled: true,
+                },
+                crate::connection::settings::ExternalFileConfig {
+                    path: ext_path_2_str.clone(),
+                    enabled: true,
+                },
+            ],
+            ..Default::default()
+        })
+        .unwrap();
+
+    fold_connections_from_manager(app.handle());
+    assert_eq!(
+        store.connection_count(),
+        2,
+        "both external files now reflected after the reload-shaped fold"
+    );
+    let conns = store.snapshot()["connections"].as_array().unwrap().clone();
+    assert!(conns.iter().any(|c| c["sourceFile"] == json!(ext_path)));
+    assert!(conns
+        .iter()
+        .any(|c| c["sourceFile"] == json!(ext_path_2_str)));
+    assert_eq!(sink.diffs().len(), 2, "one diff per fold");
+}
+
+/// An external file that fails to load contributes **no** rows to the region and
+/// does not panic — exactly how the frontend flatten handles it (a failed source
+/// yields an empty `connections` list; the error is logged, never part of the
+/// `appStore` connections slice, so it is not modelled in the region either).
+#[test]
+fn server_side_fold_skips_a_failed_external_file_like_the_frontend() {
+    let (manager, dir) = test_manager();
+    manager
+        .save_connection(connection("Main", "Main", None))
+        .expect("manager persists the main connection");
+
+    // A malformed (non-empty, invalid JSON) external file fails to load.
+    let bad_path = dir.path().join("broken.json");
+    std::fs::write(&bad_path, "{ not valid json").unwrap();
+    manager
+        .save_settings(crate::connection::settings::AppSettings {
+            external_connection_files: vec![crate::connection::settings::ExternalFileConfig {
+                path: bad_path.to_str().unwrap().to_string(),
+                enabled: true,
+            }],
+            ..Default::default()
+        })
+        .unwrap();
+
+    let (app, store, sink, _cache) = wire_app(manager);
+
+    // Must not panic; the region reflects only the main connection.
+    fold_connections_from_manager(app.handle());
+    assert_eq!(
+        store.connection_count(),
+        1,
+        "only the main connection; the broken external file adds no rows"
+    );
+    assert!(
+        store.snapshot()["connections"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|c| c["sourceFile"].is_null()),
+        "no external rows from the failed file"
+    );
+    assert_eq!(
+        sink.diffs().len(),
+        1,
+        "one diff (the main connection seeded into the region)"
+    );
+}
+
 #[test]
 fn a_dead_subscriber_is_reaped_on_publish() {
     let store = seeded_store();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -935,19 +935,22 @@ pub fn run() {
                     );
                 }
                 // Seed the shared `connections` region from the persisted
-                // `ConnectionManager` authority (#2389), so the shadow store — and
-                // the region a subscriber attaches to before the first
-                // `connection.*` intent — reflects the real saved-connection /
-                // folder tree from startup rather than an empty baseline. The
-                // manager is the coarse authority: seeding its whole snapshot here
-                // is the startup counterpart to `fold_connections_from_manager`,
-                // which keeps the store in sync on every later mutation (#2225).
+                // `ConnectionManager` authority (#2389/#2394), so the shadow store
+                // — and the region a subscriber attaches to before the first
+                // `connection.*` intent — reflects the real connections tree from
+                // startup rather than an empty baseline. The seed uses the same
+                // unified main + external-file view the frontend `appStore` holds,
+                // so external-file connections are present in the region from
+                // startup. The manager is the coarse authority: seeding its whole
+                // snapshot here is the startup counterpart to
+                // `fold_connections_from_manager`, which keeps the store in sync on
+                // every later mutation (#2225).
                 if let Some(store) =
                     app.handle().try_state::<Arc<connections_projection::ConnectionsStore>>()
                 {
                     if let Some(manager) = app.handle().try_state::<ConnectionManager>() {
-                        if let Ok(flat) = manager.get_all() {
-                            store.replace(flat.folders, flat.connections);
+                        if let Ok(view) = manager.load_unified_view() {
+                            store.replace(view.folders, view.connections);
                         }
                     }
                     projection_state.projector.register_region(


### PR DESCRIPTION
## What

Follow-up to #2389 (PR #2393). Extends the server-authoritative `connections` projection region to carry the **external-file overlay** as well as the main persisted store, so it holds the same connections set the frontend `appStore` slice holds (main + external). Prerequisite for #2225's render cut to be **non-lossy** for external-file connections.

Backend-only, additive, no user-facing change.

## Representation decision

**Fold external-source connections into the same `connections` region alongside the main store** — the simplest non-lossy option, and an exact mirror of the frontend. The frontend `appStore.connections` slice is already a single flat list of main connections **plus** external-file connections (each external row carrying `sourceFile`); `load_connections_and_folders` / `reloadExternalConnections` produce it by flattening `load_external_sources()` into the main list. Modelling the overlay as a separate region/field would diverge from that shape and complicate the render cut. So the region's `connections` array = main + external, folders = main folders (external files contribute no folders to the tree, same as today).

## Changes

- **New `ConnectionManager::load_unified_view`** (`connection/manager.rs`) — the single source of truth for the merged main + external view (`UnifiedConnectionView { folders, connections, agents, external_errors }`). Its append order and error handling match `load_connections_and_folders`'s previous inline flattening exactly.
- **`fold_connections_from_manager`** (`connections_projection/projection.rs`) now reflects `load_unified_view` (main + external) instead of `get_all` (main only). Because the fold already runs on every persisted saved-connection / folder mutation, an external-file-routed `save_connection` / `delete_connection` and an external↔external `move_connection_to_file` are now reflected too (previously coalesced to no diff).
- **Fold at the external source** (`commands/connection.rs`): `reload_external_connections` and `save_external_file` now fold after the change (both gain a Tauri-injected `AppHandle` — no JS invoke change), so the frontend's `reloadExternalConnections` path keeps the region in sync. `load_connections_and_folders` now builds its `ConnectionData` from `load_unified_view` (no behavior change, just DRY).
- **Startup seed** (`lib.rs`) seeds the region from `load_unified_view`, so external-file connections are present from startup.
- **Tests** (`connections_projection/projection_tests.rs`): drive the production fold end to end against `tauri::test::mock_app()` with an enabled external file on disk — the region carries main + external (external tagged with `sourceFile`); a change to the enabled external set re-reflects on the next fold; and a **failed** external file contributes no rows without panicking.

## External-file load errors

Handled consistently with the frontend: the frontend only **logs** per-file `ExternalFileError`s (`loadFromBackend`) — they are never stored in the `appStore` connections slice — and `reloadExternalConnections` surfaces none per-file. So the region does **not** model errors either; a file that fails to load simply contributes no connection rows, exactly as the frontend flatten does. `load_unified_view` still returns the errors for `load_connections_and_folders` to forward to the frontend as before.

## Additive / no user-facing change

- The per-transition `connection.*` intents and the render-cut `connection.replace` mirror stay in place; `appStore.ts` and the frontend mirror are untouched. No reducer removed (#2225 is out of scope).
- Nothing in the live UI subscribes to the region yet. Backend-only → no changelog fragment.

## Verification

- `cargo test --lib connections_projection` — 32 pass (6 new)
- `cargo test --lib connection::` — 195 pass
- `cargo build`, `cargo fmt --check`, `cargo clippy --all-targets --all-features` — clean
- `pnpm exec prettier --check` (src/**, docs/**/*.md) — clean (only the pre-existing unrelated `lucide-tags.json` warning; no frontend files touched)

Closes #2394