### PR TITLE
feat(session): backend reconnect redrive wiring behind the reattach flag (Closes #2454)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -46,6 +46,13 @@ use crate::window::WindowManager;
 /// source can be folded server-side as `session.reconnect` (resilient) vs
 /// `session.dropped` (non-resilient) — converging with the client's
 /// `setTerminalExited` classification. Defaults to `false`.
+///
+/// `backend_reattach` carries the client's `sessionBackendReattach` flag (#2454,
+/// default-off). It is recorded on the tab's retained connection request as the
+/// sole gate on whether the backend reconnect timer re-establishes the transport
+/// itself (the server-side redrive) — the counterpart to the frontend re-attach
+/// (#2457) the same flag switches on. Defaults to `false`: the client drives the
+/// reconnect redrive exactly as on `develop`.
 // Tauri command: the argument list is the IPC surface (typed params + injected
 // State), so it cannot be collapsed into a struct without losing the command
 // binding — the arity lint does not apply here.
@@ -58,6 +65,7 @@ pub async fn create_connection(
     connect_id: Option<String>,
     spawned: Option<bool>,
     resilient_reconnect: Option<bool>,
+    backend_reattach: Option<bool>,
     app_handle: tauri::AppHandle,
     manager: State<'_, SessionManager>,
     conn_manager: State<'_, ConnectionManager>,
@@ -98,6 +106,7 @@ pub async fn create_connection(
             connect_id.as_deref(),
             spawned.unwrap_or(false),
             resilient_reconnect.unwrap_or(false),
+            backend_reattach.unwrap_or(false),
             app_handle.clone(),
         )
         .await;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1019,16 +1019,29 @@ pub fn run() {
                     let store: Arc<session_projection::SessionLifecycleStore> = (*store).clone();
                     let projector = projection_state.projector.clone();
                     let store_for_publish = store.clone();
-                    let driver = Arc::new(session_projection::ReconnectTimerDriver::new(
-                        store,
-                        Arc::new(session_projection::TokioReconnectScheduler::new()),
-                        Arc::new(move || {
-                            session_projection::projection::publish_sessions(
-                                &projector,
-                                &store_for_publish,
-                            );
-                        }),
-                    ));
+                    // Backend-driven reconnect redrive (#2454): on the fired
+                    // attempt the backend re-establishes the transport itself for
+                    // a tab that opted into `sessionBackendReattach`, mints a new
+                    // session and publishes its id for the frontend to re-attach
+                    // to (#2457). Resolves managed state lazily, so it can be fed
+                    // back into the very driver that invokes it without a cycle.
+                    // No-op for a client-driven (flag-off) tab.
+                    let redrive: Arc<dyn session_projection::ReconnectRedrive> = Arc::new(
+                        session_projection::AppReconnectRedrive::new(app.handle().clone()),
+                    );
+                    let driver = Arc::new(
+                        session_projection::ReconnectTimerDriver::new(
+                            store,
+                            Arc::new(session_projection::TokioReconnectScheduler::new()),
+                            Arc::new(move || {
+                                session_projection::projection::publish_sessions(
+                                    &projector,
+                                    &store_for_publish,
+                                );
+                            }),
+                        )
+                        .with_redrive(redrive),
+                    );
                     app.manage(driver);
                 }
                 app.manage(projection_state);

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -668,10 +668,19 @@ impl SessionManager {
     /// (#1446, #1466) so the Open Connections panel groups it under "Spawned
     /// Containers" from this backend marker rather than the frontend tab flag.
     ///
+    /// `backend_reattach` carries the client's `sessionBackendReattach` flag
+    /// (#2454). It is recorded on a resilient direct session's retained request as
+    /// the sole gate on whether the backend reconnect timer re-establishes the
+    /// transport itself (the redrive) vs. leaving that to the client. Defaults to
+    /// `false` (client-driven, `develop` behavior); the backend redrive itself
+    /// passes `true` when it re-connects an opted-in tab so the refresh keeps the
+    /// gate on.
+    ///
     /// Returns the session ID on success.
     // The parameters mirror the `create_connection` IPC surface (type + settings +
     // routing flags + the connect-time signals: spawn origin #1466, resilient
-    // reconnect #2439); grouping them into a struct would only obscure the call.
+    // reconnect #2439, backend reattach #2454); grouping them into a struct would
+    // only obscure the call.
     #[allow(clippy::too_many_arguments)]
     pub async fn create_connection<E: EventEmitter>(
         &self,
@@ -681,6 +690,7 @@ impl SessionManager {
         connect_id: Option<&str>,
         spawned: bool,
         resilient_reconnect: bool,
+        backend_reattach: bool,
         emitter: E,
     ) -> Result<String, TerminalError> {
         // Enforce session limit.
@@ -835,6 +845,10 @@ impl SessionManager {
                         settings: settings.clone(),
                         agent_id: None,
                         resilient: true,
+                        // The client's `sessionBackendReattach` determination
+                        // (#2454): the sole gate on whether the backend reconnect
+                        // timer re-establishes the transport itself for this tab.
+                        backend_reattach,
                     },
                 );
             }
@@ -1049,6 +1063,17 @@ impl SessionManager {
     #[allow(dead_code)] // consumed by the retention tests and the follow-up backend redrive
     pub fn has_retained_request(&self, tab_id: &str) -> bool {
         self.retained_requests.contains(tab_id)
+    }
+
+    /// A clone of the retained connection request for a tab, for the backend
+    /// reconnect redrive (#2454). The redrive reads `type_id` / `settings` /
+    /// `agent_id` to re-establish the transport itself and `backend_reattach` to
+    /// decide whether it is authorised to (the flag gate). Cloning copies the
+    /// secret-bearing settings; the returned value zeroizes on drop, so the
+    /// caller must clone out only the fields it forwards and let it fall out of
+    /// scope promptly. `None` when nothing is retained for the tab.
+    pub(crate) fn retained_request(&self, tab_id: &str) -> Option<RetainedConnectionRequest> {
+        self.retained_requests.get(tab_id)
     }
 
     /// The frontend `tab_id` that owns a backend `session_id`, or `None` for a
@@ -2675,6 +2700,7 @@ mod tests {
                 Some("tab-42:0"),
                 false,
                 false,
+                false,
                 MockEventEmitter::new(),
             )
             .await
@@ -2693,6 +2719,7 @@ mod tests {
                 serde_json::json!({}),
                 None,
                 None,
+                false,
                 false,
                 false,
                 MockEventEmitter::new(),
@@ -2715,6 +2742,7 @@ mod tests {
                 serde_json::json!({}),
                 None,
                 Some("tab-7:0"),
+                false,
                 false,
                 false,
                 MockEventEmitter::new(),
@@ -2745,6 +2773,7 @@ mod tests {
                 Some("tab-r:0"),
                 false,
                 true, // resilient
+                false,
                 MockEventEmitter::new(),
             )
             .await
@@ -2752,6 +2781,57 @@ mod tests {
         assert!(
             manager.has_retained_request("tab-r"),
             "a resilient direct session retains its connection request (#2454 Model A)"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_connection_records_backend_reattach_on_the_retained_request() {
+        // The `backend_reattach` param (the client's `sessionBackendReattach`
+        // flag) is the sole gate on the backend reconnect redrive (#2454): it must
+        // land on the retained request so the redrive can read it back.
+        let manager = make_test_manager();
+        manager
+            .create_connection(
+                "mock",
+                serde_json::json!({ "password": "secret" }),
+                None,
+                Some("tab-on:0"),
+                false,
+                true, // resilient
+                true, // backend_reattach opted in
+                MockEventEmitter::new(),
+            )
+            .await
+            .expect("session should open");
+        let req = manager
+            .retained_request("tab-on")
+            .expect("a resilient direct session retains its request");
+        assert!(
+            req.backend_reattach,
+            "the client's backend-reattach opt-in is recorded as the redrive gate"
+        );
+
+        // The default (flag off) records `false`, so the redrive stays off and the
+        // client drives the reconnect exactly as on develop.
+        manager
+            .create_connection(
+                "mock",
+                serde_json::json!({}),
+                None,
+                Some("tab-off:0"),
+                false,
+                true,  // resilient
+                false, // backend_reattach opted out (default)
+                MockEventEmitter::new(),
+            )
+            .await
+            .expect("session should open");
+        let off = manager
+            .retained_request("tab-off")
+            .expect("a resilient direct session retains its request");
+        assert!(
+            !off.backend_reattach,
+            "flag-off keeps the redrive gate closed (client-driven, develop parity)"
         );
     }
 
@@ -2766,6 +2846,7 @@ mod tests {
                 Some("tab-nr:0"),
                 false,
                 false, // not resilient
+                false,
                 MockEventEmitter::new(),
             )
             .await
@@ -2787,6 +2868,7 @@ mod tests {
                 None, // no connect_id → no tab id to key by
                 false,
                 true,
+                false,
                 MockEventEmitter::new(),
             )
             .await
@@ -2805,6 +2887,7 @@ mod tests {
                 Some("tab-c:0"),
                 false,
                 true,
+                false,
                 MockEventEmitter::new(),
             )
             .await
@@ -2870,6 +2953,7 @@ mod tests {
                 Some("tab-r:0"),
                 false,
                 true, // resilient-reconnect tab
+                false,
                 MockEventEmitter::new(),
             )
             .await
@@ -3008,6 +3092,7 @@ mod tests {
                 Some("tab-f:0"), // initial attempt
                 false,
                 false,
+                false,
                 emitter.clone(),
             )
             .await;
@@ -3038,6 +3123,7 @@ mod tests {
                 serde_json::json!({}),
                 None,
                 Some("tab-f:2"), // a reconnect attempt
+                false,
                 false,
                 false,
                 emitter.clone(),
@@ -3072,6 +3158,7 @@ mod tests {
                     serde_json::json!({}),
                     None,
                     Some("tab-c:0"), // initial attempt, but cancelled
+                    false,
                     false,
                     false,
                     spawned_emitter,
@@ -3193,6 +3280,7 @@ mod tests {
                     Some("c1"),
                     false,
                     false,
+                    false,
                     MockEventEmitter::new(),
                 )
                 .await
@@ -3236,6 +3324,7 @@ mod tests {
                 None,
                 true,
                 false,
+                false,
                 MockEventEmitter::new(),
             )
             .await
@@ -3247,6 +3336,7 @@ mod tests {
                 serde_json::json!({}),
                 None,
                 None,
+                false,
                 false,
                 false,
                 MockEventEmitter::new(),

--- a/src-tauri/src/session/persistent_controller.rs
+++ b/src-tauri/src/session/persistent_controller.rs
@@ -93,6 +93,7 @@ impl<'a> PersistentController<'a> {
                 None,
                 false,
                 false,
+                false,
                 emitter.clone(),
             )
             .await?;

--- a/src-tauri/src/session/retained_request.rs
+++ b/src-tauri/src/session/retained_request.rs
@@ -67,6 +67,16 @@ pub(crate) struct RetainedConnectionRequest {
     pub(crate) agent_id: Option<String>,
     /// The tab's resilient-reconnect determination at connect time.
     pub(crate) resilient: bool,
+    /// Whether the owning tab opted into the **backend-driven** reconnect redrive
+    /// (#2454) — the client's `sessionBackendReattach` flag at connect time,
+    /// threaded through `create_connection`. The backend reconnect timer only
+    /// re-establishes the transport itself for a tab whose retained request
+    /// carries `true`; when `false` (the default-off flag) the timer fires the
+    /// `Waiting → Attempt` edge and the **client** drives the redrive exactly as
+    /// on `develop`. This is the sole gate that keeps the flag-off path
+    /// byte-identical while the two halves (backend redrive here, frontend
+    /// re-attach #2457) share one flag.
+    pub(crate) backend_reattach: bool,
 }
 
 impl Drop for RetainedConnectionRequest {
@@ -181,6 +191,7 @@ mod tests {
                 settings: json!({ "host": "h", "password": "p" }),
                 agent_id: None,
                 resilient: true,
+                backend_reattach: false,
             },
         );
         assert!(store.contains("tab-1"));
@@ -208,6 +219,7 @@ mod tests {
                 settings: json!({ "password": "old" }),
                 agent_id: None,
                 resilient: true,
+                backend_reattach: false,
             },
         );
         store.retain(
@@ -217,6 +229,7 @@ mod tests {
                 settings: json!({ "password": "new" }),
                 agent_id: None,
                 resilient: true,
+                backend_reattach: false,
             },
         );
         assert_eq!(

--- a/src-tauri/src/session_projection/mod.rs
+++ b/src-tauri/src/session_projection/mod.rs
@@ -21,8 +21,10 @@
 //! a clean per-domain boundary.
 
 pub mod projection;
+pub mod redrive;
 pub mod store;
 pub mod timer;
 
+pub use redrive::AppReconnectRedrive;
 pub use store::SessionLifecycleStore;
-pub use timer::{ReconnectTimerDriver, TokioReconnectScheduler};
+pub use timer::{ReconnectRedrive, ReconnectTimerDriver, TokioReconnectScheduler};

--- a/src-tauri/src/session_projection/redrive.rs
+++ b/src-tauri/src/session_projection/redrive.rs
@@ -1,0 +1,184 @@
+//! Backend-driven reconnect redrive — the transport half of Phase 4's
+//! session-lifecycle inversion (#2454, remainder of #2446; unblocks #2205 PR-B).
+//!
+//! [`crate::session_projection::timer`] (#2203) moved the reconnect backoff
+//! loop's *timing* server-side: its [`ReconnectTimerDriver`] fires the
+//! `Waiting → Attempt` edge itself. Until now the attempt's *transport* still
+//! lived in the client — the frontend, reconciling the `Connecting` diff, called
+//! `create_connection` again. This module moves that transport server-side too,
+//! for **resilient direct** connections: on the fired attempt the backend
+//! re-establishes the connection itself from the retained request (retention
+//! Model A, #2458), mints a new backend session, folds the outcome at the source
+//! into the shared `session-lifecycle` store, and publishes the new `sessionId`
+//! so the frontend re-attaches terminal I/O to it (#2457) without a client
+//! `create_connection`.
+//!
+//! # The flag gate — byte-identical when off
+//!
+//! The whole redrive is gated by the retained request's `backend_reattach`
+//! field, threaded from the client's default-off `sessionBackendReattach` flag
+//! through `create_connection`. [`AppReconnectRedrive::redrive`] no-ops for any
+//! tab that did not opt in, so the fired attempt's `Connecting` diff simply fans
+//! out and the **client** drives the redrive exactly as on `develop`. Turning the
+//! flag on is a real authority cut, not an additive double-write: the reconnect
+//! engine is non-idempotent, so under the flag the client suppresses its own
+//! redrive + outcome mirrors and the backend is the sole driver of the attempt
+//! and its `connected` / `reconnectFailed` outcome.
+//!
+//! # Secret lifetime
+//!
+//! The retained `settings` may carry resolved secrets. A successful redrive
+//! re-retains a fresh request (for the next drop); a give-up (exhausted attempts)
+//! drops + **zeroizes** it here so no resolved secret outlives the loop — the
+//! backend-redrive counterpart to the intent-route scrubs #2458 wired.
+
+use std::sync::Arc;
+
+use tauri::{AppHandle, Manager, Runtime};
+use termihub_core::reconnect_backoff::ReconnectPhase;
+
+use crate::session::manager::SessionManager;
+use crate::session_projection::projection::fold_session_transition;
+use crate::session_projection::store::SessionLifecycleStore;
+use crate::session_projection::timer::{ReconnectRedrive, ReconnectTimerDriver};
+
+/// Production [`ReconnectRedrive`] over a Tauri [`AppHandle`]. Resolves the
+/// managed [`SessionManager`], [`SessionLifecycleStore`] and
+/// [`ReconnectTimerDriver`] lazily at redrive time (never at construction, so the
+/// timer driver it feeds back into can hold it without a cycle), mirroring the
+/// resolve-managed-state pattern of [`fold_session_transition`].
+pub struct AppReconnectRedrive<R: Runtime> {
+    app: AppHandle<R>,
+}
+
+impl<R: Runtime> AppReconnectRedrive<R> {
+    /// Build a redrive hook over an app handle.
+    pub fn new(app: AppHandle<R>) -> Self {
+        Self { app }
+    }
+}
+
+impl<R: Runtime> ReconnectRedrive for AppReconnectRedrive<R> {
+    fn redrive(&self, tab_id: &str) {
+        // Off-path unless everything the redrive needs is managed (a headless
+        // projection unit-test app never runs `setup()`), matching
+        // `fold_session_transition` / `sync_timer`.
+        let Some(manager) = self.app.try_state::<SessionManager>() else {
+            return;
+        };
+        let Some(store) = self.app.try_state::<Arc<SessionLifecycleStore>>() else {
+            return;
+        };
+
+        // The opt-in gate: only a tab whose retained request carries
+        // `backend_reattach` (the client's `sessionBackendReattach` flag) is
+        // backend-driven. Absent request or an opted-out tab → the client drives.
+        let request = match manager.retained_request(tab_id) {
+            Some(req) if req.backend_reattach => req,
+            _ => return,
+        };
+
+        // Only redrive an attempt the store is actually running: `fire` advances
+        // `Waiting → Connecting` before calling here, but a cancel/give-up that
+        // landed in between leaves the phase elsewhere — do not connect then.
+        if store.reconnect_state(tab_id).map(|s| s.phase) != Some(ReconnectPhase::Connecting) {
+            return;
+        }
+        let attempt = store
+            .reconnect_state(tab_id)
+            .map(|s| s.attempt)
+            .unwrap_or(0);
+
+        // Clone out the fields to forward before the secret-bearing request drops
+        // (its `Drop` zeroizes the clone). `agent_id` is always `None` for the
+        // direct connections this covers; the field is forwarded for #2455.
+        let type_id = request.type_id.clone();
+        let settings = request.settings.clone();
+        let agent_id = request.agent_id.clone();
+        drop(request);
+
+        // A unique per-attempt connect id in the `${tabId}:${retry}` form so the
+        // new session records the tab-id identity bridge (#2431) and a Stop can
+        // cancel the in-flight handshake. `retry >= 1` (never `0`) so
+        // `create_connection`'s initial-attempt connect-failed fold does not fire
+        // — the redrive folds the reconnect outcome itself, below.
+        let connect_id = format!("{tab_id}:{}", attempt.max(1));
+
+        let app = self.app.clone();
+        let manager = (*manager).clone();
+        let tab_id = tab_id.to_string();
+        tauri::async_runtime::spawn(async move {
+            let result = manager
+                .create_connection(
+                    &type_id,
+                    settings,
+                    agent_id.as_deref(),
+                    Some(&connect_id),
+                    false, // not a spawn-origin session
+                    true,  // resilient (this loop only runs for resilient tabs)
+                    true,  // backend_reattach: keep the gate on across the refresh
+                    app.clone(),
+                )
+                .await;
+
+            match result {
+                Ok(new_session_id) => {
+                    // Guard the cancel race: a user cancel / give-up that landed
+                    // while the connect was in flight moved the loop off
+                    // `Connecting`. Do not settle it live — tear the orphan
+                    // session down instead so nothing outlives the cancelled loop.
+                    let still_connecting = app
+                        .try_state::<Arc<SessionLifecycleStore>>()
+                        .and_then(|store| store.reconnect_state(&tab_id))
+                        .map(|s| s.phase)
+                        == Some(ReconnectPhase::Connecting);
+                    if !still_connecting {
+                        let _ = manager.close_session(&new_session_id).await;
+                        return;
+                    }
+                    // Fold the success at the source: settle the tab live and hand
+                    // the frontend the new backend session id to re-attach to
+                    // (#2457) — the region is keyed by the stable tab id.
+                    let sid = new_session_id.clone();
+                    fold_session_transition(&app, |store| {
+                        store.connected(&tab_id);
+                        store.set_backend_session_id(&tab_id, Some(sid.clone()));
+                    });
+                    sync_timer(&app, &tab_id);
+                }
+                Err(e) => {
+                    // Fold the failure at the source: the engine either arms the
+                    // next backoff window (stay reconnecting) or gives up
+                    // (terminal `Failed`). Re-sync re-arms / cancels the timer.
+                    fold_session_transition(&app, |store| {
+                        store.reconnect_failed(&tab_id, Some(e.to_string()));
+                    });
+                    sync_timer(&app, &tab_id);
+                    // On give-up the loop is over: drop + zeroize the retained
+                    // request so no resolved secret outlives it (#2454 mitigation).
+                    let gave_up = app
+                        .try_state::<Arc<SessionLifecycleStore>>()
+                        .and_then(|store| store.reconnect_state(&tab_id))
+                        .map(|s| s.phase)
+                        == Some(ReconnectPhase::Gaveup);
+                    if gave_up {
+                        if let Some(manager) = app.try_state::<SessionManager>() {
+                            manager.clear_retained_request(&tab_id);
+                        }
+                    }
+                }
+            }
+        });
+    }
+}
+
+/// Re-arm / cancel the backend reconnect timer for `tab_id` after the redrive
+/// folded its outcome, when the driver is managed. A backoff (stay `Waiting`)
+/// re-arms the next one-shot; a success / give-up cancels. Off-path no-op when
+/// the driver is absent (matches [`crate::session_projection::projection`]'s
+/// `sync_timer`, which the intent routes use).
+fn sync_timer<R: Runtime>(app: &AppHandle<R>, tab_id: &str) {
+    if let Some(driver) = app.try_state::<Arc<ReconnectTimerDriver>>() {
+        driver.inner().sync(tab_id);
+    }
+}

--- a/src-tauri/src/session_projection/timer.rs
+++ b/src-tauri/src/session_projection/timer.rs
@@ -52,6 +52,32 @@ use crate::session_projection::store::SessionLifecycleStore;
 /// The action a fired timer runs: advance the store and fan the diff out.
 type FireTask = Box<dyn FnOnce() + Send>;
 
+/// The **backend-driven reconnect redrive** hook (#2454), invoked on the
+/// `Waiting → Attempt` edge after the store has advanced to `Connecting`.
+///
+/// Where [`ReconnectTimerDriver`] owns only the loop's *timing*, this owns the
+/// *transport*: for a tab that opted into backend reattach (the retained
+/// request's `backend_reattach` gate, threaded from the client's
+/// `sessionBackendReattach` flag), the production implementation re-establishes
+/// the connection itself from the retained request, mints a new backend session,
+/// folds the attempt's outcome (`connected` + the new `sessionId`, or
+/// `reconnectFailed`) at the source, re-syncs this timer, and zeroizes the
+/// retained request on give-up.
+///
+/// It is deliberately abstracted so the timer module stays free of the
+/// `SessionManager` / `AppHandle` machinery (that lives in
+/// [`crate::session_projection::redrive`]) and so tests can inject a recording
+/// double. A tab that did **not** opt in is a no-op here: the fired attempt's
+/// `Connecting` diff still fans out and the **client** drives the redrive exactly
+/// as on `develop` — the sole gate that keeps the flag-off path byte-identical.
+pub trait ReconnectRedrive: Send + Sync {
+    /// Attempt a backend-driven reconnect for `tab_id`. Called from
+    /// [`ReconnectTimerDriver::fire`] after the store advanced `Waiting →
+    /// Connecting`. Must itself check the opt-in gate and no-op when the tab is
+    /// client-driven. Cheap/non-blocking: any real connect work is spawned.
+    fn redrive(&self, tab_id: &str);
+}
+
 /// A cancellable, per-key one-shot timer — the wall-clock behind the reconnect
 /// loop, abstracted so tests inject a deterministic double.
 ///
@@ -120,10 +146,20 @@ pub struct ReconnectTimerDriver {
     /// Fan the advanced region out after a fired timer mutates the store. In
     /// production this republishes the shared `session-lifecycle` region.
     publish: Arc<dyn Fn() + Send + Sync>,
+    /// The optional backend-driven reconnect redrive (#2454). Present once the
+    /// production wiring ([`crate::session_projection::redrive`]) is installed;
+    /// `None` in shadow-only setups and plain timer unit tests, where a fired
+    /// timer only advances the store + publishes and the client drives the
+    /// redrive. When present, it is invoked on every fired attempt but no-ops for
+    /// a tab that did not opt into backend reattach.
+    redrive: Option<Arc<dyn ReconnectRedrive>>,
 }
 
 impl ReconnectTimerDriver {
     /// Build a driver over a store, a scheduler, and a publish hook.
+    ///
+    /// The backend redrive hook is absent by default (client-driven / shadow);
+    /// install it with [`Self::with_redrive`].
     pub fn new(
         store: Arc<SessionLifecycleStore>,
         scheduler: Arc<dyn ReconnectScheduler>,
@@ -133,7 +169,16 @@ impl ReconnectTimerDriver {
             store,
             scheduler,
             publish,
+            redrive: None,
         }
+    }
+
+    /// Install the backend-driven reconnect redrive hook (#2454). Consuming
+    /// builder so the driver can be constructed and then `manage`d as-is in
+    /// `setup()`.
+    pub fn with_redrive(mut self, redrive: Arc<dyn ReconnectRedrive>) -> Self {
+        self.redrive = Some(redrive);
+        self
     }
 
     /// Reconcile the timer for `session_id` with the store's current reconnect
@@ -168,6 +213,16 @@ impl ReconnectTimerDriver {
     fn fire(&self, session_id: &str) {
         self.store.reconnect_attempt(session_id);
         (self.publish)();
+        // Backend-driven redrive (#2454): with the hook installed, re-establish
+        // the transport for a tab that opted into backend reattach. The hook
+        // itself checks the opt-in gate and no-ops for a client-driven tab, so a
+        // flag-off tab sees exactly the pre-#2454 behavior (advance + publish;
+        // the client drives the attempt). Ordered after the publish so a
+        // subscriber sees the `Connecting` edge before the redrive's own
+        // outcome diff lands.
+        if let Some(redrive) = &self.redrive {
+            redrive.redrive(session_id);
+        }
     }
 }
 

--- a/src-tauri/src/session_projection/timer_tests.rs
+++ b/src-tauri/src/session_projection/timer_tests.rs
@@ -11,10 +11,10 @@ use std::sync::{Arc, Mutex};
 use serde_json::json;
 use termihub_core::reconnect_backoff::ReconnectPhase;
 
-use super::{ReconnectScheduler, ReconnectTimerDriver};
+use super::{ReconnectRedrive, ReconnectScheduler, ReconnectTimerDriver};
 use crate::projection::Projector;
 use crate::session_projection::projection::{publish_sessions, SESSION_LIFECYCLE_REGION};
-use crate::session_projection::store::{SessionLifecycleStore, SessionStatus};
+use crate::session_projection::store::{EndReason, SessionLifecycleStore, SessionStatus};
 
 /// The armed one-shots a [`ManualScheduler`] records: `key → (delay, task)`.
 type ArmedTasks = std::collections::HashMap<String, (u64, Box<dyn FnOnce() + Send>)>;
@@ -208,6 +208,163 @@ fn cancel_reconnect_stops_the_timer() {
         "user cancel disarms the loop"
     );
     assert_eq!(store.get("s1").unwrap().status, SessionStatus::Disconnected);
+}
+
+// ── Backend redrive hook (#2454) ───────────────────────────────────────────
+
+/// A recording [`ReconnectRedrive`] double: captures the tab ids a fired timer
+/// asked it to redrive, so a test can assert the hook is invoked on the
+/// `Waiting → Attempt` edge (the transport half of #2454).
+#[derive(Default)]
+struct RecordingRedrive {
+    calls: Mutex<Vec<String>>,
+}
+
+impl ReconnectRedrive for RecordingRedrive {
+    fn redrive(&self, tab_id: &str) {
+        self.calls.lock().unwrap().push(tab_id.to_string());
+    }
+}
+
+/// A driver whose fire hook also invokes a recording redrive, over the same
+/// store/scheduler as [`harness`]. Returns the store, scheduler, driver and the
+/// recorder.
+fn harness_with_redrive() -> (
+    Arc<SessionLifecycleStore>,
+    Arc<ManualScheduler>,
+    Arc<ReconnectTimerDriver>,
+    Arc<RecordingRedrive>,
+) {
+    let store = Arc::new(SessionLifecycleStore::new());
+    store.set_rand_for_test(Box::new(|| 0.5));
+    let projector = Arc::new(Projector::new());
+    projector.register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let scheduler = Arc::new(ManualScheduler::new());
+    let redrive = Arc::new(RecordingRedrive::default());
+
+    let store_for_publish = store.clone();
+    let projector_for_publish = projector.clone();
+    let driver = Arc::new(
+        ReconnectTimerDriver::new(
+            store.clone(),
+            scheduler.clone(),
+            Arc::new(move || {
+                publish_sessions(&projector_for_publish, &store_for_publish);
+            }),
+        )
+        .with_redrive(redrive.clone() as Arc<dyn ReconnectRedrive>),
+    );
+    (store, scheduler, driver, redrive)
+}
+
+#[test]
+fn a_fired_timer_invokes_the_backend_redrive_after_advancing_to_connecting() {
+    let (store, scheduler, driver, redrive) = harness_with_redrive();
+    store.connect("s1");
+    store.reconnect("s1"); // Drop → Waiting
+    driver.sync("s1");
+    assert!(redrive.calls.lock().unwrap().is_empty(), "no redrive yet");
+
+    scheduler.fire("s1");
+
+    // The store advanced to Connecting first, then the redrive was asked to
+    // re-establish the transport for this tab — the order the frontend relies on.
+    assert_eq!(
+        store.get("s1").unwrap().reconnect.phase,
+        ReconnectPhase::Connecting
+    );
+    assert_eq!(
+        &*redrive.calls.lock().unwrap(),
+        &["s1".to_string()],
+        "the fired attempt drove the backend redrive"
+    );
+}
+
+#[test]
+fn without_a_redrive_hook_a_fired_timer_only_advances_the_store() {
+    // The default harness installs NO redrive (the shadow / client-driven path):
+    // a fired timer advances + publishes, and the client owns the transport.
+    let (store, _projector, scheduler, driver, publishes) = harness();
+    store.connect("s1");
+    store.reconnect("s1");
+    driver.sync("s1");
+
+    scheduler.fire("s1");
+
+    assert_eq!(
+        store.get("s1").unwrap().reconnect.phase,
+        ReconnectPhase::Connecting
+    );
+    assert_eq!(publishes.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn a_backend_redrive_success_publishes_the_new_session_id_and_cancels_the_timer() {
+    // Play the backend redrive's success role: after the fired attempt, the
+    // redrive re-establishes the transport, mints a new backend session, and
+    // folds `connected` + the new `sessionId` at the source, then re-syncs.
+    let (store, projector, scheduler, driver, _pub) = harness();
+    store.connect("s1");
+    store.reconnect("s1");
+    driver.sync("s1");
+    scheduler.fire("s1"); // Waiting → Connecting (attempt 1)
+
+    store.connected("s1");
+    store.set_backend_session_id("s1", Some("backend-new".to_string()));
+    publish_sessions(&projector, &store);
+    driver.sync("s1");
+
+    let snap = projector.snapshot(SESSION_LIFECYCLE_REGION);
+    assert_eq!(snap.view["sessions"]["s1"]["status"], json!("connected"));
+    assert_eq!(
+        snap.view["sessions"]["s1"]["sessionId"],
+        json!("backend-new"),
+        "the region carries the new backend session id for the frontend to re-attach to"
+    );
+    assert_eq!(
+        scheduler.armed_delay("s1"),
+        None,
+        "a successful redrive cancels the timer"
+    );
+}
+
+#[test]
+fn backend_redrive_giveup_settles_failed_error_distinct_from_user_cancel_disconnected() {
+    // Give-up (exhausted attempts) and user-cancel are the two terminal loop
+    // states the backend redrive must resolve differently (#2454): the parity
+    // the frontend and the retained-request scrub both key off.
+
+    // (a) Give-up: drive the failure loop to exhaustion.
+    let (store, _p, scheduler, driver, _pub) = harness();
+    store.connect("g");
+    store.reconnect("g");
+    driver.sync("g");
+    for _ in 0..10 {
+        scheduler.fire("g");
+        store.reconnect_failed("g", Some("still down".into()));
+        driver.sync("g");
+    }
+    let gave_up = store.get("g").unwrap();
+    assert_eq!(gave_up.status, SessionStatus::Failed);
+    assert_eq!(gave_up.reconnect.phase, ReconnectPhase::Gaveup);
+    assert_eq!(gave_up.end_reason, Some(EndReason::Error));
+    assert!(gave_up.error.is_some(), "give-up carries the last error");
+
+    // (b) User cancel mid-loop: distinct terminal state.
+    let (store, _p2, scheduler2, driver2, _pub2) = harness();
+    store.connect("c");
+    store.reconnect("c");
+    driver2.sync("c");
+    scheduler2.fire("c"); // attempt in flight
+    store.cancel_reconnect("c");
+    driver2.sync("c");
+    let cancelled = store.get("c").unwrap();
+    assert_eq!(cancelled.status, SessionStatus::Disconnected);
+    assert_eq!(cancelled.end_reason, Some(EndReason::User));
+    assert_eq!(
+        cancelled.error, None,
+        "a user cancel carries no failure error"
+    );
 }
 
 #[test]

--- a/src-tauri/src/terminal/agent_setup.rs
+++ b/src-tauri/src/terminal/agent_setup.rs
@@ -180,6 +180,7 @@ where
         None,
         false,
         false,
+        false,
         app_handle.clone(),
     ))?;
 

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -594,11 +594,19 @@ export function Terminal({
                 // `session.dropped`, converging with `setTerminalExited`. Computed
                 // from the live store the same way the client's drop path does.
                 const resilientReconnect = isResilientReconnectTabId(tabId);
+                // The backend-reattach determination (#2454): recorded on the
+                // retained request so the backend reconnect timer knows it may
+                // redrive this tab itself. Passed on the initial connect (this is
+                // the client redrive path, reached only when the flag is off or as
+                // the #2457 fallback); the redrive's own re-connect keeps the gate
+                // on server-side.
+                const backendReattach = sessionBackendReattachEnabled();
                 resolved = await createTerminal(
                   sessionConfig,
                   connectId,
                   spawned,
-                  resilientReconnect
+                  resilientReconnect,
+                  backendReattach
                 );
               } finally {
                 connectInFlightRef.current.delete(connectId);

--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -101,6 +101,7 @@ describe("api service", () => {
         connectId: null,
         spawned: false,
         resilientReconnect: false,
+        backendReattach: false,
       });
       expect(result).toBe("session-456");
     });
@@ -117,6 +118,7 @@ describe("api service", () => {
         connectId: null,
         spawned: false,
         resilientReconnect: false,
+        backendReattach: false,
       });
       expect(result).toBe("session-789");
     });
@@ -133,6 +135,7 @@ describe("api service", () => {
         connectId: "tab-7",
         spawned: false,
         resilientReconnect: false,
+        backendReattach: false,
       });
     });
 
@@ -149,6 +152,7 @@ describe("api service", () => {
         connectId: "tab-9",
         spawned: false,
         resilientReconnect: false,
+        backendReattach: false,
       });
     });
 
@@ -165,6 +169,7 @@ describe("api service", () => {
         connectId: "tab-s",
         spawned: true,
         resilientReconnect: false,
+        backendReattach: false,
       });
     });
 
@@ -181,6 +186,24 @@ describe("api service", () => {
         connectId: "tab-r",
         spawned: false,
         resilientReconnect: true,
+        backendReattach: false,
+      });
+    });
+
+    it("createTerminal forwards backendReattach to create_connection (#2454)", async () => {
+      mockedInvoke.mockResolvedValue("session-br");
+      const config = { type: "ssh", config: { host: "h" } };
+
+      await createTerminal(config, "tab-br", false, true, true);
+
+      expect(mockedInvoke).toHaveBeenCalledWith("create_connection", {
+        typeId: "ssh",
+        settings: { host: "h" },
+        agentId: null,
+        connectId: "tab-br",
+        spawned: false,
+        resilientReconnect: true,
+        backendReattach: true,
       });
     });
 
@@ -218,6 +241,7 @@ describe("api service", () => {
         connectId: null,
         spawned: false,
         resilientReconnect: false,
+        backendReattach: false,
       });
       expect(result).toBe("session-123");
     });
