### PR TITLE
feat(terminal): frontend re-attach for backend-driven direct reconnect (Closes #2457)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -102,8 +102,18 @@ pub async fn create_connection(
         )
         .await;
 
-    if let (Some(tab_id), Ok(_)) = (&initial_tab_id, &result) {
-        fold_session_transition(&app_handle, |store| store.connected(tab_id));
+    if let (Some(tab_id), Ok(session_id)) = (&initial_tab_id, &result) {
+        // Also propagate the backend session id into the shared region (#2457):
+        // the region is keyed by tab id, so carrying the current backend session
+        // id lets the frontend re-attach terminal I/O to a backend-chosen id after
+        // a server-side reconnect redrive (#2454) mints a new one. On the initial
+        // connect the frontend already learns this id from the return value, so
+        // this is the mechanism being established, not a behavior change — nothing
+        // reads it unless the (default-off) backend-reattach flag is on.
+        fold_session_transition(&app_handle, |store| {
+            store.connected(tab_id);
+            store.set_backend_session_id(tab_id, Some(session_id.clone()));
+        });
     }
     result
 }

--- a/src-tauri/src/session_projection/store.rs
+++ b/src-tauri/src/session_projection/store.rs
@@ -102,6 +102,20 @@ pub struct SessionLifecycle {
     /// otherwise.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reconnect_error: Option<String>,
+    /// The **backend** session id the frontend should currently be attached to
+    /// for this tab, when known (#2457). The region is keyed by the frontend
+    /// *tab* id (stable across a reconnect); this carries the *backend* session
+    /// id that id currently maps to, so a backend-driven reconnect redrive
+    /// (#2454) — which mints a **new** backend session id after tearing the old
+    /// `SessionEntry` down — can hand the frontend the id to re-attach terminal
+    /// I/O to, without the client calling `create_connection`. Set on a
+    /// successful (re)connect via
+    /// [`SessionLifecycleStore::set_backend_session_id`]; cleared the moment the
+    /// session is torn down (drop / disconnect / reconnect-loop start /
+    /// connect-failure / cancel) so the region never advertises a dead id.
+    /// `None` whenever there is no live backend session for the tab.
+    #[serde(rename = "sessionId", skip_serializing_if = "Option::is_none")]
+    pub backend_session_id: Option<String>,
 }
 
 impl SessionLifecycle {
@@ -113,6 +127,7 @@ impl SessionLifecycle {
             end_reason: None,
             error: None,
             reconnect_error: None,
+            backend_session_id: None,
         }
     }
 }
@@ -239,6 +254,8 @@ impl SessionLifecycleStore {
         entry.end_reason = Some(EndReason::Error);
         entry.error = error;
         entry.reconnect_error = None;
+        // The connect never established a session; nothing to re-attach to (#2457).
+        entry.backend_session_id = None;
     }
 
     /// `session.disconnect` — a user-initiated graceful disconnect. Stops any
@@ -254,6 +271,9 @@ impl SessionLifecycleStore {
         entry.end_reason = Some(EndReason::User);
         entry.error = None;
         entry.reconnect_error = None;
+        // The session is torn down; drop the re-attach id so the region never
+        // advertises a dead backend session (#2457).
+        entry.backend_session_id = None;
     }
 
     /// `session.dropped` — the link dropped without the user asking. Lands in
@@ -271,6 +291,9 @@ impl SessionLifecycleStore {
         entry.end_reason = Some(EndReason::Unexpected);
         entry.error = error;
         entry.reconnect_error = None;
+        // The backend session is gone on a genuine drop; drop the re-attach id
+        // (#2457). A backend-driven redrive sets the new id once it reconnects.
+        entry.backend_session_id = None;
     }
 
     /// `session.reconnect` — begin (or restart) the auto-reconnect loop. Feeds
@@ -289,6 +312,10 @@ impl SessionLifecycleStore {
         entry.reconnect = reconnect;
         entry.end_reason = None;
         entry.reconnect_error = None;
+        // The loop is (re)starting from a dead session; drop the stale re-attach
+        // id so the frontend never re-attaches to a corpse (#2457). The redrive
+        // repopulates it via `set_backend_session_id` once an attempt succeeds.
+        entry.backend_session_id = None;
     }
 
     /// `session.reconnectAttempt` — the backoff timer fired; start an attempt.
@@ -338,6 +365,9 @@ impl SessionLifecycleStore {
             entry.reconnect = INITIAL_RECONNECT_STATE;
             entry.end_reason = Some(EndReason::User);
             entry.reconnect_error = None;
+            // Loop cancelled; the session is not coming back — drop the re-attach
+            // id (#2457).
+            entry.backend_session_id = None;
         }
     }
 
