### PR TITLE
feat(settings): fold shell-integration changes into the settings region server-side (Closes #2407)

### DIFF
--- a/src-tauri/src/commands/shell_integration.rs
+++ b/src-tauri/src/commands/shell_integration.rs
@@ -1,7 +1,7 @@
 //! Tauri commands for the shell-integration config model (#1367) and OS
 //! context-menu registration (#1368).
 
-use tauri::State;
+use tauri::{AppHandle, State};
 
 use crate::connection::manager::ConnectionManager;
 use crate::connection::settings::AppSettings;
@@ -32,6 +32,22 @@ fn current_status(manager: &ConnectionManager) -> ShellIntegrationStatus {
     )
 }
 
+/// Reflect the just-persisted `AppSettings` document — including the updated
+/// `shell_integration` block — into the shared `SettingsStore` server-side, so
+/// the `settings` projection region mirrors a shell-integration change at the
+/// source (#2407, hardening #2227's reducer-removal).
+///
+/// The analog of the `save_settings` fold (#2386): every shell-integration
+/// command below persists through the `ConnectionManager` authority and then
+/// calls this, so the region reflects install / uninstall / edit / remembered-
+/// choice outcomes without depending on the frontend's follow-up `settings.patch`
+/// dispatch. Best-effort and non-fatal — it is a no-op when the store or manager
+/// is unmanaged (see [`fold_settings_from_manager`]). `AppHandle` is Tauri-
+/// injected, so this adds nothing to the JS invoke surface.
+fn fold_settings(app: &AppHandle) {
+    crate::settings_projection::projection::fold_settings_from_manager(app);
+}
+
 /// Report the current shell-integration registration status.
 ///
 /// Combines the persisted settings with runtime facts: whether the integration
