### PR TITLE
feat(sftp): add frontend session_* api wrappers for the SFTP convergence (Part of #2313)

### DIFF
--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -63,6 +63,13 @@ import {
   localWriteFile,
   sftpReadFileContent,
   sftpWriteFileContent,
+  sessionRealpath,
+  sessionCheckWritable,
+  sessionWriteFileElevated,
+  sessionHasExecCapability,
+  sessionDownload,
+  sessionUpload,
+  sessionVscodeOpenRemote,
   vscodeAvailable,
   vscodeOpenLocal,
   vscodeOpenRemote,
@@ -647,6 +654,147 @@ describe("api service", () => {
         sessionId: "sftp-1",
         remotePath: "/remote/file.txt",
         content: "new content",
+      });
+    });
+  });
+
+  // Session-path mirrors of the SFTP advanced ops (#2312/#2383), the frontend
+  // half of the #2307 convergence (#2313). Each must invoke its `session_*`
+  // command with the same camelCase arg shape as its `sftp_*` twin so an SSH
+  // session id can drive the file browser / editor without a separate
+  // `SftpManager` session.
+  describe("session-scoped SFTP advanced commands", () => {
+    // Wait until `awaitTransfer` has registered its `transfer-progress`
+    // listener (it does so after a dynamic import), then emit `payload`.
+    const fireWhenListening = async (payload: unknown) => {
+      for (let i = 0; i < 50 && !transferListener; i++) {
+        await flushMacrotask();
+      }
+      if (!transferListener) throw new Error("transfer listener never registered");
+      transferListener({ payload });
+    };
+
+    it("sessionRealpath invokes with session ID and path", async () => {
+      mockedInvoke.mockResolvedValue("/home/pi");
+
+      const result = await sessionRealpath("ssh-1", ".");
+
+      expect(mockedInvoke).toHaveBeenCalledWith("session_realpath", {
+        sessionId: "ssh-1",
+        path: ".",
+      });
+      expect(result).toBe("/home/pi");
+    });
+
+    it("sessionCheckWritable invokes with session ID and remote path", async () => {
+      mockedInvoke.mockResolvedValue("writable");
+
+      const result = await sessionCheckWritable("ssh-1", "/etc/hosts");
+
+      expect(mockedInvoke).toHaveBeenCalledWith("session_check_writable", {
+        sessionId: "ssh-1",
+        remotePath: "/etc/hosts",
+      });
+      expect(result).toBe("writable");
+    });
+
+    it("sessionWriteFileElevated invokes with session ID, path, content and sudo password", async () => {
+      mockedInvoke.mockResolvedValue({ kind: "success" });
+
+      const result = await sessionWriteFileElevated("ssh-1", "/etc/hosts", "127.0.0.1 x", "pw");
+
+      expect(mockedInvoke).toHaveBeenCalledWith("session_write_file_elevated", {
+        sessionId: "ssh-1",
+        remotePath: "/etc/hosts",
+        content: "127.0.0.1 x",
+        sudoPassword: "pw",
+      });
+      expect(result).toEqual({ kind: "success" });
+    });
+
+    it("sessionHasExecCapability invokes with session ID", async () => {
+      mockedInvoke.mockResolvedValue(true);
+
+      const result = await sessionHasExecCapability("ssh-1");
+
+      expect(mockedInvoke).toHaveBeenCalledWith("session_has_exec_capability", {
+        sessionId: "ssh-1",
+      });
+      expect(result).toBe(true);
+    });
+
+    it("sessionDownload invokes with correct params and returns bytes on the done event", async () => {
+      mockedInvoke.mockResolvedValue("transfer-s1");
+
+      const pending = sessionDownload("ssh-1", "/remote/file.txt", "/local/file.txt");
+      await fireWhenListening({
+        transferId: "transfer-s1",
+        phase: "done",
+        transferred: 4096,
+      });
+
+      const result = await pending;
+      expect(mockedInvoke).toHaveBeenCalledWith("session_download", {
+        sessionId: "ssh-1",
+        remotePath: "/remote/file.txt",
+        localPath: "/local/file.txt",
+      });
+      expect(result).toBe(4096);
+    });
+
+    it("sessionDownload fires onRegistered with the transfer id before completion", async () => {
+      mockedInvoke.mockResolvedValue("transfer-seed-s");
+      const onRegistered = vi.fn();
+
+      const pending = sessionDownload("ssh-1", "/remote/file.txt", "/local/file.txt", onRegistered);
+      // onRegistered fires from the command's synchronous return, ahead of the event.
+      await flushMacrotask();
+      expect(onRegistered).toHaveBeenCalledWith("transfer-seed-s");
+
+      await fireWhenListening({ transferId: "transfer-seed-s", phase: "done", transferred: 1 });
+      await pending;
+    });
+
+    it("sessionUpload invokes with correct params and returns bytes on the done event", async () => {
+      mockedInvoke.mockResolvedValue("transfer-s2");
+
+      const pending = sessionUpload("ssh-1", "/local/file.txt", "/remote/file.txt");
+      await fireWhenListening({
+        transferId: "transfer-s2",
+        phase: "done",
+        transferred: 8192,
+      });
+
+      const result = await pending;
+      expect(mockedInvoke).toHaveBeenCalledWith("session_upload", {
+        sessionId: "ssh-1",
+        localPath: "/local/file.txt",
+        remotePath: "/remote/file.txt",
+      });
+      expect(result).toBe(8192);
+    });
+
+    it("sessionDownload rejects when the transfer errors", async () => {
+      mockedInvoke.mockResolvedValue("transfer-s3");
+
+      const pending = sessionDownload("ssh-1", "/remote/file.txt", "/local/file.txt");
+      await fireWhenListening({
+        transferId: "transfer-s3",
+        phase: "error",
+        message: "boom",
+      });
+
+      await expect(pending).rejects.toThrow("boom");
+    });
+
+    it("sessionVscodeOpenRemote invokes with session ID and remote path", async () => {
+      mockedInvoke.mockResolvedValue(undefined);
+
+      await sessionVscodeOpenRemote("ssh-1", "/remote/file.txt");
+
+      expect(mockedInvoke).toHaveBeenCalledWith("session_vscode_open_remote", {
+        sessionId: "ssh-1",
+        remotePath: "/remote/file.txt",
       });
     });
   });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1637,6 +1637,131 @@ export async function sessionMkdir(sessionId: string, path: string): Promise<voi
   await invoke("session_mkdir", { sessionId, path });
 }
 
