### PR TITLE
test(ssh): verify transfer-queue region panel + gate harness save-connect on form validity (part of #2398)

### DIFF
--- a/tests/system/termihub_harness/ui/connections.py
+++ b/tests/system/termihub_harness/ui/connections.py
@@ -276,9 +276,29 @@ class ConnectionsUi(HarnessMixin):
                 what="the Save credentials toggle",
             )
             self.driver.click("field-savePassword")
-        self.driver.click(
-            "connection-editor-save-connect" if connect else "connection-editor-save"
+        self._click_editor_save(connect)
+
+    def _click_editor_save(self, connect: bool) -> None:
+        """Click Save / Save & Connect once the form reports itself valid.
+
+        The editor gates both buttons on ``canSave``, which is recomputed
+        asynchronously: the schema-driven form validates (react-hook-form + zod)
+        and reports validity up through an effect, so it trails the last field we
+        type by a render or two. The buttons are ``aria-disabled``/``data-invalid``
+        rather than natively ``disabled``, so a bridge click still dispatches — but
+        ``handleSaveAndConnect``/``handleSave`` early-return on ``!canSave`` (they
+        just focus the first invalid field). A click that lands in that window is
+        therefore a silent no-op: the editor stays open and — on the connect path —
+        the SSH password prompt never appears. Gate on the button clearing its
+        ``data-invalid`` flag (``data-invalid={!canSave || undefined}``, so absent
+        once valid) before clicking, so the click is never swallowed.
+        """
+        button = "connection-editor-save-connect" if connect else "connection-editor-save"
+        self.wait(
+            lambda: self.driver.get_attribute(button, "data-invalid") is None,
+            what="the connection form to report itself valid",
         )
+        self.driver.click(button)
 
     def create_telnet_connection(
         self,


### PR DESCRIPTION
Part of #2398 (follow-up to #2229). Verifies the transfer-queue integration suite against the region-authoritative Transfer Queue panel, and lands a harness robustness fix found during that verification.

## Outcome

**Region-authoritative panel: VERIFIED.** `TestTransferQueuePanel` (7 tests, no container) passes reliably across every run. It drives the panel through the **real Tauri projection channel** — injecting `transfer.progress` intents into the shared `transfers` region and reading rows back from the projection cache — exercising exactly the region-authoritative reader + intent path #2229 introduced (rising percent, `paused`, `failed`, `cancelled`, per-state control sets, cancel-all, clear-completed, minimize/restore). This is the substance of #2398 and it is confirmed correct at runtime, not just correct-by-construction.

**Live SFTP sub-suite: BLOCKED (not by the transfer-queue code).** `TestTransferQueueLiveTransfer` could not be driven to green on this macOS bridge harness. The blocker is in the **live-SSH-connect flow**, upstream of any transfer/region code, and reproduces **identically** on `test_ssh.py::TestSshPasswordAuth` — so it is systemic to live-connect, independent of #2229/#2398. Details and next steps tracked in **#2460**.

## Evidence

Region suite (stable across runs):

```
tests/test_transfer_queue.py ... 2 failed, 7 passed in 59.09s   # run 1 (full build)
tests/test_transfer_queue.py ... 2 failed, 7 passed in 115.12s  # run 4 (with this fix)
```
The 7 passing are `TestTransferQueuePanel`; the 2 failing are the live sub-suite (below).

Live sub-suite — never initiates a connection; failure point varies with 10s bridge-command timeouts:

```
# run 1 / run 2 / test_ssh.py::TestSshPasswordAuth
E   AssertionError: timed out waiting for the SSH password prompt (last error: None)
# run 4 / run 5 (isolated)
E   AssertionError: timed out waiting for the 'ssh' connection-type option to load (last error: command timed out after 10.0s)
```
Across 5 runs the app log always stops after `Loading connections and folders` with **no SSH/session backend activity** — the connect is never initiated. Failure-bundle screenshot shows the editor fully filled (TYPE=SSH, HOST=127.0.0.1, PORT=2201). The recurring 10s command timeouts (app JS not acking) indicate webview unresponsiveness / host contention, not a deterministic transfer-queue defect.

## Change in this PR

`create_ssh_connection` in the bridge harness now waits for the connection editor to report itself valid before clicking Save / Save & Connect. Root cause: the editor buttons are `aria-disabled`/`data-invalid` (not natively `disabled`), so a bridge click dispatches but `handleSaveAndConnect` early-returns on `!canSave`; a click landing before async form validation settles is a silent no-op (editor stays open, password prompt never appears) — exactly the run-1/2 symptom. Waiting for `data-invalid` to clear removes that race. Note: this fix could **not** be validated end-to-end because the `select_connection_type` jank (#2460) fails the run earlier; it is included as a correct, evidenced robustness fix and its validation is part of #2460.

## Not closing #2398

The live half is not green, so this does not `Closes` #2398. #2398 stays open pending #2460 (live-connect blocker); this PR lands the verified region-half result and the connect-save harness fix.
