### PR TITLE
refactor(sftp): flip the SSH file browser to the session path (Closes #2421)

### DIFF
--- a/src/components/FileEditor/FileEditor.test.tsx
+++ b/src/components/FileEditor/FileEditor.test.tsx
@@ -929,16 +929,27 @@ describe("FileEditor — session-layer backed tabs (#1557)", () => {
     expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(true);
   });
 
-  it("marks the tab remote but offers no SFTP-only affordances", async () => {
+  it("offers no SFTP-advanced affordances for a byte-based (non-SFTP) backend", async () => {
+    // A byte-based session backend (FTP here) rejects the SFTP-advanced probe —
+    // exactly how the backend's SessionManager::sftp_transfer_browser behaves for
+    // a non-SFTP browser. That reject is the capability signal (#2420): the tab
+    // stays on the plain read/write path with none of the advanced affordances,
+    // and even a read-only verdict would never be probed for.
+    const calls: string[] = [];
     mockedInvoke.mockImplementation((cmd) => {
+      calls.push(String(cmd));
       if (cmd === "session_read_file") return Promise.resolve(bytes("body\n"));
+      if (cmd === "session_has_exec_capability")
+        return Promise.reject(
+          new Error("Session file browser does not support SFTP advanced operations")
+        );
       // Were these ever reached, they would light up the sudo / fallback UI.
-      if (cmd === "sftp_has_exec_capability") return Promise.resolve(true);
-      if (cmd === "sftp_check_writable") return Promise.resolve("readOnly");
+      if (cmd === "session_check_writable") return Promise.resolve("readOnly");
       return Promise.resolve(undefined);
     });
 
     render(SESSION_META);
+    await flush();
     await flush();
 
     // The session layer exposes read/write only: no writability probe, no sudo,
@@ -948,6 +959,12 @@ describe("FileEditor — session-layer backed tabs (#1557)", () => {
     expect(query("file-editor-edit-with-sudo")).toBeNull();
     expect(query("file-editor-save-copy")).toBeNull();
     expect(query("file-editor-download")).toBeNull();
+    // The advanced ops are gated off the failed probe: no writability / realpath
+    // round-trip is made once the backend reports it is not SFTP-backed.
+    expect(calls).not.toContain("session_check_writable");
+    expect(calls).not.toContain("session_realpath");
+    // The SFTP-family commands are never used on the session path either.
+    expect(calls.filter((c) => c.startsWith("sftp_"))).toEqual([]);
   });
 
   it("surfaces a session read failure as a load error", async () => {
@@ -960,5 +977,234 @@ describe("FileEditor — session-layer backed tabs (#1557)", () => {
     await flush();
 
     expect(container.textContent ?? "").toMatch(/no such file/i);
+  });
+});
+
+describe("FileEditor — SFTP-backed session tab reaches SFTP parity (#2420)", () => {
+  // A session-layer tab whose backend IS SFTP-backed (SSH). The
+  // `session_has_exec_capability` probe resolves for it (rather than rejecting as
+  // a byte-based backend would), which is the capability signal that unlocks the
+  // SFTP-advanced affordances on the session path.
+  const SESSION_SSH_META: EditorTabMeta = {
+    filePath: "/etc/hosts",
+    isRemote: true,
+    sessionBrowser: { sessionId: "sess-ssh-1", connectionType: "ssh" },
+    permissions: "-rw-r--r--",
+  };
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState({ ...useAppStore.getInitialState() });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  function docQuery(testId: string): HTMLElement | null {
+    return document.querySelector(`[data-testid="${testId}"]`);
+  }
+
+  function typeInto(el: HTMLInputElement, value: string): void {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value"
+    )!.set!;
+    act(() => {
+      setter.call(el, value);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
+
+  /** Encode text the way session_read_file returns it: a plain byte array. */
+  function bytes(text: string): number[] {
+    return Array.from(new TextEncoder().encode(text));
+  }
+
+  /**
+   * Mock a session-backed SFTP connection through the `session_*` twins, so the
+   * advanced ops resolve exactly as they would for an SSH-backed session.
+   */
+  function mockSessionSftp(opts: {
+    execCapable?: boolean;
+    writable?: "writable" | "readOnly" | "unknown";
+    home?: string;
+    elevatedResults?: unknown[];
+  }): {
+    calls: string[];
+    elevatedCalls: Array<Record<string, unknown>>;
+    writeCalls: Array<Record<string, unknown>>;
+    downloadCalls: Array<Record<string, unknown>>;
+  } {
+    const { execCapable = true, writable = "readOnly", home, elevatedResults = [] } = opts;
+    const calls: string[] = [];
+    const elevatedCalls: Array<Record<string, unknown>> = [];
+    const writeCalls: Array<Record<string, unknown>> = [];
+    const downloadCalls: Array<Record<string, unknown>> = [];
+    const queue = [...elevatedResults];
+    mockedInvoke.mockImplementation((cmd, args) => {
+      calls.push(String(cmd));
+      if (cmd === "session_read_file") return Promise.resolve(bytes("127.0.0.1 localhost\n"));
+      // The probe resolves (does not reject) → the session is SFTP-backed.
+      if (cmd === "session_has_exec_capability") return Promise.resolve(execCapable);
+      if (cmd === "session_check_writable") return Promise.resolve(writable);
+      if (cmd === "session_realpath") {
+        return home !== undefined
+          ? Promise.resolve(home)
+          : Promise.reject(new Error("no realpath"));
+      }
+      if (cmd === "session_write_file_elevated") {
+        elevatedCalls.push((args ?? {}) as Record<string, unknown>);
+        return Promise.resolve(queue.shift() ?? { kind: "success" });
+      }
+      if (cmd === "session_write_file") {
+        writeCalls.push((args ?? {}) as Record<string, unknown>);
+        return Promise.resolve(undefined);
+      }
+      if (cmd === "session_download") {
+        downloadCalls.push((args ?? {}) as Record<string, unknown>);
+        return Promise.resolve("transfer-1");
+      }
+      return Promise.resolve(undefined);
+    });
+    return { calls, elevatedCalls, writeCalls, downloadCalls };
+  }
+
+  it("probes writability over the session path and shows the read-only badge", async () => {
+    const { calls } = mockSessionSftp({ execCapable: false, writable: "readOnly" });
+    render(SESSION_SSH_META);
+    await flush();
+    await flush();
+
+    // Writability was probed via the session twin, never the SftpManager path.
+    expect(calls).toContain("session_check_writable");
+    expect(calls.filter((c) => c.startsWith("sftp_"))).toEqual([]);
+    const badge = query("file-editor-readonly-badge");
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute("title") ?? "").toContain("rw-r--r--");
+  });
+
+  it("offers 'Edit with sudo' for a read-only file on an exec-capable session", async () => {
+    mockSessionSftp({ execCapable: true, writable: "readOnly" });
+    render(SESSION_SSH_META);
+    await flush();
+    await flush();
+
+    expect(query("file-editor-edit-with-sudo")).not.toBeNull();
+    expect(query("file-editor-save")).toBeNull();
+  });
+
+  it("routes an authorized elevated save through session_write_file_elevated", async () => {
+    const { elevatedCalls } = mockSessionSftp({
+      execCapable: true,
+      writable: "readOnly",
+      elevatedResults: [{ kind: "success" }],
+    });
+    render(SESSION_SSH_META);
+    await flush();
+    await flush();
+
+    editContent("127.0.0.1 localhost\nedited\n");
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-edit-with-sudo") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    typeInto(docQuery("sudo-prompt-input") as HTMLInputElement, "sudo-pw");
+    await act(async () => {
+      (docQuery("sudo-prompt-submit") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(elevatedCalls).toHaveLength(1);
+    expect(elevatedCalls[0].sessionId).toBe("sess-ssh-1");
+    expect(elevatedCalls[0].remotePath).toBe("/etc/hosts");
+    expect(elevatedCalls[0].sudoPassword).toBe("sudo-pw");
+    expect(useAppStore.getState().editorDirtyTabs[TAB_ID]).toBe(false);
+    expect(query("file-editor-sudo-badge")).not.toBeNull();
+  });
+
+  it("offers the SFTP-only copy/download fallback when the session has no shell", async () => {
+    mockSessionSftp({ execCapable: false, writable: "readOnly" });
+    render(SESSION_SSH_META);
+    await flush();
+    await flush();
+
+    const banner = query("file-editor-readonly-banner");
+    expect(banner?.textContent ?? "").toMatch(/sudo elevation isn't available/i);
+    expect(query("file-editor-edit-with-sudo")).toBeNull();
+    expect((query("file-editor-save") as HTMLButtonElement).disabled).toBe(true);
+    expect(query("file-editor-save-copy")).not.toBeNull();
+    expect(query("file-editor-download")).not.toBeNull();
+  });
+
+  it("writes a copy to a writable path via the session layer", async () => {
+    const { writeCalls } = mockSessionSftp({ execCapable: false, writable: "readOnly" });
+    render(SESSION_SSH_META);
+    await flush();
+    await flush();
+    editContent("127.0.0.1 localhost\nmy edit\n");
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-save-copy") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    typeInto(docQuery("save-copy-input") as HTMLInputElement, "/home/user/hosts.copy");
+    await act(async () => {
+      (docQuery("save-copy-submit") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    // Save-a-copy on the session path writes bytes through session_write_file.
+    expect(writeCalls).toHaveLength(1);
+    expect(writeCalls[0].sessionId).toBe("sess-ssh-1");
+    expect(writeCalls[0].path).toBe("/home/user/hosts.copy");
+    expect(new TextDecoder().decode(new Uint8Array(writeCalls[0].data as number[]))).toBe(
+      "127.0.0.1 localhost\nmy edit\n"
+    );
+  });
+
+  it("pre-fills Save a copy under the session realpath home", async () => {
+    mockSessionSftp({ execCapable: false, writable: "readOnly", home: "/home/user" });
+    render(SESSION_SSH_META);
+    await flush();
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-save-copy") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect((docQuery("save-copy-input") as HTMLInputElement).value).toBe("/home/user/hosts");
+  });
+
+  it("downloads the file via session_download", async () => {
+    const { downloadCalls } = mockSessionSftp({ execCapable: false, writable: "readOnly" });
+    vi.mocked(save).mockResolvedValueOnce("/local/hosts.txt");
+    render(SESSION_SSH_META);
+    await flush();
+    await flush();
+
+    await act(async () => {
+      (query("file-editor-download") as HTMLButtonElement).click();
+    });
+    await flush();
+    await flush();
+
+    expect(downloadCalls).toHaveLength(1);
+    expect(downloadCalls[0].sessionId).toBe("sess-ssh-1");
+    expect(downloadCalls[0].remotePath).toBe("/etc/hosts");
+    expect(downloadCalls[0].localPath).toBe("/local/hosts.txt");
   });
 });

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useId } from "react";
+import { useState, useEffect, useRef, useCallback, useId, useMemo } from "react";
 import Editor, { loader } from "@monaco-editor/react";
 import * as monaco from "monaco-editor";
 import {
@@ -41,12 +41,18 @@ import {
   sessionReadFile,
   sessionStat,
   sessionWriteFile,
+  sessionCheckWritable,
+  sessionHasExecCapability,
+  sessionWriteFileElevated,
+  sessionDownload,
+  sessionRealpath,
   storeCredential,
   resolveCredential,
   removeCredential,
   TransferTerminalError,
   type ElevatedWriteResult,
 } from "@/services/api";
+import type { Writability } from "@/types/connection";
 import { onLocalFileChanged } from "@/services/events";
 import { UnsavedChangesDialog } from "@/components/ConnectionEditor/UnsavedChangesDialog";
 import { SudoPromptDialog, type SudoAuthorizeOptions } from "./SudoPromptDialog";
@@ -95,6 +101,33 @@ async function sessionWriteFileContent(
   content: string
 ): Promise<void> {
   await sessionWriteFile(sessionId, path, Array.from(new TextEncoder().encode(content)));
+}
+
+/**
+ * The SFTP-advanced file operations available to a remote editor tab, bound to
+ * whichever remote transport backs it (#2420).
+ *
+ * Two transports can back a remote tab (see {@link EditorTabMeta}): the legacy
+ * `sftpSessionId` (`sftp_*` commands) and the protocol-agnostic session layer
+ * (`session_*` twins). The advanced affordances — writability probe, exec
+ * capability, elevated/sudo write, realpath (home), download, save-a-copy — exist
+ * only for an **SFTP-backed** connection: the session-path twins resolve via the
+ * backend's `SftpFileBrowser` and error for a byte-based backend (Docker / FTP /
+ * remote-agent). This handle exposes exactly those ops with the transport already
+ * bound, so the editor's affordance code is transport-agnostic; it is `null` for
+ * local tabs, scratch buffers, and byte-based session backends (which keep plain
+ * read/write only).
+ */
+interface RemoteAdvancedOps {
+  checkWritable: (path: string) => Promise<Writability>;
+  realpath: (path: string) => Promise<string>;
+  writeElevated: (
+    path: string,
+    content: string,
+    password: string
+  ) => Promise<ElevatedWriteResult>;
+  writeContent: (path: string, content: string) => Promise<void>;
+  download: (remotePath: string, localPath: string) => Promise<number>;
 }
 
 /**
@@ -192,6 +225,15 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // run `sudo`. `false` for local files and SFTP-only connections.
   const [execCapable, setExecCapable] = useState(false);
 
+  // Whether a session-layer-backed remote tab's backend is SFTP-backed and can
+  // therefore drive the SFTP-advanced ops (#2420). Determined by the exec-
+  // capability probe: `session_has_exec_capability` resolves only for an
+  // SFTP-backed session and errors for a byte-based backend (Docker / FTP /
+  // remote-agent), so a resolved probe flips this on. Always `false` for the
+  // legacy `sftpSessionId` path (which is SFTP-backed by construction and gated
+  // directly), for local tabs, and for byte-based session backends.
+  const [sessionSftpCapable, setSessionSftpCapable] = useState(false);
+
   // Authoritative writability of the remote file, from a non-destructive SFTP
   // write-open probe (#1324/#1325): `false` = read-only (server denied the
   // write-open), `true` = writable, `"unknown"` = probe inconclusive. Only
@@ -254,6 +296,40 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // independent of the file name also preserves the model (and undo history)
   // when the buffer is later renamed via Save As.
   const monacoPath = meta.scratch ? `scratch/${tabId}` : fileName;
+
+  // The SFTP-advanced ops for this tab, bound to its remote transport, or null
+  // when none apply (#2420). The legacy `sftpSessionId` path is SFTP-backed by
+  // construction, so its ops are available immediately; the session path is
+  // offered these ops only once the capability probe has confirmed the backend is
+  // SFTP-backed (`sessionSftpCapable`) — a byte-based backend (Docker / FTP /
+  // remote-agent) keeps plain read/write only and this stays null, as do local
+  // tabs and scratch buffers. See {@link RemoteAdvancedOps}.
+  const advancedOps = useMemo<RemoteAdvancedOps | null>(() => {
+    if (!meta.isRemote || meta.scratch) return null;
+    const sftpId = meta.sftpSessionId;
+    if (sftpId) {
+      return {
+        checkWritable: (path) => sftpCheckWritable(sftpId, path),
+        realpath: (path) => sftpRealpath(sftpId, path),
+        writeElevated: (path, fileContent, password) =>
+          sftpWriteFileContentElevated(sftpId, path, fileContent, password),
+        writeContent: (path, fileContent) => sftpWriteFileContent(sftpId, path, fileContent),
+        download: (remotePath, localPath) => sftpDownload(sftpId, remotePath, localPath),
+      };
+    }
+    const sessionId = meta.sessionBrowser?.sessionId;
+    if (sessionId && sessionSftpCapable) {
+      return {
+        checkWritable: (path) => sessionCheckWritable(sessionId, path),
+        realpath: (path) => sessionRealpath(sessionId, path),
+        writeElevated: (path, fileContent, password) =>
+          sessionWriteFileElevated(sessionId, path, fileContent, password),
+        writeContent: (path, fileContent) => sessionWriteFileContent(sessionId, path, fileContent),
+        download: (remotePath, localPath) => sessionDownload(sessionId, remotePath, localPath),
+      };
+    }
+    return null;
+  }, [meta.isRemote, meta.scratch, meta.sftpSessionId, meta.sessionBrowser, sessionSftpCapable]);
 
   // Re-derive Monaco theme when the settings theme changes (dark / light / system).
   useEffect(() => {
@@ -322,26 +398,66 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   ]);
 
   // Probe whether the remote connection can run remote commands (shell vs
-  // SFTP-only). Determines whether privilege-elevated writes will be offered.
+  // SFTP-only) and, for a session-layer tab, whether its backend is SFTP-backed
+  // at all (#2420). Determines whether privilege-elevated writes will be offered.
+  //
+  // For the legacy `sftpSessionId` path the connection is SFTP-backed by
+  // construction, so this only measures exec capability. For the session path the
+  // same probe doubles as the SFTP-capability signal: `session_has_exec_capability`
+  // resolves (with the exec boolean) only for an SFTP-backed session and rejects
+  // for a byte-based backend, so a resolve flips `sessionSftpCapable` on (unlocking
+  // the advanced affordances) and a reject leaves the tab on the byte-based
+  // read/write path with no advanced ops.
   useEffect(() => {
     let cancelled = false;
-    if (!meta.isRemote || !meta.sftpSessionId) {
-      setExecCapable(false);
-      return;
+    setExecCapable(false);
+    setSessionSftpCapable(false);
+    if (!meta.isRemote || meta.scratch) return;
+
+    const sftpId = meta.sftpSessionId;
+    if (sftpId) {
+      sftpHasExecCapability(sftpId)
+        .then((capable) => {
+          if (cancelled) return;
+          setExecCapable(capable);
+          frontendLog("file_editor", `exec capability for sftp session ${sftpId}: ${capable}`);
+        })
+        .catch((err) => {
+          if (cancelled) return;
+          setExecCapable(false);
+          frontendLog(
+            "file_editor",
+            `exec capability probe failed for sftp session ${sftpId}: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        });
+      return () => {
+        cancelled = true;
+      };
     }
-    const sessionId = meta.sftpSessionId;
-    sftpHasExecCapability(sessionId)
+
+    const sessionId = meta.sessionBrowser?.sessionId;
+    if (!sessionId) return;
+    sessionHasExecCapability(sessionId)
       .then((capable) => {
         if (cancelled) return;
+        // Resolved → the session is SFTP-backed; the boolean is its exec capability.
+        setSessionSftpCapable(true);
         setExecCapable(capable);
-        frontendLog("file_editor", `exec capability for sftp session ${sessionId}: ${capable}`);
+        frontendLog(
+          "file_editor",
+          `session ${sessionId} is SFTP-backed; exec capability: ${capable}`
+        );
       })
       .catch((err) => {
         if (cancelled) return;
+        // Rejected → not SFTP-backed (byte-based backend); keep read/write only.
+        setSessionSftpCapable(false);
         setExecCapable(false);
         frontendLog(
           "file_editor",
-          `exec capability probe failed for sftp session ${sessionId}: ${
+          `session ${sessionId} is not SFTP-backed; advanced editor ops disabled: ${
             err instanceof Error ? err.message : String(err)
           }`
         );
@@ -349,39 +465,38 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     return () => {
       cancelled = true;
     };
-  }, [meta.isRemote, meta.sftpSessionId]);
+  }, [meta.isRemote, meta.scratch, meta.sftpSessionId, meta.sessionBrowser]);
 
   // Resolve the connecting user's remote home directory so the "Save a copy…"
-  // dialog can default to a likely-writable destination there (#1535). Passing
-  // "." to realpath yields the session's home. Best-effort: a failure just
-  // leaves home null and the dialog falls back to a same-directory sibling.
+  // dialog can default to a likely-writable destination there (#1535). Uses the
+  // tab's SFTP-advanced transport (sftp or session, #2420); passing "." to
+  // realpath yields the session's home. Best-effort: a failure just leaves home
+  // null and the dialog falls back to a same-directory sibling.
   useEffect(() => {
     let cancelled = false;
-    if (!meta.isRemote || !meta.sftpSessionId || meta.scratch) {
+    if (!advancedOps) {
       setRemoteHome(null);
       return;
     }
-    const sessionId = meta.sftpSessionId;
-    sftpRealpath(sessionId, ".")
+    advancedOps
+      .realpath(".")
       .then((home) => {
         if (cancelled) return;
         setRemoteHome(home);
-        frontendLog("file_editor", `resolved remote home for sftp session ${sessionId}: ${home}`);
+        frontendLog("file_editor", `resolved remote home: ${home}`);
       })
       .catch((err) => {
         if (cancelled) return;
         setRemoteHome(null);
         frontendLog(
           "file_editor",
-          `remote home resolution failed for sftp session ${sessionId}: ${
-            err instanceof Error ? err.message : String(err)
-          }`
+          `remote home resolution failed: ${err instanceof Error ? err.message : String(err)}`
         );
       });
     return () => {
       cancelled = true;
     };
-  }, [meta.isRemote, meta.sftpSessionId, meta.scratch]);
+  }, [advancedOps]);
 
   // Probe the connecting user's actual write access to this remote file, in
   // parallel with the content read (it never blocks the load; a failure just
@@ -390,13 +505,13 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   useEffect(() => {
     let cancelled = false;
     setReadonlyBannerDismissed(false);
-    if (!meta.isRemote || !meta.sftpSessionId || meta.scratch) {
+    if (!advancedOps) {
       setWritable("unknown");
       return;
     }
-    const sessionId = meta.sftpSessionId;
     const filePath = meta.filePath;
-    sftpCheckWritable(sessionId, filePath)
+    advancedOps
+      .checkWritable(filePath)
       .then((result) => {
         if (cancelled) return;
         const mapped = result === "readOnly" ? false : result === "writable" ? true : "unknown";
@@ -416,7 +531,7 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     return () => {
       cancelled = true;
     };
-  }, [meta.isRemote, meta.sftpSessionId, meta.filePath, meta.scratch]);
+  }, [advancedOps, meta.filePath]);
 
   // An unsaved scratch buffer has no on-disk copy, so it is always considered
   // dirty (closing it would lose the captured content) until saved via Save As.
@@ -427,15 +542,13 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // "Save": a remote file the probe reported read-only, on an exec-capable
   // (shell) connection, before the session has been elevated. Once elevated the
   // normal Save button returns (it routes through the sudo path).
-  const offerEditWithSudo =
-    meta.isRemote && !!meta.sftpSessionId && writable === false && execCapable && !elevated;
+  const offerEditWithSudo = !!advancedOps && writable === false && execCapable && !elevated;
   // Whether a failed direct save can be retried with sudo (a shell exists).
-  const canRetryWithSudo = meta.isRemote && !!meta.sftpSessionId && execCapable && !elevated;
+  const canRetryWithSudo = !!advancedOps && execCapable && !elevated;
   // SFTP-only read-only file (#1330): read-only on a connection with no exec
   // channel, so no sudo path exists. The direct Save stays disabled; the user is
   // offered "Save a copy" (to a writable remote path) or a local download.
-  const sftpOnlyReadonly =
-    meta.isRemote && !!meta.sftpSessionId && writable === false && !execCapable;
+  const sftpOnlyReadonly = !!advancedOps && writable === false && !execCapable;
 
   // Sync dirty state to the store (drives the tab dirty dot and close prompt).
   useEffect(() => {
@@ -753,20 +866,14 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // in the #969 banner here; the password is never logged.
   const attemptElevatedWrite = useCallback(
     async (password: string, bufferContent: string): Promise<"success" | "wrong" | "error"> => {
-      const sessionId = meta.sftpSessionId;
-      if (!sessionId) return "error";
+      if (!advancedOps) return "error";
       frontendLog(
         "file_editor",
         `elevated save attempt for ${meta.filePath} on ${hostLabel ?? "unknown host"}`
       );
       let result: ElevatedWriteResult;
       try {
-        result = await sftpWriteFileContentElevated(
-          sessionId,
-          meta.filePath,
-          bufferContent,
-          password
-        );
+        result = await advancedOps.writeElevated(meta.filePath, bufferContent, password);
       } catch (err) {
         frontendLog(
           "file_editor",
@@ -783,7 +890,7 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
       setSaveError(`Save failed: ${result.message}`);
       return "error";
     },
-    [meta.sftpSessionId, meta.filePath, hostLabel]
+    [advancedOps, meta.filePath, hostLabel]
   );
 
   // Save via the elevated (sudo) path, prompting only when needed. Tries the
@@ -901,11 +1008,11 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // buffer's dirty state is intentionally left as-is.
   const handleSaveCopySubmit = useCallback(
     async (destPath: string) => {
-      if (content === null || !meta.sftpSessionId) return;
+      if (content === null || !advancedOps) return;
       setSaveCopyBusy(true);
       const toastId = toast.loading(`Saving a copy to ${destPath}…`);
       try {
-        await sftpWriteFileContent(meta.sftpSessionId, destPath, content);
+        await advancedOps.writeContent(destPath, content);
         toast.success(`Saved a copy to ${destPath}`, { id: toastId });
         setSaveCopyDialogOpen(false);
         frontendLog("file_editor", `saved a copy of ${meta.filePath} to ${destPath}`);
@@ -917,7 +1024,7 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
         setSaveCopyBusy(false);
       }
     },
-    [content, meta.sftpSessionId, meta.filePath]
+    [content, advancedOps, meta.filePath]
   );
 
   // Download the read-only remote file to a user-chosen local path (#1330). The
@@ -925,12 +1032,12 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // (useTransferEvents); here we only show the pending toast and surface an
   // early failure that never produced a transfer event.
   const handleDownloadCopy = useCallback(async () => {
-    if (!meta.sftpSessionId) return;
+    if (!advancedOps) return;
     const localPath = await save({ title: "Download a copy…", defaultPath: fileName });
     if (!localPath) return;
     const toastId = toast.loading(`Downloading ${fileName}…`);
     try {
-      await sftpDownload(meta.sftpSessionId, meta.filePath, localPath);
+      await advancedOps.download(meta.filePath, localPath);
       toast.dismiss(toastId);
       frontendLog("file_editor", `downloaded ${meta.filePath} to ${localPath}`);
     } catch (err) {
@@ -943,14 +1050,15 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
       toast.error(`Download failed: ${message}`, { id: toastId });
       frontendLog("file_editor", `download of ${meta.filePath} failed: ${message}`);
     }
-  }, [meta.sftpSessionId, meta.filePath, fileName]);
+  }, [advancedOps, meta.filePath, fileName]);
 
   const handleSave = useCallback(async () => {
     if (content === null || saving) return;
 
     // Read-only remote file that has a shell, or an already-elevated session:
-    // route through the sudo path instead of the direct SFTP write.
-    if (meta.isRemote && meta.sftpSessionId && (elevated || (writable === false && execCapable))) {
+    // route through the sudo path instead of the direct write. Applies to both
+    // SFTP-advanced transports (legacy sftp and SFTP-backed session, #2420).
+    if (advancedOps && (elevated || (writable === false && execCapable))) {
       await saveElevated();
       return;
     }
@@ -998,6 +1106,7 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
     meta.isRemote,
     meta.sftpSessionId,
     meta.sessionBrowser,
+    advancedOps,
     tabId,
     renameTab,
     elevated,

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -121,11 +121,7 @@ async function sessionWriteFileContent(
 interface RemoteAdvancedOps {
   checkWritable: (path: string) => Promise<Writability>;
   realpath: (path: string) => Promise<string>;
-  writeElevated: (
-    path: string,
-    content: string,
-    password: string
-  ) => Promise<ElevatedWriteResult>;
+  writeElevated: (path: string, content: string, password: string) => Promise<ElevatedWriteResult>;
   writeContent: (path: string, content: string) => Promise<void>;
   download: (remotePath: string, localPath: string) => Promise<number>;
 }

--- a/src/components/Sidebar/FileBrowser.test.tsx
+++ b/src/components/Sidebar/FileBrowser.test.tsx
@@ -266,13 +266,13 @@ describe("FileBrowser – useFileBrowserSync", () => {
     expect(useAppStore.getState().sessionFileBrowserId).toBe("ftp-sess-1");
   });
 
-  it("keeps fileBrowserMode on 'sftp' for an SSH tab (legacy SftpManager path)", async () => {
-    // 'sftp' mode auto-connects an SFTP session, so the SFTP command surface
-    // has to answer for real here rather than resolving undefined.
+  it("puts an SSH tab in 'session' mode via the tab session id (#2421 convergence)", async () => {
+    // Post-convergence, SSH browses through the shared session layer like FTP /
+    // Docker — no `sftp_open` / SftpManager auto-connect. Its SFTP-backed session
+    // still drives the dedicated transfer channel, resolved by session id.
     mockedInvoke.mockImplementation((cmd: string) => {
-      if (cmd === "sftp_open") return Promise.resolve("sftp-sess-1");
-      if (cmd === "sftp_realpath") return Promise.resolve("/root");
-      if (cmd === "sftp_list_dir") return Promise.resolve([]);
+      if (cmd === "session_has_exec_capability") return Promise.resolve(true);
+      if (cmd === "session_list_files") return Promise.resolve([]);
       return Promise.resolve(undefined);
     });
 
@@ -293,7 +293,10 @@ describe("FileBrowser – useFileBrowserSync", () => {
     });
     await flushAsync();
 
-    expect(useAppStore.getState().fileBrowserMode).toBe("sftp");
+    expect(useAppStore.getState().fileBrowserMode).toBe("session");
+    expect(useAppStore.getState().sessionFileBrowserId).toBe("ssh-sess-1");
+    // No legacy SftpManager connect was attempted.
+    expect(mockedInvoke).not.toHaveBeenCalledWith("sftp_open", expect.anything());
   });
 
   it("sets fileBrowserMode to 'none' for an FTP tab that has no session yet", () => {
@@ -1593,146 +1596,11 @@ describe("FileBrowser – Go to Terminal CWD button", () => {
   });
 });
 
-describe("FileBrowser – failed-connect recovery UI (S1)", () => {
-  /** An SSH connection type that supports the file browser (→ sftp mode). */
-  function seedSshCapability() {
-    useAppStore.setState({
-      sidebarView: "files",
-      connectionTypes: [
-        {
-          typeId: "ssh",
-          displayName: "SSH",
-          icon: "terminal",
-          schema: { groups: [] },
-          capabilities: {
-            monitoring: false,
-            fileBrowser: true,
-            resize: true,
-            persistent: false,
-          },
-        },
-      ],
-    });
-  }
-
-  function makeSshTab() {
-    return makeTab({
-      connectionType: "ssh",
-      config: {
-        type: "ssh",
-        config: {
-          host: "example.com",
-          port: 22,
-          username: "alice",
-          authMethod: "password",
-          password: "pw",
-        },
-      },
-    });
-  }
-
-  beforeEach(() => {
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
-    useAppStore.setState(useAppStore.getInitialState());
-  });
-
-  afterEach(() => {
-    act(() => {
-      root.unmount();
-    });
-    container.remove();
-    vi.clearAllMocks();
-  });
-
-  it("shows Retry + Dismiss controls when the SFTP connect fails", async () => {
-    mockedInvoke.mockImplementation((cmd: string) => {
-      if (cmd === "sftp_open") return Promise.reject(new Error("auth failed"));
-      return Promise.resolve(undefined);
-    });
-    seedSshCapability();
-    setActiveTab(makeSshTab());
-
-    await act(async () => {
-      root.render(
-        <TooltipProvider delayDuration={0}>
-          <FileBrowser />
-        </TooltipProvider>
-      );
-    });
-    await flushAsync();
-
-    expect(useAppStore.getState().sftpError).toBe("auth failed");
-    const retryBtn = container.querySelector('[data-testid="file-browser-sftp-retry"]');
-    const dismissBtn = container.querySelector('[data-testid="file-browser-sftp-dismiss"]');
-    expect(retryBtn).toBeTruthy();
-    expect(dismissBtn).toBeTruthy();
-  });
-
-  it("Retry re-invokes the SFTP connect", async () => {
-    let openCalls = 0;
-    mockedInvoke.mockImplementation((cmd: string) => {
-      if (cmd === "sftp_open") {
-        openCalls += 1;
-        return Promise.reject(new Error("auth failed"));
-      }
-      return Promise.resolve(undefined);
-    });
-    seedSshCapability();
-    setActiveTab(makeSshTab());
-
-    await act(async () => {
-      root.render(
-        <TooltipProvider delayDuration={0}>
-          <FileBrowser />
-        </TooltipProvider>
-      );
-    });
-    await flushAsync();
-
-    const callsAfterAutoConnect = openCalls;
-    expect(callsAfterAutoConnect).toBeGreaterThanOrEqual(1);
-
-    const retryBtn = container.querySelector(
-      '[data-testid="file-browser-sftp-retry"]'
-    ) as HTMLButtonElement;
-    await act(async () => {
-      retryBtn.click();
-    });
-    await flushAsync();
-
-    expect(openCalls).toBeGreaterThan(callsAfterAutoConnect);
-  });
-
-  it("Dismiss clears the error", async () => {
-    mockedInvoke.mockImplementation((cmd: string) => {
-      if (cmd === "sftp_open") return Promise.reject(new Error("auth failed"));
-      return Promise.resolve(undefined);
-    });
-    seedSshCapability();
-    setActiveTab(makeSshTab());
-
-    await act(async () => {
-      root.render(
-        <TooltipProvider delayDuration={0}>
-          <FileBrowser />
-        </TooltipProvider>
-      );
-    });
-    await flushAsync();
-
-    const dismissBtn = container.querySelector(
-      '[data-testid="file-browser-sftp-dismiss"]'
-    ) as HTMLButtonElement;
-    await act(async () => {
-      dismissBtn.click();
-    });
-    await flushAsync();
-
-    expect(useAppStore.getState().sftpError).toBeNull();
-  });
-});
+// (Removed in #2421) The SFTP failed-connect recovery UI (S1) tests covered the
+// SSH SFTP auto-connect flow, which the convergence retires: SSH now browses
+// through the session layer, so no tab auto-connects an SftpManager session and
+// the sftp connect-failure placeholder is unreachable. The placeholder + Retry/
+// Dismiss controls are dead code removed with the sftp model in #2422 (B4).
 
 describe("FileBrowser – navigation UX (#1361)", () => {
   const navEntries = [

--- a/src/components/Sidebar/FileBrowser.tsx
+++ b/src/components/Sidebar/FileBrowser.tsx
@@ -37,7 +37,6 @@ import {
   ChevronDown,
 } from "lucide-react";
 import { useAppStore, getActiveTab } from "@/store/appStore";
-import { useProjectedConnections } from "@/store/useProjectedConnections";
 import { useProjectedAgents } from "@/store/useProjectedAgents";
 import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { useProjectedFileBrowsers } from "@/store/useProjectedFileBrowsers";
@@ -558,15 +557,11 @@ function useFileBrowserSync() {
   const navigateSftp = useAppStore((s) => s.navigateSftp);
   const navigateSession = useAppStore((s) => s.navigateSession);
   const setSessionFileBrowserId = useAppStore((s) => s.setSessionFileBrowserId);
-  const connectSftp = useAppStore((s) => s.connectSftp);
   const sftpSessionId = useAppStore((s) => s.sftpSessionId);
-  const sftpConnectedHost = useAppStore((s) => s.sftpConnectedHost);
   const sessionFileBrowserId = useAppStore((s) => s.sessionFileBrowserId);
-  const requestPassword = useAppStore((s) => s.requestPassword);
   const localCurrentPath = useAppStore((s) => s.localCurrentPath);
   const sftpCurrentPath = useAppStore((s) => s.currentPath);
   const sessionCurrentPath = useAppStore((s) => s.sessionCurrentPath);
-  const { connections } = useProjectedConnections();
   const { remoteAgents } = useProjectedAgents();
   const fileBrowserMode = useAppStore((s) => s.fileBrowserMode);
   const globalFileBrowserEnabled = useProjectedSettings().fileBrowserEnabled;
@@ -656,17 +651,15 @@ function useFileBrowserSync() {
       if (!fileBrowserEnabled) {
         setSessionFileBrowserId(null);
         setFileBrowserMode("none");
-      } else if (activeTabConnectionType === "ssh") {
-        // SSH keeps the legacy SftpManager/sftp_* path, which carries features
-        // the shared FileBrowser trait does not expose yet (realpath, writability
-        // probes, elevated writes, exec capability). Converging it onto the
-        // session layer is tracked as a follow-up to #1335.
-        setFileBrowserMode("sftp");
       } else if (activeTab.sessionId) {
-        // Every other file-browser-capable type (FTP, Docker, ...) dispatches
-        // through the session layer: SessionManager already keys sessions by id
-        // and routes file ops via ConnectionType::file_browser(), so this works
-        // for any backend that implements the trait (#1335).
+        // Every file-browser-capable type dispatches through the session layer:
+        // SessionManager keys sessions by id and routes file ops via
+        // ConnectionType::file_browser(), so this works for any backend that
+        // implements the trait (#1335). Since the SFTP convergence (#2421) this
+        // includes SSH — its SFTP-backed session drives the dedicated transfer
+        // channel + VS Code remote open through useSessionFileSystem, retiring the
+        // separate SftpManager/sftp_* browser path (the sftpSessionId model is
+        // removed in #2422).
         setSessionFileBrowserId(activeTab.sessionId);
         setFileBrowserMode("session");
       } else {
@@ -766,58 +759,11 @@ function useFileBrowserSync() {
     navigateSession(sessionFileBrowserId, cwd ?? "~");
   }, [fileBrowserMode, sessionFileBrowserId, navigateSession, cwd]);
 
-  // Auto-connect SFTP for tabs with file browser capability
-  useEffect(() => {
-    // Editor tabs use a dummy local config — skip SFTP auto-connect for them.
-    // The session they need is already stored in editorMeta.sftpSessionId.
-    if (fileBrowserMode !== "sftp" || !activeTab || activeTabContentType === "editor") return;
-
-    const cfg = activeTab.config.config;
-    const host = (cfg.host as string) ?? "";
-    const port = (cfg.port as number) ?? 0;
-    const username = (cfg.username as string) ?? "";
-    const hostKey = `${username}@${host}:${port}`;
-
-    // Already connected to the right host
-    if (sftpSessionId && sftpConnectedHost === hostKey) return;
-
-    const owningTabId = activeTabId ?? undefined;
-
-    // Need to connect (or switch to a different host). We no longer close the
-    // previous session here: each tab owns its own SFTP session, so the store's
-    // connectSftp leaves a still-owned previous session registered (and closes
-    // it only if its owning tab is gone). Sessions are closed on tab close (#1241).
-    const doConnect = async () => {
-      let configToUse = cfg;
-      const authMethod = cfg.authMethod as string | undefined;
-      if (authMethod === "password" && !cfg.password) {
-        // Look for the saved connection to get any config details
-        const savedConn = connections.find((c) => {
-          const sc = c.config.config;
-          return sc.host === host && sc.port === port && sc.username === username;
-        });
-        const baseConfig = savedConn ? savedConn.config.config : cfg;
-
-        const password = await requestPassword(host, username);
-        if (password === null) return;
-        configToUse = { ...baseConfig, password };
-      }
-
-      connectSftp(configToUse, owningTabId);
-    };
-
-    doConnect();
-  }, [
-    fileBrowserMode,
-    activeTabId,
-    activeTab,
-    activeTabContentType,
-    sftpSessionId,
-    sftpConnectedHost,
-    connections,
-    connectSftp,
-    requestPassword,
-  ]);
+  // (Removed in #2421) The SSH-specific SFTP auto-connect effect that opened a
+  // separate SftpManager session when a file-browser-capable tab entered "sftp"
+  // mode. SSH now browses through the session layer (mode "session"), so no tab
+  // enters "sftp" mode and the standalone connect is dead. The legacy sftp store
+  // model itself is retired in #2422.
 
   // Callback to jump the file browser back to the terminal's current CWD.
   const navigateToCwd = useCallback(() => {
@@ -1397,11 +1343,17 @@ export function FileBrowser() {
     );
   }
 
-  // In-flight transfers owned by the SFTP session this browser is showing
-  // (#1247). Only these belong in the footer; other sessions' transfers live in
-  // the Open Connections panel. The list above stays live regardless.
-  const activeTransfers = sftpSessionId
-    ? Object.values(transfers).filter((t) => t.sessionId === sftpSessionId)
+  // In-flight transfers owned by the session this browser is showing (#1247).
+  // Only these belong in the footer; other sessions' transfers live in the Open
+  // Connections panel. The list above stays live regardless. Both transport
+  // shapes register on the `transfers` map keyed by session id: the legacy SFTP
+  // browser by `sftpSessionId`, and — since the convergence (#2421) — an
+  // SFTP-backed session browser (SSH) by its `sessionFileBrowserId`. A byte-based
+  // session backend (Docker / FTP / agent) registers no transfers, so its footer
+  // stays empty as before.
+  const footerSessionId = sftpSessionId ?? sessionFileBrowserId;
+  const activeTransfers = footerSessionId
+    ? Object.values(transfers).filter((t) => t.sessionId === footerSessionId)
     : [];
 
   const handleCancelTransfer = async (transferId: string) => {

--- a/src/hooks/transferFeedback.ts
+++ b/src/hooks/transferFeedback.ts
@@ -1,0 +1,99 @@
+import { TransferTerminalError } from "@/services/api";
+import { toast } from "@/components/ui";
+import { frontendLog } from "@/utils/frontendLog";
+import { dispatchTransferIntentBestEffort } from "@/store/transfersBridge";
+import type { TransferDirection } from "@/types/transfer";
+
+/**
+ * Shared transfer-feedback helpers used by both the SFTP (`useFileSystem`) and
+ * session (`useSessionFileSystem`) file-browser hooks. Extracted during the SFTP
+ * convergence (#2421) so the two hooks drive an identical transfer contract —
+ * the pending toast, the single-terminal-toast rule, and the Transfer-Queue seed
+ * — over their respective dedicated-channel commands (`sftp_*` vs `session_*`).
+ */
+
+/** Basename of a POSIX/Windows path (the file name the queue row displays). */
+export function baseName(path: string): string {
+  const parts = path.replace(/\\/g, "/").split("/");
+  return parts[parts.length - 1] || path;
+}
+
+/** Extract a human-readable message from an unknown transfer error. */
+export function transferErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return String(error);
+}
+
+/**
+ * Seed a `queued` Transfer Queue row from the id a transfer start command
+ * returns — the panel then opens without waiting for a `transfer-progress`
+ * event, which can be dropped/delayed under memory pressure (#1632). The row is
+ * keyed by the backend `transferId`, so a later event upserts (never duplicates)
+ * it. Since #2229 the `transfers` region is authoritative, so the seed is a
+ * reliable client `transfer.seed` intent against the shared store (idempotent
+ * server-side — it never overwrites an already-advanced row); a bridge hiccup is
+ * swallowed and logged.
+ */
+export function seedTransferQueueRow(seed: {
+  transferId: string;
+  sessionId: string;
+  direction: TransferDirection;
+  remotePath: string;
+}): void {
+  dispatchTransferIntentBestEffort("transfer.seed", {
+    seed: {
+      id: seed.transferId,
+      sessionId: seed.sessionId,
+      direction: seed.direction,
+      name: baseName(seed.remotePath),
+      path: seed.remotePath,
+    },
+  });
+}
+
+/**
+ * Run a file transfer with user feedback: a pending toast shown while the
+ * transfer runs (audit gap D2 — transfers must never fail silently).
+ *
+ * The **terminal** success/error toast is owned exclusively by the
+ * `transfer-progress` event path (`useTransferEvents`, #1286) so a single
+ * transfer produces exactly one terminal toast. This helper therefore does not
+ * emit its own success/error toast for a transfer that reached the backend:
+ *   - success → dismiss the pending toast (the event path raises the "Downloaded
+ *     …/Uploaded …" success toast);
+ *   - a {@link TransferTerminalError} (`done`/`cancelled`/`error` from the
+ *     transfer channel) → dismiss the pending toast; the event path already
+ *     surfaced the outcome (and stays quiet on cancel).
+ *
+ * An **early** failure that never produced a transfer event (invalid session,
+ * permission error thrown before the transfer starts, a copy temp-file paste leg
+ * that fails synchronously) is still surfaced here via `toast.error`, since no
+ * `transfer-progress` event will cover it. The rejection is always swallowed so
+ * callers never produce an unhandled rejection. Returns whether the transfer
+ * succeeded.
+ */
+export async function runTransfer(
+  label: string,
+  action: () => Promise<unknown>,
+  messages: { loading: string }
+): Promise<boolean> {
+  const toastId = toast.loading(messages.loading);
+  try {
+    await action();
+    // Success toast is raised by the transfer-progress event path (#1286).
+    toast.dismiss(toastId);
+    return true;
+  } catch (error) {
+    if (error instanceof TransferTerminalError) {
+      // The event path already surfaced this (success/error toast) or is
+      // intentionally quiet (cancel) — just clear the pending toast.
+      toast.dismiss(toastId);
+      return false;
+    }
+    const message = transferErrorMessage(error);
+    frontendLog("sftp_transfer", `${label} failed: ${message}`);
+    toast.error(`${label} failed: ${message}`, { id: toastId });
+    return false;
+  }
+}

--- a/src/hooks/useFileSystem.ts
+++ b/src/hooks/useFileSystem.ts
@@ -9,71 +9,9 @@ import {
   sftpRename,
   sftpWriteFileContent,
   vscodeOpenRemote,
-  TransferTerminalError,
 } from "@/services/api";
 import { FileEntry } from "@/types/connection";
-import { toast } from "@/components/ui";
-import { frontendLog } from "@/utils/frontendLog";
-import { dispatchTransferIntentBestEffort } from "@/store/transfersBridge";
-
-/** Basename of a POSIX/Windows path (the file name the queue row displays). */
-function baseName(path: string): string {
-  const parts = path.replace(/\\/g, "/").split("/");
-  return parts[parts.length - 1] || path;
-}
-
-/** Extract a human-readable message from an unknown transfer error. */
-function transferErrorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  if (typeof error === "string") return error;
-  return String(error);
-}
-
-/**
- * Run an SFTP transfer with user feedback: a pending toast shown while the
- * transfer runs (audit gap D2 — transfers must never fail silently).
- *
- * The **terminal** success/error toast is owned exclusively by the
- * `transfer-progress` event path (`useTransferEvents`, #1286) so a single
- * transfer produces exactly one terminal toast. This helper therefore does not
- * emit its own success/error toast for a transfer that reached the backend:
- *   - success → dismiss the pending toast (the event path raises the "Downloaded
- *     …/Uploaded …" success toast);
- *   - a {@link TransferTerminalError} (`done`/`cancelled`/`error` from the
- *     transfer channel) → dismiss the pending toast; the event path already
- *     surfaced the outcome (and stays quiet on cancel).
- *
- * An **early** failure that never produced a transfer event (invalid session,
- * permission error thrown before the transfer starts, an sftp→sftp temp-file
- * paste leg that fails synchronously) is still surfaced here via `toast.error`,
- * since no `transfer-progress` event will cover it. The rejection is always
- * swallowed so callers never produce an unhandled rejection. Returns whether
- * the transfer succeeded.
- */
-async function runTransfer(
-  label: string,
-  action: () => Promise<unknown>,
-  messages: { loading: string }
-): Promise<boolean> {
-  const toastId = toast.loading(messages.loading);
-  try {
-    await action();
-    // Success toast is raised by the transfer-progress event path (#1286).
-    toast.dismiss(toastId);
-    return true;
-  } catch (error) {
-    if (error instanceof TransferTerminalError) {
-      // The event path already surfaced this (success/error toast) or is
-      // intentionally quiet (cancel) — just clear the pending toast.
-      toast.dismiss(toastId);
-      return false;
-    }
-    const message = transferErrorMessage(error);
-    frontendLog("sftp_transfer", `${label} failed: ${message}`);
-    toast.error(`${label} failed: ${message}`, { id: toastId });
-    return false;
-  }
-}
+import { runTransfer, seedTransferQueueRow } from "./transferFeedback";
 
 /**
  * Hook for SFTP file system operations.
@@ -90,38 +28,18 @@ export function useFileSystem() {
   // Wrap the transfer helpers so every transfer seeds a `queued` Transfer Queue
   // row from the id the start command returns — the panel then opens without
   // waiting for a `transfer-progress` event, which can be dropped/delayed under
-  // memory pressure (#1632). The row is keyed by the backend `transferId`, so a
-  // later event upserts (never duplicates) it. Since #2229 the `transfers` region
-  // is authoritative, so the seed is a reliable client `transfer.seed` intent
-  // against the shared store (idempotent server-side — it never overwrites an
-  // already-advanced row); a bridge hiccup is swallowed and logged.
+  // memory pressure (#1632). See {@link seedTransferQueueRow}.
   const startDownload = useCallback(
     (sessionId: string, remotePath: string, localPath: string) =>
       sftpDownload(sessionId, remotePath, localPath, (transferId) =>
-        dispatchTransferIntentBestEffort("transfer.seed", {
-          seed: {
-            id: transferId,
-            sessionId,
-            direction: "download",
-            name: baseName(remotePath),
-            path: remotePath,
-          },
-        })
+        seedTransferQueueRow({ transferId, sessionId, direction: "download", remotePath })
       ),
     []
   );
   const startUpload = useCallback(
     (sessionId: string, localPath: string, remotePath: string) =>
       sftpUpload(sessionId, localPath, remotePath, (transferId) =>
-        dispatchTransferIntentBestEffort("transfer.seed", {
-          seed: {
-            id: transferId,
-            sessionId,
-            direction: "upload",
-            name: baseName(remotePath),
-            path: remotePath,
-          },
-        })
+        seedTransferQueueRow({ transferId, sessionId, direction: "upload", remotePath })
       ),
     []
   );

--- a/src/hooks/useSessionFileSystem.test.ts
+++ b/src/hooks/useSessionFileSystem.test.ts
@@ -33,11 +33,38 @@ vi.mock("@/services/api", () => ({
   sessionDeleteFile: vi.fn(() => Promise.resolve()),
   sessionRenameFile: vi.fn(() => Promise.resolve()),
   sessionMkdir: vi.fn(() => Promise.resolve()),
+  sessionDownload: vi.fn(() => Promise.resolve(0)),
+  sessionUpload: vi.fn(() => Promise.resolve(0)),
+  sessionVscodeOpenRemote: vi.fn(() => Promise.resolve()),
+  // Default: reject → session is byte-based (Docker / FTP / agent). The
+  // SFTP-backed suite overrides this to resolve.
+  sessionHasExecCapability: vi.fn(() => Promise.reject(new Error("not sftp-backed"))),
+  // The real marker class so `error instanceof TransferTerminalError` in
+  // runTransfer resolves correctly (#1286).
+  TransferTerminalError: class TransferTerminalError extends Error {
+    readonly phase: "cancelled" | "error";
+    constructor(phase: "cancelled" | "error", message: string) {
+      super(message);
+      this.name = "TransferTerminalError";
+      this.phase = phase;
+    }
+  },
 }));
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({
   open: vi.fn(() => Promise.resolve(null)),
-  save: vi.fn(() => Promise.resolve(null)),
+  save: vi.fn(() => Promise.resolve("/local/save.txt")),
+}));
+
+vi.mock("@/components/ui", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    promise: vi.fn(),
+    dismiss: vi.fn(),
+  },
 }));
 
 vi.mock("@tauri-apps/plugin-fs", () => ({
@@ -212,5 +239,150 @@ describe("useSessionFileSystem — store integration", () => {
     expect(sessionFileBrowserId).toBeNull();
     // isConnected = sessionFileBrowserId !== null
     expect(sessionFileBrowserId !== null).toBe(false);
+  });
+});
+
+// SFTP-capability gating (#2421): an SFTP-backed session (SSH) drives the
+// dedicated transfer channel + VS Code remote open; a byte-based backend
+// (Docker / FTP / agent) falls back to session_read_file / session_write_file
+// and has no VS Code remote open. The transport is detected by the
+// session_has_exec_capability probe (resolve → SFTP-backed, reject → byte-based).
+import {
+  sessionDownload,
+  sessionUpload,
+  sessionVscodeOpenRemote,
+  sessionReadFile,
+  sessionHasExecCapability,
+} from "@/services/api";
+
+describe("useSessionFileSystem — SFTP-backed transport (probe resolves)", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+    // Resolve → the session is SFTP-backed (the boolean is exec capability).
+    vi.mocked(sessionHasExecCapability).mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  type SessionFs = ReturnType<typeof useSessionFileSystem>;
+
+  async function mountHook(): Promise<SessionFs> {
+    useAppStore.setState({ sessionFileBrowserId: "ssh-1", sessionCurrentPath: "/remote/dir" });
+    let api: SessionFs | undefined;
+    function Harness() {
+      api = useSessionFileSystem();
+      return null;
+    }
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+    // Flush the capability probe so sftpCapable settles before the action runs.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    return api!;
+  }
+
+  it("routes downloadFile through the dedicated session_download channel", async () => {
+    const api = await mountHook();
+    await act(async () => {
+      await api.downloadFile("/remote/dir/file.txt", "file.txt");
+    });
+    expect(vi.mocked(sessionDownload)).toHaveBeenCalledWith(
+      "ssh-1",
+      "/remote/dir/file.txt",
+      "/local/save.txt",
+      expect.any(Function)
+    );
+    expect(vi.mocked(sessionReadFile)).not.toHaveBeenCalled();
+  });
+
+  it("routes uploadFileFromPath through the dedicated session_upload channel", async () => {
+    const api = await mountHook();
+    await act(async () => {
+      await api.uploadFileFromPath("/local/data.csv");
+    });
+    expect(vi.mocked(sessionUpload)).toHaveBeenCalledWith(
+      "ssh-1",
+      "/local/data.csv",
+      "/remote/dir/data.csv",
+      expect.any(Function)
+    );
+  });
+
+  it("wires openInVscode to session_vscode_open_remote", async () => {
+    const api = await mountHook();
+    await act(async () => {
+      await api.openInVscode("/remote/dir/file.txt");
+    });
+    expect(vi.mocked(sessionVscodeOpenRemote)).toHaveBeenCalledWith(
+      "ssh-1",
+      "/remote/dir/file.txt"
+    );
+  });
+});
+
+describe("useSessionFileSystem — byte-based transport (probe rejects)", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+    // Reject → the session is byte-based (Docker / FTP / agent).
+    vi.mocked(sessionHasExecCapability).mockRejectedValue(new Error("not sftp-backed"));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  type SessionFs = ReturnType<typeof useSessionFileSystem>;
+
+  async function mountHook(): Promise<SessionFs> {
+    useAppStore.setState({ sessionFileBrowserId: "docker-1", sessionCurrentPath: "/remote/dir" });
+    let api: SessionFs | undefined;
+    function Harness() {
+      api = useSessionFileSystem();
+      return null;
+    }
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    return api!;
+  }
+
+  it("falls back to session_read_file for downloadFile (no dedicated channel)", async () => {
+    const api = await mountHook();
+    await act(async () => {
+      await api.downloadFile("/remote/dir/file.txt", "file.txt");
+    });
+    expect(vi.mocked(sessionReadFile)).toHaveBeenCalledWith("docker-1", "/remote/dir/file.txt");
+    expect(vi.mocked(sessionDownload)).not.toHaveBeenCalled();
+  });
+
+  it("makes openInVscode a no-op (VS Code remote open unavailable)", async () => {
+    const api = await mountHook();
+    await act(async () => {
+      await api.openInVscode("/remote/dir/file.txt");
+    });
+    expect(vi.mocked(sessionVscodeOpenRemote)).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useSessionFileSystem.ts
+++ b/src/hooks/useSessionFileSystem.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { save } from "@tauri-apps/plugin-dialog";
 import { useAppStore } from "@/store/appStore";
 import {
@@ -7,15 +7,42 @@ import {
   sessionDeleteFile,
   sessionRenameFile,
   sessionMkdir,
+  sessionDownload,
+  sessionUpload,
+  sessionVscodeOpenRemote,
+  sessionHasExecCapability,
 } from "@/services/api";
 import { FileEntry } from "@/types/connection";
+import { frontendLog } from "@/utils/frontendLog";
+import { runTransfer, seedTransferQueueRow } from "./transferFeedback";
 
 /**
  * Hook for session-based file system operations.
  *
- * Used for remote-agent connections where file browsing is performed
- * through the active terminal session's file browser capability rather
- * than a separate SFTP session.
+ * Backs every file-browser-capable connection type routed through the session
+ * layer: remote-agent sessions, Docker, FTP, and — since the SFTP convergence
+ * (#2421) — SSH. File ops flow through the active terminal session's file
+ * browser capability (`session_*` commands) rather than a separate `SftpManager`
+ * session.
+ *
+ * # SFTP-backed vs byte-based transfers (#2421)
+ *
+ * Two transport shapes back a session (mirroring the editor split in #2420):
+ *
+ * - An **SFTP-backed** session (SSH) resolves its ops via the backend's
+ *   `SftpFileBrowser`, so it can drive the **dedicated per-transfer channel** —
+ *   `session_download` / `session_upload` register a background transfer that
+ *   keeps the listing live and feeds the Transfer Queue + progress events, and
+ *   `session_vscode_open_remote` supports remote VS Code editing.
+ * - A **byte-based** backend (Docker / FTP / remote-agent) has no SFTP channel,
+ *   so transfers fall back to a blocking `session_read_file` / `session_write_file`
+ *   round-trip and VS Code remote open is unavailable.
+ *
+ * The transport is detected with the same signal #2420 chose for the editor: the
+ * `session_has_exec_capability` probe **resolves** (with the exec boolean) only
+ * for an SFTP-backed session and **rejects** for a byte-based backend. A resolved
+ * probe flips {@link sftpCapable} on, unlocking the dedicated channel + VS Code;
+ * a rejection leaves the session on the byte-based path.
  */
 export function useSessionFileSystem() {
   const sessionFileEntries = useAppStore((s) => s.sessionFileEntries);
@@ -25,6 +52,60 @@ export function useSessionFileSystem() {
   const sessionFileError = useAppStore((s) => s.sessionFileError);
   const navigateSession = useAppStore((s) => s.navigateSession);
   const refreshSession = useAppStore((s) => s.refreshSession);
+
+  // Whether the current session's backend is SFTP-backed and can therefore drive
+  // the dedicated transfer channel + VS Code remote open (#2421). Determined by
+  // the `session_has_exec_capability` probe, which resolves only for an
+  // SFTP-backed session and rejects for a byte-based backend (see the hook
+  // doc-comment). `false` until the probe resolves, so a byte-based backend (and
+  // the brief pre-probe window) uses the byte-based read/write fallback.
+  const [sftpCapable, setSftpCapable] = useState(false);
+
+  useEffect(() => {
+    setSftpCapable(false);
+    if (!sessionFileBrowserId) return;
+    let cancelled = false;
+    const sessionId = sessionFileBrowserId;
+    sessionHasExecCapability(sessionId)
+      .then(() => {
+        if (cancelled) return;
+        // Resolved → the session is SFTP-backed; enable the dedicated channel.
+        setSftpCapable(true);
+        frontendLog("session_file_browser", `session ${sessionId} is SFTP-backed`);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        // Rejected → byte-based backend; keep the read/write fallback.
+        setSftpCapable(false);
+        frontendLog(
+          "session_file_browser",
+          `session ${sessionId} is not SFTP-backed; byte-based transfers: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionFileBrowserId]);
+
+  // Dedicated-channel transfer wrappers that seed a Transfer Queue row from the
+  // id the start command returns (#1632), mirroring the SFTP hook. Only used on
+  // the SFTP-backed path; the byte-based fallback has no transfer id to seed.
+  const startDownload = useCallback(
+    (sessionId: string, remotePath: string, localPath: string) =>
+      sessionDownload(sessionId, remotePath, localPath, (transferId) =>
+        seedTransferQueueRow({ transferId, sessionId, direction: "download", remotePath })
+      ),
+    []
+  );
+  const startUpload = useCallback(
+    (sessionId: string, localPath: string, remotePath: string) =>
+      sessionUpload(sessionId, localPath, remotePath, (transferId) =>
+        seedTransferQueueRow({ transferId, sessionId, direction: "upload", remotePath })
+      ),
+    []
+  );
 
   const navigateTo = useCallback(
     (path: string) => {
@@ -49,11 +130,21 @@ export function useSessionFileSystem() {
       if (!sessionFileBrowserId) return;
       const localPath = await save({ title: "Save file as...", defaultPath: fileName });
       if (!localPath) return;
+      if (sftpCapable) {
+        // SFTP-backed: stream over the dedicated transfer channel (#2421).
+        await runTransfer(
+          "Download",
+          () => startDownload(sessionFileBrowserId, remotePath, localPath),
+          { loading: `Downloading ${fileName}…` }
+        );
+        return;
+      }
+      // Byte-based fallback (Docker / FTP / remote-agent): blocking round-trip.
       const data = await sessionReadFile(sessionFileBrowserId, remotePath);
       const { writeFile } = await import("@tauri-apps/plugin-fs");
       await writeFile(localPath, new Uint8Array(data));
     },
-    [sessionFileBrowserId]
+    [sessionFileBrowserId, sftpCapable, startDownload]
   );
 
   const uploadFile = useCallback(async () => {
@@ -61,29 +152,51 @@ export function useSessionFileSystem() {
     const { open } = await import("@tauri-apps/plugin-dialog");
     const localPath = await open({ title: "Select file to upload", multiple: false });
     if (!localPath) return;
-    const { readFile } = await import("@tauri-apps/plugin-fs");
-    const data = await readFile(localPath);
     const fileName =
       (localPath as string).split("/").pop() ?? (localPath as string).split("\\").pop() ?? "upload";
     const remotePath =
       sessionCurrentPath === "/" ? `/${fileName}` : `${sessionCurrentPath}/${fileName}`;
+    if (sftpCapable) {
+      // SFTP-backed: stream over the dedicated transfer channel (#2421).
+      const ok = await runTransfer(
+        "Upload",
+        () => startUpload(sessionFileBrowserId, localPath as string, remotePath),
+        { loading: `Uploading ${fileName}…` }
+      );
+      if (ok) refreshSession();
+      return;
+    }
+    // Byte-based fallback (Docker / FTP / remote-agent): blocking round-trip.
+    const { readFile } = await import("@tauri-apps/plugin-fs");
+    const data = await readFile(localPath as string);
     await sessionWriteFile(sessionFileBrowserId, remotePath, Array.from(data));
     refreshSession();
-  }, [sessionFileBrowserId, sessionCurrentPath, refreshSession]);
+  }, [sessionFileBrowserId, sessionCurrentPath, refreshSession, sftpCapable, startUpload]);
 
   const uploadFileFromPath = useCallback(
     async (localPath: string) => {
       if (!sessionFileBrowserId) return;
-      const { readFile } = await import("@tauri-apps/plugin-fs");
-      const data = await readFile(localPath);
       const parts = localPath.replace(/\\/g, "/").split("/");
       const fileName = parts[parts.length - 1] || "upload";
       const remotePath =
         sessionCurrentPath === "/" ? `/${fileName}` : `${sessionCurrentPath}/${fileName}`;
+      if (sftpCapable) {
+        // SFTP-backed: stream over the dedicated transfer channel (#2421).
+        const ok = await runTransfer(
+          "Upload",
+          () => startUpload(sessionFileBrowserId, localPath, remotePath),
+          { loading: `Uploading ${fileName}…` }
+        );
+        if (ok) refreshSession();
+        return;
+      }
+      // Byte-based fallback (Docker / FTP / remote-agent): blocking round-trip.
+      const { readFile } = await import("@tauri-apps/plugin-fs");
+      const data = await readFile(localPath);
       await sessionWriteFile(sessionFileBrowserId, remotePath, Array.from(data));
       refreshSession();
     },
-    [sessionFileBrowserId, sessionCurrentPath, refreshSession]
+    [sessionFileBrowserId, sessionCurrentPath, refreshSession, sftpCapable, startUpload]
   );
 
   const createDirectory = useCallback(
@@ -126,9 +239,15 @@ export function useSessionFileSystem() {
     [sessionFileBrowserId, refreshSession]
   );
 
-  const openInVscode = useCallback(async (_remotePath: string) => {
-    // VS Code remote open is not supported for session-based connections.
-  }, []);
+  const openInVscode = useCallback(
+    async (remotePath: string) => {
+      // Only an SFTP-backed session can drive VS Code remote open (download →
+      // edit → re-upload). A byte-based backend has no such channel (#2421).
+      if (!sessionFileBrowserId || !sftpCapable) return;
+      await sessionVscodeOpenRemote(sessionFileBrowserId, remotePath);
+    },
+    [sessionFileBrowserId, sftpCapable]
+  );
 
   const copyEntry = useCallback(
     (entries: FileEntry[]) => {
@@ -164,15 +283,20 @@ export function useSessionFileSystem() {
 
     const destDir = sessionCurrentPath;
 
-    for (const clipEntry of clipboard.entries) {
+    const pasteOne = async (clipEntry: FileEntry): Promise<void> => {
       const destPath = destDir === "/" ? `/${clipEntry.name}` : `${destDir}/${clipEntry.name}`;
 
       if (clipboard.sourceMode === "session") {
+        // Cross-pane paste keys the source session on `terminalSessionId` (the
+        // session id) — SSH now flows through here too since the convergence
+        // (#2421), so the retired `sftpSessionId` clipboard field is unused.
         const srcId = clipboard.terminalSessionId;
         if (clipboard.operation === "cut" && srcId === sessionFileBrowserId) {
           await sessionRenameFile(sessionFileBrowserId, clipEntry.path, destPath);
         } else {
-          // Cross-session or copy: read source, write to dest
+          // Cross-session or copy: read source, write to dest. No dedicated
+          // session-to-session copy command exists, so this stays a byte-based
+          // round-trip regardless of the SFTP capability.
           const srcSession = srcId ?? sessionFileBrowserId;
           const data = await sessionReadFile(srcSession, clipEntry.path);
           await sessionWriteFile(sessionFileBrowserId, destPath, data);
@@ -181,12 +305,27 @@ export function useSessionFileSystem() {
           }
         }
       } else if (clipboard.sourceMode === "local") {
-        // local→session: read local file and write to session
-        const { readFile } = await import("@tauri-apps/plugin-fs");
-        const data = await readFile(clipEntry.path);
-        await sessionWriteFile(sessionFileBrowserId, destPath, Array.from(data));
+        // local→session: upload the local file to the remote destination.
+        if (sftpCapable) {
+          // SFTP-backed: stream over the dedicated transfer channel (#2421).
+          await startUpload(sessionFileBrowserId, clipEntry.path, destPath);
+        } else {
+          // Byte-based fallback (Docker / FTP / remote-agent).
+          const { readFile } = await import("@tauri-apps/plugin-fs");
+          const data = await readFile(clipEntry.path);
+          await sessionWriteFile(sessionFileBrowserId, destPath, Array.from(data));
+        }
       }
-      // sftp→session: not yet supported
+      // sftp→session: not supported (no legacy SFTP source pane remains post-#2421)
+    };
+
+    for (const clipEntry of clipboard.entries) {
+      const ok = await runTransfer("Paste", () => pasteOne(clipEntry), {
+        loading: `Pasting ${clipEntry.name}…`,
+      });
+      // Abort on first failure so a cut clipboard is not cleared and the user is
+      // not left with a partial, silently-incomplete paste.
+      if (!ok) return;
     }
 
     if (clipboard.operation === "cut") {
@@ -194,7 +333,7 @@ export function useSessionFileSystem() {
     }
 
     refreshSession();
-  }, [sessionFileBrowserId, sessionCurrentPath, refreshSession]);
+  }, [sessionFileBrowserId, sessionCurrentPath, refreshSession, sftpCapable, startUpload]);
 
   return {
     fileEntries: sessionFileEntries,


### PR DESCRIPTION
Flips the SSH `FileBrowser` branch from the legacy SFTP path to the session path (step B3 of the SFTP convergence), so opening the Files sidebar on an SSH tab browses through the session layer with no `sftp_open` / `connectSftp`, while keeping the dedicated per-transfer channel, the eager fail-loudly open contract, and VS Code remote open.

Part of #2313 / #2307.

## Stacked PR
> This PR is **stacked on #2423 (B2, #2420)** and contains its commits. B2 brought the remote `FileEditor` session path to SFTP parity + capability gating; this slice depends on that. Merge order: **#2423 then this**. Review this PR's own commits (from `refactor(sftp): extract shared transfer-feedback helpers` onward).

## What changed
- **Browser flip** (`FileBrowser.tsx`): SSH tabs now enter `"session"` mode keyed by the tab session id, like FTP/Docker. The now-dead SSH-specific SFTP auto-connect effect is removed. The footer shows the SFTP-backed session's transfers (`sftpSessionId ?? sessionFileBrowserId`).
- **Dedicated channel** (`useSessionFileSystem`): an SFTP-backed session (SSH) is detected from the `session_has_exec_capability` probe (resolve = SFTP-backed, reject = byte-based) — the same signal #2420 chose for the editor. On that path, `downloadFile` / `uploadFile` / paste route through `session_download` / `session_upload` with the `runTransfer` + Transfer-Queue seed wrapper, and `openInVscode` wires to `session_vscode_open_remote`.
- **Byte-based fallback unchanged**: non-SFTP session backends (Docker / FTP / remote-agent) keep the `session_read_file` / `session_write_file` path and have no VS Code remote open — no regression.
- **Shared helpers** (`transferFeedback.ts`): `runTransfer`, the Transfer-Queue seed, and the path/error helpers are extracted out of `useFileSystem` so both hooks drive an identical transfer contract.
- Cross-pane paste keys the source session on the session id (the retired `sftpSessionId` clipboard field is unused on this path).

## Scope notes / deviations
- **`hostLabel` for session-backed SSH editor tabs → follow-up #2424.** A session-backed SSH tab has no `hostLabel` source, so the editor sudo prompt falls back to the file path and skips credential-store persistence. Wiring it cleanly (reconnect-stable label matching the legacy sftp label, credential-store parity) is a distinct, separately-reviewable change; filed as #2424 rather than sprawling this stacked PR.
- **Legacy sftp model kept idle**: the `sftpSessionId` slice and projection sftp pane are left in place (unreachable for SSH after this flip) and are retired in **#2422 (B4)**, per the slice plan.
- Removed the obsolete "failed-connect recovery UI (S1)" `FileBrowser` tests — they covered the SSH SFTP auto-connect flow this convergence retires; the placeholder + Retry/Dismiss UI is dead code removed in #2422.

## Verification
Unit-level only, per coordinator (GitHub Actions outage + this machine's host contention flakes the live-SSH/integration suites): `tsc --noEmit`, ESLint, `prettier --check` (src + docs), and the **full `pnpm` unit suite (4953 tests) pass**. Added session-hook tests cover the dedicated-channel routing and byte-based gating in both directions. **Integration / Docker / live-SSH verification is deferred to CI** (it does not run in per-PR CI anyway; a real container run at merge covers the SFTP/Docker/FTP file-browser lanes).

Closes #2421