@@ -356,6 +386,25 @@ impl SessionLifecycleStore {
         let mut inner = self.lock();
         if let Some(entry) = inner.sessions.get_mut(session_id) {
             entry.reconnect_error = error;
+        }
+    }
+
+    /// Record (or clear) the **backend** session id the frontend should attach
+    /// terminal I/O to for a tab (#2457). `session_id` is the region key (the
+    /// frontend tab id); `backend_session_id` is the id of the live backend
+    /// session that tab currently maps to (`None` clears it). This is a pure
+    /// metadata write — it does not touch `status`, the reconnect engine or the
+    /// backend timer.
+    ///
+    /// Called at the source the instant a (re)connect establishes a session: the
+    /// initial-connect fold (`create_connection`) and, later, the backend
+    /// reconnect redrive (#2454). A no-op for an unknown session (mirrors
+    /// [`set_reconnect_trigger`](Self::set_reconnect_trigger)): the id is only
+    /// ever set for a tab whose lifecycle the store already tracks.
+    pub fn set_backend_session_id(&self, session_id: &str, backend_session_id: Option<String>) {
+        let mut inner = self.lock();
+        if let Some(entry) = inner.sessions.get_mut(session_id) {
+            entry.backend_session_id = backend_session_id;
         }
     }
 

--- a/src-tauri/src/session_projection/store_tests.rs
+++ b/src-tauri/src/session_projection/store_tests.rs
@@ -282,3 +282,91 @@ fn reconnect_trigger_cause_is_serialized_only_when_set() {
         serde_json::json!("why")
     );
 }
+
+#[test]
+fn set_backend_session_id_records_and_clears_the_id() {
+    // #2457: the backend session id is region-owned, set/cleared by its own pure
+    // metadata write without perturbing status or the reconnect engine.
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connected("s1");
+    store.set_backend_session_id("s1", Some("backend-42".to_string()));
+    let s = store.get("s1").unwrap();
+    assert_eq!(s.backend_session_id.as_deref(), Some("backend-42"));
+    // Status / reconnect detail untouched — this is pure metadata.
+    assert_eq!(s.status, SessionStatus::Connected);
+    assert_eq!(s.reconnect.phase, ReconnectPhase::Idle);
+    // A None clears it.
+    store.set_backend_session_id("s1", None);
+    assert_eq!(store.get("s1").unwrap().backend_session_id, None);
+}
+
+#[test]
+fn set_backend_session_id_is_a_no_op_for_an_unknown_session() {
+    let store = deterministic_store();
+    store.set_backend_session_id("ghost", Some("backend-1".to_string()));
+    assert!(store.get("ghost").is_none());
+}
+
+#[test]
+fn backend_session_id_is_serialized_only_when_set() {
+    // Twin of the Rust field `backend_session_id`, serialized as `sessionId`.
+    let store = deterministic_store();
+    store.connect("s1");
+    assert!(store.snapshot()["sessions"]["s1"]
+        .get("sessionId")
+        .is_none());
+    store.set_backend_session_id("s1", Some("backend-7".to_string()));
+    assert_eq!(
+        store.snapshot()["sessions"]["s1"]["sessionId"],
+        serde_json::json!("backend-7")
+    );
+}
+
+#[test]
+fn teardown_transitions_clear_the_backend_session_id() {
+    // The re-attach id must never outlive the live session it names, so the
+    // region never advertises a dead backend session (#2457). Each teardown
+    // transition drops it.
+    for teardown in [
+        SessionLifecycleStore::disconnect as fn(&SessionLifecycleStore, &str),
+        SessionLifecycleStore::reconnect,
+        SessionLifecycleStore::cancel_reconnect,
+    ] {
+        let store = deterministic_store();
+        store.connect("s1");
+        store.connected("s1");
+        store.set_backend_session_id("s1", Some("backend-live".to_string()));
+        teardown(&store, "s1");
+        assert_eq!(
+            store.get("s1").unwrap().backend_session_id,
+            None,
+            "teardown transition should clear the backend session id"
+        );
+    }
+    // dropped / connect_failed take a message arg — exercise them separately.
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connected("s1");
+    store.set_backend_session_id("s1", Some("backend-live".to_string()));
+    store.dropped("s1", Some("link lost".to_string()));
+    assert_eq!(store.get("s1").unwrap().backend_session_id, None);
+
+    let store = deterministic_store();
+    store.connect("s2");
+    store.set_backend_session_id("s2", Some("backend-live".to_string()));
+    store.connect_failed("s2", Some("auth denied".to_string()));
+    assert_eq!(store.get("s2").unwrap().backend_session_id, None);
+}
+
+#[test]
+fn a_fresh_connect_starts_without_a_stale_backend_session_id() {
+    // `connect` replaces the whole entry, so a prior id never leaks into a new
+    // connect cycle for a reused tab id (#2457).
+    let store = deterministic_store();
+    store.connect("s1");
+    store.connected("s1");
+    store.set_backend_session_id("s1", Some("old-backend".to_string()));
+    store.connect("s1");
+    assert_eq!(store.get("s1").unwrap().backend_session_id, None);
+}

