### PR TITLE
feat(backend): fold genuine session drops server-side (Part of #2439)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -39,6 +39,13 @@ use crate::window::WindowManager;
 /// Containers" from this authoritative marker, which survives the tab close that
 /// would otherwise strip the frontend-only `spawned` tab flag. Defaults to
 /// `false` when the frontend omits it (normal local/agent connections).
+///
+/// `resilient_reconnect` carries the client's `isResilientReconnectTab`
+/// determination for the owning tab (#2439, part of #2205). Recorded on the
+/// session's tab binding so a **genuine drop** observed at the `terminal-exit`
+/// source can be folded server-side as `session.reconnect` (resilient) vs
+/// `session.dropped` (non-resilient) — converging with the client's
+/// `setTerminalExited` classification. Defaults to `false`.
 // Tauri command: the argument list is the IPC surface (typed params + injected
 // State), so it cannot be collapsed into a struct without losing the command
 // binding — the arity lint does not apply here.
@@ -50,6 +57,7 @@ pub async fn create_connection(
     agent_id: Option<String>,
     connect_id: Option<String>,
     spawned: Option<bool>,
+    resilient_reconnect: Option<bool>,
     app_handle: tauri::AppHandle,
     manager: State<'_, SessionManager>,
     conn_manager: State<'_, ConnectionManager>,
@@ -84,6 +92,7 @@ pub async fn create_connection(
             agent_id.as_deref(),
             connect_id.as_deref(),
             spawned.unwrap_or(false),
+            resilient_reconnect.unwrap_or(false),
             app_handle.clone(),
         )
         .await;

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -147,6 +147,15 @@ pub trait EventEmitter: Clone + Send + Sync + 'static {
 
     /// Emit a persistent session state change. Default no-op for test implementations.
     fn emit_persistent_state(&self, _event: &PersistentSessionStateEvent) {}
+
+    /// Fold a genuine-drop session-lifecycle transition **server-side** (#2439).
+    ///
+    /// Called from the `terminal-exit` source ([`SessionManager::emit_and_cleanup`])
+    /// for a genuine drop, keyed by the frontend `tab_id`. Default no-op for test
+    /// emitters (no projection store); the production `AppHandle` folds into the
+    /// managed `session-lifecycle` store — a benign convergent double-write with
+    /// the client's `setTerminalExited` mirror (like the connect/kill folds).
+    fn fold_session_drop(&self, _tab_id: &str, _fold: DropFold) {}
 }
 
 impl<R: tauri::Runtime> EventEmitter for tauri::AppHandle<R> {
@@ -160,6 +169,14 @@ impl<R: tauri::Runtime> EventEmitter for tauri::AppHandle<R> {
 
     fn emit_persistent_state(&self, event: &PersistentSessionStateEvent) {
         let _ = self.emit("persistent-session-state-changed", event);
+    }
+
+    fn fold_session_drop(&self, tab_id: &str, fold: DropFold) {
+        use crate::session_projection::projection::fold_session_transition;
+        match fold {
+            DropFold::Reconnect => fold_session_transition(self, |store| store.reconnect(tab_id)),
+            DropFold::Dropped => fold_session_transition(self, |store| store.dropped(tab_id, None)),
+        }
     }
 }
 
@@ -243,7 +260,55 @@ type SessionLoggers = Arc<StdMutex<HashMap<String, Arc<StdMutex<SessionLogger>>>
 /// region entry. `create_connection` records the mapping (parsing the tab id from
 /// `connect_id = ${tabId}:${retryCount}`), and every session-removal path clears
 /// it, so the map tracks exactly the live sessions that carry a tab id.
-type SessionTabIds = Arc<StdMutex<HashMap<String, String>>>;
+///
+/// The value is a [`TabBinding`], not a bare tab id: it also carries the tab's
+/// **resilient-reconnect** determination (#2439), so a genuine drop observed at
+/// the `terminal-exit` source can be folded as `reconnect` (resilient) vs
+/// `dropped` (non-resilient) server-side, converging with the client.
+type SessionTabIds = Arc<StdMutex<HashMap<String, TabBinding>>>;
+
+/// A live session's frontend identity + drop classification (#2431, #2439).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct TabBinding {
+    /// The frontend tab id the `session-lifecycle` region is keyed by.
+    pub(super) tab_id: String,
+    /// Whether the owning tab is a resilient-reconnect tab — the client's
+    /// `isResilientReconnectTab` computed at connect time and passed to the
+    /// backend (#2439). Decides a genuine drop's server-side fold:
+    /// `reconnect` when `true`, `dropped` when `false`.
+    pub(super) resilient: bool,
+}
+
+/// The session-lifecycle transition to fold for a **genuine** (non-killed) exit
+/// observed at the `terminal-exit` source, mirroring the client's
+/// `setTerminalExited` classification exactly (#2439). Returned by
+/// [`drop_fold_for`]; `None` means fold nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DropFold {
+    /// A resilient-reconnect tab's drop → `session.reconnect` (→ Reconnecting).
+    Reconnect,
+    /// A non-resilient tab's drop → `session.dropped` (→ Disconnected).
+    Dropped,
+}
+
+/// The server-side fold for a genuine (non-killed) terminal exit, mirroring the
+/// client's `setTerminalExited` reason classification (#2439).
+///
+/// The client computes `reason = exitCode === 0 ? "clean" : "dropped"` for a
+/// non-killed exit, then folds `session.reconnect` for a resilient-reconnect
+/// tab's drop, `session.dropped` for a non-resilient drop, and **nothing** for a
+/// clean exit. This reproduces that: `Some(0)` → `None` (clean folds neither);
+/// any other code (or an unknown `None`, which the desktop `terminal-exit`
+/// currently always emits) → a drop, resilient-gated. The *killed* case never
+/// reaches here — a deliberate close clears the tab binding before the exit
+/// fires (see `close_session`), so this is only called for genuine drops.
+pub(super) fn drop_fold_for(exit_code: Option<i32>, resilient: bool) -> Option<DropFold> {
+    match exit_code {
+        Some(0) => None,
+        _ if resilient => Some(DropFold::Reconnect),
+        _ => Some(DropFold::Dropped),
+    }
+}
 
 /// Status of a session's output logging, returned to the frontend.
 #[derive(Debug, Clone, Serialize)]
