### PR TITLE
feat(backend): fold initial direct connect-failed server-side (Part of #2439)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -72,14 +72,19 @@ pub async fn create_connection(
     // Server-authority fold (#2431): make the *initial* connect's lifecycle
     // server-authoritative in the shared `session-lifecycle` region, keyed by the
     // frontend tab id this attempt carries in its `connect_id`. Only the initial
-    // attempt (`retryCount == 0`) is folded: a reconnect attempt's lifecycle is
-    // owned by the client + backend reconnect timer (#2203), and a failed connect
-    // is deliberately left to the client — the frontend silently auto-retries an
-    // agent connect without an intent, so folding `connect_failed` here would
-    // diverge. The `connect` → `connected` edge, by contrast, converges exactly
-    // with the client's `session.connect` / `session.connected` dispatch, so both
-    // running is a benign convergent double-write. Additive; see
-    // `fold_session_transition`.
+    // attempt (`retryCount == 0`) is folded here: a reconnect attempt's lifecycle
+    // is owned by the client + backend reconnect timer (#2203). The `connect` →
+    // `connected` edge converges exactly with the client's `session.connect` /
+    // `session.connected` dispatch, so both running is a benign convergent
+    // double-write. Additive; see `fold_session_transition`.
+    //
+    // The failure arm is *not* folded here — a **genuine, non-cancelled, initial
+    // direct** connect failure is folded inside `manager.create_connection`
+    // (#2439, `EventEmitter::fold_connect_failed`), where the cancel token is
+    // visible so a Stop is not misread as a failure. An **agent** connect (silent
+    // client-side auto-retry) and a **reconnect attempt** (retry>0) stay
+    // client-owned; the reconnect-loop give-up is not yet source-foldable (its
+    // attempt redrive + outcome live in the client engine, part of #2205).
     let initial_tab_id = initial_connect_tab_id(connect_id.as_deref());
     if let Some(tab_id) = &initial_tab_id {
         fold_session_transition(&app_handle, |store| store.connect(tab_id));

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -156,6 +156,24 @@ pub trait EventEmitter: Clone + Send + Sync + 'static {
     /// managed `session-lifecycle` store — a benign convergent double-write with
     /// the client's `setTerminalExited` mirror (like the connect/kill folds).
     fn fold_session_drop(&self, _tab_id: &str, _fold: DropFold) {}
+
+    /// Fold an **initial** connect failure server-side (#2439, part of #2205).
+    ///
+    /// Called from the [`SessionManager::create_connection`] source for a
+    /// **genuine** (non-cancelled), **initial** (`retryCount == 0`), **direct**
+    /// (non-agent) connect failure, keyed by the frontend `tab_id`. It is the
+    /// symmetric third arm of the command's connect/connected fold: a failed
+    /// initial direct connect settles the tab-keyed region entry `Failed`. Default
+    /// no-op for test emitters (no projection store); the production `AppHandle`
+    /// folds `session.connectFailed` into the managed `session-lifecycle` store.
+    ///
+    /// Deliberately **not** folded here (each still owned by the client, so folding
+    /// would diverge): a **cancellation** (a Stop, not a failure — gated on the
+    /// connect token by the caller); a **reconnect attempt** (`retryCount > 0`,
+    /// owned by the client reconnect loop + the backend timer #2203, whose
+    /// give-up is not yet source-foldable); and an **agent** connect (the frontend
+    /// silently auto-retries it without an intent).
+    fn fold_connect_failed(&self, _tab_id: &str, _error: &str) {}
 }
 
 impl<R: tauri::Runtime> EventEmitter for tauri::AppHandle<R> {
@@ -177,6 +195,13 @@ impl<R: tauri::Runtime> EventEmitter for tauri::AppHandle<R> {
             DropFold::Reconnect => fold_session_transition(self, |store| store.reconnect(tab_id)),
             DropFold::Dropped => fold_session_transition(self, |store| store.dropped(tab_id, None)),
         }
+    }
+
+    fn fold_connect_failed(&self, tab_id: &str, error: &str) {
+        use crate::session_projection::projection::fold_session_transition;
+        fold_session_transition(self, |store| {
+            store.connect_failed(tab_id, Some(error.to_string()))
+        });
     }
 }
 
