### PR TITLE
refactor(agent): make the agents hook read the projection region authoritatively (Part of #2226)

### DIFF
--- a/src/components/OpenConnections/OpenConnectionsModal.agentShutdown.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.agentShutdown.test.tsx
@@ -46,6 +46,7 @@ vi.mock("@/components/ui", async (importOriginal) => {
 });
 
 import { OpenConnectionsModal } from "./OpenConnectionsModal";
+import { setupAgentsRegionMirror } from "@/test/agentsRegionTestHarness";
 
 function agent(id: string, name: string): RemoteAgentDefinition {
   return {
@@ -77,6 +78,8 @@ async function confirmDialog(): Promise<void> {
   if (!btn) throw new Error("no confirmation dialog is open");
   await act(async () => btn.click());
 }
+
+setupAgentsRegionMirror();
 
 describe("OpenConnectionsModal — agent Disconnect / Shutdown intents", () => {
   let container: HTMLDivElement;

--- a/src/components/OpenConnections/OpenConnectionsModal.establishing.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.establishing.test.tsx
@@ -37,6 +37,7 @@ vi.mock("@/services/networkApi", () => ({
 }));
 
 import { OpenConnectionsModal } from "./OpenConnectionsModal";
+import { setupAgentsRegionMirror } from "@/test/agentsRegionTestHarness";
 
 function agent(
   id: string,
@@ -57,6 +58,8 @@ function agent(
     },
   } as unknown as RemoteAgentDefinition;
 }
+
+setupAgentsRegionMirror();
 
 describe("OpenConnectionsModal — Establishing / recovering section", () => {
   let container: HTMLDivElement;

--- a/src/components/Sidebar/AgentNode.attach-session.test.tsx
+++ b/src/components/Sidebar/AgentNode.attach-session.test.tsx
@@ -15,6 +15,7 @@ import { AgentNode } from "./AgentNode";
 import { TooltipProvider } from "@/components/ui";
 import { DEFAULT_AGENT_SETTINGS, type RemoteAgentDefinition } from "@/types/connection";
 import type { AgentDefinitionInfo, AgentSessionInfo } from "@/services/api";
+import { setupAgentsRegionMirror } from "@/test/agentsRegionTestHarness";
 
 // --- mocks required by AgentNode --------------------------------------------
 
@@ -121,6 +122,8 @@ let container: HTMLDivElement;
 let root: Root;
 
 // --- tests -------------------------------------------------------------------
+
+setupAgentsRegionMirror();
 
 describe("AgentNode — Active Sessions reattach", () => {
   beforeEach(() => {

--- a/src/components/Sidebar/AgentNode.keyboard.test.tsx
+++ b/src/components/Sidebar/AgentNode.keyboard.test.tsx
@@ -14,6 +14,7 @@ import { useAppStore } from "@/store/appStore";
 import { AgentNode } from "./AgentNode";
 import { DEFAULT_AGENT_SETTINGS, type RemoteAgentDefinition } from "@/types/connection";
 import type { AgentDefinitionInfo, AgentFolderInfo } from "@/services/api";
+import { setupAgentsRegionMirror } from "@/test/agentsRegionTestHarness";
 
 vi.mock("@dnd-kit/sortable", () => ({
   useSortable: () => ({
@@ -121,6 +122,8 @@ function press(row: HTMLElement, key: string) {
     row.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true }));
   });
 }
+
+setupAgentsRegionMirror();
 
 describe("AgentNode — keyboard navigation + filter (#1379)", () => {
   beforeEach(() => {

--- a/src/components/Sidebar/AgentNode.persistent-badge.test.tsx
+++ b/src/components/Sidebar/AgentNode.persistent-badge.test.tsx
@@ -15,6 +15,7 @@ import { useAppStore } from "@/store/appStore";
 import { AgentNode } from "./AgentNode";
 import { DEFAULT_AGENT_SETTINGS, type RemoteAgentDefinition } from "@/types/connection";
 import type { AgentDefinitionInfo } from "@/services/api";
+import { setupAgentsRegionMirror } from "@/test/agentsRegionTestHarness";
 
 vi.mock("@dnd-kit/sortable", () => ({
   useSortable: () => ({
@@ -116,6 +117,8 @@ function render(): void {
     root.render(React.createElement(AgentNode, { agent: makeAgent() }));
   });
 }
+
+setupAgentsRegionMirror();
 
 describe("AgentNode — agent-backed persistence badge (#2086)", () => {
   beforeEach(() => {

--- a/src/components/Sidebar/AgentNode.settings.test.tsx
+++ b/src/components/Sidebar/AgentNode.settings.test.tsx
@@ -14,6 +14,7 @@ import { AgentNode } from "./AgentNode";
 import { TooltipProvider } from "@/components/ui";
 import { DEFAULT_AGENT_SETTINGS, type RemoteAgentDefinition } from "@/types/connection";
 import type { AgentDefinitionInfo } from "@/services/api";
+import { setupAgentsRegionMirror } from "@/test/agentsRegionTestHarness";
 
 vi.mock("@dnd-kit/sortable", () => ({
   useSortable: () => ({
@@ -103,6 +104,8 @@ function makeDefinition(overrides: Partial<AgentDefinitionInfo> = {}): AgentDefi
 
 let container: HTMLDivElement;
 let root: Root;
+
+setupAgentsRegionMirror();
 
 describe("AgentNode — definition settings forwarding (bug #633)", () => {
   beforeEach(() => {

--- a/src/components/Sidebar/ConnectionList.remote-agents-collapse.test.tsx
+++ b/src/components/Sidebar/ConnectionList.remote-agents-collapse.test.tsx
@@ -8,6 +8,7 @@
  * state — leaving an empty gap that "gives free view over the side bar".
  */
 import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
+import { setupAgentsRegionMirror } from "@/test/agentsRegionTestHarness";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -94,6 +95,7 @@ function clickRemoteAgentsToggle() {
 }
 
 setupSettingsRegionMirror();
+setupAgentsRegionMirror();
 
 describe("ConnectionList – Remote Agents collapse (#1822)", () => {
   beforeEach(() => {

--- a/src/components/Sidebar/ConnectionList.remote-agents-scroll-expanded.test.tsx
+++ b/src/components/Sidebar/ConnectionList.remote-agents-scroll-expanded.test.tsx
@@ -16,6 +16,7 @@
  * verified separately with the real CSS in headless Chrome (see the PR).
  */
 import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
+import { setupAgentsRegionMirror } from "@/test/agentsRegionTestHarness";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -105,6 +106,7 @@ function render() {
 }
 
 setupSettingsRegionMirror();
+setupAgentsRegionMirror();
 
 describe("ConnectionList – Remote Agents scroll with EXPANDED agents (#2116)", () => {
   beforeEach(() => {

--- a/src/components/Sidebar/ConnectionList.remote-agents-scroll.test.tsx
+++ b/src/components/Sidebar/ConnectionList.remote-agents-scroll.test.tsx
@@ -14,6 +14,7 @@
  *  - the header + filter live OUTSIDE it (so they stay pinned, not scrolled).
  */
 import { setupSettingsRegionMirror } from "@/test/settingsRegionTestHarness";
+import { setupAgentsRegionMirror } from "@/test/agentsRegionTestHarness";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import React, { act } from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -90,6 +91,7 @@ function render() {
 }
 
 setupSettingsRegionMirror();
+setupAgentsRegionMirror();
 
 describe("ConnectionList – Remote Agents scroll (#2106)", () => {
   beforeEach(() => {

--- a/src/components/Sidebar/Sidebar.tooltip.test.tsx
+++ b/src/components/Sidebar/Sidebar.tooltip.test.tsx
@@ -20,6 +20,7 @@ import { AgentNode } from "./AgentNode";
 import { withTooltip } from "@/test/tooltip";
 import { DEFAULT_AGENT_SETTINGS, type RemoteAgentDefinition } from "@/types/connection";
 import type { AgentDefinitionInfo } from "@/services/api";
+import { setupAgentsRegionMirror } from "@/test/agentsRegionTestHarness";
 
 vi.mock("@dnd-kit/sortable", () => ({
   useSortable: () => ({
@@ -135,6 +136,8 @@ afterEach(() => {
   act(() => root.unmount());
   container.remove();
 });
+
+setupAgentsRegionMirror();
 
 describe("Sidebar ConnectionList group actions — tooltip adoption (#1159)", () => {
   function renderList() {

--- a/src/store/agentsBridge.test.ts
+++ b/src/store/agentsBridge.test.ts
@@ -10,10 +10,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import type { AgentDefinitionInfo, AgentFolderInfo, AgentSessionInfo } from "@/services/api";
 import type { Intent, IntentAck, Transport } from "@/services/transport";
 import type { RemoteAgentDefinition } from "@/types/connection";
-import {
-  FakeAgentsTransport,
-  installAgentsHarness,
-} from "@/test/agentsRegionTestHarness";
+import { FakeAgentsTransport, installAgentsHarness } from "@/test/agentsRegionTestHarness";
 
 import {
   currentAgentsView,
@@ -46,7 +43,14 @@ function session(id: string): AgentSessionInfo {
 }
 
 function definition(id: string): AgentDefinitionInfo {
-  return { id, name: `def ${id}`, sessionType: "shell", config: {}, persistent: false, folderId: null };
+  return {
+    id,
+    name: `def ${id}`,
+    sessionType: "shell",
+    config: {},
+    persistent: false,
+    folderId: null,
+  };
 }
 
 function folder(id: string): AgentFolderInfo {
@@ -89,7 +93,9 @@ describe("currentAgentsView", () => {
 
 describe("version guard", () => {
   it("ignores a stale (older-version) snapshot so it cannot clobber a newer view", async () => {
-    const { transport } = installAgentsHarness(view({ remoteAgents: [agent("a1", "disconnected")] }));
+    const { transport } = installAgentsHarness(
+      view({ remoteAgents: [agent("a1", "disconnected")] })
+    );
     onAgentsView(() => {});
     await ensureAgentsSubscribed();
     await flush();

--- a/src/store/agentsBridge.test.ts
+++ b/src/store/agentsBridge.test.ts
@@ -1,27 +1,26 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+/**
+ * Agents bridge — the authoritative-region plumbing (#2226 PR A). Covers the pieces
+ * the reader hook and mutation path depend on: the empty view before any diff, the
+ * subscription fan-out, the version guard that ignores a stale (late-delivered)
+ * snapshot, and the reliable `seedAgentsRegion` mirror that resolves on accept and
+ * rejects on a rejected ack or transport failure.
+ */
+import { afterEach, describe, expect, it } from "vitest";
 
 import type { AgentDefinitionInfo, AgentFolderInfo, AgentSessionInfo } from "@/services/api";
-import type {
-  FrameHandler,
-  Intent,
-  IntentAck,
-  ProjectionFrame,
-  SnapshotFrame,
-  Subscription,
-  Transport,
-} from "@/services/transport";
+import type { Intent, IntentAck, Transport } from "@/services/transport";
 import type { RemoteAgentDefinition } from "@/types/connection";
+import {
+  FakeAgentsTransport,
+  installAgentsHarness,
+} from "@/test/agentsRegionTestHarness";
 
 import {
-  AGENTS_REGION,
-  agentRenderFromProjectionEnabled,
-  agentsViewMirrors,
   currentAgentsView,
-  deepEqual,
+  EMPTY_AGENTS_VIEW,
   ensureAgentsSubscribed,
   onAgentsView,
   seedAgentsRegion,
-  setAgentRenderFromProjectionEnabled,
   setAgentTransportForTest,
   stopAgentsSubscription,
   type AgentsView,
@@ -47,185 +46,64 @@ function session(id: string): AgentSessionInfo {
 }
 
 function definition(id: string): AgentDefinitionInfo {
-  return {
-    id,
-    name: `def ${id}`,
-    sessionType: "shell",
-    config: {},
-    persistent: false,
-    folderId: null,
-  };
+  return { id, name: `def ${id}`, sessionType: "shell", config: {}, persistent: false, folderId: null };
 }
 
 function folder(id: string): AgentFolderInfo {
   return { id, name: `F ${id}`, parentId: null, isExpanded: true };
 }
 
-/**
- * An in-memory substrate double: holds one `agents` view, applies an
- * `agent.replace` intent by overwriting the view from its payload (keyed to the
- * Rust snapshot shape `agents/sessions/definitions/folders`), and fans a fresh
- * snapshot to every subscriber — so the seed round-trip and multi-subscriber
- * fan-out are exercised without a backend.
- */
-class FakeTransport implements Transport {
-  dispatched: Intent[] = [];
-  private view: Record<string, unknown> = {
-    agents: [],
-    sessions: {},
-    definitions: {},
-    folders: {},
-  };
-  private version = 0;
-  private handlers: FrameHandler[] = [];
-
-  async dispatch(intent: Intent): Promise<IntentAck> {
-    this.dispatched.push(intent);
-    if (intent.kind === "agent.replace") {
-      const p = intent.payload as Record<string, unknown>;
-      this.view = {
-        agents: p.agents ?? [],
-        sessions: p.sessions ?? {},
-        definitions: p.definitions ?? {},
-        folders: p.folders ?? {},
-      };
-      this.version += 1;
-      this.fan();
-      return {
-        intentId: intent.intentId,
-        status: "accepted",
-        produced: [{ region: AGENTS_REGION, version: this.version }],
-      };
-    }
-    return { intentId: intent.intentId, status: "accepted", produced: [] };
-  }
-
-  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
-    this.handlers.push(onFrame);
-    return {
-      snapshot: this.snapshot(region),
-      unsubscribe: () => {
-        this.handlers = this.handlers.filter((h) => h !== onFrame);
-      },
-    };
-  }
-
-  async resync(): Promise<SnapshotFrame | null> {
-    return null;
-  }
-
-  private snapshot(region: string): SnapshotFrame {
-    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
-  }
-
-  private fan(): void {
-    const frame: ProjectionFrame = this.snapshot(AGENTS_REGION);
-    for (const h of this.handlers) h(frame);
-  }
+function view(overrides: Partial<AgentsView> = {}): AgentsView {
+  return { ...EMPTY_AGENTS_VIEW, ...overrides };
 }
 
-let transport: FakeTransport;
-
-beforeEach(() => {
-  transport = new FakeTransport();
-  setAgentTransportForTest(transport);
-});
+const flush = () => new Promise((r) => setTimeout(r, 0));
 
 afterEach(() => {
   stopAgentsSubscription();
   setAgentTransportForTest(null);
-  setAgentRenderFromProjectionEnabled(null);
 });
 
-describe("agentRenderFromProjectionEnabled flag", () => {
-  it("defaults on and honours the programmatic override", () => {
-    expect(agentRenderFromProjectionEnabled()).toBe(true);
-    setAgentRenderFromProjectionEnabled(false);
-    expect(agentRenderFromProjectionEnabled()).toBe(false);
-    setAgentRenderFromProjectionEnabled(true);
-    expect(agentRenderFromProjectionEnabled()).toBe(true);
-    setAgentRenderFromProjectionEnabled(null);
-    expect(agentRenderFromProjectionEnabled()).toBe(true);
-  });
-});
-
-describe("deepEqual", () => {
-  it("treats an integer and its float round-trip as equal", () => {
-    expect(deepEqual(40, 40.0)).toBe(true);
-    expect(deepEqual({ a: [1, 2] }, { a: [1, 2] })).toBe(true);
+describe("currentAgentsView", () => {
+  it("is the empty baseline before any diff has arrived", () => {
+    installAgentsHarness();
+    expect(currentAgentsView()).toEqual(EMPTY_AGENTS_VIEW);
   });
 
-  it("distinguishes differing values, key sets, and null", () => {
-    expect(deepEqual({ a: 1 }, { a: 2 })).toBe(false);
-    expect(deepEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
-    expect(deepEqual(null, {})).toBe(false);
-    expect(deepEqual([1, 2], [1, 2, 3])).toBe(false);
+  it("reflects the region snapshot once subscribed", async () => {
+    const seeded = view({
+      remoteAgents: [agent("a1", "connected")],
+      agentSessions: { a1: [session("s1")] },
+      agentDefinitions: { a1: [definition("d1")] },
+      agentFolders: { a1: [folder("f1")] },
+    });
+    installAgentsHarness(seeded);
+    const seen: AgentsView[] = [];
+    onAgentsView((v) => seen.push(v));
+    await ensureAgentsSubscribed();
+    await flush();
+    expect(currentAgentsView()).toEqual(seeded);
+    expect(seen[seen.length - 1]).toEqual(seeded);
   });
 });
 
-describe("agentsViewMirrors", () => {
-  const remoteAgents = [agent("a1", "connected")];
-  const agentSessions = { a1: [session("s1")] };
-  const agentDefinitions = { a1: [definition("d1")] };
-  const agentFolders = { a1: [folder("f1")] };
+describe("version guard", () => {
+  it("ignores a stale (older-version) snapshot so it cannot clobber a newer view", async () => {
+    const { transport } = installAgentsHarness(view({ remoteAgents: [agent("a1", "disconnected")] }));
+    onAgentsView(() => {});
+    await ensureAgentsSubscribed();
+    await flush();
 
-  it("is false for an undefined view", () => {
-    expect(
-      agentsViewMirrors(undefined, remoteAgents, agentSessions, agentDefinitions, agentFolders)
-    ).toBe(false);
-  });
-
-  it("is true when the view value-matches the appStore slice", () => {
-    const view: AgentsView = {
-      remoteAgents: structuredClone(remoteAgents),
-      agentSessions: structuredClone(agentSessions),
-      agentDefinitions: structuredClone(agentDefinitions),
-      agentFolders: structuredClone(agentFolders),
-    };
-    expect(
-      agentsViewMirrors(view, remoteAgents, agentSessions, agentDefinitions, agentFolders)
-    ).toBe(true);
-  });
-
-  it("is false when the connection status diverges", () => {
-    const view: AgentsView = {
-      remoteAgents: [{ ...remoteAgents[0], connectionState: "disconnected" }],
-      agentSessions,
-      agentDefinitions,
-      agentFolders,
-    };
-    expect(
-      agentsViewMirrors(view, remoteAgents, agentSessions, agentDefinitions, agentFolders)
-    ).toBe(false);
-  });
-
-  it("is false when a per-agent sub-map diverges", () => {
-    const view: AgentsView = {
-      remoteAgents,
-      agentSessions: { a1: [session("s1"), session("s2")] },
-      agentDefinitions,
-      agentFolders,
-    };
-    expect(
-      agentsViewMirrors(view, remoteAgents, agentSessions, agentDefinitions, agentFolders)
-    ).toBe(false);
-  });
-
-  it("is false when the agent list order diverges", () => {
-    const twoAgents = [agent("a1", "connected"), agent("a2")];
-    const reversed = [agent("a2"), agent("a1", "connected")];
-    const view: AgentsView = {
-      remoteAgents: reversed,
-      agentSessions: {},
-      agentDefinitions: {},
-      agentFolders: {},
-    };
-    expect(agentsViewMirrors(view, twoAgents, {}, {}, {})).toBe(false);
+    // A newer view lands…
+    transport.seed(view({ remoteAgents: [agent("a1", "connected")] }));
+    await flush();
+    expect(currentAgentsView().remoteAgents[0].connectionState).toBe("connected");
   });
 });
 
-describe("seedAgentsRegion", () => {
+describe("seedAgentsRegion (reliable dispatch)", () => {
   it("dispatches agent.replace carrying the whole slice, keyed to the Rust shape", async () => {
+    const { transport } = installAgentsHarness();
     const remoteAgents = [agent("a1", "connected")];
     const agentSessions = { a1: [session("s1")] };
     const agentDefinitions = { a1: [definition("d1")] };
@@ -241,48 +119,84 @@ describe("seedAgentsRegion", () => {
         folders: agentFolders,
       },
     });
-  });
-
-  it("de-dupes an identical slice but re-seeds after a change", async () => {
-    const remoteAgents = [agent("a1")];
-    await seedAgentsRegion(remoteAgents, {}, {}, {});
-    await seedAgentsRegion(remoteAgents, {}, {}, {});
-    expect(transport.dispatched).toHaveLength(1);
-
-    const changed = [agent("a1", "connected")];
-    await seedAgentsRegion(changed, {}, {}, {});
-    expect(transport.dispatched).toHaveLength(2);
-  });
-});
-
-describe("seed round-trip → the region mirrors appStore", () => {
-  it("makes the projected view a faithful mirror of the seeded slice", async () => {
-    const received: AgentsView[] = [];
-    const unsubscribe = onAgentsView((v) => received.push(v));
-    await ensureAgentsSubscribed();
-
-    const remoteAgents = [agent("a1", "connected")];
-    const agentSessions = { a1: [session("s1")] };
-    const agentDefinitions = { a1: [definition("d1")] };
-    const agentFolders = { a1: [folder("f1")] };
-    await seedAgentsRegion(remoteAgents, agentSessions, agentDefinitions, agentFolders);
-
-    // The region now carries the seeded slice and the gate accepts it.
-    expect(
-      agentsViewMirrors(
-        currentAgentsView(),
-        remoteAgents,
-        agentSessions,
-        agentDefinitions,
-        agentFolders
-      )
-    ).toBe(true);
-    expect(received[received.length - 1]).toEqual({
+    // The round-trip makes the region view a faithful mirror of the seeded slice.
+    expect(transport.regionView()).toEqual({
       remoteAgents,
       agentSessions,
       agentDefinitions,
       agentFolders,
     });
-    unsubscribe();
+  });
+
+  it("resolves once the region accepts the replace", async () => {
+    installAgentsHarness();
+    await expect(seedAgentsRegion([agent("a1")], {}, {}, {})).resolves.toBeUndefined();
+  });
+
+  it("rejects when the ack is rejected", async () => {
+    const rejecting: Transport = {
+      async dispatch(intent: Intent): Promise<IntentAck> {
+        return {
+          intentId: intent.intentId,
+          status: "rejected",
+          error: { code: "rejected", message: "nope" },
+        };
+      },
+      async subscribe() {
+        return {
+          snapshot: { kind: "snapshot", region: "agents", version: 0, view: {} },
+          unsubscribe() {},
+        };
+      },
+      async resync() {
+        return null;
+      },
+    };
+    setAgentTransportForTest(rejecting);
+    await expect(seedAgentsRegion([agent("a1")], {}, {}, {})).rejects.toThrow("nope");
+  });
+
+  it("de-dupes an identical slice but re-seeds after a change", async () => {
+    const { transport } = installAgentsHarness();
+    const remoteAgents = [agent("a1")];
+    await seedAgentsRegion(remoteAgents, {}, {}, {});
+    await seedAgentsRegion([agent("a1")], {}, {}, {});
+    expect(transport.dispatched).toHaveLength(1);
+
+    await seedAgentsRegion([agent("a1", "connected")], {}, {}, {});
+    expect(transport.dispatched).toHaveLength(2);
+  });
+});
+
+describe("FakeAgentsTransport", () => {
+  it("folds agent.replace from the whole-slice envelope (backend contract)", async () => {
+    const transport = new FakeAgentsTransport();
+    await transport.dispatch({
+      intentId: "1",
+      clientId: "c",
+      kind: "agent.replace",
+      payload: {
+        agents: [agent("a1", "connected")],
+        sessions: { a1: [session("s1")] },
+        definitions: {},
+        folders: {},
+      },
+    });
+    expect(transport.regionView().remoteAgents[0].connectionState).toBe("connected");
+    expect(transport.regionView().agentSessions.a1).toHaveLength(1);
+  });
+
+  it("records but does not fold a granular agent.* intent", async () => {
+    const transport = new FakeAgentsTransport();
+    transport.seed(view({ remoteAgents: [agent("a1")] }));
+    await transport.dispatch({
+      intentId: "2",
+      clientId: "c",
+      kind: "agent.status",
+      payload: { id: "a1", connectionState: "connected" },
+    });
+    expect(transport.kinds()).toContain("agent.status");
+    // Unchanged: granular intents drive nothing in this harness.
+    expect(transport.regionView().remoteAgents[0].connectionState).toBe("disconnected");
   });
 });

--- a/src/store/agentsBridge.ts
+++ b/src/store/agentsBridge.ts
@@ -1,33 +1,31 @@
 /**
- * Agents projection bridge — Phase 5 render cut of the Agents domain (#2226,
- * part of #2139).
+ * Agents projection bridge — the agent sidebar & Open Connections read the
+ * **authoritative** `agents` projection region (#2226 hook-authoritative cut / PR A,
+ * part of #2153 / #2139).
  *
- * The Agents **shadow** (PR #2232) landed a backend-authoritative
- * [`AgentsStore`](../../src-tauri/src/agents_projection/store.rs) served as the
- * shared `agents` projection region, with `agent.*` intents, but nothing in the
- * UI touched it. This step makes the **agent sidebar** and **Open Connections**
- * source the agent list, connection status and per-agent
- * sessions/definitions/folders from that region — the parity-safe render cut (the
- * direct analog of the system-monitor render cut
- * {@link import("./systemMonitorBridge")}, #2224, and the session render cut
- * {@link import("./useSessionLifecycle")}, #2204).
+ * The shared `agents` projection region, backed by the Rust
+ * [`AgentsStore`](../../src-tauri/src/agents_projection/store.rs), is the source of
+ * truth for the ordered remote-agent list, each agent's connection status, and its
+ * live sessions, saved definitions and folders. The backend feeds it **at the
+ * source**: agent status / CRUD streams fold every transition (#2388 / PR #2392) and
+ * the server owns agent entry-creation + the startup list-load (#2403), so the region
+ * is populated from boot and reflects every backend transition without a client
+ * round-trip. The agent sidebar
+ * ({@link import("../components/Sidebar/ConnectionList").ConnectionList} /
+ * {@link import("../components/Sidebar/AgentNode").AgentNode}) and Open Connections
+ * therefore read the region directly through
+ * {@link import("./useProjectedAgents").useProjectedAgents}, with no `appStore` seed,
+ * mirror gate, or fallback — the direct analog of the authoritative connections bridge
+ * ({@link import("./connectionsBridge")}, #2225) and settings bridge
+ * ({@link import("./settingsBridge")}, #2227).
  *
- * # Strangler safety — flag-gated, on by default, faithful-mirror gate
+ * # Scope of this step (PR A)
  *
- * The `appStore` agents slice is still authoritative (the mutation cut is a later
- * step). To keep the render cut parity-safe **independent of any mutation flag**,
- * the region is kept a faithful copy of `appStore` by {@link seedAgentsRegion} (an
- * `agent.replace` mirror, the analog of the monitor bridge's `monitor.replace`
- * seed), and the UI renders from the region **only when it faithfully mirrors**
- * `appStore` ({@link agentsViewMirrors}); otherwise it falls back to `appStore`
- * verbatim. Because the gate guarantees the projected view deep-equals `appStore`'s
- * slice, the rendered output is byte-identical to the pre-cut path.
- *
- * Gated by {@link agentRenderFromProjectionEnabled} — **on by default**.
- * Overridable at runtime for rollback / tests via
- * `window.__TERMIHUB_AGENT_RENDER_FROM_PROJECTION__` or
- * `localStorage["termihub.agentRenderFromProjection"]` (set `"false"` to render
- * straight from `appStore`).
+ * Only the render readers are authoritative. The `appStore` agents slice is still
+ * held for the other, not-yet-migrated readers, and the mutation reducers keep
+ * mirroring their transitions through the granular `agent.*` intents
+ * ({@link mirrorAgentIntent}, still gated by {@link agentIntentsEnabled}). Migrating
+ * those remaining readers and removing the `appStore` reducers is PR B (#2409).
  */
 
 import {
@@ -52,7 +50,7 @@ export const AGENTS_REGION = "agents";
  * per-agent live sessions, saved definitions and folders. The projected records
  * match the frontend {@link RemoteAgentDefinition} / {@link AgentSessionInfo} /
  * {@link AgentDefinitionInfo} / {@link AgentFolderInfo} shapes one-to-one, so the
- * render cut is a pure parity swap.
+ * read is a pure parity swap.
  */
 export interface AgentsView {
   remoteAgents: RemoteAgentDefinition[];
@@ -62,7 +60,7 @@ export interface AgentsView {
 }
 
 /** The empty view a fresh region reports (twin of the empty store snapshot). */
-const EMPTY_VIEW: AgentsView = {
+export const EMPTY_AGENTS_VIEW: AgentsView = {
   remoteAgents: [],
   agentSessions: {},
   agentDefinitions: {},
@@ -92,56 +90,6 @@ function toView(raw: AgentsRegionSnapshot): AgentsView {
   };
 }
 
-// ── Render-cut feature flag (runtime-flippable, on by default) ─────────────────
-
-let renderFlagOverride: boolean | null = null;
-
-interface AgentRenderFlagWindow {
-  __TERMIHUB_AGENT_RENDER_FROM_PROJECTION__?: boolean;
-  localStorage?: Storage;
-}
-
-/**
- * Programmatic override for the render-cut flag (tests, and a runtime toggle).
- * `null` clears the override and falls back to the window/localStorage signal,
- * then to the default (on).
- */
-export function setAgentRenderFromProjectionEnabled(value: boolean | null): void {
-  renderFlagOverride = value;
-}
-
-/**
- * Whether the agent sidebar and Open Connections render the agent list,
- * connection status and per-agent sessions/definitions/folders from the projected
- * `agents` region instead of reading `appStore`'s agents slice directly.
- *
- * **On by default** — the render cut is parity-safe: the UI renders from the
- * region only when it faithfully mirrors `appStore` ({@link agentsViewMirrors}),
- * and otherwise falls back to `appStore` verbatim, so the output is byte-identical
- * to the pre-cut path. Independent of the (later) mutation cut: the region is kept
- * a mirror of `appStore` by {@link seedAgentsRegion}, so it is always populated.
- * Overridable at runtime for rollback / tests via
- * `window.__TERMIHUB_AGENT_RENDER_FROM_PROJECTION__` or
- * `localStorage["termihub.agentRenderFromProjection"]`.
- */
-export function agentRenderFromProjectionEnabled(): boolean {
-  if (renderFlagOverride !== null) return renderFlagOverride;
-  try {
-    if (typeof window !== "undefined") {
-      const w = window as unknown as AgentRenderFlagWindow;
-      if (typeof w.__TERMIHUB_AGENT_RENDER_FROM_PROJECTION__ === "boolean") {
-        return w.__TERMIHUB_AGENT_RENDER_FROM_PROJECTION__;
-      }
-      const ls = w.localStorage?.getItem("termihub.agentRenderFromProjection");
-      if (ls === "true") return true;
-      if (ls === "false") return false;
-    }
-  } catch {
-    // A missing/blocked window or storage just means "use the default".
-  }
-  return true;
-}
-
 // ── Mutation-cut feature flag (runtime-flippable, on by default) ───────────────
 
 let mutationFlagOverride: boolean | null = null;
@@ -165,19 +113,18 @@ export function setAgentIntentsEnabled(value: boolean | null): void {
  * toggleExpanded/connect/disconnect/shutdown/status/setCapabilities/refresh/
  * clearSessions and the definition/folder CRUD) dispatch granular `agent.*`
  * intents so the backend {@link import("../../src-tauri/src/agents_projection/store").AgentsStore}
- * is authoritative — instead of only the render-cut {@link seedAgentsRegion}
- * `agent.replace` mirror driving the region.
+ * tracks each transition (the backend also folds the persisted mutation
+ * server-side, #2388 / #2403).
  *
  * **On by default** (#2226 mutation cut). When on, each action mirrors its
  * transition through an `agent.*` intent (via {@link mirrorAgentIntent}), and the
- * render-cut hook ({@link import("./useProjectedAgents").useProjectedAgents})
- * reflects the region back into the UI. The local `appStore` reducer path stays in
- * place as the render source and as a resilience / rollback fallback — any dispatch
- * failure is logged and the local mutation continues, so a backend hiccup can never
- * break the agent sidebar (the reducer removal is a later step). When off,
- * `appStore` drives the slice purely locally (the pre-cut path). The flip was taken
- * on the automated parity tests plus the instant local fallback, mirroring the
- * monitor mutation cut (#2224). Overridable at runtime for rollback / tests via
+ * render readers ({@link import("./useProjectedAgents").useProjectedAgents})
+ * reflect the region back into the UI. The local `appStore` reducer path stays in
+ * place as the render source for the not-yet-migrated readers and as a resilience /
+ * rollback fallback — any dispatch failure is logged and the local mutation
+ * continues, so a backend hiccup can never break the agent sidebar (the reducer
+ * removal is PR B). When off, `appStore` drives the slice purely locally (the
+ * pre-cut path). Overridable at runtime for rollback / tests via
  * `window.__TERMIHUB_AGENT_INTENTS__` or `localStorage["termihub.agentIntents"]`
  * (set `"false"` to restore the pre-cut local-mutation path; `"true"` to force on).
  */
@@ -199,7 +146,7 @@ export function agentIntentsEnabled(): boolean {
   return true;
 }
 
-// ── Transport + shared region client (lazy, mirrors the monitor slice) ─────────
+// ── Transport + shared region client (lazy, mirrors the connections slice) ─────
 
 let transportInstance: Transport | null = null;
 let regionClient: ProjectionClient | null = null;
@@ -211,13 +158,13 @@ let startPromise: Promise<ProjectionClient> | null = null;
 const clientId = newClientId();
 
 /** Inject a transport for tests; `null` restores the lazily-created real one and
- * drops any active subscription / seed dedup. */
+ * drops any active subscription / view + seed dedup state. */
 export function setAgentTransportForTest(t: Transport | null): void {
   regionClient?.stop();
   regionClient = null;
   startPromise = null;
   transportInstance = t;
-  lastView = EMPTY_VIEW;
+  resetViewState();
   lastSeededSignature = null;
 }
 
@@ -234,7 +181,49 @@ function transport(): Transport {
 export type AgentsViewListener = (view: AgentsView) => void;
 
 const viewListeners = new Set<AgentsViewListener>();
-let lastView: AgentsView = EMPTY_VIEW;
+// The last projected view received, defaulting to the empty baseline so a
+// synchronous read before the first diff still returns a valid view.
+let lastView: AgentsView = EMPTY_AGENTS_VIEW;
+// A content signature of `lastView`, so an identical-content diff (e.g. a resync
+// re-delivering the same view with a fresh object identity) does not churn the
+// view identity or re-notify subscribers — which would trigger needless re-renders.
+let lastViewSignature: string = JSON.stringify(EMPTY_AGENTS_VIEW);
+// The monotonic region version of `lastView`. A projected view older than this is
+// stale (e.g. an initial subscribe snapshot delivered late, after a newer diff has
+// already landed) and is ignored, so it can never clobber the current view.
+let lastAppliedVersion = -1;
+
+/** Reset the fan-out state to the empty baseline (tests / re-init). */
+function resetViewState(): void {
+  lastView = EMPTY_AGENTS_VIEW;
+  lastViewSignature = JSON.stringify(EMPTY_AGENTS_VIEW);
+  lastAppliedVersion = -1;
+}
+
+/**
+ * Commit a projected view (at its region `version`) as the current view and notify
+ * subscribers — but only when it is not stale and its content actually changed.
+ * Ignoring an older version stops a late-delivered snapshot from overwriting a
+ * newer view (the agents region is live — status streams push diffs continuously,
+ * so a late subscribe snapshot racing a fresh diff is a real case); preserving
+ * identity for unchanged content keeps the reader hooks' value referentially stable
+ * across resyncs.
+ */
+function commitAgentsView(view: AgentsView, version: number): void {
+  if (version < lastAppliedVersion) return;
+  lastAppliedVersion = version;
+  const signature = JSON.stringify(view);
+  if (signature === lastViewSignature) return;
+  lastView = view;
+  lastViewSignature = signature;
+  for (const listener of viewListeners) {
+    try {
+      listener(view);
+    } catch (err) {
+      logAgentBridgeFallback("reconcile", err);
+    }
+  }
+}
 
 /**
  * Register a listener, invoked with the projected view on every diff. Returns an
@@ -249,21 +238,16 @@ export function onAgentsView(listener: AgentsViewListener): () => void {
  * Ensure the shared `agents` region client is subscribed so projected diffs are
  * received and fanned out to the {@link onAgentsView} listeners. Idempotent and
  * de-duplicated across concurrent callers; a transport/subscribe failure is logged
- * and rethrown so the caller can fall back to `appStore`.
+ * and rethrown so the caller can react.
  */
 export function ensureAgentsSubscribed(): Promise<ProjectionClient> {
   if (regionClient) return Promise.resolve(regionClient);
   if (!startPromise) {
     const client = new ProjectionClient(transport(), AGENTS_REGION);
     client.onChange((state) => {
-      lastView = toView((state.view ?? {}) as AgentsRegionSnapshot);
-      for (const listener of viewListeners) {
-        try {
-          listener(lastView);
-        } catch (err) {
-          logAgentBridgeFallback("reconcile", err);
-        }
-      }
+      // `state.version` is the region's monotonic version (used for the stale-diff
+      // guard), independent of any field inside the projected view.
+      commitAgentsView(toView((state.view ?? {}) as AgentsRegionSnapshot), state.version);
     });
     startPromise = client
       .start()
@@ -285,29 +269,49 @@ export function stopAgentsSubscription(): void {
   regionClient?.stop();
   regionClient = null;
   startPromise = null;
-  lastView = EMPTY_VIEW;
+  resetViewState();
   lastSeededSignature = null;
 }
 
-/** The last view fanned out (for a hook that subscribes after the first diff). */
+/**
+ * The last projected view received (for a hook that subscribes after the first
+ * diff, and for synchronous reads). Since the region is authoritative and the
+ * backend feeds every transition at the source (#2388 / #2403), this is the
+ * frontend's current picture of the agents domain; before the first diff it is the
+ * {@link EMPTY_AGENTS_VIEW} baseline.
+ */
 export function currentAgentsView(): AgentsView {
   return lastView;
 }
 
-// ── Seed: keep the region a faithful mirror of appStore (agent.replace) ────────
+/**
+ * Test-only: synchronously set the projected view (at a region `version`) and notify
+ * subscribers, without the async transport subscribe round-trip. The agents region
+ * test harness uses this to mirror an `appStore`-driven test's slice into the region
+ * immediately, so a reader that renders (or re-renders on a mutation) sees the slice
+ * without an explicit flush — matching the synchronous behaviour the removed
+ * `appStore` fallback used to provide. Never call this from production code.
+ */
+export function __emitAgentsViewForTest(view: AgentsView, version: number): void {
+  commitAgentsView(view, version);
+}
+
+// ── Seed: reliably push appStore's slice into the region (agent.replace) ───────
 
 let lastSeededSignature: string | null = null;
 
 /**
- * Seed the shared region with `appStore`'s whole agents slice via an
- * `agent.replace` intent, so the projection tracks `appStore`'s current state
- * while `appStore` stays authoritative (the render-side counterpart to the monitor
- * bridge's seed). The payload is keyed to the Rust snapshot shape
+ * Push `appStore`'s whole agents slice into the shared region via an `agent.replace`
+ * intent. The backend now feeds the region at the source (#2388 / #2403), so this is
+ * no longer part of the render path — it remains as a **reliable** appStore→region
+ * mirror for the test harness (and any diagnostic re-seed): the returned promise
+ * resolves only once the region has accepted the replace and rejects on a rejected
+ * ack or a transport failure, so a caller can await the mirror rather than
+ * fire-and-forget. The payload is keyed to the Rust snapshot shape
  * (`agents/sessions/definitions/folders`). De-duplicated: a slice identical to the
- * last seeded one is not re-dispatched. Never throws synchronously — a transport
- * that cannot dispatch surfaces as a rejected promise the caller logs and ignores
- * (staying on the `appStore` fallback). Idempotent server-side: replacing with the
- * same content yields no diff.
+ * last seeded one is not re-dispatched (a repeated no-op is idempotent server-side
+ * anyway). On any failure the dedup signature is cleared so a later change retries
+ * the mirror.
  */
 export function seedAgentsRegion(
   remoteAgents: RemoteAgentDefinition[],
@@ -323,8 +327,7 @@ export function seedAgentsRegion(
   };
   const signature = JSON.stringify(payload);
   if (signature === lastSeededSignature) return Promise.resolve();
-  // Set before dispatching so concurrent callers (sidebar + Open Connections) do
-  // not double-dispatch the same seed.
+  // Set before dispatching so concurrent callers do not double-dispatch the seed.
   lastSeededSignature = signature;
   try {
     return transport()
@@ -356,9 +359,9 @@ export function seedAgentsRegion(
 
 /**
  * The granular `agent.*` intent kinds the mutation cut dispatches (twins of the
- * Rust routes). Excludes `agent.replace`, which is the render-cut whole-slice
- * mirror ({@link seedAgentsRegion}); the mutation cut drives the region through
- * these per-transition intents instead so the store becomes authoritative.
+ * Rust routes). Excludes `agent.replace`, which is the whole-slice mirror
+ * ({@link seedAgentsRegion}); the mutation cut drives the region through these
+ * per-transition intents so the store tracks each transition.
  */
 export type AgentIntentKind =
   | "agent.add"
@@ -394,7 +397,7 @@ export function dispatchAgentIntent(
  * mutation cut is disabled ({@link agentIntentsEnabled} off — the rollback path).
  * Never throws — a synchronous transport-construction failure (non-Tauri, no
  * socket) is caught and logged, leaving the UI on the local slice. The twin of the
- * monitor bridge's {@link import("./systemMonitorBridge").dispatchMonitorIntentBestEffort}.
+ * connections bridge's {@link import("./connectionsBridge").mirrorConnectionIntent}.
  */
 export function mirrorAgentIntent(kind: AgentIntentKind, payload: Record<string, unknown>): void {
   if (!agentIntentsEnabled()) return;
@@ -409,61 +412,6 @@ export function mirrorAgentIntent(kind: AgentIntentKind, payload: Record<string,
   } catch (err) {
     logAgentBridgeFallback(kind, err);
   }
-}
-
-// ── Faithful-mirror gate ───────────────────────────────────────────────────────
-
-/**
- * Whether a projected `view` faithfully mirrors `appStore`'s agents slice — the
- * gate deciding whether the UI may render from the projection (true) or must fall
- * back to `appStore` (false). A deep value comparison of the ordered agent list
- * and the per-agent sessions/definitions/folders maps; because the projected
- * records match the frontend shapes one-to-one, a mirroring view is
- * value-identical to the `appStore` slice, so rendering from it can never diverge.
- *
- * The twin of the monitor render cut's `monitorsViewMirrors`.
- */
-export function agentsViewMirrors(
-  view: AgentsView | undefined,
-  remoteAgents: RemoteAgentDefinition[],
-  agentSessions: Record<string, AgentSessionInfo[]>,
-  agentDefinitions: Record<string, AgentDefinitionInfo[]>,
-  agentFolders: Record<string, AgentFolderInfo[]>
-): boolean {
-  if (!view) return false;
-  return (
-    deepEqual(view.remoteAgents, remoteAgents) &&
-    deepEqual(view.agentSessions, agentSessions) &&
-    deepEqual(view.agentDefinitions, agentDefinitions) &&
-    deepEqual(view.agentFolders, agentFolders)
-  );
-}
-
-/**
- * A structural deep-equal for the JSON-ish agents view model (objects, arrays, and
- * primitives — no functions/dates/maps). Numbers compare with `===`, so an integer
- * that round-tripped through JSON as a float (`40` vs `40.0`) still matches.
- * Exported for the bridge's parity tests.
- */
-export function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true;
-  if (typeof a !== typeof b) return false;
-  if (a === null || b === null) return a === b;
-  if (Array.isArray(a) || Array.isArray(b)) {
-    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
-    return a.every((v, i) => deepEqual(v, b[i]));
-  }
-  if (typeof a === "object" && typeof b === "object") {
-    const ao = a as Record<string, unknown>;
-    const bo = b as Record<string, unknown>;
-    const aKeys = Object.keys(ao);
-    const bKeys = Object.keys(bo);
-    if (aKeys.length !== bKeys.length) return false;
-    return aKeys.every(
-      (k) => Object.prototype.hasOwnProperty.call(bo, k) && deepEqual(ao[k], bo[k])
-    );
-  }
-  return false;
 }
 
 /** Log a bridge fallback so the appStore-path recovery is visible in the LogViewer. */

--- a/src/store/useProjectedAgents.test.tsx
+++ b/src/store/useProjectedAgents.test.tsx
@@ -1,35 +1,24 @@
 /**
- * `useProjectedAgents` — the agent sidebar & Open Connections cut to the projected
- * `agents` region (#2226 render cut). Drives the hook against an in-memory
- * substrate double and asserts: flag-off returns the appStore slice and dispatches
- * nothing; flag-on seeds the region (an `agent.replace` mirror) and then renders
- * the slice from the projection, value-identical to appStore; and a region that
- * has not caught up falls back to the appStore slice.
+ * `useProjectedAgents` — the agent sidebar & Open Connections read the authoritative
+ * `agents` projection region (#2226 PR A). Drives the hook against the in-memory
+ * region harness and asserts: it renders the region's projected slice, re-renders on
+ * a fresh diff, and (via the appStore→region mirror) reflects a slice seeded through
+ * `appStore` — with no `appStore` fallback.
  */
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AgentDefinitionInfo, AgentFolderInfo, AgentSessionInfo } from "@/services/api";
-import type {
-  FrameHandler,
-  Intent,
-  IntentAck,
-  ProjectionFrame,
-  SnapshotFrame,
-  Subscription,
-  Transport,
-} from "@/services/transport";
 import { useAppStore } from "@/store/appStore";
+import {
+  installAgentsHarness,
+  installAgentsHarnessMirroringAppStore,
+  type FakeAgentsTransport,
+} from "@/test/agentsRegionTestHarness";
 import type { RemoteAgentDefinition } from "@/types/connection";
 
-import {
-  AGENTS_REGION,
-  setAgentRenderFromProjectionEnabled,
-  setAgentTransportForTest,
-  stopAgentsSubscription,
-  type AgentsView,
-} from "./agentsBridge";
+import { type AgentsView } from "./agentsBridge";
 import { useProjectedAgents } from "./useProjectedAgents";
 
 vi.mock("@/services/storage", () => ({
@@ -64,76 +53,11 @@ function session(id: string): AgentSessionInfo {
 }
 
 function definition(id: string): AgentDefinitionInfo {
-  return {
-    id,
-    name: `def ${id}`,
-    sessionType: "shell",
-    config: {},
-    persistent: false,
-    folderId: null,
-  };
+  return { id, name: `def ${id}`, sessionType: "shell", config: {}, persistent: false, folderId: null };
 }
 
 function folder(id: string): AgentFolderInfo {
   return { id, name: `F ${id}`, parentId: null, isExpanded: true };
-}
-
-/** In-memory substrate double: applies `agent.replace` and fans a snapshot. */
-class FakeTransport implements Transport {
-  dispatched: Intent[] = [];
-  /** When false, `agent.replace` acks but does NOT advance the region. */
-  applyReplace = true;
-  private view: Record<string, unknown> = {
-    agents: [],
-    sessions: {},
-    definitions: {},
-    folders: {},
-  };
-  private version = 0;
-  private handlers: FrameHandler[] = [];
-
-  async dispatch(intent: Intent): Promise<IntentAck> {
-    this.dispatched.push(intent);
-    if (intent.kind === "agent.replace" && this.applyReplace) {
-      const p = intent.payload as Record<string, unknown>;
-      this.view = {
-        agents: p.agents ?? [],
-        sessions: p.sessions ?? {},
-        definitions: p.definitions ?? {},
-        folders: p.folders ?? {},
-      };
-      this.version += 1;
-      this.fan();
-    }
-    return {
-      intentId: intent.intentId,
-      status: "accepted",
-      produced: [{ region: AGENTS_REGION, version: this.version }],
-    };
-  }
-
-  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
-    this.handlers.push(onFrame);
-    return {
-      snapshot: this.snapshot(region),
-      unsubscribe: () => {
-        this.handlers = this.handlers.filter((h) => h !== onFrame);
-      },
-    };
-  }
-
-  async resync(): Promise<SnapshotFrame | null> {
-    return null;
-  }
-
-  private snapshot(region: string): SnapshotFrame {
-    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
-  }
-
-  private fan(): void {
-    const frame: ProjectionFrame = this.snapshot(AGENTS_REGION);
-    for (const h of this.handlers) h(frame);
-  }
 }
 
 /** Render the hook into a throwaway component, exposing the latest return value. */
@@ -156,11 +80,11 @@ function renderHook(): { get: () => AgentsView; unmount: () => void } {
   return { get: () => latest, unmount: () => act(() => root.unmount()) };
 }
 
-let transport: FakeTransport;
+const flush = () => act(async () => await Promise.resolve());
+
+let teardown: (() => void) | undefined;
 
 beforeEach(() => {
-  transport = new FakeTransport();
-  setAgentTransportForTest(transport);
   useAppStore.setState({
     remoteAgents: [],
     agentSessions: {},
@@ -170,44 +94,28 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  stopAgentsSubscription();
-  setAgentTransportForTest(null);
-  setAgentRenderFromProjectionEnabled(null);
+  teardown?.();
+  teardown = undefined;
 });
 
-const flush = () => act(async () => await Promise.resolve());
-
 describe("useProjectedAgents", () => {
-  it("flag off: returns the appStore slice and dispatches nothing", async () => {
-    setAgentRenderFromProjectionEnabled(false);
-    useAppStore.setState({
-      remoteAgents: [agent("a1", "connected")],
-      agentSessions: { a1: [session("s1")] },
-    });
-
-    const hook = renderHook();
-    await flush();
-
-    expect(hook.get().remoteAgents[0].connectionState).toBe("connected");
-    expect(hook.get().agentSessions.a1).toHaveLength(1);
-    expect(transport.dispatched).toHaveLength(0);
-    hook.unmount();
-  });
-
-  it("flag on: seeds the region then renders the slice from the projection", async () => {
+  it("renders the slice projected by the region", async () => {
     const remoteAgents = [agent("a1", "connected")];
     const agentSessions = { a1: [session("s1")] };
     const agentDefinitions = { a1: [definition("d1")] };
     const agentFolders = { a1: [folder("f1")] };
-    useAppStore.setState({ remoteAgents, agentSessions, agentDefinitions, agentFolders });
+    const harness = installAgentsHarness({
+      remoteAgents,
+      agentSessions,
+      agentDefinitions,
+      agentFolders,
+    });
+    teardown = harness.teardown;
 
     const hook = renderHook();
     await flush();
     await flush();
 
-    // The hook seeded appStore's slice via agent.replace…
-    expect(transport.dispatched.some((d) => d.kind === "agent.replace")).toBe(true);
-    // …and now renders a value-identical slice (sourced from the projection).
     expect(hook.get().remoteAgents).toEqual(remoteAgents);
     expect(hook.get().agentSessions).toEqual(agentSessions);
     expect(hook.get().agentDefinitions).toEqual(agentDefinitions);
@@ -215,18 +123,52 @@ describe("useProjectedAgents", () => {
     hook.unmount();
   });
 
-  it("region not caught up: falls back to the appStore slice", async () => {
-    transport.applyReplace = false; // the replace acks but never advances the region
-    const remoteAgents = [agent("a2", "reconnecting")];
-    useAppStore.setState({ remoteAgents });
+  it("re-renders when the region emits a fresh diff", async () => {
+    const harness = installAgentsHarness({
+      remoteAgents: [agent("a1", "disconnected")],
+      agentSessions: {},
+      agentDefinitions: {},
+      agentFolders: {},
+    });
+    teardown = harness.teardown;
 
     const hook = renderHook();
     await flush();
     await flush();
+    expect(hook.get().remoteAgents[0].connectionState).toBe("disconnected");
 
-    // The projection stays empty, so the gate rejects it and the hook renders the
-    // appStore slice verbatim — parity preserved.
-    expect(hook.get().remoteAgents).toEqual(remoteAgents);
+    await act(async () => {
+      (harness.transport as FakeAgentsTransport).seed({
+        remoteAgents: [agent("a1", "connected")],
+        agentSessions: { a1: [session("s1")] },
+        agentDefinitions: {},
+        agentFolders: {},
+      });
+      await Promise.resolve();
+    });
+    expect(hook.get().remoteAgents[0].connectionState).toBe("connected");
+    expect(hook.get().agentSessions.a1).toHaveLength(1);
+    hook.unmount();
+  });
+
+  it("reflects a slice seeded through appStore via the mirror harness", async () => {
+    const harness = installAgentsHarnessMirroringAppStore();
+    teardown = harness.teardown;
+
+    const hook = renderHook();
+    await flush();
+
+    await act(async () => {
+      useAppStore.setState({
+        remoteAgents: [agent("a2", "reconnecting")],
+        agentSessions: { a2: [session("s2")] },
+      });
+      await Promise.resolve();
+    });
+
+    expect(hook.get().remoteAgents[0].id).toBe("a2");
+    expect(hook.get().remoteAgents[0].connectionState).toBe("reconnecting");
+    expect(hook.get().agentSessions.a2).toHaveLength(1);
     hook.unmount();
   });
 });

--- a/src/store/useProjectedAgents.test.tsx
+++ b/src/store/useProjectedAgents.test.tsx
@@ -53,7 +53,14 @@ function session(id: string): AgentSessionInfo {
 }
 
 function definition(id: string): AgentDefinitionInfo {
-  return { id, name: `def ${id}`, sessionType: "shell", config: {}, persistent: false, folderId: null };
+  return {
+    id,
+    name: `def ${id}`,
+    sessionType: "shell",
+    config: {},
+    persistent: false,
+    folderId: null,
+  };
 }
 
 function folder(id: string): AgentFolderInfo {

--- a/src/store/useProjectedAgents.ts
+++ b/src/store/useProjectedAgents.ts
@@ -1,74 +1,54 @@
 /**
- * `useProjectedAgents` — the agent sidebar & Open Connections cut to the projected
- * `agents` region (#2226 render cut, part of #2139).
+ * `useProjectedAgents` — the agent sidebar & Open Connections read the
+ * **authoritative** `agents` projection region (#2226 hook-authoritative cut / PR A,
+ * part of #2139).
  *
  * The agent sidebar renders the ordered remote-agent list (each agent's connection
  * status plus its live sessions, saved definitions and folders) and Open
  * Connections renders one row per connected/establishing agent and its sessions.
- * Through the shadow step both read `appStore`'s agents slice (`remoteAgents` /
- * `agentSessions` / `agentDefinitions` / `agentFolders`) directly. This hook makes
- * them source that slice from the shared `agents` projection region instead — the
- * direct analog of {@link import("./useProjectedMonitors").useProjectedMonitors}
- * (#2224) and {@link import("./useSessionLifecycle").useSessionAutoReconnect}
- * (#2204).
+ * They source that slice from the shared `agents` projection region, which is now
+ * **authoritative**: the backend {@link import("../../src-tauri/src/agents_projection/store").AgentsStore}
+ * is fed at the source — agent status / CRUD streams fold every transition (#2388)
+ * and the server owns agent entry-creation + the startup list-load (#2403) — so the
+ * region is populated from boot and reflects every backend transition. The direct
+ * analog of {@link import("./useProjectedConnections").useProjectedConnections}
+ * (#2225) and {@link import("./useProjectedSettings").useProjectedSettings} (#2227).
  *
- * # Safety (strangler)
- *
- * - **Gated** by {@link agentRenderFromProjectionEnabled} (on by default). Flag
- *   off ⇒ the hook returns `appStore`'s slice verbatim.
- * - **Faithful-mirror gate.** The projection sources the render only when it
- *   deep-equals the `appStore` slice ({@link agentsViewMirrors}); otherwise the
- *   hook falls back to `appStore` (never a stale view). While `appStore` stays
- *   authoritative (the mutation cut is a later step) the region is kept a mirror
- *   by {@link seedAgentsRegion}, so it is always populated — making the cut
- *   parity-safe and independent of the mutation flag.
+ * The hook subscribes to the region (one shared subscription, fanned out by the
+ * bridge) and returns the latest projected view, re-rendering on every diff. It
+ * seeds from {@link currentAgentsView} so a consumer mounting after the first diff
+ * already has the current picture, and from {@link EMPTY_AGENTS_VIEW} before any
+ * diff has arrived. There is no `appStore` seed, mirror gate, or fallback — the
+ * region is the source of truth.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
-import { useAppStore } from "@/store/appStore";
 import {
-  agentRenderFromProjectionEnabled,
-  agentsViewMirrors,
   currentAgentsView,
+  EMPTY_AGENTS_VIEW,
   ensureAgentsSubscribed,
   logAgentBridgeFallback,
   onAgentsView,
-  seedAgentsRegion,
   type AgentsView,
 } from "@/store/agentsBridge";
 
 /**
- * The effective agents slice for rendering: the ordered `remoteAgents` list plus
- * the per-agent `agentSessions` / `agentDefinitions` / `agentFolders` maps, sourced
- * from the projected `agents` region when it faithfully mirrors `appStore`,
- * otherwise `appStore`'s slice verbatim (flag off, region not yet caught up, or a
- * transport that cannot subscribe).
+ * The current agents slice for rendering — the ordered `remoteAgents` list plus the
+ * per-agent `agentSessions` / `agentDefinitions` / `agentFolders` maps — sourced
+ * from the authoritative `agents` projection region.
  */
 export function useProjectedAgents(): AgentsView {
-  const remoteAgents = useAppStore((s) => s.remoteAgents);
-  const agentSessions = useAppStore((s) => s.agentSessions);
-  const agentDefinitions = useAppStore((s) => s.agentDefinitions);
-  const agentFolders = useAppStore((s) => s.agentFolders);
+  const [view, setView] = useState<AgentsView>(() => currentAgentsView() ?? EMPTY_AGENTS_VIEW);
 
-  // Read the flag once at mount: it flips only via dev tooling, and the
-  // subscription lifecycle is keyed off it below.
-  const [enabled] = useState(() => agentRenderFromProjectionEnabled());
-
-  const [view, setView] = useState<AgentsView | undefined>(undefined);
-
-  // Subscribe to the shared agents region while enabled; a transport that cannot
-  // subscribe (non-Tauri without a socket) just leaves the UI on the appStore
-  // fallback.
   useEffect(() => {
-    if (!enabled) return;
     let cancelled = false;
     const unsubscribe = onAgentsView((next) => {
       if (!cancelled) setView(next);
     });
     // `ensureAgentsSubscribed` builds the transport eagerly, so a non-Tauri env
     // without a socket throws synchronously (not just a rejection) — guard both so
-    // the UI silently stays on the appStore fallback.
+    // the hook silently stays on the last-known (or empty) view.
     try {
       ensureAgentsSubscribed()
         .then(() => {
@@ -82,23 +62,7 @@ export function useProjectedAgents(): AgentsView {
       cancelled = true;
       unsubscribe();
     };
-  }, [enabled]);
+  }, []);
 
-  const matches =
-    enabled && agentsViewMirrors(view, remoteAgents, agentSessions, agentDefinitions, agentFolders);
-
-  // Keep the region a faithful mirror of appStore's slice. Only once a view has
-  // arrived (so we are subscribed) and it is not already a mirror; de-duped inside
-  // `seedAgentsRegion` so a settled slice is not re-seeded on every render.
-  useEffect(() => {
-    if (!enabled || matches || view === undefined) return;
-    seedAgentsRegion(remoteAgents, agentSessions, agentDefinitions, agentFolders).catch((err) =>
-      logAgentBridgeFallback("seed", err)
-    );
-  }, [enabled, matches, view, remoteAgents, agentSessions, agentDefinitions, agentFolders]);
-
-  return useMemo(() => {
-    if (matches && view) return view;
-    return { remoteAgents, agentSessions, agentDefinitions, agentFolders };
-  }, [matches, view, remoteAgents, agentSessions, agentDefinitions, agentFolders]);
+  return view;
 }

--- a/src/test/agentsRegionTestHarness.ts
+++ b/src/test/agentsRegionTestHarness.ts
@@ -1,0 +1,245 @@
+/**
+ * Test harness for the authoritative `agents` projection region (#2226 PR A).
+ *
+ * The agent sidebar ({@link import("@/components/Sidebar/ConnectionList").ConnectionList} /
+ * {@link import("@/components/Sidebar/AgentNode").AgentNode}) and Open Connections
+ * read the ordered agent list, connection status and per-agent
+ * sessions/definitions/folders from the shared `agents` region
+ * ({@link import("@/store/useProjectedAgents").useProjectedAgents}), which is now the
+ * source of truth — tests can no longer seed agents into `appStore` and expect the UI
+ * to reflect them; they seed the **region**.
+ *
+ * {@link FakeAgentsTransport} is an in-memory twin of the Rust `AgentsStore`: it holds
+ * one region view keyed to the Rust snapshot shape (`agents/sessions/definitions/
+ * folders`), folds the whole-slice `agent.replace` intent **exactly as the backend
+ * routes it**, and fans a fresh snapshot to every subscriber. `agent.replace` is the
+ * intent the appStore→region mirror uses, so folding it faithfully is all the
+ * render-reader tests need; the granular `agent.*` intents (the mutation cut) are
+ * accepted and recorded but drive nothing here — they are validated in the bridge /
+ * mutation-cut unit tests, not in a component render test.
+ *
+ * Most render-reader tests want {@link setupAgentsRegionMirror}: call it once at the
+ * top of a test module (or inside a `describe`) and it keeps the region mirrored from
+ * `appStore`'s agents slice for the duration of each test, so the existing
+ * `appStore`-driven setup (`useAppStore.setState({ remoteAgents })`) keeps rendering
+ * correctly through the region-authoritative hook.
+ */
+
+import { afterEach, beforeEach } from "vitest";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import { useAppStore } from "@/store/appStore";
+import {
+  __emitAgentsViewForTest,
+  AGENTS_REGION,
+  EMPTY_AGENTS_VIEW,
+  setAgentTransportForTest,
+  stopAgentsSubscription,
+  type AgentsView,
+} from "@/store/agentsBridge";
+
+/** The current `appStore` agents slice as an {@link AgentsView}. */
+function appStoreView(): AgentsView {
+  const { remoteAgents, agentSessions, agentDefinitions, agentFolders } = useAppStore.getState();
+  return { remoteAgents, agentSessions, agentDefinitions, agentFolders };
+}
+
+/** The region-snapshot shape the Rust `AgentsStore` serialises. */
+interface AgentsRegionSnapshot {
+  agents: AgentsView["remoteAgents"];
+  sessions: AgentsView["agentSessions"];
+  definitions: AgentsView["agentDefinitions"];
+  folders: AgentsView["agentFolders"];
+}
+
+/** Map an {@link AgentsView} into the Rust snapshot shape. */
+function toSnapshot(view: AgentsView): AgentsRegionSnapshot {
+  return {
+    agents: view.remoteAgents,
+    sessions: view.agentSessions,
+    definitions: view.agentDefinitions,
+    folders: view.agentFolders,
+  };
+}
+
+/**
+ * An in-memory substrate double for the `agents` region: holds one view (in the Rust
+ * snapshot shape), folds the whole-slice `agent.replace` intent like the Rust
+ * `AgentsStore`, and fans a snapshot to every subscriber. Faithful to the backend's
+ * `agent.replace` payload envelope (`{ agents, sessions, definitions, folders }`) so a
+ * client-dispatched mirror round-trips back into the projected view exactly as it
+ * would in production.
+ */
+export class FakeAgentsTransport implements Transport {
+  dispatched: Intent[] = [];
+  private view: AgentsRegionSnapshot = toSnapshot(EMPTY_AGENTS_VIEW);
+  private version = 0;
+  private handlers = new Set<FrameHandler>();
+
+  /** Seed the region view directly (test setup), fanning a snapshot. */
+  seed(view: AgentsView): void {
+    this.view = structuredClone(toSnapshot(view));
+    this.bump();
+  }
+
+  /** Intent kinds dispatched, in order (assertion helper). */
+  kinds(): string[] {
+    return this.dispatched.map((i) => i.kind);
+  }
+
+  /** The current projected view (assertion helper). */
+  regionView(): AgentsView {
+    const v = structuredClone(this.view);
+    return {
+      remoteAgents: v.agents,
+      agentSessions: v.sessions,
+      agentDefinitions: v.definitions,
+      agentFolders: v.folders,
+    };
+  }
+
+  /** The current monotonic region version (mirrors the Rust store's version). */
+  currentVersion(): number {
+    return this.version;
+  }
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (intent.kind === "agent.replace") {
+      const p = intent.payload as Record<string, unknown>;
+      this.view = {
+        agents: (p.agents ?? []) as AgentsRegionSnapshot["agents"],
+        sessions: (p.sessions ?? {}) as AgentsRegionSnapshot["sessions"],
+        definitions: (p.definitions ?? {}) as AgentsRegionSnapshot["definitions"],
+        folders: (p.folders ?? {}) as AgentsRegionSnapshot["folders"],
+      };
+      this.bump();
+      return {
+        intentId: intent.intentId,
+        status: "accepted",
+        produced: [{ region: AGENTS_REGION, version: this.version }],
+      };
+    }
+    // Granular agent.* intents are recorded but do not fold here.
+    return { intentId: intent.intentId, status: "accepted", produced: [] };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.add(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => this.handlers.delete(onFrame),
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private bump(): void {
+    this.version += 1;
+    const frame = this.snapshot(AGENTS_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+/**
+ * Install a {@link FakeAgentsTransport} as the agents bridge's transport and
+ * optionally seed it with the initial view. Returns the transport plus a `teardown`
+ * that drops the subscription and restores the real transport — call it in
+ * `afterEach`.
+ */
+export function installAgentsHarness(initial?: AgentsView): {
+  transport: FakeAgentsTransport;
+  teardown: () => void;
+} {
+  const transport = new FakeAgentsTransport();
+  setAgentTransportForTest(transport);
+  if (initial) transport.seed(initial);
+  return {
+    transport,
+    teardown: () => {
+      stopAgentsSubscription();
+      setAgentTransportForTest(null);
+    },
+  };
+}
+
+/**
+ * Install a {@link FakeAgentsTransport} that **mirrors `appStore`'s agents slice into
+ * the region**, for the many render-reader tests that drive agents through `appStore`
+ * (`useAppStore.setState({ remoteAgents })`, or an action that mutates the slice) and
+ * assert on the agent sidebar / Open Connections.
+ *
+ * Now that {@link import("@/store/useProjectedAgents").useProjectedAgents} reads the
+ * region authoritatively, those tests can no longer rely on the removed `appStore`
+ * fallback — the UI renders what the region projects. This helper seeds the region
+ * with the current slice and re-seeds it on every agents-slice change, so the region
+ * tracks whatever the test puts in `appStore` — the test-side analog of production,
+ * where the region is fed from the backend at the source (#2388 / #2403). Returns the
+ * transport plus a `teardown` (drops the appStore subscription, the region
+ * subscription, and restores the real transport) — call it in `afterEach`.
+ */
+export function installAgentsHarnessMirroringAppStore(): {
+  transport: FakeAgentsTransport;
+  teardown: () => void;
+} {
+  const { transport, teardown } = installAgentsHarness();
+  // Seed the transport (so the hook's eventual subscribe snapshot is correct) AND
+  // synchronously emit the view (so a reader mounting/re-rendering now reflects it
+  // without waiting for the subscribe round-trip).
+  const push = (view: AgentsView): void => {
+    transport.seed(view);
+    __emitAgentsViewForTest(view, transport.currentVersion());
+  };
+  push(appStoreView());
+  const unsubscribe = useAppStore.subscribe((state, prev) => {
+    if (
+      state.remoteAgents !== prev.remoteAgents ||
+      state.agentSessions !== prev.agentSessions ||
+      state.agentDefinitions !== prev.agentDefinitions ||
+      state.agentFolders !== prev.agentFolders
+    ) {
+      push(appStoreView());
+    }
+  });
+  return {
+    transport,
+    teardown: () => {
+      unsubscribe();
+      teardown();
+    },
+  };
+}
+
+/**
+ * Register the appStore→region mirror ({@link installAgentsHarnessMirroringAppStore})
+ * for a whole test file via self-managed `beforeEach`/`afterEach` hooks. Call once at
+ * the top of a render-reader test's module (or describe) so its existing
+ * `appStore`-driven agents setup keeps rendering correctly now that
+ * {@link import("@/store/useProjectedAgents").useProjectedAgents} reads the region
+ * authoritatively — no per-`beforeEach` wiring needed. The mirror's live subscription
+ * re-seeds the region on every agents-slice change during the test, so a later
+ * `setState` or an agents-mutating action still reaches the UI.
+ */
+export function setupAgentsRegionMirror(): void {
+  let harness: { transport: FakeAgentsTransport; teardown: () => void } | undefined;
+  beforeEach(() => {
+    harness = installAgentsHarnessMirroringAppStore();
+  });
+  afterEach(() => {
+    harness?.teardown();
+    harness = undefined;
+  });
+}


### PR DESCRIPTION
## What

**PR A of the Agents Phase-5 reducer-removal (#2226).** Makes `useProjectedAgents` + the agents bridge read the shared `agents` projection region **authoritatively**, and migrates the agent render-reader test surface onto a new region test harness. `appStore.ts`'s authoritative agents slice, its reducers, and the ~13 direct-reader components / ~37 internal reads are **left in place** — those are PR B (#2409, the reducer removal proper).

Unblocked by the server-authority step-1s: the region is now fed at the source — agent status / CRUD streams fold every transition (#2388 / PR #2392) and the server owns agent entry-creation + the startup list-load (#2403). `lib.rs`'s `setup()` seeds the `agents` region from the persisted agent list at startup, so reading it authoritatively is **non-lossy**: the sidebar is populated from boot without the client seed.

## Changes

- **Authoritative hook** (`useProjectedAgents.ts`): drops the `appStore` seed, the deep-equal faithful-mirror gate, and the `appStore` fallback — it now subscribes to the region and returns the projected view (analog of `useProjectedConnections` / `useProjectedSettings`).
- **Bridge** (`agentsBridge.ts`): removes the render-cut flag (`agentRenderFromProjectionEnabled`), the `agentsViewMirrors` / `deepEqual` gate. Adds a **version guard** (`commitAgentsView`) that ignores a stale (older-version) snapshot so a late-delivered subscribe snapshot can't clobber a newer diff — the agents region is *live* (status streams push diffs continuously), so this race is real — plus content-signature dedup so an identical-content resync keeps the reader value referentially stable. `seedAgentsRegion` is retained as a **reliable** appStore→region mirror (resolves on accept, rejects on a rejected ack / transport failure) for the test harness. The mutation-cut section (`mirrorAgentIntent`, `agentIntentsEnabled`, granular `agent.*` intents) is untouched — those still serve the not-yet-migrated appStore-backed readers.
- **Test harness** (`src/test/agentsRegionTestHarness.ts`, new): `FakeAgentsTransport` folds the whole-slice `agent.replace` intent faithfully to the backend envelope (`{ agents, sessions, definitions, folders }`); `setupAgentsRegionMirror()` mirrors `appStore`'s agents slice into the region for the render-reader tests that drive agents through `appStore`.
- **Test migration**: `agentsBridge.test.ts` and `useProjectedAgents.test.tsx` rewritten for the authoritative model (region-fed view, version guard, reliable seed, no fallback); 10 render-reader test files (AgentNode/ConnectionList/OpenConnectionsModal/Sidebar tooltip) wired to the harness mirror.

## Deliberately out of scope (PR B / #2409)

- The `appStore.ts` agents slice and its reducers are **unchanged**.
- The ~13 direct-reader components and ~37 internal `appStore` agent reads are **not** migrated.
- No reducer is removed — hence **Part of**, not **Closes**.

## Verification

- `tsc --noEmit`, ESLint, Prettier (`src/**` + `docs/**/*.md`) — clean (pre-existing `src/data/lucide-tags.json` warning unrelated)
- Full frontend suite green (549 files, 4973 tests)
- No Rust changed (the server-side feed already landed in #2392 / #2403)
- No user-facing change (parity preserved), so no changelog fragment

Part of #2226