### PR TITLE
refactor(sftp): bring the session-path FileEditor to SFTP parity (Closes #2420)

### DIFF
--- a/src/components/FileEditor/FileEditor.test.tsx
+++ b/src/components/FileEditor/FileEditor.test.tsx
@@ -929,16 +929,27 @@ describe("FileEditor — session-layer backed tabs (#1557)", () => {
     expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(true);
   });
 
-  it("marks the tab remote but offers no SFTP-only affordances", async () => {
+  it("offers no SFTP-advanced affordances for a byte-based (non-SFTP) backend", async () => {
+    // A byte-based session backend (FTP here) rejects the SFTP-advanced probe —
+    // exactly how the backend's SessionManager::sftp_transfer_browser behaves for
+    // a non-SFTP browser. That reject is the capability signal (#2420): the tab
+    // stays on the plain read/write path with none of the advanced affordances,
+    // and even a read-only verdict would never be probed for.
+    const calls: string[] = [];
     mockedInvoke.mockImplementation((cmd) => {
+      calls.push(String(cmd));
       if (cmd === "session_read_file") return Promise.resolve(bytes("body\n"));
+      if (cmd === "session_has_exec_capability")
+        return Promise.reject(
+          new Error("Session file browser does not support SFTP advanced operations")
+        );
       // Were these ever reached, they would light up the sudo / fallback UI.
-      if (cmd === "sftp_has_exec_capability") return Promise.resolve(true);
-      if (cmd === "sftp_check_writable") return Promise.resolve("readOnly");
+      if (cmd === "session_check_writable") return Promise.resolve("readOnly");
       return Promise.resolve(undefined);
     });
 
     render(SESSION_META);
+    await flush();
     await flush();
 
     // The session layer exposes read/write only: no writability probe, no sudo,
@@ -948,6 +959,12 @@ describe("FileEditor — session-layer backed tabs (#1557)", () => {
     expect(query("file-editor-edit-with-sudo")).toBeNull();
     expect(query("file-editor-save-copy")).toBeNull();
     expect(query("file-editor-download")).toBeNull();
+    // The advanced ops are gated off the failed probe: no writability / realpath
+    // round-trip is made once the backend reports it is not SFTP-backed.
+    expect(calls).not.toContain("session_check_writable");
+    expect(calls).not.toContain("session_realpath");
+    // The SFTP-family commands are never used on the session path either.
+    expect(calls.filter((c) => c.startsWith("sftp_"))).toEqual([]);
   });
 
   it("surfaces a session read failure as a load error", async () => {
@@ -960,5 +977,234 @@ describe("FileEditor — session-layer backed tabs (#1557)", () => {
     await flush();
 
     expect(container.textContent ?? "").toMatch(/no such file/i);
+  });
+});
+
+describe("FileEditor — SFTP-backed session tab reaches SFTP parity (#2420)", () => {
+  // A session-layer tab whose backend IS SFTP-backed (SSH). The
+  // `session_has_exec_capability` probe resolves for it (rather than rejecting as
+  // a byte-based backend would), which is the capability signal that unlocks the
+  // SFTP-advanced affordances on the session path.
+  const SESSION_SSH_META: EditorTabMeta = {
+    filePath: "/etc/hosts",
+    isRemote: true,
+    sessionBrowser: { sessionId: "sess-ssh-1", connectionType: "ssh" },
+    permissions: "-rw-r--r--",
+  };
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState({ ...useAppStore.getInitialState() });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  function docQuery(testId: string): HTMLElement | null {
+    return document.querySelector(`[data-testid="${testId}"]`);
+  }
+
+  function typeInto(el: HTMLInputElement, value: string): void {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value"
+    )!.set!;
+    act(() => {
+      setter.call(el, value);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
+
+  /** Encode text the way session_read_file returns it: a plain byte array. */
+  function bytes(text: string): number[] {
+    return Array.from(new TextEncoder().encode(text));
+  }
+
+  /**
+   * Mock a session-backed SFTP connection through the `session_*` twins, so the
+   * advanced ops resolve exactly as they would for an SSH-backed session.
+   */
+  function mockSessionSftp(opts: {
+    execCapable?: boolean;
+    writable?: "writable" | "readOnly" | "unknown";
+    home?: string;
+    elevatedResults?: unknown[];
+  }): {
+    calls: string[];
+    elevatedCalls: Array<Record<string, unknown>>;
+    writeCalls: Array<Record<string, unknown>>;
+    downloadCalls: Array<Record<string, unknown>>;
+  } {
+    const { execCapable = true, writable = "readOnly", home, elevatedResults = [] } = opts;
+    const calls: string[] = [];
+    const elevatedCalls: Array<Record<string, unknown>> = [];
+    const writeCalls: Array<Record<string, unknown>> = [];
+    const downloadCalls: Array<Record<string, unknown>> = [];
+    const queue = [...elevatedResults];
+    mockedInvoke.mockImplementation((cmd, args) => {
+      calls.push(String(cmd));
+      if (cmd === "session_read_file") return Promise.resolve(bytes("127.0.0.1 localhost\n"));
+      // The probe resolves (does not reject) → the session is SFTP-backed.
+      if (cmd === "session_has_exec_capability") return Promise.resolve(execCapable);
+      if (cmd === "session_check_writable") return Promise.resolve(writable);
+      if (cmd === "session_realpath") {
+        return home !== undefined
+          ? Promise.resolve(home)
+          : Promise.reject(new Error("no realpath"));
+      }
+      if (cmd === "session_write_file_elevated") {
+        elevatedCalls.push((args ?? {}) as Record<string, unknown>);
+        return Promise.resolve(queue.shift() ?? { kind: "success" });
+      }
+      if (cmd === "session_write_file") {
+        writeCalls.push((args ?? {}) as Record<string, unknown>);
+        return Promise.resolve(undefined);
+      }
+      if (cmd === "session_download") {
+        downloadCalls.push((args ?? {}) as Record<string, unknown>);
+        return Promise.resolve("transfer-1");
+      }
+      return Promise.resolve(undefined);
+    });
+    return { calls, elevatedCalls, writeCalls, downloadCalls };
+  }
+
+  it("probes writability over the session path and shows the read-only badge", async () => {
+    const { calls } = mockSessionSftp({ execCapable: false, writable: "readOnly" });
+    render(SESSION_SSH_META);
+    await flush();
+    await flush();
+
+    // Writability was probed via the session twin, never the SftpManager path.
+    expect(calls).toContain("session_check_writable");
+    expect(calls.filter((c) => c.startsWith("sftp_"))).toEqual([]);
+    const badge = query("file-editor-readonly-badge");
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute("title") ?? "").toContain("rw-r--r--");
+  });
+
+  it("offers 'Edit with sudo' for a read-only file on an exec-capable session", async () => {
+    mockSessionSftp({ execCapable: true, writable: "readOnly" });
+    render(SESSION_SSH_META);
+    await flush();
+    await flush();
+
+    expect(query("file-editor-edit-with-sudo")).not.toBeNull();
+    expect(query("file-editor-save")).toBeNull();
+  });
+
+  it("routes an authorized elevated save through session_write_file_elevated", async () => {
+    const { elevatedCalls } = mockSessionSftp({
+      execCapable: true,
+      writable: "readOnly",
+      elevatedResults: [{ kind: "success" }],
+    });
+    render(SESSION_SSH_META);
+    await flush();
+    await flush();
+
+    editContent("127.0.0.1 localhost\nedited\n");
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-edit-with-sudo") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    typeInto(docQuery("sudo-prompt-input") as HTMLInputElement, "sudo-pw");
+    await act(async () => {
+      (docQuery("sudo-prompt-submit") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(elevatedCalls).toHaveLength(1);
+    expect(elevatedCalls[0].sessionId).toBe("sess-ssh-1");
+    expect(elevatedCalls[0].remotePath).toBe("/etc/hosts");
+    expect(elevatedCalls[0].sudoPassword).toBe("sudo-pw");
+    expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(false);
+    expect(query("file-editor-sudo-badge")).not.toBeNull();
+  });
+
+  it("offers the SFTP-only copy/download fallback when the session has no shell", async () => {
+    mockSessionSftp({ execCapable: false, writable: "readOnly" });
+    render(SESSION_SSH_META);
+    await flush();
+    await flush();
+
+    const banner = query("file-editor-readonly-banner");
+    expect(banner?.textContent ?? "").toMatch(/sudo elevation isn't available/i);
+    expect(query("file-editor-edit-with-sudo")).toBeNull();
+    expect((query("file-editor-save") as HTMLButtonElement).disabled).toBe(true);
+    expect(query("file-editor-save-copy")).not.toBeNull();
+    expect(query("file-editor-download")).not.toBeNull();
+  });
+
+  it("writes a copy to a writable path via the session layer", async () => {
+    const { writeCalls } = mockSessionSftp({ execCapable: false, writable: "readOnly" });
+    render(SESSION_SSH_META);
+    await flush();
+    await flush();
+    editContent("127.0.0.1 localhost\nmy edit\n");
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-save-copy") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    typeInto(docQuery("save-copy-input") as HTMLInputElement, "/home/user/hosts.copy");
+    await act(async () => {
+      (docQuery("save-copy-submit") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    // Save-a-copy on the session path writes bytes through session_write_file.
+    expect(writeCalls).toHaveLength(1);
+    expect(writeCalls[0].sessionId).toBe("sess-ssh-1");
+    expect(writeCalls[0].path).toBe("/home/user/hosts.copy");
+    expect(new TextDecoder().decode(new Uint8Array(writeCalls[0].data as number[]))).toBe(
+      "127.0.0.1 localhost\nmy edit\n"
+    );
+  });
+
+  it("pre-fills Save a copy under the session realpath home", async () => {
+    mockSessionSftp({ execCapable: false, writable: "readOnly", home: "/home/user" });
+    render(SESSION_SSH_META);
+    await flush();
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-save-copy") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect((docQuery("save-copy-input") as HTMLInputElement).value).toBe("/home/user/hosts");
+  });
+
+  it("downloads the file via session_download", async () => {
+    const { downloadCalls } = mockSessionSftp({ execCapable: false, writable: "readOnly" });
+    vi.mocked(save).mockResolvedValueOnce("/local/hosts.txt");
+    render(SESSION_SSH_META);
+    await flush();
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-download") as HTMLButtonElement).click();
+    });
+    await flush();
+    await flush();
+
+    expect(downloadCalls).toHaveLength(1);
+    expect(downloadCalls[0].sessionId).toBe("sess-ssh-1");
+    expect(downloadCalls[0].remotePath).toBe("/etc/hosts");
+    expect(downloadCalls[0].localPath).toBe("/local/hosts.txt");
   });
 });

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useId } from "react";
+import { useState, useEffect, useRef, useCallback, useId, useMemo } from "react";
 import Editor, { loader } from "@monaco-editor/react";
 import * as monaco from "monaco-editor";
 import {
@@ -41,12 +41,18 @@ import {
   sessionReadFile,
   sessionStat,
   sessionWriteFile,
+  sessionCheckWritable,
+  sessionHasExecCapability,
+  sessionWriteFileElevated,
+  sessionDownload,
+  sessionRealpath,
   storeCredential,
   resolveCredential,
   removeCredential,
   TransferTerminalError,
   type ElevatedWriteResult,
 } from "@/services/api";
+import type { Writability } from "@/types/connection";
 import { onLocalFileChanged } from "@/services/events";
 import { UnsavedChangesDialog } from "@/components/ConnectionEditor/UnsavedChangesDialog";
 import { SudoPromptDialog, type SudoAuthorizeOptions } from "./SudoPromptDialog";
@@ -95,6 +101,33 @@ async function sessionWriteFileContent(
   content: string
 ): Promise<void> {
   await sessionWriteFile(sessionId, path, Array.from(new TextEncoder().encode(content)));
+}
+
+/**
+ * The SFTP-advanced file operations available to a remote editor tab, bound to
+ * whichever remote transport backs it (#2420).
+ *
+ * Two transports can back a remote tab (see {@link EditorTabMeta}): the legacy
+ * `sftpSessionId` (`sftp_*` commands) and the protocol-agnostic session layer
+ * (`session_*` twins). The advanced affordances — writability probe, exec
+ * capability, elevated/sudo write, realpath (home), download, save-a-copy — exist
+ * only for an **SFTP-backed** connection: the session-path twins resolve via the
+ * backend's `SftpFileBrowser` and error for a byte-based backend (Docker / FTP /
+ * remote-agent). This handle exposes exactly those ops with the transport already
+ * bound, so the editor's affordance code is transport-agnostic; it is `null` for
+ * local tabs, scratch buffers, and byte-based session backends (which keep plain
+ * read/write only).
+ */
+interface RemoteAdvancedOps {
+  checkWritable: (path: string) => Promise<Writability>;
+  realpath: (path: string) => Promise<string>;
+  writeElevated: (
+    path: string,
+    content: string,
+    password: string
+  ) => Promise<ElevatedWriteResult>;
+  writeContent: (path: string, content: string) => Promise<void>;
+  download: (remotePath: string, localPath: string) => Promise<number>;
 }
 
 /**
@@ -192,6 +225,15 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // run `sudo`. `false` for local files and SFTP-only connections.
   const [execCapable, setExecCapable] = useState(false);
 
+  // Whether a session-layer-backed remote tab's backend is SFTP-backed and can
+  // therefore drive the SFTP-advanced ops (#2420). Determined by the exec-
+  // capability probe: `session_has_exec_capability` resolves only for an
+  // SFTP-backed session and errors for a byte-based backend (Docker / FTP /
+  // remote-agent), so a resolved probe flips this on. Always `false` for the
+  // legacy `sftpSessionId` path (which is SFTP-backed by construction and gated
+  // directly), for local tabs, and for byte-based session backends.
+  const [sessionSftpCapable, setSessionSftpCapable] = useState(false);
+
   // Authoritative writability of the remote file, from a non-destructive SFTP
   // write-open probe (#1324/#1325): `false` = read-only (server denied the
   // write-open), `true` = writable, `"unknown"` = probe inconclusive. Only
@@ -254,6 +296,40 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // independent of the file name also preserves the model (and undo history)
   // when the buffer is later renamed via Save As.
   const monacoPath = meta.scratch ? `scratch/${tabId}` : fileName;
+
+  // The SFTP-advanced ops for this tab, bound to its remote transport, or null
+  // when none apply (#2420). The legacy `sftpSessionId` path is SFTP-backed by
+  // construction, so its ops are available immediately; the session path is
+  // offered these ops only once the capability probe has confirmed the backend is
+  // SFTP-backed (`sessionSftpCapable`) — a byte-based backend (Docker / FTP /
+  // remote-agent) keeps plain read/write only and this stays null, as do local
+  // tabs and scratch buffers. See {@link RemoteAdvancedOps}.
+  const advancedOps = useMemo<RemoteAdvancedOps | null>(() => {
+    if (!meta.isRemote || meta.scratch) return null;
+    const sftpId = meta.sftpSessionId;
+    if (sftpId) {
+      return {
+        checkWritable: (path) => sftpCheckWritable(sftpId, path),
+        realpath: (path) => sftpRealpath(sftpId, path),
+        writeElevated: (path, fileContent, password) =>
+          sftpWriteFileContentElevated(sftpId, path, fileContent, password),
+        writeContent: (path, fileContent) => sftpWriteFileContent(sftpId, path, fileContent),
+        download: (remotePath, localPath) => sftpDownload(sftpId, remotePath, localPath),
+      };
+    }
+    const sessionId = meta.sessionBrowser?.sessionId;
+    if (sessionId && sessionSftpCapable) {
+      return {
+        checkWritable: (path) => sessionCheckWritable(sessionId, path),
+        realpath: (path) => sessionRealpath(sessionId, path),
+        writeElevated: (path, fileContent, password) =>
+          sessionWriteFileElevated(sessionId, path, fileContent, password),
+        writeContent: (path, fileContent) => sessionWriteFileContent(sessionId, path, fileContent),
+        download: (remotePath, localPath) => sessionDownload(sessionId, remotePath, localPath),
+      };
+    }
+    return null;
+  }, [meta.isRemote, meta.scratch, meta.sftpSessionId, meta.sessionBrowser, sessionSftpCapable]);
 
   // Re-derive Monaco theme when the settings theme changes (dark / light / system).
   useEffect(() => {
@@ -322,26 +398,66 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   ]);
 
   // Probe whether the remote connection can run remote commands (shell vs
-  // SFTP-only). Determines whether privilege-elevated writes will be offered.
+  // SFTP-only) and, for a session-layer tab, whether its backend is SFTP-backed
+  // at all (#2420). Determines whether privilege-elevated writes will be offered.
+  //
+  // For the legacy `sftpSessionId` path the connection is SFTP-backed by
+  // construction, so this only measures exec capability. For the session path the
+  // same probe doubles as the SFTP-capability signal: `session_has_exec_capability`
+  // resolves (with the exec boolean) only for an SFTP-backed session and rejects
+  // for a byte-based backend, so a resolve flips `sessionSftpCapable` on (unlocking
+  // the advanced affordances) and a reject leaves the tab on the byte-based
+  // read/write path with no advanced ops.
   useEffect(() => {
     let cancelled = false;
-    if (!meta.isRemote || !meta.sftpSessionId) {
-      setExecCapable(false);
-      return;
+    setExecCapable(false);
+    setSessionSftpCapable(false);
+    if (!meta.isRemote || meta.scratch) return;
+
+    const sftpId = meta.sftpSessionId;
+    if (sftpId) {
+      sftpHasExecCapability(sftpId)
+        .then((capable) => {
+          if (cancelled) return;
+          setExecCapable(capable);
+          frontendLog("file_editor", `exec capability for sftp session ${sftpId}: ${capable}`);
+        })
+        .catch((err) => {
+          if (cancelled) return;
+          setExecCapable(false);
+          frontendLog(
+            "file_editor",
+            `exec capability probe failed for sftp session ${sftpId}: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        });
+      return () => {
+        cancelled = true;
+      };
     }
-    const sessionId = meta.sftpSessionId;
-    sftpHasExecCapability(sessionId)
+
+    const sessionId = meta.sessionBrowser?.sessionId;
+    if (!sessionId) return;
+    sessionHasExecCapability(sessionId)
       .then((capable) => {
         if (cancelled) return;
+        // Resolved → the session is SFTP-backed; the boolean is its exec capability.
+        setSessionSftpCapable(true);
         setExecCapable(capable);
-        frontendLog("file_editor", `exec capability for sftp session ${sessionId}: ${capable}`);
+        frontendLog(
+          "file_editor",
+          `session ${sessionId} is SFTP-backed; exec capability: ${capable}`
+        );
       })
       .catch((err) => {
         if (cancelled) return;
+        // Rejected → not SFTP-backed (byte-based backend); keep read/write only.
+        setSessionSftpCapable(false);
         setExecCapable(false);
         frontendLog(
           "file_editor",
-          `exec capability probe failed for sftp session ${sessionId}: ${
+          `session ${sessionId} is not SFTP-backed; advanced editor ops disabled: ${
             err instanceof Error ? err.message : String(err)
           }`
         );
@@ -349,39 +465,38 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     return () => {
       cancelled = true;
     };
-  }, [meta.isRemote, meta.sftpSessionId]);
+  }, [meta.isRemote, meta.scratch, meta.sftpSessionId, meta.sessionBrowser]);
 
   // Resolve the connecting user's remote home directory so the "Save a copy…"
-  // dialog can default to a likely-writable destination there (#1535). Passing
-  // "." to realpath yields the session's home. Best-effort: a failure just
-  // leaves home null and the dialog falls back to a same-directory sibling.
+  // dialog can default to a likely-writable destination there (#1535). Uses the
+  // tab's SFTP-advanced transport (sftp or session, #2420); passing "." to
+  // realpath yields the session's home. Best-effort: a failure just leaves home
+  // null and the dialog falls back to a same-directory sibling.
   useEffect(() => {
     let cancelled = false;
-    if (!meta.isRemote || !meta.sftpSessionId || meta.scratch) {
+    if (!advancedOps) {
       setRemoteHome(null);
       return;
     }
-    const sessionId = meta.sftpSessionId;
-    sftpRealpath(sessionId, ".")
+    advancedOps
+      .realpath(".")
       .then((home) => {
         if (cancelled) return;
         setRemoteHome(home);
-        frontendLog("file_editor", `resolved remote home for sftp session ${sessionId}: ${home}`);
+        frontendLog("file_editor", `resolved remote home: ${home}`);
       })
       .catch((err) => {
         if (cancelled) return;
         setRemoteHome(null);
         frontendLog(
           "file_editor",
-          `remote home resolution failed for sftp session ${sessionId}: ${
-            err instanceof Error ? err.message : String(err)
-          }`
+          `remote home resolution failed: ${err instanceof Error ? err.message : String(err)}`
         );
       });
     return () => {
       cancelled = true;
     };
-  }, [meta.isRemote, meta.sftpSessionId, meta.scratch]);
+  }, [advancedOps]);
 
   // Probe the connecting user's actual write access to this remote file, in
   // parallel with the content read (it never blocks the load; a failure just
@@ -390,13 +505,13 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   useEffect(() => {
     let cancelled = false;
     setReadonlyBannerDismissed(false);
-    if (!meta.isRemote || !meta.sftpSessionId || meta.scratch) {
+    if (!advancedOps) {
       setWritable("unknown");
       return;
     }
-    const sessionId = meta.sftpSessionId;
     const filePath = meta.filePath;
-    sftpCheckWritable(sessionId, filePath)
+    advancedOps
+      .checkWritable(filePath)
       .then((result) => {
         if (cancelled) return;
         const mapped = result === "readOnly" ? false : result === "writable" ? true : "unknown";
@@ -416,7 +531,7 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     return () => {
       cancelled = true;
     };
-  }, [meta.isRemote, meta.sftpSessionId, meta.filePath, meta.scratch]);
+  }, [advancedOps, meta.filePath]);
 
   // An unsaved scratch buffer has no on-disk copy, so it is always considered
   // dirty (closing it would lose the captured content) until saved via Save As.
@@ -427,15 +542,13 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // "Save": a remote file the probe reported read-only, on an exec-capable
   // (shell) connection, before the session has been elevated. Once elevated the
   // normal Save button returns (it routes through the sudo path).
-  const offerEditWithSudo =
-    meta.isRemote && !!meta.sftpSessionId && writable === false && execCapable && !elevated;
+  const offerEditWithSudo = !!advancedOps && writable === false && execCapable && !elevated;
   // Whether a failed direct save can be retried with sudo (a shell exists).
-  const canRetryWithSudo = meta.isRemote && !!meta.sftpSessionId && execCapable && !elevated;
+  const canRetryWithSudo = !!advancedOps && execCapable && !elevated;
   // SFTP-only read-only file (#1330): read-only on a connection with no exec
   // channel, so no sudo path exists. The direct Save stays disabled; the user is
   // offered "Save a copy" (to a writable remote path) or a local download.
-  const sftpOnlyReadonly =
-    meta.isRemote && !!meta.sftpSessionId && writable === false && !execCapable;
+  const sftpOnlyReadonly = !!advancedOps && writable === false && !execCapable;
 
   // Sync dirty state to the store (drives the tab dirty dot and close prompt).
   useEffect(() => {
@@ -753,20 +866,14 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // in the #969 banner here; the password is never logged.
   const attemptElevatedWrite = useCallback(
     async (password: string, bufferContent: string): Promise<"success" | "wrong" | "error"> => {
-      const sessionId = meta.sftpSessionId;
-      if (!sessionId) return "error";
+      if (!advancedOps) return "error";
       frontendLog(
         "file_editor",
         `elevated save attempt for ${meta.filePath} on ${hostLabel ?? "unknown host"}`
       );
       let result: ElevatedWriteResult;
       try {
-        result = await sftpWriteFileContentElevated(
-          sessionId,
-          meta.filePath,
-          bufferContent,
-          password
-        );
+        result = await advancedOps.writeElevated(meta.filePath, bufferContent, password);
       } catch (err) {
         frontendLog(
           "file_editor",
@@ -783,7 +890,7 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
       setSaveError(`Save failed: ${result.message}`);
       return "error";
     },
-    [meta.sftpSessionId, meta.filePath, hostLabel]
+    [advancedOps, meta.filePath, hostLabel]
   );
 
   // Save via the elevated (sudo) path, prompting only when needed. Tries the
@@ -901,11 +1008,11 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // buffer's dirty state is intentionally left as-is.
   const handleSaveCopySubmit = useCallback(
     async (destPath: string) => {
-      if (content === null || !meta.sftpSessionId) return;
+      if (content === null || !advancedOps) return;
       setSaveCopyBusy(true);
       const toastId = toast.loading(`Saving a copy to ${destPath}…`);
       try {
-        await sftpWriteFileContent(meta.sftpSessionId, destPath, content);
+        await advancedOps.writeContent(destPath, content);
         toast.success(`Saved a copy to ${destPath}`, { id: toastId });
         setSaveCopyDialogOpen(false);
         frontendLog("file_editor", `saved a copy of ${meta.filePath} to ${destPath}`);
@@ -917,7 +1024,7 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
         setSaveCopyBusy(false);
       }
     },
-    [content, meta.sftpSessionId, meta.filePath]
+    [content, advancedOps, meta.filePath]
   );
 
   // Download the read-only remote file to a user-chosen local path (#1330). The
@@ -925,12 +1032,12 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // (useTransferEvents); here we only show the pending toast and surface an
   // early failure that never produced a transfer event.
   const handleDownloadCopy = useCallback(async () => {
-    if (!meta.sftpSessionId) return;
+    if (!advancedOps) return;
     const localPath = await save({ title: "Download a copy…", defaultPath: fileName });
     if (!localPath) return;
     const toastId = toast.loading(`Downloading ${fileName}…`);
     try {
-      await sftpDownload(meta.sftpSessionId, meta.filePath, localPath);
+      await advancedOps.download(meta.filePath, localPath);
       toast.dismiss(toastId);
       frontendLog("file_editor", `downloaded ${meta.filePath} to ${localPath}`);
     } catch (err) {
@@ -943,14 +1050,15 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
       toast.error(`Download failed: ${message}`, { id: toastId });
       frontendLog("file_editor", `download of ${meta.filePath} failed: ${message}`);
     }
-  }, [meta.sftpSessionId, meta.filePath, fileName]);
+  }, [advancedOps, meta.filePath, fileName]);
 
   const handleSave = useCallback(async () => {
     if (content === null || saving) return;
 
     // Read-only remote file that has a shell, or an already-elevated session:
-    // route through the sudo path instead of the direct SFTP write.
-    if (meta.isRemote && meta.sftpSessionId && (elevated || (writable === false && execCapable))) {
+    // route through the sudo path instead of the direct write. Applies to both
+    // SFTP-advanced transports (legacy sftp and SFTP-backed session, #2420).
+    if (advancedOps && (elevated || (writable === false && execCapable))) {
       await saveElevated();
       return;
     }
@@ -998,6 +1106,7 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     meta.isRemote,
     meta.sftpSessionId,
     meta.sessionBrowser,
+    advancedOps,
     tabId,
     renameTab,
     elevated,

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -121,11 +121,7 @@ async function sessionWriteFileContent(
 interface RemoteAdvancedOps {
   checkWritable: (path: string) => Promise<Writability>;
   realpath: (path: string) => Promise<string>;
-  writeElevated: (
-    path: string,
-    content: string,
-    password: string
-  ) => Promise<ElevatedWriteResult>;
+  writeElevated: (path: string, content: string, password: string) => Promise<ElevatedWriteResult>;
   writeContent: (path: string, content: string) => Promise<void>;
   download: (remotePath: string, localPath: string) => Promise<number>;
 }


### PR DESCRIPTION
## What

sftp convergence **B2 (editor)**: bring the remote `FileEditor` **session path** to full SFTP parity using the #2419 `session_*` wrappers, so the SFTP-advanced editor affordances no longer depend on `sftpSessionId`.

Follow-up to #2313 (PR #2419). Part of #2307 (step B, slice 2).

Closes #2420

## How

The editor previously gated every SFTP-advanced affordance — writability probe, exec capability, elevated/sudo write, realpath (home), download, save-a-copy — on `meta.sftpSessionId`, so a `sessionBrowser`-backed remote tab silently lost them.

- Introduce a `RemoteAdvancedOps` handle (a `useMemo`) that binds those ops to whichever remote transport backs the tab: the legacy `sftpSessionId` path keeps the `sftp_*` commands; the session path uses the `session_*` twins from #2419. All affordance code (effects, derived flags, handlers) is now transport-agnostic — it reads `advancedOps`, never `sftpSessionId`.
- **Capability gating.** The `session_*` advanced ops resolve via `SessionManager::sftp_transfer_browser` and error for a non-SFTP backend (Docker / FTP / remote-agent → byte-based). The gate reuses the exec-capability probe as the SFTP-capability signal: `session_has_exec_capability` **resolves** (with the exec boolean) only for an SFTP-backed session and **rejects** for a byte-based one. A resolve flips `sessionSftpCapable` on (unlocking the advanced ops); a reject leaves the tab on the plain byte-based read/write path with no advanced affordances. This is the "try/fallback" signal the issue asked to decide on — self-correcting and independent of any connection-type string.
- The byte-based read/write path for non-SFTP sessions is unchanged; the legacy `sftpSessionId` path is preserved byte-for-byte (the memo's sftp branch calls the exact same api functions with the same args).

### Deliberately out of scope (kept for the sibling slices)
- **Not** flipping the FileBrowser SSH branch / "open remote file in editor/VS Code" to populate `sessionBrowser` — that is **B3/#2421**. No caller creates a `sessionBrowser` SSH editor tab yet; this slice makes the session path *reach* parity so B3 can migrate callers onto it.
- **Not** retiring the `sftpSessionId` slice — that is **B4/#2422**. `sftpSessionId` still works.

**Host label / credential-store keying** for a session-backed SSH tab: `hostLabel` is still resolved only from `sftpSessions[…]` (no session→host map exists yet), so a session tab's sudo prompt falls back to the file path for display and skips credential-store persistence — the existing graceful-degradation path. Wiring a host label for session tabs belongs with B3 (which creates those tabs with host context); noted as a follow-up rather than grown into this diff.

## Verification (local)

GitHub Actions is in a major outage, so this was verified locally. Coordinator is **holding merge until real CI returns**.

- `tsc --noEmit` — **PASS**
- ESLint (`pnpm run lint`, `src/`) — **PASS**
- `pnpm exec prettier --check` over `src/**/*.{ts,tsx}` + `docs/**/*.md` — **PASS**
- Full `pnpm` unit suite — **PASS** (548 files, 4951 tests)
  - Includes new `FileEditor` coverage: SFTP-backed session-path parity (writability badge, edit-with-sudo, elevated write via `session_write_file_elevated`, SFTP-only copy/download fallback, realpath home pre-fill, download via `session_download`) and the non-SFTP gating case (byte-based backend rejects the probe → no advanced affordances, no writability/realpath round-trip). 60/60 `FileEditor` tests pass.
- Editor system suite (`./scripts/test-system-py.sh tests/test_editor.py`): **17/18 passed**. The one failure — `test_cursor_movement_updates_line_and_column` (Monaco cursor position via synthetic `pressKey`) — is **inconclusive locally due to host contention** and is unrelated to this change (local-file editing hits none of the modified code; `advancedOps` is null and every new effect early-returns; the sibling `test_save_keybinding_clears_dirty`, which drives Monaco through the same hidden-input path, passes). Same flaky pattern as noted for live integration under host load; **deferred to CI**.
- Integration note: SFTP integration tests do not run in per-PR CI, and no caller opens a session-backed SSH editor tab yet (B3), so the new session-parity path is exercised by the unit suite; the release-cadence integration lane will cover it once callers migrate.
