### PR TITLE
feat(backend): plumb kill-intent and fold session.disconnect server-side (Part of #2439)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -184,13 +184,57 @@ pub async fn resize_terminal(
 }
 
 /// Close a session.
+///
+/// `intentional` marks a **user-initiated kill** (the Open Connections panel's
+/// kill actions, which the frontend also tags via `markSessionKilled`) — as
+/// opposed to a tab close or resource-cleanup close. It is the kill-intent signal
+/// plumbed to the backend for the server-authoritative `session-lifecycle`
+/// migration (#2439, part of #2205): with it the backend can classify a
+/// terminal's end as *killed* rather than *dropped*, and fold the graceful
+/// `session.disconnect` transition server-side (see below). Defaults to `false`
+/// when the frontend omits it (a normal, non-kill close).
 #[tauri::command]
 pub async fn close_terminal(
     session_id: String,
+    intentional: Option<bool>,
+    app_handle: tauri::AppHandle,
     manager: State<'_, SessionManager>,
 ) -> Result<(), TerminalError> {
-    info!(session_id, "Closing session");
-    manager.close_session(&session_id).await
+    let intentional = intentional.unwrap_or(false);
+    info!(session_id, intentional, "Closing session");
+
+    // Server-authority fold (#2439, part of #2205): a user-initiated kill is the
+    // one exit the backend can classify *before* the session ends — the frontend
+    // tagged it `intentional`. Resolve the frontend tab id through the identity
+    // bridge (#2431) **before** the close clears the mapping, so the fold can
+    // address the tab-id-keyed region. Only the **convergent** kill edge is folded
+    // here: the client mirrors a `killed` exit as `session.disconnect`, so folding
+    // `disconnect` server-side is a benign convergent double-write (like the
+    // initial connect's `connect`/`connected` fold in `create_connection`).
+    //
+    // The genuine-drop → `session.dropped` fold is deliberately **not** done here:
+    // for a resilient-reconnect tab the client resolves an unexpected drop to
+    // `session.reconnect` (not `dropped`), and the backend cannot yet distinguish a
+    // resilient tab (that signal is step 2, #2439). Folding `dropped` for all
+    // non-killed drops would therefore conflict with the client's `reconnect` on
+    // the ventilator hot path, so it waits for the resilient-reconnect signal.
+    let killed_tab_id = killed_disconnect_tab_id(intentional, manager.tab_id_for(&session_id));
+    let result = manager.close_session(&session_id).await;
+    if let (Ok(()), Some(tab_id)) = (&result, &killed_tab_id) {
+        fold_session_transition(&app_handle, |store| store.disconnect(tab_id));
+    }
+    result
+}
+
+/// The frontend `tab_id` to fold a `session.disconnect` for when a session is
+/// closed, or `None` when no fold should happen (#2439).
+///
+/// Returns `Some(tab_id)` only for an **intentional** (user-kill) close of a
+/// session that carries a tab mapping. A non-intentional close (tab close,
+/// cleanup) or a session with no tab (`tab_id` is `None`) yields `None`: those
+/// ends are either owned by the client mirror or have no region entry to address.
+fn killed_disconnect_tab_id(intentional: bool, tab_id: Option<String>) -> Option<String> {
+    intentional.then_some(tab_id).flatten()
 }
 
 /// List all active local sessions.
