### PR TITLE
feat(agent): fold server-owned agent entry-creation + list-load into the projection store (Closes #2403)

### DIFF
--- a/src-tauri/src/agents_projection/projection.rs
+++ b/src-tauri/src/agents_projection/projection.rs
@@ -63,8 +63,11 @@ use tauri::{AppHandle, Manager};
 
 use crate::agents_projection::store::{
     AgentConnectionState, AgentDefinition, AgentEntry, AgentFolder, AgentSession, AgentsStore,
+    SavedAgentSeed,
 };
 use crate::commands::projection::ProjectionState;
+use crate::connection::config::SavedRemoteAgent;
+use crate::connection::manager::ConnectionManager;
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
 
 /// The projection region id for the agents domain (shared, per Open Design
@@ -118,6 +121,70 @@ pub fn fold_agent_transition<R: tauri::Runtime>(
     apply(store.inner().as_ref());
     if let Some(projection) = app_handle.try_state::<ProjectionState>() {
         publish_agents(&projection.projector, store.inner().as_ref());
+    }
+}
+
+/// Serialise one persisted agent into a [`SavedAgentSeed`] — the persisted-only
+/// input to [`AgentsStore::reflect_saved_agents`]. The `config` / `agentSettings`
+/// blobs are serialised with the same serde attributes the frontend receives from
+/// `load_connections_and_folders`, so a server-created entry and the client
+/// `agent.add` mirror carry the identical shape (a parity swap for #2226). A
+/// serialisation failure (should not happen for these plain structs) degrades the
+/// blob to `null` rather than dropping the agent from the list.
+fn saved_agent_seed(agent: SavedRemoteAgent) -> SavedAgentSeed {
+    SavedAgentSeed {
+        id: agent.id,
+        name: agent.name,
+        config: serde_json::to_value(agent.config).unwrap_or(Value::Null),
+        agent_settings: serde_json::to_value(agent.agent_settings).unwrap_or(Value::Null),
+    }
+}
+
+/// Reflect the whole persisted agent list from the [`ConnectionManager`] authority
+/// into the managed [`AgentsStore`] **server-side**, making the `agents` region
+/// authoritative for **list-membership** — entry creation + list load, the gap
+/// #2388 deferred (#2403, prerequisite for #2226).
+///
+/// This is the list-membership counterpart to [`fold_agent_transition`]: where the
+/// per-field #2388 folds (`set_status` / `set_definitions` / …) update an
+/// **existing** entry and are a no-op for an unknown id, this feeds the store the
+/// full persisted agent set (via [`ConnectionManager::load_unified_view`] +
+/// [`AgentsStore::reflect_saved_agents`]) so a newly-added agent's identity enters
+/// the region without a client `agent.add`, and a boot / reload reflects the whole
+/// persisted list. It is the agents analog of
+/// `connections_projection::fold_connections_from_manager` (#2389/#2394) — the
+/// difference being that an agent's live status lives only in the store, so
+/// `reflect_saved_agents` preserves it for surviving ids rather than replacing the
+/// whole slice.
+///
+/// It is **additive**: the persisted-list authority and the client `agent.*` mirror
+/// stay in place, and nothing in the live UI subscribes to the region yet, so this
+/// changes no user-facing behavior. Best-effort and non-fatal: if the store, the
+/// connection manager, or the projection state is not managed (e.g. a headless
+/// unit-test app that never ran `setup()`), or the disk reload inside
+/// `load_unified_view` fails, the fold is skipped rather than erroring.
+pub fn fold_agents_from_manager<R: tauri::Runtime>(app_handle: &AppHandle<R>) {
+    let Some(manager) = app_handle.try_state::<ConnectionManager>() else {
+        return;
+    };
+    let Ok(view) = manager.load_unified_view() else {
+        return;
+    };
+    let seeds: Vec<SavedAgentSeed> = view.agents.into_iter().map(saved_agent_seed).collect();
+    fold_agent_transition(app_handle, |store| store.reflect_saved_agents(seeds));
+}
+
+/// Reflect the persisted agent list from the [`ConnectionManager`] into the store
+/// **without** a projector publish — the startup-seed counterpart to
+/// [`fold_agents_from_manager`] (#2403). Used by `lib.rs::setup()` to seed the
+/// `agents` region from the persisted list before the region is registered (the
+/// projector is not built yet at that point), so a subscriber attaching before the
+/// first `agent.*` intent sees the real agent list rather than an empty baseline —
+/// the agents analog of the `connections` startup seed (#2389). A disk-reload
+/// failure leaves the store empty rather than erroring.
+pub fn seed_agents_from_manager(store: &AgentsStore, manager: &ConnectionManager) {
+    if let Ok(view) = manager.load_unified_view() {
+        store.reflect_saved_agents(view.agents.into_iter().map(saved_agent_seed).collect());
     }
 }
 

--- a/src-tauri/src/agents_projection/projection_tests.rs
+++ b/src-tauri/src/agents_projection/projection_tests.rs
@@ -19,7 +19,7 @@ use tauri::Manager;
 
 use crate::agents_projection::projection::{fold_agent_transition, publish_agents, AGENTS_REGION};
 use crate::agents_projection::store::{
-    AgentConnectionState, AgentDefinition, AgentFolder, AgentSession, AgentsStore,
+    AgentConnectionState, AgentDefinition, AgentFolder, AgentSession, AgentsStore, SavedAgentSeed,
 };
 use crate::commands::projection::ProjectionState;
 use crate::projection::{
@@ -705,4 +705,133 @@ fn server_side_fold_is_a_noop_without_managed_state() {
     fold_agent_transition(app.handle(), |s| {
         s.set_status("a1", AgentConnectionState::Connected, None)
     });
+}
+
+// ── Server-owned list-membership fold (#2403, prerequisite for #2226) ──────────
+//
+// These drive `reflect_saved_agents` through the production `fold_agent_transition`
+// end to end against a `mock_app()` — the exact store+publish path
+// `fold_agents_from_manager` / `seed_agents_from_manager` run once they have read
+// the `ConnectionManager` agent list. They prove the region carries full
+// list-membership fed from the backend (entry creation for an unknown id, a whole
+// list load, and a boot/reload reflecting the persisted list) **without any client
+// `agent.add` dispatch**. The thin manager-reading wiring is integration-verified
+// via a local `./scripts/dev.sh` run (same as the #2388 folds).
+
+/// A persisted-list seed carrying only the backend-owned fields.
+fn seed(id: &str, name: &str, host: &str) -> SavedAgentSeed {
+    SavedAgentSeed {
+        id: id.to_string(),
+        name: name.to_string(),
+        config: json!({ "host": host }),
+        agent_settings: json!({}),
+    }
+}
+
+/// A list-load fold creates the whole persisted agent list in the region — with no
+/// client `agent.add` — and fans one diff out to every subscriber.
+#[test]
+fn server_side_list_load_fold_creates_membership_without_client_dispatch() {
+    let app = tauri::test::mock_app();
+    // The store starts empty — the analog of a boot before any client seed.
+    let store = Arc::new(AgentsStore::new());
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(AGENTS_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    let snap = projection
+        .projector
+        .subscribe(AGENTS_REGION, "sub", "C", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+    app.manage(projection);
+
+    // Server folds the persisted agent list at the source — no `agent.add` runs.
+    fold_agent_transition(app.handle(), |s| {
+        s.reflect_saved_agents(vec![seed("a1", "One", "h1"), seed("a2", "Two", "h2")])
+    });
+
+    // The store is authoritative for list-membership server-side.
+    assert_eq!(store.agent_ids(), vec!["a1", "a2"]);
+
+    // Exactly one region diff; the client cache converges with no round-trip.
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "one diff from the server-side list load");
+    cache.apply(&diffs[0]);
+    assert_eq!(cache.view["agents"][0]["id"], json!("a1"));
+    assert_eq!(cache.view["agents"][1]["id"], json!("a2"));
+    assert_eq!(
+        cache.view["agents"][0]["connectionState"],
+        json!("disconnected")
+    );
+}
+
+/// An entry-creation fold for an id **not** already in the store creates it — the
+/// gap #2388's per-field folds (all no-ops for an unknown id) left open.
+#[test]
+fn server_side_fold_creates_an_unknown_agent_entry() {
+    let app = tauri::test::mock_app();
+    let store = Arc::new(AgentsStore::new());
+    store.add("a1", "One", json!({ "host": "h1" }), json!({}));
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(AGENTS_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    projection
+        .projector
+        .subscribe(AGENTS_REGION, "sub", "C", sink.clone());
+    app.manage(projection);
+
+    // A newly-added agent's identity enters the region via the persisted list —
+    // the a2 id was never dispatched client-side.
+    fold_agent_transition(app.handle(), |s| {
+        s.reflect_saved_agents(vec![seed("a1", "One", "h1"), seed("a2", "Two", "h2")])
+    });
+
+    assert_eq!(store.agent_ids(), vec!["a1", "a2"]);
+    assert_eq!(sink.diffs().len(), 1, "the new entry advanced the region");
+}
+
+/// The boot/reload fold reflects the persisted list while **preserving** the live
+/// status the store owns for a surviving agent (a reload must not reset an
+/// in-flight connection).
+#[test]
+fn server_side_list_fold_preserves_live_status_on_reload() {
+    let app = tauri::test::mock_app();
+    let store = Arc::new(AgentsStore::new());
+    store.add("a1", "One", json!({ "host": "h1" }), json!({}));
+    store.set_status("a1", AgentConnectionState::Connected, None);
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(AGENTS_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    projection
+        .projector
+        .subscribe(AGENTS_REGION, "sub", "C", sink.clone());
+    app.manage(projection);
+
+    // A reload reflects the persisted list; a1 survives (renamed) + a2 is added.
+    fold_agent_transition(app.handle(), |s| {
+        s.reflect_saved_agents(vec![
+            seed("a1", "One Renamed", "h1"),
+            seed("a2", "Two", "h2"),
+        ])
+    });
+
+    let a1 = store.get("a1").expect("a1 survives the reload");
+    assert_eq!(a1.name, "One Renamed");
+    assert_eq!(
+        a1.connection_state,
+        AgentConnectionState::Connected,
+        "the reload preserves the in-flight connection state"
+    );
+    assert_eq!(store.agent_ids(), vec!["a1", "a2"]);
 }

--- a/src-tauri/src/agents_projection/store.rs
+++ b/src-tauri/src/agents_projection/store.rs
@@ -28,7 +28,7 @@
 //! steps cut rendering, then mutation, over to the region, then remove the
 //! `appStore` state.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, MutexGuard};
 
 use serde::{Deserialize, Serialize};
@@ -98,6 +98,28 @@ impl AgentEntry {
             last_error: None,
         }
     }
+}
+
+/// The persisted identity of one configured agent, as produced by the backend
+/// authority (the `ConnectionManager` agent list) — the input to
+/// [`AgentsStore::reflect_saved_agents`] (#2403).
+///
+/// Carries **only** the persisted fields the backend owns (id / name / config /
+/// settings); it deliberately excludes the live status the store owns
+/// (connection state, capabilities, last error, expansion, sessions), so
+/// reflecting the persisted list can create/refresh list-membership without
+/// clobbering an agent's in-flight connection state.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SavedAgentSeed {
+    /// Stable agent id.
+    pub id: String,
+    /// Human-readable agent name.
+    pub name: String,
+    /// The agent's `RemoteAgentConfig`, serialised opaquely (matches the shape
+    /// the frontend stores, so the eventual render cut is a parity swap).
+    pub config: Value,
+    /// The agent's `AgentSettings`, serialised opaquely.
+    pub agent_settings: Value,
 }
 
 /// A live remote session on an agent — mirrors the frontend `AgentSessionInfo`.
@@ -203,6 +225,67 @@ impl AgentsStore {
         inner
             .agents
             .push(AgentEntry::new(id, name, config, agent_settings));
+    }
+
+    /// Reflect the whole persisted agent list into the store from the backend
+    /// authority (the `ConnectionManager` agent list), making the `agents` region
+    /// authoritative for **list-membership** — not just the per-field status /
+    /// sessions / definitions / folders #2388 already folds (#2403, prerequisite
+    /// for #2226).
+    ///
+    /// This is the entry-**creation** + list-**load** counterpart to the #2388
+    /// per-field setters (all of which are a no-op for an unknown id): the persisted
+    /// list is the sole source of agent identity, so the store must reflect it to be
+    /// authoritative. It is the agents analog of the `connections_projection`
+    /// `ConnectionsStore::replace` from the manager snapshot (#2389), the difference
+    /// being that an agent's **live status lives only in the store** (never in the
+    /// persisted config), so this reflects list-membership *without* the clobbering a
+    /// naive whole-slice replace would cause:
+    ///
+    /// - a `seed` whose id is **new** → a fresh disconnected entry (like [`Self::add`]);
+    /// - a `seed` whose id **exists** → its persisted fields (name / config / settings)
+    ///   are refreshed while its live status (connection state, capabilities, last
+    ///   error, expansion) and its sessions / definitions / folders are **preserved**;
+    /// - an existing agent **absent** from `seed`s → dropped, along with its
+    ///   sessions / definitions / folders (it was deleted from the persisted list).
+    ///
+    /// The resulting list order follows `seeds` (the persisted order the frontend's
+    /// `reorderRemoteAgents` writes back), so the region mirrors the sidebar order.
+    /// Idempotent: reflecting the same list twice yields no change, so it composes
+    /// with the still-present client `agent.*` mirror without drift.
+    pub fn reflect_saved_agents(&self, seeds: Vec<SavedAgentSeed>) {
+        let mut inner = self.lock();
+        // Index the current entries by id so surviving agents keep their live status.
+        let mut previous: HashMap<String, AgentEntry> = std::mem::take(&mut inner.agents)
+            .into_iter()
+            .map(|entry| (entry.id.clone(), entry))
+            .collect();
+        let mut kept: HashSet<String> = HashSet::with_capacity(seeds.len());
+        let mut next: Vec<AgentEntry> = Vec::with_capacity(seeds.len());
+        for seed in seeds {
+            kept.insert(seed.id.clone());
+            match previous.remove(&seed.id) {
+                // Existing agent: refresh persisted fields, preserve live status.
+                Some(mut entry) => {
+                    entry.name = seed.name;
+                    entry.config = seed.config;
+                    entry.agent_settings = seed.agent_settings;
+                    next.push(entry);
+                }
+                // New agent: a fresh disconnected entry.
+                None => next.push(AgentEntry::new(
+                    &seed.id,
+                    &seed.name,
+                    seed.config,
+                    seed.agent_settings,
+                )),
+            }
+        }
+        inner.agents = next;
+        // Drop the sub-state of agents no longer in the persisted list.
+        inner.sessions.retain(|id, _| kept.contains(id));
+        inner.definitions.retain(|id, _| kept.contains(id));
+        inner.folders.retain(|id, _| kept.contains(id));
     }
 
     /// `agent.update` — update one agent's persisted fields (name, config,

--- a/src-tauri/src/agents_projection/store_tests.rs
+++ b/src-tauri/src/agents_projection/store_tests.rs
@@ -6,7 +6,9 @@
 
 use serde_json::json;
 
-use super::{AgentConnectionState, AgentDefinition, AgentFolder, AgentSession, AgentsStore};
+use super::{
+    AgentConnectionState, AgentDefinition, AgentFolder, AgentSession, AgentsStore, SavedAgentSeed,
+};
 
 /// A deterministic agent config blob.
 fn config(host: &str) -> serde_json::Value {
@@ -49,6 +51,17 @@ fn session(id: &str) -> AgentSession {
         status: "running".to_string(),
         attached: true,
         definition_id: None,
+    }
+}
+
+/// A persisted-list seed (id / name / config / settings) — the input to
+/// `reflect_saved_agents`, carrying only the persisted fields the backend owns.
+fn seed(id: &str, name: &str, host: &str) -> SavedAgentSeed {
+    SavedAgentSeed {
+        id: id.to_string(),
+        name: name.to_string(),
+        config: config(host),
+        agent_settings: settings(),
     }
 }
 
@@ -511,6 +524,113 @@ fn replace_with_empty_maps_clears_everything() {
         Default::default(),
     );
 
+    assert_eq!(
+        store.snapshot(),
+        json!({ "agents": [], "sessions": {}, "definitions": {}, "folders": {} })
+    );
+}
+
+// ── reflect_saved_agents — server-owned list-membership (#2403) ────────────────
+
+#[test]
+fn reflect_saved_agents_creates_entries_on_an_empty_store() {
+    let store = AgentsStore::new();
+    // The list-load path feeds the whole persisted list; entries are created.
+    store.reflect_saved_agents(vec![seed("a1", "One", "h1"), seed("a2", "Two", "h2")]);
+
+    assert_eq!(store.agent_ids(), vec!["a1", "a2"]);
+    let a1 = store.get("a1").expect("a1 created");
+    assert_eq!(a1.name, "One");
+    assert_eq!(a1.config, config("h1"));
+    // A freshly reflected agent starts disconnected/collapsed (live status is
+    // store-owned, never carried by the persisted list).
+    assert_eq!(a1.connection_state, AgentConnectionState::Disconnected);
+    assert!(!a1.is_expanded);
+    assert_eq!(a1.capabilities, None);
+}
+
+#[test]
+fn reflect_saved_agents_preserves_live_status_of_surviving_ids() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    // Give a1 live status + sub-state that only lives in the store.
+    store.set_status("a1", AgentConnectionState::Connected, None);
+    store.set_capabilities("a1", json!({ "maxSessions": 4 }));
+    store.toggle_expanded("a1");
+    store.refresh(
+        "a1",
+        vec![session("s1")],
+        vec![definition("d1", None)],
+        vec![folder("f1")],
+    );
+
+    // A reload reflects the persisted list; a1 survives with a renamed config.
+    store.reflect_saved_agents(vec![seed("a1", "One Renamed", "h1-new")]);
+
+    let a1 = store.get("a1").expect("a1 survives");
+    // Persisted fields refreshed…
+    assert_eq!(a1.name, "One Renamed");
+    assert_eq!(a1.config, config("h1-new"));
+    // …live status preserved.
+    assert_eq!(a1.connection_state, AgentConnectionState::Connected);
+    assert_eq!(a1.capabilities, Some(json!({ "maxSessions": 4 })));
+    assert!(a1.is_expanded);
+    // Sub-state preserved for the surviving id.
+    assert_eq!(store.definitions_of("a1").len(), 1);
+    assert_eq!(store.folders_of("a1").len(), 1);
+    assert_eq!(
+        store.snapshot()["sessions"]["a1"].as_array().unwrap().len(),
+        1
+    );
+}
+
+#[test]
+fn reflect_saved_agents_drops_ids_absent_from_the_list() {
+    let store = AgentsStore::new();
+    store.reflect_saved_agents(vec![seed("a1", "One", "h1"), seed("a2", "Two", "h2")]);
+    store.refresh(
+        "a2",
+        vec![session("s1")],
+        vec![definition("d1", None)],
+        vec![],
+    );
+
+    // a2 is deleted from the persisted list → gone from the region, sub-state too.
+    store.reflect_saved_agents(vec![seed("a1", "One", "h1")]);
+
+    assert_eq!(store.agent_ids(), vec!["a1"]);
+    assert!(store.get("a2").is_none());
+    let view = store.snapshot();
+    assert!(view["sessions"].get("a2").is_none());
+    assert!(view["definitions"].get("a2").is_none());
+}
+
+#[test]
+fn reflect_saved_agents_follows_the_persisted_list_order() {
+    let store = AgentsStore::new();
+    store.reflect_saved_agents(vec![seed("a1", "One", "h1"), seed("a2", "Two", "h2")]);
+    // The persisted order (what `reorderRemoteAgents` writes back) is reflected.
+    store.reflect_saved_agents(vec![seed("a2", "Two", "h2"), seed("a1", "One", "h1")]);
+    assert_eq!(store.agent_ids(), vec!["a2", "a1"]);
+}
+
+#[test]
+fn reflect_saved_agents_is_idempotent() {
+    let store = AgentsStore::new();
+    let list = vec![seed("a1", "One", "h1"), seed("a2", "Two", "h2")];
+    store.reflect_saved_agents(list.clone());
+    let first = store.snapshot();
+    store.reflect_saved_agents(list);
+    // Reflecting the same list twice yields the identical view (no drift alongside
+    // the still-present client mirror).
+    assert_eq!(store.snapshot(), first);
+}
+
+#[test]
+fn reflect_saved_agents_with_an_empty_list_clears_membership() {
+    let store = AgentsStore::new();
+    store.reflect_saved_agents(vec![seed("a1", "One", "h1")]);
+    store.reflect_saved_agents(Vec::new());
     assert_eq!(
         store.snapshot(),
         json!({ "agents": [], "sessions": {}, "definitions": {}, "folders": {} })

--- a/src-tauri/src/commands/connection.rs
+++ b/src-tauri/src/commands/connection.rs
@@ -34,6 +34,7 @@ pub struct ExternalFileError {
 /// Load all saved connections, folders, and agents (unified view).
 #[tauri::command]
 pub fn load_connections_and_folders(
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
 ) -> Result<ConnectionData, String> {
     info!("Loading connections and folders");
@@ -41,6 +42,12 @@ pub fn load_connections_and_folders(
     // `ConnectionsStore` server-side, #2394), so the command and the projection
     // region cannot drift.
     let view = manager.load_unified_view().map_err(|e| e.to_string())?;
+
+    // Server-authority fold (#2403): reflect the loaded agent list-membership into
+    // the shadow `AgentsStore` at the source, so the `agents` region tracks the
+    // persisted list on a reload — not only the client seed. Additive; no
+    // user-facing change.
+    crate::agents_projection::projection::fold_agents_from_manager(&app);
 
     Ok(ConnectionData {
         connections: view.connections,
@@ -228,29 +235,42 @@ pub fn reload_external_connections(
 #[tauri::command]
 pub fn save_remote_agent(
     agent: SavedRemoteAgent,
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
 ) -> Result<(), String> {
-    manager.save_agent(agent).map_err(|e| e.to_string())
+    manager.save_agent(agent).map_err(|e| e.to_string())?;
+    // Server-authority fold (#2403): reflect the persisted agent list-membership
+    // into the shadow `AgentsStore` at the source, so a newly-added agent's identity
+    // enters the `agents` region without a client `agent.add`. Additive; no
+    // user-facing change.
+    crate::agents_projection::projection::fold_agents_from_manager(&app);
+    Ok(())
 }
 
 /// Delete a remote agent definition by ID.
 #[tauri::command]
 pub fn delete_remote_agent(
     id: String,
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
 ) -> Result<(), String> {
-    manager.delete_agent(&id).map_err(|e| e.to_string())
+    manager.delete_agent(&id).map_err(|e| e.to_string())?;
+    crate::agents_projection::projection::fold_agents_from_manager(&app);
+    Ok(())
 }
 
 /// Reorder remote agents by providing a list of agent IDs in the desired order.
 #[tauri::command]
 pub fn reorder_remote_agents(
     agent_ids: Vec<String>,
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
 ) -> Result<(), String> {
     manager
         .reorder_agents(&agent_ids)
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    crate::agents_projection::projection::fold_agents_from_manager(&app);
+    Ok(())
 }
 
 /// Export connections with optional encrypted credentials.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -923,12 +923,24 @@ pub fn run() {
                         store.snapshot(),
                     );
                 }
-                // Seed the shared `agents` region with the (empty) store baseline
-                // at version 0, so a subscriber attaches to a real region before
-                // the first `agent.*` intent (#2226).
+                // Seed the shared `agents` region from the persisted
+                // `ConnectionManager` agent list (#2403), so the shadow store — and
+                // the region a subscriber attaches to before the first `agent.*`
+                // intent — reflects the real agent list-membership from startup
+                // rather than an empty baseline. Seeding the persisted list here is
+                // the startup counterpart to `fold_agents_from_manager`, which keeps
+                // the store's list-membership in sync on every later add / delete /
+                // reorder / reload (#2226). The per-agent live status stays store-
+                // owned and starts disconnected.
                 if let Some(store) =
                     app.handle().try_state::<Arc<agents_projection::AgentsStore>>()
                 {
+                    if let Some(manager) = app.handle().try_state::<ConnectionManager>() {
+                        agents_projection::projection::seed_agents_from_manager(
+                            store.inner().as_ref(),
+                            manager.inner(),
+                        );
+                    }
                     projection_state.projector.register_region(
                         agents_projection::projection::AGENTS_REGION,
                         store.snapshot(),


### PR DESCRIPTION
## What

Makes the shadow \`AgentsStore\` (the \`agents\` projection region) **server-authoritative for agent list-membership** — entry creation + list load — the gap the Agents step-1 #2388 (PR #2392) explicitly deferred. #2388 folded the live status / sessions / definitions / folders of **existing** entries, but every one of those folds is a no-op for an unknown id, nothing server-side created an agent entry or loaded the list, and boot hydrated the region only via the client render-cut seed. So the region was **not** authoritative for list-membership, which blocks #2226's reducer-removal (dropping the client seed would empty the sidebar at boot).

This feeds the store the persisted list from the source, so #2226's data-flow inversion becomes non-lossy. It is the agents analog of Connections #2389/#2394 (\`fold_connections_from_manager\` from the \`ConnectionManager\` snapshot) and Monitors #2385 (server owns entry creation).

## The source of the agent list

Agent list-membership is persisted by the \`ConnectionManager\` (the same authority as saved connections): \`save_agent\` / \`delete_agent\` / \`reorder_agents\`, exposed by the \`save_remote_agent\` / \`delete_remote_agent\` / \`reorder_remote_agents\` commands, and read via \`load_unified_view().agents\` (what \`load_connections_and_folders\` returns to the frontend). These are exactly the analog of the connection commands #2389/#2394 fold at.

## Changes

- **New \`AgentsStore::reflect_saved_agents\`** (\`agents_projection/store.rs\`): reflects the whole persisted agent list into the store — creating a fresh disconnected entry for a new id, refreshing the persisted fields (name/config/settings) of a surviving id **while preserving the live status the store owns** (connection state, capabilities, last error, expansion, sessions/definitions/folders), and dropping an id absent from the list. Order follows the persisted list (the sidebar order \`reorderRemoteAgents\` writes back). Idempotent. Takes a new persisted-only \`SavedAgentSeed\` input so the store stays decoupled from the \`connection\` config types.
  - Unlike Connections' whole-slice \`replace\`, an agent's live status lives **only** in the store (never in the persisted config), so reflecting list-membership must preserve it for surviving ids rather than clobber it — hence a bespoke merge, not \`replace\`.
- **New \`fold_agents_from_manager\` + \`seed_agents_from_manager\`** (\`agents_projection/projection.rs\`): resolve the \`ConnectionManager\`, serialise \`load_unified_view().agents\` into \`SavedAgentSeed\`s (same serde shape the frontend receives, so a server-created entry and the client \`agent.add\` mirror are a parity swap), and reflect them into the store — the fold publishes the region diff; the seed variant is the publish-free startup counterpart. Best-effort/non-fatal when unmanaged.
- **Fold at the source** (\`commands/connection.rs\`): \`save_remote_agent\` (entry creation — a new agent's identity enters the region with no client \`agent.add\`), \`delete_remote_agent\`, \`reorder_remote_agents\`, and \`load_connections_and_folders\` (a reload reflects the list) fold after the manager mutation. \`AppHandle\` is Tauri-injected — no change to the JS invoke surface.
- **Startup seed** (\`lib.rs\`): the \`agents\` region is now seeded from the persisted \`ConnectionManager\` agent list instead of an empty baseline, so a subscriber attaching before the first \`agent.*\` intent sees the real agent list from boot. The per-agent live status stays store-owned and starts disconnected.
- **Tests**: store-level unit tests for \`reflect_saved_agents\` (unknown-id creation, full list load, live-status preservation for surviving ids, drop of absent ids, persisted order, idempotence, empty-list clear) and projection-level tests driving the list load through the production \`fold_agent_transition\` end to end against \`tauri::test::mock_app()\` (membership created with no client dispatch, unknown-id creation, live status preserved on reload).

## Additive / no user-facing change

- The persisted-list authority and the client \`agent.*\` mirror (incl. the render-cut \`agent.replace\` seed) stay in place; nothing in the live UI subscribes to the \`agents\` region yet, so the UI is unchanged. \`src/store/appStore.ts\` is intentionally untouched. Dropping the redundant client seed / inverting the data flow is the later #2226 step.
- Backend-only, no user-facing behavior change → no changelog fragment.

## Verification

- \`cargo test -p termihub --lib agents_projection\` — 43 pass (11 new)
- \`cargo test -p termihub --lib connection::\` — 195 pass
- \`cargo build\`, \`cargo fmt -- --check\`, \`cargo clippy --all-targets --all-features -- -D warnings\` — clean
- The manager-reading wiring (\`fold_agents_from_manager\` / \`seed_agents_from_manager\`) is thin and integration-verified via a local \`./scripts/dev.sh\` run, same as the #2388 folds; the store+publish path it uses is covered by the \`mock_app()\` tests.

Closes #2403
Part of #2226