@@ -243,6 +267,7 @@ describe("api service", () => {
         connectId: null,
         spawned: false,
         resilientReconnect: false,
+        backendReattach: false,
       });
       expect(result).toBe("session-remote");
     });

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -72,6 +72,12 @@ export async function getConnectionTypes(): Promise<ConnectionTypeInfo[]> {
  * `resilientReconnect` carries the tab's `isResilientReconnectTab` determination
  * (#2439) so the backend can fold a genuine drop server-side as `session.reconnect`
  * (resilient) vs `session.dropped` (non-resilient), converging with the client.
+ *
+ * `backendReattach` carries the client's `sessionBackendReattach` flag (#2454,
+ * default-off) so the backend records it on the tab's retained request — the sole
+ * gate on whether the backend reconnect timer re-establishes the transport itself
+ * (the redrive), the counterpart to the frontend re-attach (#2457) the same flag
+ * switches on. Omitted / `false` ⇒ the client drives the redrive, as on `develop`.
  */
 export async function createConnection(
   typeId: string,
@@ -79,7 +85,8 @@ export async function createConnection(
   agentId?: string,
   connectId?: string,
   spawned?: boolean,
-  resilientReconnect?: boolean
+  resilientReconnect?: boolean,
+  backendReattach?: boolean
 ): Promise<SessionId> {
   return await invoke<string>("create_connection", {
     typeId,
@@ -88,6 +95,7 @@ export async function createConnection(
     connectId: connectId ?? null,
     spawned: spawned ?? false,
     resilientReconnect: resilientReconnect ?? false,
+    backendReattach: backendReattach ?? false,
   });
 }
 
@@ -178,12 +186,18 @@ export async function importInventoryHosts(path: string): Promise<InventoryHost[
  * forwarded to the backend so a genuine drop is folded server-side as
  * `session.reconnect` vs `session.dropped`. Only plain-SSH tabs opt in; the
  * `remote-session` (agent) path is never resilient, so it is not forwarded there.
+ *
+ * `backendReattach` is the client's `sessionBackendReattach` flag (#2454), passed
+ * on the direct path only so the backend records it on the retained request as the
+ * redrive gate. The `remote-session` (agent) path is out of scope (#2455), so it
+ * is not forwarded there.
  */
 export async function createTerminal(
   config: ConnectionConfig,
   connectId?: string,
   spawned?: boolean,
-  resilientReconnect?: boolean
+  resilientReconnect?: boolean,
+  backendReattach?: boolean
 ): Promise<SessionId> {
   if (config.type === "remote-session") {
     const { agentId, sessionType, ...rest } = config.config as {
@@ -199,7 +213,8 @@ export async function createTerminal(
     undefined,
     connectId,
     spawned,
-    resilientReconnect
+    resilientReconnect,
+    backendReattach
   );
 }
 

--- a/src/store/appStore.backendReattach.test.ts
+++ b/src/store/appStore.backendReattach.test.ts
@@ -1,0 +1,236 @@
+/**
+ * appStore parity tests for the backend-reattach authority cut (#2454).
+ *
+ * When the default-off `sessionBackendReattach` flag is ON, the **backend**
+ * reconnect redrive owns the attempt OUTCOME — it folds `connected` /
+ * `reconnectFailed` at the source. The client must therefore NOT also mirror
+ * those (the reconnect engine is non-idempotent: a double `failure` would
+ * double-count the attempt and give up early). This suite pins that surgical cut:
+ *
+ *  - flag ON  → a failed attempt does NOT dispatch `session.reconnectFailed`,
+ *    but the local loop record still settles (the overlay is unaffected), and
+ *    `drop` (`session.reconnect`) + user `cancel` (`session.cancelReconnect`)
+ *    stay client-driven (the backend cannot observe those otherwise).
+ *  - flag OFF → develop parity: a failed attempt DOES dispatch
+ *    `session.reconnectFailed` exactly as before.
+ *
+ * The `sessionIntents` cut stays on throughout (its default), so only the new
+ * `sessionBackendReattach` flag differs between the two cases.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushMacrotask as flush } from "@/test/flushAsync";
+
+// The loop never calls the backend directly; these mocks only satisfy imports
+// (mirrors appStore.sessionBridge.test.ts).
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  persistAgent: vi.fn(() => Promise.resolve()),
+  removeAgent: vi.fn(() => Promise.resolve()),
+  reorderAgents: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve()),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  startPersistentSession: vi.fn(() => Promise.resolve("sid")),
+  stopPersistentSession: vi.fn(() => Promise.resolve()),
+  attachPersistentTab: vi.fn(() => Promise.resolve(1)),
+  connectAgent: vi.fn(() => Promise.resolve({ capabilities: {} })),
+  disconnectAgent: vi.fn(),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  listAgentConnections: vi.fn(() => Promise.resolve({ connections: [], folders: [] })),
+  saveAgentDefinition: vi.fn(),
+  updateAgentDefinition: vi.fn(),
+  deleteAgentDefinition: vi.fn(() => Promise.resolve()),
+  createAgentFolder: vi.fn(),
+  updateAgentFolder: vi.fn(() => Promise.resolve({})),
+  deleteAgentFolder: vi.fn(() => Promise.resolve()),
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  removeCredential: vi.fn(() => Promise.resolve()),
+  getConnectionTypes: vi.fn(() => Promise.resolve([])),
+  sessionGetCapabilities: vi.fn(() => Promise.resolve({})),
+}));
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+
+import { useAppStore } from "./appStore";
+import {
+  SESSION_LIFECYCLE_REGION,
+  setSessionBackendReattachEnabled,
+  setSessionIntentsEnabled,
+  setSessionTransportForTest,
+  stopSessionSubscription,
+  type ProjectedSessionLifecycle,
+} from "./sessionBridge";
+
+/** A transport double that records every dispatched intent and can project a
+ * Waiting→Connecting edge, so the appStore mirror + reconcile round-trip runs. */
+class RecordingTransport implements Transport {
+  dispatched: Intent[] = [];
+  private sessions: Record<string, ProjectedSessionLifecycle> = {};
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    const id = (intent.payload as { sessionId: string }).sessionId;
+    if (intent.kind === "session.reconnect") {
+      this.sessions[id] = {
+        status: "reconnecting",
+        reconnect: { phase: "waiting", attempt: 0, delayMs: 1000 },
+      };
+      this.version += 1;
+      this.fan();
+    }
+    return { intentId: intent.intentId, status: "accepted", produced: [] };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  /** Simulate the backend timer firing the Waiting→Connecting edge. */
+  fireAttempt(id: string, attempt: number): void {
+    this.sessions[id] = {
+      status: "reconnecting",
+      reconnect: { phase: "connecting", attempt, delayMs: 0 },
+    };
+    this.version += 1;
+    this.fan();
+  }
+
+  kinds(): string[] {
+    return this.dispatched.map((i) => i.kind);
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return {
+      kind: "snapshot",
+      region,
+      version: this.version,
+      view: structuredClone({ sessions: this.sessions }),
+    };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(SESSION_LIFECYCLE_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+const auto = (tabId: string) => useAppStore.getState().terminalAutoReconnect[tabId];
+
+function makeSshTab(): string {
+  return useAppStore.getState().addTab(
+    "web01",
+    "ssh",
+    {
+      type: "ssh",
+      config: { host: "web01.example.com", username: "deploy", resilientReconnect: true },
+    },
+    { contentType: "terminal", sessionId: "sess-1" }
+  );
+}
+
+/** Drive a resilient tab into a connecting reconnect attempt, then fail it. */
+async function dropAttemptThenFail(fake: RecordingTransport): Promise<string> {
+  const tabId = makeSshTab();
+  useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+  await flush(); // subscription established; projected = waiting
+  fake.fireAttempt(tabId, 1);
+  await flush(); // ensureSessionReconcileWired → local attempt (connecting)
+  expect(auto(tabId)?.phase).toBe("connecting");
+  // A failed connect attempt while the loop is connecting drives "failure".
+  useAppStore.getState().setTerminalSpawnError(tabId, "connection refused");
+  await flush();
+  return tabId;
+}
+
+describe("appStore — backend-reattach outcome-mirror suppression (#2454)", () => {
+  let fake: RecordingTransport;
+
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    fake = new RecordingTransport();
+    setSessionTransportForTest(fake);
+    setSessionIntentsEnabled(true); // the underlying cut stays on (its default)
+  });
+
+  afterEach(() => {
+    stopSessionSubscription();
+    setSessionTransportForTest(null);
+    setSessionIntentsEnabled(null);
+    setSessionBackendReattachEnabled(null);
+  });
+
+  it("flag ON: a failed attempt does NOT dispatch session.reconnectFailed (backend owns it)", async () => {
+    setSessionBackendReattachEnabled(true);
+    const tabId = await dropAttemptThenFail(fake);
+
+    expect(fake.kinds()).not.toContain("session.reconnectFailed");
+    // The local loop still settles for the overlay — the record moved off
+    // "connecting" (backed off to waiting or gave up), proving suppression is
+    // scoped to the intent mirror, not the local state machine.
+    expect(auto(tabId)?.phase).not.toBe("connecting");
+  });
+
+  it("flag OFF: a failed attempt DOES dispatch session.reconnectFailed (develop parity)", async () => {
+    setSessionBackendReattachEnabled(false);
+    await dropAttemptThenFail(fake);
+
+    expect(fake.kinds()).toContain("session.reconnectFailed");
+  });
+
+  it("flag ON: drop still mirrors session.reconnect and user cancel still mirrors session.cancelReconnect", async () => {
+    setSessionBackendReattachEnabled(true);
+    const tabId = makeSshTab();
+    useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+    await flush();
+    expect(fake.kinds()).toContain("session.reconnect");
+
+    // A user cancel is client-originated — the backend cannot observe it
+    // otherwise, so it must still reach `session.cancelReconnect`.
+    useAppStore.getState().cancelAutoReconnect(tabId, "stopped by user");
+    await flush();
+    expect(fake.kinds()).toContain("session.cancelReconnect");
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -254,6 +254,7 @@ import {
   logSessionBridgeFallback,
   mirrorSessionIntent,
   onSessionView,
+  sessionBackendReattachEnabled,
   sessionIntentsEnabled,
   type SessionIntentKind,
 } from "@/store/sessionBridge";
@@ -2235,8 +2236,21 @@ function driveAutoReconnect(
   // `attempt` event is not mirrored here: under the cut, an attempt originates
   // from the backend timer (reconciled below), so re-dispatching it would be a
   // redundant no-op against the store already in `Connecting`.
+  //
+  // Backend-reattach authority cut (#2454): when `sessionBackendReattach` is on,
+  // the backend redrive owns the attempt OUTCOME — it folds `connected` /
+  // `reconnectFailed` at the source. The client must NOT also mirror those, since
+  // the reconnect engine is non-idempotent (a double `failure` would
+  // double-count the attempt and give up early). So `success` / `failure` are
+  // suppressed here under the flag; the local record still settles for the
+  // overlay, but the intent is the backend's to drive. `drop` (idempotent, also
+  // folded server-side) and `cancel` (user-originated — the backend cannot
+  // observe it otherwise, and it is how a user stop reaches `cancelReconnect`)
+  // stay client-driven.
   const cutOn = sessionIntentsEnabled();
-  if (cutOn && event !== "attempt") {
+  const backendOwnsOutcome =
+    sessionBackendReattachEnabled() && (event === "success" || event === "failure");
+  if (cutOn && event !== "attempt" && !backendOwnsOutcome) {
     mirrorAutoReconnectEvent(tabId, event, error);
   }
 


### PR DESCRIPTION
Wires the **backend** reconnect redrive — the transport half of the session-lifecycle inversion — behind the existing default-off `sessionBackendReattach` flag (#2457). Builds on #2458 (retention Model A) and #2457 (frontend re-attach), both already in develop.

Closes #2454

## The flag
`sessionBackendReattach` (frontend localStorage, default **off**), threaded to the backend through `create_connection` and recorded on the tab's retained request as the sole redrive gate. **Flag off ⇒ byte-identical to develop** — the timer fires the `Waiting→Attempt` edge and the client drives the redrive exactly as before. The flag is the same one #2457 gates the frontend re-attach on; turning it on is a real authority cut, not an additive double-write (the reconnect engine is non-idempotent).

## What the backend now drives (flag on, resilient DIRECT only)
On the #2203 timer's `Waiting→Attempt` (Connecting) edge:
1. Re-establishes the transport itself from the retained `RetainedConnectionRequest` (Model A), minting a **new** backend session.
2. Folds the attempt outcome **at the source** — `connected` + the new `sessionId` into the shared `session-lifecycle` region (so the frontend re-attaches I/O without `create_connection`, #2457), or `reconnectFailed` (backoff or give-up).
3. Re-syncs the timer (re-arm on backoff, cancel on success/give-up).
4. **Zeroizes** the retained request on give-up so no resolved secret outlives the loop (backend-redrive counterpart to #2458's intent-route scrubs).

Mechanism: a `ReconnectRedrive` hook on `ReconnectTimerDriver` (`with_redrive`); the production `AppReconnectRedrive` resolves the manager/store/driver from the `AppHandle` lazily (no construction cycle). A cancel-race guard tears down an orphan session if a success lands after the loop already left `Connecting`.

## How the client path is suppressed under the flag
The backend owns the attempt **outcome**, so `driveAutoReconnect` suppresses the `session.connected` / `session.reconnectFailed` client mirrors under the flag (the local record still settles for the overlay). `drop` (idempotent, also folded server-side) and user `cancel` (client-originated — the backend can't observe it otherwise) stay client-driven, so **user-cancel → Disconnected/User** and **give-up → Failed/Error** still resolve distinctly. The client `create_connection` redrive itself was already suppressed by #2457's re-attach path.

## Verification (unit + parity)
- **Rust:** fired timer invokes the redrive after advancing to Connecting; no-redrive (shadow) path unchanged; a success publishes the new `sessionId` and cancels the timer; give-up settles Failed/Error distinct from user-cancel Disconnected/User; `create_connection` records the reattach gate (on/off).
- **Frontend:** appStore parity — flag on suppresses `session.reconnectFailed` (local record still settles) and keeps `session.reconnect` / `session.cancelReconnect`; flag off dispatches `session.reconnectFailed` exactly as on develop. #2457's re-attach tests still green.
- `cargo fmt` / `clippy -D warnings` / `tsc` / `eslint` / `prettier` all clean.

**End-to-end live-drop verification is deferred to #2447** (needs a quiet machine; the local E2E bridge harness is load-sensitive per #2460). Green per-PR CI does not exercise a real reconnect — this PR is verified via unit/parity only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)