@@ -911,4 +955,42 @@ pub async fn get_agent_session_buffer(
         .get_remote_session_buffer(&session_id)
         .await
         .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{initial_connect_tab_id, killed_disconnect_tab_id};
+
+    #[test]
+    fn killed_disconnect_folds_only_for_an_intentional_kill_with_a_tab() {
+        // Intentional kill of a tab-bearing session → fold disconnect for that tab.
+        assert_eq!(
+            killed_disconnect_tab_id(true, Some("tab-1".to_string())),
+            Some("tab-1".to_string())
+        );
+        // Non-intentional close (tab close / cleanup) → never fold, even with a tab.
+        assert_eq!(
+            killed_disconnect_tab_id(false, Some("tab-1".to_string())),
+            None
+        );
+        // Intentional kill of a session with no tab mapping → nothing to address.
+        assert_eq!(killed_disconnect_tab_id(true, None), None);
+        // Non-intentional close of a tabless session → None.
+        assert_eq!(killed_disconnect_tab_id(false, None), None);
+    }
+
+    #[test]
+    fn initial_connect_tab_id_folds_only_the_initial_attempt() {
+        // Initial attempt (retry 0) of a tab-bearing connect → fold that tab.
+        assert_eq!(
+            initial_connect_tab_id(Some("tab-1:0")),
+            Some("tab-1".to_string())
+        );
+        // A reconnect attempt (retry > 0) is owned by the client + backend timer.
+        assert_eq!(initial_connect_tab_id(Some("tab-1:2")), None);
+        // No connect_id (e.g. internal agent-setup session) → None.
+        assert_eq!(initial_connect_tab_id(None), None);
+        // A connect_id not carrying the tab-id:retry form → None.
+        assert_eq!(initial_connect_tab_id(Some("no-colon")), None);
+    }
 }

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -857,11 +857,12 @@ impl SessionManager {
     /// backend lifecycle source that knows only the uuid `session_id` (the
     /// `terminal-exit` emission, `close_session`) resolves it to the tab id the
     /// region is keyed by. The initial-connect fold (`create_connection`) reads
-    /// the tab id straight off the `connect_id`, so this uuid→tab lookup is only
-    /// consumed by the *deferred* drop / disconnect folds (see #2205 and the
-    /// follow-up); the map it reads is populated and cleaned up live, and the
-    /// lookup is covered by unit tests.
-    #[allow(dead_code)] // staged API: the deferred drop / disconnect folds consume this (#2205).
+    /// the tab id straight off the `connect_id`, so this uuid→tab lookup backs the
+    /// close/kill path: `close_terminal` resolves it to fold the graceful
+    /// `session.disconnect` for a user-initiated kill (#2439). The map it reads is
+    /// populated and cleaned up live, and the lookup is covered by unit tests. The
+    /// genuine-drop `session.dropped` fold at `terminal-exit` is still deferred
+    /// (needs the resilient-reconnect signal — see #2439).
     pub fn tab_id_for(&self, session_id: &str) -> Option<String> {
         self.session_tab_ids
             .lock()

--- a/src-tauri/src/session_projection/projection_tests.rs
+++ b/src-tauri/src/session_projection/projection_tests.rs
@@ -472,3 +472,76 @@ fn server_side_connect_fold_matches_the_client_session_connect_route() {
         "the server fold reproduces the client route's transition exactly"
     );
 }
+
+/// A user-initiated kill (`close_terminal` with `intentional = true`) folds the
+/// graceful `session.disconnect` server-side under the tab id: the session lands
+/// idle `Disconnected` with reason `User`, and the region diff fans out — no
+/// client dispatch (#2439, part of #2205).
+#[test]
+fn server_side_kill_disconnect_fold_settles_the_session_disconnected() {
+    let app = tauri::test::mock_app();
+    let store = Arc::new(SessionLifecycleStore::new());
+    store.connect("tab-1");
+    store.connected("tab-1");
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    let snap = projection
+        .projector
+        .subscribe(SESSION_LIFECYCLE_REGION, "sub", "C", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+    app.manage(projection);
+
+    // The kill path folds the graceful disconnect at the source, keyed by the tab
+    // id — the same transition the client mirrors for a `killed` exit.
+    fold_session_transition(app.handle(), |s| s.disconnect("tab-1"));
+
+    assert_eq!(
+        store.get("tab-1").map(|s| s.status),
+        Some(crate::session_projection::store::SessionStatus::Disconnected)
+    );
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "one diff from the server-side kill fold");
+    cache.apply(&diffs[0]);
+    assert_eq!(
+        cache.view["sessions"]["tab-1"]["status"],
+        json!("disconnected")
+    );
+    assert_eq!(cache.view["sessions"]["tab-1"]["endReason"], json!("user"));
+}
+
+/// The server-side kill-disconnect fold reproduces the client `session.disconnect`
+/// route's store transition exactly — so the convergent double-write (server fold
+/// + still-present client mirror) never drifts for a `killed` exit.
+#[test]
+fn server_side_kill_disconnect_fold_matches_the_client_session_disconnect_route() {
+    // (a) Server-side fold.
+    let server = SessionLifecycleStore::new();
+    server.connect("tab-1");
+    server.connected("tab-1");
+    server.disconnect("tab-1");
+
+    // (b) Client route: the `session.disconnect` intent through the production registry.
+    let client = Arc::new(SessionLifecycleStore::new());
+    client.connect("tab-1");
+    client.connected("tab-1");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SESSION_LIFECYCLE_REGION, client.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(client.clone())));
+    let ack = dispatcher.dispatch(intent(
+        "session.disconnect",
+        json!({ "sessionId": "tab-1" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    assert_eq!(
+        server.snapshot(),
+        client.snapshot(),
+        "the server kill fold reproduces the client disconnect route's transition exactly"
+    );
+}

--- a/src/components/OpenConnections/OpenConnectionsModal.spawned.test.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.spawned.test.tsx
@@ -18,7 +18,7 @@ import { TooltipProvider } from "@/components/ui";
 import type { TerminalTab } from "@/types/terminal";
 import type { LocalSessionInfo } from "@/services/api";
 
-const closeTerminal = vi.fn((_id: string) => Promise.resolve());
+const closeTerminal = vi.fn((_id: string, _intentional?: boolean) => Promise.resolve());
 const listLocalSessions = vi.fn<() => Promise<LocalSessionInfo[]>>();
 
 vi.mock("@/services/api", () => ({
@@ -26,7 +26,7 @@ vi.mock("@/services/api", () => ({
   focusWindow: vi.fn(() => Promise.resolve()),
   listLocalSessions: () => listLocalSessions(),
   listAgentSessions: vi.fn(() => Promise.resolve([])),
-  closeTerminal: (id: string) => closeTerminal(id),
+  closeTerminal: (id: string, intentional?: boolean) => closeTerminal(id, intentional),
   closeAgentSession: vi.fn(() => Promise.resolve()),
   cancelConnecting: vi.fn(() => Promise.resolve(true)),
   cancelConnectAgent: vi.fn(() => Promise.resolve()),
@@ -162,7 +162,8 @@ describe("OpenConnectionsModal — Spawned Containers section", () => {
       killBtn.click();
       await Promise.resolve();
     });
-    expect(closeTerminal).toHaveBeenCalledWith("sess-spawn");
+    // The kill routes the intentional kill-intent flag to the backend (#2439).
+    expect(closeTerminal).toHaveBeenCalledWith("sess-spawn", true);
   });
 
   it("groups a spawned session from the backend marker alone (no spawned tab flag)", async () => {
@@ -199,6 +200,7 @@ describe("OpenConnectionsModal — Spawned Containers section", () => {
       killBtn.click();
       await Promise.resolve();
     });
-    expect(closeTerminal).toHaveBeenCalledWith("sess-spawn");
+    // The kill routes the intentional kill-intent flag to the backend (#2439).
+    expect(closeTerminal).toHaveBeenCalledWith("sess-spawn", true);
   });
 });

--- a/src/components/OpenConnections/OpenConnectionsModal.tsx
+++ b/src/components/OpenConnections/OpenConnectionsModal.tsx
@@ -346,7 +346,7 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
     // Tag the kill as intentional so the terminal-exit handler suppresses the
     // "unexpected disconnect" overlay for the owning tab (#1121).
     markSessionKilled(id);
-    await closeTerminal(id).catch(() => {});
+    await closeTerminal(id, true).catch(() => {});
     setLocalSessions((prev) => prev.filter((s) => s.id !== id));
   };
 
@@ -356,7 +356,7 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const killSessions = async (sessions: LocalSessionInfo[]) => {
     const ids = new Set(sessions.map((s) => s.id));
     sessions.forEach((s) => markSessionKilled(s.id));
-    await Promise.all(sessions.map((s) => closeTerminal(s.id).catch(() => {})));
+    await Promise.all(sessions.map((s) => closeTerminal(s.id, true).catch(() => {})));
     setLocalSessions((prev) => prev.filter((s) => !ids.has(s.id)));
   };
 
@@ -423,7 +423,7 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
 
   const handleKillProxy = async (agentId: string, id: string) => {
     markSessionKilled(id);
-    await closeTerminal(id).catch(() => {});
+    await closeTerminal(id, true).catch(() => {});
     setProxySessions((prev) => ({
       ...prev,
       [agentId]: (prev[agentId] ?? []).filter((s) => s.id !== id),
@@ -433,7 +433,7 @@ export function OpenConnectionsModal({ open, onOpenChange }: OpenConnectionsModa
   const handleKillAllProxy = async (agentId: string) => {
     const sessions = proxySessions[agentId] ?? [];
     sessions.forEach((s) => markSessionKilled(s.id));
-    await Promise.all(sessions.map((s) => closeTerminal(s.id).catch(() => {})));
+    await Promise.all(sessions.map((s) => closeTerminal(s.id, true).catch(() => {})));
     setProxySessions((prev) => ({ ...prev, [agentId]: [] }));
   };
 

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -247,13 +247,25 @@ describe("api service", () => {
       });
     });
 
-    it("closeTerminal invokes with session ID", async () => {
+    it("closeTerminal invokes with session ID (non-kill close by default)", async () => {
       mockedInvoke.mockResolvedValue(undefined);
 
       await closeTerminal("session-1");
 
       expect(mockedInvoke).toHaveBeenCalledWith("close_terminal", {
         sessionId: "session-1",
+        intentional: false,
+      });
+    });
+
+    it("closeTerminal forwards the intentional kill-intent flag (#2439)", async () => {
+      mockedInvoke.mockResolvedValue(undefined);
+
+      await closeTerminal("session-1", true);
+
+      expect(mockedInvoke).toHaveBeenCalledWith("close_terminal", {
+        sessionId: "session-1",
+        intentional: true,
       });
     });
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -524,9 +524,17 @@ export async function resizeTerminal(
   await invoke("resize_terminal", { sessionId, cols, rows });
 }
 
-/** Close a terminal session */
-export async function closeTerminal(sessionId: SessionId): Promise<void> {
-  await invoke("close_terminal", { sessionId });
+/**
+ * Close a terminal session.
+ *
+ * `intentional` tags a user-initiated kill (the Open Connections panel's kill
+ * actions) as opposed to a tab close or resource cleanup. It is the kill-intent
+ * signal the backend uses to classify the terminal's end as *killed* rather than
+ * *dropped* and fold the graceful `session.disconnect` transition server-side
+ * (#2439, part of #2205). Defaults to `false` for a normal, non-kill close.
+ */
+export async function closeTerminal(sessionId: SessionId, intentional = false): Promise<void> {
+  await invoke("close_terminal", { sessionId, intentional });
 }
 
 // --- Remote-desktop (graphical) commands (#1680) ---


### PR DESCRIPTION
## Summary

Part of #2439 (step 1 of making session-lifecycle server-authoritative — the prerequisite for #2205 PR-B). This plumbs the UI **kill-intent** to the backend so the shared `session-lifecycle` region reflects a user-initiated kill **server-authoritatively**, and folds the convergent transition at the source.

Additive and careful on the ventilator reconnect hot path — the frontend `session.*` mirror, `driveAutoReconnect` engine, and appStore slice are all left intact.

## What changed

- **`close_terminal` carries an `intentional` flag.** The Open Connections panel's kill actions (the `markSessionKilled` sites) pass `intentional: true`; a tab close / resource cleanup passes `false` (default). This is the kill-intent signal the backend previously never learned.
- **On an intentional kill, the backend folds `session.disconnect` server-side.** The command resolves the frontend tab id via the `SessionManager::tab_id_for` identity bridge (#2431) **before** the close clears it, then calls `fold_session_transition(app, tab_id, disconnect)`. This is a **benign convergent double-write** with the client's `session.disconnect` mirror for a `killed` exit — exactly the pattern `create_connection` already uses for the initial `connect`/`connected` fold.
- `tab_id_for` is now consumed in production; its stale `#[allow(dead_code)]` (staged-API note) is removed.

## Deferred (STOP-reported boundary): the genuine-drop `session.dropped` fold

The issue's step-1 bundles "fold `session.dropped` server-side for non-killed drops". That fold is **deliberately not done here** because it cannot be made non-conflicting yet:

- For a genuine drop, the client resolves the exit differently **depending on frontend-only tab config**: a resilient-reconnect SSH tab (`isResilientReconnectTab`) folds `session.reconnect` (→ `Reconnecting`), while a non-resilient tab folds `session.dropped` (→ `Disconnected`).
- `sessionIntentsEnabled()` is **on by default**, so that client mirror is live.
- The backend does **not** know `resilientReconnect` (it is a frontend SSH tab-config flag; even the connection-type is not enough to distinguish an opted-in tab). So a server `dropped` fold for all non-killed drops would **conflict with the client's `session.reconnect`** for resilient tabs and risk a reconnect-behavior regression.

This is exactly the divergence pattern already handled by deferring `create_connection`'s `connect_failed` fold. The `dropped` fold therefore waits for the **resilient-reconnect signal (#2439 step 2)**; once the backend can identify a resilient tab, the drop fold becomes unambiguous.

The killed edge (`disconnect`) is unambiguous — a killed exit never reconnects — so it is safe to fold now, and it satisfies "a killed exit does NOT fold dropped".

## Tests

- Rust unit (`killed_disconnect_tab_id`): folds only for an intentional kill of a tab-bearing session; a non-intentional close or a tabless session folds nothing. (Plus a companion test for the existing `initial_connect_tab_id`.)
- Rust projection (end-to-end against `mock_app`, mirroring the #2431 fold tests): a server-side disconnect fold lands the session `disconnected`/`user` under the tab id and fans exactly one region diff — with no client dispatch — and reproduces the client `session.disconnect` route's snapshot exactly (parity, no drift).
- Frontend: `closeTerminal` forwards the `intentional` flag; the Open Connections kill routes it as `true`.

## Verification

- `cargo build` / `cargo clippy --all-targets` / `cargo fmt --check`: clean.
- `cargo test -p termihub --lib`: pass, except the pre-existing `agent_deploy_sftp_upload_round_trips_over_real_ssh` integration test (needs the `ssh-password` docker fixture; unrelated to this change and excluded from per-PR CI).
- `tsc`, eslint, `prettier --check`: clean. Full `pnpm test`: 4877 pass.
- Reconnect behavior is integration-tested at release cadence (not per-PR CI). This change does not touch the drop/reconnect path — only the explicit user-kill path — but a local `./scripts/dev.sh` kill-from-Open-Connections check is the manual confirmation.

Part of #2439