### PR TITLE
feat(session): session_id->tab_id identity bridge + initial-connect fold (Closes #2431)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -20,6 +20,7 @@ use crate::session::line_ending::LineEnding;
 use crate::session::manager::{
     PersistentSessionSummary, SessionInfo, SessionLogStatus, SessionManager,
 };
+use crate::session_projection::projection::fold_session_transition;
 use crate::system_monitor_projection::projection::fold_monitor_transition;
 use crate::utils::errors::TerminalError;
 use crate::utils::fs::file_name_of;
@@ -59,16 +60,51 @@ pub async fn create_connection(
     conn_manager
         .resolve_jump_host_refs(&mut settings, None)
         .map_err(|e| TerminalError::ConnectionFailed(e.to_string()))?;
-    manager
+
+    // Server-authority fold (#2431): make the *initial* connect's lifecycle
+    // server-authoritative in the shared `session-lifecycle` region, keyed by the
+    // frontend tab id this attempt carries in its `connect_id`. Only the initial
+    // attempt (`retryCount == 0`) is folded: a reconnect attempt's lifecycle is
+    // owned by the client + backend reconnect timer (#2203), and a failed connect
+    // is deliberately left to the client — the frontend silently auto-retries an
+    // agent connect without an intent, so folding `connect_failed` here would
+    // diverge. The `connect` → `connected` edge, by contrast, converges exactly
+    // with the client's `session.connect` / `session.connected` dispatch, so both
+    // running is a benign convergent double-write. Additive; see
+    // `fold_session_transition`.
+    let initial_tab_id = initial_connect_tab_id(connect_id.as_deref());
+    if let Some(tab_id) = &initial_tab_id {
+        fold_session_transition(&app_handle, |store| store.connect(tab_id));
+    }
+
+    let result = manager
         .create_connection(
             &type_id,
             settings,
             agent_id.as_deref(),
             connect_id.as_deref(),
             spawned.unwrap_or(false),
-            app_handle,
+            app_handle.clone(),
         )
-        .await
+        .await;
+
+    if let (Some(tab_id), Ok(_)) = (&initial_tab_id, &result) {
+        fold_session_transition(&app_handle, |store| store.connected(tab_id));
+    }
+    result
+}
+
+/// The frontend `tab_id` to fold an *initial*-connect lifecycle edge for, parsed
+/// from a `connect_id` of the form `${tabId}:${retryCount}` (#2431).
+///
+/// Returns `Some(tab_id)` only for the initial attempt (`retryCount == 0`).
+/// Reconnect attempts (`retryCount > 0`) and any `connect_id` not carrying the
+/// tab-id form (e.g. the internal agent-setup session, which passes `None`) yield
+/// `None`: those lifecycle edges are owned by the client and the backend reconnect
+/// timer, not this fold.
+fn initial_connect_tab_id(connect_id: Option<&str>) -> Option<String> {
+    let (tab_id, retry) = connect_id?.rsplit_once(':')?;
+    (retry == "0" && !tab_id.is_empty()).then(|| tab_id.to_string())
 }
 
 /// Cancel an in-flight (still connecting) session by its `connect_id`.

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -232,6 +232,19 @@ type OutputBuffers = Arc<StdMutex<HashMap<String, Arc<StdMutex<RingBuffer>>>>>;
 /// session without disturbing the reader.
 type SessionLoggers = Arc<StdMutex<HashMap<String, Arc<StdMutex<SessionLogger>>>>>;
 
+/// Backend `session_id` (uuid) → frontend `tab_id` identity bridge (#2431).
+///
+/// The shared `session-lifecycle` projection region is keyed by the **frontend
+/// tab id** (deliberately — it survives a reconnect even as the backend
+/// `session_id` changes; see `src/store/sessionBridge.ts`). Backend sources of
+/// lifecycle transitions (`create_connection`, the `terminal-exit` emission,
+/// `close_session`) only know the uuid `session_id` / the caller's `connect_id`,
+/// so without this map the server could not address a session's tab-id-keyed
+/// region entry. `create_connection` records the mapping (parsing the tab id from
+/// `connect_id = ${tabId}:${retryCount}`), and every session-removal path clears
+/// it, so the map tracks exactly the live sessions that carry a tab id.
+type SessionTabIds = Arc<StdMutex<HashMap<String, String>>>;
+
 /// Status of a session's output logging, returned to the frontend.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -286,6 +299,10 @@ pub struct SessionManager {
     /// each emitted chunk through the matching logger, so a session's transcript
     /// captures exactly what the frontend receives — for every session type.
     pub(super) session_loggers: SessionLoggers,
+    /// Backend `session_id` → frontend `tab_id` identity bridge (#2431). See
+    /// [`SessionTabIds`]. Populated in [`Self::create_connection`] from the
+    /// caller's `connect_id`, cleared on every session-removal path.
+    pub(super) session_tab_ids: SessionTabIds,
 }
 
 /// Removes a `connect_id` from the [`SessionManager::connecting`] map when the
