### PR TITLE
refactor(connections): make the sidebar read the projection region authoritatively (Part of #2225)

### DIFF
--- a/src/components/Sidebar/ConnectionList.credential.test.tsx
+++ b/src/components/Sidebar/ConnectionList.credential.test.tsx
@@ -14,6 +14,7 @@ import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { ConnectionList } from "./ConnectionList";
+import { setupConnectionsRegionFromAppStore } from "@/test/connectionsRegionTestHarness";
 import { TooltipProvider } from "@/components/ui";
 import type { SavedConnection, RemoteAgentDefinition } from "@/types/connection";
 import { resolveCredential, storeCredential, isSshKeyEncrypted } from "@/services/api";
@@ -103,6 +104,8 @@ afterEach(() => {
   });
   container.remove();
 });
+
+setupConnectionsRegionFromAppStore();
 
 describe("ConnectionList — password dialog conditions", () => {
   it("shows dialog for password auth when no credential is stored", async () => {

--- a/src/components/Sidebar/ConnectionList.experimental-gating.test.tsx
+++ b/src/components/Sidebar/ConnectionList.experimental-gating.test.tsx
@@ -12,6 +12,7 @@ import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { ConnectionList } from "./ConnectionList";
+import { setupConnectionsRegionFromAppStore } from "@/test/connectionsRegionTestHarness";
 import { TooltipProvider } from "@/components/ui";
 import type {
   SavedConnection,
@@ -110,6 +111,8 @@ afterEach(() => {
   });
   container.remove();
 });
+
+setupConnectionsRegionFromAppStore();
 
 describe("ConnectionList — experimental remote-desktop gating", () => {
   it("hides graphical remote-desktop connections when the flag is off", () => {

--- a/src/components/Sidebar/ConnectionList.filter-folder-toggle.test.tsx
+++ b/src/components/Sidebar/ConnectionList.filter-folder-toggle.test.tsx
@@ -9,6 +9,7 @@ import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { ConnectionList } from "./ConnectionList";
+import { setupConnectionsRegionFromAppStore } from "@/test/connectionsRegionTestHarness";
 import { TooltipProvider } from "@/components/ui";
 import type { SavedConnection, ConnectionFolder, RemoteAgentDefinition } from "@/types/connection";
 
@@ -84,6 +85,8 @@ function keydown(el: Element, key: string) {
 function folderExpanded(folderId: string): boolean | undefined {
   return useAppStore.getState().folders.find((f) => f.id === folderId)?.isExpanded;
 }
+
+setupConnectionsRegionFromAppStore();
 
 describe("ConnectionList — folder toggle ignored while filtering (#1378)", () => {
   let container: HTMLDivElement;

--- a/src/components/Sidebar/ConnectionList.filter.test.tsx
+++ b/src/components/Sidebar/ConnectionList.filter.test.tsx
@@ -8,6 +8,7 @@ import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { ConnectionList } from "./ConnectionList";
+import { setupConnectionsRegionFromAppStore } from "@/test/connectionsRegionTestHarness";
 import { TooltipProvider } from "@/components/ui";
 import type { SavedConnection, ConnectionFolder, RemoteAgentDefinition } from "@/types/connection";
 
@@ -79,6 +80,8 @@ function keydown(el: Element, key: string) {
     el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
   });
 }
+
+setupConnectionsRegionFromAppStore();
 
 describe("ConnectionList — filter/search", () => {
   let container: HTMLDivElement;

--- a/src/components/Sidebar/ConnectionList.folder-chevron.test.tsx
+++ b/src/components/Sidebar/ConnectionList.folder-chevron.test.tsx
@@ -11,6 +11,7 @@ import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { ConnectionList } from "./ConnectionList";
+import { setupConnectionsRegionFromAppStore } from "@/test/connectionsRegionTestHarness";
 import { TooltipProvider } from "@/components/ui";
 import type { ConnectionFolder } from "@/types/connection";
 import type { RemoteAgentDefinition } from "@/types/connection";
@@ -58,6 +59,8 @@ const baseSettings = {
   fileBrowserEnabled: false,
   experimentalFeaturesEnabled: false,
 };
+
+setupConnectionsRegionFromAppStore();
 
 describe("ConnectionList — folder chevron placement", () => {
   let container: HTMLDivElement;

--- a/src/components/Sidebar/ConnectionList.ftp-warning.test.tsx
+++ b/src/components/Sidebar/ConnectionList.ftp-warning.test.tsx
@@ -12,6 +12,7 @@ import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { ConnectionList } from "./ConnectionList";
+import { setupConnectionsRegionFromAppStore } from "@/test/connectionsRegionTestHarness";
 import { TooltipProvider } from "@/components/ui";
 import type { SavedConnection, RemoteAgentDefinition } from "@/types/connection";
 
@@ -105,6 +106,8 @@ afterEach(() => {
   });
   container.remove();
 });
+
+setupConnectionsRegionFromAppStore();
 
 describe("ConnectionList — insecure-FTP warning modal", () => {
   it("shows the modal before connecting for plain FTP", async () => {

--- a/src/components/Sidebar/ConnectionList.jump-badge.test.tsx
+++ b/src/components/Sidebar/ConnectionList.jump-badge.test.tsx
@@ -10,6 +10,7 @@ import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { ConnectionList } from "./ConnectionList";
+import { setupConnectionsRegionFromAppStore } from "@/test/connectionsRegionTestHarness";
 import { TooltipProvider } from "@/components/ui";
 import type { SavedConnection, JumpHostConfig } from "@/types/connection";
 
@@ -44,6 +45,8 @@ function sshConnection(id: string, settings: Record<string, unknown>): SavedConn
     config: { type: "ssh", config: { host: "target", username: "deploy", ...settings } },
   };
 }
+
+setupConnectionsRegionFromAppStore();
 
 describe("ConnectionList — jump-host hop badge", () => {
   let container: HTMLDivElement;

--- a/src/components/Sidebar/ConnectionList.jump-delete.test.tsx
+++ b/src/components/Sidebar/ConnectionList.jump-delete.test.tsx
@@ -10,6 +10,7 @@ import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { ConnectionList } from "./ConnectionList";
+import { setupConnectionsRegionFromAppStore } from "@/test/connectionsRegionTestHarness";
 import { TooltipProvider } from "@/components/ui";
 import type { SavedConnection, JumpHostConfig } from "@/types/connection";
 
@@ -49,6 +50,8 @@ function sshConnection(id: string, settings: Record<string, unknown> = {}): Save
 }
 
 const q = (testId: string) => document.querySelector(`[data-testid="${testId}"]`) as HTMLElement;
+
+setupConnectionsRegionFromAppStore();
 
 describe("ConnectionList — jump-host delete protection", () => {
   let container: HTMLDivElement;

--- a/src/components/Sidebar/ConnectionList.jump-menu.test.tsx
+++ b/src/components/Sidebar/ConnectionList.jump-menu.test.tsx
@@ -10,6 +10,7 @@ import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { ConnectionList } from "./ConnectionList";
+import { setupConnectionsRegionFromAppStore } from "@/test/connectionsRegionTestHarness";
 import { TooltipProvider } from "@/components/ui";
 import type { SavedConnection, JumpHostConfig } from "@/types/connection";
 import { resolveCredential } from "@/services/api";
@@ -55,6 +56,8 @@ function sshConnection(id: string, settings: Record<string, unknown>): SavedConn
     config: { type: "ssh", config: { host: "target", username: "deploy", ...settings } },
   };
 }
+
+setupConnectionsRegionFromAppStore();
 
 describe("ConnectionList — jump-host context menu", () => {
   let container: HTMLDivElement;

--- a/src/components/Sidebar/ConnectionList.keyboard-nav.test.tsx
+++ b/src/components/Sidebar/ConnectionList.keyboard-nav.test.tsx
@@ -8,6 +8,7 @@ import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { ConnectionList } from "./ConnectionList";
+import { setupConnectionsRegionFromAppStore } from "@/test/connectionsRegionTestHarness";
 import { TooltipProvider } from "@/components/ui";
 import type { SavedConnection, ConnectionFolder, RemoteAgentDefinition } from "@/types/connection";
 
@@ -71,6 +72,8 @@ function keydown(el: Element, key: string) {
     el.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
   });
 }
+
+setupConnectionsRegionFromAppStore();
 
 describe("ConnectionList — keyboard navigation & ARIA", () => {
   let container: HTMLDivElement;

--- a/src/components/Sidebar/ConnectionList.multiselect.test.tsx
+++ b/src/components/Sidebar/ConnectionList.multiselect.test.tsx
@@ -9,6 +9,7 @@ import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { ConnectionList } from "./ConnectionList";
+import { setupConnectionsRegionFromAppStore } from "@/test/connectionsRegionTestHarness";
 import { TooltipProvider } from "@/components/ui";
 import type { SavedConnection, ConnectionFolder } from "@/types/connection";
 import type { RemoteAgentDefinition } from "@/types/connection";
@@ -70,6 +71,8 @@ const baseSettings = {
   fileBrowserEnabled: false,
   experimentalFeaturesEnabled: false,
 };
+
+setupConnectionsRegionFromAppStore();
 
 describe("ConnectionList — multi-select", () => {
   let container: HTMLDivElement;

--- a/src/components/Sidebar/ConnectionList.persistent.test.tsx
+++ b/src/components/Sidebar/ConnectionList.persistent.test.tsx
@@ -20,6 +20,7 @@ import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { ConnectionList } from "./ConnectionList";
+import { setupConnectionsRegionFromAppStore } from "@/test/connectionsRegionTestHarness";
 import { TooltipProvider } from "@/components/ui";
 import type {
   SavedConnection,
@@ -121,6 +122,8 @@ afterEach(() => {
   act(() => root.unmount());
   container.remove();
 });
+
+setupConnectionsRegionFromAppStore();
 
 describe("ConnectionList — desktop-local persistent controls", () => {
   it("shows NO persistence marker and NO state dot for a plain (desktop-local) connection", () => {

--- a/src/store/connectionsBridge.test.ts
+++ b/src/store/connectionsBridge.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+/**
+ * Connections bridge — the connection tree sidebar is region-authoritative (#2225,
+ * PR A). These tests drive the bridge against the in-memory {@link FakeTransport}
+ * store double and assert: it subscribes and fans the projected view out to
+ * listeners, caches the latest view for synchronous reads, and dispatches the
+ * granular `connection.*` mutation-cut intents (gated by the intents flag).
+ * Best-effort dispatch never throws, even on a rejected ack.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
   FrameHandler,
@@ -13,14 +21,12 @@ import type { ConnectionFolder, SavedConnection } from "@/types/connection";
 
 import {
   CONNECTIONS_REGION,
-  connectionRenderFromProjectionEnabled,
-  connectionsViewMirrors,
+  connectionIntentsEnabled,
   currentConnectionsView,
-  deepEqual,
   ensureConnectionsSubscribed,
+  mirrorConnectionIntent,
   onConnectionsView,
-  seedConnectionsRegion,
-  setConnectionRenderFromProjectionEnabled,
+  setConnectionIntentsEnabled,
   setConnectionTransportForTest,
   stopConnectionsSubscription,
   type ConnectionsView,
@@ -42,11 +48,10 @@ function folder(id: string, parentId: string | null = null, isExpanded = true): 
 }
 
 /**
- * An in-memory substrate double: holds one `connections` view, applies a
- * `connection.replace` intent by overwriting the view from its payload (keyed to
- * the Rust snapshot shape `folders`/`connections`), and fans a fresh snapshot to
- * every subscriber — so the seed round-trip and multi-subscriber fan-out are
- * exercised without a backend.
+ * An in-memory substrate double: holds one `connections` view (fed via
+ * {@link seed}, standing in for the server-side fold), records every dispatched
+ * intent, and fans a fresh snapshot to every subscriber — so subscription fan-out
+ * and mutation-cut dispatch are exercised without a backend.
  */
 class FakeTransport implements Transport {
   dispatched: Intent[] = [];
@@ -54,19 +59,15 @@ class FakeTransport implements Transport {
   private version = 0;
   private handlers: FrameHandler[] = [];
 
+  /** Feed the region as the server-side fold would, and fan the diff out. */
+  seed(view: ConnectionsView): void {
+    this.view = { folders: view.folders, connections: view.connections };
+    this.version += 1;
+    this.fan();
+  }
+
   async dispatch(intent: Intent): Promise<IntentAck> {
     this.dispatched.push(intent);
-    if (intent.kind === "connection.replace") {
-      const p = intent.payload as Record<string, unknown>;
-      this.view = { folders: p.folders ?? [], connections: p.connections ?? [] };
-      this.version += 1;
-      this.fan();
-      return {
-        intentId: intent.intentId,
-        status: "accepted",
-        produced: [{ region: CONNECTIONS_REGION, version: this.version }],
-      };
-    }
     return { intentId: intent.intentId, status: "accepted", produced: [] };
   }
 
@@ -104,111 +105,81 @@ beforeEach(() => {
 afterEach(() => {
   stopConnectionsSubscription();
   setConnectionTransportForTest(null);
-  setConnectionRenderFromProjectionEnabled(null);
+  setConnectionIntentsEnabled(null);
 });
 
-describe("connectionRenderFromProjectionEnabled flag", () => {
-  it("defaults on and honours the programmatic override", () => {
-    expect(connectionRenderFromProjectionEnabled()).toBe(true);
-    setConnectionRenderFromProjectionEnabled(false);
-    expect(connectionRenderFromProjectionEnabled()).toBe(false);
-    setConnectionRenderFromProjectionEnabled(true);
-    expect(connectionRenderFromProjectionEnabled()).toBe(true);
-    setConnectionRenderFromProjectionEnabled(null);
-    expect(connectionRenderFromProjectionEnabled()).toBe(true);
-  });
-});
+const flush = () => new Promise((r) => setTimeout(r, 0));
 
-describe("deepEqual", () => {
-  it("treats an integer and its float round-trip as equal", () => {
-    expect(deepEqual(22, 22.0)).toBe(true);
-    expect(deepEqual({ a: [1, 2] }, { a: [1, 2] })).toBe(true);
-  });
+describe("subscription + fan-out", () => {
+  it("fans the server-fed region view out to listeners and caches it", async () => {
+    const received: ConnectionsView[] = [];
+    const unsubscribe = onConnectionsView((v) => received.push(v));
 
-  it("distinguishes differing values, key sets, and null", () => {
-    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
-    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
-    expect(deepEqual(null, {})).toBe(false);
-    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
-  });
-});
-
-describe("connectionsViewMirrors", () => {
-  const folders = [folder("Work")];
-  const connections = [connection("Work/A", "Work")];
-
-  it("is false for an undefined view", () => {
-    expect(connectionsViewMirrors(undefined, folders, connections)).toBe(false);
-  });
-
-  it("is true when the view value-matches the appStore slice", () => {
-    const view: ConnectionsView = {
-      folders: structuredClone(folders),
-      connections: structuredClone(connections),
-    };
-    expect(connectionsViewMirrors(view, folders, connections)).toBe(true);
-  });
-
-  it("is false when a folder's isExpanded diverges", () => {
-    const view: ConnectionsView = {
-      folders: [{ ...folders[0], isExpanded: false }],
-      connections,
-    };
-    expect(connectionsViewMirrors(view, folders, connections)).toBe(false);
-  });
-
-  it("is false when a connection's folderId diverges", () => {
-    const view: ConnectionsView = {
-      folders,
-      connections: [{ ...connections[0], folderId: null }],
-    };
-    expect(connectionsViewMirrors(view, folders, connections)).toBe(false);
-  });
-
-  it("is false when the folder order diverges", () => {
-    const two = [folder("A"), folder("B")];
-    const view: ConnectionsView = { folders: [folder("B"), folder("A")], connections: [] };
-    expect(connectionsViewMirrors(view, two, [])).toBe(false);
-  });
-});
-
-describe("seedConnectionsRegion", () => {
-  it("dispatches connection.replace carrying the whole slice, keyed to the Rust shape", async () => {
     const folders = [folder("Work")];
     const connections = [connection("Work/A", "Work")];
-    await seedConnectionsRegion(folders, connections);
-    expect(transport.dispatched).toHaveLength(1);
-    expect(transport.dispatched[0]).toMatchObject({
-      kind: "connection.replace",
-      payload: { folders, connections },
-    });
+    transport.seed({ folders, connections });
+    await ensureConnectionsSubscribed();
+
+    // A synchronous read returns the latest server-fed view…
+    expect(currentConnectionsView()).toEqual({ folders, connections });
+    // …and the same view was fanned out to the listener.
+    expect(received[received.length - 1]).toEqual({ folders, connections });
+    unsubscribe();
   });
 
-  it("de-dupes an identical slice but re-seeds after a change", async () => {
-    const folders = [folder("Work")];
-    await seedConnectionsRegion(folders, []);
-    await seedConnectionsRegion(folders, []);
-    expect(transport.dispatched).toHaveLength(1);
-
-    const changed = [folder("Work", null, false)];
-    await seedConnectionsRegion(changed, []);
-    expect(transport.dispatched).toHaveLength(2);
-  });
-});
-
-describe("seed round-trip → the region mirrors appStore", () => {
-  it("makes the projected view a faithful mirror of the seeded slice", async () => {
+  it("re-fans on every region diff", async () => {
     const received: ConnectionsView[] = [];
     const unsubscribe = onConnectionsView((v) => received.push(v));
     await ensureConnectionsSubscribed();
 
-    const folders = [folder("Work")];
-    const connections = [connection("Work/A", "Work")];
-    await seedConnectionsRegion(folders, connections);
+    transport.seed({ folders: [folder("A")], connections: [] });
+    transport.seed({ folders: [folder("A")], connections: [connection("A/1", "A")] });
 
-    // The region now carries the seeded slice and the gate accepts it.
-    expect(connectionsViewMirrors(currentConnectionsView(), folders, connections)).toBe(true);
-    expect(received[received.length - 1]).toEqual({ folders, connections });
+    expect(currentConnectionsView().connections).toHaveLength(1);
+    expect(received[received.length - 1].connections[0].id).toBe("A/1");
     unsubscribe();
+  });
+});
+
+describe("connectionIntentsEnabled flag", () => {
+  it("defaults on and honours the programmatic override", () => {
+    expect(connectionIntentsEnabled()).toBe(true);
+    setConnectionIntentsEnabled(false);
+    expect(connectionIntentsEnabled()).toBe(false);
+    setConnectionIntentsEnabled(true);
+    expect(connectionIntentsEnabled()).toBe(true);
+    setConnectionIntentsEnabled(null);
+    expect(connectionIntentsEnabled()).toBe(true);
+  });
+});
+
+describe("mirrorConnectionIntent (mutation cut)", () => {
+  it("dispatches the granular intent when enabled", async () => {
+    mirrorConnectionIntent("connection.add", { connection: connection("A/1", "A") });
+    await flush();
+    expect(transport.dispatched).toHaveLength(1);
+    expect(transport.dispatched[0]).toMatchObject({
+      kind: "connection.add",
+      payload: { connection: { id: "A/1" } },
+    });
+  });
+
+  it("is a no-op when the mutation cut is disabled", async () => {
+    setConnectionIntentsEnabled(false);
+    mirrorConnectionIntent("connection.remove", { connectionId: "A/1" });
+    await flush();
+    expect(transport.dispatched).toHaveLength(0);
+  });
+
+  it("never throws even when the ack is rejected", async () => {
+    vi.spyOn(transport, "dispatch").mockResolvedValue({
+      intentId: "x",
+      status: "rejected",
+      error: { message: "boom" },
+    } as IntentAck);
+    expect(() =>
+      mirrorConnectionIntent("connection.toggleFolder", { folderId: "A" })
+    ).not.toThrow();
+    await flush();
   });
 });

--- a/src/store/connectionsBridge.ts
+++ b/src/store/connectionsBridge.ts
@@ -231,6 +231,22 @@ export function currentConnectionsView(): ConnectionsView {
   return lastView;
 }
 
+/**
+ * Test seam: synchronously set the cached region view and fan it to listeners,
+ * standing in for the server-side fold so a unit/component test can drive the
+ * authoritative region without a live backend. Not used in production.
+ */
+export function setConnectionsViewForTest(view: ConnectionsView): void {
+  lastView = { folders: view.folders, connections: view.connections };
+  for (const listener of viewListeners) {
+    try {
+      listener(lastView);
+    } catch (err) {
+      logConnectionBridgeFallback("reconcile", err);
+    }
+  }
+}
+
 // ── Mutation cut: granular connection.* intent dispatch ───────────────────────
 
 /**

--- a/src/store/connectionsBridge.ts
+++ b/src/store/connectionsBridge.ts
@@ -1,34 +1,28 @@
 /**
- * Connections projection bridge — Phase 5 render cut of the Connections-tree
- * domain (#2225, part of #2139 and #2153).
+ * Connections projection bridge — Phase 5 Connections-tree domain (#2225, part of
+ * #2139 and #2153).
  *
- * The Connections **shadow** (PR #2231) landed a backend-authoritative
- * [`ConnectionsStore`](../../src-tauri/src/connections_projection/store.rs)
- * served as the shared `connections` projection region, with `connection.*`
- * intents, but nothing in the UI touched it. This step makes the **connection
- * tree sidebar** ({@link import("../components/Sidebar/ConnectionList").ConnectionList})
- * source the saved-connection / folder inventory from that region — the
- * parity-safe render cut (the direct analog of the agents render cut
- * {@link import("./agentsBridge")}, #2226, and the system-monitor render cut
- * {@link import("./systemMonitorBridge")}, #2224).
+ * The Connections **shadow** (PR #2231) landed a backend
+ * [`ConnectionsStore`](../../src-tauri/src/connections_projection/store.rs) served
+ * as the shared `connections` projection region, with `connection.*` intents. The
+ * region is now **authoritative** for the connection tree sidebar
+ * ({@link import("../components/Sidebar/ConnectionList").ConnectionList}): the store
+ * is fed at the source — every persisted saved-connection / folder mutation and the
+ * external-file overlay are folded server-side (#2389 and #2394) — so the sidebar
+ * reads the region directly through {@link import("./useProjectedConnections").useProjectedConnections},
+ * with no `appStore` seed, mirror gate, or fallback (the direct analog of the
+ * authoritative transfers bridge {@link import("./transfersBridge")}, #2229, and the
+ * authoritative system-monitor bridge {@link import("./systemMonitorBridge")},
+ * #2224).
  *
- * # Strangler safety — flag-gated, on by default, faithful-mirror gate
+ * # Scope of this step
  *
- * The `appStore` connections slice is still authoritative (the mutation cut is a
- * later step). To keep the render cut parity-safe **independent of any mutation
- * flag**, the region is kept a faithful copy of `appStore` by
- * {@link seedConnectionsRegion} (a `connection.replace` mirror, the analog of the
- * agents bridge's `agent.replace` seed), and the UI renders from the region
- * **only when it faithfully mirrors** `appStore` ({@link connectionsViewMirrors});
- * otherwise it falls back to `appStore` verbatim. Because the gate guarantees the
- * projected view deep-equals `appStore`'s slice, the rendered output is
- * byte-identical to the pre-cut path.
- *
- * Gated by {@link connectionRenderFromProjectionEnabled} — **on by default**.
- * Overridable at runtime for rollback / tests via
- * `window.__TERMIHUB_CONNECTION_RENDER_FROM_PROJECTION__` or
- * `localStorage["termihub.connectionRenderFromProjection"]` (set `"false"` to
- * render straight from `appStore`).
+ * Only the **sidebar** is authoritative. The `appStore` connections slice is still
+ * held for the other, not-yet-migrated readers, and the mutation reducers keep
+ * mirroring their transitions through the granular `connection.*` intents
+ * ({@link mirrorConnectionIntent}, still gated by {@link connectionIntentsEnabled}).
+ * Migrating those remaining readers and removing the `appStore` reducers is a later
+ * step.
  */
 
 import {
@@ -85,56 +79,6 @@ function toView(raw: ConnectionsRegionSnapshot): ConnectionsView {
   };
 }
 
-// ── Render-cut feature flag (runtime-flippable, on by default) ─────────────────
-
-let renderFlagOverride: boolean | null = null;
-
-interface ConnectionRenderFlagWindow {
-  __TERMIHUB_CONNECTION_RENDER_FROM_PROJECTION__?: boolean;
-  localStorage?: Storage;
-}
-
-/**
- * Programmatic override for the render-cut flag (tests, and a runtime toggle).
- * `null` clears the override and falls back to the window/localStorage signal,
- * then to the default (on).
- */
-export function setConnectionRenderFromProjectionEnabled(value: boolean | null): void {
-  renderFlagOverride = value;
-}
-
-/**
- * Whether the connection tree sidebar renders the saved-connection / folder
- * inventory from the projected `connections` region instead of reading
- * `appStore`'s connections slice directly.
- *
- * **On by default** — the render cut is parity-safe: the UI renders from the
- * region only when it faithfully mirrors `appStore` ({@link connectionsViewMirrors}),
- * and otherwise falls back to `appStore` verbatim, so the output is byte-identical
- * to the pre-cut path. Independent of the (later) mutation cut: the region is kept
- * a mirror of `appStore` by {@link seedConnectionsRegion}, so it is always
- * populated. Overridable at runtime for rollback / tests via
- * `window.__TERMIHUB_CONNECTION_RENDER_FROM_PROJECTION__` or
- * `localStorage["termihub.connectionRenderFromProjection"]`.
- */
-export function connectionRenderFromProjectionEnabled(): boolean {
-  if (renderFlagOverride !== null) return renderFlagOverride;
-  try {
-    if (typeof window !== "undefined") {
-      const w = window as unknown as ConnectionRenderFlagWindow;
-      if (typeof w.__TERMIHUB_CONNECTION_RENDER_FROM_PROJECTION__ === "boolean") {
-        return w.__TERMIHUB_CONNECTION_RENDER_FROM_PROJECTION__;
-      }
-      const ls = w.localStorage?.getItem("termihub.connectionRenderFromProjection");
-      if (ls === "true") return true;
-      if (ls === "false") return false;
-    }
-  } catch {
-    // A missing/blocked window or storage just means "use the default".
-  }
-  return true;
-}
-
 // ── Mutation-cut feature flag (runtime-flippable, on by default) ───────────────
 
 let mutationFlagOverride: boolean | null = null;
@@ -156,21 +100,22 @@ export function setConnectionIntentsEnabled(value: boolean | null): void {
 /**
  * Whether the connection-tree lifecycle actions (add/update/remove/move the saved
  * connections, and add/remove/toggle folders) dispatch granular `connection.*`
- * intents so the backend {@link import("../../src-tauri/src/connections_projection/store").ConnectionsStore}
- * is authoritative — instead of only the render-cut {@link seedConnectionsRegion}
- * `connection.replace` mirror driving the region.
+ * intents to the backend {@link import("../../src-tauri/src/connections_projection/store").ConnectionsStore}
+ * so it tracks each transition (the backend also folds the persisted mutation
+ * server-side, #2389 / #2394).
  *
  * **On by default** (#2225 mutation cut). When on, each action mirrors its
  * transition through a `connection.*` intent (via {@link mirrorConnectionIntent}),
- * and the render-cut hook
+ * and the sidebar hook
  * ({@link import("./useProjectedConnections").useProjectedConnections}) reflects
  * the region back into the UI. The local `appStore` reducer path stays in place as
- * the render source and as a resilience / rollback fallback — any dispatch failure
- * is logged and the local mutation continues, so a backend hiccup can never break
- * the connection tree (the reducer removal is a later step). When off, `appStore`
- * drives the slice purely locally (the pre-cut path). The flip was taken on the
- * automated parity tests plus the instant local fallback, mirroring the agents
- * mutation cut (#2226). Overridable at runtime for rollback / tests via
+ * the render source for the not-yet-migrated readers and as a resilience / rollback
+ * fallback — any dispatch failure is logged and the local mutation continues, so a
+ * backend hiccup can never break the connection tree (the reducer removal is a later
+ * step). When off, `appStore` drives the slice purely locally (the pre-cut path).
+ * The flip was taken on the automated parity tests plus the instant local fallback,
+ * mirroring the agents mutation cut (#2226). Overridable at runtime for rollback /
+ * tests via
  * `window.__TERMIHUB_CONNECTION_INTENTS__` or
  * `localStorage["termihub.connectionIntents"]` (set `"false"` to restore the
  * pre-cut local-mutation path; `"true"` to force on).
@@ -205,14 +150,13 @@ let startPromise: Promise<ProjectionClient> | null = null;
 const clientId = newClientId();
 
 /** Inject a transport for tests; `null` restores the lazily-created real one and
- * drops any active subscription / seed dedup. */
+ * drops any active subscription. */
 export function setConnectionTransportForTest(t: Transport | null): void {
   regionClient?.stop();
   regionClient = null;
   startPromise = null;
   transportInstance = t;
   lastView = EMPTY_VIEW;
-  lastSeededSignature = null;
 }
 
 function transport(): Transport {
@@ -280,7 +224,6 @@ export function stopConnectionsSubscription(): void {
   regionClient = null;
   startPromise = null;
   lastView = EMPTY_VIEW;
-  lastSeededSignature = null;
 }
 
 /** The last view fanned out (for a hook that subscribes after the first diff). */
@@ -288,64 +231,13 @@ export function currentConnectionsView(): ConnectionsView {
   return lastView;
 }
 
-// ── Seed: keep the region a faithful mirror of appStore (connection.replace) ───
-
-let lastSeededSignature: string | null = null;
-
-/**
- * Seed the shared region with `appStore`'s whole connections slice via a
- * `connection.replace` intent, so the projection tracks `appStore`'s current
- * state while `appStore` stays authoritative (the render-side counterpart to the
- * agents bridge's seed). The payload is keyed to the Rust snapshot shape
- * (`folders`/`connections`). De-duplicated: a slice identical to the last seeded
- * one is not re-dispatched. Never throws synchronously — a transport that cannot
- * dispatch surfaces as a rejected promise the caller logs and ignores (staying on
- * the `appStore` fallback). Idempotent server-side: replacing with the same
- * content yields no diff.
- */
-export function seedConnectionsRegion(
-  folders: ConnectionFolder[],
-  connections: SavedConnection[]
-): Promise<void> {
-  const payload = { folders, connections };
-  const signature = JSON.stringify(payload);
-  if (signature === lastSeededSignature) return Promise.resolve();
-  // Set before dispatching so concurrent callers do not double-dispatch the seed.
-  lastSeededSignature = signature;
-  try {
-    return transport()
-      .dispatch({
-        intentId: newIntentId(),
-        kind: "connection.replace",
-        payload,
-        clientId,
-      })
-      .then((ack: IntentAck) => {
-        if (ack.status === "rejected") {
-          // Let a later change retry the seed rather than latch on a failure.
-          lastSeededSignature = null;
-          throw new Error(ack.error?.message ?? "connection.replace rejected");
-        }
-      })
-      .catch((err) => {
-        lastSeededSignature = null;
-        throw err;
-      });
-  } catch (err) {
-    // A synchronous transport-construction failure (non-Tauri, no socket).
-    lastSeededSignature = null;
-    return Promise.reject(err instanceof Error ? err : new Error(String(err)));
-  }
-}
-
 // ── Mutation cut: granular connection.* intent dispatch ───────────────────────
 
 /**
  * The granular `connection.*` intent kinds the mutation cut dispatches (twins of
- * the Rust routes). Excludes `connection.replace`, which is the render-cut
- * whole-slice mirror ({@link seedConnectionsRegion}); the mutation cut drives the
- * region through these per-transition intents instead so the store becomes
- * authoritative.
+ * the Rust routes). Excludes the whole-slice `connection.replace` mirror; the
+ * mutation reducers drive the region through these per-transition intents so the
+ * store tracks each transition.
  */
 export type ConnectionIntentKind =
   | "connection.add"
@@ -389,54 +281,6 @@ export function mirrorConnectionIntent(
   } catch (err) {
     logConnectionBridgeFallback(kind, err);
   }
-}
-
-// ── Faithful-mirror gate ───────────────────────────────────────────────────────
-
-/**
- * Whether a projected `view` faithfully mirrors `appStore`'s connections slice —
- * the gate deciding whether the UI may render from the projection (true) or must
- * fall back to `appStore` (false). A deep value comparison of the ordered folder
- * and connection arrays; because the projected records match the frontend shapes
- * one-to-one, a mirroring view is value-identical to the `appStore` slice, so
- * rendering from it can never diverge.
- *
- * The twin of the agents render cut's `agentsViewMirrors`.
- */
-export function connectionsViewMirrors(
-  view: ConnectionsView | undefined,
-  folders: ConnectionFolder[],
-  connections: SavedConnection[]
-): boolean {
-  if (!view) return false;
-  return deepEqual(view.folders, folders) && deepEqual(view.connections, connections);
-}
-
-/**
- * A structural deep-equal for the JSON-ish connections view model (objects,
- * arrays, and primitives — no functions/dates/maps). Numbers compare with `===`,
- * so an integer that round-tripped through JSON as a float (`22` vs `22.0`) still
- * matches. Exported for the bridge's parity tests.
- */
-export function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (typeof a !== typeof b) return false;
-  if (a === null || b === null) return a === b;
-  if (Array.isArray(a) || Array.isArray(b)) {
-    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
-    return a.every((v, i) => deepEqual(v, b[i]));
-  }
-  if (typeof a === "object" && typeof b === "object") {
-    const ao = a as Record<string, unknown>;
-    const bo = b as Record<string, unknown>;
-    const aKeys = Object.keys(ao);
-    const bKeys = Object.keys(bo);
-    if (aKeys.length !== bKeys.length) return false;
-    return aKeys.every(
-      (k) => Object.prototype.hasOwnProperty.call(bo, k) && deepEqual(ao[k], bo[k])
-    );
-  }
-  return false;
 }
 
 /** Log a bridge fallback so the appStore-path recovery is visible in the LogViewer. */

--- a/src/store/useProjectedConnections.test.tsx
+++ b/src/store/useProjectedConnections.test.tsx
@@ -1,10 +1,9 @@
 /**
- * `useProjectedConnections` — the connection tree sidebar cut to the projected
- * `connections` region (#2225 render cut). Drives the hook against an in-memory
- * substrate double and asserts: flag-off returns the appStore slice and dispatches
- * nothing; flag-on seeds the region (a `connection.replace` mirror) and then
- * renders the slice from the projection, value-identical to appStore; and a region
- * that has not caught up falls back to the appStore slice.
+ * `useProjectedConnections` — the connection tree sidebar reads the authoritative
+ * `connections` region (#2225, PR A). Drives the hook against an in-memory
+ * substrate double and asserts: it renders the server-fed region view directly,
+ * re-renders on every region diff, and never reads the `appStore` slice (no seed,
+ * no mirror gate, no fallback).
  */
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -24,7 +23,6 @@ import type { ConnectionFolder, SavedConnection } from "@/types/connection";
 
 import {
   CONNECTIONS_REGION,
-  setConnectionRenderFromProjectionEnabled,
   setConnectionTransportForTest,
   stopConnectionsSubscription,
   type ConnectionsView,
@@ -57,28 +55,23 @@ function folder(id: string, parentId: string | null = null, isExpanded = true): 
   return { id, name: `F ${id}`, parentId, isExpanded };
 }
 
-/** In-memory substrate double: applies `connection.replace` and fans a snapshot. */
+/** In-memory substrate double: feeds the region via {@link seed} and fans snapshots. */
 class FakeTransport implements Transport {
   dispatched: Intent[] = [];
-  /** When false, `connection.replace` acks but does NOT advance the region. */
-  applyReplace = true;
   private view: Record<string, unknown> = { folders: [], connections: [] };
   private version = 0;
   private handlers: FrameHandler[] = [];
 
+  /** Feed the region as the server-side fold would, and fan the diff out. */
+  seed(view: ConnectionsView): void {
+    this.view = { folders: view.folders, connections: view.connections };
+    this.version += 1;
+    this.fan();
+  }
+
   async dispatch(intent: Intent): Promise<IntentAck> {
     this.dispatched.push(intent);
-    if (intent.kind === "connection.replace" && this.applyReplace) {
-      const p = intent.payload as Record<string, unknown>;
-      this.view = { folders: p.folders ?? [], connections: p.connections ?? [] };
-      this.version += 1;
-      this.fan();
-    }
-    return {
-      intentId: intent.intentId,
-      status: "accepted",
-      produced: [{ region: CONNECTIONS_REGION, version: this.version }],
-    };
+    return { intentId: intent.intentId, status: "accepted", produced: [] };
   }
 
   async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
@@ -131,59 +124,54 @@ beforeEach(() => {
 afterEach(() => {
   stopConnectionsSubscription();
   setConnectionTransportForTest(null);
-  setConnectionRenderFromProjectionEnabled(null);
 });
 
 const flush = () => act(async () => await Promise.resolve());
 
 describe("useProjectedConnections", () => {
-  it("flag off: returns the appStore slice and dispatches nothing", async () => {
-    setConnectionRenderFromProjectionEnabled(false);
-    useAppStore.setState({
-      folders: [folder("Work")],
-      connections: [connection("Work/A", "Work")],
-    });
+  it("renders the server-fed region view directly", async () => {
+    const folders = [folder("Work")];
+    const connections = [connection("Work/A", "Work")];
+    transport.seed({ folders, connections });
 
     const hook = renderHook();
     await flush();
 
-    expect(hook.get().folders[0].id).toBe("Work");
-    expect(hook.get().connections).toHaveLength(1);
+    expect(hook.get().folders).toEqual(folders);
+    expect(hook.get().connections).toEqual(connections);
+    // The authoritative read dispatches nothing (no appStore seed).
     expect(transport.dispatched).toHaveLength(0);
     hook.unmount();
   });
 
-  it("flag on: seeds the region then renders the slice from the projection", async () => {
-    const folders = [folder("Work")];
-    const connections = [connection("Work/A", "Work")];
-    useAppStore.setState({ folders, connections });
-
+  it("re-renders when the region diffs after mount", async () => {
     const hook = renderHook();
     await flush();
+    expect(hook.get().connections).toHaveLength(0);
+
+    act(() => transport.seed({ folders: [folder("A")], connections: [connection("A/1", "A")] }));
     await flush();
 
-    // The hook seeded appStore's slice via connection.replace…
-    expect(transport.dispatched.some((d) => d.kind === "connection.replace")).toBe(true);
-    // …and now renders a value-identical slice (sourced from the projection).
-    expect(hook.get().folders).toEqual(folders);
-    expect(hook.get().connections).toEqual(connections);
+    expect(hook.get().folders[0].id).toBe("A");
+    expect(hook.get().connections[0].id).toBe("A/1");
     hook.unmount();
   });
 
-  it("region not caught up: falls back to the appStore slice", async () => {
-    transport.applyReplace = false; // the replace acks but never advances the region
-    const folders = [folder("Solo", null, false)];
-    const connections = [connection("root-a")];
-    useAppStore.setState({ folders, connections });
+  it("ignores the appStore slice entirely (region is the source of truth)", async () => {
+    // appStore holds a divergent slice; the hook must not read it.
+    useAppStore.setState({
+      folders: [folder("Stale")],
+      connections: [connection("stale-1")],
+    });
+    const regionFolders = [folder("Live")];
+    const regionConnections = [connection("live-1", "Live")];
+    transport.seed({ folders: regionFolders, connections: regionConnections });
 
     const hook = renderHook();
     await flush();
-    await flush();
 
-    // The projection stays empty, so the gate rejects it and the hook renders the
-    // appStore slice verbatim — parity preserved.
-    expect(hook.get().folders).toEqual(folders);
-    expect(hook.get().connections).toEqual(connections);
+    expect(hook.get().folders).toEqual(regionFolders);
+    expect(hook.get().connections).toEqual(regionConnections);
     hook.unmount();
   });
 });

--- a/src/store/useProjectedConnections.ts
+++ b/src/store/useProjectedConnections.ts
@@ -1,68 +1,51 @@
 /**
- * `useProjectedConnections` — the connection tree sidebar cut to the projected
- * `connections` region (#2225 render cut, part of #2139 and #2153).
+ * `useProjectedConnections` — read the authoritative `connections` region (#2225,
+ * part of #2139 and #2153).
  *
- * The connection tree sidebar renders the saved-connection / folder tree (two flat
- * arrays whose nesting is expressed by parent pointers). Through the shadow step it
- * reads `appStore`'s connections slice (`folders` / `connections`) directly. This
- * hook makes it source that slice from the shared `connections` projection region
- * instead — the direct analog of {@link import("./useProjectedAgents").useProjectedAgents}
- * (#2226) and {@link import("./useProjectedMonitors").useProjectedMonitors} (#2224).
+ * The connection tree sidebar ({@link import("../components/Sidebar/ConnectionList").ConnectionList})
+ * renders the saved-connection / folder inventory (two flat arrays whose nesting is
+ * expressed by parent pointers). It sources that inventory from the shared
+ * `connections` projection region, which is now **authoritative**: the backend
+ * `ConnectionsStore` is fed at the source — every persisted saved-connection /
+ * folder mutation and the external-file overlay are folded server-side (#2389 and
+ * #2394) — so the region is the single source of truth. `appStore` still holds a
+ * connections slice for the other, not-yet-migrated readers (the wider
+ * reader-migration + reducer removal is a later step), but the sidebar no longer
+ * reads it.
  *
- * # Safety (strangler)
- *
- * - **Gated** by {@link connectionRenderFromProjectionEnabled} (on by default).
- *   Flag off ⇒ the hook returns `appStore`'s slice verbatim.
- * - **Faithful-mirror gate.** The projection sources the render only when it
- *   deep-equals the `appStore` slice ({@link connectionsViewMirrors}); otherwise the
- *   hook falls back to `appStore` (never a stale view). While `appStore` stays
- *   authoritative (the mutation cut is a later step) the region is kept a mirror by
- *   {@link seedConnectionsRegion}, so it is always populated — making the cut
- *   parity-safe and independent of the mutation flag.
+ * The hook subscribes to the region (one shared subscription, fanned out by the
+ * bridge) and returns the latest projected view, re-rendering on every diff. It
+ * seeds from {@link currentConnectionsView} so a consumer mounting after the first
+ * diff already has the current picture. There is no `appStore` fallback and no
+ * mirror gate — the region is the source of truth.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
-import { useAppStore } from "@/store/appStore";
 import {
-  connectionRenderFromProjectionEnabled,
-  connectionsViewMirrors,
   currentConnectionsView,
   ensureConnectionsSubscribed,
   logConnectionBridgeFallback,
   onConnectionsView,
-  seedConnectionsRegion,
   type ConnectionsView,
 } from "@/store/connectionsBridge";
 
 /**
- * The effective connections slice for rendering: the flat `folders` tree plus the
- * flat `connections` list, sourced from the projected `connections` region when it
- * faithfully mirrors `appStore`, otherwise `appStore`'s slice verbatim (flag off,
- * region not yet caught up, or a transport that cannot subscribe).
+ * The current connections slice for rendering: the flat `folders` tree plus the
+ * flat `connections` list, sourced from the authoritative `connections` projection
+ * region.
  */
 export function useProjectedConnections(): ConnectionsView {
-  const folders = useAppStore((s) => s.folders);
-  const connections = useAppStore((s) => s.connections);
+  const [view, setView] = useState<ConnectionsView>(() => currentConnectionsView());
 
-  // Read the flag once at mount: it flips only via dev tooling, and the
-  // subscription lifecycle is keyed off it below.
-  const [enabled] = useState(() => connectionRenderFromProjectionEnabled());
-
-  const [view, setView] = useState<ConnectionsView | undefined>(undefined);
-
-  // Subscribe to the shared connections region while enabled; a transport that
-  // cannot subscribe (non-Tauri without a socket) just leaves the UI on the
-  // appStore fallback.
   useEffect(() => {
-    if (!enabled) return;
     let cancelled = false;
     const unsubscribe = onConnectionsView((next) => {
       if (!cancelled) setView(next);
     });
     // `ensureConnectionsSubscribed` builds the transport eagerly, so a non-Tauri
-    // env without a socket throws synchronously (not just a rejection) — guard both
-    // so the UI silently stays on the appStore fallback.
+    // env without a socket throws synchronously (not just a rejection) — guard
+    // both so the hook silently stays on the last-known (or empty) view.
     try {
       ensureConnectionsSubscribed()
         .then(() => {
@@ -76,22 +59,7 @@ export function useProjectedConnections(): ConnectionsView {
       cancelled = true;
       unsubscribe();
     };
-  }, [enabled]);
+  }, []);
 
-  const matches = enabled && connectionsViewMirrors(view, folders, connections);
-
-  // Keep the region a faithful mirror of appStore's slice. Only once a view has
-  // arrived (so we are subscribed) and it is not already a mirror; de-duped inside
-  // `seedConnectionsRegion` so a settled slice is not re-seeded on every render.
-  useEffect(() => {
-    if (!enabled || matches || view === undefined) return;
-    seedConnectionsRegion(folders, connections).catch((err) =>
-      logConnectionBridgeFallback("seed", err)
-    );
-  }, [enabled, matches, view, folders, connections]);
-
-  return useMemo(() => {
-    if (matches && view) return view;
-    return { folders, connections };
-  }, [matches, view, folders, connections]);
+  return view;
 }

--- a/src/test/connectionsRegionTestHarness.ts
+++ b/src/test/connectionsRegionTestHarness.ts
@@ -1,0 +1,98 @@
+/**
+ * Test harness for the region-authoritative connection tree sidebar (#2225).
+ *
+ * The sidebar ({@link import("../components/Sidebar/ConnectionList").ConnectionList})
+ * reads the saved-connection / folder inventory from the authoritative
+ * `connections` projection region, not from `appStore`. In production that region
+ * is fed server-side (#2389 / #2394); in a unit/component test there is no backend,
+ * so this harness mirrors `appStore`'s `connections` / `folders` slice into the
+ * region on every change — a faithful stand-in for the server-side fold. It lets a
+ * component test keep seeding `appStore` (the pre-#2225 idiom) while the sidebar
+ * still renders from the region.
+ *
+ * Usage: call {@link setupConnectionsRegionFromAppStore} once at the top of a test
+ * module (or inside a `describe`); it registers its own `beforeEach` / `afterEach`.
+ */
+
+import { afterEach, beforeEach } from "vitest";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import { useAppStore } from "@/store/appStore";
+import {
+  setConnectionsViewForTest,
+  setConnectionTransportForTest,
+  stopConnectionsSubscription,
+  type ConnectionsView,
+} from "@/store/connectionsBridge";
+
+/** The current `appStore` connections slice in region-snapshot shape. */
+function appStoreView(): ConnectionsView {
+  const { folders, connections } = useAppStore.getState();
+  return { folders, connections };
+}
+
+/**
+ * A transport double whose region subscription snapshot always reflects the
+ * current `appStore` slice — so the sidebar hook's mount-time subscribe agrees
+ * with the synchronously-primed region view (no clobber back to empty). Dispatch
+ * is accepted and recorded but drives nothing (mutation intents are validated in
+ * the bridge unit test, not here).
+ */
+class AppStoreBackedTransport implements Transport {
+  dispatched: Intent[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    return { intentId: intent.intentId, status: "accepted", produced: [] };
+  }
+
+  async subscribe(region: string, _onFrame: FrameHandler): Promise<Subscription> {
+    return {
+      snapshot: { kind: "snapshot", region, version: 1, view: structuredClone(appStoreView()) },
+      unsubscribe: () => {},
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+}
+
+/**
+ * Install the appStore→region mirror and return a teardown. Prefer
+ * {@link setupConnectionsRegionFromAppStore}, which wires the lifecycle for you.
+ */
+export function installConnectionsRegionFromAppStore(): () => void {
+  setConnectionTransportForTest(new AppStoreBackedTransport());
+  const prime = () => setConnectionsViewForTest(appStoreView());
+  prime();
+  const unsubscribe = useAppStore.subscribe(prime);
+  return () => {
+    unsubscribe();
+    stopConnectionsSubscription();
+    setConnectionTransportForTest(null);
+  };
+}
+
+/**
+ * Register a `beforeEach` / `afterEach` pair that keeps the authoritative
+ * `connections` region mirrored from `appStore` for the duration of each test in
+ * the current module. Call once at module scope.
+ */
+export function setupConnectionsRegionFromAppStore(): void {
+  let teardown: (() => void) | undefined;
+  beforeEach(() => {
+    teardown = installConnectionsRegionFromAppStore();
+  });
+  afterEach(() => {
+    teardown?.();
+    teardown = undefined;
+  });
+}


### PR DESCRIPTION
First step (PR A) of the Connections Phase-5 reducer-removal (#2225, part of #2139 / #2153), split from the wider inversion. Makes the **connection tree sidebar** read the shared \`connections\` projection region **authoritatively**. This is now non-lossy because the backend \`ConnectionsStore\` is fed at the source: every persisted saved-connection / folder mutation and the external-file overlay are folded server-side (#2389 / PR #2393 and #2394 / PR #2400).

### What changed

1. **The sidebar reads the region directly.** \`useProjectedConnections\` now subscribes to the server-fed \`connections\` region and returns its view — the appStore seed, the deep-equal faithful-mirror gate, and the appStore fallback are gone (mirrors the authoritative \`useProjectedTransfers\` #2229 / \`useProjectedMonitors\` #2224).
2. **Render-side of the bridge trimmed.** \`connectionsBridge\` drops the render flag (\`connectionRenderFromProjectionEnabled\`), the \`connection.replace\` \`seedConnectionsRegion\` mirror, and the \`connectionsViewMirrors\` / \`deepEqual\` gate. The subscription plumbing, \`currentConnectionsView\`, and the mutation-cut \`connection.*\` intents (\`mirrorConnectionIntent\`, still gated by \`connectionIntentsEnabled\`) stay in place for the still-appStore-backed readers.

### Deliberately out of scope (PR B)

- The \`appStore\` \`connections\` / \`folders\` slice and its reducers are **unchanged**.
- The other ~16 components and ~34 internal appStore reads that still read \`appStore.connections\` / \`folders\` are **not** migrated.
- No reducer is removed. Migrating the remaining readers, converting the reducers to backend-command wrappers, and deleting the appStore slice (the data-flow inversion that *closes* #2225) is the larger follow-on, tracked separately — hence **Part of**, not **Closes**.

### Testing

- \`useProjectedConnections\` and \`connectionsBridge\` unit tests rewritten for the authoritative model (region-fed view, mutation-cut dispatch); obsolete render-flag / seed / gate / \`deepEqual\` tests removed.
- New \`src/test/connectionsRegionTestHarness.ts\`: mirrors \`appStore\`'s connections/folders into the region on every change — a faithful stand-in for the server-side fold — so the 12 \`ConnectionList\` component suites (which seed \`appStore\`) still drive the region-authoritative sidebar via a single \`setupConnectionsRegionFromAppStore()\` call. Adds a narrow \`setConnectionsViewForTest\` seam to the bridge.
- Full frontend suite green: **4971 tests / 548 files**; \`tsc\`, ESLint, and Prettier (over \`src/**\` and \`docs/**/*.md\`) all clean. No Rust touched (the server-side feed already landed in #2389 / #2394).
- No user-facing change (parity preserved), so no changelog fragment.

Part of #2225