### PR TITLE
feat(terminal): give the reconnect-trigger error a region-owned home (Closes #2442)

### DIFF
--- a/src-tauri/src/session_projection/projection.rs
+++ b/src-tauri/src/session_projection/projection.rs
@@ -31,6 +31,7 @@
 //! | `session.reconnectAttempt`  | `{ sessionId }`             | backoff timer fired; start an attempt          |
 //! | `session.reconnectFailed`   | `{ sessionId, error? }`     | the attempt failed (back off or give up)       |
 //! | `session.cancelReconnect`   | `{ sessionId }`             | user stopped the retry loop                    |
+//! | `session.reconnectTrigger`  | `{ sessionId, error? }`     | record/clear the reconnect-trigger cause       |
 //! | `session.remove`            | `{ sessionId }`             | session/tab gone; drop it from the region      |
 //!
 //! # Shadow mode
@@ -204,6 +205,14 @@ pub fn register_session_intents(registry: &mut HandlerRegistry, app_handle: AppH
         let produced = publish_sessions(projector, &store);
         sync_timer(&handle, &id);
         Ok(produced)
+    });
+
+    let handle = app_handle.clone();
+    registry.route("session.reconnectTrigger", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let id = required_str(intent, "sessionId")?;
+        store.set_reconnect_trigger(&id, optional_str(intent, "error"));
+        Ok(publish_sessions(projector, &store))
     });
 
     let handle = app_handle;

--- a/src-tauri/src/session_projection/projection_tests.rs
+++ b/src-tauri/src/session_projection/projection_tests.rs
@@ -93,6 +93,11 @@ fn registry_for(store: Arc<SessionLifecycleStore>) -> HandlerRegistry {
         s.cancel_reconnect(&required_id(intent)?);
         Ok(publish_sessions(projector, &s))
     });
