### PR TITLE
refactor(terminal): render session-lifecycle status from the projected region (Part of #2205)

### DIFF
--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -37,6 +37,7 @@ import { MONITORING_INTERVAL_OPTIONS, DEFAULT_MONITORING_INTERVAL_MS } from "@/t
 import { useAppStore } from "@/store/appStore";
 import { useProjectedAgents } from "@/store/useProjectedAgents";
 import { useProjectedMonitors } from "@/store/useProjectedMonitors";
+import { useProjectedSessionLifecycleMaps } from "@/store/useSessionLifecycle";
 import { getAllLeaves } from "@/utils/panelTree";
 import {
   listLocalSessions,
@@ -125,7 +126,9 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const httpMonitors = useAppStore((s) => s.httpMonitors);
   const setHttpMonitors = useAppStore((s) => s.setHttpMonitors);
   const rootPanel = useAppStore((s) => s.rootPanel);
-  const terminalConnecting = useAppStore((s) => s.terminalConnecting);
+  // Render cut (#2205 PR-A): connecting flags sourced from the projected
+  // `session-lifecycle` region (falls back to appStore per key when not mirrored).
+  const { terminalConnecting } = useProjectedSessionLifecycleMaps();
   const closeTab = useAppStore((s) => s.closeTab);
   const markSessionKilled = useAppStore((s) => s.markSessionKilled);
 

--- a/src/components/SplitView/SplitView.tsx
+++ b/src/components/SplitView/SplitView.tsx
@@ -35,6 +35,11 @@ import {
 import { useAppStore } from "@/store/appStore";
 import { useProjectedSettings } from "@/store/useProjectedSettings";
 import { useProjectedBroadcast } from "@/store/useProjectedBroadcast";
+import {
+  useProjectedSessionLifecycle,
+  useProjectedSessionLifecycleMaps,
+  useSessionAutoReconnect,
+} from "@/store/useSessionLifecycle";
 import { useLayoutRenderTree } from "@/store/useLayoutRenderTree";
 import { PanelNode, LeafPanel, TerminalTab, DropEdge } from "@/types/terminal";
 import { getAllLeaves, findLeafByTab, isWindowEmpty, normalizeSizes } from "@/utils/panelTree";
@@ -86,7 +91,9 @@ export function SplitView() {
   const zoomedTabId = useAppStore((s) => s.zoomedTabId);
   const setZoomedTabId = useAppStore((s) => s.setZoomedTabId);
   const terminalSpawnErrors = useAppStore((s) => s.terminalSpawnErrors);
-  const terminalConnecting = useAppStore((s) => s.terminalConnecting);
+  // Render cut (#2205 PR-A): connecting flags sourced from the projected
+  // `session-lifecycle` region (falls back to appStore per key when not mirrored).
+  const { terminalConnecting } = useProjectedSessionLifecycleMaps();
   const terminalAutoRetryCountZoom = useAppStore((s) => s.terminalAutoRetryCount);
   const terminalWaitingForAgentZoom = useAppStore((s) => s.terminalWaitingForAgent);
   const terminalReattachingZoom = useAppStore((s) => s.terminalReattaching);
@@ -630,7 +637,9 @@ function LeafPanelView({ panel, setActivePanel, activeDragTab }: LeafPanelViewPr
   const tabColors = useAppStore((s) => s.tabColors);
   const setTabColor = useAppStore((s) => s.setTabColor);
   const terminalSpawnErrors = useAppStore((s) => s.terminalSpawnErrors);
-  const terminalConnecting = useAppStore((s) => s.terminalConnecting);
+  // Render cut (#2205 PR-A): connecting flags sourced from the projected
+  // `session-lifecycle` region (falls back to appStore per key when not mirrored).
+  const { terminalConnecting } = useProjectedSessionLifecycleMaps();
   const terminalAutoRetryCount = useAppStore((s) => s.terminalAutoRetryCount);
   const terminalWaitingForAgent = useAppStore((s) => s.terminalWaitingForAgent);
   const terminalReattaching = useAppStore((s) => s.terminalReattaching);
@@ -963,13 +972,14 @@ function TerminalSlot({ tabId, isVisible }: { tabId: string; isVisible: boolean 
   const tabColor = useAppStore((s) => s.tabColors[tabId]);
   const isExited = useAppStore((s) => s.terminalExitedTabs[tabId] ?? false);
   const isViewMode = useAppStore((s) => s.terminalViewMode[tabId] ?? false);
-  const isReconnecting = useAppStore((s) => s.terminalReconnectingTabs[tabId] ?? false);
+  // Render cut (#2205 PR-A / #2204): the reconnect flag and the auto-reconnect
+  // countdown gate are sourced from the projected `session-lifecycle` region (both
+  // fall back to appStore when it does not mirror).
+  const isReconnecting = useProjectedSessionLifecycle(tabId).reconnecting;
   const isReconnectPromptVisible = useAppStore((s) => s.terminalReconnectPrompt[tabId] ?? false);
   // Agentless resilient reconnect (#1962): the backoff countdown overlay must
   // show even after the first attempt cleared the exited flag mid-loop.
-  const isAutoReconnectWaiting = useAppStore(
-    (s) => s.terminalAutoReconnect[tabId]?.phase === "waiting"
-  );
+  const isAutoReconnectWaiting = useSessionAutoReconnect(tabId)?.phase === "waiting";
 
   useEffect(() => {
     const slotEl = slotRef.current;

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -4,6 +4,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useAppStore } from "@/store/appStore";
 import { currentSettingsView } from "@/store/settingsBridge";
 import { useProjectedBroadcast } from "@/store/useProjectedBroadcast";
+import { useProjectedSessionLifecycleMaps } from "@/store/useSessionLifecycle";
 import { TerminalTab } from "@/types/terminal";
 import type { WindowInfo } from "@/types/window";
 import { listWindows } from "@/services/api";
@@ -41,10 +42,13 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
   const setPendingSessionCloseConfirm = useAppStore((s) => s.setPendingSessionCloseConfirm);
   const setPendingAttachedTabCloseConfirm = useAppStore((s) => s.setPendingAttachedTabCloseConfirm);
   // Tab-id-keyed lifecycle maps that drive the per-tab connection status dot.
-  const terminalConnecting = useAppStore((s) => s.terminalConnecting);
-  const terminalReconnectingTabs = useAppStore((s) => s.terminalReconnectingTabs);
+  // Render cut (#2205 PR-A): the session-lifecycle maps (connecting / reconnecting
+  // / disconnect errors) are sourced from the projected region (falls back to
+  // appStore per key when not mirrored); spawn errors and exited tabs stay on
+  // appStore (not part of the session-lifecycle region).
+  const { terminalConnecting, terminalReconnectingTabs, terminalDisconnectErrors } =
+    useProjectedSessionLifecycleMaps();
   const terminalSpawnErrors = useAppStore((s) => s.terminalSpawnErrors);
-  const terminalDisconnectErrors = useAppStore((s) => s.terminalDisconnectErrors);
   const terminalExitedTabs = useAppStore((s) => s.terminalExitedTabs);
   // Broadcast participation (#1957): the badge shows on every tab in the target
   // set, active or not, so participation is visible at a glance. Render cut

--- a/src/components/Terminal/TerminalConnectionOverlay.tsx
+++ b/src/components/Terminal/TerminalConnectionOverlay.tsx
@@ -4,6 +4,7 @@ import { writeText as writeClipboard } from "@tauri-apps/plugin-clipboard-manage
 import { Button } from "@/components/ui/Button";
 import { toast } from "@/components/ui";
 import { useAppStore } from "@/store/appStore";
+import { useProjectedSessionLifecycle } from "@/store/useSessionLifecycle";
 import { useElapsed } from "@/hooks/useElapsed";
 import { getPlatform } from "@/utils/platform";
 import { backendFamilyFromSessionType, connectionErrorHint } from "@/utils/connectionErrorHints";
@@ -113,7 +114,9 @@ export function TerminalConnectionOverlay({
   const retryTerminalSpawn = useAppStore((s) => s.retryTerminalSpawn);
   const reconnectTerminal = useAppStore((s) => s.reconnectTerminal);
   const abortTerminalConnect = useAppStore((s) => s.abortTerminalConnect);
-  const isConnecting = useAppStore((s) => s.terminalConnecting[tabId] ?? false);
+  // Render cut (#2205 PR-A): the connect flag is sourced from the projected
+  // `session-lifecycle` region (falls back to appStore when it does not mirror).
+  const isConnecting = useProjectedSessionLifecycle(tabId).connecting;
   const autoRetryCount = useAppStore((s) => s.terminalAutoRetryCount[tabId] ?? 0);
   const waitingForAgent = useAppStore((s) => s.terminalWaitingForAgent[tabId]);
   const isReattaching = useAppStore((s) => s.terminalReattaching[tabId] ?? false);

--- a/src/components/Terminal/TerminalDisconnectOverlay.projection.test.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.projection.test.tsx
@@ -4,23 +4,17 @@ import { createRoot } from "react-dom/client";
 import { TerminalDisconnectOverlay } from "./TerminalDisconnectOverlay";
 import { withTooltip } from "@/test/tooltip";
 import { useAppStore } from "@/store/appStore";
-import type {
-  FrameHandler,
-  Intent,
-  IntentAck,
-  ProjectionFrame,
-  SnapshotFrame,
-  Subscription,
-  Transport,
-} from "@/services/transport";
 import {
-  SESSION_LIFECYCLE_REGION,
   setSessionIntentsEnabled,
   setSessionRenderFromProjectionEnabled,
   setSessionTransportForTest,
   stopSessionSubscription,
-  type ProjectedSessionLifecycle,
 } from "@/store/sessionBridge";
+import {
+  failed,
+  FakeSessionTransport,
+  reconnecting,
+} from "@/test/sessionLifecycleRegionTestHarness";
 import type { TerminalAutoReconnectState } from "@/types/terminal";
 
 // Stub lucide-react icons used in the overlay.
@@ -32,54 +26,6 @@ vi.mock("lucide-react", () => ({
   Loader2: () => null,
   CheckCircle2: () => null,
 }));
-
-/**
- * An in-memory `session-lifecycle` region double: holds one view and fans a fresh
- * snapshot to every subscriber on each mutation, so the overlay's render can be
- * driven by projected snapshots without a backend (#2204, reusing the #2164
- * harness idea from `sessionBridge.test.ts`).
- */
-class FakeTransport implements Transport {
-  private view: { sessions: Record<string, ProjectedSessionLifecycle> } = { sessions: {} };
-  private version = 0;
-  private handlers: FrameHandler[] = [];
-  subscribeCount = 0;
-
-  async dispatch(intent: Intent): Promise<IntentAck> {
-    return { intentId: intent.intentId, status: "accepted", produced: [] };
-  }
-
-  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
-    this.subscribeCount += 1;
-    this.handlers.push(onFrame);
-    return {
-      snapshot: this.snapshot(region),
-      unsubscribe: () => {
-        this.handlers = this.handlers.filter((h) => h !== onFrame);
-      },
-    };
-  }
-
-  async resync(): Promise<SnapshotFrame | null> {
-    return null;
-  }
-
-  /** Set a session's projected lifecycle and fan the snapshot out. */
-  setSession(id: string, life: ProjectedSessionLifecycle): void {
-    this.view.sessions[id] = life;
-    this.version += 1;
-    this.fan();
-  }
-
-  private snapshot(region: string): SnapshotFrame {
-    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
-  }
-
-  private fan(): void {
-    const frame: ProjectionFrame = this.snapshot(SESSION_LIFECYCLE_REGION);
-    for (const h of this.handlers) h(frame);
-  }
-}
 
 const TAB = "tab-1";
 
@@ -94,12 +40,6 @@ function record(over: Partial<TerminalAutoReconnectState> = {}): TerminalAutoRec
   };
 }
 
-function reconnecting(
-  reconnect: ProjectedSessionLifecycle["reconnect"]
-): ProjectedSessionLifecycle {
-  return { status: "reconnecting", reconnect };
-}
-
 /** Flush the bridge's async subscribe + fan-out so the projected snapshot lands. */
 async function flush(): Promise<void> {
   await act(async () => {
@@ -111,13 +51,13 @@ async function flush(): Promise<void> {
 describe("TerminalDisconnectOverlay — projected session-lifecycle render cut (#2204)", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
-  let transport: FakeTransport;
+  let transport: FakeSessionTransport;
 
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
-    transport = new FakeTransport();
+    transport = new FakeSessionTransport();
     setSessionTransportForTest(transport);
     setSessionRenderFromProjectionEnabled(true);
     setSessionIntentsEnabled(true);
@@ -182,6 +122,30 @@ describe("TerminalDisconnectOverlay — projected session-lifecycle render cut (
     expect(countdown?.textContent).toContain("Attempt 4 of 10");
     // With the cut off the hook never subscribes to the region.
     expect(transport.subscribeCount).toBe(0);
+  });
+
+  it("renders the reconnecting spinner sourced from a mirroring projected snapshot", async () => {
+    useAppStore.setState({ terminalReconnectingTabs: { [TAB]: true } });
+    transport.setSession(TAB, reconnecting({ phase: "connecting", attempt: 1, delayMs: 0 }));
+
+    act(() => root.render(withTooltip(<TerminalDisconnectOverlay tabId={TAB} />)));
+    await flush();
+
+    expect(transport.subscribeCount).toBeGreaterThan(0);
+    // The reconnecting variant shows its Stop affordance (no countdown variant).
+    const overlay = container.querySelector("[data-testid='terminal-disconnect-overlay']");
+    expect(overlay?.textContent).toContain("Reconnecting");
+  });
+
+  it("renders the disconnect error sourced from a mirroring failed snapshot", async () => {
+    useAppStore.setState({ terminalDisconnectErrors: { [TAB]: "auth failed" } });
+    transport.setSession(TAB, failed("auth failed"));
+
+    act(() => root.render(withTooltip(<TerminalDisconnectOverlay tabId={TAB} />)));
+    await flush();
+
+    const overlay = container.querySelector("[data-testid='terminal-disconnect-overlay']");
+    expect(overlay?.textContent).toContain("auth failed");
   });
 
   it("shows no auto-reconnect overlay when there is no local loop, whatever the region says", async () => {

--- a/src/components/Terminal/TerminalDisconnectOverlay.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { WifiOff, RefreshCw, X, AlertTriangle, Loader2, CheckCircle2 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
-import { useSessionAutoReconnect } from "@/store/useSessionLifecycle";
+import {
+  useProjectedSessionLifecycle,
+  useSessionAutoReconnect,
+} from "@/store/useSessionLifecycle";
 import { Button, Tooltip } from "@/components/ui";
 import type { TerminalExitInfo } from "@/types/terminal";
 import "./TerminalDisconnectOverlay.css";
@@ -139,8 +142,14 @@ export function TerminalDisconnectOverlay({ tabId }: TerminalDisconnectOverlayPr
   const reconnectTerminal = useAppStore((s) => s.reconnectTerminal);
   const dismissTerminalDisconnect = useAppStore((s) => s.dismissTerminalDisconnect);
   const setTerminalExited = useAppStore((s) => s.setTerminalExited);
-  const disconnectError = useAppStore((s) => s.terminalDisconnectErrors[tabId]);
-  const isReconnecting = useAppStore((s) => s.terminalReconnectingTabs[tabId] ?? false);
+  // Render cut (#2205 PR-A): the disconnect error and reconnect flag are sourced
+  // from the projected `session-lifecycle` region (falls back to appStore when it
+  // does not mirror). `terminalReconnectTriggerErrors` stays on appStore — the
+  // region has no distinct field for a manual-reconnect-trigger error, so PR-A
+  // cannot faithfully mirror it (see #2205 PR-A notes).
+  const lifecycle = useProjectedSessionLifecycle(tabId);
+  const disconnectError = lifecycle.disconnectError;
+  const isReconnecting = lifecycle.reconnecting;
   // The auto-reconnect gate reads the same projected-with-fallback loop detail as
   // the countdown overlay itself, so the region drives which variant shows (#2204).
   const autoReconnectWaiting = useSessionAutoReconnect(tabId)?.phase === "waiting";

--- a/src/components/Terminal/TerminalDisconnectOverlay.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.tsx
@@ -1,10 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { WifiOff, RefreshCw, X, AlertTriangle, Loader2, CheckCircle2 } from "lucide-react";
 import { useAppStore } from "@/store/appStore";
-import {
-  useProjectedSessionLifecycle,
-  useSessionAutoReconnect,
-} from "@/store/useSessionLifecycle";
+import { useProjectedSessionLifecycle, useSessionAutoReconnect } from "@/store/useSessionLifecycle";
 import { Button, Tooltip } from "@/components/ui";
 import type { TerminalExitInfo } from "@/types/terminal";
 import "./TerminalDisconnectOverlay.css";

--- a/src/store/sessionBridge.ts
+++ b/src/store/sessionBridge.ts
@@ -469,6 +469,120 @@ export function effectiveAutoReconnect(
   return projectedToAutoReconnect(projected!, now0, record.onReconnectCommand) ?? record;
 }
 
+// ── Render cut: status / disconnect-error fields (#2205 PR-A) ───────────────────
+//
+// Phase 4 step 4 (#2205) flips the terminal lifecycle *readers* — the overlays,
+// the tab-strip status dot, the split-panel overlay gates and Open Connections —
+// off the `appStore` status slices (`terminalConnecting`,
+// `terminalReconnectingTabs`, `terminalDisconnectErrors`) and onto the projected
+// `session-lifecycle` region. PR-A is the render cut only: the readers consult the
+// region, `appStore` keeps its slices + the `driveAutoReconnect` engine + the
+// client `session.*` dispatch, and the reducer / authority removal is PR-B.
+//
+// Each field uses the same faithful-mirror gate as {@link effectiveAutoReconnect}:
+// the region sources the render only when its status agrees with `appStore`'s
+// slice; otherwise the reader falls back to `appStore` verbatim. Because the gate
+// guarantees agreement, the rendered value is byte-identical to the pre-cut path,
+// independent of {@link sessionIntentsEnabled} and of the deferred server-side
+// folds (#2439) — a region that has not (yet) observed a drop / disconnect /
+// connect-failure simply falls back to `appStore`.
+
+/** The last-known reconciled `session-lifecycle` view (the `sessions` map), for a
+ * consumer seeding before its first diff arrives. */
+export function currentSessionView(): Record<string, ProjectedSessionLifecycle> {
+  return lastSessions;
+}
+
+/**
+ * Effective `terminalConnecting[tabId]` for rendering: `true` when the projected
+ * status is `connecting` and it mirrors the local `terminalConnecting` bool,
+ * otherwise the local bool verbatim (flag off, or the region does not mirror).
+ */
+export function effectiveConnecting(
+  local: boolean,
+  projected: ProjectedSessionLifecycle | undefined
+): boolean {
+  if (!sessionRenderFromProjectionEnabled()) return local;
+  const projectedConnecting = projected?.status === "connecting";
+  if (projectedConnecting !== local) return local;
+  return projectedConnecting;
+}
+
+/**
+ * Effective `terminalReconnectingTabs[tabId]` for rendering: `true` when the
+ * projected status is `reconnecting` and it mirrors the local bool, otherwise the
+ * local bool verbatim.
+ */
+export function effectiveReconnecting(
+  local: boolean,
+  projected: ProjectedSessionLifecycle | undefined
+): boolean {
+  if (!sessionRenderFromProjectionEnabled()) return local;
+  const projectedReconnecting = projected?.status === "reconnecting";
+  if (projectedReconnecting !== local) return local;
+  return projectedReconnecting;
+}
+
+/**
+ * Effective `terminalDisconnectErrors[tabId]` for rendering: the projected error
+ * when the status is `failed` and the error string mirrors the local one exactly,
+ * otherwise the local error verbatim (`undefined` ⇒ no error).
+ */
+export function effectiveDisconnectError(
+  local: string | undefined,
+  projected: ProjectedSessionLifecycle | undefined
+): string | undefined {
+  if (!sessionRenderFromProjectionEnabled()) return local;
+  const projectedError = projected?.status === "failed" ? projected.error : undefined;
+  if (projectedError !== local) return local;
+  return projectedError;
+}
+
+/**
+ * Effective `terminalConnecting` map for the list consumers (the tab-strip status
+ * dot, Open Connections, the split-panel overlay gates): each `true` key sourced
+ * through {@link effectiveConnecting} against the projected view. Byte-identical to
+ * `local` — the gate only ever sources a key the local map already carries.
+ */
+export function effectiveConnectingMap(
+  local: Record<string, boolean>,
+  view: Record<string, ProjectedSessionLifecycle>
+): Record<string, boolean> {
+  if (!sessionRenderFromProjectionEnabled()) return local;
+  const out: Record<string, boolean> = {};
+  for (const id of Object.keys(local)) {
+    if (effectiveConnecting(local[id] ?? false, view[id])) out[id] = true;
+  }
+  return out;
+}
+
+/** Effective `terminalReconnectingTabs` map, sourced through {@link effectiveReconnecting}. */
+export function effectiveReconnectingMap(
+  local: Record<string, boolean>,
+  view: Record<string, ProjectedSessionLifecycle>
+): Record<string, boolean> {
+  if (!sessionRenderFromProjectionEnabled()) return local;
+  const out: Record<string, boolean> = {};
+  for (const id of Object.keys(local)) {
+    if (effectiveReconnecting(local[id] ?? false, view[id])) out[id] = true;
+  }
+  return out;
+}
+
+/** Effective `terminalDisconnectErrors` map, sourced through {@link effectiveDisconnectError}. */
+export function effectiveDisconnectErrorMap(
+  local: Record<string, string>,
+  view: Record<string, ProjectedSessionLifecycle>
+): Record<string, string> {
+  if (!sessionRenderFromProjectionEnabled()) return local;
+  const out: Record<string, string> = {};
+  for (const id of Object.keys(local)) {
+    const eff = effectiveDisconnectError(local[id], view[id]);
+    if (eff !== undefined) out[id] = eff;
+  }
+  return out;
+}
+
 /** Log a bridge fallback so the local-path recovery is visible in the LogViewer. */
 export function logSessionBridgeFallback(kind: string, err: unknown): void {
   const message = err instanceof Error ? err.message : String(err);

--- a/src/store/sessionLifecycleRenderCut.test.ts
+++ b/src/store/sessionLifecycleRenderCut.test.ts
@@ -25,7 +25,10 @@ import {
 
 const idle = { phase: "idle" as const, attempt: 0, delayMs: 0 };
 
-function life(status: ProjectedSessionLifecycle["status"], error?: string): ProjectedSessionLifecycle {
+function life(
+  status: ProjectedSessionLifecycle["status"],
+  error?: string
+): ProjectedSessionLifecycle {
   return { status, reconnect: idle, ...(error !== undefined ? { error } : {}) };
 }
 

--- a/src/store/sessionLifecycleRenderCut.test.ts
+++ b/src/store/sessionLifecycleRenderCut.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the #2205 PR-A render-cut helpers in `sessionBridge`: the
+ * faithful-mirror gate that lets the terminal lifecycle readers source their
+ * connect / reconnect / disconnect-error status from the projected
+ * `session-lifecycle` region, with an `appStore` fallback per field / key.
+ *
+ * The contract under test: when the region mirrors the local slice the effective
+ * value is sourced from the region; otherwise it is the local slice verbatim, so
+ * the rendered output is byte-identical to the pre-cut path (and identical when the
+ * render flag is off).
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  effectiveConnecting,
+  effectiveConnectingMap,
+  effectiveDisconnectError,
+  effectiveDisconnectErrorMap,
+  effectiveReconnecting,
+  effectiveReconnectingMap,
+  setSessionRenderFromProjectionEnabled,
+  type ProjectedSessionLifecycle,
+} from "@/store/sessionBridge";
+
+const idle = { phase: "idle" as const, attempt: 0, delayMs: 0 };
+
+function life(status: ProjectedSessionLifecycle["status"], error?: string): ProjectedSessionLifecycle {
+  return { status, reconnect: idle, ...(error !== undefined ? { error } : {}) };
+}
+
+afterEach(() => {
+  setSessionRenderFromProjectionEnabled(null);
+});
+
+describe("effectiveConnecting", () => {
+  it("sources true from a mirroring projected connecting status", () => {
+    expect(effectiveConnecting(true, life("connecting"))).toBe(true);
+  });
+
+  it("falls back to the local bool when the region does not mirror", () => {
+    // Region says connecting, local says not — mismatch → local wins.
+    expect(effectiveConnecting(false, life("connecting"))).toBe(false);
+    // Local says connecting, region has no such session — local wins.
+    expect(effectiveConnecting(true, undefined)).toBe(true);
+    // Region reports a different status — local wins.
+    expect(effectiveConnecting(true, life("connected"))).toBe(true);
+  });
+
+  it("returns the local bool verbatim when the render cut is off", () => {
+    setSessionRenderFromProjectionEnabled(false);
+    expect(effectiveConnecting(true, life("connected"))).toBe(true);
+    expect(effectiveConnecting(false, life("connecting"))).toBe(false);
+  });
+});
+
+describe("effectiveReconnecting", () => {
+  it("sources true from a mirroring projected reconnecting status", () => {
+    expect(effectiveReconnecting(true, life("reconnecting"))).toBe(true);
+  });
+
+  it("falls back to the local bool when the region does not mirror", () => {
+    expect(effectiveReconnecting(false, life("reconnecting"))).toBe(false);
+    expect(effectiveReconnecting(true, life("connected"))).toBe(true);
+    expect(effectiveReconnecting(true, undefined)).toBe(true);
+  });
+});
+
+describe("effectiveDisconnectError", () => {
+  it("sources the error from a mirroring failed status", () => {
+    expect(effectiveDisconnectError("boom", life("failed", "boom"))).toBe("boom");
+  });
+
+  it("falls back to the local error when the strings diverge", () => {
+    expect(effectiveDisconnectError("boom", life("failed", "different"))).toBe("boom");
+    // Region reports no error (deferred server fold #2439) but local has one.
+    expect(effectiveDisconnectError("boom", life("connected"))).toBe("boom");
+    expect(effectiveDisconnectError("boom", undefined)).toBe("boom");
+  });
+
+  it("returns undefined when neither has an error", () => {
+    expect(effectiveDisconnectError(undefined, life("connected"))).toBeUndefined();
+  });
+});
+
+describe("effective*Map helpers", () => {
+  it("produce byte-identical maps to the local slice (sourced through the gate)", () => {
+    const view: Record<string, ProjectedSessionLifecycle> = {
+      a: life("connecting"),
+      b: life("reconnecting"),
+      c: life("failed", "nope"),
+    };
+    expect(effectiveConnectingMap({ a: true }, view)).toEqual({ a: true });
+    expect(effectiveReconnectingMap({ b: true }, view)).toEqual({ b: true });
+    expect(effectiveDisconnectErrorMap({ c: "nope" }, view)).toEqual({ c: "nope" });
+  });
+
+  it("never adds a key the local map lacks, even if the region reports one", () => {
+    const view: Record<string, ProjectedSessionLifecycle> = { ghost: life("connecting") };
+    expect(effectiveConnectingMap({}, view)).toEqual({});
+    expect(effectiveReconnectingMap({}, { ghost: life("reconnecting") })).toEqual({});
+  });
+
+  it("keeps a local error key whose region entry diverges (fallback)", () => {
+    const view: Record<string, ProjectedSessionLifecycle> = { c: life("failed", "stale") };
+    expect(effectiveDisconnectErrorMap({ c: "fresh" }, view)).toEqual({ c: "fresh" });
+  });
+
+  it("returns the local map reference verbatim when the render cut is off", () => {
+    setSessionRenderFromProjectionEnabled(false);
+    const connecting = { a: true };
+    expect(effectiveConnectingMap(connecting, {})).toBe(connecting);
+  });
+});

--- a/src/store/useProjectedSessionLifecycle.test.tsx
+++ b/src/store/useProjectedSessionLifecycle.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * `useProjectedSessionLifecycle` / `useProjectedSessionLifecycleMaps` — the #2205
+ * PR-A render cut for the terminal lifecycle status readers. Drives the hooks
+ * against the in-memory `session-lifecycle` region harness and asserts they source
+ * the connect / reconnect / disconnect-error status from a mirroring projected
+ * snapshot, fall back to `appStore` when the region does not mirror, and never
+ * subscribe when the render cut is off.
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { useAppStore } from "@/store/appStore";
+import {
+  connecting,
+  connected,
+  failed,
+  flushSessionRegion,
+  installSessionLifecycleHarness,
+  reconnecting,
+} from "@/test/sessionLifecycleRegionTestHarness";
+
+import {
+  useProjectedSessionLifecycle,
+  useProjectedSessionLifecycleMaps,
+  type ProjectedSessionLifecycleMaps,
+  type ProjectedSessionLifecycleSlice,
+} from "./useSessionLifecycle";
+
+const TAB = "tab-1";
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+function mount(node: React.ReactElement): void {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root!.render(node));
+}
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  container?.remove();
+  root = null;
+  container = null;
+  useAppStore.setState({
+    terminalConnecting: {},
+    terminalReconnectingTabs: {},
+    terminalDisconnectErrors: {},
+  });
+});
+
+describe("useProjectedSessionLifecycle (per tab)", () => {
+  const harness = installSessionLifecycleHarness();
+
+  function Probe({ onValue }: { onValue: (v: ProjectedSessionLifecycleSlice) => void }) {
+    onValue(useProjectedSessionLifecycle(TAB));
+    return null;
+  }
+
+  it("sources connecting from a mirroring projected snapshot", async () => {
+    useAppStore.setState({ terminalConnecting: { [TAB]: true } });
+    harness.transport.setSession(TAB, connecting());
+    let latest: ProjectedSessionLifecycleSlice | undefined;
+    mount(<Probe onValue={(v) => (latest = v)} />);
+    await flushSessionRegion();
+
+    expect(harness.transport.subscribeCount).toBeGreaterThan(0);
+    expect(latest?.connecting).toBe(true);
+  });
+
+  it("sources reconnecting and the disconnect error from mirroring snapshots", async () => {
+    useAppStore.setState({
+      terminalReconnectingTabs: { [TAB]: true },
+      terminalDisconnectErrors: {},
+    });
+    harness.transport.setSession(TAB, reconnecting({ phase: "waiting", attempt: 1, delayMs: 3000 }));
+    let latest: ProjectedSessionLifecycleSlice | undefined;
+    mount(<Probe onValue={(v) => (latest = v)} />);
+    await flushSessionRegion();
+    expect(latest?.reconnecting).toBe(true);
+
+    // Now a failed disconnect with a matching error string.
+    useAppStore.setState({
+      terminalReconnectingTabs: {},
+      terminalDisconnectErrors: { [TAB]: "auth failed" },
+    });
+    act(() => harness.transport.setSession(TAB, failed("auth failed")));
+    await flushSessionRegion();
+    expect(latest?.disconnectError).toBe("auth failed");
+  });
+
+  it("falls back to appStore when the region diverges", async () => {
+    // appStore says connecting; region reports connected — the gate rejects it.
+    useAppStore.setState({ terminalConnecting: { [TAB]: true } });
+    harness.transport.setSession(TAB, connected());
+    let latest: ProjectedSessionLifecycleSlice | undefined;
+    mount(<Probe onValue={(v) => (latest = v)} />);
+    await flushSessionRegion();
+    expect(latest?.connecting).toBe(true);
+  });
+});
+
+describe("useProjectedSessionLifecycle — render cut off", () => {
+  const harness = installSessionLifecycleHarness(false);
+
+  function Probe({ onValue }: { onValue: (v: ProjectedSessionLifecycleSlice) => void }) {
+    onValue(useProjectedSessionLifecycle(TAB));
+    return null;
+  }
+
+  it("returns appStore verbatim and never subscribes", async () => {
+    useAppStore.setState({ terminalConnecting: { [TAB]: true } });
+    // A divergent snapshot exists but must be ignored with the flag off.
+    harness.transport.setSession(TAB, connected());
+    let latest: ProjectedSessionLifecycleSlice | undefined;
+    mount(<Probe onValue={(v) => (latest = v)} />);
+    await flushSessionRegion();
+    expect(latest?.connecting).toBe(true);
+    expect(harness.transport.subscribeCount).toBe(0);
+  });
+});
+
+describe("useProjectedSessionLifecycleMaps (list consumers)", () => {
+  const harness = installSessionLifecycleHarness();
+
+  function Probe({ onValue }: { onValue: (v: ProjectedSessionLifecycleMaps) => void }) {
+    onValue(useProjectedSessionLifecycleMaps());
+    return null;
+  }
+
+  it("mirrors the appStore maps sourced through the region", async () => {
+    useAppStore.setState({
+      terminalConnecting: { a: true },
+      terminalReconnectingTabs: { b: true },
+      terminalDisconnectErrors: { c: "boom" },
+    });
+    harness.transport.setSession("a", connecting());
+    harness.transport.setSession("b", reconnecting({ phase: "waiting", attempt: 0, delayMs: 1000 }));
+    harness.transport.setSession("c", failed("boom"));
+    let latest: ProjectedSessionLifecycleMaps | undefined;
+    mount(<Probe onValue={(v) => (latest = v)} />);
+    await flushSessionRegion();
+
+    expect(harness.transport.subscribeCount).toBeGreaterThan(0);
+    expect(latest?.terminalConnecting).toEqual({ a: true });
+    expect(latest?.terminalReconnectingTabs).toEqual({ b: true });
+    expect(latest?.terminalDisconnectErrors).toEqual({ c: "boom" });
+  });
+});

--- a/src/store/useProjectedSessionLifecycle.test.tsx
+++ b/src/store/useProjectedSessionLifecycle.test.tsx
@@ -75,7 +75,10 @@ describe("useProjectedSessionLifecycle (per tab)", () => {
       terminalReconnectingTabs: { [TAB]: true },
       terminalDisconnectErrors: {},
     });
-    harness.transport.setSession(TAB, reconnecting({ phase: "waiting", attempt: 1, delayMs: 3000 }));
+    harness.transport.setSession(
+      TAB,
+      reconnecting({ phase: "waiting", attempt: 1, delayMs: 3000 })
+    );
     let latest: ProjectedSessionLifecycleSlice | undefined;
     mount(<Probe onValue={(v) => (latest = v)} />);
     await flushSessionRegion();
@@ -137,7 +140,10 @@ describe("useProjectedSessionLifecycleMaps (list consumers)", () => {
       terminalDisconnectErrors: { c: "boom" },
     });
     harness.transport.setSession("a", connecting());
-    harness.transport.setSession("b", reconnecting({ phase: "waiting", attempt: 0, delayMs: 1000 }));
+    harness.transport.setSession(
+      "b",
+      reconnecting({ phase: "waiting", attempt: 0, delayMs: 1000 })
+    );
     harness.transport.setSession("c", failed("boom"));
     let latest: ProjectedSessionLifecycleMaps | undefined;
     mount(<Probe onValue={(v) => (latest = v)} />);

--- a/src/store/useSessionLifecycle.ts
+++ b/src/store/useSessionLifecycle.ts
@@ -27,11 +27,18 @@
  *   making the cut parity-safe and independent of the mutation flag.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useAppStore } from "@/store/appStore";
 import {
+  currentSessionView,
   effectiveAutoReconnect,
+  effectiveConnecting,
+  effectiveConnectingMap,
+  effectiveDisconnectError,
+  effectiveDisconnectErrorMap,
+  effectiveReconnecting,
+  effectiveReconnectingMap,
   ensureSessionSubscribed,
   logSessionBridgeFallback,
   onSessionView,
@@ -87,4 +94,148 @@ export function useSessionAutoReconnect(tabId: string): TerminalAutoReconnectSta
   }, [enabled, tabId]);
 
   return effectiveAutoReconnect(record, enabled ? projected : undefined);
+}
+
+/**
+ * The per-tab session-status slice the terminal overlays render: the connect /
+ * reconnect flags and the disconnect error, sourced from the projected
+ * `session-lifecycle` region when it faithfully mirrors `appStore` and otherwise
+ * from `appStore` verbatim (#2205 PR-A render cut).
+ */
+export interface ProjectedSessionLifecycleSlice {
+  /** True while an initial connect is in flight (mirrors `terminalConnecting`). */
+  connecting: boolean;
+  /** True while the agent is actively reconnecting (mirrors `terminalReconnectingTabs`). */
+  reconnecting: boolean;
+  /** The failed-(re)connect error, if any (mirrors `terminalDisconnectErrors`). */
+  disconnectError: string | undefined;
+}
+
+/**
+ * `useProjectedSessionLifecycle` — the per-tab render cut for the terminal
+ * lifecycle overlays (#2205 PR-A). Returns the connect / reconnect flags and the
+ * disconnect error for one tab, sourced from the shared `session-lifecycle`
+ * projection region under the faithful-mirror gate, with an `appStore` fallback so
+ * the rendered output is byte-identical to the pre-cut path. The direct analog of
+ * {@link useSessionAutoReconnect} for the coarse status fields.
+ *
+ * `appStore` remains the authoritative writer (its slices, the
+ * `driveAutoReconnect` engine and the client `session.*` dispatch are untouched by
+ * PR-A) — this hook only changes where components *read*.
+ */
+export function useProjectedSessionLifecycle(tabId: string): ProjectedSessionLifecycleSlice {
+  const connectingLocal = useAppStore((s) => s.terminalConnecting[tabId] ?? false);
+  const reconnectingLocal = useAppStore((s) => s.terminalReconnectingTabs[tabId] ?? false);
+  const disconnectErrorLocal = useAppStore((s) => s.terminalDisconnectErrors[tabId]);
+
+  // Read the flag once at mount: it flips only via dev tooling, and the
+  // subscription lifecycle is keyed off it below.
+  const [enabled] = useState(() => sessionRenderFromProjectionEnabled());
+
+  const [projected, setProjected] = useState<ProjectedSessionLifecycle | undefined>(undefined);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const unsubscribe = onSessionView((next) => {
+      if (!cancelled) setProjected(next[tabId]);
+    });
+    // `ensureSessionSubscribed` builds the transport eagerly, so a non-Tauri env
+    // without a socket throws synchronously (not just a rejection) — guard both so
+    // the reader silently stays on the appStore fallback.
+    try {
+      ensureSessionSubscribed()
+        .then((client) => {
+          if (cancelled) return;
+          const view = client.state.view as SessionLifecycleView | undefined;
+          setProjected(view?.sessions?.[tabId]);
+        })
+        .catch((err) => logSessionBridgeFallback("subscribe", err));
+    } catch (err) {
+      logSessionBridgeFallback("subscribe", err);
+    }
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [enabled, tabId]);
+
+  const p = enabled ? projected : undefined;
+  return {
+    connecting: effectiveConnecting(connectingLocal, p),
+    reconnecting: effectiveReconnecting(reconnectingLocal, p),
+    disconnectError: effectiveDisconnectError(disconnectErrorLocal, p),
+  };
+}
+
+/**
+ * The tab-id-keyed session-status maps the list consumers render: the tab-strip
+ * status dot ({@link import("@/utils/tabStatus").deriveTabStatus}), Open
+ * Connections' connecting filter and the split-panel overlay gates all read the
+ * whole maps rather than a single tab. Same fields, same faithful-mirror gate as
+ * {@link useProjectedSessionLifecycle}, sourced from the region view.
+ */
+export interface ProjectedSessionLifecycleMaps {
+  terminalConnecting: Record<string, boolean>;
+  terminalReconnectingTabs: Record<string, boolean>;
+  terminalDisconnectErrors: Record<string, string>;
+}
+
+/**
+ * `useProjectedSessionLifecycleMaps` — the map-level render cut for the list
+ * consumers (#2205 PR-A). Subscribes to the shared `session-lifecycle` region once
+ * and returns the connect / reconnect / disconnect-error maps sourced through the
+ * faithful-mirror gate, falling back to `appStore` per key. Byte-identical to the
+ * pre-cut `appStore` reads; the analog of
+ * {@link import("./useLayoutRenderTree").useLayoutRenderTree} for the lifecycle
+ * status maps.
+ */
+export function useProjectedSessionLifecycleMaps(): ProjectedSessionLifecycleMaps {
+  const connectingLocal = useAppStore((s) => s.terminalConnecting);
+  const reconnectingLocal = useAppStore((s) => s.terminalReconnectingTabs);
+  const disconnectErrorsLocal = useAppStore((s) => s.terminalDisconnectErrors);
+
+  const [enabled] = useState(() => sessionRenderFromProjectionEnabled());
+
+  const [view, setView] = useState<Record<string, ProjectedSessionLifecycle>>(() =>
+    currentSessionView()
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const unsubscribe = onSessionView((next) => {
+      if (!cancelled) setView(next);
+    });
+    try {
+      ensureSessionSubscribed()
+        .then((client) => {
+          if (cancelled) return;
+          const clientView = client.state.view as SessionLifecycleView | undefined;
+          setView(clientView?.sessions ?? {});
+        })
+        .catch((err) => logSessionBridgeFallback("subscribe", err));
+    } catch (err) {
+      logSessionBridgeFallback("subscribe", err);
+    }
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, [enabled]);
+
+  return useMemo(() => {
+    if (!enabled) {
+      return {
+        terminalConnecting: connectingLocal,
+        terminalReconnectingTabs: reconnectingLocal,
+        terminalDisconnectErrors: disconnectErrorsLocal,
+      };
+    }
+    return {
+      terminalConnecting: effectiveConnectingMap(connectingLocal, view),
+      terminalReconnectingTabs: effectiveReconnectingMap(reconnectingLocal, view),
+      terminalDisconnectErrors: effectiveDisconnectErrorMap(disconnectErrorsLocal, view),
+    };
+  }, [enabled, connectingLocal, reconnectingLocal, disconnectErrorsLocal, view]);
 }

--- a/src/test/sessionLifecycleRegionTestHarness.ts
+++ b/src/test/sessionLifecycleRegionTestHarness.ts
@@ -167,7 +167,10 @@ export function reconnecting(reconnect: ProjectedReconnect): ProjectedSessionLif
 }
 
 /** A terminal `failed` projected lifecycle carrying the disconnect error. */
-export function failed(error: string, endReason: ProjectedEndReason = "error"): ProjectedSessionLifecycle {
+export function failed(
+  error: string,
+  endReason: ProjectedEndReason = "error"
+): ProjectedSessionLifecycle {
   return { status: "failed", reconnect: idleReconnect(), endReason, error };
 }
 

--- a/src/test/sessionLifecycleRegionTestHarness.ts
+++ b/src/test/sessionLifecycleRegionTestHarness.ts
@@ -1,0 +1,177 @@
+/**
+ * Test harness for the projected `session-lifecycle` region (#2205 PR-A render
+ * cut, part of #2152 / #2139).
+ *
+ * The terminal lifecycle readers — the connection / disconnect overlays, the
+ * tab-strip status dot, the split-panel overlay gates and Open Connections — source
+ * their connect / reconnect / disconnect status from the shared `session-lifecycle`
+ * region via {@link import("@/store/useSessionLifecycle").useProjectedSessionLifecycle}
+ * / {@link import("@/store/useSessionLifecycle").useProjectedSessionLifecycleMaps},
+ * under a faithful-mirror gate with an `appStore` fallback. This harness lets a test
+ * drive that region without a backend.
+ *
+ * It generalises the in-memory region double first written inline in
+ * `TerminalDisconnectOverlay.projection.test.tsx` (#2204): {@link FakeSessionTransport}
+ * holds one `{ sessions }` view and fans a fresh snapshot to every subscriber on
+ * each mutation. {@link installSessionLifecycleHarness} wires it (plus the render /
+ * intent flags) into a `beforeEach` / `afterEach` pair and hands back a small handle
+ * for seeding sessions. The `connecting` / `reconnecting` / `disconnected` /
+ * `connected` builders produce the twin serde shapes the Rust `SessionLifecycleStore`
+ * serialises.
+ *
+ * PR-A is a render cut: `appStore` is still the authoritative writer, so a component
+ * test typically seeds *both* — `appStore` for the authoritative slice the gate
+ * compares against, and the region for the value the render should source. Seeding
+ * only `appStore` (region empty) is the fallback path and stays byte-identical.
+ */
+
+import { afterEach, beforeEach } from "vitest";
+import { act } from "react";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import {
+  SESSION_LIFECYCLE_REGION,
+  setSessionIntentsEnabled,
+  setSessionRenderFromProjectionEnabled,
+  setSessionTransportForTest,
+  stopSessionSubscription,
+  type ProjectedReconnect,
+  type ProjectedEndReason,
+  type ProjectedSessionLifecycle,
+} from "@/store/sessionBridge";
+
+/**
+ * An in-memory `session-lifecycle` region double: holds one view and fans a fresh
+ * snapshot to every subscriber on each mutation, so a reader's render can be driven
+ * by projected snapshots without a backend. Intents are accepted as no-ops (PR-A
+ * changes reads, not writes — the authoritative slice lives in `appStore`).
+ */
+export class FakeSessionTransport implements Transport {
+  private view: { sessions: Record<string, ProjectedSessionLifecycle> } = { sessions: {} };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+  /** How many times a client subscribed — asserts the region was actually read. */
+  subscribeCount = 0;
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    return { intentId: intent.intentId, status: "accepted", produced: [] };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.subscribeCount += 1;
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  /** Set a session's projected lifecycle and fan the fresh snapshot out. */
+  setSession(id: string, life: ProjectedSessionLifecycle): void {
+    this.view.sessions[id] = life;
+    this.version += 1;
+    this.fan();
+  }
+
+  /** Remove a session from the projected view and fan the fresh snapshot out. */
+  clearSession(id: string): void {
+    delete this.view.sessions[id];
+    this.version += 1;
+    this.fan();
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(SESSION_LIFECYCLE_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+/** A handle onto the installed harness for seeding the region within a test. */
+export interface SessionLifecycleHarness {
+  /** The live region double; use {@link FakeSessionTransport.setSession}. */
+  transport: FakeSessionTransport;
+}
+
+/**
+ * Install the `session-lifecycle` region double for a test suite: wire the fake
+ * transport and turn the render / intent flags on in `beforeEach`, and tear the
+ * subscription / transport / flag overrides down in `afterEach`. Returns a handle
+ * whose `transport` is refreshed for each test.
+ *
+ * @param renderFromProjection Whether the render cut is on (default `true`). Pass
+ *   `false` to exercise the flag-off fallback path.
+ */
+export function installSessionLifecycleHarness(
+  renderFromProjection = true
+): SessionLifecycleHarness {
+  const handle: SessionLifecycleHarness = { transport: new FakeSessionTransport() };
+
+  beforeEach(() => {
+    handle.transport = new FakeSessionTransport();
+    setSessionTransportForTest(handle.transport);
+    setSessionRenderFromProjectionEnabled(renderFromProjection);
+    setSessionIntentsEnabled(true);
+  });
+
+  afterEach(() => {
+    stopSessionSubscription();
+    setSessionTransportForTest(null);
+    setSessionRenderFromProjectionEnabled(null);
+    setSessionIntentsEnabled(null);
+  });
+
+  return handle;
+}
+
+/** Flush the bridge's async subscribe + fan-out so a projected snapshot lands. */
+export async function flushSessionRegion(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+// ── Projected-lifecycle builders (twins of the Rust serde shapes) ───────────────
+
+/** A `connecting` (initial connect in flight) projected lifecycle. */
+export function connecting(): ProjectedSessionLifecycle {
+  return { status: "connecting", reconnect: idleReconnect() };
+}
+
+/** A `connected` projected lifecycle. */
+export function connected(): ProjectedSessionLifecycle {
+  return { status: "connected", reconnect: idleReconnect() };
+}
+
+/** A `reconnecting` projected lifecycle carrying the loop detail. */
+export function reconnecting(reconnect: ProjectedReconnect): ProjectedSessionLifecycle {
+  return { status: "reconnecting", reconnect };
+}
+
+/** A terminal `failed` projected lifecycle carrying the disconnect error. */
+export function failed(error: string, endReason: ProjectedEndReason = "error"): ProjectedSessionLifecycle {
+  return { status: "failed", reconnect: idleReconnect(), endReason, error };
+}
+
+/** The idle reconnect detail (no loop active). */
+export function idleReconnect(): ProjectedReconnect {
+  return { phase: "idle", attempt: 0, delayMs: 0 };
+}


### PR DESCRIPTION
## Summary

Phase 4 step 4 **render cut** for the shared `session-lifecycle` region — **PR-A of #2205** (the low-risk half of the split; the reducer / authority removal is PR-B). This is the terminal reconnect hot path in a ventilator-grade app, so it is deliberately parity-preserving: it changes **where components read** the connect / reconnect / disconnect status, not who writes it.

`appStore` remains the authoritative writer — its lifecycle slices, the `driveAutoReconnect` / `reconnectReducer` engine, and the client `session.*` dispatch are **untouched**. Readers now source their status from the projected region under a faithful-mirror gate, falling back to `appStore` per field/key, so the rendered output is byte-identical to the pre-cut path — independent of the mutation flag and of the deferred server-side folds (#2439).

## What changed

- **`sessionBridge.ts`** — `currentSessionView()` plus mirror-gated `effective{Connecting,Reconnecting,DisconnectError}` field helpers and their `*Map` variants (same idiom as the existing `effectiveAutoReconnect`).
- **`useSessionLifecycle.ts`** — two hooks: `useProjectedSessionLifecycle(tabId)` (per-tab overlays) and `useProjectedSessionLifecycleMaps()` (list consumers), both subscribing to the shared region with an `appStore` fallback.
- **Readers flipped** to the region: `TerminalConnectionOverlay` (connecting), `TerminalDisconnectOverlay` (disconnect error + reconnecting), `TabBar` status dot (connecting/reconnecting/disconnect-error maps), `SplitView` overlay gates + `TerminalSlot` (connecting map, reconnecting, and the `#2204` auto-reconnect gate now via `useSessionAutoReconnect`), `OpenConnections` (connecting map).
- **Tests** — a shared `sessionLifecycleRegionTestHarness` (extracted from the inline region double in `TerminalDisconnectOverlay.projection.test.tsx`), plus unit coverage for the gate helpers, the two hooks, and the overlay rendering reconnecting / disconnect-error from a mirroring projected snapshot.

## Deliberately NOT migrated (parity gap, noted)

- `terminalReconnectTriggerErrors` stays on `appStore`: the region has **no distinct field** for a manual-reconnect-trigger error (it is frontend-only UX with no `session.*` intent), so PR-A cannot faithfully mirror it. It remains an `appStore` read in `TerminalDisconnectOverlay`; PR-B / the deferred server folds (#2439) can revisit it.
- **Imperative engine reads** of the slices in `TerminalView.tsx` (agent-reconnect orchestration) are left on `appStore` — they are `getState()` reads inside event handlers, not render reads, and belong to the engine that PR-A keeps as-is.

## Verification

- `tsc --noEmit`, ESLint, `prettier --check` (src + docs) all clean.
- Full frontend suite green: **542 files / 4876 tests**.
- No Rust touched.

Part of #2205