@@ -399,6 +424,20 @@ fn tab_id_from_connect_id(connect_id: &str) -> Option<String> {
         .map(|(tab_id, _retry)| tab_id)
         .filter(|tab_id| !tab_id.is_empty())
         .map(str::to_string)
+}
+
+/// The frontend `tab_id` to fold a `session.connectFailed` for when an **initial**
+/// connect fails, parsed from `connect_id = ${tabId}:${retryCount}` (#2439).
+///
+/// Returns `Some(tab_id)` only for the initial attempt (`retryCount == 0`) of a
+/// session carrying the tab-id form. A **reconnect attempt** (`retryCount > 0`,
+/// owned by the client reconnect loop + the backend timer #2203) or a `connect_id`
+/// not carrying the tab-id form (e.g. the internal agent-setup session, `None`)
+/// yields `None`. The **agent** and **cancellation** exclusions are applied by the
+/// caller (the non-agent branch, gated on the connect token), not here.
+fn initial_connect_failed_tab_id(connect_id: Option<&str>) -> Option<String> {
+    let (tab_id, retry) = connect_id?.rsplit_once(':')?;
+    (retry == "0" && !tab_id.is_empty()).then(|| tab_id.to_string())
 }
 
 impl SessionManager {
@@ -694,9 +733,30 @@ impl SessionManager {
                         .create(type_id)
                         .map_err(|e| TerminalError::SpawnFailed(e.to_string()))?
                 };
-                conn.connect_cancellable(settings.clone(), cancel_token.clone())
+                if let Err(e) = conn
+                    .connect_cancellable(settings.clone(), cancel_token.clone())
                     .await
-                    .map_err(|e| TerminalError::SpawnFailed(e.to_string()))?;
+                {
+                    // Server-authority fold (#2439, part of #2205): a **genuine**
+                    // (non-cancelled) **initial** direct-connect failure is a terminal
+                    // `session.connectFailed`, folded at the source keyed by the tab id —
+                    // the symmetric third arm of the command's connect/connected fold.
+                    // Left to the client (as before, so no divergence): a **cancellation**
+                    // (a Stop, not a failure — the token fired); a **reconnect attempt**
+                    // (retry>0, owned by the client loop + backend timer #2203, whose
+                    // give-up is not yet source-foldable); and **agent** connects (this is
+                    // the non-agent branch — an agent connect silently auto-retries
+                    // client-side without an intent). Additive, shadow-only.
+                    let cancelled = cancel_token
+                        .as_ref()
+                        .is_some_and(CancellationToken::is_cancelled);
+                    if !cancelled {
+                        if let Some(tab_id) = initial_connect_failed_tab_id(connect_id) {
+                            emitter.fold_connect_failed(&tab_id, &e.to_string());
+                        }
+                    }
+                    return Err(TerminalError::SpawnFailed(e.to_string()));
+                }
                 (conn, None)
             };
 
@@ -1791,6 +1851,8 @@ mod tests {
     struct MockEventEmitter {
         outputs: std::sync::Arc<std::sync::Mutex<Vec<TerminalOutputEvent>>>,
         exits: std::sync::Arc<std::sync::Mutex<Vec<TerminalExitEvent>>>,
+        /// Recorded `fold_connect_failed` calls as `(tab_id, error)` (#2439).
+        connect_faileds: std::sync::Arc<std::sync::Mutex<Vec<(String, String)>>>,
         fail_output: bool,
     }
 
@@ -1816,6 +1878,12 @@ mod tests {
         }
         fn emit_exit(&self, event: &TerminalExitEvent) {
             self.exits.lock().unwrap().push(event.clone());
+        }
+        fn fold_connect_failed(&self, tab_id: &str, error: &str) {
+            self.connect_faileds
+                .lock()
+                .unwrap()
+                .push((tab_id.to_string(), error.to_string()));
         }
     }
 
