### PR TITLE
fix(sftp): source sudo host-label from the session for SSH editor tabs (Closes #2424)

### DIFF
--- a/docs/changes/dev1/fix/2424-session-hostlabel.md
+++ b/docs/changes/dev1/fix/2424-session-hostlabel.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Sudo edits on SSH files opened via the session path again name the host
+  (`user@host:port`) in the sudo-password prompt and namespace the optional
+  "remember my sudo password" credential-store entry per host, instead of
+  falling back to the file path. The host label lost its source when the legacy
+  `sftpSessionId` model was retired (#2422); it is now sourced from the owning
+  terminal tab's connection config, reconnect-stable, and byte-identical to the
+  label the legacy SFTP path used, so sudo passwords saved before the
+  sftp→session convergence still resolve (#2424, #2426).

--- a/src/components/FileEditor/FileEditor.test.tsx
+++ b/src/components/FileEditor/FileEditor.test.tsx
@@ -4,9 +4,9 @@ import React from "react";
 import { createRoot, Root } from "react-dom/client";
 import { invoke } from "@tauri-apps/api/core";
 import { save } from "@tauri-apps/plugin-dialog";
-import { useAppStore } from "@/store/appStore";
+import { useAppStore, deriveEditorHostLabel } from "@/store/appStore";
 import { FileEditor } from "./FileEditor";
-import type { EditorTabMeta } from "@/types/terminal";
+import type { EditorTabMeta, LeafPanel, TerminalTab } from "@/types/terminal";
 
 // Render Monaco as a plain textarea so the editor mounts in jsdom and we can
 // drive content changes through its onChange.
@@ -582,6 +582,245 @@ describe("FileEditor — elevated (sudo) edit mode (#1329)", () => {
 
     expect(query("file-editor-save-error")).not.toBeNull();
     expect(query("file-editor-save-error-retry-sudo")).not.toBeNull();
+  });
+});
+
+describe("FileEditor — sudo host label from the session (#2424 / #2426)", () => {
+  // A session-backed SSH editor tab (no legacy `sftpSessionId`). Read-only +
+  // exec-capable so it reaches the sudo path.
+  const SSH_META: EditorTabMeta = {
+    filePath: "/etc/hosts",
+    isRemote: true,
+    sessionBrowser: { sessionId: "sftp-sess-1", connectionType: "ssh" },
+    sessionKey: "session:term-owner",
+    permissions: "-rw-r--r--",
+  };
+
+  /**
+   * Seed the owning terminal tab whose connection config supplies the host
+   * label. `sessionId` defaults to the editor tab's live session id; pass a
+   * different one to simulate a reconnect (the tab id / `sessionKey` stays put).
+   */
+  function seedOwningTab(
+    opts: {
+      tabId?: string;
+      sessionId?: string;
+      config?: Record<string, unknown>;
+      type?: string;
+    } = {}
+  ): void {
+    const {
+      tabId = "term-owner",
+      sessionId = "sftp-sess-1",
+      config = { username: "pi", host: "raspberrypi", port: 22 },
+      type = "ssh",
+    } = opts;
+    const tab = {
+      id: tabId,
+      sessionId,
+      title: "owner",
+      connectionType: type,
+      contentType: "terminal",
+      config: { type, config },
+      panelId: "leaf-1",
+      isActive: true,
+    } as unknown as TerminalTab;
+    const leaf: LeafPanel = { type: "leaf", id: "leaf-1", tabs: [tab], activeTabId: tabId };
+    useAppStore.setState({ rootPanel: leaf, activePanelId: "leaf-1" });
+  }
+
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState({ ...useAppStore.getInitialState() });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  function docQuery(testId: string): HTMLElement | null {
+    return document.querySelector(`[data-testid="${testId}"]`);
+  }
+
+  function typeInto(el: HTMLInputElement, value: string): void {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value"
+    )!.set!;
+    act(() => {
+      setter.call(el, value);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  }
+
+  /**
+   * Mock the elevated backend and capture credential-store calls. `resolvePw`
+   * seeds a stored sudo password returned by `resolve_credential`.
+   */
+  function mockBackend(opts: { resolvePw?: string | null; unlocked?: boolean } = {}): {
+    elevatedCalls: Array<Record<string, unknown>>;
+    credentialCalls: Array<{ cmd: string; args: Record<string, unknown> }>;
+  } {
+    const { resolvePw = null } = opts;
+    const elevatedCalls: Array<Record<string, unknown>> = [];
+    const credentialCalls: Array<{ cmd: string; args: Record<string, unknown> }> = [];
+    mockedInvoke.mockImplementation((cmd, args) => {
+      if (cmd === "session_read_file") return Promise.resolve(toBytes("127.0.0.1 localhost\n"));
+      if (cmd === "session_has_exec_capability") return Promise.resolve(true);
+      if (cmd === "session_check_writable") return Promise.resolve("readOnly");
+      if (cmd === "session_write_file_elevated") {
+        elevatedCalls.push((args ?? {}) as Record<string, unknown>);
+        return Promise.resolve({ kind: "success" });
+      }
+      if (cmd === "store_credential") {
+        credentialCalls.push({ cmd, args: (args ?? {}) as Record<string, unknown> });
+        return Promise.resolve(undefined);
+      }
+      if (cmd === "resolve_credential") {
+        credentialCalls.push({ cmd, args: (args ?? {}) as Record<string, unknown> });
+        return Promise.resolve(resolvePw);
+      }
+      if (cmd === "remove_credential") {
+        credentialCalls.push({ cmd, args: (args ?? {}) as Record<string, unknown> });
+        return Promise.resolve(undefined);
+      }
+      return Promise.resolve(undefined);
+    });
+    return { elevatedCalls, credentialCalls };
+  }
+
+  function unlockCredentialStore(): void {
+    act(() => {
+      useAppStore.setState({
+        credentialStoreStatus: { status: "unlocked", mode: "master_password" },
+      });
+    });
+  }
+
+  it("derives the legacy `user@host:port` label from the owning tab config", () => {
+    seedOwningTab();
+    const label = deriveEditorHostLabel(useAppStore.getState(), SSH_META);
+    expect(label).toBe("pi@raspberrypi:22");
+  });
+
+  it("stays reconnect-stable: resolves via the owning tab id after the session id changes", () => {
+    // A reconnect swapped the live session id, but the owning tab id (and its
+    // config) is unchanged — the stale `sessionBrowser.sessionId` no longer
+    // matches any tab, yet the label must still resolve via `sessionKey`.
+    seedOwningTab({ sessionId: "sftp-sess-RECONNECTED" });
+    const label = deriveEditorHostLabel(useAppStore.getState(), SSH_META);
+    expect(label).toBe("pi@raspberrypi:22");
+  });
+
+  it("returns null for a byte-based backend (no host) → path fallback", () => {
+    // A Docker/agent-style session has no user@host:port in its config.
+    seedOwningTab({ type: "docker", config: { image: "alpine" } });
+    const label = deriveEditorHostLabel(useAppStore.getState(), {
+      ...SSH_META,
+      sessionBrowser: { sessionId: "sftp-sess-1", connectionType: "docker" },
+    });
+    expect(label).toBeNull();
+  });
+
+  it("returns null when the owning terminal tab is gone", () => {
+    // No tab seeded → nothing to source the label from.
+    expect(deriveEditorHostLabel(useAppStore.getState(), SSH_META)).toBeNull();
+  });
+
+  it("names the host in the sudo prompt for a session-backed SSH tab", async () => {
+    mockBackend();
+    seedOwningTab();
+    render(SSH_META);
+    await flush();
+
+    editContent("127.0.0.1 localhost\nedited\n");
+    await flush();
+    await act(async () => {
+      (query("file-editor-edit-with-sudo") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    // Prompt shows the host, not the file path.
+    expect(docQuery("sudo-prompt-host")?.textContent).toBe("raspberrypi:22");
+    expect(docQuery("sudo-prompt-user")?.textContent).toBe("pi");
+  });
+
+  it("falls back to the file path in the sudo prompt when no host label resolves", async () => {
+    mockBackend();
+    // No owning tab seeded → hostLabel null → file-path fallback.
+    render(SSH_META);
+    await flush();
+
+    editContent("127.0.0.1 localhost\nedited\n");
+    await flush();
+    await act(async () => {
+      (query("file-editor-edit-with-sudo") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(docQuery("sudo-prompt-host")?.textContent).toBe("/etc/hosts");
+  });
+
+  it("namespaces the persisted sudo password under the host label", async () => {
+    const { credentialCalls } = mockBackend();
+    seedOwningTab();
+    render(SSH_META);
+    await flush();
+    unlockCredentialStore();
+    await flush();
+
+    editContent("127.0.0.1 localhost\nedited\n");
+    await flush();
+    await act(async () => {
+      (query("file-editor-edit-with-sudo") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    typeInto(docQuery("sudo-prompt-input") as HTMLInputElement, "sudo-pw");
+    // Opt into persisting to the credential store.
+    await act(async () => {
+      (docQuery("sudo-prompt-persist") as HTMLElement).click();
+    });
+    await act(async () => {
+      (docQuery("sudo-prompt-submit") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    const store = credentialCalls.find((c) => c.cmd === "store_credential");
+    expect(store).toBeDefined();
+    // The credential is keyed by the host label, not the file path.
+    expect(store?.args.connectionId).toBe("pi@raspberrypi:22");
+    expect(store?.args.credentialType).toBe("sudo_password");
+  });
+
+  it("resolves a saved sudo password under the host label without prompting", async () => {
+    const { elevatedCalls, credentialCalls } = mockBackend({ resolvePw: "stored-pw" });
+    seedOwningTab();
+    render(SSH_META);
+    await flush();
+    unlockCredentialStore();
+    await flush();
+
+    editContent("127.0.0.1 localhost\nedited\n");
+    await flush();
+    await act(async () => {
+      (query("file-editor-edit-with-sudo") as HTMLButtonElement).click();
+    });
+    await flush();
+
+    // The stored password satisfied the save; no prompt was shown.
+    expect(docQuery("sudo-prompt-dialog")).toBeNull();
+    expect(elevatedCalls).toHaveLength(1);
+    expect(elevatedCalls[0].sudoPassword).toBe("stored-pw");
+    const resolve = credentialCalls.find((c) => c.cmd === "resolve_credential");
+    expect(resolve?.args.connectionId).toBe("pi@raspberrypi:22");
   });
 });
 

--- a/src/components/FileEditor/FileEditor.tsx
+++ b/src/components/FileEditor/FileEditor.tsx
@@ -17,7 +17,7 @@ import {
 import { Button, toast } from "@/components/ui";
 import { save } from "@tauri-apps/plugin-dialog";
 import { EditorTabMeta, EditorStatus } from "@/types/terminal";
-import { useAppStore } from "@/store/appStore";
+import { useAppStore, deriveEditorHostLabel } from "@/store/appStore";
 import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { resolveLanguage } from "@/utils/languageMapping";
 import { getBasename } from "@/utils/formatters";
@@ -175,12 +175,13 @@ export function FileEditor({ tabId, meta, isVisible, keepModel = false }: FileEd
   // user explicitly switches between dark / light / system in the settings.
   const themeSetting = projectedSettings.theme;
   // Host label (`user@host:port`) that names the host in the sudo prompt and keys
-  // the (optional) credential-store entry. The legacy `SftpManager` session that
-  // carried this label was retired when SSH file editing converged onto the
-  // session path (#2422); a session-backed tab has no host label wired here yet,
-  // so this stays null and the sudo prompt / credential namespacing falls back to
-  // the file path (see follow-up).
-  const hostLabel: string | null = null;
+  // the (optional) credential-store entry. Sourced from the owning terminal tab's
+  // connection config, reconnect-stable and byte-identical to the label the legacy
+  // SFTP path used, so sudo passwords saved before the sftp→session convergence
+  // (#2422) still resolve (#2424 / #2426). Null for local tabs and non-labelable
+  // session backends (Docker / FTP / agent) — the sudo prompt / credential
+  // namespacing then falls back to the file path.
+  const hostLabel = useAppStore((s) => deriveEditorHostLabel(s, meta));
   // Live credential-store status — the "save in credential store" option only
   // appears when it is unlocked.
   const credentialStoreUnlocked = useAppStore(

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1986,6 +1986,55 @@ function resolveEditorSessionKey(
 }
 
 /**
+ * Derive the sudo host label (`user@host:port`) for a session-backed remote
+ * editor tab, or `null` when none applies.
+ *
+ * The file editor's sudo flow uses this label to (a) name the host in the
+ * sudo-password prompt and (b) namespace the optional credential-store entry for
+ * a remembered sudo password. Two properties are load-bearing (#2424 / #2426):
+ *
+ * - **Reconnect-stable** — the saved sudo password must keep resolving after the
+ *   owning terminal reconnects. The owning tab is therefore located by its
+ *   *stable id* (encoded in the editor tab's reconnect-stable `sessionKey`,
+ *   `session:<owningTabId>`), falling back to the live `sessionBrowser.sessionId`
+ *   only when no `sessionKey` is present. A reconnect swaps the session id but
+ *   keeps the tab (and its connection config), so the label value is unchanged.
+ * - **Byte-identical to the legacy SFTP label** — before SSH file editing
+ *   converged onto the session path (#2420 / #2421) and the `sftpSessionId` model
+ *   was retired (#2422), this label came from `sftpSessions[id].hostLabel`, built
+ *   as `${username}@${host}:${port}` from the connection config. Reproducing that
+ *   exact string here means sudo passwords saved before the convergence still
+ *   resolve — the migration does not orphan them.
+ *
+ * Returns `null` for local tabs, tabs whose owning terminal cannot be found, and
+ * non-labelable backends (e.g. Docker / FTP / agent, which carry no
+ * `user@host:port`); callers then fall back to the file path, preserving the
+ * pre-convergence graceful-degradation behaviour.
+ */
+export function deriveEditorHostLabel(
+  state: { rootPanel: PanelNode },
+  meta: Pick<EditorTabMeta, "isRemote" | "sessionBrowser" | "sessionKey">
+): string | null {
+  if (!meta.isRemote || !meta.sessionBrowser) return null;
+  const tabs = getAllLeaves(state.rootPanel).flatMap((l) => l.tabs);
+  const owningTabId = meta.sessionKey?.startsWith("session:")
+    ? meta.sessionKey.slice("session:".length)
+    : undefined;
+  const owner =
+    (owningTabId ? tabs.find((t) => t.id === owningTabId) : undefined) ??
+    tabs.find((t) => t.sessionId === meta.sessionBrowser?.sessionId);
+  if (!owner) return null;
+  const cfg = owner.config.config;
+  const { username, host, port } = cfg;
+  // A labelable connection (SSH) carries all three; byte-based backends
+  // (Docker / FTP / agent) don't, so they fall through to the path fallback.
+  if (typeof host !== "string" || host === "" || typeof username !== "string" || port == null) {
+    return null;
+  }
+  return `${username}@${host}:${port}`;
+}
+
+/**
  * Enumerate every live tab across all tab groups (the active group is
  * represented by the live `rootPanel`, the others by their stored trees). Used
  * by the bulk-reconnect control to filter captured failed ids down to tabs that


### PR DESCRIPTION
## Summary

Restores the sudo **host label** and credential-store namespacing for session-backed SSH editor tabs, which lost their `hostLabel` source when the `sftpSessionId` model was retired (B4 / #2422).

`FileEditor`'s sudo flow uses a `hostLabel` (`user@host:port`) to (a) name the host in the sudo-password prompt and (b) namespace the optional remembered-sudo-password credential entry. It derived that label only from `meta.sftpSessionId → sftpSessions[...].hostLabel`; after the SSH file-browser convergence onto the session path (#2420 / #2421) and the removal of the `sftpSessionId` model (#2422), it resolved to `null` for session-backed SSH tabs — so the prompt fell back to the file path and "remember my sudo password" silently stopped being host-namespaced.

## Changes

- New `deriveEditorHostLabel(state, meta)` helper in `appStore.ts`: locates the owning terminal tab and builds `${username}@${host}:${port}` from its connection config.
  - **Reconnect-stable:** resolves the owning tab by its stable id (encoded in the editor tab's `sessionKey`, `session:<owningTabId>`), falling back to the live `sessionBrowser.sessionId`. A reconnect swaps the session id but keeps the tab and its config, so the label value is unchanged.
  - **Legacy-label continuity:** reproduces the exact string the legacy SFTP path produced (`connectSftp` built `${config.username}@${config.host}:${config.port}` from the same SSH connection config), so sudo passwords saved before the convergence still resolve — no orphaned credentials.
  - Returns `null` for local tabs, tabs whose owning terminal is gone, and non-labelable backends (Docker / FTP / agent, which carry no `user@host:port`) — the file-path fallback (graceful degradation) is preserved.
- Wire it into `FileEditor`'s `hostLabel`, restoring both the sudo-prompt host name and the `storeCredential`/`resolveCredential`/`removeCredential` namespacing.

**Design choice:** frontend-only, no backend getter — the owning tab's `config.config` already carries `username`/`host`/`port`, matching where the legacy SFTP path read them, so no `commands/session.rs` change was needed (keeps this disjoint from dev0's SftpManager retirement, #2314).

## Tests

Extended `FileEditor.test.tsx`: `deriveEditorHostLabel` unit cases (legacy label, reconnect stability via the owning tab id after the session id changes, byte-based/no-owning-tab → null) plus rendered cases — the sudo prompt names the host, falls back to the file path when no label resolves, and the credential-store store/resolve calls are namespaced by the host label. Full frontend suite green (4892 tests).

Closes #2424
Closes #2426