### PR TITLE
refactor(store): extract password-prompt into a slice (Part of #2300)

### DIFF
--- a/src/store/appStore.passwordPrompt.test.ts
+++ b/src/store/appStore.passwordPrompt.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(),
+}));
+
+import { useAppStore } from "./appStore";
+
+/**
+ * The promise-based interactive host/SSH password prompt (PasswordPromptSlice,
+ * extracted under #2077 via #2300): requestPassword opens the prompt and hands
+ * back a promise that settles when the user submits (with the password) or
+ * dismisses (with `null`) it, then clears the prompt state each time.
+ */
+describe("appStore password prompt", () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      passwordPromptOpen: false,
+      passwordPromptHost: "",
+      passwordPromptUsername: "",
+      passwordPromptResolve: null,
+      passwordPromptShouldSave: false,
+    });
+  });
+
+  it("starts closed and empty", () => {
+    const s = useAppStore.getState();
+    expect(s.passwordPromptOpen).toBe(false);
+    expect(s.passwordPromptHost).toBe("");
+    expect(s.passwordPromptUsername).toBe("");
+    expect(s.passwordPromptResolve).toBeNull();
+    expect(s.passwordPromptShouldSave).toBe(false);
+  });
+
+  it("requestPassword opens the prompt with the host/username and a pending resolver", () => {
+    useAppStore.getState().requestPassword("example.com", "alice");
+    const s = useAppStore.getState();
+    expect(s.passwordPromptOpen).toBe(true);
+    expect(s.passwordPromptHost).toBe("example.com");
+    expect(s.passwordPromptUsername).toBe("alice");
+    expect(typeof s.passwordPromptResolve).toBe("function");
+    expect(s.passwordPromptShouldSave).toBe(false);
+  });
+
+  it("submitPassword resolves the pending promise with the password and closes the prompt", async () => {
+    const pending = useAppStore.getState().requestPassword("example.com", "alice");
+    useAppStore.getState().submitPassword("hunter2", true);
+
+    await expect(pending).resolves.toBe("hunter2");
+
+    const s = useAppStore.getState();
+    expect(s.passwordPromptOpen).toBe(false);
+    expect(s.passwordPromptHost).toBe("");
+    expect(s.passwordPromptUsername).toBe("");
+    expect(s.passwordPromptResolve).toBeNull();
+    expect(s.passwordPromptShouldSave).toBe(true);
+  });
+
+  it("submitPassword defaults shouldSave to false", async () => {
+    const pending = useAppStore.getState().requestPassword("example.com", "alice");
+    useAppStore.getState().submitPassword("hunter2");
+
+    await expect(pending).resolves.toBe("hunter2");
+    expect(useAppStore.getState().passwordPromptShouldSave).toBe(false);
+  });
+
+  it("dismissPasswordPrompt resolves the pending promise with null and closes the prompt", async () => {
+    const pending = useAppStore.getState().requestPassword("example.com", "alice");
+    useAppStore.getState().dismissPasswordPrompt();
+
+    await expect(pending).resolves.toBeNull();
+
+    const s = useAppStore.getState();
+    expect(s.passwordPromptOpen).toBe(false);
+    expect(s.passwordPromptHost).toBe("");
+    expect(s.passwordPromptUsername).toBe("");
+    expect(s.passwordPromptResolve).toBeNull();
+    expect(s.passwordPromptShouldSave).toBe(false);
+  });
+
+  it("submit/dismiss with no pending prompt are safe no-ops", () => {
+    expect(() => useAppStore.getState().submitPassword("x")).not.toThrow();
+    expect(() => useAppStore.getState().dismissPasswordPrompt()).not.toThrow();
+    expect(useAppStore.getState().passwordPromptOpen).toBe(false);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -150,6 +150,7 @@ import {
   createRemoteDesktopResolutionsSlice,
   RemoteDesktopResolutionsSlice,
 } from "./slices/remoteDesktopResolutionsSlice";
+import { createPasswordPromptSlice, PasswordPromptSlice } from "./slices/passwordPromptSlice";
 
 export type { MacroPlaybackState, PlayMacroOptions } from "./slices/macrosSlice";
 import {
@@ -464,7 +465,8 @@ export interface AppState
     CommandPaletteSlice,
     HttpMonitorsSlice,
     DialogsSlice,
-    RemoteDesktopResolutionsSlice {
+    RemoteDesktopResolutionsSlice,
+    PasswordPromptSlice {
   // Connection type registry (loaded from backend at startup)
   connectionTypes: ConnectionTypeInfo[];
 
@@ -479,16 +481,10 @@ export interface AppState
   toggleSidebar: () => void;
   setSidebarWidth: (width: number) => void;
 
-  // Password prompt
-  passwordPromptOpen: boolean;
-  passwordPromptHost: string;
-  passwordPromptUsername: string;
-  passwordPromptResolve: ((password: string | null) => void) | null;
-  /** Whether the user checked "Save password" in the last password prompt. */
-  passwordPromptShouldSave: boolean;
-  requestPassword: (host: string, username: string) => Promise<string | null>;
-  submitPassword: (password: string, shouldSave?: boolean) => void;
-  dismissPasswordPrompt: () => void;
+  // Password prompt — the promise-based interactive host/SSH password prompt
+  // (open flag, host/username, pending resolver, "Save password" choice) plus
+  // requestPassword / submitPassword / dismissPasswordPrompt is provided by
+  // PasswordPromptSlice (extracted under #2077 via #2300).
 
   // Tab Groups (workspace-level named panel trees)
   tabGroups: TabGroup[];
@@ -2749,6 +2745,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
     ...createHttpMonitorsSlice(set, get, store),
     ...createDialogsSlice(set, get, store),
     ...createRemoteDesktopResolutionsSlice(set, get, store),
+    ...createPasswordPromptSlice(set, get, store),
 
     // Connection type registry — updated by loadFromBackend()
     connectionTypes: [],
@@ -2778,48 +2775,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
     },
     setSidebarWidth: (width) => set({ sidebarWidth: width }),
 
-    // Password prompt
-    passwordPromptOpen: false,
-    passwordPromptHost: "",
-    passwordPromptUsername: "",
-    passwordPromptResolve: null,
-    passwordPromptShouldSave: false,
-
-    requestPassword: (host, username) => {
-      return new Promise<string | null>((resolve) => {
-        set({
-          passwordPromptOpen: true,
-          passwordPromptHost: host,
-          passwordPromptUsername: username,
-          passwordPromptResolve: resolve,
-          passwordPromptShouldSave: false,
-        });
-      });
-    },
-
-    submitPassword: (password, shouldSave = false) => {
-      const { passwordPromptResolve } = get();
-      if (passwordPromptResolve) passwordPromptResolve(password);
-      set({
-        passwordPromptOpen: false,
-        passwordPromptHost: "",
-        passwordPromptUsername: "",
-        passwordPromptResolve: null,
-        passwordPromptShouldSave: shouldSave,
-      });
-    },
-
-    dismissPasswordPrompt: () => {
-      const { passwordPromptResolve } = get();
-      if (passwordPromptResolve) passwordPromptResolve(null);
-      set({
-        passwordPromptOpen: false,
-        passwordPromptHost: "",
-        passwordPromptUsername: "",
-        passwordPromptResolve: null,
-        passwordPromptShouldSave: false,
-      });
-    },
+    // Password prompt — the promise-based interactive host/SSH password prompt
+    // is provided by createPasswordPromptSlice (extracted under #2077 via #2300).
 
     // Tab Groups
     tabGroups: [initialGroup],

--- a/src/store/slices/passwordPromptSlice.ts
+++ b/src/store/slices/passwordPromptSlice.ts
@@ -1,0 +1,79 @@
+import { StateCreator } from "zustand";
+
+import type { AppState } from "../appStore";
+
+/**
+ * Password-prompt domain slice (extracted under #2077 via #2300): the
+ * promise-based interactive SSH/host password prompt — the open/closed flag,
+ * the host/username being prompted for, the pending resolver, and the last
+ * "Save password" choice, together with the {@link PasswordPromptSlice.requestPassword}
+ * /{@link PasswordPromptSlice.submitPassword}/{@link PasswordPromptSlice.dismissPasswordPrompt}
+ * actions that drive it. `requestPassword` returns a promise that settles when
+ * the user submits (with the password) or dismisses (with `null`) the prompt.
+ * Extracted verbatim from the monolithic root store as a behavior-preserving
+ * Zustand slice — every action still receives the shared `set`/`get` typed
+ * against the full {@link AppState}, so the public store shape and behavior are
+ * unchanged. Mirrors the SSH tunnel slice (#2077) and the embedded-server /
+ * macros / plugins / session-history / zoom / command-palette / http-monitors /
+ * dialogs / remote-desktop-resolutions slices
+ * (#2113/#2114/#2115/#2299/#2300).
+ */
+
+export interface PasswordPromptSlice {
+  passwordPromptOpen: boolean;
+  passwordPromptHost: string;
+  passwordPromptUsername: string;
+  passwordPromptResolve: ((password: string | null) => void) | null;
+  /** Whether the user checked "Save password" in the last password prompt. */
+  passwordPromptShouldSave: boolean;
+  requestPassword: (host: string, username: string) => Promise<string | null>;
+  submitPassword: (password: string, shouldSave?: boolean) => void;
+  dismissPasswordPrompt: () => void;
+}
+
+export const createPasswordPromptSlice: StateCreator<AppState, [], [], PasswordPromptSlice> = (
+  set,
+  get
+) => ({
+  passwordPromptOpen: false,
+  passwordPromptHost: "",
+  passwordPromptUsername: "",
+  passwordPromptResolve: null,
+  passwordPromptShouldSave: false,
+
+  requestPassword: (host, username) => {
+    return new Promise<string | null>((resolve) => {
+      set({
+        passwordPromptOpen: true,
+        passwordPromptHost: host,
+        passwordPromptUsername: username,
+        passwordPromptResolve: resolve,
+        passwordPromptShouldSave: false,
+      });
+    });
+  },
+
+  submitPassword: (password, shouldSave = false) => {
+    const { passwordPromptResolve } = get();
+    if (passwordPromptResolve) passwordPromptResolve(password);
+    set({
+      passwordPromptOpen: false,
+      passwordPromptHost: "",
+      passwordPromptUsername: "",
+      passwordPromptResolve: null,
+      passwordPromptShouldSave: shouldSave,
+    });
+  },
+
+  dismissPasswordPrompt: () => {
+    const { passwordPromptResolve } = get();
+    if (passwordPromptResolve) passwordPromptResolve(null);
+    set({
+      passwordPromptOpen: false,
+      passwordPromptHost: "",
+      passwordPromptUsername: "",
+      passwordPromptResolve: null,
+      passwordPromptShouldSave: false,
+    });
+  },
+});


### PR DESCRIPTION
Part of #2300.

Continues the Zustand domain-slice extraction established by #2077. This PR slices out **exactly one** domain: the **password-prompt** cluster.

## Domain sliced
The promise-based interactive host/SSH password prompt, extracted verbatim into `src/store/slices/passwordPromptSlice.ts`:
- state: `passwordPromptOpen`, `passwordPromptHost`, `passwordPromptUsername`, `passwordPromptResolve`, `passwordPromptShouldSave`
- actions: `requestPassword`, `submitPassword`, `dismissPasswordPrompt`

This is a fully self-contained, cohesive cluster — every occurrence in `appStore.ts` lived either in its own interface block or its own reducer block (zero cross-reducer entanglement). The slice uses the shared `(set, get)` typed against the full `AppState`, so the **public store API is byte-identical** — no call-site churn (`useAppStore((s) => s.passwordPromptOpen)`, `get().requestPassword()`, etc. unchanged). Wired via the standard trio: import, `AppState extends … PasswordPromptSlice`, and `...createPasswordPromptSlice(set, get, store)` in `create()`.

Note (survey): the originally-briefed command-palette/overlay domain was already sliced (`commandPaletteSlice.ts` on develop), as were zoom/dialogs/http-monitors/remote-desktop-resolutions — the #2300 checklist is stale. Terminal-search was deliberately skipped (it is read/rewritten inside the large tab-close reducer, so it is not a clean extraction). Password-prompt was the cleanest genuinely-remaining cluster.

## Tests
Added `src/store/appStore.passwordPrompt.test.ts` (6 cases: initial state, open-on-request, submit resolves-with-password + clears + records shouldSave, shouldSave default, dismiss resolves-with-null + clears, and submit/dismiss-with-no-pending no-op safety), following the sibling `appStore.<domain>.test.ts` convention.

## Verification (local — GitHub Actions is in a major outage, per-PR CI unavailable)
- `tsc --noEmit`: clean
- ESLint (changed files): clean
- Prettier over `src/**` and `docs/**/*.md`: clean (only the pre-existing unrelated `src/data/lucide-tags.json` warning)
- Full `pnpm test` suite: **548 files, 4935 tests passed**