### PR TITLE
refactor(store): extract remote-desktop-resolutions into a slice (Part of #2300)

### DIFF
--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -146,6 +146,10 @@ import { createZoomSlice, ZoomSlice } from "./slices/zoomSlice";
 import { createCommandPaletteSlice, CommandPaletteSlice } from "./slices/commandPaletteSlice";
 import { createHttpMonitorsSlice, HttpMonitorsSlice } from "./slices/httpMonitorsSlice";
 import { createDialogsSlice, DialogsSlice } from "./slices/dialogsSlice";
+import {
+  createRemoteDesktopResolutionsSlice,
+  RemoteDesktopResolutionsSlice,
+} from "./slices/remoteDesktopResolutionsSlice";
 
 export type { MacroPlaybackState, PlayMacroOptions } from "./slices/macrosSlice";
 import {
@@ -459,7 +463,8 @@ export interface AppState
     ZoomSlice,
     CommandPaletteSlice,
     HttpMonitorsSlice,
-    DialogsSlice {
+    DialogsSlice,
+    RemoteDesktopResolutionsSlice {
   // Connection type registry (loaded from backend at startup)
   connectionTypes: ConnectionTypeInfo[];
 
@@ -1371,15 +1376,8 @@ export interface AppState
     caps: { monitoring: boolean; fileBrowser: boolean }
   ) => void;
 
-  /**
-   * Live framebuffer resolution of each active graphical remote-desktop session,
-   * keyed by session id (#1709). Fed from the `remote-desktop-frame` /
-   * `onDimensions` path so the shared status-bar segment can show `WxH` for the
-   * active tab. Cleared when the session ends.
-   */
-  remoteDesktopResolutions: Record<string, { width: number; height: number }>;
-  setRemoteDesktopResolution: (sessionId: string, width: number, height: number) => void;
-  clearRemoteDesktopResolution: (sessionId: string) => void;
+  // Remote-desktop resolutions — the live per-session framebuffer WxH provided
+  // by RemoteDesktopResolutionsSlice (#1709, extracted under #2077 via #2300).
 
   // SSH Tunnels — tunnel data + lifecycle live in TunnelSlice (#2077); the
   // tab-opening action stays here as it belongs to the panel/tab domain.
@@ -2750,6 +2748,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
     ...createCommandPaletteSlice(set, get, store),
     ...createHttpMonitorsSlice(set, get, store),
     ...createDialogsSlice(set, get, store),
+    ...createRemoteDesktopResolutionsSlice(set, get, store),
 
     // Connection type registry — updated by loadFromBackend()
     connectionTypes: [],
@@ -6906,7 +6905,10 @@ export const useAppStore = create<AppState>((set, get, store) => {
     // Monitoring — state lives in the authoritative `system-monitors` region
     // (#2224), not here (audit gap G6, #1231).
     sessionCapabilities: {},
-    remoteDesktopResolutions: {},
+
+    // Remote-desktop resolutions (remoteDesktopResolutions + set/clear) provided
+    // by createRemoteDesktopResolutionsSlice (#1709, extracted under #2077 via
+    // #2300).
 
     clearMonitoringError: (key) => {
       const entry = currentMonitorsView().monitors[key];
@@ -6921,26 +6923,6 @@ export const useAppStore = create<AppState>((set, get, store) => {
       set((state) => ({
         sessionCapabilities: { ...state.sessionCapabilities, [sessionId]: caps },
       })),
-
-    setRemoteDesktopResolution: (sessionId, width, height) =>
-      set((state) => {
-        const prev = state.remoteDesktopResolutions[sessionId];
-        if (prev && prev.width === width && prev.height === height) return {};
-        return {
-          remoteDesktopResolutions: {
-            ...state.remoteDesktopResolutions,
-            [sessionId]: { width, height },
-          },
-        };
-      }),
-
-    clearRemoteDesktopResolution: (sessionId) =>
-      set((state) => {
-        if (!(sessionId in state.remoteDesktopResolutions)) return {};
-        return {
-          remoteDesktopResolutions: omitKey(state.remoteDesktopResolutions, sessionId),
-        };
-      }),
 
     connectMonitoring: async (sessionId: string, host: string | null = null) => {
       // Unified session-based (push) monitoring: the key is the id of the terminal

--- a/src/store/slices/remoteDesktopResolutionsSlice.ts
+++ b/src/store/slices/remoteDesktopResolutionsSlice.ts
@@ -1,0 +1,62 @@
+import { StateCreator } from "zustand";
+
+import type { AppState } from "../appStore";
+
+/**
+ * Remote-desktop resolution domain slice (extracted under #2077 via #2300): the
+ * runtime-only (never persisted) live framebuffer resolution of each active
+ * graphical remote-desktop session, keyed by session id (#1709), plus the
+ * set/clear actions that feed it from the `remote-desktop-frame` / `onDimensions`
+ * path so the shared status-bar segment can show `WxH` for the active tab.
+ * Extracted verbatim from the monolithic root store as a behavior-preserving
+ * Zustand slice — every action still receives the shared `set` typed against the
+ * full {@link AppState}, so the public store shape and behavior are unchanged.
+ * Mirrors the SSH tunnel slice (#2077) and the embedded-server / macros /
+ * plugins / session-history / zoom / command-palette / http-monitors / dialogs
+ * slices (#2113/#2114/#2115/#2299/#2300).
+ */
+
+/** Return a copy of `rec` with `key` removed, without mutating the original. */
+function omitKey<V>(rec: Record<string, V>, key: string): Record<string, V> {
+  const { [key]: _, ...rest } = rec;
+  return rest;
+}
+
+export interface RemoteDesktopResolutionsSlice {
+  /**
+   * Live framebuffer resolution of each active graphical remote-desktop session,
+   * keyed by session id (#1709). Fed from the `remote-desktop-frame` /
+   * `onDimensions` path so the shared status-bar segment can show `WxH` for the
+   * active tab. Cleared when the session ends.
+   */
+  remoteDesktopResolutions: Record<string, { width: number; height: number }>;
+  setRemoteDesktopResolution: (sessionId: string, width: number, height: number) => void;
+  clearRemoteDesktopResolution: (sessionId: string) => void;
+}
+
+export const createRemoteDesktopResolutionsSlice: StateCreator<
+  AppState,
+  [],
+  [],
+  RemoteDesktopResolutionsSlice
+> = (set) => ({
+  remoteDesktopResolutions: {},
+  setRemoteDesktopResolution: (sessionId, width, height) =>
+    set((state) => {
+      const prev = state.remoteDesktopResolutions[sessionId];
+      if (prev && prev.width === width && prev.height === height) return {};
+      return {
+        remoteDesktopResolutions: {
+          ...state.remoteDesktopResolutions,
+          [sessionId]: { width, height },
+        },
+      };
+    }),
+  clearRemoteDesktopResolution: (sessionId) =>
+    set((state) => {
+      if (!(sessionId in state.remoteDesktopResolutions)) return {};
+      return {
+        remoteDesktopResolutions: omitKey(state.remoteDesktopResolutions, sessionId),
+      };
+    }),
+});


### PR DESCRIPTION
## Summary

Continues the appStore slicing effort from #2077 by extracting **one** cohesive, self-contained domain — **remote-desktop resolutions** — into a dedicated Zustand slice.

Moved out of the monolithic `src/store/appStore.ts` into the new `src/store/slices/remoteDesktopResolutionsSlice.ts`:

- `remoteDesktopResolutions: Record<string, { width; height }>` — runtime-only, never-persisted per-session framebuffer WxH (#1709)
- `setRemoteDesktopResolution(sessionId, width, height)`
- `clearRemoteDesktopResolution(sessionId)`

The slice follows the exact `StateCreator<AppState, [], [], …Slice>` idiom of the existing slices (tunnel/zoom/dialogs/etc.): the interface is added to `AppState extends …`, the factory spread into `create()`, and every action still receives the shared `set` typed against the full `AppState`.

This is a **pure internal refactor** — the public store API is byte-identical, so no call sites move (`useAppStore((s) => s.remoteDesktopResolutions)` in StatusBar, `setRemoteDesktopResolution`/`clearRemoteDesktopResolution` in `RemoteDesktopTab`, etc. are unchanged) and there is no behavior change. The existing store-level test `src/store/appStore.remoteDesktopResolution.test.ts` exercises the domain through the preserved public API and still passes unmodified.

Only one domain is sliced here; the remaining candidates (terminal-search, command-palette overlays, etc.) stay for follow-up PRs, per the one-domain-per-PR sequencing #2300 mandates.

## Verification (CI degraded)

GitHub Actions is in a major outage, so per-PR CI is unavailable — everything was verified **locally**:

- `tsc --noEmit` — clean
- `pnpm run lint` (ESLint, full `src/`) — clean
- `pnpm exec prettier --check` over `src/**` and `docs/**/*.md` — clean
- Full `pnpm test` suite — **547 files, 4929 tests, all passing**

Part of #2300