@@ -564,6 +629,7 @@ impl SessionManager {
         agent_id: Option<&str>,
         connect_id: Option<&str>,
         spawned: bool,
+        resilient_reconnect: bool,
         emitter: E,
     ) -> Result<String, TerminalError> {
         // Enforce session limit.
@@ -664,12 +730,21 @@ impl SessionManager {
         // tab-id-keyed `session-lifecycle` region entry. The tab id is the
         // `connect_id` up to its trailing `:${retryCount}` (see `Terminal.tsx`);
         // a session created without a `connect_id` (e.g. the internal agent-setup
-        // session) carries no tab and is simply not mapped.
+        // session) carries no tab and is simply not mapped. The `resilient_reconnect`
+        // flag (the client's `isResilientReconnectTab` at connect time) is recorded
+        // alongside so a genuine drop can be folded server-side as `reconnect` vs
+        // `dropped` at the `terminal-exit` source (#2439).
         if let Some(tab_id) = connect_id.and_then(tab_id_from_connect_id) {
             self.session_tab_ids
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .insert(session_id.clone(), tab_id);
+                .insert(
+                    session_id.clone(),
+                    TabBinding {
+                        tab_id,
+                        resilient: resilient_reconnect,
+                    },
+                );
         }
 
         // Determine if we should wait for screen clear (initial command).
@@ -836,17 +911,24 @@ impl SessionManager {
     /// — notably Serial, which clears `output_tx` to stop its reader thread —
     /// are cleaned up immediately.
     pub async fn close_session(&self, session_id: &str) -> Result<(), TerminalError> {
+        // Clear the identity bridge entry (#2431) **before** disconnecting — the
+        // session is gone, so its tab mapping must not linger. Clearing it *first*
+        // is what makes the map's presence at the `terminal-exit` source a
+        // race-free discriminator for the drop fold (#2439): a deliberate close
+        // (a user kill via `close_terminal`, or a tab close) drops the tab binding
+        // before `disconnect()` triggers the reader's EOF, so `emit_and_cleanup`
+        // never sees a binding and never folds a `dropped`/`reconnect` for it. Only
+        // a *genuine* spontaneous drop — where no `close_session` ran — leaves the
+        // binding intact to arm that fold.
+        self.session_tab_ids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(session_id);
         let mut sessions = self.sessions.lock().await;
         if let Some(mut entry) = sessions.remove(session_id) {
             entry.connection.disconnect().await.ok();
             info!(session_id, "Closed session");
         }
-        // Clear the identity bridge entry (#2431) — the session is gone, so its
-        // tab mapping must not linger.
-        self.session_tab_ids
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .remove(session_id);
         Ok(())
     }
 
@@ -861,14 +943,14 @@ impl SessionManager {
     /// close/kill path: `close_terminal` resolves it to fold the graceful
     /// `session.disconnect` for a user-initiated kill (#2439). The map it reads is
     /// populated and cleaned up live, and the lookup is covered by unit tests. The
-    /// genuine-drop `session.dropped` fold at `terminal-exit` is still deferred
-    /// (needs the resilient-reconnect signal — see #2439).
+    /// genuine-drop `reconnect`/`dropped` fold at the `terminal-exit` source reads
+    /// the full binding directly (see `emit_and_cleanup`), keyed off the same map.
     pub fn tab_id_for(&self, session_id: &str) -> Option<String> {
         self.session_tab_ids
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .get(session_id)
-            .cloned()
+            .map(|binding| binding.tab_id.clone())
     }
 
     /// List all active sessions.
@@ -1485,6 +1567,25 @@ impl SessionManager {
         };
         emitter.emit_exit(&exit_event);
 
+        // Capture-and-clear the identity bridge entry (#2431/#2439). A binding
+        // still present here means this exit is a **genuine spontaneous drop** — a
+        // deliberate close (kill/tab-close) clears the binding before disconnecting
+        // (see `close_session`), so those never carry a binding to this point. Fold
+        // the drop server-side, keyed by the tab id, mirroring the client's
+        // `setTerminalExited` classification exactly (#2439): a resilient-reconnect
+        // tab folds `session.reconnect` (→ Reconnecting), a non-resilient tab
+        // `session.dropped` (→ Disconnected); a clean exit-code-0 exit folds
+        // nothing. Convergent double-write with the still-live client mirror.
+        let drop_binding = session_tab_ids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(session_id);
+        if let Some(binding) = &drop_binding {
+            if let Some(fold) = drop_fold_for(exit_event.exit_code, binding.resilient) {
+                emitter.fold_session_drop(&binding.tab_id, fold);
+            }
+        }
+
         {
             let mut sessions = sessions.lock().await;
             sessions.remove(session_id);
@@ -1497,13 +1598,8 @@ impl SessionManager {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .remove(session_id);
 
-        // Clear the identity bridge entry (#2431) — mirrors the explicit
-        // `close_session` cleanup for the natural-exit / dropped path, so a
-        // session's tab mapping is released whichever way the session ends.
-        session_tab_ids
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .remove(session_id);
+        // (The identity bridge entry for this session was already captured and
+        // removed above, where its presence gated the genuine-drop fold — #2439.)
 
         // Flush and drop the session's output logger (#1960) so the transcript's
         // tail is persisted and its file handle is released when the session ends.
@@ -2451,6 +2547,7 @@ mod tests {
                 None,
                 Some("tab-42:0"),
                 false,
+                false,
                 MockEventEmitter::new(),
             )
             .await
@@ -2469,6 +2566,7 @@ mod tests {
                 serde_json::json!({}),
                 None,
                 None,
+                false,
                 false,
                 MockEventEmitter::new(),
             )
@@ -2490,6 +2588,7 @@ mod tests {
                 serde_json::json!({}),
                 None,
                 Some("tab-7:0"),
+                false,
                 false,
                 MockEventEmitter::new(),
             )
@@ -2513,10 +2612,13 @@ mod tests {
         let emitter = MockEventEmitter::new();
         let sessions = sessions_with_mock("sess-tab").await;
         let session_tab_ids = new_session_tab_ids();
-        session_tab_ids
-            .lock()
-            .unwrap()
-            .insert("sess-tab".to_string(), "tab-9".to_string());
+        session_tab_ids.lock().unwrap().insert(
+            "sess-tab".to_string(),
+            TabBinding {
+                tab_id: "tab-9".to_string(),
+                resilient: false,
+            },
+        );
 
         SessionManager::emit_and_cleanup(
             "sess-tab",
@@ -2533,6 +2635,50 @@ mod tests {
             !session_tab_ids.lock().unwrap().contains_key("sess-tab"),
             "the natural-exit / dropped path clears the identity-bridge entry"
         );
+    }
+
+    #[tokio::test]
+    async fn create_connection_records_the_resilient_reconnect_flag() {
+        let manager = make_test_manager();
+        let session_id = manager
+            .create_connection(
+                "mock",
+                serde_json::json!({}),
+                None,
+                Some("tab-r:0"),
+                false,
+                true, // resilient-reconnect tab
+                MockEventEmitter::new(),
+            )
+            .await
+            .expect("session should open");
+
+        let binding = manager
+            .session_tab_ids
+            .lock()
+            .unwrap()
+            .get(&session_id)
+            .cloned()
+            .expect("a connect_id-bearing session records a binding");
+        assert_eq!(binding.tab_id, "tab-r");
+        assert!(
+            binding.resilient,
+            "the client's resilient-reconnect determination is recorded on the binding (#2439)"
+        );
+    }
+
+    #[test]
+    fn drop_fold_classifies_a_genuine_exit_like_the_client() {
+        // Clean exit (code 0) folds nothing — mirrors the client's `"clean"` reason.
+        assert_eq!(drop_fold_for(Some(0), false), None);
+        assert_eq!(drop_fold_for(Some(0), true), None);
+        // A non-zero code is a drop: resilient → reconnect, otherwise dropped.
+        assert_eq!(drop_fold_for(Some(1), false), Some(DropFold::Dropped));
+        assert_eq!(drop_fold_for(Some(1), true), Some(DropFold::Reconnect));
+        // An unknown code (`None`) — what the desktop `terminal-exit` always emits —
+        // is a drop too, resilient-gated.
+        assert_eq!(drop_fold_for(None, false), Some(DropFold::Dropped));
+        assert_eq!(drop_fold_for(None, true), Some(DropFold::Reconnect));
     }
 
     /// A connection whose `connect_cancellable` blocks until its token fires —
@@ -2626,6 +2772,7 @@ mod tests {
                     None,
                     Some("c1"),
                     false,
+                    false,
                     MockEventEmitter::new(),
                 )
                 .await
@@ -2668,6 +2815,7 @@ mod tests {
                 None,
                 None,
                 true,
+                false,
                 MockEventEmitter::new(),
             )
             .await
@@ -2679,6 +2827,7 @@ mod tests {
                 serde_json::json!({}),
                 None,
                 None,
+                false,
                 false,
                 MockEventEmitter::new(),
             )

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -622,6 +622,10 @@ impl SessionManager {
     /// Containers" from this backend marker rather than the frontend tab flag.
     ///
     /// Returns the session ID on success.
+    // The parameters mirror the `create_connection` IPC surface (type + settings +
+    // routing flags + the connect-time signals: spawn origin #1466, resilient
+    // reconnect #2439); grouping them into a struct would only obscure the call.
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_connection<E: EventEmitter>(
         &self,
         type_id: &str,

--- a/src-tauri/src/session/persistent_controller.rs
+++ b/src-tauri/src/session/persistent_controller.rs
@@ -86,7 +86,7 @@ impl<'a> PersistentController<'a> {
 
         let session_id = self
             .manager
-            .create_connection(type_id, settings, agent_id, None, false, emitter.clone())
+            .create_connection(type_id, settings, agent_id, None, false, false, emitter.clone())
             .await?;
 
         // Capture the agent-side remote session ID so that attach_persistent_tab

--- a/src-tauri/src/session/persistent_controller.rs
+++ b/src-tauri/src/session/persistent_controller.rs
@@ -86,7 +86,15 @@ impl<'a> PersistentController<'a> {
 
         let session_id = self
             .manager
-            .create_connection(type_id, settings, agent_id, None, false, false, emitter.clone())
+            .create_connection(
+                type_id,
+                settings,
+                agent_id,
+                None,
+                false,
+                false,
+                emitter.clone(),
+            )
             .await?;
 
         // Capture the agent-side remote session ID so that attach_persistent_tab

--- a/src-tauri/src/session_projection/projection_tests.rs
+++ b/src-tauri/src/session_projection/projection_tests.rs
@@ -22,6 +22,7 @@ use crate::projection::{
     apply_ops, DiffFrame, Dispatcher, HandlerRegistry, Intent, IntentStatus, ProjectionError,
     ProjectionFrame, ProjectionSink, Projector, SnapshotFrame,
 };
+use crate::session::manager::{DropFold, EventEmitter};
 use crate::session_projection::projection::{
     fold_session_transition, publish_sessions, SESSION_LIFECYCLE_REGION,
 };
@@ -543,5 +544,145 @@ fn server_side_kill_disconnect_fold_matches_the_client_session_disconnect_route(
         server.snapshot(),
         client.snapshot(),
         "the server kill fold reproduces the client disconnect route's transition exactly"
+    );
+}
+
+/// A genuine drop of a **resilient-reconnect** tab folds `session.reconnect`
+/// server-side via the production `AppHandle::fold_session_drop` (the exact call
+/// `emit_and_cleanup` makes at the `terminal-exit` source): the session enters
+/// `Reconnecting` and one region diff fans out — no client dispatch (#2439).
+#[test]
+fn server_side_resilient_drop_fold_starts_reconnecting() {
+    let app = tauri::test::mock_app();
+    let store = Arc::new(SessionLifecycleStore::new());
+    store.set_rand_for_test(Box::new(|| 0.5));
+    store.connect("tab-1");
+    store.connected("tab-1");
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    let snap = projection
+        .projector
+        .subscribe(SESSION_LIFECYCLE_REGION, "sub", "C", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+    app.manage(projection);
+
+    // The genuine-drop path folds `reconnect` for a resilient tab at the source —
+    // the same transition the client mirrors via `startAutoReconnect`.
+    app.handle().fold_session_drop("tab-1", DropFold::Reconnect);
+
+    assert_eq!(
+        store.get("tab-1").map(|s| s.status),
+        Some(crate::session_projection::store::SessionStatus::Reconnecting)
+    );
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "one diff from the server-side reconnect fold");
+    cache.apply(&diffs[0]);
+    assert_eq!(
+        cache.view["sessions"]["tab-1"]["status"],
+        json!("reconnecting")
+    );
+}
+
+/// A genuine drop of a **non-resilient** tab folds `session.dropped` server-side
+/// via the production `AppHandle::fold_session_drop`: the session lands idle
+/// `Disconnected` with reason `Unexpected`, and one region diff fans out (#2439).
+#[test]
+fn server_side_nonresilient_drop_fold_settles_disconnected() {
+    let app = tauri::test::mock_app();
+    let store = Arc::new(SessionLifecycleStore::new());
+    store.connect("tab-1");
+    store.connected("tab-1");
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    let snap = projection
+        .projector
+        .subscribe(SESSION_LIFECYCLE_REGION, "sub", "C", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+    app.manage(projection);
+
+    app.handle().fold_session_drop("tab-1", DropFold::Dropped);
+
+    assert_eq!(
+        store.get("tab-1").map(|s| s.status),
+        Some(crate::session_projection::store::SessionStatus::Disconnected)
+    );
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 1, "one diff from the server-side dropped fold");
+    cache.apply(&diffs[0]);
+    assert_eq!(
+        cache.view["sessions"]["tab-1"]["status"],
+        json!("disconnected")
+    );
+    assert_eq!(
+        cache.view["sessions"]["tab-1"]["endReason"],
+        json!("unexpected")
+    );
+}
+
+/// The server-side drop folds reproduce the client `session.reconnect` /
+/// `session.dropped` route transitions exactly — so the convergent double-write
+/// (server fold + still-present client mirror) never drifts for a genuine drop.
+#[test]
+fn server_side_drop_folds_match_the_client_routes() {
+    // Resilient drop → reconnect parity.
+    let server_r = SessionLifecycleStore::new();
+    server_r.set_rand_for_test(Box::new(|| 0.5));
+    server_r.connect("tab-1");
+    server_r.connected("tab-1");
+    server_r.reconnect("tab-1");
+
+    let client_r = Arc::new(SessionLifecycleStore::new());
+    client_r.set_rand_for_test(Box::new(|| 0.5));
+    client_r.connect("tab-1");
+    client_r.connected("tab-1");
+    let projector_r = Arc::new(Projector::new());
+    projector_r.register_region(SESSION_LIFECYCLE_REGION, client_r.snapshot());
+    let dispatcher_r = Dispatcher::new(projector_r, Arc::new(registry_for(client_r.clone())));
+    assert_eq!(
+        dispatcher_r
+            .dispatch(intent("session.reconnect", json!({ "sessionId": "tab-1" })))
+            .status,
+        IntentStatus::Accepted
+    );
+    assert_eq!(
+        server_r.snapshot(),
+        client_r.snapshot(),
+        "the server reconnect fold reproduces the client reconnect route exactly"
+    );
+
+    // Non-resilient drop → dropped parity.
+    let server_d = SessionLifecycleStore::new();
+    server_d.connect("tab-2");
+    server_d.connected("tab-2");
+    server_d.dropped("tab-2", None);
+
+    let client_d = Arc::new(SessionLifecycleStore::new());
+    client_d.connect("tab-2");
+    client_d.connected("tab-2");
+    let projector_d = Arc::new(Projector::new());
+    projector_d.register_region(SESSION_LIFECYCLE_REGION, client_d.snapshot());
+    let dispatcher_d = Dispatcher::new(projector_d, Arc::new(registry_for(client_d.clone())));
+    assert_eq!(
+        dispatcher_d
+            .dispatch(intent("session.dropped", json!({ "sessionId": "tab-2" })))
+            .status,
+        IntentStatus::Accepted
+    );
+    assert_eq!(
+        server_d.snapshot(),
+        client_d.snapshot(),
+        "the server dropped fold reproduces the client dropped route exactly"
     );
 }

--- a/src-tauri/src/session_projection/projection_tests.rs
+++ b/src-tauri/src/session_projection/projection_tests.rs
@@ -581,7 +581,11 @@ fn server_side_resilient_drop_fold_starts_reconnecting() {
     );
 
     let diffs = sink.diffs();
-    assert_eq!(diffs.len(), 1, "one diff from the server-side reconnect fold");
+    assert_eq!(
+        diffs.len(),
+        1,
+        "one diff from the server-side reconnect fold"
+    );
     cache.apply(&diffs[0]);
     assert_eq!(
         cache.view["sessions"]["tab-1"]["status"],

--- a/src-tauri/src/terminal/agent_setup.rs
+++ b/src-tauri/src/terminal/agent_setup.rs
@@ -179,6 +179,7 @@ where
         None,
         None,
         false,
+        false,
         app_handle.clone(),
     ))?;
 

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -568,7 +568,12 @@ export function Terminal({
                 // `session.dropped`, converging with `setTerminalExited`. Computed
                 // from the live store the same way the client's drop path does.
                 const resilientReconnect = isResilientReconnectTabId(tabId);
-                resolved = await createTerminal(sessionConfig, connectId, spawned, resilientReconnect);
+                resolved = await createTerminal(
+                  sessionConfig,
+                  connectId,
+                  spawned,
+                  resilientReconnect
+                );
               } finally {
                 connectInFlightRef.current.delete(connectId);
               }

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/services/api";
 import { terminalDispatcher } from "@/services/events";
 import { useTerminalRegistry } from "./TerminalRegistry";
-import { useAppStore } from "@/store/appStore";
+import { useAppStore, isResilientReconnectTabId } from "@/store/appStore";
 import { currentBroadcastView } from "@/store/broadcastBridge";
 import { currentAgentsView } from "@/store/agentsBridge";
 import { currentSettingsView } from "@/store/settingsBridge";
@@ -563,7 +563,12 @@ export function Terminal({
               // attempt's token instead of its own (#1125).
               connectInFlightRef.current.add(connectId);
               try {
-                resolved = await createTerminal(sessionConfig, connectId, spawned);
+                // Pass the tab's resilient-reconnect determination (#2439) so a
+                // genuine drop is folded server-side as `session.reconnect` vs
+                // `session.dropped`, converging with `setTerminalExited`. Computed
+                // from the live store the same way the client's drop path does.
+                const resilientReconnect = isResilientReconnectTabId(tabId);
+                resolved = await createTerminal(sessionConfig, connectId, spawned, resilientReconnect);
               } finally {
                 connectInFlightRef.current.delete(connectId);
               }

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -100,6 +100,7 @@ describe("api service", () => {
         agentId: null,
         connectId: null,
         spawned: false,
+        resilientReconnect: false,
       });
       expect(result).toBe("session-456");
     });
@@ -115,6 +116,7 @@ describe("api service", () => {
         agentId: "agent-1",
         connectId: null,
         spawned: false,
+        resilientReconnect: false,
       });
       expect(result).toBe("session-789");
     });
@@ -130,6 +132,7 @@ describe("api service", () => {
         agentId: null,
         connectId: "tab-7",
         spawned: false,
+        resilientReconnect: false,
       });
     });
 
@@ -145,6 +148,7 @@ describe("api service", () => {
         agentId: null,
         connectId: "tab-9",
         spawned: false,
+        resilientReconnect: false,
       });
     });
 
@@ -160,6 +164,23 @@ describe("api service", () => {
         agentId: null,
         connectId: "tab-s",
         spawned: true,
+        resilientReconnect: false,
+      });
+    });
+
+    it("createTerminal forwards resilientReconnect to create_connection (#2439)", async () => {
+      mockedInvoke.mockResolvedValue("session-r");
+      const config = { type: "ssh", config: { host: "h", resilientReconnect: true } };
+
+      await createTerminal(config, "tab-r", false, true);
+
+      expect(mockedInvoke).toHaveBeenCalledWith("create_connection", {
+        typeId: "ssh",
+        settings: { host: "h", resilientReconnect: true },
+        agentId: null,
+        connectId: "tab-r",
+        spawned: false,
+        resilientReconnect: true,
       });
     });
 
@@ -196,6 +217,7 @@ describe("api service", () => {
         agentId: null,
         connectId: null,
         spawned: false,
+        resilientReconnect: false,
       });
       expect(result).toBe("session-123");
     });
