### PR TITLE
refactor(workspace): make restore-cohort region authoritative (Part of #2206)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -57,12 +57,12 @@ mod plugin_protocol;
 /// versioned diff channels with multi-subscriber fan-out. Public so integration
 /// tests can drive the projector directly.
 pub mod projection;
-/// Shadow restore-cohort authority (#2206, Phase 4 step 5 of #2139): the
-/// client-scoped `restore-cohort@<clientId>` projection region + `restore.*`
+/// Authoritative restore-cohort state machine (#2206, Phase 4 step 5 of #2139):
+/// the client-scoped `restore-cohort@<clientId>` projection region + `restore.*`
 /// intents, modelling the startup restore/launch cohort aggregation (#1146 /
 /// #1227) on top of the ported restore-decision engine (`termihub_core::restore_mode`,
-/// #2145). Registered and served but not yet driving the live UI — see
-/// [`restore_cohort_projection`].
+/// #2145). The sole source of truth driving the live UI's aggregate summary toast
+/// (reducer removal) — see [`restore_cohort_projection`].
 mod restore_cohort_projection;
 pub mod run_location;
 mod session;
@@ -749,16 +749,15 @@ pub fn run() {
                     &mut registry,
                     app.handle().clone(),
                 );
-                // Shadow RestoreCohortStore (#2206, Phase 4 step 5): the
-                // client-scoped `restore-cohort@<clientId>` region + `restore.*`
-                // intents modelling the startup restore/launch cohort aggregation
-                // (#1146 / #1227). Managed authoritative state that serves intents,
-                // but nothing in the live UI subscribes to or renders the region
-                // yet — a pure shadow foundation (later steps cut rendering, then
-                // the mutations, over to it, keeping the appStore reducers as the
-                // parity-safe fallback). No client region is seeded here: like
-                // layout, restore-cohort regions are client-scoped and created
-                // lazily on a client's first `restore.*` intent.
+                // RestoreCohortStore (#2206, Phase 4 step 5): the client-scoped
+                // `restore-cohort@<clientId>` region + `restore.*` intents
+                // modelling the startup restore/launch cohort aggregation (#1146 /
+                // #1227). Now the sole source of truth (reducer removal): the live
+                // UI renders the aggregate summary toast from the projected
+                // settlement and routes begin/settle through the intents; the
+                // appStore cohort reducers were removed. No client region is seeded
+                // here: like layout, restore-cohort regions are client-scoped and
+                // created lazily on a client's first `restore.*` intent.
                 app.manage(Arc::new(restore_cohort_projection::RestoreCohortStore::new()));
                 restore_cohort_projection::projection::register_restore_intents(
                     &mut registry,

--- a/src-tauri/src/restore_cohort_projection/store.rs
+++ b/src-tauri/src/restore_cohort_projection/store.rs
@@ -1,8 +1,8 @@
 //! The authoritative, client-scoped restore-cohort state machine behind the
-//! shadow `restore-cohort@<clientId>` region (#2206, Phase 4 step 5 of #2139).
+//! `restore-cohort@<clientId>` region (#2206, Phase 4 step 5 of #2139).
 //!
-//! Models the aggregate restore/launch feedback the frontend currently drives
-//! (`appStore` `restoreCohort` + `failedRestoreTabIds`, #1146 / #1227): a cohort
+//! Models the aggregate restore/launch feedback (formerly the `appStore`
+//! `restoreCohort` + `failedRestoreTabIds` reducers, #1146 / #1227): a cohort
 //! of tab ids placed by one restore, settled tab-by-tab, that raises a single
 //! summary and remembers which tabs failed so they can be bulk-reconnected. This
 //! module owns only the cohort **orchestration** state per client — not tab
@@ -17,18 +17,18 @@
 //! infrastructure, so the store keys everything by `clientId` and projects one
 //! `restore-cohort@<clientId>` region per client — mirroring `layout`.
 //!
-//! # Shadow mode — zero user-facing change
+//! # Authoritative — the sole source of truth
 //!
-//! This step is deliberately **not authoritative**. The store exists, accepts
-//! `restore.*` intents, and projects diffs, but nothing in the live UI
-//! subscribes to or renders a `restore-cohort` region, and no frontend code
-//! dispatches `restore.*` intents yet. The `appStore` cohort reducers and the
-//! toast feedback remain authoritative.
+//! This store is authoritative (#2206, reducer removal). The `appStore` cohort
+//! reducers were removed: its `beginRestoreCohort` / `settleRestoreTab` actions
+//! now only dispatch `restore.*` intents, the live UI subscribes to the
+//! `restore-cohort@<clientId>` region, and the aggregate summary toast is fired
+//! from the projected [`CohortSettlement`].
 //!
 //! ## What stays frontend
 //!
-//! Two concerns deliberately stay on the frontend at the render/mutation cut,
-//! keeping a clean per-domain boundary:
+//! Two concerns deliberately stay on the frontend, keeping a clean per-domain
+//! boundary:
 //!
 //! - **The toast itself.** The store produces the *settlement summary*
 //!   ([`CohortSettlement`], carrying a monotonic `seq` so a render can fire the

--- a/src/store/appStore.bulkReconnect.test.ts
+++ b/src/store/appStore.bulkReconnect.test.ts
@@ -62,6 +62,8 @@ import { useAppStore } from "./appStore";
 import { setupConnectionsRegion, seedConnectionsRegion } from "@/test/connectionsHarness";
 import { setupSettingsRegion, seedSettings } from "@/test/settingsRegionTestHarness";
 import { setupAgentsRegion } from "@/test/agentsRegionTestHarness";
+import { setupRestoreCohortRegion } from "@/test/restoreCohortHarness";
+import { currentRestoreCohortView } from "@/store/restoreCohortBridge";
 import { loadLastSession } from "@/services/lastSessionApi";
 import { getAllLeaves } from "@/utils/panelTree";
 import type { LastSession } from "@/types/lastSession";
@@ -103,7 +105,9 @@ function tabById(id: string) {
 
 /**
  * Restore three tabs and settle two connected + one failed, leaving one failed
- * tab captured for the bulk-reconnect control. Returns the tab ids.
+ * tab captured (in the region) for the bulk-reconnect control. Awaits the
+ * projected settlement so the summary toast has fired and the region view is
+ * current. Returns the tab ids.
  */
 async function restoreWithOneFailure(): Promise<string[]> {
   mockLoad.mockResolvedValue(threeLocalTabsSession());
@@ -112,12 +116,14 @@ async function restoreWithOneFailure(): Promise<string[]> {
   useAppStore.getState().setTabSessionId(ids[0], "sess-a");
   useAppStore.getState().setTabSessionId(ids[1], "sess-b");
   useAppStore.getState().setTerminalDisconnectWithError(ids[2], "connection refused");
+  await restore.flush();
   return ids;
 }
 
 setupConnectionsRegion();
 setupSettingsRegion();
 setupAgentsRegion();
+const restore = setupRestoreCohortRegion();
 
 describe("bulk reconnect of failed restore tabs", () => {
   beforeEach(() => {
@@ -125,8 +131,6 @@ describe("bulk reconnect of failed restore tabs", () => {
     mockLoad.mockResolvedValue(null);
     useAppStore.setState({
       defaultShell: "bash",
-      restoreCohort: null,
-      failedRestoreTabIds: [],
       terminalConnecting: {},
       terminalDisconnectErrors: {},
       terminalRetryCounters: {},
@@ -138,9 +142,11 @@ describe("bulk reconnect of failed restore tabs", () => {
   it("captures the failed tab ids from a settled partial-restore cohort", async () => {
     const ids = await restoreWithOneFailure();
 
-    // The partial summary fired and the failed terminal tab is remembered.
+    // The partial summary fired and the failed terminal tab is remembered in the
+    // authoritative region.
     expect(toastInfo).toHaveBeenCalledTimes(1);
-    expect(useAppStore.getState().failedRestoreTabIds).toEqual([ids[2]]);
+    expect(currentRestoreCohortView().failedTabIds).toEqual([ids[2]]);
+    expect(restore.transport().onlyRegionView().failedTabIds).toEqual([ids[2]]);
     // Action affordance is attached to the summary toast so it can be triggered.
     const opts = toastInfo.mock.calls[0][1] as { action?: { label: string; onClick: () => void } };
     expect(opts?.action).toBeDefined();
@@ -153,14 +159,8 @@ describe("bulk reconnect of failed restore tabs", () => {
 
     useAppStore.getState().reconnectFailedRestoreTabs();
 
-    // A fresh cohort covers exactly the previously-failed tab.
-    const cohort = useAppStore.getState().restoreCohort;
-    expect(cohort).not.toBeNull();
-    expect([...(cohort?.pending ?? [])]).toEqual([ids[2]]);
-    expect(cohort?.total).toBe(1);
-
     // The failed tab is being re-driven: its disconnect error is cleared and it
-    // is marked connecting again.
+    // is marked connecting again (synchronous, before the region round-trip).
     expect(useAppStore.getState().terminalConnecting[ids[2]]).toBe(true);
     expect(useAppStore.getState().terminalDisconnectErrors[ids[2]]).toBeUndefined();
 
@@ -170,8 +170,14 @@ describe("bulk reconnect of failed restore tabs", () => {
     expect(tabById(ids[0])?.sessionId).toBe("sess-a");
     expect(tabById(ids[1])?.sessionId).toBe("sess-b");
 
-    // The captured failed set is consumed by the retry.
-    expect(useAppStore.getState().failedRestoreTabIds).toEqual([]);
+    await restore.flush();
+    // A fresh cohort in the region covers exactly the previously-failed tab, and
+    // beginning it cleared the captured failed set.
+    const region = restore.transport().onlyRegionView();
+    expect(region.cohort).not.toBeNull();
+    expect(region.cohort?.pending).toEqual([ids[2]]);
+    expect(region.cohort?.total).toBe(1);
+    expect(region.failedTabIds).toEqual([]);
   });
 
   it("re-summarizes as a success when the bulk retry connects all failed tabs", async () => {
@@ -179,17 +185,19 @@ describe("bulk reconnect of failed restore tabs", () => {
     vi.clearAllMocks();
 
     useAppStore.getState().reconnectFailedRestoreTabs();
-    // Pending feedback for the bulk retry.
+    // Pending feedback for the bulk retry (fired synchronously).
     expect(toastLoading).toHaveBeenCalledTimes(1);
 
     // The retried tab connects.
     useAppStore.getState().setTabSessionId(ids[2], "sess-c-retry");
+    await restore.flush();
 
     expect(toastSuccess).toHaveBeenCalledTimes(1);
     expect(String(toastSuccess.mock.calls[0][0])).toContain("1");
-    // No failed tabs remain to retry.
-    expect(useAppStore.getState().failedRestoreTabIds).toEqual([]);
-    expect(useAppStore.getState().restoreCohort).toBeNull();
+    // No failed tabs remain to retry and the cohort settled.
+    const region = restore.transport().onlyRegionView();
+    expect(region.failedTabIds).toEqual([]);
+    expect(region.cohort).toBeNull();
   });
 
   it("re-summarizes as a partial when the bulk retry still fails, keeping the tab retryable", async () => {
@@ -200,34 +208,39 @@ describe("bulk reconnect of failed restore tabs", () => {
 
     // The retried tab fails again.
     useAppStore.getState().setTerminalDisconnectWithError(ids[2], "still refused");
+    await restore.flush();
 
     // A partial summary fires again and the tab is still remembered for retry.
     expect(toastInfo).toHaveBeenCalledTimes(1);
-    expect(useAppStore.getState().failedRestoreTabIds).toEqual([ids[2]]);
-    expect(useAppStore.getState().restoreCohort).toBeNull();
+    const region = restore.transport().onlyRegionView();
+    expect(region.failedTabIds).toEqual([ids[2]]);
+    expect(region.cohort).toBeNull();
   });
 
   it("is a no-op when there are no failed tabs to reconnect", () => {
-    useAppStore.setState({ failedRestoreTabIds: [], restoreCohort: null });
+    // No cohort has run, so the region's captured failed set is empty.
+    expect(currentRestoreCohortView().failedTabIds).toEqual([]);
     useAppStore.getState().reconnectFailedRestoreTabs();
 
-    expect(useAppStore.getState().restoreCohort).toBeNull();
     expect(toastLoading).not.toHaveBeenCalled();
     expect(toastInfo).not.toHaveBeenCalled();
     expect(toastSuccess).not.toHaveBeenCalled();
   });
 
   it("ignores captured tab ids that no longer exist in the tree", async () => {
-    await restoreWithOneFailure();
-    // Simulate the failed tab having been closed since the restore settled.
-    useAppStore.setState({ failedRestoreTabIds: ["ghost-tab-id"] });
+    // Seed the region with a failed tab id that is not present in the tree (as if
+    // the tab was closed since the restore settled), via a ghost begin + settle.
+    useAppStore.getState().beginRestoreCohort(["ghost-tab-id"], 0);
+    useAppStore.getState().settleRestoreTab("ghost-tab-id", "failed");
+    await restore.flush();
+    expect(currentRestoreCohortView().failedTabIds).toEqual(["ghost-tab-id"]);
     vi.clearAllMocks();
 
     useAppStore.getState().reconnectFailedRestoreTabs();
+    await restore.flush();
 
-    // Nothing live to re-drive → no cohort, no pending toast.
-    expect(useAppStore.getState().restoreCohort).toBeNull();
+    // Nothing live to re-drive → no fresh cohort begun, no pending toast.
+    expect(restore.transport().onlyRegionView().cohort).toBeNull();
     expect(toastLoading).not.toHaveBeenCalled();
-    expect(useAppStore.getState().failedRestoreTabIds).toEqual([]);
   });
 });

--- a/src/store/appStore.restoreCohortMutationCut.test.ts
+++ b/src/store/appStore.restoreCohortMutationCut.test.ts
@@ -1,25 +1,18 @@
 /**
- * Restore-cohort mutation cut (#2241, part of #2206 / #2139) — cut-vs-local parity.
+ * Restore-cohort intents drive the authoritative region (#2206).
  *
- * The mutation cut routes `beginRestoreCohort` / `settleRestoreTab` through the
- * `restore.beginCohort` / `restore.settleTab` intents so the backend
- * `RestoreCohortStore` becomes authoritative, while the local `appStore` cohort
- * reducers stay in place as the render source and the resilience / rollback
- * fallback (removal is a later step).
+ * Since the reducer removal the `appStore` `beginRestoreCohort` / `settleRestoreTab`
+ * actions are thin dispatchers of the `restore.beginCohort` / `restore.settleTab`
+ * intents, and the `restore-cohort@<clientId>` region (a faithful in-memory port of
+ * the Rust `RestoreCohortStore`) is the sole source of truth.
  *
- * These tests prove the cut is parity-safe: with the intents flag **on**, the
- * intents dispatched by the actions — applied by a faithful in-memory port of the
- * Rust store (mirroring `restore_cohort_projection/store.rs`) — reconstruct the
- * `restore-cohort@<clientId>` region whose settled summary + captured failed-tab
- * set match the local slice. With the flag **off**, no intents are dispatched — the
- * instant rollback path the flip relies on.
- *
- * The render flag is held **off** here so the summary toast fires straight from the
- * local reducer (isolating the mutation cut); the render cut is covered separately
- * in `restoreCohortBridge.test.ts`.
+ * These tests prove the intents the actions dispatch reconstruct the expected
+ * region: the settled summary + captured failed-tab set, the in-flight cohort, the
+ * bulk-retry follow-up, and that the region — not the frontend — is the sole guard
+ * that ignores a stray settle.
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 
 const toastSuccess = vi.fn((_m: unknown, _o?: unknown) => undefined);
 const toastError = vi.fn((_m: unknown, _o?: unknown) => undefined);
@@ -76,205 +69,12 @@ import { useAppStore } from "./appStore";
 import { setupConnectionsRegion, seedConnectionsRegion } from "@/test/connectionsHarness";
 import { setupSettingsRegion, seedSettings } from "@/test/settingsRegionTestHarness";
 import { setupAgentsRegion } from "@/test/agentsRegionTestHarness";
-import {
-  setRestoreIntentsEnabled,
-  setRestoreRenderFromProjectionEnabled,
-  setRestoreTransportForTest,
-} from "./restoreCohortBridge";
+import { setupRestoreCohortRegion } from "@/test/restoreCohortHarness";
 import { loadLastSession } from "@/services/lastSessionApi";
 import { getAllLeaves } from "@/utils/panelTree";
 import type { LastSession } from "@/types/lastSession";
-import type {
-  FrameHandler,
-  Intent,
-  IntentAck,
-  ProjectionFrame,
-  SnapshotFrame,
-  Subscription,
-  Transport,
-} from "@/services/transport";
 
 const mockLoad = vi.mocked(loadLastSession);
-
-// ── In-memory twin of the Rust RestoreCohortStore (client-scoped) ──────────────
-
-interface Cohort {
-  pending: string[];
-  total: number;
-  failed: number;
-  failedTabIds: string[];
-  toastId: string | null;
-}
-interface Settlement {
-  seq: number;
-  total: number;
-  restored: number;
-  failed: number;
-  retryTabIds: string[];
-  toastId: string | null;
-}
-interface ClientState {
-  cohort: Cohort | null;
-  failedTabIds: string[];
-  settlement: Settlement | null;
-  settleSeq: number;
-}
-interface RegionView {
-  cohort: (Omit<Cohort, "toastId"> & { toastId: string | null }) | null;
-  failedTabIds: string[];
-  settlement: Settlement | null;
-}
-
-/** A transport double that applies `restore.*` intents with the same semantics as
- * the Rust `RestoreCohortStore`, keyed by `clientId`, and fans the client's region
- * snapshot to subscribers on every mutation. */
-class RestoreStoreTransport implements Transport {
-  dispatched: Intent[] = [];
-  private clients = new Map<string, ClientState>();
-  private version = 0;
-  private handlers = new Map<string, FrameHandler[]>();
-
-  async dispatch(intent: Intent): Promise<IntentAck> {
-    this.dispatched.push(intent);
-    this.apply(intent);
-    this.version += 1;
-    this.fan(intent.clientId);
-    return {
-      intentId: intent.intentId,
-      status: "accepted",
-      produced: [{ region: this.region(intent.clientId), version: this.version }],
-    };
-  }
-
-  private state(clientId: string): ClientState {
-    let s = this.clients.get(clientId);
-    if (!s) {
-      s = { cohort: null, failedTabIds: [], settlement: null, settleSeq: 0 };
-      this.clients.set(clientId, s);
-    }
-    return s;
-  }
-
-  private apply(intent: Intent): void {
-    const p = intent.payload as Record<string, unknown>;
-    const s = this.state(intent.clientId);
-    switch (intent.kind) {
-      case "restore.beginCohort": {
-        const raw = (p.pendingTabIds as string[]) ?? [];
-        const pending: string[] = [];
-        for (const id of raw) if (!pending.includes(id)) pending.push(id);
-        const preFailed = (p.preFailedCount as number | undefined) ?? 0;
-        const total = pending.length + preFailed;
-        if (total === 0) break;
-        s.cohort = {
-          pending,
-          total,
-          failed: preFailed,
-          failedTabIds: [],
-          toastId: (p.toastId as string | undefined) ?? null,
-        };
-        s.failedTabIds = [];
-        if (pending.length === 0) this.settleCohort(intent.clientId);
-        break;
-      }
-      case "restore.settleTab": {
-        if (!s.cohort) break;
-        const tabId = p.tabId as string;
-        const pos = s.cohort.pending.indexOf(tabId);
-        if (pos < 0) break;
-        s.cohort.pending.splice(pos, 1);
-        if (p.outcome === "failed") {
-          s.cohort.failed += 1;
-          if (!s.cohort.failedTabIds.includes(tabId)) s.cohort.failedTabIds.push(tabId);
-        }
-        if (s.cohort.pending.length === 0) this.settleCohort(intent.clientId);
-        break;
-      }
-      default:
-        break;
-    }
-  }
-
-  private settleCohort(clientId: string): void {
-    const s = this.state(clientId);
-    const cohort = s.cohort;
-    if (!cohort) return;
-    s.cohort = null;
-    s.failedTabIds = [...cohort.failedTabIds];
-    s.settleSeq += 1;
-    s.settlement = {
-      seq: s.settleSeq,
-      total: cohort.total,
-      restored: cohort.total - cohort.failed,
-      failed: cohort.failed,
-      retryTabIds: [...cohort.failedTabIds],
-      toastId: cohort.toastId,
-    };
-  }
-
-  regionView(clientId: string): RegionView {
-    const s = this.state(clientId);
-    return structuredClone({
-      cohort: s.cohort
-        ? {
-            pending: s.cohort.pending,
-            total: s.cohort.total,
-            failed: s.cohort.failed,
-            failedTabIds: s.cohort.failedTabIds,
-            toastId: s.cohort.toastId,
-          }
-        : null,
-      failedTabIds: s.failedTabIds,
-      settlement: s.settlement,
-    });
-  }
-
-  /** The single client's region view (there is one per-session client id). */
-  onlyRegionView(): RegionView {
-    const [clientId] = [...this.clients.keys()];
-    return this.regionView(clientId ?? "");
-  }
-
-  kinds(): string[] {
-    return this.dispatched.map((i) => i.kind);
-  }
-
-  private region(clientId: string): string {
-    return `restore-cohort@${clientId}`;
-  }
-
-  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
-    const list = this.handlers.get(region) ?? [];
-    list.push(onFrame);
-    this.handlers.set(region, list);
-    const clientId = region.slice("restore-cohort@".length);
-    return {
-      snapshot: this.snapshot(region, clientId),
-      unsubscribe: () => {
-        this.handlers.set(
-          region,
-          (this.handlers.get(region) ?? []).filter((h) => h !== onFrame)
-        );
-      },
-    };
-  }
-
-  async resync(): Promise<SnapshotFrame | null> {
-    return null;
-  }
-
-  private snapshot(region: string, clientId: string): SnapshotFrame {
-    return { kind: "snapshot", region, version: this.version, view: this.regionView(clientId) };
-  }
-
-  private fan(clientId: string): void {
-    const region = this.region(clientId);
-    const frame: ProjectionFrame = this.snapshot(region, clientId);
-    for (const h of this.handlers.get(region) ?? []) h(frame);
-  }
-}
-
-let transport: RestoreStoreTransport;
 
 /** A three-tab session that all resolve to plain local terminals. */
 function threeLocalTabsSession(): LastSession {
@@ -303,41 +103,21 @@ function restoredTabIds(): string[] {
     .map((t) => t.id);
 }
 
-async function flush(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
-}
-
 setupConnectionsRegion();
 setupSettingsRegion();
 setupAgentsRegion();
+const restore = setupRestoreCohortRegion();
 
 beforeEach(() => {
   useAppStore.setState(useAppStore.getInitialState());
   vi.clearAllMocks();
   mockLoad.mockResolvedValue(null);
-  useAppStore.setState({
-    defaultShell: "bash",
-    restoreCohort: null,
-    failedRestoreTabIds: [],
-  });
+  useAppStore.setState({ defaultShell: "bash" });
   seedSettings({ restoreLastSessionOnStartup: true });
   seedConnectionsRegion({ connections: [] });
-  transport = new RestoreStoreTransport();
-  setRestoreTransportForTest(transport);
-  setRestoreIntentsEnabled(true);
-  // Isolate the mutation cut: the summary toast fires straight from the local
-  // reducer here (the render cut is covered separately).
-  setRestoreRenderFromProjectionEnabled(false);
 });
 
-afterEach(() => {
-  setRestoreTransportForTest(null);
-  setRestoreIntentsEnabled(null);
-  setRestoreRenderFromProjectionEnabled(null);
-});
-
-describe("restore-cohort mutation cut — cut-vs-local parity (intents on)", () => {
+describe("restore-cohort intents drive the authoritative region", () => {
   it("a partial restore reproduces the settled region + captured failed set", async () => {
     mockLoad.mockResolvedValue(threeLocalTabsSession());
     await useAppStore.getState().restoreLastSession();
@@ -347,24 +127,22 @@ describe("restore-cohort mutation cut — cut-vs-local parity (intents on)", () 
     useAppStore.getState().setTabSessionId(ids[0], "sess-a");
     useAppStore.getState().setTabSessionId(ids[1], "sess-b");
     useAppStore.getState().setTerminalDisconnectWithError(ids[2], "connection refused");
-    await flush();
+    await restore.flush();
 
     // The intent stream: one begin, then one settle per tab.
-    expect(transport.kinds()).toEqual([
+    expect(restore.transport().kinds()).toEqual([
       "restore.beginCohort",
       "restore.settleTab",
       "restore.settleTab",
       "restore.settleTab",
     ]);
 
-    const region = transport.onlyRegionView();
-    // The cohort settled and the summary matches the local computation.
+    const region = restore.transport().onlyRegionView();
+    // The cohort settled and the projected summary reflects the outcome.
     expect(region.cohort).toBeNull();
     expect(region.settlement).toMatchObject({ total: 3, restored: 2, failed: 1 });
     expect(region.settlement?.retryTabIds).toEqual([ids[2]]);
-    // The captured failed set matches the local slice (all failed tabs are live).
-    expect(region.failedTabIds).toEqual(useAppStore.getState().failedRestoreTabIds);
-    expect(useAppStore.getState().failedRestoreTabIds).toEqual([ids[2]]);
+    expect(region.failedTabIds).toEqual([ids[2]]);
   });
 
   it("a full success reproduces a zero-failure settlement", async () => {
@@ -373,13 +151,12 @@ describe("restore-cohort mutation cut — cut-vs-local parity (intents on)", () 
     const ids = restoredTabIds();
 
     ids.forEach((id, i) => useAppStore.getState().setTabSessionId(id, `sess-${i}`));
-    await flush();
+    await restore.flush();
 
-    const region = transport.onlyRegionView();
+    const region = restore.transport().onlyRegionView();
     expect(region.settlement).toMatchObject({ total: 3, restored: 3, failed: 0 });
     expect(region.settlement?.retryTabIds).toEqual([]);
     expect(region.failedTabIds).toEqual([]);
-    expect(useAppStore.getState().failedRestoreTabIds).toEqual([]);
   });
 
   it("mirrors the in-flight cohort before it settles", async () => {
@@ -389,16 +166,14 @@ describe("restore-cohort mutation cut — cut-vs-local parity (intents on)", () 
 
     // Settle only one tab — the cohort is still in flight.
     useAppStore.getState().setTabSessionId(ids[0], "sess-a");
-    await flush();
+    await restore.flush();
 
-    const region = transport.onlyRegionView();
+    const region = restore.transport().onlyRegionView();
     expect(region.settlement).toBeNull();
     expect(region.cohort).not.toBeNull();
-    // The projected in-flight cohort mirrors the local one.
-    const local = useAppStore.getState().restoreCohort;
-    expect(region.cohort?.total).toBe(local?.total);
-    expect(new Set(region.cohort?.pending)).toEqual(local?.pending);
-    expect(region.cohort?.failed).toBe(local?.failed);
+    expect(region.cohort?.total).toBe(3);
+    expect(region.cohort?.pending).toEqual([ids[1], ids[2]]);
+    expect(region.cohort?.failed).toBe(0);
   });
 
   it("bulk-retry reconnect dispatches a fresh cohort + settle", async () => {
@@ -408,55 +183,42 @@ describe("restore-cohort mutation cut — cut-vs-local parity (intents on)", () 
     useAppStore.getState().setTabSessionId(ids[0], "sess-a");
     useAppStore.getState().setTabSessionId(ids[1], "sess-b");
     useAppStore.getState().setTerminalDisconnectWithError(ids[2], "refused");
-    await flush();
-    const before = transport.dispatched.length;
+    await restore.flush();
+    const before = restore.transport().dispatched.length;
 
     useAppStore.getState().reconnectFailedRestoreTabs();
     useAppStore.getState().setTabSessionId(ids[2], "sess-c-retry");
-    await flush();
+    await restore.flush();
 
     // A fresh beginCohort covering the retried tab, then its settle.
-    expect(transport.kinds().slice(before)).toEqual(["restore.beginCohort", "restore.settleTab"]);
-    const region = transport.onlyRegionView();
+    expect(restore.transport().kinds().slice(before)).toEqual([
+      "restore.beginCohort",
+      "restore.settleTab",
+    ]);
+    const region = restore.transport().onlyRegionView();
     expect(region.settlement).toMatchObject({ total: 1, restored: 1, failed: 0 });
     expect(region.failedTabIds).toEqual([]);
-    expect(useAppStore.getState().failedRestoreTabIds).toEqual([]);
   });
 
-  it("a stray settle for a non-pending tab dispatches nothing", async () => {
+  it("the region is the sole guard: a stray settle is dispatched but ignored", async () => {
     mockLoad.mockResolvedValue(threeLocalTabsSession());
     await useAppStore.getState().restoreLastSession();
     const ids = restoredTabIds();
     ids.forEach((id, i) => useAppStore.getState().setTabSessionId(id, `sess-${i}`));
-    await flush();
-    const before = transport.dispatched.length;
+    await restore.flush();
+    const settledSeq = restore.transport().onlyRegionView().settlement?.seq;
+    const before = restore.transport().dispatched.length;
 
-    // The cohort has settled — a later settle on the same tab is a no-op locally
-    // and dispatches nothing (mirrors the store ignoring a non-pending settle).
+    // The cohort has settled — a later settle on the same tab is dispatched
+    // unconditionally, but the region ignores a non-pending settle: no new
+    // settlement, so no fresh summary.
     useAppStore.getState().setTerminalDisconnectWithError(ids[0], "later drop");
-    await flush();
-    expect(transport.dispatched.length).toBe(before);
-  });
-});
+    await restore.flush();
 
-describe("restore-cohort mutation cut — flags off (rollback path)", () => {
-  beforeEach(() => {
-    setRestoreIntentsEnabled(false);
-    setRestoreRenderFromProjectionEnabled(false);
-  });
-
-  it("dispatches no intents and drives the cohort locally", async () => {
-    mockLoad.mockResolvedValue(threeLocalTabsSession());
-    await useAppStore.getState().restoreLastSession();
-    const ids = restoredTabIds();
-    useAppStore.getState().setTabSessionId(ids[0], "sess-a");
-    useAppStore.getState().setTabSessionId(ids[1], "sess-b");
-    useAppStore.getState().setTerminalDisconnectWithError(ids[2], "refused");
-    await flush();
-
-    // No mirror reached the region — the pre-cut local path is intact.
-    expect(transport.dispatched).toHaveLength(0);
-    expect(useAppStore.getState().failedRestoreTabIds).toEqual([ids[2]]);
-    expect(useAppStore.getState().restoreCohort).toBeNull();
+    expect(restore.transport().dispatched.length).toBeGreaterThan(before);
+    expect(restore.transport().kinds().slice(before)).toContain("restore.settleTab");
+    const region = restore.transport().onlyRegionView();
+    expect(region.cohort).toBeNull();
+    expect(region.settlement?.seq).toBe(settledSeq);
   });
 });

--- a/src/store/appStore.restoreCohortRenderCut.test.ts
+++ b/src/store/appStore.restoreCohortRenderCut.test.ts
@@ -1,22 +1,20 @@
 /**
- * Restore-cohort render cut (#2241, part of #2206 / #2139).
+ * Restore-cohort summary rendering from the authoritative region (#2206).
  *
- * The render cut fires the aggregate restore/launch summary toast once per new
- * projected settlement `seq` from the `restore-cohort@<clientId>` region, instead
- * of straight from the local reducer — the fired content is the gate-validated
- * local summary, so it is byte-identical to the pre-cut toast.
+ * Since the reducer removal the aggregate restore/launch summary toast is fired
+ * once per new projected settlement `seq` from the `restore-cohort@<clientId>`
+ * region — there is no local reducer path any more.
  *
  * These tests prove:
- * - with the render flag **on** and a live region, the summary fires from the
- *   projection (asynchronously, after the settle round-trips) exactly once;
- * - a dispatch failure falls back to firing the summary locally, so the toast is
- *   never lost (the parity-safe fallback);
- * - with the render flag **off**, the summary fires straight from the local
- *   reducer, synchronously (the pre-cut path).
+ * - a partial restore fires exactly one partial (info) summary from the projection,
+ *   asynchronously (after the settle round-trips), with the bulk-retry action
+ *   attached from the live-filtered projected retry set;
+ * - a full success fires exactly one success summary;
+ * - when the region is unreachable (every dispatch rejected), no toast fires and
+ *   the failure is logged (the authoritative model has no local fallback).
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { flushMacrotask } from "@/test/flushAsync";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 
 const toastSuccess = vi.fn((_m: unknown, _o?: unknown) => undefined);
 const toastError = vi.fn((_m: unknown, _o?: unknown) => undefined);
@@ -73,181 +71,12 @@ import { useAppStore } from "./appStore";
 import { setupConnectionsRegion, seedConnectionsRegion } from "@/test/connectionsHarness";
 import { setupSettingsRegion, seedSettings } from "@/test/settingsRegionTestHarness";
 import { setupAgentsRegion } from "@/test/agentsRegionTestHarness";
-import {
-  setRestoreIntentsEnabled,
-  setRestoreRenderFromProjectionEnabled,
-  setRestoreTransportForTest,
-} from "./restoreCohortBridge";
+import { setupRestoreCohortRegion } from "@/test/restoreCohortHarness";
 import { loadLastSession } from "@/services/lastSessionApi";
 import { getAllLeaves } from "@/utils/panelTree";
 import type { LastSession } from "@/types/lastSession";
-import type {
-  FrameHandler,
-  Intent,
-  IntentAck,
-  ProjectionFrame,
-  SnapshotFrame,
-  Subscription,
-  Transport,
-} from "@/services/transport";
 
 const mockLoad = vi.mocked(loadLastSession);
-
-interface Cohort {
-  pending: string[];
-  total: number;
-  failed: number;
-  failedTabIds: string[];
-  toastId: string | null;
-}
-interface Settlement {
-  seq: number;
-  total: number;
-  restored: number;
-  failed: number;
-  retryTabIds: string[];
-  toastId: string | null;
-}
-interface ClientState {
-  cohort: Cohort | null;
-  failedTabIds: string[];
-  settlement: Settlement | null;
-  settleSeq: number;
-}
-
-/** Subscription-capable twin of the Rust store; `rejectDispatch` forces every
- * intent ack to `rejected` (the transport-down fallback path). */
-class RestoreStoreTransport implements Transport {
-  rejectDispatch = false;
-  private clients = new Map<string, ClientState>();
-  private version = 0;
-  private handlers = new Map<string, FrameHandler[]>();
-
-  async dispatch(intent: Intent): Promise<IntentAck> {
-    // Real IPC round-trips asynchronously — yield before applying/fanning so the
-    // projected settlement (and its toast) never lands synchronously.
-    await Promise.resolve();
-    if (this.rejectDispatch) {
-      return {
-        intentId: intent.intentId,
-        status: "rejected",
-        error: { code: "unavailable", message: "store down" },
-      };
-    }
-    this.apply(intent);
-    this.version += 1;
-    this.fan(intent.clientId);
-    return {
-      intentId: intent.intentId,
-      status: "accepted",
-      produced: [{ region: this.region(intent.clientId), version: this.version }],
-    };
-  }
-
-  private state(clientId: string): ClientState {
-    let s = this.clients.get(clientId);
-    if (!s) {
-      s = { cohort: null, failedTabIds: [], settlement: null, settleSeq: 0 };
-      this.clients.set(clientId, s);
-    }
-    return s;
-  }
-
-  private apply(intent: Intent): void {
-    const p = intent.payload as Record<string, unknown>;
-    const s = this.state(intent.clientId);
-    if (intent.kind === "restore.beginCohort") {
-      const raw = (p.pendingTabIds as string[]) ?? [];
-      const pending: string[] = [];
-      for (const id of raw) if (!pending.includes(id)) pending.push(id);
-      const preFailed = (p.preFailedCount as number | undefined) ?? 0;
-      const total = pending.length + preFailed;
-      if (total === 0) return;
-      s.cohort = {
-        pending,
-        total,
-        failed: preFailed,
-        failedTabIds: [],
-        toastId: (p.toastId as string | undefined) ?? null,
-      };
-      s.failedTabIds = [];
-      if (pending.length === 0) this.settleCohort(intent.clientId);
-    } else if (intent.kind === "restore.settleTab") {
-      if (!s.cohort) return;
-      const tabId = p.tabId as string;
-      const pos = s.cohort.pending.indexOf(tabId);
-      if (pos < 0) return;
-      s.cohort.pending.splice(pos, 1);
-      if (p.outcome === "failed") {
-        s.cohort.failed += 1;
-        if (!s.cohort.failedTabIds.includes(tabId)) s.cohort.failedTabIds.push(tabId);
-      }
-      if (s.cohort.pending.length === 0) this.settleCohort(intent.clientId);
-    }
-  }
-
-  private settleCohort(clientId: string): void {
-    const s = this.state(clientId);
-    const cohort = s.cohort;
-    if (!cohort) return;
-    s.cohort = null;
-    s.failedTabIds = [...cohort.failedTabIds];
-    s.settleSeq += 1;
-    s.settlement = {
-      seq: s.settleSeq,
-      total: cohort.total,
-      restored: cohort.total - cohort.failed,
-      failed: cohort.failed,
-      retryTabIds: [...cohort.failedTabIds],
-      toastId: cohort.toastId,
-    };
-  }
-
-  private regionView(clientId: string) {
-    const s = this.state(clientId);
-    return structuredClone({
-      cohort: s.cohort,
-      failedTabIds: s.failedTabIds,
-      settlement: s.settlement,
-    });
-  }
-
-  private region(clientId: string): string {
-    return `restore-cohort@${clientId}`;
-  }
-
-  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
-    const list = this.handlers.get(region) ?? [];
-    list.push(onFrame);
-    this.handlers.set(region, list);
-    const clientId = region.slice("restore-cohort@".length);
-    return {
-      snapshot: this.snapshot(region, clientId),
-      unsubscribe: () => {
-        this.handlers.set(
-          region,
-          (this.handlers.get(region) ?? []).filter((h) => h !== onFrame)
-        );
-      },
-    };
-  }
-
-  async resync(): Promise<SnapshotFrame | null> {
-    return null;
-  }
-
-  private snapshot(region: string, clientId: string): SnapshotFrame {
-    return { kind: "snapshot", region, version: this.version, view: this.regionView(clientId) };
-  }
-
-  private fan(clientId: string): void {
-    const region = this.region(clientId);
-    const frame: ProjectionFrame = this.snapshot(region, clientId);
-    for (const h of this.handlers.get(region) ?? []) h(frame);
-  }
-}
-
-let transport: RestoreStoreTransport;
 
 function threeLocalTabsSession(): LastSession {
   return {
@@ -275,41 +104,21 @@ function restoredTabIds(): string[] {
     .map((t) => t.id);
 }
 
-/** Let the subscribe/dispatch promise chain settle so projection diffs land. */
-async function settleAsync(): Promise<void> {
-  for (let i = 0; i < 8; i++) await Promise.resolve();
-  await flushMacrotask();
-  for (let i = 0; i < 4; i++) await Promise.resolve();
-}
-
 setupConnectionsRegion();
 setupSettingsRegion();
 setupAgentsRegion();
+const restore = setupRestoreCohortRegion();
 
 beforeEach(() => {
   useAppStore.setState(useAppStore.getInitialState());
   vi.clearAllMocks();
   mockLoad.mockResolvedValue(null);
-  useAppStore.setState({
-    defaultShell: "bash",
-    restoreCohort: null,
-    failedRestoreTabIds: [],
-  });
+  useAppStore.setState({ defaultShell: "bash" });
   seedSettings({ restoreLastSessionOnStartup: true });
   seedConnectionsRegion({ connections: [] });
-  transport = new RestoreStoreTransport();
-  setRestoreTransportForTest(transport);
-  setRestoreIntentsEnabled(true);
-  setRestoreRenderFromProjectionEnabled(true);
 });
 
-afterEach(() => {
-  setRestoreTransportForTest(null);
-  setRestoreIntentsEnabled(null);
-  setRestoreRenderFromProjectionEnabled(null);
-});
-
-describe("restore-cohort render cut — summary fires from the projection", () => {
+describe("restore-cohort summary — fires from the authoritative region", () => {
   it("fires the partial summary from the projected settlement, once, asynchronously", async () => {
     mockLoad.mockResolvedValue(threeLocalTabsSession());
     await useAppStore.getState().restoreLastSession();
@@ -319,10 +128,10 @@ describe("restore-cohort render cut — summary fires from the projection", () =
     useAppStore.getState().setTabSessionId(ids[1], "sess-b");
     useAppStore.getState().setTerminalDisconnectWithError(ids[2], "connection refused");
 
-    // Not fired synchronously — the render cut waits for the projected settlement.
+    // Not fired synchronously — the toast waits for the projected settlement.
     expect(toastInfo).not.toHaveBeenCalled();
 
-    await settleAsync();
+    await restore.flush();
 
     // Exactly one aggregate partial summary, sourced from the projected region.
     expect(toastInfo).toHaveBeenCalledTimes(1);
@@ -334,7 +143,7 @@ describe("restore-cohort render cut — summary fires from the projection", () =
     // The bulk-retry action is attached from the projected retry set (live-filtered).
     const opts = toastInfo.mock.calls[0][1] as { action?: { label: string; onClick: () => void } };
     expect(opts?.action?.label).toBe("Reconnect failed tabs");
-    expect(useAppStore.getState().failedRestoreTabIds).toEqual([ids[2]]);
+    expect(restore.transport().onlyRegionView().failedTabIds).toEqual([ids[2]]);
   });
 
   it("fires the success summary from the projection when every tab connects", async () => {
@@ -345,15 +154,15 @@ describe("restore-cohort render cut — summary fires from the projection", () =
     ids.forEach((id, i) => useAppStore.getState().setTabSessionId(id, `sess-${i}`));
     expect(toastSuccess).not.toHaveBeenCalled();
 
-    await settleAsync();
+    await restore.flush();
 
     expect(toastSuccess).toHaveBeenCalledTimes(1);
     expect(toastInfo).not.toHaveBeenCalled();
     expect(String(toastSuccess.mock.calls[0][0])).toContain("3");
   });
 
-  it("falls back to firing the summary locally when the dispatch is rejected", async () => {
-    transport.rejectDispatch = true;
+  it("fires no toast when the region is unreachable (every dispatch rejected)", async () => {
+    restore.transport().rejectDispatch = true;
     mockLoad.mockResolvedValue(threeLocalTabsSession());
     await useAppStore.getState().restoreLastSession();
     const ids = restoredTabIds();
@@ -362,29 +171,11 @@ describe("restore-cohort render cut — summary fires from the projection", () =
     useAppStore.getState().setTabSessionId(ids[1], "sess-b");
     useAppStore.getState().setTerminalDisconnectWithError(ids[2], "refused");
 
-    await settleAsync();
+    await restore.flush();
 
-    // The rejected mirror can never advance the region, so the fallback fires the
-    // local summary — exactly once, never lost.
-    expect(toastInfo).toHaveBeenCalledTimes(1);
-    expect(useAppStore.getState().failedRestoreTabIds).toEqual([ids[2]]);
-  });
-});
-
-describe("restore-cohort render cut — flag off fires locally (pre-cut path)", () => {
-  beforeEach(() => setRestoreRenderFromProjectionEnabled(false));
-
-  it("fires the summary synchronously from the local reducer", async () => {
-    mockLoad.mockResolvedValue(threeLocalTabsSession());
-    await useAppStore.getState().restoreLastSession();
-    const ids = restoredTabIds();
-
-    useAppStore.getState().setTabSessionId(ids[0], "sess-a");
-    useAppStore.getState().setTabSessionId(ids[1], "sess-b");
-    useAppStore.getState().setTerminalDisconnectWithError(ids[2], "refused");
-
-    // Fired synchronously, before any async round-trip.
-    expect(toastInfo).toHaveBeenCalledTimes(1);
-    expect(useAppStore.getState().failedRestoreTabIds).toEqual([ids[2]]);
+    // The rejected mirror never advances the region — with no local fallback, no
+    // summary fires (the failure is logged to the LogViewer instead).
+    expect(toastInfo).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
   });
 });

--- a/src/store/appStore.restoreSummary.test.ts
+++ b/src/store/appStore.restoreSummary.test.ts
@@ -60,11 +60,13 @@ import { useAppStore } from "./appStore";
 import { setupConnectionsRegion, seedConnectionsRegion } from "@/test/connectionsHarness";
 import { setupSettingsRegion, seedSettings } from "@/test/settingsRegionTestHarness";
 import { setupAgentsRegion } from "@/test/agentsRegionTestHarness";
+import { setupRestoreCohortRegion } from "@/test/restoreCohortHarness";
 import { loadLastSession } from "@/services/lastSessionApi";
 
 setupConnectionsRegion();
 setupSettingsRegion();
 setupAgentsRegion();
+const restore = setupRestoreCohortRegion();
 import { getAllLeaves } from "@/utils/panelTree";
 import type { LastSession } from "@/types/lastSession";
 
@@ -101,10 +103,7 @@ describe("partial-restore summary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockLoad.mockResolvedValue(null);
-    useAppStore.setState({
-      defaultShell: "bash",
-      restoreCohort: null,
-    });
+    useAppStore.setState({ defaultShell: "bash" });
     seedSettings({ restoreLastSessionOnStartup: true });
     seedConnectionsRegion({ connections: [] });
   });
@@ -129,6 +128,7 @@ describe("partial-restore summary", () => {
     expect(toastSuccess).not.toHaveBeenCalled();
 
     useAppStore.getState().setTerminalDisconnectWithError(ids[2], "connection refused");
+    await restore.flush();
 
     // Exactly one aggregate summary, and it is the partial (info) variant.
     expect(toastInfo).toHaveBeenCalledTimes(1);
@@ -147,8 +147,8 @@ describe("partial-restore summary", () => {
 
     useAppStore.getState().setTabSessionId(ids[0], "sess-a");
     useAppStore.getState().setTabSessionId(ids[1], "sess-b");
-    expect(toastSuccess).not.toHaveBeenCalled();
     useAppStore.getState().setTabSessionId(ids[2], "sess-c");
+    await restore.flush();
 
     expect(toastSuccess).toHaveBeenCalledTimes(1);
     expect(toastInfo).not.toHaveBeenCalled();
@@ -162,17 +162,20 @@ describe("partial-restore summary", () => {
     const ids = restoredTabIds();
 
     ids.forEach((id, i) => useAppStore.getState().setTabSessionId(id, `sess-${i}`));
+    await restore.flush();
     expect(toastSuccess).toHaveBeenCalledTimes(1);
 
-    // Later reconnect churn on the same tabs must not re-fire a summary.
+    // Later reconnect churn on the same tabs must not re-fire a summary: the region
+    // ignores a settle for a tab that is not pending in any cohort.
     useAppStore.getState().setTerminalDisconnectWithError(ids[0], "later drop");
     useAppStore.getState().setTabSessionId(ids[0], "sess-0b");
+    await restore.flush();
 
     expect(toastSuccess).toHaveBeenCalledTimes(1);
     expect(toastInfo).not.toHaveBeenCalled();
   });
 
-  it("does not summarize session-id changes that are outside a restore cohort", () => {
+  it("does not summarize session-id changes that are outside a restore cohort", async () => {
     // A plain manual tab, no restore cohort registered.
     seedConnectionsRegion({ connections: [] });
     useAppStore.getState().addTab("Shell", "local", { type: "local", config: { shell: "bash" } });
@@ -180,6 +183,7 @@ describe("partial-restore summary", () => {
 
     useAppStore.getState().setTabSessionId(id, "sess-manual");
     useAppStore.getState().setTerminalDisconnectWithError(id, "boom");
+    await restore.flush();
 
     expect(toastSuccess).not.toHaveBeenCalled();
     expect(toastInfo).not.toHaveBeenCalled();

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -277,10 +277,11 @@ import {
 } from "@/store/settingsBridge";
 import { mirrorBroadcastIntent } from "@/store/broadcastBridge";
 import {
-  expectProjectedRestoreSettlement,
+  currentRestoreCohortView,
   mirrorRestoreBegin,
   mirrorRestoreSettle,
-  restoreRenderFromProjectionEnabled,
+  setRestoreSettlementRenderer,
+  type ProjectedSettlement,
 } from "@/store/restoreCohortBridge";
 import {
   mirrorWorkflowDismissOutput,
@@ -1086,57 +1087,34 @@ export interface AppState
   setTerminalDisconnectWithError: (tabId: string, error: string) => void;
 
   /**
-   * Aggregate feedback for a fan-out restore/launch (#1146, audit G4). When a
-   * restore or workspace launch places N tabs, each reconnects independently
-   * inside its own Terminal.tsx mount, so failures are otherwise only visible
-   * per-tab. This cohort tracks the set of tab ids placed by one restore/launch
-   * and settles them as each connects ({@link setTabSessionId}) or fails
-   * ({@link setTerminalDisconnectWithError}); when the last one settles a single
-   * summary toast is raised. `null` when no restore/launch is in flight.
+   * Register the cohort of tabs placed by a restore/launch (#1146, audit G4).
+   * When a restore or workspace launch places N tabs, each reconnects
+   * independently inside its own Terminal.tsx mount, so failures are otherwise
+   * only visible per-tab. This dispatches `restore.beginCohort` to the
+   * authoritative `restore-cohort@<clientId>` region, which tracks the cohort and
+   * raises a single aggregate summary toast once every tab settles.
    *
-   * `failedTabIds` is the subset of settled tabs that failed and can be
-   * re-driven through the per-tab reconnect path — it feeds the bulk
-   * "Reconnect failed tabs" control (#1227). `toastId`, when present, is the
-   * id of a pending toast this cohort should resolve in place on settle
-   * (used by {@link reconnectFailedRestoreTabs} for pending → result feedback).
-   */
-  restoreCohort: {
-    pending: Set<string>;
-    total: number;
-    failed: number;
-    failedTabIds: Set<string>;
-    toastId?: string | number;
-  } | null;
-  /**
-   * The failed terminal tab ids captured from the most recently settled
-   * restore/launch (or bulk-reconnect) cohort. Drives the bulk "Reconnect
-   * failed tabs" control (#1227, audit M2); empty when there is nothing to
-   * retry. Consumed (cleared) by {@link reconnectFailedRestoreTabs}.
-   */
-  failedRestoreTabIds: string[];
-  /**
-   * Register the cohort of tabs placed by a restore/launch. `pendingTabIds` are
-   * the live terminal tabs that will attempt to connect; `preFailedCount` counts
-   * tabs already known to have failed at build time (e.g. agent-error tabs that
-   * never emit a connect/fail signal). `toastId`, when given, is a pending toast
-   * the settle should resolve in place instead of raising a fresh one. If
-   * nothing is pending, the summary is raised immediately.
+   * `pendingTabIds` are the live terminal tabs that will attempt to connect;
+   * `preFailedCount` counts tabs already known to have failed at build time (e.g.
+   * agent-error tabs that never emit a connect/fail signal). `toastId`, when
+   * given, is a pending toast the settle should resolve in place instead of
+   * raising a fresh one. A cohort with nothing to wait on settles immediately.
    */
   beginRestoreCohort: (
     pendingTabIds: string[],
     preFailedCount: number,
     toastId?: string | number
   ) => void;
-  /** Settle one tab of the active restore cohort; raises the summary once the cohort empties. */
+  /** Settle one tab of the active restore cohort (dispatches `restore.settleTab`);
+   * the region raises the summary once the cohort empties. */
   settleRestoreTab: (tabId: string, outcome: "connected" | "failed") => void;
-  /** Raise the single aggregate summary toast for the settled cohort and clear it. Internal. */
-  settleRestoreCohort: () => void;
   /**
-   * Bulk-retry every failed tab remembered from the last partial restore
-   * ({@link failedRestoreTabIds}) in one action (#1227, audit M2). Re-drives
-   * only those tabs through the existing per-tab {@link reconnectTerminal}
-   * path, registers a fresh cohort so the outcome re-summarizes, and shows a
-   * pending toast that resolves into the aggregate result.
+   * Bulk-retry every failed tab remembered from the last partial restore (the
+   * region's captured failed-tab set, {@link currentRestoreCohortView}) in one
+   * action (#1227, audit M2). Re-drives only the tabs that still exist as live
+   * terminals through the existing per-tab {@link reconnectTerminal} path,
+   * registers a fresh cohort so the outcome re-summarizes, and shows a pending
+   * toast that resolves into the aggregate result.
    */
   reconnectFailedRestoreTabs: () => void;
   setTerminalReconnecting: (tabId: string, reconnecting: boolean) => void;
@@ -5623,95 +5601,29 @@ export const useAppStore = create<AppState>((set, get, store) => {
       }
     },
 
-    // Aggregate partial-restore feedback (#1146, audit G4) + bulk retry (#1227, M2).
-    restoreCohort: null,
-    failedRestoreTabIds: [],
+    // Aggregate partial-restore feedback (#1146, audit G4) + bulk retry (#1227,
+    // M2). Region-authoritative (#2206): the `restore-cohort@<clientId>` store
+    // owns the cohort, the captured failed-tab set and the settlement summary; the
+    // actions below are thin dispatchers, and the summary toast fires from the
+    // projected settlement via the renderer registered at store init (see below).
     beginRestoreCohort: (pendingTabIds, preFailedCount, toastId) => {
-      const pending = new Set(pendingTabIds);
-      const total = pending.size + preFailedCount;
-      if (total === 0) return;
-      frontendLog(
-        "workspace_restore",
-        `restore cohort started: ${total} tab(s), ${pending.size} pending, ${preFailedCount} pre-failed`
-      );
-      // A fresh cohort supersedes any leftover retry set from the prior one.
-      set({
-        restoreCohort: { pending, total, failed: preFailedCount, failedTabIds: new Set(), toastId },
-        failedRestoreTabIds: [],
-      });
-      // A cohort with no live tabs to wait on (e.g. all agent-error) settles now.
-      // Settle locally first so the projected-render summary is registered before
-      // the mirror dispatch (a synchronous transport failure then fires it now).
-      if (pending.size === 0) get().settleRestoreCohort();
-      // Mutation + render cut (#2241): mirror the cohort to the backend
-      // `RestoreCohortStore` and the render region. Off/failure falls back to the
-      // local reducers, which already ran above.
+      // The region folds begin/settle and settles a no-live cohort itself. A
+      // total-0 cohort is a backend no-op, matching the pre-cut early return.
       mirrorRestoreBegin({ pendingTabIds, preFailedCount, toastId });
     },
     settleRestoreTab: (tabId, outcome) => {
-      const cohort = get().restoreCohort;
-      // Ignore a tab that is not pending in the current cohort (mirrors the store):
-      // dispatch no intent for a stray/duplicate settle.
-      if (!cohort || !cohort.pending.has(tabId)) return;
-      const pending = new Set(cohort.pending);
-      pending.delete(tabId);
-      const failed = cohort.failed + (outcome === "failed" ? 1 : 0);
-      // Remember which terminal tabs failed so they can be bulk-reconnected.
-      const failedTabIds = new Set(cohort.failedTabIds);
-      if (outcome === "failed") failedTabIds.add(tabId);
-      set({ restoreCohort: { ...cohort, pending, failed, failedTabIds } });
-      // Settle locally first so the projected-render summary is registered before
-      // the mirror dispatch (see beginRestoreCohort).
-      if (pending.size === 0) get().settleRestoreCohort();
-      // Mutation + render cut (#2241): mirror the settle to the store + region.
+      // Dispatch unconditionally: the region is the sole guard and ignores a settle
+      // for a tab that is not pending in the current cohort (a stray/duplicate, or
+      // a disconnect outside any restore), so nothing settles and no toast fires.
       mirrorRestoreSettle({ tabId, outcome });
     },
-    settleRestoreCohort: () => {
-      const cohort = get().restoreCohort;
-      if (!cohort) return;
-      // Restrict the retry set to tabs that still exist as live terminal tabs (a
-      // frontend concern — it needs the tab registry; the store keeps the raw set).
-      const liveTerminalIds = new Set(
-        collectLiveTabs(get())
-          .filter((t) => t.contentType === "terminal")
-          .map((t) => t.id)
-      );
-      const retryTabIds = [...cohort.failedTabIds].filter((id) => liveTerminalIds.has(id));
-      // Clear first (and record the retry set) so this fires exactly once even
-      // if a stray settle races in.
-      set({ restoreCohort: null, failedRestoreTabIds: retryTabIds });
-      const { total, failed, toastId } = cohort;
-      const restored = total - failed;
-      frontendLog(
-        "workspace_restore",
-        `restore cohort settled: ${restored}/${total} connected, ${failed} failed`
-      );
-      const summary = { total, restored, failed, toastId };
-      const fire = () =>
-        raiseRestoreSummary(summary, retryTabIds, () => get().reconnectFailedRestoreTabs());
-      if (restoreRenderFromProjectionEnabled()) {
-        // Render cut (#2241): fire the summary toast once per new projected
-        // settlement `seq` — the fired content is this gate-validated local summary.
-        // The upcoming begin/settle mirror dispatch drives the region; if it fails,
-        // the fallback fires this same closure, so the toast is never lost. The raw
-        // failed set is the gate baseline (the store keeps the retry set unfiltered).
-        expectProjectedRestoreSettlement(fire, {
-          total,
-          restored,
-          failed,
-          retryTabIds: [...cohort.failedTabIds],
-        });
-      } else {
-        // Pre-cut path: fire straight from the local reducer.
-        fire();
-      }
-    },
     reconnectFailedRestoreTabs: () => {
-      const captured = get().failedRestoreTabIds;
-      // Consume the captured set regardless of outcome.
-      set({ failedRestoreTabIds: [] });
+      // The region keeps the raw captured failed-tab set; consume it here and, as
+      // before, only re-drive tabs that still exist as live terminal tabs (the
+      // live-terminal filter is a frontend concern). The fresh cohort begun below
+      // clears the region's failed set.
+      const captured = currentRestoreCohortView().failedTabIds;
       if (captured.length === 0) return;
-      // Only re-drive tabs that still exist as live terminal tabs.
       const liveTerminalIds = new Set(
         collectLiveTabs(get())
           .filter((t) => t.contentType === "terminal")
@@ -7892,6 +7804,34 @@ useAppStore.subscribe((state, prev) => {
     }
   }
 });
+
+/**
+ * Render a settled restore/launch cohort's aggregate summary toast from the
+ * projected settlement (#2206, reducer removal). Fired once per new monotonic
+ * settlement `seq` by the restore-cohort bridge. The store owns this render because
+ * it needs the tab registry: the region keeps the raw retry set, and the summary's
+ * bulk "Reconnect failed tabs" action is offered only for tabs that still exist as
+ * live terminals (the live-terminal filter, exactly as before).
+ */
+function renderProjectedRestoreSummary(settlement: ProjectedSettlement): void {
+  const { total, restored, failed, retryTabIds, toastId } = settlement;
+  frontendLog(
+    "workspace_restore",
+    `restore cohort settled: ${restored}/${total} connected, ${failed} failed`
+  );
+  const liveTerminalIds = new Set(
+    collectLiveTabs(useAppStore.getState())
+      .filter((t) => t.contentType === "terminal")
+      .map((t) => t.id)
+  );
+  const filtered = retryTabIds.filter((id) => liveTerminalIds.has(id));
+  raiseRestoreSummary({ total, restored, failed, toastId: toastId ?? undefined }, filtered, () =>
+    useAppStore.getState().reconnectFailedRestoreTabs()
+  );
+}
+
+// Wire the projected-settlement render surface to the store once at module init.
+setRestoreSettlementRenderer(renderProjectedRestoreSummary);
 
 /**
  * Get the active tab from the current store state.

--- a/src/store/restoreCohortBridge.test.ts
+++ b/src/store/restoreCohortBridge.test.ts
@@ -1,64 +1,32 @@
 /**
- * Unit tests for the restore-cohort bridge flags + region id (#2241).
+ * Unit tests for the restore-cohort bridge region id + default view (#2206).
  *
- * Behavioural coverage (mirror dispatch, projected-settlement rendering, and the
- * local fallback) lives in `appStore.restoreCohortMutationCut.test.ts` and
- * `appStore.restoreCohortRenderCut.test.ts`, which drive the bridge through the
- * real `appStore` actions.
+ * Behavioural coverage (intent dispatch, projected-settlement rendering, and the
+ * captured failed-tab set) lives in `appStore.restoreCohortMutationCut.test.ts`,
+ * `appStore.restoreCohortRenderCut.test.ts`, `appStore.restoreSummary.test.ts` and
+ * `appStore.bulkReconnect.test.ts`, which drive the bridge through the real
+ * `appStore` actions and the in-memory region twin.
  */
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import {
+  currentRestoreCohortView,
+  EMPTY_RESTORE_COHORT_VIEW,
   restoreCohortRegion,
-  restoreIntentsEnabled,
-  restoreRenderFromProjectionEnabled,
-  setRestoreIntentsEnabled,
-  setRestoreRenderFromProjectionEnabled,
 } from "./restoreCohortBridge";
-
-interface RestoreFlagWindow {
-  __TERMIHUB_RESTORE_INTENTS__?: boolean;
-  __TERMIHUB_RESTORE_RENDER__?: boolean;
-}
-
-afterEach(() => {
-  setRestoreIntentsEnabled(null);
-  setRestoreRenderFromProjectionEnabled(null);
-  const w = window as unknown as RestoreFlagWindow;
-  delete w.__TERMIHUB_RESTORE_INTENTS__;
-  delete w.__TERMIHUB_RESTORE_RENDER__;
-});
-
-describe("restoreCohortBridge flags", () => {
-  it("both flags default on", () => {
-    expect(restoreIntentsEnabled()).toBe(true);
-    expect(restoreRenderFromProjectionEnabled()).toBe(true);
-  });
-
-  it("programmatic overrides win, and null restores the default", () => {
-    setRestoreIntentsEnabled(false);
-    setRestoreRenderFromProjectionEnabled(false);
-    expect(restoreIntentsEnabled()).toBe(false);
-    expect(restoreRenderFromProjectionEnabled()).toBe(false);
-
-    setRestoreIntentsEnabled(null);
-    setRestoreRenderFromProjectionEnabled(null);
-    expect(restoreIntentsEnabled()).toBe(true);
-    expect(restoreRenderFromProjectionEnabled()).toBe(true);
-  });
-
-  it("a window override flips a flag off (rollback switch)", () => {
-    const w = window as unknown as RestoreFlagWindow;
-    w.__TERMIHUB_RESTORE_INTENTS__ = false;
-    w.__TERMIHUB_RESTORE_RENDER__ = false;
-    expect(restoreIntentsEnabled()).toBe(false);
-    expect(restoreRenderFromProjectionEnabled()).toBe(false);
-  });
-});
 
 describe("restoreCohortRegion", () => {
   it("is client-scoped, matching the Rust region id", () => {
     expect(restoreCohortRegion("abc123")).toBe("restore-cohort@abc123");
+  });
+});
+
+describe("currentRestoreCohortView", () => {
+  it("is the empty view before any projection diff", () => {
+    expect(currentRestoreCohortView()).toEqual(EMPTY_RESTORE_COHORT_VIEW);
+    expect(currentRestoreCohortView().cohort).toBeNull();
+    expect(currentRestoreCohortView().failedTabIds).toEqual([]);
+    expect(currentRestoreCohortView().settlement).toBeNull();
   });
 });

--- a/src/store/restoreCohortBridge.ts
+++ b/src/store/restoreCohortBridge.ts
@@ -1,42 +1,38 @@
 /**
- * Restore-cohort projection bridge — Phase 4 step 5a render + mutation cut of the
- * restore-cohort machine (#2241, part of #2206 / #2152 / #2139).
+ * Restore-cohort projection bridge — the restore-cohort machine is now
+ * **region-authoritative** (#2206, Phase 4 step 5; reducer removal after the
+ * render + mutation cut of #2241).
  *
- * The restore-cohort **shadow** (PR #2240) landed a backend-authoritative,
- * client-scoped [`RestoreCohortStore`](../../src-tauri/src/restore_cohort_projection/store.rs)
- * served as the `restore-cohort@<clientId>` projection region, with `restore.*`
- * intents (`restore.beginCohort` / `restore.settleTab`), but nothing in the UI
- * touched it. This step cuts the live UI over to it — the direct analog of the
- * session render cut ({@link import("./useSessionLifecycle")}, #2204), the monitor
- * render + mutation cuts ({@link import("./systemMonitorBridge")}, #2224) and the
- * agents cut ({@link import("./agentsBridge")}, #2226).
+ * The client-scoped [`RestoreCohortStore`](../../src-tauri/src/restore_cohort_projection/store.rs)
+ * served as the `restore-cohort@<clientId>` projection region is the sole source
+ * of truth for the aggregate restore/launch feedback (#1146 / #1227): it owns the
+ * in-flight cohort, the captured failed-tab set, and the monotonic settlement
+ * summary. `appStore` holds no cohort slice — its `beginRestoreCohort` /
+ * `settleRestoreTab` actions are thin dispatchers of the `restore.beginCohort` /
+ * `restore.settleTab` intents, and the aggregate summary toast is fired from the
+ * projected settlement diff (the direct analog of the monitors reducer removal,
+ * {@link import("./systemMonitorBridge")}, #2385, and the transfers one,
+ * {@link import("./transfersBridge")}, #2399).
  *
- * Unlike the declarative render cuts (agents/monitors read a slice from the region
- * every render), the restore-cohort render surface is a single **fire-once side
- * effect**: the aggregate summary toast raised when a restore/launch cohort
- * settles. So the "render cut" here is a projection subscriber that fires the toast
- * exactly once per new monotonic settlement `seq`, driven by the region.
+ * # Render surface: a fire-once settlement side effect
  *
- * # Two independent flags, both on by default
+ * Unlike the declarative render cuts (agents/monitors read a slice every render),
+ * the restore-cohort render surface is a single **fire-once side effect**: the
+ * aggregate summary toast raised when a restore/launch cohort settles. So instead
+ * of a `useProjected*` hook, the bridge fires the toast exactly once per new
+ * monotonic settlement `seq` via a renderer the store registers
+ * ({@link setRestoreSettlementRenderer}). The renderer lives in `appStore` because
+ * firing the toast and intersecting the retry set with the live terminal tabs both
+ * need the tab registry — concerns that deliberately stay frontend-side.
  *
- * - {@link restoreRenderFromProjectionEnabled} (render cut) — when on, the summary
- *   toast is fired under the projected settlement `seq` (validated to faithfully
- *   mirror the locally-computed summary) instead of straight from the local
- *   reducer. Parity-safe: the fired content is the gate-validated local summary, so
- *   it is byte-identical to the pre-cut toast, and any dispatch failure falls back
- *   to firing locally **synchronously**, so the toast can never be lost.
- * - {@link restoreIntentsEnabled} (mutation cut) — when on, the cohort transitions
- *   dispatch `restore.beginCohort` / `restore.settleTab` so the backend store is
- *   authoritative. The local `appStore` reducers stay in place as the resilience /
- *   rollback fallback (removal is a later step).
+ * # What stays frontend
  *
- * The region is populated by these same begin/settle intents, dispatched whenever
- * **either** flag is on ({@link shouldMirrorRestore}); that keeps the render cut
- * independent of the mutation flag (the region is always populated when rendering
- * from it). Overridable at runtime for rollback / tests via
- * `window.__TERMIHUB_RESTORE_RENDER__` / `localStorage["termihub.restoreRender"]`
- * and `window.__TERMIHUB_RESTORE_INTENTS__` / `localStorage["termihub.restoreIntents"]`
- * (set `"false"` to restore the pre-cut local path).
+ * - **The toast itself.** The backend produces the settlement summary (tallies +
+ *   raw retry set + `seq`); rendering it as a `sonner` toast is presentation.
+ * - **The live-terminal filter.** The store keeps the raw failed-tab set; the
+ *   frontend intersects it with its live terminal tabs when it renders the retry
+ *   action and when {@link import("./appStore").AppState.reconnectFailedRestoreTabs}
+ *   re-drives — exactly as before.
  */
 
 import {
@@ -86,97 +82,12 @@ export interface RestoreCohortView {
   settlement: ProjectedSettlement | null;
 }
 
-// ── Feature flags (runtime-flippable so a dev build can verify either path) ────
-
-interface RestoreFlagWindow {
-  __TERMIHUB_RESTORE_RENDER__?: boolean;
-  __TERMIHUB_RESTORE_INTENTS__?: boolean;
-  localStorage?: Storage;
-}
-
-let renderFlagOverride: boolean | null = null;
-let intentsFlagOverride: boolean | null = null;
-
-/** Programmatic override for the render-cut flag (tests, runtime toggle). `null`
- * clears it and falls back to the window/localStorage signal, then the default. */
-export function setRestoreRenderFromProjectionEnabled(value: boolean | null): void {
-  renderFlagOverride = value;
-}
-
-/** Programmatic override for the mutation-cut flag (tests, runtime toggle). */
-export function setRestoreIntentsEnabled(value: boolean | null): void {
-  intentsFlagOverride = value;
-}
-
-/** Read a boolean feature signal from `window`/`localStorage`, else `dflt`. */
-function readFlag(
-  override: boolean | null,
-  windowKey: keyof RestoreFlagWindow,
-  storageKey: string,
-  dflt: boolean
-): boolean {
-  if (override !== null) return override;
-  try {
-    if (typeof window !== "undefined") {
-      const w = window as unknown as RestoreFlagWindow;
-      const wv = w[windowKey];
-      if (typeof wv === "boolean") return wv;
-      const ls = w.localStorage?.getItem(storageKey);
-      if (ls === "true") return true;
-      if (ls === "false") return false;
-    }
-  } catch {
-    // A missing/blocked window or storage just means "use the default".
-  }
-  return dflt;
-}
-
-/**
- * Whether the aggregate restore-cohort summary toast is fired under the projected
- * settlement `seq` (render cut) instead of straight from the local reducer.
- *
- * **On by default.** Parity-safe: the fired content is the local summary validated
- * to faithfully mirror the projected settlement, so the toast is byte-identical to
- * the pre-cut path; a dispatch failure falls back to firing locally. Independent of
- * the mutation cut — the region is populated whenever either flag is on. Overridable
- * via `window.__TERMIHUB_RESTORE_RENDER__` / `localStorage["termihub.restoreRender"]`.
- */
-export function restoreRenderFromProjectionEnabled(): boolean {
-  return readFlag(
-    renderFlagOverride,
-    "__TERMIHUB_RESTORE_RENDER__",
-    "termihub.restoreRender",
-    true
-  );
-}
-
-/**
- * Whether the cohort transitions (`beginRestoreCohort` / `settleRestoreTab`)
- * dispatch `restore.beginCohort` / `restore.settleTab` intents so the backend
- * {@link import("../../src-tauri/src/restore_cohort_projection/store").RestoreCohortStore}
- * is authoritative (mutation cut).
- *
- * **On by default.** The local `appStore` reducers stay in place as the render
- * source and the resilience / rollback fallback (removal is a later step) — a
- * dispatch failure is logged and the local mutation continues, so a backend hiccup
- * can never break restore feedback. Overridable via
- * `window.__TERMIHUB_RESTORE_INTENTS__` / `localStorage["termihub.restoreIntents"]`.
- */
-export function restoreIntentsEnabled(): boolean {
-  return readFlag(
-    intentsFlagOverride,
-    "__TERMIHUB_RESTORE_INTENTS__",
-    "termihub.restoreIntents",
-    true
-  );
-}
-
-/** The begin/settle intents are dispatched whenever either flag is on: the
- * mutation cut needs them for authority, and the render cut needs them to keep the
- * region populated (making the render cut independent of the mutation flag). */
-function shouldMirrorRestore(): boolean {
-  return restoreIntentsEnabled() || restoreRenderFromProjectionEnabled();
-}
+/** The empty view returned before the first projection diff lands. */
+export const EMPTY_RESTORE_COHORT_VIEW: RestoreCohortView = {
+  cohort: null,
+  failedTabIds: [],
+  settlement: null,
+};
 
 // ── Transport + client-scoped region client (lazy, mirrors the layout slice) ───
 
@@ -190,15 +101,19 @@ let transportInstance: Transport | null = null;
 let regionClient: ProjectionClient | null = null;
 let startPromise: Promise<ProjectionClient> | null = null;
 
+/** The last projected view received — the frontend's current picture of the
+ * authoritative cohort state, read synchronously by the store's cohort actions. */
+let lastView: RestoreCohortView = EMPTY_RESTORE_COHORT_VIEW;
+
 /** Inject a transport for tests; `null` restores the lazily-created real one and
- * drops any active subscription and pending settlement. */
+ * drops any active subscription and cached view. */
 export function setRestoreTransportForTest(t: Transport | null): void {
   regionClient?.stop();
   regionClient = null;
   startPromise = null;
   transportInstance = t;
   lastObservedSeq = 0;
-  pendingSettlement = null;
+  lastView = EMPTY_RESTORE_COHORT_VIEW;
 }
 
 function transport(): Transport {
@@ -212,7 +127,7 @@ function transport(): Transport {
  * Ensure the `restore-cohort@<clientId>` region client is subscribed so settlement
  * diffs are received and the summary toast can be fired from them. Idempotent and
  * de-duplicated across concurrent callers; a transport/subscribe failure is logged
- * and rethrown so the caller can fall back to the local reducer.
+ * and rethrown so the caller can log a bridge fallback.
  */
 export function ensureRestoreSubscribed(): Promise<ProjectionClient> {
   if (regionClient) return Promise.resolve(regionClient);
@@ -240,94 +155,47 @@ export function stopRestoreSubscription(): void {
   regionClient = null;
   startPromise = null;
   lastObservedSeq = 0;
-  pendingSettlement = null;
+  lastView = EMPTY_RESTORE_COHORT_VIEW;
+}
+
+/**
+ * The current projected restore-cohort view. Since the region is authoritative,
+ * this is the frontend's picture of the cohort state — read by
+ * {@link import("./appStore").AppState.reconnectFailedRestoreTabs} for the captured
+ * failed-tab set. Empty until the first projection diff lands.
+ */
+export function currentRestoreCohortView(): RestoreCohortView {
+  return lastView;
 }
 
 // ── Fire-once settlement rendering ─────────────────────────────────────────────
 
-/**
- * A settlement awaiting its toast: the local closure that fires it (using the
- * gate-validated local summary) plus the expected numbers used to check the
- * projection faithfully mirrors it. Set by {@link expectProjectedRestoreSettlement}
- * when the render cut is on; consumed exactly once — by the projection subscriber
- * on the matching `seq` (the happy path) or by {@link firePendingRestoreFallback}
- * on a dispatch failure (the fallback). Whichever runs first clears it, so the
- * toast fires exactly once.
- */
-interface PendingSettlement {
-  fire: () => void;
-  expected: { total: number; restored: number; failed: number; retryTabIds: string[] };
-}
+/** Renders a settled cohort's aggregate summary (fires the toast, intersecting the
+ * retry set with the live terminal tabs). Registered by `appStore`, which owns the
+ * tab registry the render needs. */
+export type RestoreSettlementRenderer = (settlement: ProjectedSettlement) => void;
 
-let pendingSettlement: PendingSettlement | null = null;
+let settlementRenderer: RestoreSettlementRenderer | null = null;
 let lastObservedSeq = 0;
 
-/**
- * Register the local summary to be fired under the projected settlement `seq`
- * (render cut). Called by `appStore.settleRestoreCohort` when the render flag is on,
- * in place of firing the toast directly. The subsequent begin/settle mirror
- * dispatch drives the region; its diff fires this via {@link onRegionChange}, or a
- * dispatch failure fires it via {@link firePendingRestoreFallback}.
- */
-export function expectProjectedRestoreSettlement(
-  fire: () => void,
-  expected: { total: number; restored: number; failed: number; retryTabIds: string[] }
-): void {
-  pendingSettlement = { fire, expected };
+/** Register the settlement renderer (the store's toast + live-filter logic). `null`
+ * clears it (tests). Called once at store init. */
+export function setRestoreSettlementRenderer(fn: RestoreSettlementRenderer | null): void {
+  settlementRenderer = fn;
 }
 
-/** Whether the projected settlement faithfully mirrors the locally-computed one:
- * identical tallies and the same raw failed-tab set (the backend keeps the retry
- * set raw; the frontend live-filters it, so compare against the raw expectation). */
-function settlementMirrors(
-  settlement: ProjectedSettlement,
-  expected: PendingSettlement["expected"]
-): boolean {
-  return (
-    settlement.total === expected.total &&
-    settlement.restored === expected.restored &&
-    settlement.failed === expected.failed &&
-    sameSet(settlement.retryTabIds, expected.retryTabIds)
-  );
-}
-
-/** Unordered set equality over two string arrays. */
-function sameSet(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) return false;
-  const set = new Set(a);
-  return b.every((id) => set.has(id));
-}
-
-/** React to a region diff: fire the pending settlement once per new `seq`. */
+/** React to a region diff: cache the view, and fire the settlement renderer once
+ * per new monotonic `seq` so the aggregate summary toast appears exactly once. */
 function onRegionChange(state: ProjectionCacheState): void {
-  const view = state.view as RestoreCohortView | undefined;
-  const settlement = view?.settlement;
+  const view = (state.view as RestoreCohortView | undefined) ?? EMPTY_RESTORE_COHORT_VIEW;
+  lastView = view;
+  const settlement = view.settlement;
   if (!settlement || settlement.seq <= lastObservedSeq) return;
   lastObservedSeq = settlement.seq;
-  const pending = pendingSettlement;
-  if (!pending) return; // already fired locally, or nothing awaiting render
-  pendingSettlement = null;
-  if (!settlementMirrors(settlement, pending.expected)) {
-    // Not a faithful mirror — still fire the local summary (never lose the toast),
-    // but log the divergence so the render-cut drift is visible.
-    logRestoreBridgeFallback("settlement", new Error("projected settlement diverged from local"));
-  }
-  pending.fire();
+  settlementRenderer?.(settlement);
 }
 
-/** Fire a pending settlement's local toast now (the fallback path), if one is
- * awaiting. Called when a begin/settle mirror dispatch cannot reach the region
- * (synchronous transport failure, rejected ack, or async error), so the projected
- * `seq` will never arrive — the toast must still fire. No-op if already consumed. */
-function firePendingRestoreFallback(reason: string, err: unknown): void {
-  const pending = pendingSettlement;
-  if (!pending) return;
-  pendingSettlement = null;
-  logRestoreBridgeFallback(reason, err);
-  pending.fire();
-}
-
-// ── Mutation cut: begin/settle intent dispatch (also seeds the render region) ──
+// ── Mutation: begin/settle intent dispatch (also seeds the render region) ──────
 
 /** Dispatch a `restore.*` intent, resolving with the ack (parity tests). */
 export function dispatchRestoreIntent(
@@ -337,26 +205,21 @@ export function dispatchRestoreIntent(
   return transport().dispatch({ intentId: newIntentId(), kind, payload, clientId });
 }
 
-/** Fire a `restore.*` mirror intent, keeping the backend store authoritative and
- * the render region populated. Any failure falls back to firing the pending
- * settlement's local toast so a bridge hiccup never loses the summary and never
- * disrupts the local reducer path. A no-op when both flags are off (pure rollback).
- * A synchronous transport-construction failure (non-Tauri, no socket) fires the
- * fallback synchronously — preserving the pre-cut synchronous toast in that env. */
+/** Fire a `restore.*` intent against the authoritative region and keep the
+ * subscription warm so the settlement diff (and its toast) arrives. Best-effort:
+ * any failure is logged and swallowed so a bridge/transport hiccup never throws out
+ * of a store action. A synchronous transport-construction failure (non-Tauri, no
+ * socket) is caught the same way. */
 function mirrorRestore(
   kind: "restore.beginCohort" | "restore.settleTab",
   payload: Record<string, unknown>
 ): void {
-  if (!shouldMirrorRestore()) {
-    // Both flags off: the local reducer already fired the toast; nothing to mirror.
-    return;
-  }
   // Keep the subscription warm so settlement diffs are received. Guarded because a
   // non-Tauri env without a socket throws *synchronously* from transport
-  // construction (not as a rejection) — the dispatch below then fires the fallback.
+  // construction (not as a rejection) — logged via the dispatch catch below.
   try {
     void ensureRestoreSubscribed().catch(() => {
-      /* logged in ensureRestoreSubscribed; fallback handled per-dispatch below */
+      /* logged in ensureRestoreSubscribed */
     });
   } catch {
     /* handled by the dispatch try/catch below */
@@ -365,22 +228,19 @@ function mirrorRestore(
   try {
     dispatchPromise = dispatchRestoreIntent(kind, payload);
   } catch (err) {
-    // Synchronous transport-construction failure — fire the fallback now so the
-    // toast still appears synchronously (the pre-cut behaviour without a transport).
-    firePendingRestoreFallback(kind, err);
+    logRestoreBridgeFallback(kind, err);
     return;
   }
   void dispatchPromise
     .then((ack) => {
       if (ack.status === "rejected") {
-        firePendingRestoreFallback(kind, new Error(ack.error?.message ?? "rejected"));
+        logRestoreBridgeFallback(kind, new Error(ack.error?.message ?? "rejected"));
       }
-      // Accepted: the region diff will fire the pending settlement via onRegionChange.
     })
-    .catch((err) => firePendingRestoreFallback(kind, err));
+    .catch((err) => logRestoreBridgeFallback(kind, err));
 }
 
-/** Mirror `restore.beginCohort` (register a restore/launch cohort). */
+/** Dispatch `restore.beginCohort` (register a restore/launch cohort). */
 export function mirrorRestoreBegin(payload: {
   pendingTabIds: string[];
   preFailedCount: number;
@@ -394,7 +254,7 @@ export function mirrorRestoreBegin(payload: {
   mirrorRestore("restore.beginCohort", body);
 }
 
-/** Mirror `restore.settleTab` (settle one tab of the active cohort). */
+/** Dispatch `restore.settleTab` (settle one tab of the active cohort). */
 export function mirrorRestoreSettle(payload: {
   tabId: string;
   outcome: "connected" | "failed";
@@ -402,8 +262,8 @@ export function mirrorRestoreSettle(payload: {
   mirrorRestore("restore.settleTab", { tabId: payload.tabId, outcome: payload.outcome });
 }
 
-/** Log a bridge fallback so the local-path recovery is visible in the LogViewer. */
+/** Log a bridge failure so a dropped restore summary is visible in the LogViewer. */
 export function logRestoreBridgeFallback(kind: string, err: unknown): void {
   const message = err instanceof Error ? err.message : String(err);
-  frontendLog("restore_cohort_bridge", `${kind} fell back to local restore summary: ${message}`);
+  frontendLog("restore_cohort_bridge", `${kind} restore intent failed: ${message}`);
 }

--- a/src/test/restoreCohortHarness.ts
+++ b/src/test/restoreCohortHarness.ts
@@ -1,0 +1,265 @@
+/**
+ * Test harness for the region-authoritative restore-cohort domain (#2206).
+ *
+ * Since the reducer removal, the `restore-cohort@<clientId>` region owns the whole
+ * aggregate restore/launch feedback machine (#1146 / #1227): the in-flight cohort,
+ * the captured failed-tab set, and the monotonic settlement summary. `appStore`
+ * holds no cohort slice — its `beginRestoreCohort` / `settleRestoreTab` actions
+ * dispatch `restore.*` intents, and the summary toast fires from the projected
+ * settlement diff. Tests therefore drive the cohort through those actions and let
+ * the region fold and fan the result back.
+ *
+ * {@link FakeRestoreCohortTransport} is an in-memory twin of the Rust
+ * `RestoreCohortStore` that folds `restore.beginCohort` / `restore.settleTab` with
+ * the same semantics (dedupe, no-live immediate settle, stray-settle ignore,
+ * monotonic settlement `seq`) and fans a client-scoped snapshot to subscribers on
+ * every mutation. Dispatch resolves on a microtask so the projected settlement (and
+ * its toast) lands asynchronously, exactly like the real IPC round-trip.
+ *
+ * {@link setupRestoreCohortRegion} installs a fresh transport per test and returns
+ * accessors for the live transport plus a {@link RestoreCohortHandle.flush} that
+ * drains the dispatch → fan → render chain.
+ */
+
+import { afterEach, beforeEach } from "vitest";
+
+import { flushMacrotask } from "@/test/flushAsync";
+import { setRestoreTransportForTest, stopRestoreSubscription } from "@/store/restoreCohortBridge";
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+
+const REGION_PREFIX = "restore-cohort@";
+
+interface Cohort {
+  pending: string[];
+  total: number;
+  failed: number;
+  failedTabIds: string[];
+  toastId: string | null;
+}
+
+interface Settlement {
+  seq: number;
+  total: number;
+  restored: number;
+  failed: number;
+  retryTabIds: string[];
+  toastId: string | null;
+}
+
+interface ClientState {
+  cohort: Cohort | null;
+  failedTabIds: string[];
+  settlement: Settlement | null;
+  settleSeq: number;
+}
+
+/** The region snapshot the Rust `ClientState::to_view` serialises. */
+export interface RestoreCohortRegionView {
+  cohort: Cohort | null;
+  failedTabIds: string[];
+  settlement: Settlement | null;
+}
+
+/**
+ * An in-memory substrate double for the client-scoped restore-cohort region,
+ * folding `restore.*` intents like the Rust `RestoreCohortStore` and fanning a
+ * client snapshot on every mutation. Faithful to the store's semantics so a
+ * client-dispatched begin/settle round-trips back into the projected view exactly
+ * as it would in production.
+ */
+export class FakeRestoreCohortTransport implements Transport {
+  /** Every intent dispatched, in order (assertion helper). */
+  dispatched: Intent[] = [];
+  /** Force every dispatch ack to `rejected` (the transport-down path). */
+  rejectDispatch = false;
+  private clients = new Map<string, ClientState>();
+  private version = 0;
+  private handlers = new Map<string, FrameHandler[]>();
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    // Real IPC round-trips asynchronously — yield before applying/fanning so the
+    // projected settlement (and its toast) never lands synchronously.
+    await Promise.resolve();
+    if (this.rejectDispatch) {
+      return {
+        intentId: intent.intentId,
+        status: "rejected",
+        error: { code: "unavailable", message: "store down" },
+      };
+    }
+    this.apply(intent);
+    this.version += 1;
+    this.fan(intent.clientId);
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: this.region(intent.clientId), version: this.version }],
+    };
+  }
+
+  /** Intent kinds dispatched, in order (assertion helper). */
+  kinds(): string[] {
+    return this.dispatched.map((i) => i.kind);
+  }
+
+  /** The single per-session client's region view (there is one client id). */
+  onlyRegionView(): RestoreCohortRegionView {
+    const [id] = [...this.clients.keys()];
+    return this.regionView(id ?? "");
+  }
+
+  private state(clientId: string): ClientState {
+    let s = this.clients.get(clientId);
+    if (!s) {
+      s = { cohort: null, failedTabIds: [], settlement: null, settleSeq: 0 };
+      this.clients.set(clientId, s);
+    }
+    return s;
+  }
+
+  private apply(intent: Intent): void {
+    const p = intent.payload as Record<string, unknown>;
+    const s = this.state(intent.clientId);
+    switch (intent.kind) {
+      case "restore.beginCohort": {
+        const raw = (p.pendingTabIds as string[]) ?? [];
+        const pending: string[] = [];
+        for (const id of raw) if (!pending.includes(id)) pending.push(id);
+        const preFailed = (p.preFailedCount as number | undefined) ?? 0;
+        const total = pending.length + preFailed;
+        if (total === 0) break;
+        s.cohort = {
+          pending,
+          total,
+          failed: preFailed,
+          failedTabIds: [],
+          toastId: (p.toastId as string | undefined) ?? null,
+        };
+        s.failedTabIds = [];
+        if (pending.length === 0) this.settleCohort(intent.clientId);
+        break;
+      }
+      case "restore.settleTab": {
+        if (!s.cohort) break;
+        const tabId = p.tabId as string;
+        const pos = s.cohort.pending.indexOf(tabId);
+        if (pos < 0) break;
+        s.cohort.pending.splice(pos, 1);
+        if (p.outcome === "failed") {
+          s.cohort.failed += 1;
+          if (!s.cohort.failedTabIds.includes(tabId)) s.cohort.failedTabIds.push(tabId);
+        }
+        if (s.cohort.pending.length === 0) this.settleCohort(intent.clientId);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  private settleCohort(clientId: string): void {
+    const s = this.state(clientId);
+    const cohort = s.cohort;
+    if (!cohort) return;
+    s.cohort = null;
+    s.failedTabIds = [...cohort.failedTabIds];
+    s.settleSeq += 1;
+    s.settlement = {
+      seq: s.settleSeq,
+      total: cohort.total,
+      restored: cohort.total - cohort.failed,
+      failed: cohort.failed,
+      retryTabIds: [...cohort.failedTabIds],
+      toastId: cohort.toastId,
+    };
+  }
+
+  private regionView(clientId: string): RestoreCohortRegionView {
+    const s = this.state(clientId);
+    return structuredClone({
+      cohort: s.cohort,
+      failedTabIds: s.failedTabIds,
+      settlement: s.settlement,
+    });
+  }
+
+  private region(clientId: string): string {
+    return `${REGION_PREFIX}${clientId}`;
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    const list = this.handlers.get(region) ?? [];
+    list.push(onFrame);
+    this.handlers.set(region, list);
+    const clientId = region.slice(REGION_PREFIX.length);
+    return {
+      snapshot: this.snapshot(region, clientId),
+      unsubscribe: () => {
+        this.handlers.set(
+          region,
+          (this.handlers.get(region) ?? []).filter((h) => h !== onFrame)
+        );
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string, clientId: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: this.regionView(clientId) };
+  }
+
+  private fan(clientId: string): void {
+    const region = this.region(clientId);
+    const frame: ProjectionFrame = this.snapshot(region, clientId);
+    for (const h of this.handlers.get(region) ?? []) h(frame);
+  }
+}
+
+/** Drain the dispatch → fan → onChange → render chain so projection diffs (and the
+ * settlement toast) land. Microtasks bracket a single macrotask to cover the async
+ * dispatch and the ProjectionClient's own scheduling. */
+export async function flushRestore(): Promise<void> {
+  for (let i = 0; i < 8; i++) await Promise.resolve();
+  await flushMacrotask();
+  for (let i = 0; i < 4; i++) await Promise.resolve();
+}
+
+/** Accessors returned by {@link setupRestoreCohortRegion}. */
+export interface RestoreCohortHandle {
+  /** The transport installed for the current test. */
+  transport: () => FakeRestoreCohortTransport;
+  /** Drain the dispatch → fan → render chain (alias of {@link flushRestore}). */
+  flush: () => Promise<void>;
+}
+
+/**
+ * Install a fresh {@link FakeRestoreCohortTransport} into the restore-cohort bridge
+ * for each test (before-each), and drop the subscription after each. Call at the
+ * top of a test module; use the returned {@link RestoreCohortHandle.transport} to
+ * inspect dispatched intents / the projected region, and
+ * {@link RestoreCohortHandle.flush} to await settlement.
+ */
+export function setupRestoreCohortRegion(): RestoreCohortHandle {
+  let current: FakeRestoreCohortTransport;
+  beforeEach(() => {
+    current = new FakeRestoreCohortTransport();
+    setRestoreTransportForTest(current);
+  });
+  afterEach(() => {
+    stopRestoreSubscription();
+    setRestoreTransportForTest(null);
+  });
+  return { transport: () => current, flush: flushRestore };
+}


### PR DESCRIPTION
Phase-4 restore-cohort domain reducer-removal — **replaces #2435** (which had a 105-char commit subject that failed commitlint's 100-char header limit; recommitted here as one compliant commit, no force-push). Identical diff.

Makes the `restore-cohort@<clientId>` region authoritative and deletes the appStore `restoreCohort`/`failedRestoreTabIds` slice + `settleRestoreCohort` reducer (0 component readers — contained appStore-internal inversion). `beginRestoreCohort`/`settleRestoreTab` are now thin intent dispatchers; the summary toast fires from the projected settlement; `reconnectFailedRestoreTabs` reads `currentRestoreCohortView().failedTabIds`. Non-lossy (client-owned, no server feed). Added `src/test/restoreCohortHarness.ts` region twin; full frontend suite green (4873) + Rust restore_cohort_projection (20) locally.

Part of #2206.