### PR TITLE
fix(config): make WSL settings schema advertise literal paths (Closes #2452)

### DIFF
--- a/core/src/backends/wsl.rs
+++ b/core/src/backends/wsl.rs
@@ -628,8 +628,13 @@ impl ConnectionType for Wsl {
                         required: false,
                         default: None,
                         placeholder: Some("~ (home directory)".to_string()),
-                        supports_env_expansion: true,
-                        supports_tilde_expansion: true,
+                        // WSL paths are literal: values are handed to `wsl --cd`
+                        // and resolved by the Linux guest, so host-side `~` /
+                        // `${VAR}` expansion (which resolves against the Windows
+                        // host) would corrupt a valid Linux path. See
+                        // docs/concepts/backlog/wsl-path-expansion-semantics.html.
+                        supports_env_expansion: false,
+                        supports_tilde_expansion: false,
                         visible_when: None,
                     },
                     SettingsField {
@@ -641,7 +646,8 @@ impl ConnectionType for Wsl {
                         required: false,
                         default: None,
                         placeholder: None,
-                        supports_env_expansion: true,
+                        // Literal: passed verbatim to the WSL guest (see startingDirectory).
+                        supports_env_expansion: false,
                         supports_tilde_expansion: false,
                         visible_when: None,
                     },
@@ -685,7 +691,8 @@ impl ConnectionType for Wsl {
                         required: false,
                         default: None,
                         placeholder: None,
-                        supports_env_expansion: true,
+                        // Literal: values cross into the guest verbatim via WSLENV.
+                        supports_env_expansion: false,
                         supports_tilde_expansion: false,
                         visible_when: None,
                     },
@@ -1046,8 +1053,32 @@ mod tests {
         assert!(dir_field.is_some());
         let f = dir_field.unwrap();
         assert!(!f.required);
-        assert!(f.supports_tilde_expansion);
-        assert!(f.supports_env_expansion);
+        // WSL values are literal — the connect path never expands them, and
+        // host-side expansion would corrupt Linux paths. The schema must
+        // advertise no expansion so it matches the connect path.
+        assert!(!f.supports_tilde_expansion);
+        assert!(!f.supports_env_expansion);
+    }
+
+    #[test]
+    fn schema_wsl_fields_advertise_no_expansion() {
+        // Regression guard for the literal-path contract: no WSL field may
+        // claim host-side expansion (see wsl-path-expansion-semantics concept).
+        let wsl = Wsl::new();
+        let schema = wsl.settings_schema();
+        let fields = &schema.groups[0].fields;
+        for f in fields {
+            assert!(
+                !f.supports_env_expansion,
+                "WSL field `{}` must not advertise env expansion",
+                f.key
+            );
+            assert!(
+                !f.supports_tilde_expansion,
+                "WSL field `{}` must not advertise tilde expansion",
+                f.key
+            );
+        }
     }
 
     #[test]

--- a/core/src/config/mod.rs
+++ b/core/src/config/mod.rs
@@ -595,15 +595,11 @@ impl ShellConfig {
     }
 }
 
-impl WslConfig {
-    /// Return a copy with all `${VAR}` placeholders and `~` expanded.
-    pub fn expand(mut self) -> Self {
-        self.distribution = expand_config_value(&self.distribution);
-        self.starting_directory = self.starting_directory.map(|s| expand_config_value(&s));
-        self.initial_command = self.initial_command.map(|s| expand_config_value(&s));
-        self
-    }
-}
+// NOTE: WslConfig intentionally has no `expand()`. WSL values are passed to the
+// guest literally: the connect path (`core/src/backends/wsl.rs`) never expands
+// them, and host-side expansion (`expand_config_value` resolves `~` / `${VAR}`
+// against the Windows host) would corrupt a Linux path. See the concept
+// `docs/concepts/backlog/wsl-path-expansion-semantics.html`.
 
 impl TelnetConfig {
     /// Return a copy with all `${VAR}` placeholders and `~` expanded.
@@ -1890,35 +1886,6 @@ mod tests {
                 .unwrap()
                 .starts_with('~'),
             "tilde should be expanded in working directory"
-        );
-    }
-
-    #[test]
-    fn wsl_config_expand_replaces_placeholders() {
-        temp_env::with_vars(
-            [
-                ("TERMIHUB_TEST_WSL_DISTRO", Some("Ubuntu")),
-                ("TERMIHUB_TEST_WSL_CMD", Some("echo hello")),
-            ],
-            || {
-                let cfg = WslConfig {
-                    distribution: "${TERMIHUB_TEST_WSL_DISTRO}".into(),
-                    starting_directory: Some("~/projects".into()),
-                    initial_command: Some("${TERMIHUB_TEST_WSL_CMD}".into()),
-                    ..WslConfig::default()
-                };
-                let expanded = cfg.expand();
-                assert_eq!(expanded.distribution, "Ubuntu");
-                assert!(
-                    !expanded
-                        .starting_directory
-                        .as_ref()
-                        .unwrap()
-                        .starts_with('~'),
-                    "tilde should be expanded in starting directory"
-                );
-                assert_eq!(expanded.initial_command, Some("echo hello".into()));
-            },
         );
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1371,6 +1371,7 @@ flowchart LR
 - New connection types render automatically without any frontend changes
 - Conditional visibility (`visibleWhen`) handles dependent fields (e.g., show "Key Path" only when "Auth Method" is "key")
 - Supports environment variable expansion (`${VAR}`) and tilde expansion markers per field
+  - **WSL is the deliberate exception:** its `startingDirectory`, `env`, and `initialCommand` fields advertise **no** expansion (`supports_*_expansion: false`) and are passed to the guest literally. `expand_config_value` resolves `~` / `${VAR}` against the **Windows host**, so host-side expansion would corrupt a Linux path (`~` → `C:\Users\…`). The WSL connect path never expands; the guest / `wsl --cd` / login shell resolve these values in the Linux namespace that actually contains them. See `docs/concepts/backlog/wsl-path-expansion-semantics.html` (#2360).
 - The schema is serializable as JSON — enables remote agents to report their available types and schemas to the desktop
 - Plugin-provided connection types (future) can declare schemas without shipping frontend code
 

--- a/docs/changes/dev0/fix/2452-wsl-literal-path-semantics.md
+++ b/docs/changes/dev0/fix/2452-wsl-literal-path-semantics.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- WSL connection settings are now correctly documented and advertised as
+  **literal**: the `startingDirectory`, `initialCommand`, and `env` fields no
+  longer claim `~` / `${VAR}` expansion in the settings schema. termiHub never
+  expanded WSL values (the connect path spawns `wsl.exe` directly, and the guest
+  resolves `~` and environment references itself); the schema previously
+  advertised host-side expansion that would corrupt Linux paths (`~` →
+  `C:\Users\…`). The schema now matches the connect path — a value like
+  `~/projects` reaches `wsl --cd ~/projects` verbatim. Behaviour is unchanged;
+  the schema is now honest (#2452, concept #2360).


### PR DESCRIPTION
Implements the maintainer decision documented in the concept `docs/concepts/backlog/wsl-path-expansion-semantics.html` (issue #2360): **WSL paths are literal.** Host-side expansion does not apply to WSL, so the WSL settings schema no longer advertises `~` / `${VAR}` expansion.

## Why
WSL's `connect()` spawns `wsl.exe` directly and never calls `WslConfig::expand()`, so WSL values were already passed through literally. But the schema advertised expansion that never happens. Worse, wiring the existing `expand()` into the connect path would be *wrong*: `expand_config_value` resolves `~` / `${VAR}` against the **Windows host** (`USERPROFILE`, host env), which would rewrite a Linux `~/projects` to `C:\Users\...` and corrupt the path. The Linux guest / `wsl --cd` / login shell already resolve these correctly in the namespace that contains them.

This is a schema/behaviour honesty fix — **zero runtime behaviour change**.

## Changes
- `core/src/backends/wsl.rs` `settings_schema()`: set `supports_env_expansion` / `supports_tilde_expansion` to `false` for `startingDirectory` (both), `initialCommand` (env), and `env` (env). `distribution` / `shellIntegration` were already false.
- Inverted the `schema_has_starting_directory` test assertions and added `schema_wsl_fields_advertise_no_expansion`, a regression guard asserting **no** WSL field advertises expansion.
- Removed the never-called `WslConfig::expand()` and its test `wsl_config_expand_replaces_placeholders` (confirmed unreferenced outside the removed test — the connect path parses `WslConfig` directly). Prevents a future change from silently re-wiring host-side expansion.
- `docs/architecture.md` (ADR-8): documented WSL as the deliberate per-field expansion exception.
- Change fragment under `docs/changes/dev0/`.

## Scope notes
- Frontend impact: none. `supports_*_expansion` are advisory schema metadata (`src/types/schema.ts`); no form component renders an expansion hint from them, so no UI change. `agentSchema.ts` is the SSH-agent transport, not WSL.
- No golden schema fixture encodes WSL flags (the two `schema_defaults` fixtures don't reference WSL).

## Verification
- `cargo test -p termihub-core --lib` — 648 passed (config/WslConfig tests green; removed test gone). The `backends/wsl.rs` schema tests are `#[cfg(windows)]`-gated and validated on Windows CI (macOS can't compile that module); edits are mechanical flag flips.
- `cargo fmt --check`, `cargo clippy -p termihub-core --all-targets`, `prettier --check` on touched files — all clean.

Concept: `docs/concepts/backlog/wsl-path-expansion-semantics.html`. Refs #2360.

Closes #2452

🤖 Generated with [Claude Code](https://claude.com/claude-code)