@@ -302,6 +319,21 @@ impl Drop for ConnectingGuard {
             map.remove(&self.id);
         }
     }
+}
+
+/// Extract the frontend `tab_id` from a `connect_id` of the form
+/// `${tabId}:${retryCount}` (#2431).
+///
+/// The frontend builds `connect_id = ${tabId}:${retryCount}` (`Terminal.tsx`);
+/// the retry count is a trailing numeric segment, so the tab id is everything
+/// before the last `:`. A `connect_id` with no `:` (an unexpected form) yields
+/// `None` rather than guessing. An empty tab id is likewise rejected.
+fn tab_id_from_connect_id(connect_id: &str) -> Option<String> {
+    connect_id
+        .rsplit_once(':')
+        .map(|(tab_id, _retry)| tab_id)
+        .filter(|tab_id| !tab_id.is_empty())
+        .map(str::to_string)
 }
 
 impl SessionManager {
@@ -335,6 +367,7 @@ impl SessionManager {
             connecting: Arc::new(StdMutex::new(HashMap::new())),
             output_buffers: Arc::new(StdMutex::new(HashMap::new())),
             session_loggers: Arc::new(StdMutex::new(HashMap::new())),
+            session_tab_ids: Arc::new(StdMutex::new(HashMap::new())),
         }
     }
 
@@ -626,6 +659,19 @@ impl SessionManager {
             );
         }
 
+        // Record the backend `session_id` → frontend `tab_id` identity bridge
+        // (#2431) so server-side lifecycle sources can address this session's
+        // tab-id-keyed `session-lifecycle` region entry. The tab id is the
+        // `connect_id` up to its trailing `:${retryCount}` (see `Terminal.tsx`);
+        // a session created without a `connect_id` (e.g. the internal agent-setup
+        // session) carries no tab and is simply not mapped.
+        if let Some(tab_id) = connect_id.and_then(tab_id_from_connect_id) {
+            self.session_tab_ids
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .insert(session_id.clone(), tab_id);
+        }
+
         // Determine if we should wait for screen clear (initial command).
         let has_initial_command = settings
             .get("initialCommand")