@@ -56,11 +72,13 @@ pub fn get_shell_integration_status(
 /// unchanged. Returns the refreshed status.
 #[tauri::command]
 pub fn install_shell_integration(
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
 ) -> Result<ShellIntegrationStatus, String> {
     let mut settings = manager.get_settings();
     registry::register(&mut settings.shell_integration).map_err(|e| format!("{e:#}"))?;
     manager.save_settings(settings).map_err(|e| e.to_string())?;
+    fold_settings(&app);
     Ok(current_status(&manager))
 }
 
@@ -68,11 +86,13 @@ pub fn install_shell_integration(
 /// updated registration status. Returns the refreshed status.
 #[tauri::command]
 pub fn uninstall_shell_integration(
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
 ) -> Result<ShellIntegrationStatus, String> {
     let mut settings = manager.get_settings();
     registry::unregister(&mut settings.shell_integration).map_err(|e| format!("{e:#}"))?;
     manager.save_settings(settings).map_err(|e| e.to_string())?;
+    fold_settings(&app);
     Ok(current_status(&manager))
 }
 
@@ -99,6 +119,7 @@ fn stage_shell_integration(settings: &mut AppSettings, new_si: ShellIntegrationS
 /// surface the staleness banner without a second round-trip.
 #[tauri::command]
 pub fn save_shell_integration_settings(
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
     shell_integration: ShellIntegrationSettings,
 ) -> Result<ShellIntegrationStatus, String> {
@@ -108,6 +129,7 @@ pub fn save_shell_integration_settings(
         registry::register(&mut settings.shell_integration).map_err(|e| format!("{e:#}"))?;
     }
     manager.save_settings(settings).map_err(|e| e.to_string())?;
+    fold_settings(&app);
     Ok(current_status(&manager))
 }
 
@@ -144,6 +166,7 @@ fn stage_remembered_choice(
 /// [`save_shell_integration_settings`].
 #[tauri::command]
 pub fn remember_spawn_choice(
+    app: AppHandle,
     manager: State<'_, ConnectionManager>,
     entry_id: String,
     target: PickedTarget,
@@ -156,6 +179,7 @@ pub fn remember_spawn_choice(
         registry::register(&mut settings.shell_integration).map_err(|e| format!("{e:#}"))?;
     }
     manager.save_settings(settings).map_err(|e| e.to_string())?;
+    fold_settings(&app);
     Ok(current_status(&manager))
 }
 

--- a/src-tauri/src/settings_projection/projection_tests.rs
+++ b/src-tauri/src/settings_projection/projection_tests.rs
@@ -407,6 +407,65 @@ fn server_side_fold_reflects_the_resolved_settings_document() {
     assert_eq!(sink.diffs().len(), 1, "one diff from the server-side fold");
 }
 
+/// A shell-integration install / uninstall (`install_shell_integration` /
+/// `uninstall_shell_integration`) persists the updated `shell_integration` block
+/// through the manager and then folds server-side (#2407). This drives the same
+/// path: persist a shell-integration change through the real manager authority,
+/// fold, and assert the `settings` region reflects the `shellIntegration` block
+/// — the region no longer depends on the frontend's follow-up `settings.patch`.
+///
+/// The real commands are not called directly here: `registry::register` /
+/// `unregister` perform OS-level context-menu writes, so this asserts the fold
+/// (the additive part of #2407) reflects the persisted shell-integration outcome,
+/// mirroring how the `save_settings` fold is verified above.
+#[test]
+fn server_side_fold_reflects_shell_integration_install_and_uninstall() {
+    let (manager, _dir) = test_manager();
+    let (app, store, sink, _cache) = wire_app(manager);
+    let manager = app.state::<ConnectionManager>();
+
+    // Baseline: the store starts on the frontend default document, which has no
+    // `shellIntegration` block until the authority is folded in.
+    assert_eq!(store.get("shellIntegration"), None);
+
+    // Install: persist the registered outcome (as `install_shell_integration`
+    // does after `registry::register`), then fold — no `settings.*` dispatch.
+    let mut settings = manager.get_settings();
+    settings.shell_integration.registered = true;
+    settings.shell_integration.registered_exe_path = Some("/opt/termihub".to_string());
+    manager.save_settings(settings).unwrap();
+    fold_settings_from_manager(app.handle());
+
+    assert_eq!(
+        store.get("shellIntegration").unwrap()["registered"],
+        json!(true)
+    );
+    assert_eq!(
+        store.get("shellIntegration").unwrap()["registeredExePath"],
+        json!("/opt/termihub")
+    );
+
+    // Uninstall: persist the unregistered outcome, then fold again.
+    let mut settings = manager.get_settings();
+    settings.shell_integration.registered = false;
+    settings.shell_integration.registered_exe_path = None;
+    manager.save_settings(settings).unwrap();
+    fold_settings_from_manager(app.handle());
+
+    assert_eq!(
+        store.get("shellIntegration").unwrap()["registered"],
+        json!(false)
+    );
+
+    // Each fold that changed the document fanned exactly one region diff out to
+    // the subscriber with no client dispatch: install + uninstall = two.
+    assert_eq!(
+        sink.diffs().len(),
+        2,
+        "install and uninstall each fold one region diff, server-side"
+    );
+}
+
 /// The fold is a best-effort no-op when the required state is not managed (e.g. a
 /// headless harness that never ran `setup()`) — it must not panic.
 #[test]


### PR DESCRIPTION
## What

Makes the shared `SettingsStore` (the `settings` projection region) **server-authoritative for shell-integration changes**. The shell-integration persistence commands persisted through the `ConnectionManager` authority but never fed the store, so the region depended solely on the frontend's follow-up `settings.patch` for these paths (the payload bug for which was just fixed in #2406). This is the direct analog of the `save_settings` fold from #2386 (PR #2397).

## Changes

- **Fold at the source** (`commands/shell_integration.rs`): each command that persists a shell-integration change now folds the persisted `AppSettings` document into the shared `SettingsStore` after saving, via a small `fold_settings` helper delegating to `settings_projection::projection::fold_settings_from_manager`:
  - `install_shell_integration`
  - `uninstall_shell_integration`
  - `save_shell_integration_settings` (entry edits / toggles / banner dismissal)
  - `remember_spawn_choice` ("Remember this choice")

  All four take a Tauri-injected `AppHandle` now — **no change to the JS invoke surface**. The fold is best-effort/non-fatal (no-op when the store or manager is unmanaged), reusing the exact `fold_settings_from_manager` path #2386 added, so the command return value and the projection cannot drift.

- **Test** (`settings_projection/projection_tests.rs`): a projection-assertion test driving the fold end to end against `tauri::test::mock_app()` — a persisted **install** then **uninstall** each fan exactly one `settings` region diff out **with no client dispatch**, and the store's `shellIntegration` block reflects the manager authority (`registered` / `registeredExePath`). The real commands are not invoked directly because `registry::register`/`unregister` perform OS-level context-menu writes; the fold — the additive part of this change — is what's asserted, mirroring how the `save_settings` fold is verified.

## Why all four commands, not just install/uninstall

The issue names install/uninstall, but its **Done when** is "removes the last client-only settings transition." `save_shell_integration_settings` and `remember_spawn_choice` persist the identical shell-integration block through the same manager path and were equally client-only, so folding all four is what actually satisfies that criterion.

## Additive / no user-facing change

- The `settings.*` intents stay in place; `appStore.ts` and the frontend mirror are intentionally untouched.
- Nothing in the live UI subscribes to the `settings` region yet. The reducer-removal (making the store authoritative) is the later #2227 step. Backend-only → no changelog fragment.

## Verification

- `cargo test --lib settings_projection` — 16 pass (1 new); `cargo test --lib shell_integration` — 41 pass
- `cargo build`, `cargo fmt --check`, `cargo clippy --all-targets --all-features` — clean
- `pnpm exec prettier --check` over `src/**` + `docs/**/*.md` — clean (pre-existing unrelated `lucide-tags.json` warning only)

Closes #2407