### PR TITLE
refactor(store): extract terminal-search into a slice (Part of #2300)

### DIFF
--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -151,6 +151,7 @@ import {
   RemoteDesktopResolutionsSlice,
 } from "./slices/remoteDesktopResolutionsSlice";
 import { createPasswordPromptSlice, PasswordPromptSlice } from "./slices/passwordPromptSlice";
+import { createTerminalSearchSlice, TerminalSearchSlice } from "./slices/terminalSearchSlice";
 
 export type { MacroPlaybackState, PlayMacroOptions } from "./slices/macrosSlice";
 import {
@@ -466,7 +467,8 @@ export interface AppState
     HttpMonitorsSlice,
     DialogsSlice,
     RemoteDesktopResolutionsSlice,
-    PasswordPromptSlice {
+    PasswordPromptSlice,
+    TerminalSearchSlice {
   // Connection type registry (loaded from backend at startup)
   connectionTypes: ConnectionTypeInfo[];
 
@@ -891,10 +893,8 @@ export interface AppState
   // Zoom (runtime-only) — scale factor + in/out/reset provided by ZoomSlice
   // (extracted under #2077 via #2300).
 
-  // Terminal search (runtime-only)
-  terminalSearchVisible: Record<string, boolean>;
-  setTerminalSearchVisible: (tabId: string, visible: boolean) => void;
-  toggleTerminalSearch: (tabId: string) => void;
+  // Terminal search (runtime-only) — per-tab search-bar visibility + set/toggle
+  // provided by TerminalSearchSlice (extracted under #2077 via #2300).
 
   /**
    * Per-session temporary syntax-highlighting toggle (runtime-only, never
@@ -2746,6 +2746,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
     ...createDialogsSlice(set, get, store),
     ...createRemoteDesktopResolutionsSlice(set, get, store),
     ...createPasswordPromptSlice(set, get, store),
+    ...createTerminalSearchSlice(set, get, store),
 
     // Connection type registry — updated by loadFromBackend()
     connectionTypes: [],
@@ -4777,17 +4778,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
     // Zoom (runtime-only) — scale factor + in/out/reset provided by
     // createZoomSlice (extracted under #2077 via #2300).
 
-    // Terminal search (runtime-only)
-    terminalSearchVisible: {},
-    setTerminalSearchVisible: (tabId, visible) =>
-      set((s) => ({ terminalSearchVisible: { ...s.terminalSearchVisible, [tabId]: visible } })),
-    toggleTerminalSearch: (tabId) =>
-      set((s) => ({
-        terminalSearchVisible: {
-          ...s.terminalSearchVisible,
-          [tabId]: !s.terminalSearchVisible[tabId],
-        },
-      })),
+    // Terminal search (runtime-only) — per-tab search-bar visibility + set/toggle
+    // provided by createTerminalSearchSlice (extracted under #2077 via #2300).
 
     // Per-session syntax-highlighting toggle (runtime-only, never persisted)
     sessionHighlighting: {},

--- a/src/store/slices/terminalSearchSlice.ts
+++ b/src/store/slices/terminalSearchSlice.ts
@@ -1,0 +1,45 @@
+import { StateCreator } from "zustand";
+
+import type { AppState } from "../appStore";
+
+/**
+ * Terminal-search domain slice (extracted under #2077 via #2300): the
+ * runtime-only (never persisted) per-tab visibility of the in-terminal search
+ * bar, keyed by tab id, plus the set/toggle actions that drive it. Extracted
+ * verbatim from the monolithic root store as a behavior-preserving Zustand
+ * slice — every action still receives the shared `set` typed against the full
+ * {@link AppState}, so the public store shape and behavior are unchanged. The
+ * tab-close reducer in `appStore.ts` still reads and rewrites
+ * `terminalSearchVisible` through the combined store, which composes across
+ * slices unchanged. Mirrors the SSH tunnel slice (#2077) and the
+ * embedded-server / macros / plugins / session-history / zoom / command-palette
+ * / http-monitors / dialogs / remote-desktop-resolutions / password-prompt
+ * slices (#2113/#2114/#2115/#2299/#2300).
+ */
+
+export interface TerminalSearchSlice {
+  /**
+   * Per-tab visibility of the in-terminal search bar, keyed by tab id
+   * (runtime-only, never persisted). Cleared for a tab when it closes.
+   */
+  terminalSearchVisible: Record<string, boolean>;
+  /** Show or hide the search bar for a specific tab. */
+  setTerminalSearchVisible: (tabId: string, visible: boolean) => void;
+  /** Flip the search-bar visibility for a specific tab. */
+  toggleTerminalSearch: (tabId: string) => void;
+}
+
+export const createTerminalSearchSlice: StateCreator<AppState, [], [], TerminalSearchSlice> = (
+  set
+) => ({
+  terminalSearchVisible: {},
+  setTerminalSearchVisible: (tabId, visible) =>
+    set((s) => ({ terminalSearchVisible: { ...s.terminalSearchVisible, [tabId]: visible } })),
+  toggleTerminalSearch: (tabId) =>
+    set((s) => ({
+      terminalSearchVisible: {
+        ...s.terminalSearchVisible,
+        [tabId]: !s.terminalSearchVisible[tabId],
+      },
+    })),
+});


### PR DESCRIPTION
Extracts the **terminal-search** domain — the last remaining low-risk candidate on #2300 — out of the `appStore.ts` monolith into a dedicated Zustand slice at `src/store/slices/terminalSearchSlice.ts`, following the idiom established by the zoom / command-palette / dialogs / remote-desktop-resolutions / password-prompt slices.

## What moved

- `terminalSearchVisible: Record<string, boolean>` (runtime-only per-tab search-bar visibility)
- `setTerminalSearchVisible(tabId, visible)`
- `toggleTerminalSearch(tabId)`

The inline `AppState` interface members and the `create()` implementation block are replaced by the slice; `appStore.ts` now imports `createTerminalSearchSlice`, adds `TerminalSearchSlice` to `AppState extends …`, and spreads the factory in `create()`.

## The entanglement (handled cleanly, no restructuring)

`terminalSearchVisible` is read/rewritten at ~3 points in the large tab-close reducer. Those references (`state.terminalSearchVisible` reads, `terminalSearchVisible: remainingSearch` writes) were left untouched — slices compose into one combined store, so the reducer reads/writes the same key across the slice boundary. No reducer restructuring, no cross-slice ordering hazard, no call-site churn.

## Public API

Byte-identical: `useAppStore((s) => s.terminalSearchVisible[tabId])`, `s.setTerminalSearchVisible`, and `get().toggleTerminalSearch(...)` are all unchanged. No component/hook/service call sites were touched.

## Verification (local — GitHub Actions is in a major outage)

- `tsc --noEmit` clean
- ESLint clean on touched files
- `prettier --check` over `src/**` and `docs/**/*.md` clean (pre-existing `src/data/lucide-tags.json` warning is unrelated)
- Full `pnpm test` suite green — **548 files / 4935 tests passed**, including the terminal-search touching tests (`TerminalSearchBar`, `CommandPalette`, `useKeyboardShortcuts`, `contextCommands`)

No dedicated store-level terminal-search test existed to relocate; coverage lives in the component/hook/service tests, which stay in place (same as prior slice extractions).

Part of #2300