@@ -637,6 +683,7 @@ impl SessionManager {
         let capture = self.ensure_output_buffer(&session_id);
         let output_buffers = self.output_buffers.clone();
         let session_loggers = self.session_loggers.clone();
+        let session_tab_ids = self.session_tab_ids.clone();
         let sid = session_id.clone();
         tokio::spawn(async move {
             Self::run_output_reader(
@@ -648,6 +695,7 @@ impl SessionManager {
                 capture,
                 output_buffers,
                 session_loggers,
+                session_tab_ids,
             )
             .await;
         });
@@ -793,7 +841,33 @@ impl SessionManager {
             entry.connection.disconnect().await.ok();
             info!(session_id, "Closed session");
         }
+        // Clear the identity bridge entry (#2431) — the session is gone, so its
+        // tab mapping must not linger.
+        self.session_tab_ids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(session_id);
         Ok(())
+    }
+
+    /// The frontend `tab_id` that owns a backend `session_id`, or `None` for a
+    /// session created without a `connect_id` (no tab) or already removed (#2431).
+    ///
+    /// The lookup backing the server-authoritative `session-lifecycle` fold: a
+    /// backend lifecycle source that knows only the uuid `session_id` (the
+    /// `terminal-exit` emission, `close_session`) resolves it to the tab id the
+    /// region is keyed by. The initial-connect fold (`create_connection`) reads
+    /// the tab id straight off the `connect_id`, so this uuid→tab lookup is only
+    /// consumed by the *deferred* drop / disconnect folds (see #2205 and the
+    /// follow-up); the map it reads is populated and cleaned up live, and the
+    /// lookup is covered by unit tests.
+    #[allow(dead_code)] // staged API: the deferred drop / disconnect folds consume this (#2205).
+    pub fn tab_id_for(&self, session_id: &str) -> Option<String> {
+        self.session_tab_ids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(session_id)
+            .cloned()
     }
 
     /// List all active sessions.
@@ -1261,6 +1335,7 @@ impl SessionManager {
     /// Coalesces pending output chunks into a single event (up to
     /// `MAX_COALESCE_BYTES`) to reduce IPC overhead.
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn run_output_reader<E: EventEmitter>(
         session_id: String,
         mut output_rx: tokio::sync::mpsc::Receiver<Vec<u8>>,
@@ -1270,6 +1345,7 @@ impl SessionManager {
         capture: Arc<StdMutex<RingBuffer>>,
         output_buffers: OutputBuffers,
         session_loggers: SessionLoggers,
+        session_tab_ids: SessionTabIds,
     ) {
         // Phase 1: optionally buffer until the screen-clear sequence.
         if wait_for_clear {
@@ -1302,6 +1378,7 @@ impl SessionManager {
                             &sessions,
                             &output_buffers,
                             &session_loggers,
+                            &session_tab_ids,
                         )
                         .await;
                         return;
@@ -1360,6 +1437,7 @@ impl SessionManager {
             &sessions,
             &output_buffers,
             &session_loggers,
+            &session_tab_ids,
         )
         .await;
     }
@@ -1382,6 +1460,7 @@ impl SessionManager {
     /// connection drops, the daemon process on the remote host survives. The
     /// `PersistentRecord` must be kept so that the next `attach_persistent_tab`
     /// call can re-create the `RemoteProxy` and reconnect to the surviving daemon.
+    #[allow(clippy::too_many_arguments)]
     async fn emit_and_cleanup<E: EventEmitter>(
         session_id: &str,
         data: Vec<u8>,
@@ -1389,6 +1468,7 @@ impl SessionManager {
         sessions: &Arc<Mutex<HashMap<String, SessionEntry>>>,
         output_buffers: &OutputBuffers,
         session_loggers: &SessionLoggers,
+        session_tab_ids: &SessionTabIds,
     ) {
         if !data.is_empty() {
             let event = TerminalOutputEvent {
@@ -1412,6 +1492,14 @@ impl SessionManager {
         // Drop the session's scrollback capture buffer (#1900) so a dead
         // session's 1 MiB ring does not linger.
         output_buffers
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(session_id);
+
+        // Clear the identity bridge entry (#2431) — mirrors the explicit
+        // `close_session` cleanup for the natural-exit / dropped path, so a
+        // session's tab mapping is released whichever way the session ends.
+        session_tab_ids
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .remove(session_id);
@@ -1565,6 +1653,11 @@ mod tests {
 
     /// A fresh, empty `session_loggers` map for the logging path (#1960).
     fn new_session_loggers() -> SessionLoggers {
+        Arc::new(StdMutex::new(HashMap::new()))
+    }
+
+    /// A fresh, empty `session_tab_ids` identity-bridge map (#2431).
+    fn new_session_tab_ids() -> SessionTabIds {
         Arc::new(StdMutex::new(HashMap::new()))
     }
 
@@ -1841,6 +1934,7 @@ mod tests {
             &sessions,
             &output_buffers,
             &new_session_loggers(),
+            &new_session_tab_ids(),
         )
         .await;
 
@@ -1866,6 +1960,7 @@ mod tests {
             &sessions,
             &output_buffers,
             &new_session_loggers(),
+            &new_session_tab_ids(),
         )
         .await;
 
@@ -1897,6 +1992,7 @@ mod tests {
             capture.clone(),
             output_buffers,
             new_session_loggers(),
+            new_session_tab_ids(),
         )
         .await;
 
@@ -1967,6 +2063,7 @@ mod tests {
             new_capture(),
             new_output_buffers(),
             session_loggers.clone(),
+            new_session_tab_ids(),
         )
         .await;
 
@@ -2003,6 +2100,7 @@ mod tests {
             new_capture(),
             new_output_buffers(),
             new_session_loggers(),
+            new_session_tab_ids(),
         )
         .await;
 
@@ -2042,6 +2140,7 @@ mod tests {
             &sessions,
             &new_output_buffers(),
             &new_session_loggers(),
+            &new_session_tab_ids(),
         )
         .await;
 
@@ -2324,6 +2423,115 @@ mod tests {
         );
         let agent_manager = Arc::new(NullAgent);
         SessionManager::new(registry, agent_manager)
+    }
+
+    // ── Identity bridge: session_id → tab_id (#2431) ──────────────────
+
+    #[test]
+    fn tab_id_from_connect_id_parses_the_tab_prefix() {
+        assert_eq!(tab_id_from_connect_id("tab-1:0").as_deref(), Some("tab-1"));
+        // The parse is retry-count-agnostic: it strips only the trailing segment.
+        assert_eq!(tab_id_from_connect_id("tab-1:3").as_deref(), Some("tab-1"));
+        // A tab id containing a colon: only the last `:retry` is stripped.
+        assert_eq!(tab_id_from_connect_id("a:b:2").as_deref(), Some("a:b"));
+        // An unexpected form (no colon) or an empty tab yields no mapping rather
+        // than a guess.
+        assert_eq!(tab_id_from_connect_id("notacolon"), None);
+        assert_eq!(tab_id_from_connect_id(":0"), None);
+    }
+
+    #[tokio::test]
+    async fn create_connection_records_the_tab_id_identity_bridge() {
+        let manager = make_test_manager();
+        let session_id = manager
+            .create_connection(
+                "mock",
+                serde_json::json!({}),
+                None,
+                Some("tab-42:0"),
+                false,
+                MockEventEmitter::new(),
+            )
+            .await
+            .expect("session should open");
+        // A synchronous read before the spawned reader task can run, so the
+        // mapping is observed exactly as create_connection recorded it.
+        assert_eq!(manager.tab_id_for(&session_id).as_deref(), Some("tab-42"));
+    }
+
+    #[tokio::test]
+    async fn create_connection_without_connect_id_records_no_tab() {
+        let manager = make_test_manager();
+        let session_id = manager
+            .create_connection(
+                "mock",
+                serde_json::json!({}),
+                None,
+                None,
+                false,
+                MockEventEmitter::new(),
+            )
+            .await
+            .expect("session should open");
+        assert_eq!(
+            manager.tab_id_for(&session_id),
+            None,
+            "a session with no connect_id carries no tab"
+        );
+    }
+
+    #[tokio::test]
+    async fn close_session_clears_the_tab_id_identity_bridge() {
+        let manager = make_test_manager();
+        let session_id = manager
+            .create_connection(
+                "mock",
+                serde_json::json!({}),
+                None,
+                Some("tab-7:0"),
+                false,
+                MockEventEmitter::new(),
+            )
+            .await
+            .expect("session should open");
+        assert_eq!(manager.tab_id_for(&session_id).as_deref(), Some("tab-7"));
+
+        manager
+            .close_session(&session_id)
+            .await
+            .expect("close should succeed");
+        assert_eq!(
+            manager.tab_id_for(&session_id),
+            None,
+            "closing a session clears its identity-bridge entry"
+        );
+    }
+
+    #[tokio::test]
+    async fn emit_and_cleanup_clears_the_tab_id_identity_bridge() {
+        let emitter = MockEventEmitter::new();
+        let sessions = sessions_with_mock("sess-tab").await;
+        let session_tab_ids = new_session_tab_ids();
+        session_tab_ids
+            .lock()
+            .unwrap()
+            .insert("sess-tab".to_string(), "tab-9".to_string());
+
+        SessionManager::emit_and_cleanup(
+            "sess-tab",
+            Vec::new(),
+            &emitter,
+            &sessions,
+            &new_output_buffers(),
+            &new_session_loggers(),
+            &session_tab_ids,
+        )
+        .await;
+
+        assert!(
+            !session_tab_ids.lock().unwrap().contains_key("sess-tab"),
+            "the natural-exit / dropped path clears the identity-bridge entry"
+        );
     }
 
     /// A connection whose `connect_cancellable` blocks until its token fires —

--- a/src-tauri/src/session/persistent_controller.rs
+++ b/src-tauri/src/session/persistent_controller.rs
@@ -306,6 +306,7 @@ impl<'a> PersistentController<'a> {
                     let capture = self.manager.ensure_output_buffer(&session_id);
                     let output_buffers = self.manager.output_buffers.clone();
                     let session_loggers = self.manager.session_loggers.clone();
+                    let session_tab_ids = self.manager.session_tab_ids.clone();
                     let sid = session_id.clone();
                     tokio::spawn(async move {
                         SessionManager::run_output_reader(
@@ -317,6 +318,7 @@ impl<'a> PersistentController<'a> {
                             capture,
                             output_buffers,
                             session_loggers,
+                            session_tab_ids,
                         )
                         .await;
                     });

--- a/src-tauri/src/session_projection/projection.rs
+++ b/src-tauri/src/session_projection/projection.rs
@@ -47,6 +47,7 @@ use std::sync::Arc;
 use serde_json::Value;
 use tauri::{AppHandle, Manager};
 
+use crate::commands::projection::ProjectionState;
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
 use crate::session_projection::store::SessionLifecycleStore;
 use crate::session_projection::timer::ReconnectTimerDriver;
@@ -68,6 +69,42 @@ pub fn publish_sessions(
             version,
         }],
         None => Vec::new(),
+    }
+}
+
+/// Fold a session-lifecycle transition into the managed [`SessionLifecycleStore`]
+/// **server-side** and fan the resulting `session-lifecycle` region diff out to
+/// every subscriber (#2431, prerequisite for #2205).
+///
+/// This is the server-authority counterpart to [`register_session_intents`]: the
+/// same store transitions the frontend currently mirrors via `session.*` intents
+/// are applied here **at the source** — the instant a backend lifecycle source
+/// (`create_connection`, and later the `terminal-exit` / `close_session` paths)
+/// observes a transition — so the store is fed server-side, addressed by the
+/// **frontend tab id** the region is keyed by (resolved through the
+/// [`SessionManager`](crate::session::manager::SessionManager) identity bridge,
+/// #2431). It is **additive**: the frontend `session.*` mirror stays in place, so
+/// this changes no user-facing behavior — the coarse status field it writes is not
+/// yet rendered from the region (that inversion is #2205). The `apply` closure
+/// must therefore only drive transitions that **converge** with the client's
+/// same-event dispatch (e.g. the initial connect's `connect` / `connected`), never
+/// one the client would resolve differently for the same event.
+///
+/// Best-effort and non-fatal: if the store or the projection state is not managed
+/// (e.g. a headless unit-test app that never ran `setup()`), the fold is skipped
+/// rather than erroring — the client mirror still drives the region. The `apply`
+/// closure runs to completion synchronously before the publish, so the store lock
+/// is never held across an await.
+pub fn fold_session_transition<R: tauri::Runtime>(
+    app_handle: &AppHandle<R>,
+    apply: impl FnOnce(&SessionLifecycleStore),
+) {
+    let Some(store) = app_handle.try_state::<Arc<SessionLifecycleStore>>() else {
+        return;
+    };
+    apply(store.inner().as_ref());
+    if let Some(projection) = app_handle.try_state::<ProjectionState>() {
+        publish_sessions(&projection.projector, store.inner().as_ref());
     }
 }
 

--- a/src-tauri/src/session_projection/projection_tests.rs
+++ b/src-tauri/src/session_projection/projection_tests.rs
@@ -15,12 +15,16 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use serde_json::{json, Value};
+use tauri::Manager;
 
+use crate::commands::projection::ProjectionState;
 use crate::projection::{
     apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
     ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
 };
-use crate::session_projection::projection::{publish_sessions, SESSION_LIFECYCLE_REGION};
+use crate::session_projection::projection::{
+    fold_session_transition, publish_sessions, SESSION_LIFECYCLE_REGION,
+};
 use crate::session_projection::store::SessionLifecycleStore;
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
@@ -353,5 +357,118 @@ fn a_dead_subscriber_is_reaped_on_publish() {
         projector.subscriber_count(SESSION_LIFECYCLE_REGION),
         1,
         "the dead subscriber was reaped"
+    );
+}
+
+// ── Server-authority fold (#2431, prerequisite for #2205) ─────────────────────
+//
+// These drive the *production* `fold_session_transition` end to end against a
+// `tauri::test::mock_app()` with the same managed state `lib.rs::setup()` wires:
+// an `Arc<SessionLifecycleStore>` and a `ProjectionState`. They prove the store
+// is fed **server-side** — the instant `create_connection` produces an initial
+// connect / connected transition — addressed by the **frontend tab id** the
+// region is keyed by, with no `session.*` client dispatch, and that the fold
+// reproduces the client route's store transition exactly (parity, no drift).
+
+/// A server-folded initial connect creates the tab-id-keyed `connecting` entry in
+/// the shared store and fans the `session-lifecycle` region diff out — without any
+/// client dispatch.
+#[test]
+fn server_side_connect_fold_creates_the_tab_keyed_entry_without_client_dispatch() {
+    let app = tauri::test::mock_app();
+    let store = Arc::new(SessionLifecycleStore::new());
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    let snap = projection
+        .projector
+        .subscribe(SESSION_LIFECYCLE_REGION, "sub", "C", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+    app.manage(projection);
+
+    // The server folds the initial connect at the source, keyed by the tab id —
+    // no `session.connect` intent is dispatched.
+    fold_session_transition(app.handle(), |s| s.connect("tab-1"));
+
+    // The store is authoritative server-side, under the tab-id key.
+    assert_eq!(
+        store.get("tab-1").map(|s| s.status),
+        Some(crate::session_projection::store::SessionStatus::Connecting)
+    );
+
+    // Exactly one region diff fanned out; the client cache converges on the server
+    // truth with no round-trip.
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "one diff from the server-side fold");
+    cache.apply(&diffs[0]);
+    assert_eq!(
+        cache.view["sessions"]["tab-1"]["status"],
+        json!("connecting")
+    );
+}
+
+/// A server-folded `connected` settles the tab-keyed session live and publishes
+/// the region diff.
+#[test]
+fn server_side_connected_fold_settles_the_session_live() {
+    let app = tauri::test::mock_app();
+    let store = Arc::new(SessionLifecycleStore::new());
+    store.connect("tab-1");
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    let snap = projection
+        .projector
+        .subscribe(SESSION_LIFECYCLE_REGION, "sub", "C", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+    app.manage(projection);
+
+    fold_session_transition(app.handle(), |s| s.connected("tab-1"));
+
+    assert_eq!(
+        store.get("tab-1").map(|s| s.status),
+        Some(crate::session_projection::store::SessionStatus::Connected)
+    );
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1);
+    cache.apply(&diffs[0]);
+    assert_eq!(
+        cache.view["sessions"]["tab-1"]["status"],
+        json!("connected")
+    );
+}
+
+/// The server-side connect fold reproduces the client `session.connect` route's
+/// store transition exactly — identical snapshots, so there is no drift when the
+/// fold and the (still-present, additive) client mirror both run for the initial
+/// connect.
+#[test]
+fn server_side_connect_fold_matches_the_client_session_connect_route() {
+    // (a) Server-side fold: the store method the fold applies at the source.
+    let server = SessionLifecycleStore::new();
+    server.set_rand_for_test(Box::new(|| 0.5));
+    server.connect("tab-1");
+
+    // (b) Client route: the `session.connect` intent through the production registry.
+    let client = Arc::new(SessionLifecycleStore::new());
+    client.set_rand_for_test(Box::new(|| 0.5));
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SESSION_LIFECYCLE_REGION, client.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(client.clone())));
+    let ack = dispatcher.dispatch(intent("session.connect", json!({ "sessionId": "tab-1" })));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    assert_eq!(
+        server.snapshot(),
+        client.snapshot(),
+        "the server fold reproduces the client route's transition exactly"
     );
 }


### PR DESCRIPTION
Phase-4 step-1 for session-lifecycle — **replaces #2438** (which failed commitlint's body-max-line-length; recommitted with wrapped body, no force-push). Identical diff.

Part 1 (identity bridge, full): `SessionManager.session_tab_ids` populated in `create_connection` from `connect_id`, cleared on removal, with `tab_id_for()` — all session kinds verified (graphical/remote-desktop use a separate lifecycle and are correctly out of scope). Part 2 (safe fold): initial connect→connected keyed by tab id, converging with the still-live client dispatch. Drop/disconnect/connect_failed folds deferred to **#2439** (they'd corrupt the region against the live client until the #2205 removal). Additive; `appStore` untouched. cargo build/test/fmt/clippy green locally.

Closes #2431.