@@ -220,6 +242,7 @@ describe("api service", () => {
         agentId: "agent-1",
         connectId: null,
         spawned: false,
+        resilientReconnect: false,
       });
       expect(result).toBe("session-remote");
     });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -68,13 +68,18 @@ export async function getConnectionTypes(): Promise<ConnectionTypeInfo[]> {
  * `spawned` marks a CLI/context-menu spawn session (#1446, #1466) so the backend
  * records it on the session registry — the source of truth the Open Connections
  * panel groups "Spawned Containers" from, surviving a tab close.
+ *
+ * `resilientReconnect` carries the tab's `isResilientReconnectTab` determination
+ * (#2439) so the backend can fold a genuine drop server-side as `session.reconnect`
+ * (resilient) vs `session.dropped` (non-resilient), converging with the client.
  */
 export async function createConnection(
   typeId: string,
   settings: Record<string, unknown>,
   agentId?: string,
   connectId?: string,
-  spawned?: boolean
+  spawned?: boolean,
+  resilientReconnect?: boolean
 ): Promise<SessionId> {
   return await invoke<string>("create_connection", {
     typeId,
@@ -82,6 +87,7 @@ export async function createConnection(
     agentId: agentId ?? null,
     connectId: connectId ?? null,
     spawned: spawned ?? false,
+    resilientReconnect: resilientReconnect ?? false,
   });
 }
 
@@ -167,11 +173,17 @@ export async function importInventoryHosts(path: string): Promise<InventoryHost[
  * records the spawned origin on the session registry (the Open Connections panel
  * groups from it, surviving a tab close). Spawn sessions are never
  * `remote-session`, so the flag only applies to the local path.
+ *
+ * `resilientReconnect` is the tab's resilient-reconnect determination (#2439),
+ * forwarded to the backend so a genuine drop is folded server-side as
+ * `session.reconnect` vs `session.dropped`. Only plain-SSH tabs opt in; the
+ * `remote-session` (agent) path is never resilient, so it is not forwarded there.
  */
 export async function createTerminal(
   config: ConnectionConfig,
   connectId?: string,
-  spawned?: boolean
+  spawned?: boolean,
+  resilientReconnect?: boolean
 ): Promise<SessionId> {
   if (config.type === "remote-session") {
     const { agentId, sessionType, ...rest } = config.config as {
@@ -181,7 +193,14 @@ export async function createTerminal(
     };
     return await createConnection(sessionType, rest, agentId, connectId);
   }
-  return await createConnection(config.type, config.config, undefined, connectId, spawned);
+  return await createConnection(
+    config.type,
+    config.config,
+    undefined,
+    connectId,
+    spawned,
+    resilientReconnect
+  );
 }
 
 /**

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2054,6 +2054,19 @@ function isResilientReconnectTab(tab: TerminalTab | undefined): boolean {
 }
 
 /**
+ * Whether the tab identified by `tabId` is a resilient-reconnect tab, resolved
+ * from the live store exactly as `setTerminalExited`'s drop classification does
+ * (#2439). Passed to the backend at connect time (via `createTerminal`) so a
+ * genuine drop can be folded server-side — `session.reconnect` for a resilient
+ * tab, `session.dropped` otherwise — converging with the client mirror. An
+ * unknown/closed tab is not resilient.
+ */
+export function isResilientReconnectTabId(tabId: string): boolean {
+  const tab = collectLiveTabs(useAppStore.getState()).find((t) => t.id === tabId);
+  return isResilientReconnectTab(tab);
+}
+
+/**
  * The trimmed on-reconnect command configured for a tab's connection (#1978), or
  * `undefined` when none is set. This is the command run once in the fresh remote
  * shell after a *successful* automatic reconnect to recover some server-side


### PR DESCRIPTION
## Summary

Step 2 of making session-lifecycle server-authoritative (the prerequisite for #2205 PR-B). Step 1 (#2443) plumbed kill-intent and folded the `killed -> disconnect` edge, but **deferred the genuine-drop fold** because the backend could not tell a resilient-reconnect tab from a plain one. This step plumbs that signal and folds the drop transitions at the `terminal-exit` source.

Additive and careful on the ventilator reconnect hot path: the frontend `session.*` mirror, `driveAutoReconnect` engine, and appStore slice all stay in place (their removal is #2205 PR-B).

## What changed

- **`create_connection` carries a `resilient_reconnect` flag** — the client's `isResilientReconnectTab` computed at connect time in `Terminal.tsx` and threaded through `createTerminal` -> `createConnection` -> the `create_connection` command. It is recorded on the session's tab binding, which is now a `TabBinding { tab_id, resilient }` instead of a bare tab id.
- **On a genuine drop, `emit_and_cleanup` folds server-side, keyed by tab id**: a resilient tab -> `session.reconnect` (Reconnecting), a non-resilient tab -> `session.dropped` (Disconnected). The pure `drop_fold_for` mirrors the client's `setTerminalExited` classification exactly (exit code 0 folds nothing), so it is a **benign convergent double-write** with the still-live client mirror — exactly the pattern the connect / kill folds already use.
- **`close_session` now clears the tab binding *before* disconnecting.** This makes the binding's presence at `emit_and_cleanup` a **race-free discriminator**: a deliberate close (a user kill via `close_terminal`, or a tab close) drops the binding before `disconnect()` triggers the reader's EOF, so those exits never carry a binding to the fold point. Only a *genuine spontaneous drop* (no `close_session` ran) leaves the binding intact. A killed exit therefore still folds `disconnect` (step 1), never `dropped`.

## De-risk: how convergence is guaranteed (reconnect fidelity)

- **The desktop `terminal-exit` always emits `exit_code: None`** (the interactive path never carries a real code — verified: the sole `TerminalExitEvent` construction is `exit_code: None`). So the client always classifies a non-killed exit as `"dropped"`, never `"clean"`. The server sees the identical `None` and classifies identically — no clean-vs-dropped divergence is possible on this path. `drop_fold_for` still handles `Some(0) -> fold nothing` for future-proofing (if a real code is ever plumbed) and to satisfy the "clean folds neither" test.
- **Resilient determination is passed as the client-computed boolean**, not recomputed in Rust, so the server uses the *exact same* decision as the client's drop path. It is recorded per connect (and re-recorded on each reconnect attempt's `create_connection`), so it tracks the current tab.
- **Sessions with no tab binding** (persistent, internal agent-setup — all pass `None` connect_id) fold nothing server-side; the client mirror drives them as before. The server never contradicts the client, so no region corruption.

## Tests

- **Rust unit** (`manager.rs`): `drop_fold_classifies_a_genuine_exit_like_the_client` (clean code 0 -> none; non-zero / unknown -> resilient-gated reconnect/dropped) and `create_connection_records_the_resilient_reconnect_flag` (the binding carries `resilient`).
- **Rust projection** (`projection_tests.rs`, against `mock_app` via the production `AppHandle::fold_session_drop`): a resilient drop lands the session `reconnecting` and fans one diff; a non-resilient drop lands `disconnected`/`unexpected`; and both reproduce the client `session.reconnect` / `session.dropped` route snapshots exactly (parity, no drift). Existing killed-exit / connect-fold tests continue to assert killed folds `disconnect`, not `dropped`.
- **Frontend** (`api.test.ts`): `createTerminal` / `createConnection` forward `resilientReconnect` to `create_connection` (defaulting `false`).

## Verification

- `cargo build` / `cargo clippy -p termihub --all-targets` / `cargo fmt --all --check`: clean.
- `cargo test -p termihub --lib`: 1693 pass; the only failure is the pre-existing `agent_deploy_sftp_upload_round_trips_over_real_ssh` integration test (needs the `ssh-password` docker fixture; excluded from per-PR CI, same as #2443).
- `tsc`, eslint, `prettier --check` (src + docs): clean. Full `pnpm test`: 4878 pass.
- **Reconnect is integration-tested at release cadence, not per-PR CI.** The server fold is convergent with the still-authoritative client mirror (region not yet rendered), so behavior is unchanged, but the fold's real-drop path warrants a local `./scripts/dev.sh` SSH-drop check (drop a resilient tab -> region shows reconnecting; drop a non-resilient tab -> disconnected) and the `tests/system` SSH-disconnect suite before the #2205 inversion relies on it.

No change fragment: this is additive server-authority plumbing with no user-facing behavior change.

Part of #2439