### PR TITLE
feat(session): retain resilient direct connection requests for reconnect redrive (part of #2454)

### DIFF
--- a/agent/src/daemon/client.rs
+++ b/agent/src/daemon/client.rs
@@ -741,12 +741,27 @@ mod tests {
         );
         let endpoint = transport::session_endpoint(&session_id);
 
-        // Mock daemon: accept, send Ready, then close the connection the instant
-        // it receives MSG_DETACH — exactly what the real daemon does, EOFing the
-        // client's reader.
         let mut listener = transport::DaemonListener::bind(&endpoint)
             .await
             .expect("bind mock daemon");
+
+        // Mock daemon. The real daemon only closes the connection *in response* to
+        // MSG_DETACH, so the resulting EOF reaches the client well after detach's
+        // (asynchronous) reader-task abort has landed. The original mock instead
+        // dropped its halves the instant it saw MSG_DETACH — a tighter schedule
+        // than production that raced the abort and made this test flaky on macOS
+        // CI (#2459). Reproduce production's ordering *deterministically*: do not
+        // EOF the client until its reader task is actually gone. The reader task
+        // owns the client's read half, so once a correct detach aborts it (and
+        // detach has dropped the client's write half) the client socket is fully
+        // closed and any write from us fails; probe for exactly that. While the
+        // reader still lives, empty MSG_OUTPUT frames are accepted and ignored.
+        //
+        // `reader_gone` reports whether the reader was gone *before* we closed —
+        // the direct #2437 property. A correct detach makes it true quickly; the
+        // pre-#2437 ordering leaves the reader live, so the probe never fails and
+        // the generous deadline trips it to false.
+        let (reader_gone_tx, reader_gone_rx) = tokio::sync::oneshot::channel::<bool>();
         let server = tokio::spawn(async move {
             let (mut reader, mut writer) = listener.accept().await.expect("accept");
             protocol::write_frame_async(&mut writer, MSG_READY, &[])
@@ -757,7 +772,23 @@ mod tests {
                     break;
                 }
             }
-            // Drop both halves → the client's reader half observes EOF.
+            let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+            let reader_gone = loop {
+                if protocol::write_frame_async(&mut writer, MSG_OUTPUT, &[])
+                    .await
+                    .is_err()
+                {
+                    break true;
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    break false;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            };
+            let _ = reader_gone_tx.send(reader_gone);
+            // Only now drop our halves. On a correct detach the client's reader is
+            // already gone, so this EOF reaches no one; on the pre-#2437 ordering
+            // it is what finally trips the still-live reader's exit path.
             drop(writer);
             drop(reader);
             listener.cleanup();
@@ -773,9 +804,16 @@ mod tests {
 
         client.detach().await;
 
-        // Give any stray reader activity a chance to (wrongly) fire first.
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
+        // Deterministic synchronization (replaces the old fixed 100 ms sleep): the
+        // mock only closes the connection once the reader task is gone, so it can
+        // never deliver a detach-induced EOF to a live reader.
+        let reader_gone = reader_gone_rx
+            .await
+            .expect("mock daemon reported reader state");
+        assert!(
+            reader_gone,
+            "detach must abort the reader before the daemon connection closes (#2437)"
+        );
         assert!(
             client.is_alive(),
             "a clean detach must not mark the still-alive session dead (#2437)"

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -36,6 +36,7 @@ use super::line_ending::{normalize_line_endings, LineEnding};
 use super::monitoring_controller::MonitoringController;
 use super::persistent_controller::PersistentController;
 use super::remote_proxy::RemoteProxy;
+use super::retained_request::{RetainedConnectionRequest, RetainedRequestStore};
 use super::session_log::{default_session_log_path, desktop_clock};
 
 /// Maximum number of concurrent sessions.
@@ -393,6 +394,12 @@ pub struct SessionManager {
     /// [`SessionTabIds`]. Populated in [`Self::create_connection`] from the
     /// caller's `connect_id`, cleared on every session-removal path.
     pub(super) session_tab_ids: SessionTabIds,
+    /// Per-tab retained connection requests for the resilient-reconnect loop
+    /// (#2454, retention Model A). Populated in [`Self::create_connection`] for a
+    /// resilient **direct** session, and dropped + zeroized on every
+    /// terminal-loop / session-end path (the mandatory secret-lifetime
+    /// mitigation). See [`super::retained_request`].
+    pub(super) retained_requests: RetainedRequestStore,
 }
 
 /// Removes a `connect_id` from the [`SessionManager::connecting`] map when the
@@ -472,6 +479,7 @@ impl SessionManager {
             output_buffers: Arc::new(StdMutex::new(HashMap::new())),
             session_loggers: Arc::new(StdMutex::new(HashMap::new())),
             session_tab_ids: Arc::new(StdMutex::new(HashMap::new())),
+            retained_requests: RetainedRequestStore::new(),
         }
     }
 
@@ -805,10 +813,31 @@ impl SessionManager {
                 .insert(
                     session_id.clone(),
                     TabBinding {
-                        tab_id,
+                        tab_id: tab_id.clone(),
                         resilient: resilient_reconnect,
                     },
                 );
+
+            // Retain the connection request for the resilient-reconnect loop
+            // (#2454, retention Model A) so the backend redrive (follow-up) can
+            // re-establish the transport itself. Scoped to **resilient DIRECT**
+            // (non-agent) sessions — agent silent-retry is #2455 and a
+            // non-resilient tab never reconnects, so neither retains a secret.
+            // Refreshed on every (re)connect of the tab; dropped + zeroized on
+            // any terminal-loop / session-end path (see the module docs and the
+            // `clear_retained_request` call sites). A no-op for the internal
+            // agent-setup session, which carries no `connect_id` / tab id.
+            if resilient_reconnect && agent_id.is_none() {
+                self.retained_requests.retain(
+                    &tab_id,
+                    RetainedConnectionRequest {
+                        type_id: type_id.to_string(),
+                        settings: settings.clone(),
+                        agent_id: None,
+                        resilient: true,
+                    },
+                );
+            }
         }
 
         // Determine if we should wait for screen clear (initial command).
@@ -984,16 +1013,42 @@ impl SessionManager {
         // never sees a binding and never folds a `dropped`/`reconnect` for it. Only
         // a *genuine* spontaneous drop — where no `close_session` ran — leaves the
         // binding intact to arm that fold.
-        self.session_tab_ids
+        let removed_binding = self
+            .session_tab_ids
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .remove(session_id);
+        // Drop + zeroize the tab's retained connection request (#2454): a
+        // deliberate close of a *live* session ends its reconnect loop, so no
+        // resolved secret must linger. (A close after a spontaneous drop finds no
+        // binding here — the drop already removed it — so the post-drop terminal
+        // states clear the retained request via the lifecycle-intent routes.)
+        if let Some(binding) = &removed_binding {
+            self.retained_requests.clear(&binding.tab_id);
+        }
         let mut sessions = self.sessions.lock().await;
         if let Some(mut entry) = sessions.remove(session_id) {
             entry.connection.disconnect().await.ok();
             info!(session_id, "Closed session");
         }
         Ok(())
+    }
+
+    /// Drop + zeroize the retained connection request for a tab (#2454, retention
+    /// Model A). The security-mitigation scrub point invoked by every
+    /// terminal-loop / session-end path that the manager itself does not observe
+    /// — the give-up, user-cancel, graceful-disconnect and remove lifecycle
+    /// transitions (routed through [`crate::session_projection::projection`]).
+    /// Idempotent: clearing a tab with no retained request is a no-op.
+    pub fn clear_retained_request(&self, tab_id: &str) {
+        self.retained_requests.clear(tab_id);
+    }
+
+    /// Whether a resilient-reconnect connection request is currently retained for
+    /// a tab (#2454). Used by tests and the (follow-up) backend redrive.
+    #[allow(dead_code)] // consumed by the retention tests and the follow-up backend redrive
+    pub fn has_retained_request(&self, tab_id: &str) -> bool {
+        self.retained_requests.contains(tab_id)
     }
 
     /// The frontend `tab_id` that owns a backend `session_id`, or `None` for a
@@ -2677,6 +2732,101 @@ mod tests {
             None,
             "closing a session clears its identity-bridge entry"
         );
+    }
+
+    #[tokio::test]
+    async fn create_connection_retains_request_for_resilient_direct_session() {
+        let manager = make_test_manager();
+        manager
+            .create_connection(
+                "mock",
+                serde_json::json!({ "password": "secret" }),
+                None, // direct (no agent)
+                Some("tab-r:0"),
+                false,
+                true, // resilient
+                MockEventEmitter::new(),
+            )
+            .await
+            .expect("session should open");
+        assert!(
+            manager.has_retained_request("tab-r"),
+            "a resilient direct session retains its connection request (#2454 Model A)"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_connection_does_not_retain_for_non_resilient_session() {
+        let manager = make_test_manager();
+        manager
+            .create_connection(
+                "mock",
+                serde_json::json!({}),
+                None,
+                Some("tab-nr:0"),
+                false,
+                false, // not resilient
+                MockEventEmitter::new(),
+            )
+            .await
+            .expect("session should open");
+        assert!(
+            !manager.has_retained_request("tab-nr"),
+            "a non-resilient tab never reconnects, so nothing is retained"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_connection_without_tab_retains_nothing() {
+        let manager = make_test_manager();
+        manager
+            .create_connection(
+                "mock",
+                serde_json::json!({}),
+                None,
+                None, // no connect_id → no tab id to key by
+                false,
+                true,
+                MockEventEmitter::new(),
+            )
+            .await
+            .expect("session should open");
+        assert!(!manager.has_retained_request(""));
+    }
+
+    #[tokio::test]
+    async fn close_session_clears_the_retained_request() {
+        let manager = make_test_manager();
+        let session_id = manager
+            .create_connection(
+                "mock",
+                serde_json::json!({ "password": "secret" }),
+                None,
+                Some("tab-c:0"),
+                false,
+                true,
+                MockEventEmitter::new(),
+            )
+            .await
+            .expect("session should open");
+        assert!(manager.has_retained_request("tab-c"));
+
+        manager
+            .close_session(&session_id)
+            .await
+            .expect("close should succeed");
+        assert!(
+            !manager.has_retained_request("tab-c"),
+            "closing a live session drops + zeroizes its retained request (#2454)"
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_retained_request_is_idempotent() {
+        let manager = make_test_manager();
+        // Clearing a tab that never retained anything is a safe no-op.
+        manager.clear_retained_request("never-seen");
+        assert!(!manager.has_retained_request("never-seen"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -7,6 +7,7 @@ mod persistent_controller;
 pub mod rdp_trust_store;
 pub mod registry;
 pub mod remote_proxy;
+pub mod retained_request;
 pub mod session_log;
 pub mod ssh_host_key_verifier;
 pub mod ssh_trust_store;

--- a/src-tauri/src/session/retained_request.rs
+++ b/src-tauri/src/session/retained_request.rs
@@ -1,0 +1,241 @@
+//! Per-tab retention of the connection request for the resilient-reconnect loop
+//! — retention **Model A**, the foundation for the server-side reconnect redrive
+//! (#2454, Part 1 of #2446, unblocks #2205 PR-B).
+//!
+//! # Why retain the request
+//!
+//! When a resilient **direct** (non-agent) session drops, the backend must be
+//! able to re-establish the transport *itself* on the #2203 reconnect timer's
+//! `Waiting → Attempt` edge (the redrive), rather than relying on the client to
+//! call `create_connection` again with the settings. To do that it needs the
+//! original connection request — `type_id` + `settings` + `agent_id` + the
+//! `resilient` flag — which `create_connection` otherwise receives per attempt
+//! from the frontend and drops. Nothing else retains it: `PersistentRecord`
+//! keeps only ids/agent, and `emit_and_cleanup` tears a dropped session down.
+//!
+//! **Maintainer decision (2026-08-07): Model A** — retain the *full* request
+//! in-memory per tab across the reconnect loop, one uniform path for every
+//! connection kind (saved / ad-hoc / spawned / inline). Chosen for the cleanest,
+//! most testable architecture over re-resolving from a saved-connection ref +
+//! credential store (which would not cover ad-hoc/inline requests).
+//!
+//! # Security: resolved secrets must not outlive the session
+//!
+//! `settings` can carry **resolved secrets** — an SSH password / passphrase after
+//! credential-store and jump-host resolution. Model A therefore extends a
+//! resolved secret's in-memory lifetime past the drop, for the duration of the
+//! reconnect loop. The **mandatory** mitigation (baked into the maintainer's
+//! decision): the retained request is dropped and **zeroized** the instant the
+//! tab reaches any state where the session is neither active nor reconnecting —
+//! give-up (Failed), user-cancel (Disconnected/User), a graceful user disconnect,
+//! and tab/session removal — so no resolved secret outlives an active or
+//! reconnecting session. Zeroizing uses the same [`zeroize`] crate the credential
+//! store uses for its in-memory secrets ([`crate::credential`]).
+//!
+//! # Foundation only (this change)
+//!
+//! This module and its wiring **retain and zeroize** the request; nothing reads
+//! it back to redrive a connection yet. The redrive itself — wiring the #2203
+//! timer to re-establish the transport from the retained request behind a
+//! default-off flag, and the frontend re-attach of the new backend session — is
+//! the follow-up that completes #2454. Retaining is inert until then: the request
+//! is only ever populated for a resilient *direct* session and only ever read by
+//! the (not-yet-present) redrive, so this changes no user-facing behavior.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use serde_json::Value;
+use zeroize::Zeroize;
+
+/// A retained connection request for one tab's resilient-reconnect loop
+/// (Model A). Mirrors the `create_connection` request surface so the backend
+/// redrive can re-establish the transport without the frontend.
+///
+/// Zeroized on drop: `settings` may hold resolved secrets (see the module docs),
+/// so [`Drop`] scrubs every string it contains rather than leaving it for the
+/// allocator to reuse.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct RetainedConnectionRequest {
+    /// The connection `type_id` (e.g. `ssh`, `local`).
+    pub(crate) type_id: String,
+    /// The resolved connection settings — **may contain secrets**.
+    pub(crate) settings: Value,
+    /// The agent this request routes through, if any. Always `None` for the
+    /// direct connections this retention currently covers (#2454); kept so the
+    /// agent redrive (#2455) can reuse the same store.
+    pub(crate) agent_id: Option<String>,
+    /// The tab's resilient-reconnect determination at connect time.
+    pub(crate) resilient: bool,
+}
+
+impl Drop for RetainedConnectionRequest {
+    fn drop(&mut self) {
+        self.type_id.zeroize();
+        if let Some(agent_id) = self.agent_id.as_mut() {
+            agent_id.zeroize();
+        }
+        zeroize_json(&mut self.settings);
+    }
+}
+
+/// Recursively zeroize every string value in a JSON tree, in place.
+///
+/// Scrubs string *leaves* (a resolved password lives in a string value) through
+/// arrays and objects. Object *keys* are field names, not secrets, and are left
+/// as-is (serde_json exposes only `values_mut`, not key mutation, anyway).
+fn zeroize_json(value: &mut Value) {
+    match value {
+        Value::String(s) => s.zeroize(),
+        Value::Array(items) => items.iter_mut().for_each(zeroize_json),
+        Value::Object(map) => map.values_mut().for_each(zeroize_json),
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+/// Per-tab store of [`RetainedConnectionRequest`]s, keyed by the frontend **tab
+/// id** (the stable key that survives a reconnect, matching the
+/// `session-lifecycle` region and the `session_tab_ids` identity bridge).
+///
+/// Cloneable (`Arc`-backed) so it can be a field on the `SessionManager` and
+/// shared with the detached tasks that observe lifecycle transitions.
+#[derive(Clone, Default)]
+pub(crate) struct RetainedRequestStore {
+    inner: Arc<Mutex<HashMap<String, RetainedConnectionRequest>>>,
+}
+
+impl RetainedRequestStore {
+    /// An empty store.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, RetainedConnectionRequest>> {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Retain (replacing any prior) the request for `tab_id`. A re-connect or a
+    /// successful reconnect attempt overwrites the previous request; the replaced
+    /// value is zeroized as it drops.
+    pub(crate) fn retain(&self, tab_id: &str, request: RetainedConnectionRequest) {
+        self.lock().insert(tab_id.to_string(), request);
+    }
+
+    /// Drop and zeroize the retained request for `tab_id`, if any. Idempotent —
+    /// clearing a tab with no retained request is a no-op. This is the security
+    /// mitigation's scrub point: every terminal-loop / session-end path calls it.
+    pub(crate) fn clear(&self, tab_id: &str) {
+        // `remove` returns the value; dropping it runs the zeroizing `Drop`.
+        drop(self.lock().remove(tab_id));
+    }
+
+    /// Whether a request is currently retained for `tab_id`.
+    #[allow(dead_code)] // consumed by `SessionManager::has_retained_request` (tests + follow-up redrive)
+    pub(crate) fn contains(&self, tab_id: &str) -> bool {
+        self.lock().contains_key(tab_id)
+    }
+
+    /// A clone of the retained request for `tab_id`, for the (follow-up) redrive.
+    /// Cloning copies the secret-bearing settings; the caller owns scrubbing the
+    /// clone (its `Drop` zeroizes it).
+    #[allow(dead_code)]
+    pub(crate) fn get(&self, tab_id: &str) -> Option<RetainedConnectionRequest> {
+        self.lock().get(tab_id).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn zeroize_json_scrubs_nested_string_leaves() {
+        let mut value = json!({
+            "host": "example.com",
+            "password": "super-secret",
+            "port": 22,
+            "jump": { "passphrase": "another-secret", "enabled": true },
+            "tags": ["one", "two"],
+        });
+        zeroize_json(&mut value);
+
+        // Every string leaf is emptied; non-string leaves are untouched.
+        assert_eq!(value["host"], json!(""));
+        assert_eq!(value["password"], json!(""));
+        assert_eq!(value["jump"]["passphrase"], json!(""));
+        assert_eq!(value["tags"], json!(["", ""]));
+        assert_eq!(value["port"], json!(22));
+        assert_eq!(value["jump"]["enabled"], json!(true));
+    }
+
+    #[test]
+    fn retain_and_clear_roundtrip() {
+        let store = RetainedRequestStore::new();
+        assert!(!store.contains("tab-1"));
+
+        store.retain(
+            "tab-1",
+            RetainedConnectionRequest {
+                type_id: "ssh".to_string(),
+                settings: json!({ "host": "h", "password": "p" }),
+                agent_id: None,
+                resilient: true,
+            },
+        );
+        assert!(store.contains("tab-1"));
+
+        // `get` returns a faithful clone for the (follow-up) redrive.
+        let got = store.get("tab-1").expect("retained request");
+        assert_eq!(got.type_id, "ssh");
+        assert_eq!(got.settings["host"], json!("h"));
+        assert!(got.resilient);
+
+        store.clear("tab-1");
+        assert!(!store.contains("tab-1"));
+        // Clearing an absent tab is a no-op.
+        store.clear("tab-1");
+        assert!(!store.contains("tab-1"));
+    }
+
+    #[test]
+    fn retain_replaces_prior_request() {
+        let store = RetainedRequestStore::new();
+        store.retain(
+            "tab-1",
+            RetainedConnectionRequest {
+                type_id: "ssh".to_string(),
+                settings: json!({ "password": "old" }),
+                agent_id: None,
+                resilient: true,
+            },
+        );
+        store.retain(
+            "tab-1",
+            RetainedConnectionRequest {
+                type_id: "ssh".to_string(),
+                settings: json!({ "password": "new" }),
+                agent_id: None,
+                resilient: true,
+            },
+        );
+        assert_eq!(
+            store.get("tab-1").unwrap().settings["password"],
+            json!("new")
+        );
+    }
+
+    #[test]
+    fn drop_zeroizes_secret_settings() {
+        // The retained request's Drop must scrub secret-bearing settings. We
+        // assert the observable contract via the shared `zeroize_json` used by
+        // Drop: after scrubbing, no secret *value* survives in the tree (field
+        // *names* are not secret and are preserved).
+        let mut settings = json!({ "password": "super-secret", "host": "example.com" });
+        zeroize_json(&mut settings);
+        assert_eq!(settings["password"], json!(""));
+        assert_eq!(settings["host"], json!(""));
+        assert!(!settings.to_string().contains("super-secret"));
+        assert!(!settings.to_string().contains("example.com"));
+    }
+}

--- a/src-tauri/src/session_projection/projection.rs
+++ b/src-tauri/src/session_projection/projection.rs
@@ -47,9 +47,11 @@ use std::sync::Arc;
 
 use serde_json::Value;
 use tauri::{AppHandle, Manager};
+use termihub_core::reconnect_backoff::ReconnectPhase;
 
 use crate::commands::projection::ProjectionState;
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
+use crate::session::manager::SessionManager;
 use crate::session_projection::store::SessionLifecycleStore;
 use crate::session_projection::timer::ReconnectTimerDriver;
 
@@ -154,6 +156,9 @@ pub fn register_session_intents(registry: &mut HandlerRegistry, app_handle: AppH
         store.disconnect(&id);
         let produced = publish_sessions(projector, &store);
         sync_timer(&handle, &id);
+        // A graceful user disconnect ends the session; scrub its retained request
+        // so no resolved secret lingers (#2454 Model A mitigation).
+        clear_retained_request(&handle, &id);
         Ok(produced)
     });
 
@@ -194,6 +199,13 @@ pub fn register_session_intents(registry: &mut HandlerRegistry, app_handle: AppH
         store.reconnect_failed(&id, optional_str(intent, "error"));
         let produced = publish_sessions(projector, &store);
         sync_timer(&handle, &id);
+        // If this failure exhausted the loop (give-up → Failed), the tab is no
+        // longer reconnecting: scrub its retained request (#2454 Model A
+        // mitigation). A failure that only backs off keeps it for the next
+        // attempt.
+        if store.reconnect_state(&id).map(|s| s.phase) == Some(ReconnectPhase::Gaveup) {
+            clear_retained_request(&handle, &id);
+        }
         Ok(produced)
     });
 
@@ -204,6 +216,9 @@ pub fn register_session_intents(registry: &mut HandlerRegistry, app_handle: AppH
         store.cancel_reconnect(&id);
         let produced = publish_sessions(projector, &store);
         sync_timer(&handle, &id);
+        // The user stopped the loop: scrub the retained request (#2454 Model A
+        // mitigation) — the session is no longer active or reconnecting.
+        clear_retained_request(&handle, &id);
         Ok(produced)
     });
 
@@ -222,8 +237,24 @@ pub fn register_session_intents(registry: &mut HandlerRegistry, app_handle: AppH
         store.remove(&id);
         let produced = publish_sessions(projector, &store);
         sync_timer(&handle, &id);
+        // The tab/session is gone: scrub any retained request (#2454 Model A
+        // mitigation).
+        clear_retained_request(&handle, &id);
         Ok(produced)
     });
+}
+
+/// Drop + zeroize the retained connection request for a tab (#2454, retention
+/// Model A), when the `SessionManager` is managed. Called from the lifecycle
+/// routes that end a session's reconnect loop — give-up, user-cancel, graceful
+/// disconnect, remove — so no resolved secret outlives an active/reconnecting
+/// session. `tab_id` is the region key (the intent's `sessionId`, which the
+/// bridge keys by tab id). Off-path no-op when the manager is not managed (e.g. a
+/// headless projection unit-test app), matching [`sync_timer`].
+fn clear_retained_request(app_handle: &AppHandle, tab_id: &str) {
+    if let Some(manager) = app_handle.try_state::<SessionManager>() {
+        manager.clear_retained_request(tab_id);
+    }
 }
 
 /// Reconcile the backend reconnect timer for a session after a transition, when


### PR DESCRIPTION
Part of #2454 (retention **Model A**, part of #2446; unblocks #2205 PR-B). Lands the **safe, inert foundation** for the direct-connection backend reconnect redrive. **Does not close #2454** — the redrive itself and its frontend re-attach are deferred (see *Deferred* below), because completing them cleanly requires a new frontend I/O re-attach mechanism that does not exist yet (#2457) and can only be verified by local/release-cadence integration on the ventilator reconnect hot path, not per-PR CI.

## What moved server-side
- New `src-tauri/src/session/retained_request.rs`: `RetainedConnectionRequest` (`type_id` + `settings` + `agent_id` + `resilient`) and a per-tab `RetainedRequestStore`, keyed by the frontend **tab id** (the stable key that survives a reconnect, matching the `session-lifecycle` region and the `session_tab_ids` identity bridge).
- `SessionManager::create_connection` now **retains** the request for a resilient **DIRECT** (non-agent) session — one uniform Model A path for saved / ad-hoc / spawned / inline connections. Agent silent-retry (#2455) and non-resilient tabs never retain.
- The request is dropped + **zeroized** on every path where the tab stops being active/reconnecting:
  - `SessionManager::close_session` (user close of a live session),
  - and the lifecycle-intent routes in `session_projection::projection` — `session.disconnect` (graceful), `session.cancelReconnect` (user-cancel), `session.reconnectFailed` **when it exhausts the loop** (give-up → Failed), and `session.remove` (tab/session gone).

## The flag / default-off
No behavior flag is introduced in this PR, because it lands only the retention foundation, which is **inert**: nothing reads the retained request back yet, and it is only ever populated for a resilient direct session. Develop's behavior is therefore unchanged. The new default-off flag (backend redrive + client-mirror/redrive suppression) belongs with the redrive wiring — see *Deferred*.

## Zeroize-on-terminal-state (mandatory secret mitigation)
`settings` can carry resolved secrets (SSH password/passphrase after credential-store + jump-host resolution). Model A extends that secret's in-memory lifetime past the drop for the loop's duration, so `RetainedConnectionRequest::drop` recursively **zeroizes** every string leaf of `settings` (plus `agent_id`/`type_id`) via the same `zeroize` crate the credential store uses. Every terminal-loop / session-end path above drops + zeroizes, so no resolved secret outlives an active or reconnecting session.

## Deferred (why this doesn't complete #2454)
On a genuine drop, `emit_and_cleanup` tears down the `SessionEntry`, its output buffer, and the tab binding — so a backend-owned direct reconnect necessarily mints a **new** backend `session_id`. With the client redrive suppressed (required — the reconnect engine is non-idempotent, so #2454 must be a real authority cut, not an additive double-write), the frontend `Terminal` has no way to learn that new id and re-attach terminal I/O. That frontend re-attach / new-session-id propagation is a distinct, integration-verified prerequisite, filed as **#2457**. Once it lands, the remaining #2454 work is: wire the #2203 timer's `Attempt` edge to redrive from the retained request behind the new default-off flag + fold `connected`/`reconnectFailed` at the source + suppress the client redrive/mirror when on.

## Verification
- `cargo test --lib` (retention store, zeroize, and manager retain/clear paths): green — new tests in `retained_request.rs` and `session::manager::tests` (`create_connection_retains_request_for_resilient_direct_session`, `..._does_not_retain_for_non_resilient_session`, `..._without_tab_retains_nothing`, `close_session_clears_the_retained_request`, `clear_retained_request_is_idempotent`, plus `zeroize_json_scrubs_nested_string_leaves` / `drop_zeroizes_secret_settings`).
- `cargo clippy --lib --all-features -- -D warnings`: clean. `cargo fmt --check`: clean.
- No integration run needed: this change is behaviorally inert (no consumer reads the retained request), so there is nothing on the reconnect hot path to exercise yet. The redrive that does touch the hot path is deferred to #2457 + the #2454 follow-up, where local SSH-drop verification is mandatory.

Follow-up: #2457.

---

Closes #2459 — hardened the flaky `detach_keeps_session_alive_when_daemon_closes_connection` reader-abort race test (was failing the macOS `Run Tests` leg on a pre-existing flake unrelated to this PR). The fixed 100ms sleep is replaced with deterministic synchronization: the mock daemon now closes the connection only after the client reader task is provably gone, matching production ordering. Test-only change; no production code touched. Guard verified still to fail on the pre-#2437 ordering.
