### PR TITLE
fix(test): rAF-throttle-resilient bridge frame-yield + validity-gate all editor helpers (part of #2460)

### DIFF
--- a/src/testbridge/dispatcher.select.test.tsx
+++ b/src/testbridge/dispatcher.select.test.tsx
@@ -111,6 +111,49 @@ describe("dispatchCommand select against the Select primitive", () => {
     document.querySelector('.ui-select__item[data-value="serial"]')?.remove();
   });
 
+  it("still resolves when requestAnimationFrame is paused (occluded WebView)", async () => {
+    // Regression for #2460: a real WKWebView *has* rAF but throttles or fully
+    // pauses it when its window is occluded/backgrounded (aggravated by
+    // concurrent build load). The `select` verb polls the portal mount via
+    // `nextFrame`, so an rAF-only yield stalls with no frames delivered and the
+    // command hangs until the bridge's 10s timeout — the reported symptom. With
+    // the wall-clock fallback in `nextFrame`, a single dispatch must still locate
+    // and click a late-mounting option even while rAF never fires.
+    const realRaf = globalThis.requestAnimationFrame;
+    // Paused rAF: registers callbacks but never invokes them.
+    globalThis.requestAnimationFrame = (() => 0) as typeof requestAnimationFrame;
+    try {
+      const trigger = document.createElement("button");
+      trigger.setAttribute("data-testid", "sel");
+      trigger.className = "ui-select__trigger";
+      document.body.appendChild(trigger);
+
+      const clicked = vi.fn();
+      trigger.addEventListener("keydown", (e) => {
+        if ((e as KeyboardEvent).key !== "Enter") return;
+        setTimeout(() => {
+          const opt = document.createElement("div");
+          opt.className = "ui-select__item";
+          opt.setAttribute("data-value", "serial");
+          opt.addEventListener("click", () => clicked());
+          document.body.appendChild(opt);
+        }, 0);
+      });
+
+      const res = await dispatchCommand(
+        { action: "select", testId: "sel", value: "serial" },
+        deps()
+      );
+
+      expect(res.ok).toBe(true);
+      expect(clicked).toHaveBeenCalledTimes(1);
+      trigger.remove();
+      document.querySelector('.ui-select__item[data-value="serial"]')?.remove();
+    } finally {
+      globalThis.requestAnimationFrame = realRaf;
+    }
+  });
+
   it("reports an error when the requested option is absent", async () => {
     act(() => {
       root.render(<Select data-testid="sel" value="local" onChange={() => {}} options={OPTIONS} />);

--- a/src/testbridge/dispatcher.ts
+++ b/src/testbridge/dispatcher.ts
@@ -260,19 +260,37 @@ function keyboardEvent(type: string, init: KeyboardEventInit, key: string): Keyb
 }
 
 /**
+ * Upper bound (ms) on how long {@link nextFrame} waits for its two rAF ticks
+ * before a wall-clock timer resolves it instead. See {@link nextFrame}.
+ */
+const FRAME_YIELD_FALLBACK_MS = 100;
+
+/**
  * Yield to the event loop so React can flush a render + effects between
  * synthetic pointer events. @dnd-kit's `DndContext` measures droppable rects in
  * a post-activation render/effect cycle; without a yield, every pointer event
  * fires in one task and collision detection never sees those rects (so a drag
  * ends with `over: null` and reorders nothing). Two frames clears the commit and
- * its follow-up effects; falls back to `setTimeout` where rAF is unavailable.
+ * its follow-up effects.
+ *
+ * Never resolves purely on `requestAnimationFrame`: a real WebView *has* rAF but
+ * **throttles or fully pauses it when its window is occluded or backgrounded**
+ * (a macOS WKWebView compositor behavior, aggravated by concurrent build load).
+ * A frame-poll that awaits rAF alone then stalls with no frames delivered, so
+ * the `select`/`dragTo` verbs that call this hang until the bridge's 10s command
+ * timeout fires — the #2460 symptom. So race the two rAF ticks against a
+ * wall-clock fallback: under a healthy rAF the double-tick (~32 ms) wins and
+ * dnd-kit still gets its two real frames; under a throttled/paused rAF the timer
+ * wins and the caller advances instead of hanging. Also covers environments with
+ * no rAF at all (falls back to the timer alone).
  */
 function nextFrame(): Promise<void> {
-  const raf: (cb: FrameRequestCallback) => unknown =
-    typeof requestAnimationFrame === "function"
-      ? requestAnimationFrame
-      : (cb) => setTimeout(() => cb(0), 0);
-  return new Promise((resolve) => raf(() => raf(() => resolve())));
+  const viaTimer = new Promise<void>((resolve) => setTimeout(resolve, FRAME_YIELD_FALLBACK_MS));
+  if (typeof requestAnimationFrame !== "function") return viaTimer;
+  const viaFrames = new Promise<void>((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+  );
+  return Promise.race([viaFrames, viaTimer]);
 }
 
 /** Walk a dot-path into a plain object, returning a sentinel when unresolvable. */

--- a/tests/system/termihub_harness/ui/connections.py
+++ b/tests/system/termihub_harness/ui/connections.py
@@ -221,7 +221,7 @@ class ConnectionsUi(HarnessMixin):
             self.select_shell(shell)
         if starting_directory is not None:
             self._fill_starting_directory(starting_directory)
-        self.driver.click(self.EDITOR_SAVE_CONNECT if connect else self.EDITOR_SAVE)
+        self._click_editor_save(connect)
         self.require_connection(name)
         return name
 
@@ -281,6 +281,9 @@ class ConnectionsUi(HarnessMixin):
     def _click_editor_save(self, connect: bool) -> None:
         """Click Save / Save & Connect once the form reports itself valid.
 
+        Shared by every ``create_*_connection`` helper (SSH/local/telnet/serial/
+        FTP/WSL), which all previously fired an immediate click.
+
         The editor gates both buttons on ``canSave``, which is recomputed
         asynchronously: the schema-driven form validates (react-hook-form + zod)
         and reports validity up through an effect, so it trails the last field we
@@ -289,9 +292,9 @@ class ConnectionsUi(HarnessMixin):
         ``handleSaveAndConnect``/``handleSave`` early-return on ``!canSave`` (they
         just focus the first invalid field). A click that lands in that window is
         therefore a silent no-op: the editor stays open and — on the connect path —
-        the SSH password prompt never appears. Gate on the button clearing its
-        ``data-invalid`` flag (``data-invalid={!canSave || undefined}``, so absent
-        once valid) before clicking, so the click is never swallowed.
+        the session (and any password prompt) never opens. Gate on the button
+        clearing its ``data-invalid`` flag (``data-invalid={!canSave || undefined}``,
+        so absent once valid) before clicking, so the click is never swallowed.
         """
         button = "connection-editor-save-connect" if connect else "connection-editor-save"
         self.wait(
@@ -323,9 +326,7 @@ class ConnectionsUi(HarnessMixin):
         )
         self.driver.type("field-host", str(host))
         self.driver.type("field-port", str(port))
-        self.driver.click(
-            "connection-editor-save-connect" if connect else "connection-editor-save"
-        )
+        self._click_editor_save(connect)
 
     def create_ftp_connection(
         self,
@@ -358,9 +359,7 @@ class ConnectionsUi(HarnessMixin):
             self._select_when_available(
                 "field-tlsMode", tls_mode, what=f"the {tls_mode!r} TLS-mode option"
             )
-        self.driver.click(
-            "connection-editor-save-connect" if connect else "connection-editor-save"
-        )
+        self._click_editor_save(connect)
         self.require_connection(name)
 
     def open_serial_editor(self) -> None:
@@ -393,9 +392,7 @@ class ConnectionsUi(HarnessMixin):
         self.open_serial_editor()
         self.driver.type("connection-editor-name-input", name)
         self.driver.type("field-port", port)
-        self.driver.click(
-            "connection-editor-save-connect" if connect else "connection-editor-save"
-        )
+        self._click_editor_save(connect)
 
     def open_wsl_editor(self) -> None:
         """Open the editor and switch it to the WSL type, awaiting its fields.
@@ -437,7 +434,7 @@ class ConnectionsUi(HarnessMixin):
         )
         if starting_directory is not None:
             self._fill_starting_directory(starting_directory)
-        self.driver.click(self.EDITOR_SAVE_CONNECT if connect else self.EDITOR_SAVE)
+        self._click_editor_save(connect)
         self.require_connection(name)
         return name
 


### PR DESCRIPTION
## Summary

Part of #2460. Root-causes and fixes the **code-level** half of the "live-SSH-connect over the bridge cannot be driven to green" problem, and hardens the harness. The remaining blocker on this machine is characterized as environmental (see below), so this PR does **not** close #2460 — leave it open for a quiet-window live verification.

### Root cause of the 10s `select_connection_type` bridge timeout

`connection-editor-type-select` renders as a **Radix `Select`** (the design-system `Select` primitive), so `select_connection_type("ssh")` routes through the dispatcher's `selectRadixOption`, which opens the listbox and **polls for the portal-mounted option via `nextFrame()` → `requestAnimationFrame`**.

`nextFrame()` only fell back to `setTimeout` when `requestAnimationFrame` was *undefined*. But a real WKWebView **has** rAF — it just **throttles or fully pauses it when the window is occluded/backgrounded** (a macOS compositor behavior, badly aggravated by concurrent-build load). With rAF parked, the frame-poll stalled with no frames delivered and the `select` verb hung until the bridge's 10s command timeout fired. Synchronous verbs (`click`/`type`/`exists`) don't await frames — which is exactly why **only `select`** (and `dragTo`, which shares `nextFrame`) timed out, matching the issue's symptom precisely.

**Fix:** `nextFrame()` now races the two rAF ticks against a wall-clock fallback. A healthy rAF wins (dnd-kit still gets its two real frames); a throttled/paused rAF lets the timer advance the caller instead of hanging. Regression test drives the `select` verb with rAF paused and asserts it still clicks a late-mounting option.

### Harness hardening — validity-gate extension

Extends the #2461 validity-gate (wait for the Save button to clear `data-invalid` before clicking) from `create_ssh_connection` to **all** the other editor helpers — local, telnet, serial, FTP, WSL — which each fired an immediate click before async form validation settled, making the save a silent no-op in that window. All now route through the shared `_click_editor_save`.

## Environmental characterization (why this does not close #2460)

The live integration suite (`pytest -m integration`) needs a **quiet machine** to run green. Attempting `test_ssh.py::TestSshPasswordAuth` on this box while another checkout was running a concurrent cargo/app build (system load average ~300 on a 10-core machine) failed at **fixture setup**, before any test body ran:

```
TimeoutError: no app connected to the bridge within 30.0s
```

That is a *different* failure from the 10s command-timeout this PR fixes: the app process could not launch and connect out to the bridge within the 30s `wait_for_app` window under that load. It is upstream of the `select` verb, so it does not exercise (or contradict) the rAF fix — it just prevents an end-to-end validation on a contended machine.

**What a green live run needs:** no concurrent cargo/app builds and no competing app instances while the suite runs (the isolation `dev.local.json` gives each checkout distinct ports/containers, but not distinct CPU). On a quiet machine, re-run:

```
./scripts/test-system-py.sh --debug -m integration tests/test_ssh.py::TestSshPasswordAuth
./scripts/test-system-py.sh --debug -m integration "tests/test_transfer_queue.py::TestTransferQueueLiveTransfer"
```

Note for the coordinator: a **stale `pnpm dev` (vite) process from ~Jul 30** was found squatting dev0's port 1420 (PID 94439, parent `pnpm dev`), unrelated to this session — worth reaping, as it both consumes resources and risks the dev0 port-collision described in the coordinator CLAUDE.md.

## Test plan

- `pnpm exec vitest run src/testbridge/` — 171 pass, including the new paused-rAF regression.
- Live suite: blocked at app-connect under concurrent build load (see above); needs a quiet-window re-run for the end-to-end green.