--- a/src/components/Terminal/Terminal.backend-reattach.test.tsx
+++ b/src/components/Terminal/Terminal.backend-reattach.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * Component tests for the backend-driven direct-reconnect re-attach path (#2457,
+ * part of the server-side reconnect redrive #2454 / umbrella #2446).
+ *
+ * When the NEW default-off `sessionBackendReattach` flag is ON, a direct-
+ * connection reconnect must NOT call `create_connection`. Instead the server-side
+ * redrive (#2454) creates the connection itself, mints a new backend session id,
+ * and publishes it to the `session-lifecycle` region; the Terminal re-attaches
+ * terminal I/O (subscribe output/exit + `setTabSessionId`) to that id.
+ *
+ * With the flag OFF, the reconnect drives the client redrive exactly as on
+ * `develop` — a fresh `create_connection` — so the two tests here also pin the
+ * flag-off parity: same setup, only the flag differs.
+ *
+ * Full end-to-end drop verification (Reconnecting→Attempt→Connected fully
+ * server-side) is deferred to #2454's backend-redrive PR — nothing drives a
+ * backend reconnect until that lands. These tests verify the frontend re-attach
+ * mechanism in isolation by seeding the region directly.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Terminal } from "./Terminal";
+import { TerminalPortalProvider } from "./TerminalRegistry";
+import { useAppStore } from "@/store/appStore";
+import {
+  setSessionBackendReattachEnabled,
+  setSessionTransportForTest,
+  stopSessionSubscription,
+} from "@/store/sessionBridge";
+import {
+  FakeSessionTransport,
+  connected as connectedLifecycle,
+} from "@/test/sessionLifecycleRegionTestHarness";
+
+// --- Mocks (mirror Terminal.reconnect-fresh.test.tsx) ---
+
+vi.mock("@xterm/xterm", () => {
+  class MockXTerm {
+    open = vi.fn();
+    dispose = vi.fn();
+    loadAddon = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn(() => ({ dispose: vi.fn() }));
+    onScroll = vi.fn(() => ({ dispose: vi.fn() }));
+    onCursorMove = vi.fn(() => ({ dispose: vi.fn() }));
+    onWriteParsed = vi.fn(() => ({ dispose: vi.fn() }));
+    write = vi.fn((_data: unknown, cb?: () => void) => cb?.());
+    writeln = vi.fn();
+    reset = vi.fn();
+    scrollToBottom = vi.fn();
+    scrollLines = vi.fn();
+    selectAll = vi.fn();
+    hasSelection = vi.fn(() => false);
+    getSelection = vi.fn(() => "");
+    attachCustomKeyEventHandler = vi.fn();
+    unicode = { activeVersion: "6" };
+    cols = 80;
+    rows = 24;
+    resize = vi.fn();
+    focus = vi.fn();
+    element = document.createElement("div");
+    buffer = { active: { viewportY: 0, baseY: 0, length: 0, getLine: vi.fn() } };
+    parser = { registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })) };
+    options = {};
+  }
+  return { Terminal: MockXTerm };
+});
+
+vi.mock("@xterm/addon-fit", () => {
+  class MockFitAddon {
+    fit = vi.fn();
+    proposeDimensions = vi.fn(() => ({ cols: 80, rows: 24 }));
+    dispose = vi.fn();
+  }
+  return { FitAddon: MockFitAddon };
+});
+
+vi.mock("@xterm/addon-unicode11", () => {
+  class MockUnicode11Addon {
+    dispose = vi.fn();
+  }
+  return { Unicode11Addon: MockUnicode11Addon };
+});
+
+vi.mock("@xterm/addon-search", () => {
+  class MockSearchAddon {
+    dispose = vi.fn();
+  }
+  return { SearchAddon: MockSearchAddon };
+});
+
+vi.mock("@/themes", () => ({
+  getXtermTheme: vi.fn(() => ({})),
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+const mockCreateTerminal = vi.fn().mockResolvedValue("fresh-session");
+const mockGetAgentSessionBuffer = vi.fn().mockResolvedValue(new Uint8Array());
+
+vi.mock("@/services/api", () => ({
+  createTerminal: (...args: unknown[]) => mockCreateTerminal(...args),
+  sendInput: vi.fn().mockResolvedValue(undefined),
+  resizeTerminal: vi.fn().mockResolvedValue(undefined),
+  closeTerminal: vi.fn().mockResolvedValue(undefined),
+  detachPersistentTab: vi.fn().mockResolvedValue(0),
+  getAgentSessionBuffer: (...args: unknown[]) => mockGetAgentSessionBuffer(...args),
+}));
+
+const mockSubscribeOutput = vi.fn(() => vi.fn());
+const mockSubscribeExit = vi.fn(() => vi.fn());
+
+vi.mock("@/services/events", () => ({
+  terminalDispatcher: {
+    init: vi.fn().mockResolvedValue(undefined),
+    subscribeOutput: (...args: unknown[]) => mockSubscribeOutput(...(args as [])),
+    subscribeExit: (...args: unknown[]) => mockSubscribeExit(...(args as [])),
+    clearPendingExit: vi.fn(),
+    clearPendingOutput: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/keybindings", () => ({
+  processKeyEvent: vi.fn(() => null),
+  isAppShortcut: vi.fn(() => false),
+  isChordPending: vi.fn(() => false),
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  readText: vi.fn().mockResolvedValue(""),
+}));
+
+globalThis.ResizeObserver = class {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+} as unknown as typeof ResizeObserver;
+
+let container: HTMLDivElement;
+let root: Root;
+let transport: FakeSessionTransport;
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  mockCreateTerminal.mockClear();
+  mockCreateTerminal.mockResolvedValue("fresh-session");
+  mockGetAgentSessionBuffer.mockClear();
+  mockSubscribeOutput.mockClear();
+  mockSubscribeExit.mockClear();
+  transport = new FakeSessionTransport();
+  setSessionTransportForTest(transport);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  stopSessionSubscription();
+  setSessionTransportForTest(null);
+  setSessionBackendReattachEnabled(null);
+});
+
+// A direct (non-persistent, non-agent) connection.
+const DIRECT_CONFIG = {
+  type: "ssh" as const,
+  config: { host: "example.test", port: 22, username: "u" },
+};
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("Terminal — backend-driven direct reconnect re-attach (#2457)", () => {
+  it("flag ON: re-attaches to the backend-published session id without create_connection", async () => {
+    setSessionBackendReattachEnabled(true);
+    // The server-side redrive published the new backend session id to the region.
+    transport.setSession("tab-1", { ...connectedLifecycle(), sessionId: "backend-new" });
+
+    // Mount as if already connected to a (now to-be-dead) direct session.
+    act(() => {
+      root.render(
+        <TerminalPortalProvider>
+          <Terminal
+            tabId="tab-1"
+            config={DIRECT_CONFIG}
+            isVisible={true}
+            existingSessionId="initial-session"
+          />
+        </TerminalPortalProvider>
+      );
+    });
+    await act(async () => {
+      await wait(50);
+    });
+    // Initial mount reattaches to the existing id — no create_connection.
+    expect(mockCreateTerminal).not.toHaveBeenCalled();
+
+    // Reconnect: bump the retry counter so the effect re-runs as a reconnect.
+    act(() => {
+      useAppStore.getState().reconnectTerminal("tab-1");
+    });
+    await act(async () => {
+      await wait(80);
+    });
+
+    // The client redrive is suppressed — no create_connection on the reconnect.
+    expect(mockCreateTerminal).not.toHaveBeenCalled();
+    // Terminal I/O re-attaches to the backend-chosen id.
+    expect(mockSubscribeOutput).toHaveBeenCalledWith("backend-new", expect.any(Function));
+    expect(mockSubscribeExit).toHaveBeenCalledWith("backend-new", expect.any(Function));
+  });
+
+  it("flag OFF: reconnect drives the client redrive (create_connection) — develop parity", async () => {
+    setSessionBackendReattachEnabled(false);
+    // Even with a backend id available in the region, the flag-off path ignores it.
+    transport.setSession("tab-2", { ...connectedLifecycle(), sessionId: "backend-new" });
+
+    act(() => {
+      root.render(
+        <TerminalPortalProvider>
+          <Terminal
+            tabId="tab-2"
+            config={DIRECT_CONFIG}
+            isVisible={true}
+            existingSessionId="initial-session"
+          />
+        </TerminalPortalProvider>
+      );
+    });
+    await act(async () => {
+      await wait(50);
+    });
+    expect(mockCreateTerminal).not.toHaveBeenCalled();
+
+    act(() => {
+      useAppStore.getState().reconnectTerminal("tab-2");
+    });
+    await act(async () => {
+      await wait(80);
+    });
+
+    // develop behavior: a direct reconnect creates a fresh session via the client.
+    expect(mockCreateTerminal).toHaveBeenCalledTimes(1);
+    // And it never re-attaches to the region's backend id.
+    expect(mockSubscribeOutput).not.toHaveBeenCalledWith("backend-new", expect.any(Function));
+  });
+});

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -49,6 +49,10 @@ import { toast } from "@/components/ui";
 import { createTerminalScrollbar, type TerminalScrollbarController } from "./terminalScrollbar";
 import { SyntaxHighlightingEngine } from "@/services/syntaxHighlighting";
 import { resolveHighlightingConfig, resolveActiveRules } from "@/services/syntaxHighlightingConfig";
+import {
+  sessionBackendReattachEnabled,
+  waitForBackendReattachSessionId,
+} from "@/store/sessionBridge";
 
 const HORIZONTAL_SCROLL_COLS = 500;
 
@@ -439,9 +443,31 @@ export function Terminal({
         const isReconnect = (useAppStore.getState().terminalRetryCounters[tabId] ?? 0) > 0;
         let reattachSessionId: string | null;
         if (isReconnect) {
-          reattachSessionId = persistentConnectionId
-            ? await useAppStore.getState().restartPersistentSessionForTab(tabId)
-            : null;
+          if (persistentConnectionId) {
+            // Persistent/agent tab: restart the background session and reattach
+            // to its (possibly new) live id — never to the dead mount-time id.
+            reattachSessionId = await useAppStore.getState().restartPersistentSessionForTab(tabId);
+          } else if (sessionBackendReattachEnabled()) {
+            // Backend-driven direct reconnect (#2457): with the flag on, the
+            // reconnect redrive is server-side (#2454). The backend re-creates
+            // the connection itself — minting a NEW backend session id — and
+            // publishes it to the `session-lifecycle` region. Attach to that id
+            // instead of calling create_connection: the client redrive is
+            // suppressed here because the reconnect engine is non-idempotent, so
+            // it must be a real authority cut. The prior (now-dead) session id is
+            // excluded so a stale region value never reattaches to a corpse; a
+            // null result (backend not driving / timed out) falls through to the
+            // client redrive below, so a tab is never stranded.
+            reattachSessionId = await waitForBackendReattachSessionId(
+              tabId,
+              sessionIdRef.current,
+              isCanceled
+            );
+          } else {
+            // Direct tab, flag off: the dead session id is gone; fall through to
+            // a fresh create_connection (the client redrive) — develop behavior.
+            reattachSessionId = null;
+          }
           if (isCanceled()) return;
         } else {
           reattachSessionId = initialSessionIdRef.current ?? null;

--- a/src/store/sessionBridge.backendReattach.test.ts
+++ b/src/store/sessionBridge.backendReattach.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Unit tests for the backend-driven re-attach bridge surface (#2457, part of the
+ * server-side reconnect redrive #2454 / umbrella #2446).
+ *
+ * Covers the two new pieces this issue adds to `sessionBridge`:
+ *  - {@link sessionBackendReattachEnabled} — the NEW default-off flag that switches
+ *    a direct-connection reconnect from the client redrive to the attach-to-given-
+ *    session path. Default off ⇒ behavior identical to `develop`.
+ *  - {@link waitForBackendReattachSessionId} — resolves the backend session id the
+ *    server-side redrive publishes to the `session-lifecycle` region (keyed by tab
+ *    id), so the terminal can re-attach I/O without calling `create_connection`.
+ *
+ * The region is driven by an in-memory transport double so the round-trip is
+ * exercised without a backend.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import {
+  SESSION_LIFECYCLE_REGION,
+  sessionBackendReattachEnabled,
+  setSessionBackendReattachEnabled,
+  setSessionTransportForTest,
+  stopSessionSubscription,
+  waitForBackendReattachSessionId,
+  type ProjectedSessionLifecycle,
+} from "./sessionBridge";
+
+/** An in-memory `session-lifecycle` region double that fans a fresh snapshot to
+ * every subscriber on each mutation. */
+class FakeTransport implements Transport {
+  private view: { sessions: Record<string, ProjectedSessionLifecycle> } = { sessions: {} };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    return { intentId: intent.intentId, status: "accepted", produced: [] };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  /** Set a session's projected lifecycle and fan the fresh snapshot out. */
+  setSession(id: string, life: ProjectedSessionLifecycle): void {
+    this.view.sessions[id] = life;
+    this.version += 1;
+    this.fan();
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(SESSION_LIFECYCLE_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+const connectedWith = (sessionId: string): ProjectedSessionLifecycle => ({
+  status: "connected",
+  reconnect: { phase: "idle", attempt: 0, delayMs: 0 },
+  sessionId,
+});
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+let transport: FakeTransport;
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setSessionTransportForTest(transport);
+  setSessionBackendReattachEnabled(null);
+});
+
+afterEach(() => {
+  stopSessionSubscription();
+  setSessionTransportForTest(null);
+  setSessionBackendReattachEnabled(null);
+});
+
+describe("sessionBackendReattachEnabled flag", () => {
+  it("defaults OFF and honours the programmatic override", () => {
+    // Default off ⇒ the client redrive path is unchanged (develop behavior).
+    expect(sessionBackendReattachEnabled()).toBe(false);
+    setSessionBackendReattachEnabled(true);
+    expect(sessionBackendReattachEnabled()).toBe(true);
+    setSessionBackendReattachEnabled(false);
+    expect(sessionBackendReattachEnabled()).toBe(false);
+    setSessionBackendReattachEnabled(null);
+    expect(sessionBackendReattachEnabled()).toBe(false);
+  });
+});
+
+describe("waitForBackendReattachSessionId", () => {
+  const never = () => false;
+
+  it("resolves with the id already present in the region (fast path)", async () => {
+    // The redrive already published the new backend id before the terminal waits.
+    transport.setSession("tab-1", connectedWith("backend-new"));
+    await flush(); // let the initial snapshot land in the last-known view
+
+    const id = await waitForBackendReattachSessionId("tab-1", "backend-old", never);
+    expect(id).toBe("backend-new");
+  });
+
+  it("resolves once the region publishes the id after the wait starts", async () => {
+    const pending = waitForBackendReattachSessionId("tab-2", "backend-old", never);
+    await flush();
+    // The server-side redrive publishes the fresh id via a later diff.
+    transport.setSession("tab-2", connectedWith("backend-fresh"));
+    expect(await pending).toBe("backend-fresh");
+  });
+
+  it("excludes the prior (dead) session id so it never re-attaches to a corpse", async () => {
+    // A stale region value equal to the dead id must not resolve the wait.
+    transport.setSession("tab-3", connectedWith("backend-old"));
+    await flush();
+
+    const pending = waitForBackendReattachSessionId("tab-3", "backend-old", never, 60);
+    await flush();
+    // Only the genuinely new id resolves it.
+    transport.setSession("tab-3", connectedWith("backend-new"));
+    expect(await pending).toBe("backend-new");
+  });
+
+  it("resolves null when the effect is cancelled", async () => {
+    const id = await waitForBackendReattachSessionId("tab-4", null, () => true);
+    expect(id).toBeNull();
+  });
+
+  it("resolves null after the timeout when no id is published", async () => {
+    const id = await waitForBackendReattachSessionId("tab-5", null, never, 20);
+    expect(id).toBeNull();
+  });
+});

--- a/src/store/sessionBridge.ts
+++ b/src/store/sessionBridge.ts
@@ -82,6 +82,14 @@ export interface ProjectedSessionLifecycle {
    * are reconnecting" note shown while a session is reconnecting (#2442). Twin of
    * the Rust `reconnect_error`. Distinct from `error` (the terminal failure msg). */
   reconnectError?: string;
+  /** The **backend** session id the frontend should attach terminal I/O to for
+   * this tab, when known (#2457). Twin of the Rust `SessionLifecycle.sessionId`
+   * (`backend_session_id`). The region is keyed by the stable tab id; this
+   * carries the backend session id that tab currently maps to, so a
+   * backend-driven reconnect redrive (#2454) can hand the frontend the new id to
+   * re-attach to without calling `create_connection`. `undefined` when there is
+   * no live backend session for the tab. */
+  sessionId?: string;
 }
 
 /** The `session-lifecycle` region view model: `{ sessions: { <id>: … } }`. */
@@ -205,6 +213,60 @@ export function sessionRenderFromProjectionEnabled(): boolean {
     // A missing/blocked window or storage just means "use the default".
   }
   return true;
+}
+
+// ── Backend-reattach feature flag (#2457 / #2454, off by default) ───────────────
+
+let backendReattachFlagOverride: boolean | null = null;
+
+interface SessionBackendReattachFlagWindow {
+  __TERMIHUB_SESSION_BACKEND_REATTACH__?: boolean;
+  localStorage?: Storage;
+}
+
+/**
+ * Programmatic override for the backend-reattach flag (tests, and a runtime
+ * toggle). `null` clears the override and falls back to the window/localStorage
+ * signal, then to the default (off).
+ */
+export function setSessionBackendReattachEnabled(value: boolean | null): void {
+  backendReattachFlagOverride = value;
+}
+
+/**
+ * Whether the reconnect redrive is server-side (#2454) and the frontend
+ * re-attaches terminal I/O to a backend-chosen session id instead of driving the
+ * reconnect itself via `create_connection` (#2457).
+ *
+ * **Off by default.** When on, a direct-connection reconnect no longer calls
+ * `create_connection`; instead {@link waitForBackendReattachSessionId} reads the
+ * new backend session id the server-side redrive publishes to the
+ * `session-lifecycle` region and the terminal re-attaches to it. When off (the
+ * default) the client redrive runs exactly as on `develop` — the terminal calls
+ * `create_connection` on every reconnect — so behavior is byte-identical.
+ *
+ * This is the same flag the backend redrive wiring (#2454's remainder) gates on:
+ * turning it on without both halves present would strand the reconnect, so it
+ * stays off until that lands. Overridable at runtime for rollout / tests via
+ * `window.__TERMIHUB_SESSION_BACKEND_REATTACH__` or
+ * `localStorage["termihub.sessionBackendReattach"]` (`"true"` to force on).
+ */
+export function sessionBackendReattachEnabled(): boolean {
+  if (backendReattachFlagOverride !== null) return backendReattachFlagOverride;
+  try {
+    if (typeof window !== "undefined") {
+      const w = window as unknown as SessionBackendReattachFlagWindow;
+      if (typeof w.__TERMIHUB_SESSION_BACKEND_REATTACH__ === "boolean") {
+        return w.__TERMIHUB_SESSION_BACKEND_REATTACH__;
+      }
+      const ls = w.localStorage?.getItem("termihub.sessionBackendReattach");
+      if (ls === "true") return true;
+      if (ls === "false") return false;
+    }
+  } catch {
+    // A missing/blocked window or storage just means "use the default".
+  }
+  return false;
 }
 
 // ── Transport + region client (lazy, mirrors the tunnel slice) ─────────────────
@@ -496,6 +558,85 @@ export function effectiveAutoReconnect(
  * consumer seeding before its first diff arrives. */
 export function currentSessionView(): Record<string, ProjectedSessionLifecycle> {
   return lastSessions;
+}
+
+// ── Backend-reattach: resolve the backend session id to attach to (#2457) ───────
+
+/**
+ * Resolve the **backend** session id a tab should re-attach terminal I/O to for a
+ * backend-driven reconnect (#2457), reading it from the projected
+ * `session-lifecycle` region. The server-side reconnect redrive (#2454) publishes
+ * the new backend session id to the region keyed by tab id; this awaits that id
+ * so the terminal can subscribe output/exit + `setTabSessionId` **without**
+ * calling `create_connection`.
+ *
+ * Resolves with the region's `sessionId` for `tabId` as soon as it is present and
+ * not equal to `excludeSessionId` (the prior, now-dead session id, so a stale
+ * region value is never mistaken for the fresh one — the store also clears the id
+ * on drop, so this is belt-and-suspenders). Resolves to `null` on `isCanceled()`
+ * (the effect torn down) or after `timeoutMs` with no id — the caller then falls
+ * back to the client redrive, which keeps a not-yet-driven reconnect from
+ * stranding the terminal. With #2454 present the redrive publishes the id
+ * promptly, so the wait settles at once and the timeout never bites.
+ *
+ * The region subscription is (re-)ensured so diffs arrive; the listener is
+ * registered before the fast-path read so no diff in between is missed.
+ */
+export function waitForBackendReattachSessionId(
+  tabId: string,
+  excludeSessionId: string | null | undefined,
+  isCanceled: () => boolean,
+  timeoutMs = 10000
+): Promise<string | null> {
+  const accept = (id: string | undefined): id is string =>
+    !!id && !(excludeSessionId != null && id === excludeSessionId);
+
+  return new Promise<string | null>((resolve) => {
+    let settled = false;
+    const cleanups: Array<() => void> = [];
+    const finish = (value: string | null) => {
+      if (settled) return;
+      settled = true;
+      for (const c of cleanups) c();
+      resolve(value);
+    };
+
+    // Register the listener first so a diff arriving between the fast-path read
+    // and the subscription is not lost.
+    cleanups.push(
+      onSessionView((next) => {
+        const id = next[tabId]?.sessionId;
+        if (accept(id)) finish(id);
+      })
+    );
+
+    // Ensure the region is subscribed; a subscribe failure leaves nothing to
+    // source the id, so fall back (null) rather than hang.
+    ensureSessionSubscribed().catch((err) => {
+      logSessionBridgeFallback("subscribe", err);
+      finish(null);
+    });
+
+    // Fast path: the id may already be in the last-known view.
+    const immediate = currentSessionView()[tabId]?.sessionId;
+    if (accept(immediate)) {
+      finish(immediate);
+      return;
+    }
+    if (isCanceled()) {
+      finish(null);
+      return;
+    }
+
+    const timer = setTimeout(() => finish(null), timeoutMs);
+    cleanups.push(() => clearTimeout(timer));
+    // Poll cancellation so a torn-down effect stops waiting promptly rather than
+    // holding the promise open until the timeout.
+    const cancelPoll = setInterval(() => {
+      if (isCanceled()) finish(null);
+    }, 100);
+    cleanups.push(() => clearInterval(cancelPoll));
+  });
 }
 
 /**


### PR DESCRIPTION
Frontend I/O re-attach mechanism for the server-side reconnect redrive (umbrella #2446; direct-connection tracking #2454). This builds the mechanism a backend-driven reconnect needs — it does NOT wire the backend redrive itself (that is #2454's remainder).

## The flag
New **`sessionBackendReattach`** flag in `sessionBridge.ts`, **default OFF**. Naming follows the existing `*IntentsEnabled` / `*RenderFromProjection` convention; runtime-overridable via `window.__TERMIHUB_SESSION_BACKEND_REATTACH__` or `localStorage["termihub.sessionBackendReattach"]`.

- **OFF (default):** a direct reconnect drives the client redrive (`create_connection`) exactly as on `develop` — behavior is byte-identical.
- **ON:** a direct reconnect no longer calls `create_connection`; the terminal re-attaches I/O to a backend-chosen session id instead.

This is the same flag #2454's backend redrive will gate on, so both halves flip together.

## sessionId propagation
Added a per-tab `sessionId` to the shared `session-lifecycle` region record (Rust `SessionLifecycle.backend_session_id`, serialized as `sessionId`; TS `ProjectedSessionLifecycle.sessionId`) — the same pattern #2442 used for `reconnectError`. It carries the **backend** session id the tab (the stable region key) currently maps to. Written by `SessionLifecycleStore::set_backend_session_id` (a pure metadata write) and cleared on every teardown transition (connect / connect_failed / disconnect / dropped / reconnect / cancel_reconnect) so the region never advertises a dead id. The initial-connect fold in `create_connection` populates it from the connect result, establishing the mechanism #2454's redrive reuses after it re-creates the connection.

## What re-attaches
`Terminal.tsx`'s reconnect branch: for a direct (non-persistent) tab with the flag on, `waitForBackendReattachSessionId` reads the new backend id from the region and the existing reattach path subscribes output/exit + `setTabSessionId` to it — **without** `create_connection`. The prior (dead) session id is excluded so a stale value never re-attaches to a corpse; a null result (backend not driving / timeout) falls back to the client redrive so a tab is never stranded. Local scrollback replay is the existing non-persistent path, unchanged.

## What was verified (in isolation)
- **Rust** (`store_tests.rs`): `set_backend_session_id` sets/clears; `sessionId` serialized only when set; every teardown transition clears it; a fresh connect starts without a stale id. Full `cargo test` for the region passes.
- **TS unit** (`sessionBridge.backendReattach.test.ts`): flag defaults OFF + overrides; `waitForBackendReattachSessionId` resolves via fast-path and via a later diff, excludes the dead id, and returns null on cancel / timeout.
- **Component/parity** (`Terminal.backend-reattach.test.tsx`): flag ON re-attaches to the backend-published id with **no** `create_connection`; flag OFF drives the client redrive (`create_connection`) — develop parity.
- `cargo fmt`, clippy, prettier, eslint, tsc all clean.

**End-to-end drop verification is deferred to #2454's backend-redrive PR** — nothing drives a backend reconnect until that lands, so the "flag ON, real drop drives fully server-side" done-when cannot be exercised yet. The integration E2E lane is not in per-PR CI and the local bridge harness is jank-blocked (#2460), so this was not run against a live drop by design.

Closes #2457