+// --- Session-scoped SFTP advanced operations & transfers (#2312, #2313) ---
+//
+// Session-path mirrors of the standalone `sftp_*` advanced ops, routed through
+// the session's `ConnectionType` file browser rather than a separate
+// `SftpManager` UUID session. They only succeed for an SFTP-backed (SSH)
+// session; other backends return a "does not support SFTP advanced operations"
+// error. Part of the #2307 convergence: they let SSH file browsing / editing
+// resolve its core `SftpFileBrowser` from the session id, retiring the frontend
+// `sftpSessionId` model (#2313) without removing the backend `SftpManager`
+// registry (that is #2314).
+
+/**
+ * Resolve a remote path to its canonical absolute form via a session's SFTP
+ * realpath. Session-path mirror of {@link sftpRealpath} (#2312).
+ *
+ * Pass `"."` to resolve the session's home directory instead of guessing
+ * `/home/<user>`.
+ */
+export async function sessionRealpath(sessionId: string, path: string): Promise<string> {
+  return await invoke<string>("session_realpath", { sessionId, path });
+}
+
+/**
+ * Probe whether the connecting user can write a specific remote file, via a
+ * non-destructive SFTP write-open probe on a session. Session-path mirror of
+ * {@link sftpCheckWritable} (#2312); the probe never modifies the file.
+ */
+export async function sessionCheckWritable(
+  sessionId: string,
+  remotePath: string
+): Promise<Writability> {
+  return await invoke<Writability>("session_check_writable", { sessionId, remotePath });
+}
+
+/**
+ * Write a string to a remote file with `sudo`-elevated privileges over a
+ * session's SFTP connection. Session-path mirror of
+ * {@link sftpWriteFileContentElevated} (#2312): returns a typed
+ * {@link ElevatedWriteResult} rather than throwing on an authorization failure,
+ * so the caller can re-prompt on `incorrectPassword`. The temp file is always
+ * cleaned up and the password is never logged on the backend.
+ */
+export async function sessionWriteFileElevated(
+  sessionId: string,
+  remotePath: string,
+  content: string,
+  sudoPassword: string
+): Promise<ElevatedWriteResult> {
+  return await invoke<ElevatedWriteResult>("session_write_file_elevated", {
+    sessionId,
+    remotePath,
+    content,
+    sudoPassword,
+  });
+}
+
+/**
+ * Report whether a session's SFTP connection can open an exec channel (i.e. run
+ * remote commands such as `sudo`). Session-path mirror of
+ * {@link sftpHasExecCapability} (#2312): `true` for a normal SSH+shell
+ * connection, `false` for an SFTP-only / relayed connection.
+ */
+export async function sessionHasExecCapability(sessionId: string): Promise<boolean> {
+  return await invoke<boolean>("session_has_exec_capability", { sessionId });
+}
+
+/**
+ * Download a remote file to a local path over a session's SFTP connection.
+ *
+ * Session-path mirror of {@link sftpDownload} (#2312): registers a background
+ * transfer on a **dedicated** channel and resolves with the bytes transferred
+ * once it completes (#1245), so listing / navigating the same session stays live
+ * during the transfer. `onRegistered` fires once with the backend `transferId`
+ * the instant the start command returns, for seeding the Transfer Queue ahead of
+ * any progress event (#1632).
+ */
+export async function sessionDownload(
+  sessionId: string,
+  remotePath: string,
+  localPath: string,
+  onRegistered?: (transferId: string) => void
+): Promise<number> {
+  const transferId = await invoke<string>("session_download", {
+    sessionId,
+    remotePath,
+    localPath,
+  });
+  onRegistered?.(transferId);
+  return await awaitTransfer(transferId);
+}
+
+/**
+ * Upload a local file to a remote path over a session's SFTP connection.
+ *
+ * Session-path mirror of {@link sftpUpload} (#2312): registers a background
+ * transfer on a dedicated channel and resolves with the bytes transferred once
+ * it completes (#1245). See {@link sessionDownload} for `onRegistered`.
+ */
+export async function sessionUpload(
+  sessionId: string,
+  localPath: string,
+  remotePath: string,
+  onRegistered?: (transferId: string) => void
+): Promise<number> {
+  const transferId = await invoke<string>("session_upload", {
+    sessionId,
+    localPath,
+    remotePath,
+  });
+  onRegistered?.(transferId);
+  return await awaitTransfer(transferId);
+}
+
+/**
+ * Open a remote file in VS Code over a session's SFTP connection: download, open
+ * with `--wait`, re-upload on close. Session-path mirror of
+ * {@link vscodeOpenRemote} (#2383).
+ */
+export async function sessionVscodeOpenRemote(
+  sessionId: string,
+  remotePath: string
+): Promise<void> {
+  await invoke("session_vscode_open_remote", { sessionId, remotePath });
+}
+
 // --- VS Code integration ---
 
 /** Check if VS Code CLI (`code`) is available on PATH. */


