### PR TITLE
test(status-bar): drop dead connections fixture in monitoring-feedback prime (Closes #2413)

### DIFF
--- a/src/components/StatusBar/StatusBar.monitoring-feedback.test.tsx
+++ b/src/components/StatusBar/StatusBar.monitoring-feedback.test.tsx
@@ -18,7 +18,7 @@ import { createRoot, Root } from "react-dom/client";
 import { TooltipProvider } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
 import { StatusBar } from "./StatusBar";
-import type { ConnectionTypeInfo, SavedConnection } from "@/types/connection";
+import type { ConnectionTypeInfo } from "@/types/connection";
 import type { LeafPanel, TerminalTab } from "@/types/terminal";
 import type { MonitoringEntry } from "@/types/monitoring";
 import { currentMonitorsView, ensureMonitorsSubscribed } from "@/store/systemMonitorBridge";
@@ -44,17 +44,7 @@ const SSH_TYPE: ConnectionTypeInfo = {
   capabilities: { monitoring: true, fileBrowser: true, resize: true, persistent: false },
 };
 
-const SAVED_CONNECTION: SavedConnection = {
-  id: "conn-1",
-  name: "pi",
-  folderId: null,
-  config: {
-    type: "ssh",
-    config: { host: "pi.local", port: 22, username: "pi", authMethod: "key" },
-  },
-};
-
-/** Registers a monitoring-capable SSH type + saved connection and makes an SSH tab active. */
+/** Registers a monitoring-capable SSH type and makes an SSH tab active. */
 function primeMonitoringTab() {
   const tab: TerminalTab = {
     id: "tab-1",
@@ -77,7 +67,6 @@ function primeMonitoringTab() {
   useAppStore.setState((state) => ({
     ...state,
     connectionTypes: [SSH_TYPE],
-    connections: [SAVED_CONNECTION],
     rootPanel: leaf,
     activePanelId: "leaf-1",
   }));


### PR DESCRIPTION
## Summary

Fixes the dead `connections` fixture key in the `StatusBar.monitoring-feedback` test's monitor-prime helper (noticed in #2404 / PR #2412).

The prime helper seeded `connections: [SAVED_CONNECTION]` into the appStore, but the StatusBar monitoring-feedback render path **never reads saved connections** (`s.connections`). It drives entirely off `connectionTypes` (the monitoring-capable SSH type), the active tab, and the `system-monitors` projection region. So the fixture was dead — it seeded a field no assertion depends on.

## Change

- Remove the `connections: [SAVED_CONNECTION]` seed from `primeMonitoringTab`.
- Remove the now-unused `SAVED_CONNECTION` constant and its `SavedConnection` import.
- Trim the prime-helper docstring to match (no "+ saved connection").

The G7/G9 error/retry assertions are unchanged and still exercise the same behaviour — they were already genuine (monitoring is driven via `connectionTypes` + the seeded monitor entry), not passing because of the dead fixture.

## Verification (local — GitHub Actions is in a major outage)

- `pnpm test StatusBar.monitoring-feedback` → 2 passed
- `pnpm exec tsc --noEmit` → exit 0
- `pnpm exec eslint <file>` → exit 0
- `pnpm exec prettier --check <file>` → clean

Test-hygiene only; no production code touched.

Closes #2413