+    let s = store.clone();
+    registry.route("session.reconnectTrigger", move |intent, projector| {
+        s.set_reconnect_trigger(&required_id(intent)?, opt_error(intent));
+        Ok(publish_sessions(projector, &s))
+    });
     let s = store;
     registry.route("session.remove", move |intent, projector| {
         s.remove(&required_id(intent)?);
@@ -297,6 +302,46 @@ fn a_full_reconnect_loop_advances_monotonically_and_converges() {
     assert_eq!(cache.version, 6);
     assert_eq!(cache.view, store.snapshot(), "cache converges on authority");
     assert_eq!(cache.view["sessions"]["s2"]["status"], json!("connected"));
+}
+
+#[test]
+fn a_reconnect_trigger_intent_projects_the_cause_and_a_clear_removes_it() {
+    // #2442: `session.reconnectTrigger` records the region-owned reconnect-trigger
+    // cause without touching status, and a clear (no `error`) removes it.
+    let store = seeded_store();
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(SESSION_LIFECYCLE_REGION, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
+
+    // s2 was connected; carry a trigger cause onto it.
+    let ack = dispatcher.dispatch(intent(
+        "session.reconnectTrigger",
+        json!({ "sessionId": "s2", "error": "connection reset" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    // A clear (no error) removes it again.
+    let ack = dispatcher.dispatch(intent(
+        "session.reconnectTrigger",
+        json!({ "sessionId": "s2" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    let diffs = sink.diffs();
+    assert_eq!(diffs.len(), 2, "set + clear each change the view");
+    cache.apply(&diffs[0]);
+    assert_eq!(
+        cache.view["sessions"]["s2"]["reconnectError"],
+        json!("connection reset")
+    );
+    // Status is unaffected by the pure-metadata write.
+    assert_eq!(cache.view["sessions"]["s2"]["status"], json!("connected"));
+    cache.apply(&diffs[1]);
+    assert!(cache.view["sessions"]["s2"].get("reconnectError").is_none());
+    assert_eq!(cache.view, store.snapshot(), "cache converges on authority");
 }
 
 #[test]

--- a/src-tauri/src/session_projection/store.rs
+++ b/src-tauri/src/session_projection/store.rs
@@ -90,6 +90,18 @@ pub struct SessionLifecycle {
     /// session carried one); `None` otherwise.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// The cause that *triggered* the current reconnect — the error an agent
+    /// reported when its link dropped and started re-establishing the session
+    /// (#2442). Distinct from [`error`](Self::error): that is the terminal
+    /// `Failed` / dropped message, whereas this is the supplementary "why we are
+    /// reconnecting" note the disconnect overlay shows *while* a session is
+    /// reconnecting. Carried on the shared record because the drop cause is a
+    /// property of the session (every client observing it sees the same cause),
+    /// not a per-client presentation affordance. Cleared by any lifecycle
+    /// resolution (connect / connected / disconnect / dropped / …); `None`
+    /// otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reconnect_error: Option<String>,
 }
 
 impl SessionLifecycle {
@@ -100,6 +112,7 @@ impl SessionLifecycle {
             reconnect: INITIAL_RECONNECT_STATE,
             end_reason: None,
             error: None,
+            reconnect_error: None,
         }
     }
 }
@@ -210,6 +223,7 @@ impl SessionLifecycleStore {
         entry.reconnect = reconnect;
         entry.end_reason = None;
         entry.error = None;
+        entry.reconnect_error = None;
     }
 
     /// `session.connectFailed` — the initial connect errored. Terminal `Failed`
@@ -224,6 +238,7 @@ impl SessionLifecycleStore {
         entry.reconnect = INITIAL_RECONNECT_STATE;
         entry.end_reason = Some(EndReason::Error);
         entry.error = error;
+        entry.reconnect_error = None;
     }
 
     /// `session.disconnect` — a user-initiated graceful disconnect. Stops any
@@ -238,6 +253,7 @@ impl SessionLifecycleStore {
         entry.reconnect = INITIAL_RECONNECT_STATE;
         entry.end_reason = Some(EndReason::User);
         entry.error = None;
+        entry.reconnect_error = None;
     }
 
     /// `session.dropped` — the link dropped without the user asking. Lands in
@@ -254,6 +270,7 @@ impl SessionLifecycleStore {
         entry.reconnect = INITIAL_RECONNECT_STATE;
         entry.end_reason = Some(EndReason::Unexpected);
         entry.error = error;
+        entry.reconnect_error = None;
     }
 
     /// `session.reconnect` — begin (or restart) the auto-reconnect loop. Feeds
@@ -271,6 +288,7 @@ impl SessionLifecycleStore {
         entry.status = SessionStatus::Reconnecting;
         entry.reconnect = reconnect;
         entry.end_reason = None;
+        entry.reconnect_error = None;
     }
 
     /// `session.reconnectAttempt` — the backoff timer fired; start an attempt.
@@ -319,6 +337,25 @@ impl SessionLifecycleStore {
             entry.status = SessionStatus::Disconnected;
             entry.reconnect = INITIAL_RECONNECT_STATE;
             entry.end_reason = Some(EndReason::User);
+            entry.reconnect_error = None;
+        }
+    }
+
+    /// `session.reconnectTrigger` — record (or clear) the cause that triggered a
+    /// reconnect for a session (#2442). `Some(msg)` sets the supplementary
+    /// "why we are reconnecting" note the disconnect overlay shows while a session
+    /// is reconnecting; `None` clears it. This is a pure metadata write: it does
+    /// **not** touch `status`, the reconnect engine or the backend timer — the
+    /// agent-managed reconnect it accompanies is distinct from the agentless
+    /// backoff loop (`reconnect` / `reconnectAttempt`), and every lifecycle
+    /// resolution already clears `reconnect_error`. A no-op for an unknown session
+    /// (mirrors [`reconnect_attempt`](Self::reconnect_attempt) /
+    /// [`reconnect_failed`](Self::reconnect_failed)): the record is only ever set
+    /// for a session that has already connected.
+    pub fn set_reconnect_trigger(&self, session_id: &str, error: Option<String>) {
+        let mut inner = self.lock();
+        if let Some(entry) = inner.sessions.get_mut(session_id) {
+            entry.reconnect_error = error;
         }
     }
 

--- a/src-tauri/src/session_projection/store_tests.rs
+++ b/src-tauri/src/session_projection/store_tests.rs
@@ -217,3 +217,68 @@ fn status_and_reconnect_phase_stay_consistent_through_a_full_loop() {
     assert_eq!(s.status, SessionStatus::Connected);
     assert_eq!(s.reconnect.phase, ReconnectPhase::Connected);
 }
+
+#[test]
+fn set_reconnect_trigger_records_and_clears_the_cause() {
+    // #2442: the reconnect-trigger cause is region-owned, set/cleared by its own
+    // pure-metadata write without perturbing status or the reconnect engine.
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connected("s1");
+    store.set_reconnect_trigger("s1", Some("connection reset".to_string()));
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.reconnect_error.as_deref(), Some("connection reset"));
+    // Status / reconnect detail untouched — this is not the agentless backoff loop.
+    assert_eq!(s.status, SessionStatus::Connected);
+    assert_eq!(s.reconnect.phase, ReconnectPhase::Idle);
+    // A None clears it.
+    store.set_reconnect_trigger("s1", None);
+    assert_eq!(store.get("s1").unwrap().reconnect_error, None);
+}
+
+#[test]
+fn set_reconnect_trigger_is_a_no_op_for_an_unknown_session() {
+    let store = deterministic_store();
+    store.set_reconnect_trigger("ghost", Some("boom".to_string()));
+    assert!(store.get("ghost").is_none());
+}
+
+#[test]
+fn lifecycle_resolutions_clear_the_reconnect_trigger_cause() {
+    // Any resolution transition clears reconnect_error so a stale cause never
+    // lingers into the next connect cycle (the guarantee #2205 PR-B relies on).
+    for resolve in [
+        SessionLifecycleStore::connected as fn(&SessionLifecycleStore, &str),
+        SessionLifecycleStore::disconnect,
+    ] {
+        let store = deterministic_store();
+        store.connect("s1");
+        store.connected("s1");
+        store.set_reconnect_trigger("s1", Some("cause".to_string()));
+        resolve(&store, "s1");
+        assert_eq!(store.get("s1").unwrap().reconnect_error, None);
+    }
+    // dropped / connect_failed carry their own message into `error`, not `reconnect_error`.
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connected("s1");
+    store.set_reconnect_trigger("s1", Some("cause".to_string()));
+    store.dropped("s1", Some("link lost".to_string()));
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.reconnect_error, None);
+    assert_eq!(s.error.as_deref(), Some("link lost"));
+}
+
+#[test]
+fn reconnect_trigger_cause_is_serialized_only_when_set() {
+    let store = deterministic_store();
+    store.connect("s1");
+    assert!(store.snapshot()["sessions"]["s1"]
+        .get("reconnectError")
+        .is_none());
+    store.set_reconnect_trigger("s1", Some("why".to_string()));
+    assert_eq!(
+        store.snapshot()["sessions"]["s1"]["reconnectError"],
+        serde_json::json!("why")
+    );
+}

--- a/src/components/Terminal/TerminalDisconnectOverlay.projection.test.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.projection.test.tsx
@@ -137,6 +137,47 @@ describe("TerminalDisconnectOverlay — projected session-lifecycle render cut (
     expect(overlay?.textContent).toContain("Reconnecting");
   });
 
+  it("renders the reconnect-trigger error sourced from a mirroring region snapshot (#2442)", async () => {
+    useAppStore.setState({
+      terminalReconnectingTabs: { [TAB]: true },
+      terminalReconnectTriggerErrors: { [TAB]: "connection reset" },
+    });
+    transport.setSession(
+      TAB,
+      reconnecting({ phase: "connecting", attempt: 1, delayMs: 0 }, "connection reset")
+    );
+
+    act(() => root.render(withTooltip(<TerminalDisconnectOverlay tabId={TAB} />)));
+    await flush();
+
+    expect(transport.subscribeCount).toBeGreaterThan(0);
+    const errorBox = container.querySelector(
+      "[data-testid='terminal-disconnect-trigger-error-box']"
+    );
+    expect(errorBox?.textContent).toContain("connection reset");
+  });
+
+  it("keeps the trigger error identical to appStore when the region diverges (fallback parity, #2442)", async () => {
+    useAppStore.setState({
+      terminalReconnectingTabs: { [TAB]: true },
+      terminalReconnectTriggerErrors: { [TAB]: "local cause" },
+    });
+    // The region carries a stale/divergent trigger error; the gate must reject it.
+    transport.setSession(
+      TAB,
+      reconnecting({ phase: "connecting", attempt: 1, delayMs: 0 }, "stale cause")
+    );
+
+    act(() => root.render(withTooltip(<TerminalDisconnectOverlay tabId={TAB} />)));
+    await flush();
+
+    const errorBox = container.querySelector(
+      "[data-testid='terminal-disconnect-trigger-error-box']"
+    );
+    expect(errorBox?.textContent).toContain("local cause");
+    expect(errorBox?.textContent).not.toContain("stale cause");
+  });
+
   it("renders the disconnect error sourced from a mirroring failed snapshot", async () => {
     useAppStore.setState({ terminalDisconnectErrors: { [TAB]: "auth failed" } });
     transport.setSession(TAB, failed("auth failed"));

--- a/src/components/Terminal/TerminalDisconnectOverlay.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.tsx
@@ -139,18 +139,18 @@ export function TerminalDisconnectOverlay({ tabId }: TerminalDisconnectOverlayPr
   const reconnectTerminal = useAppStore((s) => s.reconnectTerminal);
   const dismissTerminalDisconnect = useAppStore((s) => s.dismissTerminalDisconnect);
   const setTerminalExited = useAppStore((s) => s.setTerminalExited);
-  // Render cut (#2205 PR-A): the disconnect error and reconnect flag are sourced
-  // from the projected `session-lifecycle` region (falls back to appStore when it
-  // does not mirror). `terminalReconnectTriggerErrors` stays on appStore — the
-  // region has no distinct field for a manual-reconnect-trigger error, so PR-A
-  // cannot faithfully mirror it (see #2205 PR-A notes).
+  // Render cut (#2205 PR-A / #2442): the disconnect error, reconnect flag and the
+  // reconnect-trigger error are all sourced from the projected `session-lifecycle`
+  // region (falls back to appStore when it does not mirror). #2442 added the
+  // region's distinct `reconnectError` field + `session.reconnectTrigger` intent
+  // so the trigger error is region-owned rather than read from appStore directly.
   const lifecycle = useProjectedSessionLifecycle(tabId);
   const disconnectError = lifecycle.disconnectError;
   const isReconnecting = lifecycle.reconnecting;
+  const reconnectTriggerError = lifecycle.reconnectTriggerError;
   // The auto-reconnect gate reads the same projected-with-fallback loop detail as
   // the countdown overlay itself, so the region drives which variant shows (#2204).
   const autoReconnectWaiting = useSessionAutoReconnect(tabId)?.phase === "waiting";
-  const reconnectTriggerError = useAppStore((s) => s.terminalReconnectTriggerErrors[tabId]);
   const exitInfo = useAppStore((s) => s.terminalExitInfo[tabId]);
 
   const handleReconnect = useCallback(() => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -5644,7 +5644,13 @@ export const useAppStore = create<AppState>((set, get, store) => {
         get().reconnectTerminal(id);
       }
     },
-    setTerminalReconnecting: (tabId, reconnecting) =>
+    setTerminalReconnecting: (tabId, reconnecting) => {
+      // Session-intents cut (#2442): reconnecting ending clears the region's
+      // reconnect-trigger cause too, keeping the projected `reconnectError`
+      // field in lockstep with the local slice (the two clear together).
+      if (!reconnecting && sessionIntentsEnabled()) {
+        mirrorSessionIntent("session.reconnectTrigger", tabId);
+      }
       set((state) =>
         reconnecting
           ? { terminalReconnectingTabs: { ...state.terminalReconnectingTabs, [tabId]: true } }
@@ -5652,20 +5658,28 @@ export const useAppStore = create<AppState>((set, get, store) => {
               terminalReconnectingTabs: omitKey(state.terminalReconnectingTabs, tabId),
               terminalReconnectTriggerErrors: omitKey(state.terminalReconnectTriggerErrors, tabId),
             }
-      ),
+      );
+    },
     setTerminalReattaching: (tabId, reattaching) =>
       set((state) => ({
         terminalReattaching: reattaching
           ? { ...state.terminalReattaching, [tabId]: true }
           : omitKey(state.terminalReattaching, tabId),
       })),
-    setTerminalReconnectTriggerError: (tabId, error) =>
+    setTerminalReconnectTriggerError: (tabId, error) => {
+      // Session-intents cut (#2442): the reconnect-trigger cause is region-owned.
+      // Mirror it to the shared `session-lifecycle` region so the disconnect
+      // overlay can read it from the projection (a null error clears the field).
+      if (sessionIntentsEnabled()) {
+        mirrorSessionIntent("session.reconnectTrigger", tabId, error ?? undefined);
+      }
       set((state) => ({
         terminalReconnectTriggerErrors:
           error === null
             ? omitKey(state.terminalReconnectTriggerErrors, tabId)
             : { ...state.terminalReconnectTriggerErrors, [tabId]: error },
-      })),
+      }));
+    },
     dismissTerminalDisconnect: (tabId) =>
       set((state) => ({
         // Keep terminalExitedTabs[tabId] = true so the banner can detect the dead session;

--- a/src/store/sessionBridge.ts
+++ b/src/store/sessionBridge.ts
@@ -78,6 +78,10 @@ export interface ProjectedSessionLifecycle {
   reconnect: ProjectedReconnect;
   endReason?: ProjectedEndReason;
   error?: string;
+  /** The cause that triggered the current reconnect — the supplementary "why we
+   * are reconnecting" note shown while a session is reconnecting (#2442). Twin of
+   * the Rust `reconnect_error`. Distinct from `error` (the terminal failure msg). */
+  reconnectError?: string;
 }
 
 /** The `session-lifecycle` region view model: `{ sessions: { <id>: … } }`. */
@@ -96,6 +100,7 @@ export type SessionIntentKind =
   | "session.reconnectAttempt"
   | "session.reconnectFailed"
   | "session.cancelReconnect"
+  | "session.reconnectTrigger"
   | "session.remove";
 
 // ── Feature flag (runtime-flippable, off by default) ───────────────────────────
@@ -534,6 +539,28 @@ export function effectiveDisconnectError(
 ): string | undefined {
   if (!sessionRenderFromProjectionEnabled()) return local;
   const projectedError = projected?.status === "failed" ? projected.error : undefined;
+  if (projectedError !== local) return local;
+  return projectedError;
+}
+
+/**
+ * Effective `terminalReconnectTriggerErrors[tabId]` for rendering (#2442): the
+ * projected `reconnectError` when it mirrors the local trigger error exactly,
+ * otherwise the local value verbatim (`undefined` ⇒ no error).
+ *
+ * Unlike the status-keyed gates above, this reads the region's `reconnectError`
+ * field directly rather than off a status: the reconnect-trigger cause is written
+ * by its own `session.reconnectTrigger` intent and is meaningful alongside the
+ * agent-managed reconnecting phase (which the region does not itself model as a
+ * status). The disconnect overlay only surfaces it inside the reconnecting
+ * variant, so the value is byte-identical to the pre-cut `appStore` read.
+ */
+export function effectiveReconnectTriggerError(
+  local: string | undefined,
+  projected: ProjectedSessionLifecycle | undefined
+): string | undefined {
+  if (!sessionRenderFromProjectionEnabled()) return local;
+  const projectedError = projected?.reconnectError;
   if (projectedError !== local) return local;
   return projectedError;
 }

--- a/src/store/sessionLifecycleRenderCut.test.ts
+++ b/src/store/sessionLifecycleRenderCut.test.ts
@@ -19,6 +19,7 @@ import {
   effectiveDisconnectErrorMap,
   effectiveReconnecting,
   effectiveReconnectingMap,
+  effectiveReconnectTriggerError,
   setSessionRenderFromProjectionEnabled,
   type ProjectedSessionLifecycle,
 } from "@/store/sessionBridge";
@@ -30,6 +31,14 @@ function life(
   error?: string
 ): ProjectedSessionLifecycle {
   return { status, reconnect: idle, ...(error !== undefined ? { error } : {}) };
+}
+
+/** A projected lifecycle carrying a region-owned reconnect-trigger cause (#2442). */
+function withTrigger(
+  status: ProjectedSessionLifecycle["status"],
+  reconnectError?: string
+): ProjectedSessionLifecycle {
+  return { status, reconnect: idle, ...(reconnectError !== undefined ? { reconnectError } : {}) };
 }
 
 afterEach(() => {
@@ -83,6 +92,39 @@ describe("effectiveDisconnectError", () => {
 
   it("returns undefined when neither has an error", () => {
     expect(effectiveDisconnectError(undefined, life("connected"))).toBeUndefined();
+  });
+});
+
+describe("effectiveReconnectTriggerError (#2442)", () => {
+  it("sources the trigger error from a mirroring region reconnectError field", () => {
+    expect(effectiveReconnectTriggerError("reset", withTrigger("reconnecting", "reset"))).toBe(
+      "reset"
+    );
+    // Read directly off the field, independent of status.
+    expect(effectiveReconnectTriggerError("reset", withTrigger("connected", "reset"))).toBe(
+      "reset"
+    );
+  });
+
+  it("falls back to the local error when the strings diverge or the region is silent", () => {
+    expect(effectiveReconnectTriggerError("reset", withTrigger("reconnecting", "different"))).toBe(
+      "reset"
+    );
+    // Region has no reconnectError (not yet mirrored) but local does — local wins.
+    expect(effectiveReconnectTriggerError("reset", withTrigger("reconnecting"))).toBe("reset");
+    expect(effectiveReconnectTriggerError("reset", undefined)).toBe("reset");
+  });
+
+  it("returns undefined when neither carries a trigger error", () => {
+    expect(effectiveReconnectTriggerError(undefined, withTrigger("reconnecting"))).toBeUndefined();
+  });
+
+  it("returns the local value verbatim when the render cut is off", () => {
+    setSessionRenderFromProjectionEnabled(false);
+    // A divergent region value must be ignored with the flag off.
+    expect(effectiveReconnectTriggerError("reset", withTrigger("reconnecting", "other"))).toBe(
+      "reset"
+    );
   });
 });
 

--- a/src/store/useSessionLifecycle.ts
+++ b/src/store/useSessionLifecycle.ts
@@ -39,6 +39,7 @@ import {
   effectiveDisconnectErrorMap,
   effectiveReconnecting,
   effectiveReconnectingMap,
+  effectiveReconnectTriggerError,
   ensureSessionSubscribed,
   logSessionBridgeFallback,
   onSessionView,
@@ -109,6 +110,9 @@ export interface ProjectedSessionLifecycleSlice {
   reconnecting: boolean;
   /** The failed-(re)connect error, if any (mirrors `terminalDisconnectErrors`). */
   disconnectError: string | undefined;
+  /** The reconnect-trigger cause shown while reconnecting, if any (mirrors
+   * `terminalReconnectTriggerErrors`, #2442). */
+  reconnectTriggerError: string | undefined;
 }
 
 /**
@@ -127,6 +131,7 @@ export function useProjectedSessionLifecycle(tabId: string): ProjectedSessionLif
   const connectingLocal = useAppStore((s) => s.terminalConnecting[tabId] ?? false);
   const reconnectingLocal = useAppStore((s) => s.terminalReconnectingTabs[tabId] ?? false);
   const disconnectErrorLocal = useAppStore((s) => s.terminalDisconnectErrors[tabId]);
+  const reconnectTriggerErrorLocal = useAppStore((s) => s.terminalReconnectTriggerErrors[tabId]);
 
   // Read the flag once at mount: it flips only via dev tooling, and the
   // subscription lifecycle is keyed off it below.
@@ -165,6 +170,7 @@ export function useProjectedSessionLifecycle(tabId: string): ProjectedSessionLif
     connecting: effectiveConnecting(connectingLocal, p),
     reconnecting: effectiveReconnecting(reconnectingLocal, p),
     disconnectError: effectiveDisconnectError(disconnectErrorLocal, p),
+    reconnectTriggerError: effectiveReconnectTriggerError(reconnectTriggerErrorLocal, p),
   };
 }
 

--- a/src/test/sessionLifecycleRegionTestHarness.ts
+++ b/src/test/sessionLifecycleRegionTestHarness.ts
@@ -161,9 +161,19 @@ export function connected(): ProjectedSessionLifecycle {
   return { status: "connected", reconnect: idleReconnect() };
 }
 
-/** A `reconnecting` projected lifecycle carrying the loop detail. */
-export function reconnecting(reconnect: ProjectedReconnect): ProjectedSessionLifecycle {
-  return { status: "reconnecting", reconnect };
+/**
+ * A `reconnecting` projected lifecycle carrying the loop detail and, optionally,
+ * the region-owned reconnect-trigger cause (#2442).
+ */
+export function reconnecting(
+  reconnect: ProjectedReconnect,
+  reconnectError?: string
+): ProjectedSessionLifecycle {
+  return {
+    status: "reconnecting",
+    reconnect,
+    ...(reconnectError !== undefined ? { reconnectError } : {}),
+  };
 }
 
 /** A terminal `failed` projected lifecycle carrying the disconnect error. */


### PR DESCRIPTION
## What & why

Follow-up to #2205 (PR #2441, the Phase 4 render cut PR-A). The #2441 render cut flipped the terminal lifecycle readers onto the projected `session-lifecycle` region, but one appStore slice — `terminalReconnectTriggerErrors` — could not be faithfully mirrored and was left reading appStore directly in `TerminalDisconnectOverlay`. This gives that slice an explicit, unambiguous home so #2205 PR-B can remove it.

## Decision: region-owned

The manual/agent reconnect-trigger error is **session-lifecycle state (region-owned)**, not a per-client presentation affordance like the dismissed-overlay / view-mode flags.

Rationale: the trigger error is the cause an agent reports when its link drops and it starts re-establishing a session — a property of the *session*, observed identically by every client (Open Design Decision #4's shared-domain argument), and directly analogous to the `error` the region already carries for `dropped` / `failed`. A viewer's dismissed-overlay or view-mode choice is a per-client affordance; a drop cause is not. Classifying it as presentation would have mislabelled genuine shared lifecycle state.

## How

- **Region (Rust):** added a distinct `reconnect_error` field to `SessionLifecycle` (serialized `reconnectError`, omitted when unset) and a `session.reconnectTrigger` intent (`{ sessionId, error? }`). The intent is a **pure metadata write** — it records/clears the cause without touching `status`, the reconnect engine, `end_reason`/`error`, or the backend timer. This is deliberate: the agent-managed reconnect it accompanies is distinct from the agentless backoff loop (`reconnect` / `reconnectAttempt`), which must not be falsely armed. Every lifecycle resolution (`connect` / `connected` / `connectFailed` / `disconnect` / `dropped` / `reconnect` / `cancelReconnect`) clears `reconnect_error`, so a stale cause never lingers into the next cycle — the guarantee #2205 PR-B relies on.
- **Render cut (frontend):** `TerminalDisconnectOverlay` now sources the trigger error from the region via a faithful-mirror gate (`effectiveReconnectTriggerError`) with an appStore fallback, exactly like the #2441 disconnect-error / reconnect-flag cuts. appStore mirrors set/clear of the trigger cause to the region (`session.reconnectTrigger`) from `setTerminalReconnectTriggerError` and the reconnecting-ended path, keeping the projected field in lockstep with the local slice. The output is byte-identical to the pre-cut path.

Following the PR-A strangler pattern, this cuts the *reader* and keeps the appStore slice as the writer/fallback; #2205 PR-B removes the slice alongside the others.

## Tests

- Rust store tests: set/clear, no-op for unknown session, resolutions clear it, serialize-only-when-set.
- Rust projection test: `session.reconnectTrigger` projects the cause + a clear removes it, without changing status; cache converges on authority.
- TS unit tests: `effectiveReconnectTriggerError` gate (source / diverge-fallback / silent-region-fallback / flag-off).
- TS overlay projection tests: trigger error rendered from a mirroring region snapshot, and fallback parity when the region diverges.

Full frontend + backend unit suites, `pnpm build`, `cargo clippy -D warnings`, `eslint`, `cargo fmt --check` and `prettier --check` all green. No user-facing behavior change (render parity), so no change fragment.

Closes #2442