### PR DESCRIPTION
## Summary

Frontend groundwork for the #2307 SFTP convergence step B (#2313): adds the
**session-path `session_*` API wrappers** that mirror the standalone `sftp_*`
advanced ops, so an SSH session id can eventually drive the file browser and
editor without a separate `SftpManager` UUID session.

This is the frontend twin of the additive backend step-A PRs (#2312 / #2383):
**additive only, no caller is switched yet**, so runtime behavior is unchanged.
It lands the reliable, unit-testable foundation the behavioral cut needs, and it
lets that cut be a focused per-caller swap.

`Part of #2313` (not `Closes`) deliberately — the full `sftpSessionId` retirement
is **not** done here; see "Why this is a partial" below.

## What changed

- **`src/services/api.ts`** — add seven wrappers, each a twin of its `sftp_*`
  wrapper with the same camelCase arg shape:
  - `sessionRealpath` · `sessionCheckWritable` · `sessionWriteFileElevated`
    · `sessionHasExecCapability` · `sessionVscodeOpenRemote`
  - `sessionDownload` / `sessionUpload` — keep the **dedicated per-transfer
    channel** (they `await` the `transfer-progress` event and support the
    `onRegistered` Transfer-Queue seed hook, exactly like `sftpDownload`/
    `sftpUpload`).
- **`src/services/api.test.ts`** — 9 unit tests asserting each wrapper invokes
  the correct `session_*` command with the correct args (and the transfer
  lifecycle for download/upload: done → bytes, error → reject, `onRegistered`
  fires before completion).

No `appStore`, `FileBrowser`, `FileEditor`, `useSessionFileSystem`, or type
changes — those are the behavioral cut, deferred (below).

## Why this is a partial (proposed sub-split)

#2313 is ~224 refs across 23 files. Mapping the full surface with graft first
surfaced **two foundational collisions** that make a single mega-PR both
unreviewable and un-verifiable under the current GitHub Actions outage (the SFTP
/ Docker / FTP file-browsing **integration** suites — which would catch a
regression here — don't run in per-PR CI even when Actions is healthy, and can't
run at all right now):

1. **`useSessionFileSystem` is shared across backends with divergent transfer
   semantics.** It backs SSH (SFTP-backed → needs the dedicated streaming
   transfer channel per #1245) **and** non-SFTP session backends (remote-agent,
   Docker, FTP → byte-based `session_read_file`/`session_write_file`). The new
   `session_download`/`session_upload`/`session_check_writable`/… commands
   resolve via `SessionManager::sftp_transfer_browser`, which returns
   `RemoteError("Session file browser does not support SFTP advanced operations")`
   for any non-SFTP session (`src-tauri/src/session/file_ops.rs::sftp_browser`).
   So the browser flip + editor migration require an **"is this session
   SFTP-backed?" gating decision** that must not regress the non-SFTP backends —
   a real design choice that needs the integration suite to validate.

2. **The `appStore` SFTP-slice teardown overlaps #2314 and the file-browser
   projection.** Removing `sftpSessionId` / `sftpSessions` / `connectSftp` /
   `navigateSftp` / the `"sftp"` mode from `appStore` collides with the
   `file-browser@<clientId>` projection region, which has a dedicated **`sftp`
   pane** and whose bridge (`src/store/fileBrowsersBridge.ts`) explicitly
   documents that the SFTP **session model stays on `appStore`** (`#2236` scope
   note). Fully retiring the slice is `#2314`-adjacent and high-risk.

Per the issue's own de-risk guidance ("if the single-entry-point migration
collides with something foundational … STOP and report a proposed sub-split; a
clean partial + a follow-up beats a risky mega-diff"), this PR ships the safe
additive layer and proposes the cut as follow-ups:

- **B1 (this PR):** frontend `session_*` API wrappers. ✅
- **B2:** migrate the **editor** remote path (`FileEditor` + `editorMeta`) from
  `sftpSessionId` to the session path, bringing the existing `sessionBrowser`
  editor branch to full SFTP parity (elevated write / writability probe /
  exec-cap / download / VS Code) via the B1 wrappers, gated on SFTP capability.
- **B3:** flip the **browser** SSH branch (`FileBrowser.tsx` ~L659) from
  `"sftp"` to `"session"` mode; give `useSessionFileSystem` the dedicated
  transfer channel + VS Code open for SFTP-backed sessions (byte-based fallback
  for the rest); migrate `fileClipboard.sftpSessionId`.
- **B4:** retire the now-idle `appStore` SFTP slice + the projection `sftp` pane
  and the `sftpSessionId` field (coordinated with #2314).

I'll file B2–B4 as `Ready2Implement` follow-ups referencing #2313 and this PR.

## Testing (local — Actions is in a major outage)

- `pnpm exec tsc --noEmit` — clean.
- `pnpm exec vitest run src/services/api.test.ts` — **92 passed** (9 new).
- **Full `pnpm test`** — **548 files / 4944 tests passed** (nothing regressed).
- `pnpm exec eslint src/services/api.ts src/services/api.test.ts` — clean.
- `pnpm exec prettier --check` on both files — clean.

No integration run needed for this slice: it is additive API surface with no
caller switched, so no runtime file-browsing path changes. The behavioral cut
(B2–B4) will require a local integration run since per-PR CI can't cover it.

**CI note:** GitHub Actions is degraded; this PR was verified locally only.
Please hold the merge until real CI is back.

Part of #2313. Part of #2307.