@@ -2683,6 +2751,204 @@ mod tests {
         // is a drop too, resilient-gated.
         assert_eq!(drop_fold_for(None, false), Some(DropFold::Dropped));
         assert_eq!(drop_fold_for(None, true), Some(DropFold::Reconnect));
+    }
+
+    #[test]
+    fn initial_connect_failed_tab_id_folds_only_the_initial_attempt() {
+        // Initial attempt (retry 0) of a tab-bearing connect → fold that tab.
+        assert_eq!(
+            initial_connect_failed_tab_id(Some("tab-1:0")),
+            Some("tab-1".to_string())
+        );
+        // A reconnect attempt (retry > 0) is owned by the client loop + backend timer.
+        assert_eq!(initial_connect_failed_tab_id(Some("tab-1:2")), None);
+        // No connect_id (e.g. internal agent-setup session) → None.
+        assert_eq!(initial_connect_failed_tab_id(None), None);
+        // A connect_id not carrying the tab-id:retry form → None.
+        assert_eq!(initial_connect_failed_tab_id(Some("no-colon")), None);
+        // An empty tab id is rejected rather than guessed.
+        assert_eq!(initial_connect_failed_tab_id(Some(":0")), None);
+    }
+
+    /// A connection whose `connect_cancellable` fails **immediately** (no token
+    /// wait) — lets us exercise a genuine, non-cancelled connect failure (#2439).
+    #[derive(Default)]
+    struct ImmediateFailConnect;
+
+    #[async_trait::async_trait]
+    impl ConnectionType for ImmediateFailConnect {
+        fn type_id(&self) -> &str {
+            "failing"
+        }
+        fn display_name(&self) -> &str {
+            "Failing"
+        }
+        fn settings_schema(&self) -> SettingsSchema {
+            SettingsSchema { groups: vec![] }
+        }
+        fn capabilities(&self) -> Capabilities {
+            Capabilities {
+                monitoring: false,
+                file_browser: false,
+                graphical: false,
+                resize: true,
+                persistent: false,
+                terminal: true,
+            }
+        }
+        async fn connect(&mut self, _settings: serde_json::Value) -> Result<(), SessionError> {
+            Err(SessionError::SpawnFailed("connection refused".to_string()))
+        }
+        async fn connect_cancellable(
+            &mut self,
+            _settings: serde_json::Value,
+            _cancel: Option<CancellationToken>,
+        ) -> Result<(), SessionError> {
+            // Fails at once regardless of the token, so the cancel token is never
+            // fired — a genuine failure, not a cancellation.
+            Err(SessionError::SpawnFailed("connection refused".to_string()))
+        }
+        async fn disconnect(&mut self) -> Result<(), SessionError> {
+            Ok(())
+        }
+        fn is_connected(&self) -> bool {
+            false
+        }
+        fn write(&self, _data: &[u8]) -> Result<(), SessionError> {
+            Ok(())
+        }
+        fn resize(&self, _cols: u16, _rows: u16) -> Result<(), SessionError> {
+            Ok(())
+        }
+        fn subscribe_output(&self) -> OutputReceiver {
+            let (_tx, rx) = tokio::sync::mpsc::channel(1);
+            rx
+        }
+        fn monitoring(&self) -> Option<&dyn MonitoringProvider> {
+            None
+        }
+        fn file_browser(&self) -> Option<&dyn FileBrowser> {
+            None
+        }
+    }
+
+    fn failing_manager() -> Arc<SessionManager> {
+        let mut registry = termihub_core::connection::ConnectionTypeRegistry::new();
+        registry.register(
+            "failing",
+            "Failing",
+            "mock",
+            Box::new(|| Box::new(ImmediateFailConnect)),
+        );
+        Arc::new(SessionManager::new(registry, Arc::new(NullAgent)))
+    }
+
+    /// A genuine (non-cancelled) **initial** **direct** connect failure folds
+    /// `session.connectFailed` server-side, keyed by the tab id (#2439). The
+    /// symmetric third arm of the command's connect/connected fold.
+    #[tokio::test]
+    async fn create_connection_folds_connect_failed_for_a_genuine_initial_direct_failure() {
+        let manager = failing_manager();
+        let emitter = MockEventEmitter::new();
+        let result = manager
+            .create_connection(
+                "failing",
+                serde_json::json!({}),
+                None,            // no agent → direct connect
+                Some("tab-f:0"), // initial attempt
+                false,
+                false,
+                emitter.clone(),
+            )
+            .await;
+        assert!(result.is_err(), "the connect must fail");
+
+        let folds = emitter.connect_faileds.lock().unwrap();
+        assert_eq!(
+            folds.len(),
+            1,
+            "exactly one connect_failed fold for a genuine initial direct failure"
+        );
+        assert_eq!(folds[0].0, "tab-f", "keyed by the frontend tab id");
+        assert!(
+            folds[0].1.contains("connection refused"),
+            "the failure error is carried into the fold"
+        );
+    }
+
+    /// A **reconnect attempt** (`retryCount > 0`) is owned by the client loop +
+    /// backend timer, so its failure is **not** folded as `connect_failed` (#2439).
+    #[tokio::test]
+    async fn create_connection_does_not_fold_connect_failed_for_a_reconnect_attempt() {
+        let manager = failing_manager();
+        let emitter = MockEventEmitter::new();
+        let _ = manager
+            .create_connection(
+                "failing",
+                serde_json::json!({}),
+                None,
+                Some("tab-f:2"), // a reconnect attempt
+                false,
+                false,
+                emitter.clone(),
+            )
+            .await;
+        assert!(
+            emitter.connect_faileds.lock().unwrap().is_empty(),
+            "a reconnect attempt's failure is not source-folded (client loop owns it)"
+        );
+    }
+
+    /// A **cancellation** (a Stop mid-connect) is not a failure, so it folds no
+    /// `connect_failed` even though the connect returns an error (#2439/#952).
+    #[tokio::test]
+    async fn create_connection_does_not_fold_connect_failed_on_cancellation() {
+        let mut registry = termihub_core::connection::ConnectionTypeRegistry::new();
+        registry.register(
+            "blocking",
+            "Blocking",
+            "mock",
+            Box::new(|| Box::new(BlockingConnect)),
+        );
+        let manager = Arc::new(SessionManager::new(registry, Arc::new(NullAgent)));
+        let emitter = MockEventEmitter::new();
+
+        let spawned = manager.clone();
+        let spawned_emitter = emitter.clone();
+        let join = tokio::spawn(async move {
+            spawned
+                .create_connection(
+                    "blocking",
+                    serde_json::json!({}),
+                    None,
+                    Some("tab-c:0"), // initial attempt, but cancelled
+                    false,
+                    false,
+                    spawned_emitter,
+                )
+                .await
+        });
+
+        // Poll until the connect registers its token, then fire the cancel.
+        let mut cancelled = false;
+        for _ in 0..200 {
+            if manager.cancel_connecting("tab-c:0") {
+                cancelled = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(
+            cancelled,
+            "the connecting session should have been cancellable"
+        );
+        let result = join.await.expect("join");
+        assert!(result.is_err(), "a cancelled connect returns an error");
+
+        assert!(
+            emitter.connect_faileds.lock().unwrap().is_empty(),
+            "a cancellation is a Stop, not a failure — no connect_failed fold"
+        );
     }
 
     /// A connection whose `connect_cancellable` blocks until its token fires —

--- a/src-tauri/src/session_projection/projection_tests.rs
+++ b/src-tauri/src/session_projection/projection_tests.rs
@@ -474,6 +474,83 @@ fn server_side_connect_fold_matches_the_client_session_connect_route() {
     );
 }
 
+/// A server-folded initial connect failure settles the tab-keyed session `Failed`
+/// with reason `error` and the message, and fans the region diff out — without any
+/// client dispatch (#2439, part of #2205). The failure arm of the create-connection
+/// fold, symmetric with the connect/connected folds above.
+#[test]
+fn server_side_connect_failed_fold_settles_the_session_failed() {
+    let app = tauri::test::mock_app();
+    let store = Arc::new(SessionLifecycleStore::new());
+    store.connect("tab-1");
+    app.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let sink = Arc::new(VecSink::new());
+    let snap = projection
+        .projector
+        .subscribe(SESSION_LIFECYCLE_REGION, "sub", "C", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+    app.manage(projection);
+
+    // The server folds a genuine initial connect failure at the source, keyed by
+    // the tab id — the same transition the client mirrors as `session.connectFailed`.
+    fold_session_transition(app.handle(), |s| {
+        s.connect_failed("tab-1", Some("Connection refused".to_string()))
+    });
+
+    assert_eq!(
+        store.get("tab-1").map(|s| s.status),
+        Some(crate::session_projection::store::SessionStatus::Failed)
+    );
+
+    let diffs = sink.diffs();
+    assert_eq!(
+        diffs.len(),
+        1,
+        "one diff from the server-side connect-failed fold"
+    );
+    cache.apply(&diffs[0]);
+    assert_eq!(cache.view["sessions"]["tab-1"]["status"], json!("failed"));
+    assert_eq!(cache.view["sessions"]["tab-1"]["endReason"], json!("error"));
+    assert_eq!(
+        cache.view["sessions"]["tab-1"]["error"],
+        json!("Connection refused")
+    );
+}
+
+/// The server-side connect-failed fold reproduces the client `session.connectFailed`
+/// route's store transition exactly — identical snapshots, so there is no drift
+/// between the source fold and the (still-present) client mirror.
+#[test]
+fn server_side_connect_failed_fold_matches_the_client_session_connect_failed_route() {
+    // (a) Server-side fold: the store method the fold applies at the source.
+    let server = SessionLifecycleStore::new();
+    server.set_rand_for_test(Box::new(|| 0.5));
+    server.connect_failed("tab-1", Some("boom".to_string()));
+
+    // (b) Client route: the `session.connectFailed` intent through the registry.
+    let client = Arc::new(SessionLifecycleStore::new());
+    client.set_rand_for_test(Box::new(|| 0.5));
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SESSION_LIFECYCLE_REGION, client.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(client.clone())));
+    let ack = dispatcher.dispatch(intent(
+        "session.connectFailed",
+        json!({ "sessionId": "tab-1", "error": "boom" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    assert_eq!(
+        server.snapshot(),
+        client.snapshot(),
+        "the server fold reproduces the client route's transition exactly"
+    );
+}
+
 /// A user-initiated kill (`close_terminal` with `intentional = true`) folds the
 /// graceful `session.disconnect` server-side under the tab id: the session lands
 /// idle `Disconnected` with reason `User`, and the region diff fans out — no


### PR DESCRIPTION
Part of #2439 — step 3 (final signal for the server-authoritative session-lifecycle inversion,
prereq for #2205 PR-B).

## Analysis outcome: path (B) — contained fold + boundary report

Step 3 asked to make **connect-failed + the reconnect-loop give-up** server-authoritative. The
analysis (below) shows the **give-up is not source-foldable** without moving the client reconnect
engine server-side, so this PR lands the **one contained, unambiguous, off-hot-path fold** and
reports the precise architectural boundary for the give-up.

### What is folded (this PR)
A **genuine, non-cancelled, initial (`retryCount == 0`), direct (non-agent)** connect failure now
folds `session.connectFailed` into the shared `session-lifecycle` store **at the source**
(`manager.create_connection`), keyed by the frontend tab id. This is the symmetric third arm of the
existing `create_connection` connect/connected fold (#2431) — additive and shadow-only (the client
mirror stays live; the region is not yet rendered).

- New `EventEmitter::fold_connect_failed` (default no-op; the production `AppHandle` folds via
  `fold_session_transition`), called from the manager's non-agent connect branch.
- Gated on the connect token (`CancellationToken::is_cancelled`) so a **Stop is never misread as a
  failure**, and on `retryCount == 0` so a reconnect attempt is never folded here.

### What is NOT folded (deliberately client-owned, so nothing diverges)
- **The reconnect-loop give-up** — see boundary below.
- **Agent** initial connects — the frontend silently auto-retries an agent connect internally
  (`MAX_AGENT_SPAWN_ATTEMPTS` + agent-transport parking / `connectRemoteAgent`) without an intent,
  so one loop "attempt" is not one `create_connection` call; folding at the source would diverge.
- **Reconnect attempts** (`retryCount > 0`) and **cancellations**.

## The boundary — why the give-up is not source-foldable yet (for sequencing)

The backend timer (#2203) drives only the `Waiting → Attempt` edge. Each attempt's **outcome**
(success/failure → `connected` / `reconnectFailed` / give-up) is produced by the **client**, which
owns the transport redrive: `reconnectTerminal` → `Terminal.tsx` → `createTerminal`. The give-up
decision itself lives in the store's `reconnect_failed` engine, but it can only run when the client
mirrors `session.reconnectFailed` — i.e. it is fed by client-reported attempt outcomes.

To make the give-up server-authoritative at the source, three client-only pieces must move
server-side (this is the larger move #2439 flagged as "or move the reconnect loop server-side"):

1. **The per-attempt connection redrive** — so the backend initiates each reconnect attempt and
   directly observes its `Ok`/`Err`, instead of relying on the client mirror.
2. **The agent silent-retry orchestration** (`MAX_AGENT_SPAWN_ATTEMPTS`, agent-transport
   `connecting`/`disconnected` parking, `connectRemoteAgent` re-establishment) — so "attempt failed"
   is well-defined for agent sessions (today N `create_connection` Errs can map to one loop attempt).
3. **Cancellation semantics** — a Stop/tab-close during an attempt must resolve to not-a-failure
   server-side (today the client's `isCanceled()` suppresses the error).

Until then, removing the client mirror (#2205 PR-B) would strand the backend loop at `Connecting`
(no attempt outcome ever reaches it), so the give-up must stay client-driven. Recommend sequencing
the redrive/agent-orchestration move as its own step before PR-B deletes the client engine.

## Tests
- Projection-assertion: `connect_failed` fold → `Failed` / `error` + one region diff.
- Client-route parity: the source fold reproduces the `session.connectFailed` intent's snapshot.
- Manager gating: genuine initial direct failure folds; a **cancellation** does not; a **reconnect
  attempt** (`retry>0`) does not; `initial_connect_failed_tab_id` unit test.

## Verification
`cargo build` / `clippy -D warnings` / `fmt --check` clean; new + full `termihub` lib tests pass
(one unrelated pre-existing failure: `remote_exec::…round_trips_over_real_ssh`, a real-SSH
integration test needing Docker infra — untouched by this change). Frontend unchanged: `tsc`
(`pnpm build`), `eslint`, `prettier --check` clean.

**Reconnect is release-cadence integration-tested** — the fold path (a real failing direct connect
priming the shared region) is best confirmed with a local `./scripts/dev.sh` run; per-PR CI does
not exercise it.
