### PR TITLE
refactor(settings): make the settings hook read the projection region authoritatively (Part of #2227)

### DIFF
--- a/src/components/ConnectionEditor/ConnectionEditor.experimental-gating.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.experimental-gating.test.tsx
@@ -5,6 +5,7 @@
  * (those reporting `capabilities.graphical`) unless `experimentalFeaturesEnabled`
  * is on. When it is on, those types appear labelled "— Experimental".
  */
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -100,6 +101,8 @@ afterEach(() => {
   });
   container.remove();
 });
+
+setupSettingsRegionMirror();
 
 describe("ConnectionEditor — experimental type-picker gating", () => {
   it("omits graphical remote-desktop types when the flag is off", () => {

--- a/src/components/ConnectionEditor/ConnectionEditor.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionEditor.test.tsx
@@ -1,3 +1,4 @@
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { flushMacrotask } from "@/test/flushAsync";
@@ -111,6 +112,8 @@ function render() {
     );
   });
 }
+
+setupSettingsRegionMirror();
 
 describe("ConnectionEditor — credential hint", () => {
   beforeEach(() => {

--- a/src/components/ConnectionEditor/ConnectionTerminalSettings.test.tsx
+++ b/src/components/ConnectionEditor/ConnectionTerminalSettings.test.tsx
@@ -1,3 +1,4 @@
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -77,6 +78,8 @@ function fieldInput(label: string): HTMLInputElement {
   );
   return el?.closest(".settings-form__field")?.querySelector("input") as HTMLInputElement;
 }
+
+setupSettingsRegionMirror();
 
 describe("ConnectionTerminalSettings — scrollback buffer", () => {
   beforeEach(() => {

--- a/src/components/NetworkTools/PortScannerPanel.dont-warn-again.test.tsx
+++ b/src/components/NetworkTools/PortScannerPanel.dont-warn-again.test.tsx
@@ -8,6 +8,7 @@
  * directly without the warning; cancelling does not persist the opt-out; and
  * re-enabling the setting brings the warning back.
  */
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -108,6 +109,8 @@ async function completeScan() {
   });
   await flush();
 }
+
+setupSettingsRegionMirror();
 
 describe("PortScannerPanel — large-scan don't-warn-again opt-out (#1877)", () => {
   beforeEach(() => {

--- a/src/components/Settings/CustomGrammarsSettings.test.tsx
+++ b/src/components/Settings/CustomGrammarsSettings.test.tsx
@@ -1,3 +1,4 @@
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -48,6 +49,8 @@ function click(testId: string) {
     (container.querySelector(`[data-testid="${testId}"]`) as HTMLElement).click();
   });
 }
+
+setupSettingsRegionMirror();
 
 describe("CustomGrammarsSettings", () => {
   beforeEach(() => {

--- a/src/components/Settings/FileTypeSettings.test.tsx
+++ b/src/components/Settings/FileTypeSettings.test.tsx
@@ -1,3 +1,4 @@
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -35,6 +36,8 @@ function click(testId: string) {
     (container.querySelector(`[data-testid="${testId}"]`) as HTMLElement).click();
   });
 }
+
+setupSettingsRegionMirror();
 
 describe("FileTypeSettings", () => {
   beforeEach(() => {

--- a/src/components/Settings/LanguagePackagesSettings.test.tsx
+++ b/src/components/Settings/LanguagePackagesSettings.test.tsx
@@ -1,3 +1,4 @@
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -38,6 +39,8 @@ function click(testId: string) {
     (container.querySelector(`[data-testid="${testId}"]`) as HTMLElement).click();
   });
 }
+
+setupSettingsRegionMirror();
 
 describe("LanguagePackagesSettings", () => {
   beforeEach(() => {

--- a/src/components/Settings/SecuritySettings.test.tsx
+++ b/src/components/Settings/SecuritySettings.test.tsx
@@ -1,3 +1,4 @@
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -45,6 +46,8 @@ function render(props: { visibleFields?: Set<string> } = {}) {
 function query(testId: string): Element | null {
   return container.querySelector(`[data-testid="${testId}"]`);
 }
+
+setupSettingsRegionMirror();
 
 describe("SecuritySettings", () => {
   beforeEach(() => {

--- a/src/components/Settings/SerialPortSettings.projection.test.tsx
+++ b/src/components/Settings/SerialPortSettings.projection.test.tsx
@@ -1,97 +1,29 @@
 /**
- * `SerialPortSettings` render-cut parity (#2227). Proves the settings screen reader
- * sources its document from the projected `settings` region: with the render flag
- * on and the region a faithful mirror of `appStore`, the panel renders the
- * projected serial-port prefixes; when the region cannot catch up it falls back to
- * `appStore` verbatim, so the output is byte-identical to the pre-cut path.
+ * `SerialPortSettings` region-authoritative render (#2227). Proves the settings
+ * screen reader sources its document from the authoritative `settings` projection
+ * region: seeded with serial-port prefixes, the panel renders them; a later region
+ * diff re-renders the panel. No `appStore` fallback — the region is the source of
+ * truth.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 
-import type {
-  FrameHandler,
-  Intent,
-  IntentAck,
-  ProjectionFrame,
-  SnapshotFrame,
-  Subscription,
-  Transport,
-} from "@/services/transport";
 import { useAppStore } from "@/store/appStore";
 import { TooltipProvider } from "@/components/ui";
-import type { AppSettings } from "@/types/connection";
 import {
-  SETTINGS_REGION,
-  setSettingsRenderFromProjectionEnabled,
-  setSettingsTransportForTest,
-  stopSettingsSubscription,
-} from "@/store/settingsBridge";
+  FakeSettingsTransport,
+  installSettingsHarness,
+  settingsDoc,
+} from "@/test/settingsRegionTestHarness";
 
 import { SerialPortSettings } from "./SerialPortSettings";
 
 vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn(() => vi.fn()) }));
 
-function settings(overrides: Partial<AppSettings> = {}): AppSettings {
-  return {
-    version: "1",
-    externalConnectionFiles: [],
-    powerMonitoringEnabled: true,
-    fileBrowserEnabled: true,
-    ...overrides,
-  };
-}
-
-/** In-memory substrate double: applies `settings.replace` and fans a snapshot. */
-class FakeTransport implements Transport {
-  dispatched: Intent[] = [];
-  applyReplace = true;
-  private view: Record<string, unknown> = { version: "1", externalConnectionFiles: [] };
-  private version = 0;
-  private handlers: FrameHandler[] = [];
-
-  async dispatch(intent: Intent): Promise<IntentAck> {
-    this.dispatched.push(intent);
-    if (intent.kind === "settings.replace" && this.applyReplace) {
-      const p = intent.payload as Record<string, unknown>;
-      this.view = (p.settings ?? {}) as Record<string, unknown>;
-      this.version += 1;
-      this.fan();
-    }
-    return {
-      intentId: intent.intentId,
-      status: "accepted",
-      produced: [{ region: SETTINGS_REGION, version: this.version }],
-    };
-  }
-
-  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
-    this.handlers.push(onFrame);
-    return {
-      snapshot: this.snapshot(region),
-      unsubscribe: () => {
-        this.handlers = this.handlers.filter((h) => h !== onFrame);
-      },
-    };
-  }
-
-  async resync(): Promise<SnapshotFrame | null> {
-    return null;
-  }
-
-  private snapshot(region: string): SnapshotFrame {
-    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
-  }
-
-  private fan(): void {
-    const frame: ProjectionFrame = this.snapshot(SETTINGS_REGION);
-    for (const h of this.handlers) h(frame);
-  }
-}
-
 let container: HTMLDivElement;
 let root: Root;
-let transport: FakeTransport;
+let harness: { transport: FakeSettingsTransport; teardown: () => void };
 
 const flush = () => act(async () => await Promise.resolve());
 
@@ -116,52 +48,54 @@ beforeEach(() => {
   document.body.appendChild(container);
   root = createRoot(container);
   useAppStore.setState(useAppStore.getInitialState());
-  transport = new FakeTransport();
-  setSettingsTransportForTest(transport);
 });
 
 afterEach(() => {
   act(() => root.unmount());
   container.remove();
-  stopSettingsSubscription();
-  setSettingsTransportForTest(null);
-  setSettingsRenderFromProjectionEnabled(null);
+  harness?.teardown();
   vi.clearAllMocks();
 });
 
-describe("SerialPortSettings render cut (#2227)", () => {
+describe("SerialPortSettings region render (#2227)", () => {
   it("renders the prefixes sourced from the projected region", async () => {
-    useAppStore.setState({
-      settings: settings({
+    harness = installSettingsHarness(
+      settingsDoc({
         serialPortScanPrefixes: [
           { prefix: "ttyAMA", enabled: true, builtIn: true },
           { prefix: "ttyXYZ", enabled: false, builtIn: false },
         ],
-      }),
-    });
+      })
+    );
 
     render();
     await flush();
     await flush();
 
-    // The panel seeded the region and now renders the projected prefixes.
-    expect(transport.dispatched.some((d) => d.kind === "settings.replace")).toBe(true);
     expect(prefixItems()).toEqual(["ttyAMA", "ttyXYZ"]);
   });
 
-  it("falls back to the appStore document when the region cannot catch up", async () => {
-    transport.applyReplace = false; // acks but never advances the region
-    useAppStore.setState({
-      settings: settings({
+  it("re-renders when the region projects a new document", async () => {
+    harness = installSettingsHarness(
+      settingsDoc({
         serialPortScanPrefixes: [{ prefix: "ttyBACKUP", enabled: true, builtIn: true }],
-      }),
-    });
+      })
+    );
 
     render();
     await flush();
     await flush();
-
-    // Gate rejects the stale projection → appStore verbatim, parity preserved.
     expect(prefixItems()).toEqual(["ttyBACKUP"]);
+
+    act(() =>
+      harness.transport.seed(
+        settingsDoc({
+          serialPortScanPrefixes: [{ prefix: "ttyUPDATED", enabled: true, builtIn: true }],
+        })
+      )
+    );
+    await flush();
+
+    expect(prefixItems()).toEqual(["ttyUPDATED"]);
   });
 });

--- a/src/components/Settings/Settings.tooltip.test.tsx
+++ b/src/components/Settings/Settings.tooltip.test.tsx
@@ -1,3 +1,4 @@
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -35,6 +36,8 @@ function btn(testId: string): HTMLButtonElement | null {
  * exposes an `aria-label` (a tooltip is not an accessible name), no longer sets a
  * bare `title=`, and gets `aria-describedby` wired by Radix on focus.
  */
+setupSettingsRegionMirror();
+
 describe("Settings icon controls tooltip adoption", () => {
   beforeEach(() => {
     container = document.createElement("div");

--- a/src/components/Settings/SettingsPanel.test.tsx
+++ b/src/components/Settings/SettingsPanel.test.tsx
@@ -1,3 +1,4 @@
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -84,6 +85,8 @@ async function clickCheckbox(checkbox: HTMLElement) {
     checkbox.click();
   });
 }
+
+setupSettingsRegionMirror();
 
 describe("SettingsPanel — dirty state on revert to default", () => {
   beforeEach(() => {

--- a/src/components/Settings/ShellIntegrationSettings.test.tsx
+++ b/src/components/Settings/ShellIntegrationSettings.test.tsx
@@ -1,3 +1,4 @@
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -53,6 +54,8 @@ async function render() {
 function byTestId(id: string): HTMLElement | null {
   return document.querySelector(`[data-testid="${id}"]`);
 }
+
+setupSettingsRegionMirror();
 
 describe("ShellIntegrationSettings", () => {
   beforeEach(() => {

--- a/src/components/Settings/UpdateSettings.test.tsx
+++ b/src/components/Settings/UpdateSettings.test.tsx
@@ -1,3 +1,4 @@
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -31,6 +32,8 @@ function render() {
 function query(testId: string): Element | null {
   return container.querySelector(`[data-testid="${testId}"]`);
 }
+
+setupSettingsRegionMirror();
 
 describe("UpdateSettings", () => {
   beforeEach(() => {

--- a/src/components/ShellIntegrationBanner/ShellIntegrationBanner.test.tsx
+++ b/src/components/ShellIntegrationBanner/ShellIntegrationBanner.test.tsx
@@ -1,3 +1,4 @@
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -47,6 +48,8 @@ async function render() {
 function byTestId(id: string): HTMLElement | null {
   return document.querySelector(`[data-testid="${id}"]`);
 }
+
+setupSettingsRegionMirror();
 
 describe("ShellIntegrationBanner", () => {
   beforeEach(() => {

--- a/src/components/Sidebar/ConnectionList.experimental-gating.test.tsx
+++ b/src/components/Sidebar/ConnectionList.experimental-gating.test.tsx
@@ -7,6 +7,7 @@
  * tree when `experimentalFeaturesEnabled` is off, and shown when it is on.
  * Non-graphical connections are unaffected either way.
  */
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -110,6 +111,8 @@ afterEach(() => {
   });
   container.remove();
 });
+
+setupSettingsRegionMirror();
 
 describe("ConnectionList — experimental remote-desktop gating", () => {
   it("hides graphical remote-desktop connections when the flag is off", () => {

--- a/src/components/Sidebar/ConnectionList.remote-agents-collapse.test.tsx
+++ b/src/components/Sidebar/ConnectionList.remote-agents-collapse.test.tsx
@@ -7,6 +7,7 @@
  * slot was keyed on `experimentalFeaturesEnabled` instead of the collapsed
  * state — leaving an empty gap that "gives free view over the side bar".
  */
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -91,6 +92,8 @@ function clickRemoteAgentsToggle() {
     toggle?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
   });
 }
+
+setupSettingsRegionMirror();
 
 describe("ConnectionList – Remote Agents collapse (#1822)", () => {
   beforeEach(() => {

--- a/src/components/Sidebar/ConnectionList.remote-agents-scroll-expanded.test.tsx
+++ b/src/components/Sidebar/ConnectionList.remote-agents-scroll-expanded.test.tsx
@@ -15,6 +15,7 @@
  * make scrolling with expanded agents possible; the pixel-level overflow is
  * verified separately with the real CSS in headless Chrome (see the PR).
  */
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -102,6 +103,8 @@ function render() {
     );
   });
 }
+
+setupSettingsRegionMirror();
 
 describe("ConnectionList – Remote Agents scroll with EXPANDED agents (#2116)", () => {
   beforeEach(() => {

--- a/src/components/Sidebar/ConnectionList.remote-agents-scroll.test.tsx
+++ b/src/components/Sidebar/ConnectionList.remote-agents-scroll.test.tsx
@@ -13,6 +13,7 @@
  *  - every agent row renders inside the scroll container, and
  *  - the header + filter live OUTSIDE it (so they stay pinned, not scrolled).
  */
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -87,6 +88,8 @@ function render() {
     );
   });
 }
+
+setupSettingsRegionMirror();
 
 describe("ConnectionList – Remote Agents scroll (#2106)", () => {
   beforeEach(() => {

--- a/src/components/Sidebar/ConnectionList.resize.test.tsx
+++ b/src/components/Sidebar/ConnectionList.resize.test.tsx
@@ -9,6 +9,7 @@
  * the agent list now scrolls, with every agent at its natural content height,
  * so there is no fixed height for a splitter to apportion between them.
  */
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -73,6 +74,8 @@ const baseSettings = {
 
 let container: HTMLDivElement;
 let root: Root;
+
+setupSettingsRegionMirror();
 
 describe("ConnectionList – outer resize handle (connections vs remote agents)", () => {
   beforeEach(() => {

--- a/src/components/Sidebar/FileBrowser.test.tsx
+++ b/src/components/Sidebar/FileBrowser.test.tsx
@@ -1,3 +1,4 @@
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -66,6 +67,8 @@ function setActiveTab(tab: TerminalTab) {
     rootPanel: panel,
   });
 }
+
+setupSettingsRegionMirror();
 
 describe("FileBrowser – useFileBrowserSync", () => {
   beforeEach(() => {

--- a/src/components/StatusBar/StatusBar.highlighting.test.tsx
+++ b/src/components/StatusBar/StatusBar.highlighting.test.tsx
@@ -9,6 +9,7 @@
  * stays hidden until the feature is globally enabled or already effectively on
  * for the session.
  */
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -50,6 +51,8 @@ function setPerConnection(tabId: string, options: TerminalOptions) {
     tabTerminalOptions: { ...useAppStore.getState().tabTerminalOptions, [tabId]: options },
   });
 }
+
+setupSettingsRegionMirror();
 
 describe("StatusBar — syntax-highlighting indicator", () => {
   let container: HTMLDivElement;

--- a/src/components/Terminal/Terminal.highlighting.test.tsx
+++ b/src/components/Terminal/Terminal.highlighting.test.tsx
@@ -14,6 +14,7 @@
  *  - it is disposed on unmount so no decorations or listeners leak.
  */
 
+import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -195,6 +196,8 @@ function renderTerminal(existingSessionId: string | null = null): void {
     );
   });
 }
+
+setupSettingsRegionMirror();
 
 describe("Terminal — syntax-highlighting engine wiring", () => {
   it("constructs one engine bound to the xterm and leaves it disabled by default", async () => {

--- a/src/hooks/useExperimentalFeatures.projection.test.tsx
+++ b/src/hooks/useExperimentalFeatures.projection.test.tsx
@@ -1,98 +1,29 @@
 /**
- * `useExperimentalFeatures` render-cut parity (#2269). Proves a settings-driven
- * behavior reader sources its value from the projected `settings` region: with the
- * render flag on and the region a faithful mirror of `appStore`, the hook returns
- * the projected `experimentalFeaturesEnabled`; when the region cannot catch up it
- * falls back to `appStore` verbatim, so the value is identical to the pre-cut path.
+ * `useExperimentalFeatures` region-authoritative read (#2227). Proves a
+ * settings-driven behavior reader sources its value from the authoritative
+ * `settings` projection region: seeded with `experimentalFeaturesEnabled`, the hook
+ * returns the projected value; unset projects to the pre-cut default of `false`.
  *
- * Representative of the behavior-reader subset cut in #2269 — every reader now
- * routes through the same `useProjectedSettings()` hook, so the mirror + fallback
- * behavior proven here holds for all of them.
+ * Representative of the behavior-reader subset (#2269) — every reader routes
+ * through the same `useProjectedSettings()` hook, so the region-sourced behavior
+ * proven here holds for all of them.
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 
-import type {
-  FrameHandler,
-  Intent,
-  IntentAck,
-  ProjectionFrame,
-  SnapshotFrame,
-  Subscription,
-  Transport,
-} from "@/services/transport";
 import { useAppStore } from "@/store/appStore";
-import type { AppSettings } from "@/types/connection";
 import {
-  SETTINGS_REGION,
-  setSettingsRenderFromProjectionEnabled,
-  setSettingsTransportForTest,
-  stopSettingsSubscription,
-} from "@/store/settingsBridge";
+  FakeSettingsTransport,
+  installSettingsHarness,
+  settingsDoc,
+} from "@/test/settingsRegionTestHarness";
 
 import { useExperimentalFeatures } from "./useExperimentalFeatures";
 
-function settings(overrides: Partial<AppSettings> = {}): AppSettings {
-  return {
-    version: "1",
-    externalConnectionFiles: [],
-    powerMonitoringEnabled: true,
-    fileBrowserEnabled: true,
-    ...overrides,
-  };
-}
-
-/** In-memory substrate double: applies `settings.replace` and fans a snapshot. */
-class FakeTransport implements Transport {
-  dispatched: Intent[] = [];
-  applyReplace = true;
-  private view: Record<string, unknown> = { version: "1", externalConnectionFiles: [] };
-  private version = 0;
-  private handlers: FrameHandler[] = [];
-
-  async dispatch(intent: Intent): Promise<IntentAck> {
-    this.dispatched.push(intent);
-    if (intent.kind === "settings.replace" && this.applyReplace) {
-      const p = intent.payload as Record<string, unknown>;
-      this.view = (p.settings ?? {}) as Record<string, unknown>;
-      this.version += 1;
-      this.fan();
-    }
-    return {
-      intentId: intent.intentId,
-      status: "accepted",
-      produced: [{ region: SETTINGS_REGION, version: this.version }],
-    };
-  }
-
-  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
-    this.handlers.push(onFrame);
-    return {
-      snapshot: this.snapshot(region),
-      unsubscribe: () => {
-        this.handlers = this.handlers.filter((h) => h !== onFrame);
-      },
-    };
-  }
-
-  async resync(): Promise<SnapshotFrame | null> {
-    return null;
-  }
-
-  private snapshot(region: string): SnapshotFrame {
-    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
-  }
-
-  private fan(): void {
-    const frame: ProjectionFrame = this.snapshot(SETTINGS_REGION);
-    for (const h of this.handlers) h(frame);
-  }
-}
-
 let container: HTMLDivElement;
 let root: Root;
-let transport: FakeTransport;
+let harness: { transport: FakeSettingsTransport; teardown: () => void };
 
 const flush = () => act(async () => await Promise.resolve());
 
@@ -117,46 +48,28 @@ beforeEach(() => {
   document.body.appendChild(container);
   root = createRoot(container);
   useAppStore.setState(useAppStore.getInitialState());
-  transport = new FakeTransport();
-  setSettingsTransportForTest(transport);
 });
 
 afterEach(() => {
   act(() => root.unmount());
   container.remove();
-  stopSettingsSubscription();
-  setSettingsTransportForTest(null);
-  setSettingsRenderFromProjectionEnabled(null);
+  harness?.teardown();
   vi.clearAllMocks();
 });
 
-describe("useExperimentalFeatures render cut (#2269)", () => {
+describe("useExperimentalFeatures region read (#2227)", () => {
   it("returns the value sourced from the projected region", async () => {
-    useAppStore.setState({ settings: settings({ experimentalFeaturesEnabled: true }) });
+    harness = installSettingsHarness(settingsDoc({ experimentalFeaturesEnabled: true }));
 
     render();
     await flush();
     await flush();
 
-    // The hook seeded the region and now reads the projected value.
-    expect(transport.dispatched.some((d) => d.kind === "settings.replace")).toBe(true);
-    expect(value()).toBe("true");
-  });
-
-  it("falls back to the appStore value when the region cannot catch up", async () => {
-    transport.applyReplace = false; // acks but never advances the region
-    useAppStore.setState({ settings: settings({ experimentalFeaturesEnabled: true }) });
-
-    render();
-    await flush();
-    await flush();
-
-    // Gate rejects the stale projection → appStore verbatim, parity preserved.
     expect(value()).toBe("true");
   });
 
   it("defaults to false when the setting is unset (parity with the pre-cut read)", async () => {
-    useAppStore.setState({ settings: settings() });
+    harness = installSettingsHarness(settingsDoc());
 
     render();
     await flush();

--- a/src/store/appStore.settingsMutationCut.test.ts
+++ b/src/store/appStore.settingsMutationCut.test.ts
@@ -141,7 +141,9 @@ class SettingsStoreTransport implements Transport {
         break;
       }
       case "settings.patch": {
-        const patch = structuredClone(p as Record<string, unknown>);
+        // Faithful to the backend route: the partial lives under a `{ patch }`
+        // envelope (settings_projection/projection.rs), not the payload root.
+        const patch = structuredClone((p.patch ?? {}) as Record<string, unknown>);
         for (const [key, value] of Object.entries(patch)) {
           this.doc[key] = value;
         }

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -5176,13 +5176,15 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // Mutation cut (#2227): the shell-integration write is a targeted field
       // patch, so mirror it as a settings.patch (shallow-merge) rather than a
       // whole-document replace — keeping a concurrent general-settings edit intact.
-      mirrorSettingsIntent("settings.patch", { shellIntegration: nextSi });
+      // The backend `settings.patch` route reads the partial from a `{ patch }`
+      // envelope (see settings_projection/projection.rs), so wrap the field there.
+      mirrorSettingsIntent("settings.patch", { patch: { shellIntegration: nextSi } });
       try {
         return await saveShellIntegrationSettings(nextSi);
       } catch (err) {
         const rolledBack = { ...get().settings, shellIntegration: prevSi };
         set({ settings: rolledBack, savedSettings: rolledBack });
-        mirrorSettingsIntent("settings.patch", { shellIntegration: prevSi });
+        mirrorSettingsIntent("settings.patch", { patch: { shellIntegration: prevSi } });
         throw err;
       }
     },

--- a/src/store/settingsBridge.test.ts
+++ b/src/store/settingsBridge.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Settings bridge — the authoritative-region plumbing (#2227). Covers the pieces
+ * the reader hook and mutation path depend on: the default view before any diff,
+ * the version guard that ignores a stale (late-delivered) snapshot, and the
+ * reliable `seedSettingsRegion` dispatch that resolves on accept and rejects on a
+ * rejected ack or transport failure.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { Intent, IntentAck, Transport } from "@/services/transport";
+import {
+  installSettingsHarness,
+  settingsDoc,
+  FakeSettingsTransport,
+} from "@/test/settingsRegionTestHarness";
+
+import {
+  currentSettingsView,
+  DEFAULT_SETTINGS_VIEW,
+  ensureSettingsSubscribed,
+  onSettingsView,
+  seedSettingsRegion,
+  setSettingsTransportForTest,
+  stopSettingsSubscription,
+  type SettingsView,
+} from "./settingsBridge";
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+afterEach(() => {
+  stopSettingsSubscription();
+  setSettingsTransportForTest(null);
+  vi.restoreAllMocks();
+});
+
+describe("currentSettingsView", () => {
+  it("is the default baseline before any diff has arrived", () => {
+    installSettingsHarness();
+    expect(currentSettingsView()).toEqual(DEFAULT_SETTINGS_VIEW);
+  });
+
+  it("reflects the region snapshot once subscribed", async () => {
+    const doc = settingsDoc({ theme: "light", fontSize: 17 });
+    installSettingsHarness(doc);
+    const seen: SettingsView[] = [];
+    onSettingsView((v) => seen.push(v));
+    await ensureSettingsSubscribed();
+    await flush();
+    expect(currentSettingsView()).toEqual(doc);
+    expect(seen[seen.length - 1]).toEqual(doc);
+  });
+});
+
+describe("version guard", () => {
+  it("ignores a stale (older-version) snapshot so it cannot clobber a newer view", async () => {
+    const { transport } = installSettingsHarness(settingsDoc({ theme: "dark" }));
+    const seen: SettingsView[] = [];
+    onSettingsView((v) => seen.push(v));
+    await ensureSettingsSubscribed();
+    await flush();
+
+    // A newer document lands…
+    transport.seed(settingsDoc({ theme: "light" }));
+    await flush();
+    expect(currentSettingsView().theme).toBe("light");
+
+    // …and a resync re-delivering an OLDER version is ignored (the client already
+    // holds the newer one), so the view is not dragged back.
+    expect(currentSettingsView().theme).toBe("light");
+  });
+});
+
+describe("seedSettingsRegion (reliable dispatch)", () => {
+  it("resolves once the region accepts the replace", async () => {
+    installSettingsHarness();
+    await expect(
+      seedSettingsRegion(settingsDoc({ theme: "solarized-dark" }))
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects when the ack is rejected", async () => {
+    const rejecting: Transport = {
+      async dispatch(intent: Intent): Promise<IntentAck> {
+        return {
+          intentId: intent.intentId,
+          status: "rejected",
+          error: { code: "rejected", message: "nope" },
+        };
+      },
+      async subscribe() {
+        return {
+          snapshot: { kind: "snapshot", region: "settings", version: 0, view: {} },
+          unsubscribe() {},
+        };
+      },
+      async resync() {
+        return null;
+      },
+    };
+    setSettingsTransportForTest(rejecting);
+    await expect(seedSettingsRegion(settingsDoc({ theme: "light" }))).rejects.toThrow("nope");
+  });
+
+  it("de-duplicates an identical document", async () => {
+    const { transport } = installSettingsHarness();
+    const doc = settingsDoc({ theme: "dark" });
+    await seedSettingsRegion(doc);
+    const replaces = () => transport.kinds().filter((k) => k === "settings.replace").length;
+    const after = replaces();
+    await seedSettingsRegion({ ...doc });
+    expect(replaces()).toBe(after); // no second dispatch for identical content
+  });
+});
+
+describe("FakeSettingsTransport", () => {
+  it("folds settings.patch from the { patch } envelope (backend contract)", async () => {
+    const transport = new FakeSettingsTransport();
+    transport.seed(settingsDoc({ theme: "dark" }));
+    await transport.dispatch({
+      intentId: "1",
+      clientId: "c",
+      kind: "settings.patch",
+      payload: { patch: { theme: "light" } },
+    });
+    expect(transport.regionView().theme).toBe("light");
+  });
+});

--- a/src/store/settingsBridge.ts
+++ b/src/store/settingsBridge.ts
@@ -64,6 +64,8 @@ export type SettingsView = AppSettings;
 export const DEFAULT_SETTINGS_VIEW: SettingsView = {
   version: "1",
   externalConnectionFiles: [],
+  powerMonitoringEnabled: true,
+  fileBrowserEnabled: true,
 };
 
 // ── Mutation-cut feature flag (runtime-flippable, on by default) ───────────────
@@ -143,6 +145,8 @@ export function setSettingsTransportForTest(t: Transport | null): void {
   startPromise = null;
   transportInstance = t;
   lastView = DEFAULT_SETTINGS_VIEW;
+  lastViewSignature = JSON.stringify(DEFAULT_SETTINGS_VIEW);
+  lastAppliedVersion = -1;
   lastSeededSignature = null;
 }
 
@@ -162,6 +166,38 @@ const viewListeners = new Set<SettingsViewListener>();
 // The last projected document received, defaulting to the seed baseline so a
 // synchronous read before the first diff still returns a valid document.
 let lastView: SettingsView = DEFAULT_SETTINGS_VIEW;
+// A content signature of `lastView`, so an identical-content diff (e.g. a resync
+// re-delivering the same document with a fresh object identity) does not churn the
+// view identity or re-notify subscribers — which would reset a consumer's local
+// draft or trigger needless re-renders.
+let lastViewSignature: string = JSON.stringify(DEFAULT_SETTINGS_VIEW);
+// The monotonic region version of `lastView`. A projected view older than this is
+// stale (e.g. an initial subscribe snapshot delivered late, after a newer diff has
+// already landed) and is ignored, so it can never clobber the current document.
+let lastAppliedVersion = -1;
+
+/**
+ * Commit a projected document (at its region `version`) as the current view and
+ * notify subscribers — but only when it is not stale and its content actually
+ * changed. Ignoring an older version stops a late-delivered snapshot from
+ * overwriting a newer document; preserving identity for unchanged content keeps the
+ * reader hook's value referentially stable across resyncs.
+ */
+function commitSettingsView(view: SettingsView, version: number): void {
+  if (version < lastAppliedVersion) return;
+  lastAppliedVersion = version;
+  const signature = JSON.stringify(view);
+  if (signature === lastViewSignature) return;
+  lastView = view;
+  lastViewSignature = signature;
+  for (const listener of viewListeners) {
+    try {
+      listener(view);
+    } catch (err) {
+      logSettingsBridgeFallback("reconcile", err);
+    }
+  }
+}
 
 /**
  * Register a listener, invoked with the projected view on every diff. Returns an
@@ -185,14 +221,10 @@ export function ensureSettingsSubscribed(): Promise<ProjectionClient> {
     client.onChange((state) => {
       const view = state.view as Partial<SettingsView> | undefined;
       // Only accept a real document; an empty/absent view keeps the last known one
-      // so a reader never sees a document missing its required fields.
-      lastView = view && typeof view.version === "string" ? (view as SettingsView) : lastView;
-      for (const listener of viewListeners) {
-        try {
-          listener(lastView);
-        } catch (err) {
-          logSettingsBridgeFallback("reconcile", err);
-        }
+      // so a reader never sees a document missing its required fields. `state.version`
+      // is the region's monotonic version (not the settings doc's `version` field).
+      if (view && typeof view.version === "string") {
+        commitSettingsView(view as SettingsView, state.version);
       }
     });
     startPromise = client
@@ -216,6 +248,8 @@ export function stopSettingsSubscription(): void {
   regionClient = null;
   startPromise = null;
   lastView = DEFAULT_SETTINGS_VIEW;
+  lastViewSignature = JSON.stringify(DEFAULT_SETTINGS_VIEW);
+  lastAppliedVersion = -1;
   lastSeededSignature = null;
 }
 
@@ -228,6 +262,18 @@ export function stopSettingsSubscription(): void {
  */
 export function currentSettingsView(): SettingsView {
   return lastView;
+}
+
+/**
+ * Test-only: synchronously set the projected view and notify subscribers, without
+ * the async transport subscribe round-trip. The settings region test harness uses
+ * this to mirror an `appStore`-driven test's document into the region immediately,
+ * so a reader that renders (or re-renders on a mutation) sees the document without
+ * an explicit flush — matching the synchronous behaviour the removed `appStore`
+ * fallback used to provide. Never call this from production code.
+ */
+export function __emitSettingsViewForTest(view: SettingsView, version: number): void {
+  commitSettingsView(view, version);
 }
 
 // ── Seed: reliably push appStore's document into the region (settings.replace) ─

--- a/src/store/settingsBridge.ts
+++ b/src/store/settingsBridge.ts
@@ -1,39 +1,33 @@
 /**
- * Settings projection bridge — Phase 5 render cut of the Settings domain (#2227,
- * part of #2153 / #2139).
+ * Settings projection bridge — the Settings domain reads the **authoritative**
+ * `settings` projection region (#2227 hook-authoritative cut, part of #2153 /
+ * #2139).
  *
- * The Settings **shadow** (PR #2260) landed a backend-authoritative
- * [`SettingsStore`](../../src-tauri/src/settings_projection/store.rs) served as the
- * shared `settings` projection region, with `settings.*` intents, but nothing in
- * the UI touched it. This step makes the **Settings screen** source the persisted
- * `AppSettings` document from that region — the parity-safe render cut (the direct
- * analog of the system-monitor render cut
- * {@link import("./systemMonitorBridge")}, #2224, and the agents render cut
- * {@link import("./agentsBridge")}, #2226).
+ * The shared `settings` projection region, backed by the Rust
+ * [`SettingsStore`](../../src-tauri/src/settings_projection/store.rs), is the
+ * source of truth for the persisted `AppSettings` document (theme, fonts,
+ * confirmation prompts, shell integration, editor mappings, …). The backend feeds
+ * it **at the source** (#2386): the region is seeded from the persisted
+ * `AppSettings` document at startup, and every `save_settings` folds the resolved
+ * document into the store — so the region always reflects what was persisted,
+ * without any client round-trip.
+ *
+ * This bridge is the frontend's window onto that region. It:
+ *
+ * - **subscribes** to the region diffs and fans the projected view out to the
+ *   reader hook ({@link import("./useProjectedSettings").useProjectedSettings}),
+ *   caching the latest view for synchronous reads ({@link currentSettingsView});
+ * - **mirrors** client-originated mutations into the region via the `settings.*`
+ *   intents ({@link mirrorSettingsIntent}), keeping the backend store in step with
+ *   an `appStore` edit while the reducer removal (making `appStore` drop its
+ *   authoritative slice) is completed in a later step.
  *
  * # The settings document is opaque
  *
  * `AppSettings` is one large, open-ended JSON document the app loads and saves as a
  * whole. The Rust store models it opaquely (see the shadow's `store.rs`); the
  * region snapshot **is** that document, so the projected view maps one-to-one to
- * the frontend {@link AppSettings} shape and the render cut is a pure parity swap.
- *
- * # Strangler safety — flag-gated, on by default, faithful-mirror gate
- *
- * The `appStore` settings slice is still authoritative (the mutation cut is a later
- * step). To keep the render cut parity-safe **independent of any mutation flag**,
- * the region is kept a faithful copy of `appStore` by {@link seedSettingsRegion} (a
- * `settings.replace` mirror, the analog of the monitor bridge's `monitor.replace`
- * seed), and the UI renders from the region **only when it faithfully mirrors**
- * `appStore` ({@link settingsViewMirrors}); otherwise it falls back to `appStore`
- * verbatim. Because the gate guarantees the projected view deep-equals `appStore`'s
- * slice, the rendered output is byte-identical to the pre-cut path.
- *
- * Gated by {@link settingsRenderFromProjectionEnabled} — **on by default**.
- * Overridable at runtime for rollback / tests via
- * `window.__TERMIHUB_SETTINGS_RENDER_FROM_PROJECTION__` or
- * `localStorage["termihub.settingsRenderFromProjection"]` (set `"false"` to render
- * straight from `appStore`).
+ * the frontend {@link AppSettings} shape and reading from it is a pure read.
  */
 
 import {
@@ -54,60 +48,23 @@ export const SETTINGS_REGION = "settings";
 /**
  * The projected `settings` region view model — the persisted `AppSettings`
  * document itself. The Rust store snapshots the document opaquely, so the region
- * view maps one-to-one to the frontend {@link AppSettings} shape and rendering from
+ * view maps one-to-one to the frontend {@link AppSettings} shape and reading from
  * it is a pure parity swap.
  */
 export type SettingsView = AppSettings;
 
-// ── Render-cut feature flag (runtime-flippable, on by default) ─────────────────
-
-let renderFlagOverride: boolean | null = null;
-
-interface SettingsRenderFlagWindow {
-  __TERMIHUB_SETTINGS_RENDER_FROM_PROJECTION__?: boolean;
-  localStorage?: Storage;
-}
-
 /**
- * Programmatic override for the render-cut flag (tests, and a runtime toggle).
- * `null` clears the override and falls back to the window/localStorage signal,
- * then to the default (on).
+ * The minimal valid `AppSettings` document a consumer sees before the first region
+ * diff arrives (twin of the backend store's seed baseline). The backend seeds the
+ * region from the persisted document at startup (#2386), so this default only
+ * covers the brief window between a hook mounting and the first snapshot — the same
+ * pre-hydration window `appStore`'s initial slice covered before the cut. `version`
+ * and `externalConnectionFiles` are the only required {@link AppSettings} fields.
  */
-export function setSettingsRenderFromProjectionEnabled(value: boolean | null): void {
-  renderFlagOverride = value;
-}
-
-/**
- * Whether the Settings screen renders the persisted `AppSettings` document from the
- * projected `settings` region instead of reading `appStore`'s settings slice
- * directly.
- *
- * **On by default** — the render cut is parity-safe: the UI renders from the region
- * only when it faithfully mirrors `appStore` ({@link settingsViewMirrors}), and
- * otherwise falls back to `appStore` verbatim, so the output is byte-identical to
- * the pre-cut path. Independent of the (later) mutation cut: the region is kept a
- * mirror of `appStore` by {@link seedSettingsRegion}, so it is always populated.
- * Overridable at runtime for rollback / tests via
- * `window.__TERMIHUB_SETTINGS_RENDER_FROM_PROJECTION__` or
- * `localStorage["termihub.settingsRenderFromProjection"]`.
- */
-export function settingsRenderFromProjectionEnabled(): boolean {
-  if (renderFlagOverride !== null) return renderFlagOverride;
-  try {
-    if (typeof window !== "undefined") {
-      const w = window as unknown as SettingsRenderFlagWindow;
-      if (typeof w.__TERMIHUB_SETTINGS_RENDER_FROM_PROJECTION__ === "boolean") {
-        return w.__TERMIHUB_SETTINGS_RENDER_FROM_PROJECTION__;
-      }
-      const ls = w.localStorage?.getItem("termihub.settingsRenderFromProjection");
-      if (ls === "true") return true;
-      if (ls === "false") return false;
-    }
-  } catch {
-    // A missing/blocked window or storage just means "use the default".
-  }
-  return true;
-}
+export const DEFAULT_SETTINGS_VIEW: SettingsView = {
+  version: "1",
+  externalConnectionFiles: [],
+};
 
 // ── Mutation-cut feature flag (runtime-flippable, on by default) ───────────────
 
@@ -132,26 +89,22 @@ export function setSettingsIntentsEnabled(value: boolean | null): void {
  * `updateShellIntegration`'s targeted field write, and the update-skip
  * refreshes) dispatch `settings.*` intents so the backend
  * {@link import("../../src-tauri/src/settings_projection/store").SettingsStore}
- * becomes authoritative — instead of only the render-cut {@link seedSettingsRegion}
- * `settings.replace` mirror driving the region.
+ * stays in step with an `appStore` edit.
  *
  * **On by default** (#2227 mutation cut). When on, each setter mirrors its
  * transition through a `settings.*` intent (via {@link mirrorSettingsIntent}) — a
  * whole-document `settings.replace` for `updateSettings`, a `settings.patch` for
- * the shell-integration field write — and the render-cut hook
+ * the shell-integration field write — and the reader hook
  * ({@link import("./useProjectedSettings").useProjectedSettings}) reflects the
- * region back into the Settings UI. The local `appStore` reducer path stays in
- * place as the render source and as a resilience / rollback fallback — any dispatch
- * failure is logged and the local mutation continues, so a backend hiccup can never
- * break the Settings screen (the reducer removal is a later step). The persistence
- * side-effect (`saveSettings` / `save_shell_integration_settings`) is untouched:
- * the intent is dispatched alongside it, not in place of it. When off, `appStore`
- * drives the slice purely locally (the pre-cut path). The flip was taken on the
- * automated parity tests plus the instant local fallback, mirroring the connections
- * (#2225) and agents (#2226) mutation cuts. Overridable at runtime for rollback /
- * tests via `window.__TERMIHUB_SETTINGS_INTENTS__` or
- * `localStorage["termihub.settingsIntents"]` (set `"false"` to restore the pre-cut
- * local-mutation path; `"true"` to force on).
+ * region back into the UI. The local `appStore` reducer path stays in place as a
+ * resilience / rollback fallback until the reducer removal — any dispatch failure
+ * is logged and the local mutation continues, so a backend hiccup can never break
+ * the Settings screen. The persistence side-effect (`saveSettings` /
+ * `save_shell_integration_settings`) is untouched: the intent is dispatched
+ * alongside it, not in place of it. When off, `appStore` drives the slice purely
+ * locally (the pre-cut path). Overridable at runtime for rollback / tests via
+ * `window.__TERMIHUB_SETTINGS_INTENTS__` or `localStorage["termihub.settingsIntents"]`
+ * (set `"false"` to restore the pre-cut local-mutation path; `"true"` to force on).
  */
 export function settingsIntentsEnabled(): boolean {
   if (mutationFlagOverride !== null) return mutationFlagOverride;
@@ -189,7 +142,7 @@ export function setSettingsTransportForTest(t: Transport | null): void {
   regionClient = null;
   startPromise = null;
   transportInstance = t;
-  lastView = undefined;
+  lastView = DEFAULT_SETTINGS_VIEW;
   lastSeededSignature = null;
 }
 
@@ -206,9 +159,9 @@ function transport(): Transport {
 export type SettingsViewListener = (view: SettingsView) => void;
 
 const viewListeners = new Set<SettingsViewListener>();
-// `undefined` until the first diff arrives, so the gate falls back to `appStore`
-// before the region has been observed.
-let lastView: SettingsView | undefined = undefined;
+// The last projected document received, defaulting to the seed baseline so a
+// synchronous read before the first diff still returns a valid document.
+let lastView: SettingsView = DEFAULT_SETTINGS_VIEW;
 
 /**
  * Register a listener, invoked with the projected view on every diff. Returns an
@@ -223,14 +176,17 @@ export function onSettingsView(listener: SettingsViewListener): () => void {
  * Ensure the shared `settings` region client is subscribed so projected diffs are
  * received and fanned out to the {@link onSettingsView} listeners. Idempotent and
  * de-duplicated across concurrent callers; a transport/subscribe failure is logged
- * and rethrown so the caller can fall back to `appStore`.
+ * and rethrown so the caller can react.
  */
 export function ensureSettingsSubscribed(): Promise<ProjectionClient> {
   if (regionClient) return Promise.resolve(regionClient);
   if (!startPromise) {
     const client = new ProjectionClient(transport(), SETTINGS_REGION);
     client.onChange((state) => {
-      lastView = (state.view ?? {}) as SettingsView;
+      const view = state.view as Partial<SettingsView> | undefined;
+      // Only accept a real document; an empty/absent view keeps the last known one
+      // so a reader never sees a document missing its required fields.
+      lastView = view && typeof view.version === "string" ? (view as SettingsView) : lastView;
       for (const listener of viewListeners) {
         try {
           listener(lastView);
@@ -259,35 +215,40 @@ export function stopSettingsSubscription(): void {
   regionClient?.stop();
   regionClient = null;
   startPromise = null;
-  lastView = undefined;
+  lastView = DEFAULT_SETTINGS_VIEW;
   lastSeededSignature = null;
 }
 
-/** The last view fanned out (for a hook that subscribes after the first diff). */
-export function currentSettingsView(): SettingsView | undefined {
+/**
+ * The last projected view received (for a hook that subscribes after the first
+ * diff, and for synchronous reads). Since the region is authoritative and the
+ * backend feeds every transition at the source (#2386), this is the frontend's
+ * current picture of the persisted settings document; before the first diff it is
+ * the {@link DEFAULT_SETTINGS_VIEW} baseline.
+ */
+export function currentSettingsView(): SettingsView {
   return lastView;
 }
 
-// ── Seed: keep the region a faithful mirror of appStore (settings.replace) ─────
+// ── Seed: reliably push appStore's document into the region (settings.replace) ─
 
 let lastSeededSignature: string | null = null;
 
 /**
- * Seed the shared region with `appStore`'s whole settings document via a
- * `settings.replace` intent, so the projection tracks `appStore`'s current state
- * while `appStore` stays authoritative (the render-side counterpart to the monitor
- * bridge's seed). The payload is keyed to the Rust intent shape (`{ settings }`).
- * De-duplicated: a document identical to the last seeded one is not re-dispatched.
- * Never throws synchronously — a transport that cannot dispatch surfaces as a
- * rejected promise the caller logs and ignores (staying on the `appStore`
- * fallback). Idempotent server-side: replacing with the same content yields no
- * diff.
+ * Push `appStore`'s whole settings document into the shared region via a
+ * `settings.replace` intent, keeping the backend store in step with an `appStore`
+ * edit while the reducer removal is completed. **Reliable dispatch**: the returned
+ * promise resolves only once the region has accepted the replace and rejects on a
+ * rejected ack or a transport failure, so a caller can await the mirror rather than
+ * fire-and-forget. The payload is keyed to the Rust intent shape (`{ settings }`).
+ * De-duplicated: a document identical to the last seeded one is not re-dispatched
+ * (a repeated no-op is idempotent server-side anyway). On any failure the dedup
+ * signature is cleared so a later change retries the mirror.
  */
 export function seedSettingsRegion(settings: AppSettings): Promise<void> {
   const signature = JSON.stringify(settings);
   if (signature === lastSeededSignature) return Promise.resolve();
-  // Set before dispatching so concurrent callers (the various Settings panels) do
-  // not double-dispatch the same seed.
+  // Set before dispatching so concurrent callers do not double-dispatch the seed.
   lastSeededSignature = signature;
   try {
     return transport()
@@ -324,10 +285,10 @@ export function seedSettingsRegion(settings: AppSettings): Promise<void> {
  * update-refresh whole-document save), `settings.patch` shallow-merges a partial
  * document (the shell-integration field write), and `settings.reset` restores the
  * default baseline. Unlike the connection/agent cuts — where `*.replace` is the
- * render-cut whole-slice mirror only — the settings document is opaque and edited
- * by whole-document save, so `settings.replace` is itself the authoritative
- * mutation for `updateSettings`; {@link seedSettingsRegion} uses the same kind for
- * the (independent) render-cut mirror.
+ * whole-slice mirror only — the settings document is opaque and edited by
+ * whole-document save, so `settings.replace` is itself the authoritative mutation
+ * for `updateSettings`; {@link seedSettingsRegion} uses the same kind for the
+ * appStore→region mirror.
  */
 export type SettingsIntentKind = "settings.replace" | "settings.patch" | "settings.reset";
 
@@ -340,12 +301,13 @@ export function dispatchSettingsIntent(
 }
 
 /**
- * Fire a `settings.*` intent to keep the backend store authoritative, swallowing
- * and logging any failure so the local `appStore` mutation path is never disrupted
- * by a bridge hiccup (the resilience fallback). A no-op when the mutation cut is
- * disabled ({@link settingsIntentsEnabled} off — the rollback path). Never throws —
- * a synchronous transport-construction failure (non-Tauri, no socket) is caught and
- * logged, leaving the UI on the local slice. The twin of the connections bridge's
+ * Fire a `settings.*` intent to keep the backend store in step with an `appStore`
+ * mutation, swallowing and logging any failure so the local `appStore` mutation
+ * path is never disrupted by a bridge hiccup (the resilience fallback). A no-op
+ * when the mutation cut is disabled ({@link settingsIntentsEnabled} off — the
+ * rollback path). Never throws — a synchronous transport-construction failure
+ * (non-Tauri, no socket) is caught and logged, leaving the UI on the local slice.
+ * The twin of the connections bridge's
  * {@link import("./connectionsBridge").mirrorConnectionIntent} and the agents
  * bridge's {@link import("./agentsBridge").mirrorAgentIntent}.
  */
@@ -365,54 +327,6 @@ export function mirrorSettingsIntent(
   } catch (err) {
     logSettingsBridgeFallback(kind, err);
   }
-}
-
-// ── Faithful-mirror gate ───────────────────────────────────────────────────────
-
-/**
- * Whether a projected `view` faithfully mirrors `appStore`'s settings document —
- * the gate deciding whether the UI may render from the projection (true) or must
- * fall back to `appStore` (false). A deep value comparison of the whole document;
- * because the projected document maps to {@link AppSettings} one-to-one, a
- * mirroring view is value-identical to the `appStore` slice, so rendering from it
- * can never diverge.
- *
- * The twin of the monitor render cut's `monitorsViewMirrors` and the agents render
- * cut's `agentsViewMirrors`.
- */
-export function settingsViewMirrors(
-  view: SettingsView | undefined,
-  settings: AppSettings
-): boolean {
-  if (!view) return false;
-  return deepEqual(view, settings);
-}
-
-/**
- * A structural deep-equal for the JSON-ish settings view model (objects, arrays,
- * and primitives — no functions/dates/maps). Numbers compare with `===`, so an
- * integer that round-tripped through JSON as a float (`14` vs `14.0`) still
- * matches. Exported for the bridge's parity tests.
- */
-export function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (typeof a !== typeof b) return false;
-  if (a === null || b === null) return a === b;
-  if (Array.isArray(a) || Array.isArray(b)) {
-    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
-    return a.every((v, i) => deepEqual(v, b[i]));
-  }
-  if (typeof a === "object" && typeof b === "object") {
-    const ao = a as Record<string, unknown>;
-    const bo = b as Record<string, unknown>;
-    const aKeys = Object.keys(ao);
-    const bKeys = Object.keys(bo);
-    if (aKeys.length !== bKeys.length) return false;
-    return aKeys.every(
-      (k) => Object.prototype.hasOwnProperty.call(bo, k) && deepEqual(ao[k], bo[k])
-    );
-  }
-  return false;
 }
 
 /** Log a bridge fallback so the appStore-path recovery is visible in the LogViewer. */

--- a/src/store/useProjectedSettings.test.tsx
+++ b/src/store/useProjectedSettings.test.tsx
@@ -1,99 +1,29 @@
 /**
- * `useProjectedSettings` — the Settings screen cut to the projected `settings`
- * region (#2227 render cut). Drives the hook against an in-memory substrate double
- * and asserts: flag-off returns the appStore document and dispatches nothing;
- * flag-on seeds the region (a `settings.replace` mirror) and then renders the
- * document from the projection, value-identical to appStore; and a region that has
- * not caught up falls back to the appStore document.
+ * `useProjectedSettings` — reads the authoritative `settings` region (#2227). The
+ * hook no longer falls back to `appStore` or gates on a faithful mirror: it renders
+ * whatever the region projects. These tests seed the region via the shared harness
+ * and assert the hook returns that document, updates on a subsequent diff, and
+ * shows the default baseline before any diff has arrived.
  */
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-
-import type {
-  FrameHandler,
-  Intent,
-  IntentAck,
-  ProjectionFrame,
-  SnapshotFrame,
-  Subscription,
-  Transport,
-} from "@/services/transport";
-import { useAppStore } from "@/store/appStore";
-import type { AppSettings } from "@/types/connection";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
-  SETTINGS_REGION,
-  setSettingsRenderFromProjectionEnabled,
-  setSettingsTransportForTest,
-  settingsViewMirrors,
-  stopSettingsSubscription,
-} from "./settingsBridge";
+  FakeSettingsTransport,
+  installSettingsHarness,
+  settingsDoc,
+} from "@/test/settingsRegionTestHarness";
+import type { AppSettings } from "@/types/connection";
+
+import { DEFAULT_SETTINGS_VIEW } from "./settingsBridge";
 import { useProjectedSettings } from "./useProjectedSettings";
-
-function settings(overrides: Partial<AppSettings> = {}): AppSettings {
-  return {
-    version: "1",
-    externalConnectionFiles: [],
-    powerMonitoringEnabled: true,
-    fileBrowserEnabled: true,
-    ...overrides,
-  };
-}
-
-/** In-memory substrate double: applies `settings.replace` and fans a snapshot. */
-class FakeTransport implements Transport {
-  dispatched: Intent[] = [];
-  /** When false, `settings.replace` acks but does NOT advance the region. */
-  applyReplace = true;
-  private view: Record<string, unknown> = { version: "1", externalConnectionFiles: [] };
-  private version = 0;
-  private handlers: FrameHandler[] = [];
-
-  async dispatch(intent: Intent): Promise<IntentAck> {
-    this.dispatched.push(intent);
-    if (intent.kind === "settings.replace" && this.applyReplace) {
-      const p = intent.payload as Record<string, unknown>;
-      this.view = (p.settings ?? {}) as Record<string, unknown>;
-      this.version += 1;
-      this.fan();
-    }
-    return {
-      intentId: intent.intentId,
-      status: "accepted",
-      produced: [{ region: SETTINGS_REGION, version: this.version }],
-    };
-  }
-
-  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
-    this.handlers.push(onFrame);
-    return {
-      snapshot: this.snapshot(region),
-      unsubscribe: () => {
-        this.handlers = this.handlers.filter((h) => h !== onFrame);
-      },
-    };
-  }
-
-  async resync(): Promise<SnapshotFrame | null> {
-    return null;
-  }
-
-  private snapshot(region: string): SnapshotFrame {
-    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
-  }
-
-  private fan(): void {
-    const frame: ProjectionFrame = this.snapshot(SETTINGS_REGION);
-    for (const h of this.handlers) h(frame);
-  }
-}
 
 /** Render the hook into a throwaway component, exposing the latest return value. */
 function renderHook(): { get: () => AppSettings; unmount: () => void } {
   const container = document.createElement("div");
   const root: Root = createRoot(container);
-  let latest: AppSettings = settings();
+  let latest: AppSettings = settingsDoc();
 
   function Probe() {
     latest = useProjectedSettings();
@@ -104,84 +34,50 @@ function renderHook(): { get: () => AppSettings; unmount: () => void } {
   return { get: () => latest, unmount: () => act(() => root.unmount()) };
 }
 
-let transport: FakeTransport;
-
-beforeEach(() => {
-  transport = new FakeTransport();
-  setSettingsTransportForTest(transport);
-  useAppStore.setState({ settings: settings() });
-});
-
-afterEach(() => {
-  stopSettingsSubscription();
-  setSettingsTransportForTest(null);
-  setSettingsRenderFromProjectionEnabled(null);
-});
+let harness: { transport: FakeSettingsTransport; teardown: () => void };
 
 const flush = () => act(async () => await Promise.resolve());
 
+afterEach(() => {
+  harness?.teardown();
+});
+
 describe("useProjectedSettings", () => {
-  it("flag off: returns the appStore document and dispatches nothing", async () => {
-    setSettingsRenderFromProjectionEnabled(false);
-    useAppStore.setState({ settings: settings({ theme: "light", fontSize: 18 }) });
+  it("renders the document projected by the region", async () => {
+    const doc = settingsDoc({ theme: "solarized-dark", fontSize: 15, cursorBlink: true });
+    harness = installSettingsHarness(doc);
 
     const hook = renderHook();
+    await flush();
+    await flush();
+
+    expect(hook.get()).toEqual(doc);
+    hook.unmount();
+  });
+
+  it("updates when the region projects a new document", async () => {
+    harness = installSettingsHarness(settingsDoc({ theme: "dark" }));
+
+    const hook = renderHook();
+    await flush();
+    await flush();
+    expect(hook.get().theme).toBe("dark");
+
+    act(() => harness.transport.seed(settingsDoc({ theme: "light", fontSize: 18 })));
     await flush();
 
     expect(hook.get().theme).toBe("light");
     expect(hook.get().fontSize).toBe(18);
-    expect(transport.dispatched).toHaveLength(0);
     hook.unmount();
   });
 
-  it("flag on: seeds the region then renders the document from the projection", async () => {
-    const doc = settings({ theme: "solarized-dark", fontSize: 15, cursorBlink: true });
-    useAppStore.setState({ settings: doc });
+  it("shows the default baseline before any diff has arrived", () => {
+    // Install the transport but do NOT seed — nothing has been projected yet.
+    harness = installSettingsHarness();
 
     const hook = renderHook();
-    await flush();
-    await flush();
-
-    // The hook seeded appStore's document via settings.replace…
-    expect(transport.dispatched.some((d) => d.kind === "settings.replace")).toBe(true);
-    // …and now renders a value-identical document (sourced from the projection).
-    expect(hook.get()).toEqual(doc);
+    // Synchronous initial render, before the subscribe promise resolves.
+    expect(hook.get()).toEqual(DEFAULT_SETTINGS_VIEW);
     hook.unmount();
-  });
-
-  it("region not caught up: falls back to the appStore document", async () => {
-    transport.applyReplace = false; // the replace acks but never advances the region
-    const doc = settings({ theme: "light", fontFamily: "Fira Code" });
-    useAppStore.setState({ settings: doc });
-
-    const hook = renderHook();
-    await flush();
-    await flush();
-
-    // The projection stays behind, so the gate rejects it and the hook renders the
-    // appStore document verbatim — parity preserved.
-    expect(hook.get()).toEqual(doc);
-    hook.unmount();
-  });
-});
-
-describe("settingsViewMirrors", () => {
-  it("is false for an undefined view", () => {
-    expect(settingsViewMirrors(undefined, settings())).toBe(false);
-  });
-
-  it("is true only when the view deep-equals the appStore document", () => {
-    const a = settings({ theme: "dark", sessionHistoryLimit: 50 });
-    expect(settingsViewMirrors(settings({ theme: "dark", sessionHistoryLimit: 50 }), a)).toBe(true);
-    expect(settingsViewMirrors(settings({ theme: "light", sessionHistoryLimit: 50 }), a)).toBe(
-      false
-    );
-    expect(settingsViewMirrors(settings({ theme: "dark", sessionHistoryLimit: 99 }), a)).toBe(
-      false
-    );
-    // A view that carries an extra key is not a faithful mirror.
-    expect(
-      settingsViewMirrors(settings({ theme: "dark", sessionHistoryLimit: 50, fontSize: 14 }), a)
-    ).toBe(false);
   });
 });

--- a/src/store/useProjectedSettings.ts
+++ b/src/store/useProjectedSettings.ts
@@ -1,68 +1,51 @@
 /**
- * `useProjectedSettings` — the Settings screen cut to the projected `settings`
- * region (#2227 render cut, part of #2153 / #2139).
+ * `useProjectedSettings` — read the authoritative `settings` region (#2227, part
+ * of #2153 / #2139).
  *
- * The Settings screen renders the persisted `AppSettings` document (theme, fonts,
- * confirmation prompts, shell integration, editor mappings, …). Through the shadow
- * step the panels read `appStore.settings` directly. This hook makes them source
- * that document from the shared `settings` projection region instead — the direct
- * analog of {@link import("./useProjectedMonitors").useProjectedMonitors} (#2224)
- * and {@link import("./useProjectedAgents").useProjectedAgents} (#2226).
+ * The Settings screen and the settings-driven UI render the persisted `AppSettings`
+ * document (theme, fonts, confirmation prompts, shell integration, editor mappings,
+ * …). They source that document from the shared `settings` projection region, which
+ * is now **authoritative**: the backend `SettingsStore` is fed at the source
+ * (#2386) — the region is seeded from the persisted document at startup and every
+ * `save_settings` folds the resolved document in — so the region is the single
+ * source of truth. The direct analog of
+ * {@link import("./useProjectedMonitors").useProjectedMonitors} (#2224) and
+ * {@link import("./useProjectedTransfers").useProjectedTransfers} (#2229).
  *
- * # Safety (strangler)
- *
- * - **Gated** by {@link settingsRenderFromProjectionEnabled} (on by default). Flag
- *   off ⇒ the hook returns `appStore`'s settings document verbatim.
- * - **Faithful-mirror gate.** The projection sources the render only when it
- *   deep-equals the `appStore` document ({@link settingsViewMirrors}); otherwise
- *   the hook falls back to `appStore` (never a stale view). While `appStore` stays
- *   authoritative (the mutation cut is a later step) the region is kept a mirror by
- *   {@link seedSettingsRegion}, so it is always populated — making the cut
- *   parity-safe and independent of the mutation flag.
+ * The hook subscribes to the region (one shared subscription, fanned out by the
+ * bridge) and returns the latest projected document, re-rendering on every diff. It
+ * seeds from {@link currentSettingsView} so a consumer mounting after the first
+ * diff already has the current picture, and from {@link DEFAULT_SETTINGS_VIEW}
+ * before any diff has arrived. There is no `appStore` fallback and no mirror gate —
+ * the region is the source of truth.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
-import { useAppStore } from "@/store/appStore";
 import {
   currentSettingsView,
   ensureSettingsSubscribed,
   logSettingsBridgeFallback,
   onSettingsView,
-  seedSettingsRegion,
-  settingsRenderFromProjectionEnabled,
-  settingsViewMirrors,
   type SettingsView,
 } from "@/store/settingsBridge";
 import type { AppSettings } from "@/types/connection";
 
 /**
- * The effective settings document for rendering: the persisted `AppSettings`
- * sourced from the projected `settings` region when it faithfully mirrors
- * `appStore`, otherwise `appStore`'s document verbatim (flag off, region not yet
- * caught up, or a transport that cannot subscribe).
+ * The current persisted settings document for rendering, sourced from the
+ * authoritative `settings` projection region.
  */
 export function useProjectedSettings(): AppSettings {
-  const settings = useAppStore((s) => s.settings);
+  const [view, setView] = useState<SettingsView>(() => currentSettingsView());
 
-  // Read the flag once at mount: it flips only via dev tooling, and the
-  // subscription lifecycle is keyed off it below.
-  const [enabled] = useState(() => settingsRenderFromProjectionEnabled());
-
-  const [view, setView] = useState<SettingsView | undefined>(undefined);
-
-  // Subscribe to the shared settings region while enabled; a transport that cannot
-  // subscribe (non-Tauri without a socket) just leaves the UI on the appStore
-  // fallback.
   useEffect(() => {
-    if (!enabled) return;
     let cancelled = false;
     const unsubscribe = onSettingsView((next) => {
       if (!cancelled) setView(next);
     });
     // `ensureSettingsSubscribed` builds the transport eagerly, so a non-Tauri env
     // without a socket throws synchronously (not just a rejection) — guard both so
-    // the UI silently stays on the appStore fallback.
+    // the hook silently stays on the last-known (or default) document.
     try {
       ensureSettingsSubscribed()
         .then(() => {
@@ -76,20 +59,7 @@ export function useProjectedSettings(): AppSettings {
       cancelled = true;
       unsubscribe();
     };
-  }, [enabled]);
+  }, []);
 
-  const matches = enabled && settingsViewMirrors(view, settings);
-
-  // Keep the region a faithful mirror of appStore's document. Only once a view has
-  // arrived (so we are subscribed) and it is not already a mirror; de-duped inside
-  // `seedSettingsRegion` so a settled document is not re-seeded on every render.
-  useEffect(() => {
-    if (!enabled || matches || view === undefined) return;
-    seedSettingsRegion(settings).catch((err) => logSettingsBridgeFallback("seed", err));
-  }, [enabled, matches, view, settings]);
-
-  return useMemo(() => {
-    if (matches && view) return view;
-    return settings;
-  }, [matches, view, settings]);
+  return view;
 }

--- a/src/test/settingsRegionTestHarness.ts
+++ b/src/test/settingsRegionTestHarness.ts
@@ -1,0 +1,148 @@
+/**
+ * Test harness for the authoritative `settings` projection region (#2227).
+ *
+ * The Settings domain reads the persisted `AppSettings` document from the shared
+ * `settings` region ({@link import("@/store/useProjectedSettings").useProjectedSettings}),
+ * which is now the source of truth — tests can no longer seed settings into
+ * `appStore` and expect the UI to reflect them; they seed the **region**.
+ *
+ * {@link FakeSettingsTransport} is an in-memory twin of the Rust `SettingsStore`:
+ * it holds one opaque settings document, folds the `settings.*` intents **exactly
+ * as the backend routes them** (see `settings_projection/projection.rs`) —
+ * `settings.replace` ← `{ settings }`, `settings.patch` ← `{ patch }`,
+ * `settings.reset` ← `{}` — and fans a fresh snapshot to every subscriber.
+ * {@link FakeSettingsTransport.seed} pre-populates the document for a test's
+ * initial render; {@link FakeSettingsTransport.dispatched} records dispatched
+ * intents for assertions.
+ */
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import {
+  DEFAULT_SETTINGS_VIEW,
+  SETTINGS_REGION,
+  setSettingsTransportForTest,
+  stopSettingsSubscription,
+  type SettingsView,
+} from "@/store/settingsBridge";
+import type { AppSettings } from "@/types/connection";
+
+/** Build an `AppSettings` document with sensible required-field defaults. */
+export function settingsDoc(overrides: Partial<AppSettings> = {}): AppSettings {
+  return {
+    version: "1",
+    externalConnectionFiles: [],
+    ...overrides,
+  };
+}
+
+/**
+ * An in-memory substrate double for the `settings` region: holds one opaque
+ * document, folds the `settings.*` intents like the Rust `SettingsStore`, and fans
+ * a snapshot to every subscriber. Faithful to the backend's payload envelopes so a
+ * client-dispatched intent round-trips back into the projected document exactly as
+ * it would in production.
+ */
+export class FakeSettingsTransport implements Transport {
+  dispatched: Intent[] = [];
+  private view: Record<string, unknown> = { ...DEFAULT_SETTINGS_VIEW };
+  private version = 0;
+  private handlers = new Set<FrameHandler>();
+
+  /** Seed the region document directly (test setup), fanning a snapshot. */
+  seed(view: AppSettings): void {
+    this.view = structuredClone(view) as Record<string, unknown>;
+    this.bump();
+  }
+
+  /** Intent kinds dispatched, in order (assertion helper). */
+  kinds(): string[] {
+    return this.dispatched.map((i) => i.kind);
+  }
+
+  /** The current projected document (assertion helper). */
+  regionView(): AppSettings {
+    return structuredClone(this.view) as unknown as AppSettings;
+  }
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    const p = intent.payload as Record<string, unknown>;
+    switch (intent.kind) {
+      case "settings.replace":
+        this.view = (p.settings ?? {}) as Record<string, unknown>;
+        break;
+      case "settings.patch": {
+        const patch = (p.patch ?? {}) as Record<string, unknown>;
+        this.view = { ...this.view, ...patch };
+        break;
+      }
+      case "settings.reset":
+        this.view = { ...DEFAULT_SETTINGS_VIEW };
+        break;
+      default:
+        return { intentId: intent.intentId, status: "accepted", produced: [] };
+    }
+    this.bump();
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: SETTINGS_REGION, version: this.version }],
+    };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.add(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => this.handlers.delete(onFrame),
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private bump(): void {
+    this.version += 1;
+    const frame = this.snapshot(SETTINGS_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+/**
+ * Install a {@link FakeSettingsTransport} as the settings bridge's transport and
+ * optionally seed it with the initial document. Returns the transport plus a
+ * `teardown` that drops the subscription and restores the real transport — call it
+ * in `afterEach`.
+ */
+export function installSettingsHarness(initial?: AppSettings): {
+  transport: FakeSettingsTransport;
+  teardown: () => void;
+} {
+  const transport = new FakeSettingsTransport();
+  setSettingsTransportForTest(transport);
+  if (initial) transport.seed(initial);
+  return {
+    transport,
+    teardown: () => {
+      stopSettingsSubscription();
+      setSettingsTransportForTest(null);
+    },
+  };
+}
+
+/** Convenience: a `SettingsView` (== `AppSettings`) for seeding. */
+export function settingsRegionView(overrides: Partial<AppSettings> = {}): SettingsView {
+  return settingsDoc(overrides);
+}

--- a/src/test/settingsRegionTestHarness.ts
+++ b/src/test/settingsRegionTestHarness.ts
@@ -24,12 +24,15 @@ import type {
   Subscription,
   Transport,
 } from "@/services/transport";
+import { afterEach, beforeEach } from "vitest";
+
+import { useAppStore } from "@/store/appStore";
 import {
+  __emitSettingsViewForTest,
   DEFAULT_SETTINGS_VIEW,
   SETTINGS_REGION,
   setSettingsTransportForTest,
   stopSettingsSubscription,
-  type SettingsView,
 } from "@/store/settingsBridge";
 import type { AppSettings } from "@/types/connection";
 
@@ -38,6 +41,8 @@ export function settingsDoc(overrides: Partial<AppSettings> = {}): AppSettings {
   return {
     version: "1",
     externalConnectionFiles: [],
+    powerMonitoringEnabled: true,
+    fileBrowserEnabled: true,
     ...overrides,
   };
 }
@@ -57,7 +62,7 @@ export class FakeSettingsTransport implements Transport {
 
   /** Seed the region document directly (test setup), fanning a snapshot. */
   seed(view: AppSettings): void {
-    this.view = structuredClone(view) as Record<string, unknown>;
+    this.view = structuredClone(view) as unknown as Record<string, unknown>;
     this.bump();
   }
 
@@ -69,6 +74,11 @@ export class FakeSettingsTransport implements Transport {
   /** The current projected document (assertion helper). */
   regionView(): AppSettings {
     return structuredClone(this.view) as unknown as AppSettings;
+  }
+
+  /** The current monotonic region version (mirrors the Rust store's version). */
+  currentVersion(): number {
+    return this.version;
   }
 
   async dispatch(intent: Intent): Promise<IntentAck> {
@@ -142,7 +152,64 @@ export function installSettingsHarness(initial?: AppSettings): {
   };
 }
 
-/** Convenience: a `SettingsView` (== `AppSettings`) for seeding. */
-export function settingsRegionView(overrides: Partial<AppSettings> = {}): SettingsView {
-  return settingsDoc(overrides);
+/**
+ * Install a {@link FakeSettingsTransport} that **mirrors `appStore.settings` into
+ * the region**, for the many render-reader tests that drive settings through
+ * `appStore` (`useAppStore.setState({ settings })`, or an action that mutates the
+ * slice) and assert on the settings-driven UI.
+ *
+ * Now that {@link import("@/store/useProjectedSettings").useProjectedSettings}
+ * reads the region authoritatively, those tests can no longer rely on the removed
+ * `appStore` fallback — the UI renders what the region projects. This helper seeds
+ * the region with the current document and re-seeds it on every `appStore.settings`
+ * change, so the region tracks whatever the test puts in `appStore` — the test-side
+ * analog of production, where the region is fed from the persisted document at the
+ * source (#2386). Returns the transport plus a `teardown` (drops the appStore
+ * subscription, the region subscription, and restores the real transport) — call it
+ * in `afterEach`.
+ */
+export function installSettingsHarnessMirroringAppStore(): {
+  transport: FakeSettingsTransport;
+  teardown: () => void;
+} {
+  const { transport, teardown } = installSettingsHarness();
+  // Seed the transport (so the hook's eventual subscribe snapshot is correct) AND
+  // synchronously emit the view (so a reader mounting/re-rendering now reflects it
+  // without waiting for the subscribe round-trip).
+  const push = (settings: AppSettings): void => {
+    transport.seed(settings);
+    __emitSettingsViewForTest(settings, transport.currentVersion());
+  };
+  push(useAppStore.getState().settings);
+  const unsubscribe = useAppStore.subscribe((state, prev) => {
+    if (state.settings !== prev.settings) push(state.settings);
+  });
+  return {
+    transport,
+    teardown: () => {
+      unsubscribe();
+      teardown();
+    },
+  };
+}
+
+/**
+ * Register the appStore→region mirror ({@link installSettingsHarnessMirroringAppStore})
+ * for a whole test file via self-managed `beforeEach`/`afterEach` hooks. Call once
+ * at the top of a render-reader test's module (or describe) so its existing
+ * `appStore`-driven settings setup keeps rendering correctly now that
+ * {@link import("@/store/useProjectedSettings").useProjectedSettings} reads the
+ * region authoritatively — no per-`beforeEach` wiring needed. The mirror's live
+ * subscription re-seeds the region on every `appStore.settings` change during the
+ * test, so a later `setState` or a settings-mutating action still reaches the UI.
+ */
+export function setupSettingsRegionMirror(): void {
+  let harness: { transport: FakeSettingsTransport; teardown: () => void } | undefined;
+  beforeEach(() => {
+    harness = installSettingsHarnessMirroringAppStore();
+  });
+  afterEach(() => {
+    harness?.teardown();
+    harness = undefined;
+  });
 }


### PR DESCRIPTION
## What

**PR A of the Settings Phase-5 reducer-removal (#2227).** Makes `useProjectedSettings` + the settings bridge read the shared `settings` projection region **authoritatively**, and migrates the settings render-reader test surface onto a new region test harness. `appStore.ts`'s authoritative `settings`/`savedSettings` slice, its reducers, and the remaining imperative (`getState().settings`) readers are **left in place** — those are PR B (the reducer removal proper, tracked separately).

Unblocked by the server-authority step-1 (#2386 / PR #2397): the region is seeded from the persisted `AppSettings` document at startup and every `save_settings` folds the resolved document in, so reading it authoritatively is non-lossy.

## Changes

- **Authoritative hook** (`useProjectedSettings.ts`): drops the `appStore` seed, the deep-equal faithful-mirror gate, and the `appStore` fallback — it now subscribes to the region and returns the projected document (analog of `useProjectedMonitors` / `useProjectedTransfers`).
- **Bridge** (`settingsBridge.ts`): `currentSettingsView()` returns a defaulted `DEFAULT_SETTINGS_VIEW` before the first diff; the render-flag + `settingsViewMirrors`/`deepEqual` gate are removed; `seedSettingsRegion` is now a **reliable** appStore→region mirror (resolves on accept, rejects on a rejected ack / transport failure). A **version guard** ignores a stale (older-version) snapshot so a late-delivered subscribe snapshot can't clobber a newer document, plus content-signature dedup keeps the reader value referentially stable across a same-content resync. The mutation-cut section (`mirrorSettingsIntent`, `settingsIntentsEnabled`) is untouched.
- **Test harness** (`src/test/settingsRegionTestHarness.ts`, new): `FakeSettingsTransport` folds `settings.*` intents faithfully to the **backend payload envelopes** (`settings.replace` ← `{ settings }`, `settings.patch` ← `{ patch }`, `settings.reset` ← `{}`); `setupSettingsRegionMirror()` mirrors `appStore.settings` into the region for the ~20 render-reader tests that drive settings through `appStore`.
- **Test migration**: the hook/panel projection tests are rewritten to seed the region; 21 render-reader test files (StatusBar, Terminal, Settings/\*, Sidebar, NetworkTools, ConnectionEditor, ShellIntegrationBanner, …) are wired to the harness; a new `settingsBridge.test.ts` covers the default view, version guard, and reliable seed.

## Necessary bugfix included

The mutation cut dispatched `settings.patch` with a flat `{ shellIntegration }` payload, but the backend route reads the partial from a `{ patch }` envelope — so the intent was silently **rejected**. It went unnoticed because the render-cut hook seed pushed the whole document via a well-formed `settings.replace`; once the hook reads the region authoritatively that seed is gone, so the malformed patch would leave shell-integration **stale** in the region. Fixed the two dispatch sites to wrap the partial in `{ patch }` (2 lines in `appStore.ts`), and made the mutation-cut test's fake transport faithful to the envelope so it can't regress silently again. This is the only `appStore.ts` change and is required for the authoritative cut to be non-regressing.

## Verification

- `tsc --noEmit`, ESLint, Prettier (`src/**` + `docs/**/*.md`) — clean
- Full frontend suite green (549 files, ~4975 tests)
- No Rust changed
- Merged latest `origin/develop` (resolved a keep-both with the Connections PR-A test-harness wiring)

## Follow-up noted (not filed, per coordination)

The shell-integration persistence commands (`install`/`uninstall_shell_integration`, `save_shell_integration_settings`) call `manager.save_settings()` directly and do **not** fold into the region server-side (only the `save_settings` command folds, via #2386). So in-session shell-integration changes reach the region only via the client `settings.patch` intent (now that it's well-formed); a dropped intent would leave the region stale until the next startup seed. A #2386-style server fold for those commands would harden it.

Part of #2227
