### PR TITLE
test(system): raise live-connect verb timeout + capture webview evidence on timeout (part of #2460)

### DIFF
--- a/tests/system/termihub_harness/__init__.py
+++ b/tests/system/termihub_harness/__init__.py
@@ -5,7 +5,13 @@ lifecycle of the app and agent processes — the foundation for system/resilienc
 tests that run identically on Linux, Windows, and macOS (issue #802).
 """
 
-from .bridge import Bridge, BridgeError, Driver, screenshot_to_png_bytes
+from .bridge import (
+    LIVE_CONNECT_REQUEST_TIMEOUT,
+    Bridge,
+    BridgeError,
+    Driver,
+    screenshot_to_png_bytes,
+)
 from .fixtures import (
     REMOTE_AGENT_PENDING_PORT,
     REMOTE_AGENT_PENDING_SERVICE,
@@ -89,6 +95,7 @@ __all__ = [
     "Bridge",
     "BridgeError",
     "Driver",
+    "LIVE_CONNECT_REQUEST_TIMEOUT",
     "screenshot_to_png_bytes",
     "AppInstance",
     "AgentInstance",

--- a/tests/system/termihub_harness/artifacts.py
+++ b/tests/system/termihub_harness/artifacts.py
@@ -13,11 +13,23 @@ logic is unit-testable with stub driver/app objects, no app launch needed.
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 from typing import Any, Callable, Optional
 
 #: Where bundles are written (git-ignored). One subdir per failing test node id.
 ARTIFACT_ROOT = Path(__file__).resolve().parents[1] / "artifacts"
+
+#: Command timeout for the failure-path diagnostic probes (issue #2460). A bridge
+#: verb that times out is exactly when the bundle matters most, but the probes run
+#: on the *same* webview that just hung — so with the normal (possibly already
+#: raised) command timeout they would time out again and capture nothing. This
+#: generous ceiling lets a webview that is merely **slow under VM load** still
+#: return a screenshot / state late, and turns a genuinely **hung** one into a
+#: definitive timed "FAILED after Ns" record (see :func:`write_failure_artifacts`
+#: and ``probe-diagnostics.txt``) rather than silence — the #2460 slow-vs-hung
+#: verdict.
+DIAGNOSTIC_PROBE_TIMEOUT = 60.0
 
 
 def sanitize_nodeid(nodeid: str) -> str:
@@ -64,16 +76,20 @@ def _safe_write_bytes(path: Path, produce: Callable[[], bytes]) -> None:
         _record_probe_error(path, exc)
 
 
-def _capture_screenshot_png(driver: Any) -> bytes:
+def _capture_screenshot_png(driver: Any, *, timeout: Optional[float] = None) -> bytes:
     """Capture a PNG screenshot via the bridge and decode it to raw bytes.
 
     Imported lazily so this module keeps no hard dependency on the bridge for its
     unit tests, and so a driver stub without ``screenshot`` is simply skipped by
     the ``hasattr`` guard in :func:`write_failure_artifacts`.
+
+    ``timeout`` overrides the driver's default command timeout — the failure path
+    passes :data:`DIAGNOSTIC_PROBE_TIMEOUT` so a slow (not-yet-hung) webview can
+    still return a screenshot (issue #2460).
     """
     from .bridge import screenshot_to_png_bytes
 
-    return screenshot_to_png_bytes(driver.screenshot())
+    return screenshot_to_png_bytes(driver.screenshot(timeout=timeout))
 
 
 def save_manual_screenshot(
@@ -103,7 +119,42 @@ def save_manual_screenshot(
     return dest if dest.exists() else None
 
 
-def write_failure_artifacts(dest: Path, driver: Optional[Any], app: Optional[Any]) -> Path:
+def _timed_probe(
+    dest: Path, name: str, produce: Callable[[], Any], *, binary: bool = False
+) -> str:
+    """Run one capture probe, timing it, and return a one-line diagnostic record.
+
+    Writes ``produce()`` to ``dest/name`` on success (text, or bytes when
+    ``binary``), or records its error beside the target on failure — capture is
+    best-effort and must never raise (a broken bridge during a failure is exactly
+    when the bundle matters most). The returned record — ``"<name>: ok in Ns"`` or
+    ``"<name>: FAILED after Ns — Type: msg"`` — is the #2460 slow-vs-hung signal:
+    a probe that returns *late* means the webview was slow-not-hung; one that
+    times out at the probe ceiling means it is genuinely hung.
+    """
+    target = dest / name
+    start = time.monotonic()
+    try:
+        output = produce()
+        elapsed = time.monotonic() - start
+        if binary:
+            target.write_bytes(output)
+        else:
+            target.write_text(output, encoding="utf-8")
+        return f"{name}: ok in {elapsed:.1f}s"
+    except Exception as exc:  # noqa: BLE001 — capture is best-effort by design
+        elapsed = time.monotonic() - start
+        _record_probe_error(target, exc)
+        return f"{name}: FAILED after {elapsed:.1f}s — {type(exc).__name__}: {exc}"
+
+
+def write_failure_artifacts(
+    dest: Path,
+    driver: Optional[Any],
+    app: Optional[Any],
+    *,
+    probe_timeout: float = DIAGNOSTIC_PROBE_TIMEOUT,
+) -> Path:
     """Snapshot whatever app-side state is reachable into ``dest``; return ``dest``.
 
     ``driver`` / ``app`` may be ``None`` (e.g. a non-integration test) — each
@@ -113,19 +164,61 @@ def write_failure_artifacts(dest: Path, driver: Optional[Any], app: Optional[Any
     - ``driver.read_terminal()`` → ``terminal.txt``
     - ``driver.screenshot()`` → ``screenshot.png`` (when the bridge supports it)
     - ``app.read_log()`` → ``app.log``
+    - a timed record of every probe → ``probe-diagnostics.txt``
+
+    The bridge probes run with ``probe_timeout`` (default
+    :data:`DIAGNOSTIC_PROBE_TIMEOUT`), *not* the driver's normal command timeout:
+    a live-connect verb that just timed out did so on the same webview, so the
+    probes need to outlive that to capture anything from a slow-but-alive webview.
+    ``probe-diagnostics.txt`` records how long each probe took and whether it
+    returned or timed out — the #2460 slow-vs-hung verdict (issue #2460).
     """
     dest.mkdir(parents=True, exist_ok=True)
+    records: list[str] = []
     if driver is not None:
-        _safe_write(
-            dest / "state.json",
-            lambda: json.dumps(driver.get_state(), indent=2, default=str, sort_keys=True),
+        records.append(
+            _timed_probe(
+                dest,
+                "state.json",
+                lambda: json.dumps(
+                    driver.get_state(timeout=probe_timeout),
+                    indent=2,
+                    default=str,
+                    sort_keys=True,
+                ),
+            )
         )
-        _safe_write(dest / "terminal.txt", driver.read_terminal)
+        records.append(
+            _timed_probe(
+                dest, "terminal.txt", lambda: driver.read_terminal(timeout=probe_timeout)
+            )
+        )
         # The screenshot verb (#900) may be absent on older apps / driver stubs —
         # capture it only when present so the bundle gains visual evidence where
         # available without breaking where it is not.
         if hasattr(driver, "screenshot"):
-            _safe_write_bytes(dest / "screenshot.png", lambda: _capture_screenshot_png(driver))
+            records.append(
+                _timed_probe(
+                    dest,
+                    "screenshot.png",
+                    lambda: _capture_screenshot_png(driver, timeout=probe_timeout),
+                    binary=True,
+                )
+            )
     if app is not None:
-        _safe_write(dest / "app.log", app.read_log)
+        records.append(_timed_probe(dest, "app.log", app.read_log))
+    # Always leave the timed record — it is the #2460 evidence, and its header
+    # explains how to read a slow-vs-hung result even when no probe ran.
+    header = (
+        "# Failure-artifact probe diagnostics (issue #2460).\n"
+        f"# Bridge probes ran with a {probe_timeout:.0f}s timeout.\n"
+        "# 'ok in Ns' = the webview answered (late N => slow-not-hung);\n"
+        "# 'FAILED after ~{}s' at the ceiling => the webview is genuinely hung.\n".format(
+            int(probe_timeout)
+        )
+    )
+    _safe_write(
+        dest / "probe-diagnostics.txt",
+        lambda: header + ("\n".join(records) + "\n" if records else "# no probes ran\n"),
+    )
     return dest

--- a/tests/system/termihub_harness/bridge.py
+++ b/tests/system/termihub_harness/bridge.py
@@ -25,6 +25,17 @@ import websockets
 from .protocol import Command, Response, decode_response, encode_request
 
 DEFAULT_REQUEST_TIMEOUT = 10.0
+#: Command timeout for the **live-connect / SFTP** suites (issue #2460). A real
+#: SSH session negotiates while the always-on Docker (``--cpus 10``) + podman
+#: ``krunkit`` VMs intermittently starve the macOS WKWebView JS thread for >10s,
+#: so the default 10s fires mid-negotiation and the whole live suite times out
+#: even though the backend is fine. 60s is deliberately generous: it is long
+#: enough to let a webview that is merely *slow under load* finish (the suite then
+#: passes), while a run that still times out at 60s is strong evidence the webview
+#: is *genuinely hung* rather than slow — the #2460 hypothesis test. Scoped to the
+#: live suites (via ``SystemTest.request_timeout``); it does **not** slow every
+#: verb globally.
+LIVE_CONNECT_REQUEST_TIMEOUT = 60.0
 DEFAULT_APP_WAIT_TIMEOUT = 30.0
 #: After the first app connection arrives, briefly prefer a newer one that shows
 #: up within this window. An app's webview can connect and then reconnect during
@@ -128,15 +139,19 @@ class Driver:
         self._loop = loop
         self._timeout = request_timeout
 
-    def _call(self, command: Command) -> Any:
+    def _call(self, command: Command, *, timeout: Optional[float] = None) -> Any:
         # Drop None-valued keys so the wire form matches the in-process client:
         # JSON.stringify omits `undefined`, and the dispatcher distinguishes an
         # absent optional (e.g. getState path) from an explicit null.
         command = {key: value for key, value in command.items() if value is not None}
+        # A per-call ``timeout`` overrides the Driver's default — used by the
+        # failure-artifact probes, which must outlive the live path's own timeout
+        # to capture evidence from a slow (not-yet-hung) webview (issue #2460).
+        effective_timeout = self._timeout if timeout is None else timeout
         cfut = asyncio.run_coroutine_threadsafe(
-            self._conn.send(command, self._timeout), self._loop
+            self._conn.send(command, effective_timeout), self._loop
         )
-        response = cfut.result(self._timeout + 5)
+        response = cfut.result(effective_timeout + 5)
         if not response.get("ok"):
             raise BridgeError(
                 response.get("action", command.get("action", "")),
@@ -288,14 +303,19 @@ class Driver:
         )
 
     def read_terminal(
-        self, tab_id: Optional[str] = None, join_full_width_rows: bool = False
+        self,
+        tab_id: Optional[str] = None,
+        join_full_width_rows: bool = False,
+        *,
+        timeout: Optional[float] = None,
     ) -> str:
         return self._call(
             {
                 "action": "readTerminal",
                 "tabId": tab_id,
                 "joinFullWidthRows": join_full_width_rows,
-            }
+            },
+            timeout=timeout,
         )
 
     def scroll_terminal(
@@ -327,10 +347,10 @@ class Driver:
         """
         return self._call({"action": "getTerminalViewport", "tabId": tab_id})
 
-    def get_state(self, path: Optional[str] = None) -> Any:
-        return self._call({"action": "getState", "path": path})
+    def get_state(self, path: Optional[str] = None, *, timeout: Optional[float] = None) -> Any:
+        return self._call({"action": "getState", "path": path}, timeout=timeout)
 
-    def screenshot(self) -> str:
+    def screenshot(self, *, timeout: Optional[float] = None) -> str:
         """Capture a PNG screenshot of the rendered app as a data URL.
 
         Returns a ``data:image/png;base64,…`` string produced by rasterizing the
@@ -339,8 +359,12 @@ class Driver:
         does **not** capture the xterm GPU canvas or native OS dialogs — read
         terminal text via :meth:`read_terminal` instead. Decode with
         :func:`screenshot_to_png_bytes`.
+
+        Pass ``timeout`` to override the Driver's default command timeout — the
+        failure-artifact path uses a generous one so a webview that is merely slow
+        under VM load can still return a screenshot (issue #2460).
         """
-        return self._call({"action": "screenshot"})
+        return self._call({"action": "screenshot"}, timeout=timeout)
 
     # ── Projection substrate (#2149 / harness #2164) ─────────────────────────
     def projection_subscribe(self, region: str) -> dict[str, Any]:
@@ -460,6 +484,8 @@ class Bridge:
         self,
         timeout: float = DEFAULT_APP_WAIT_TIMEOUT,
         settle: float = DEFAULT_APP_SETTLE,
+        *,
+        request_timeout: float = DEFAULT_REQUEST_TIMEOUT,
     ) -> Driver:
         """Block until the next app connects out, returning a :class:`Driver`.
 
@@ -476,6 +502,10 @@ class Bridge:
         ``settle``, and if the current candidate has already closed it keeps
         waiting (up to ``timeout``) for the replacement. Pass ``settle=0`` to opt
         out (take the first arrival immediately). See :data:`DEFAULT_APP_SETTLE`.
+
+        ``request_timeout`` sets the returned Driver's default per-command timeout
+        — the live-connect / SFTP suites raise it via
+        :data:`LIVE_CONNECT_REQUEST_TIMEOUT` (issue #2460).
         """
         if self._loop is None or self._conn_queue is None:
             raise RuntimeError("bridge is not started")
@@ -488,7 +518,7 @@ class Bridge:
             raise TimeoutError(
                 f"no app connected to the bridge within {timeout}s"
             ) from exc
-        return Driver(connection, self._loop)
+        return Driver(connection, self._loop, request_timeout=request_timeout)
 
     async def _acquire_settled(self, timeout: float, settle: float) -> "_Connection":
         """Pop a connection, then prefer a newer/surviving one (see wait_for_app).

--- a/tests/system/termihub_harness/systemtest.py
+++ b/tests/system/termihub_harness/systemtest.py
@@ -35,7 +35,7 @@ from typing import Callable, ClassVar, Optional, TypeVar
 
 import pytest
 
-from .bridge import Bridge, BridgeError, Driver
+from .bridge import DEFAULT_REQUEST_TIMEOUT, Bridge, BridgeError, Driver
 from .display import ensure_local_display
 from .orchestrator import AppInstance
 
@@ -68,6 +68,15 @@ class SystemTest:
 
     #: Whether :meth:`delay4user` actually sleeps. Set from ``--delay4user``.
     _delay_enabled: ClassVar[bool] = False
+
+    #: Per-suite default for the bridge command timeout (seconds). The
+    #: live-SSH-connect / SFTP suites raise this to
+    #: :data:`~termihub_harness.bridge.LIVE_CONNECT_REQUEST_TIMEOUT` because a real
+    #: session negotiates while the always-on Docker/``krunkit`` VMs starve the
+    #: WKWebView JS thread for >10s, and the default fires mid-negotiation
+    #: (issue #2460). Left at the harness default for every other suite so it does
+    #: not slow the common path.
+    request_timeout: ClassVar[float] = DEFAULT_REQUEST_TIMEOUT
 
     @pytest.fixture(scope="class", autouse=True)
     @classmethod
@@ -106,7 +115,7 @@ class SystemTest:
         bridge = Bridge().start()
         try:
             app.start(bridge.port)
-            driver = bridge.wait_for_app()
+            driver = bridge.wait_for_app(request_timeout=request.cls.request_timeout)
         except BaseException:
             bridge.close()
             app.cleanup()
@@ -181,4 +190,6 @@ class SystemTest:
         :class:`~termihub_harness.ui.ConfigRecoveryUi`).
         """
         self.app.restart(between)
-        type(self).driver = self.bridge.wait_for_app()
+        type(self).driver = self.bridge.wait_for_app(
+            request_timeout=type(self).request_timeout
+        )

--- a/tests/system/tests/test_artifacts.py
+++ b/tests/system/tests/test_artifacts.py
@@ -32,13 +32,18 @@ class _StubDriver:
         self._state = state if state is not None else {"activePanelId": "p1"}
         self._terminal = terminal
         self._state_exc = state_exc
+        #: The last ``timeout`` the probes passed — so a test can assert the
+        #: failure path uses the long diagnostic timeout (#2460).
+        self.timeouts_seen: list = []
 
-    def get_state(self):
+    def get_state(self, *, timeout=None):
+        self.timeouts_seen.append(timeout)
         if self._state_exc is not None:
             raise self._state_exc
         return self._state
 
-    def read_terminal(self):
+    def read_terminal(self, *, timeout=None):
+        self.timeouts_seen.append(timeout)
         return self._terminal
 
 
@@ -50,7 +55,8 @@ class _ScreenshotDriver(_StubDriver):
         self._data_url = data_url
         self._screenshot_exc = screenshot_exc
 
-    def screenshot(self):
+    def screenshot(self, *, timeout=None):
+        self.timeouts_seen.append(timeout)
         if self._screenshot_exc is not None:
             raise self._screenshot_exc
         return self._data_url
@@ -121,6 +127,42 @@ def test_screenshot_capture_error_is_recorded_not_raised(tmp_path: Path):
     assert (dest / "screenshot.png.error.txt").read_text() == "RuntimeError: capture gone"
     # The other probes still ran independently.
     assert (dest / "terminal.txt").read_text() == "$ ls\n"
+
+
+def test_writes_probe_diagnostics_with_timed_records(tmp_path: Path):
+    # The bundle records a timed line per probe — the #2460 slow-vs-hung signal.
+    driver = _ScreenshotDriver(
+        data_url=f"data:image/png;base64,{_PNG_1X1}", terminal="$ ls\n"
+    )
+    app = _StubApp(log="app booted\n")
+    dest = write_failure_artifacts(tmp_path / "diag", driver, app)
+    text = (dest / "probe-diagnostics.txt").read_text()
+    for name in ("state.json", "terminal.txt", "screenshot.png", "app.log"):
+        assert f"{name}: ok in " in text
+    assert "#2460" in text
+
+
+def test_probe_diagnostics_records_a_failed_probe_as_timed(tmp_path: Path):
+    # A hung/slow probe that raises (e.g. a bridge timeout) is recorded as a
+    # timed FAILED line, not silently dropped — the definitive #2460 evidence.
+    driver = _StubDriver(state_exc=RuntimeError("command timed out after 60.0s"))
+    dest = write_failure_artifacts(tmp_path / "hung", driver, None)
+    text = (dest / "probe-diagnostics.txt").read_text()
+    assert "state.json: FAILED after" in text
+    assert "RuntimeError: command timed out after 60.0s" in text
+
+
+def test_probe_diagnostics_written_even_with_no_driver_or_app(tmp_path: Path):
+    dest = write_failure_artifacts(tmp_path / "empty", None, None)
+    assert (dest / "probe-diagnostics.txt").read_text().strip().endswith("no probes ran")
+
+
+def test_failure_probes_use_the_long_diagnostic_timeout(tmp_path: Path):
+    # The failure path must outlive the live path's own (possibly raised) command
+    # timeout, so every bridge probe runs with DIAGNOSTIC_PROBE_TIMEOUT (#2460).
+    driver = _ScreenshotDriver(data_url=f"data:image/png;base64,{_PNG_1X1}")
+    write_failure_artifacts(tmp_path / "to", driver, None, probe_timeout=42.0)
+    assert driver.timeouts_seen == [42.0, 42.0, 42.0]
 
 
 def test_save_manual_screenshot_writes_png_and_returns_a_path(tmp_path, monkeypatch):

--- a/tests/system/tests/test_roundtrip.py
+++ b/tests/system/tests/test_roundtrip.py
@@ -5,9 +5,11 @@ correlation, the synchronous Driver, and sequential-connection / restart
 support) without depending on a real build, so they run anywhere and fast.
 """
 
+import time
+
 import pytest
 
-from termihub_harness import BridgeError
+from termihub_harness import LIVE_CONNECT_REQUEST_TIMEOUT, BridgeError
 from fake_app import FakeApp, dispatcher_like
 
 
@@ -253,3 +255,26 @@ def test_wait_for_app_settle_zero_takes_the_first_arrival(bridge):
     with first, second:
         driver = bridge.wait_for_app(timeout=5, settle=0)
         assert "first" in driver.read_terminal()
+
+
+def test_request_timeout_sets_the_driver_default(bridge):
+    # The live-connect suites raise the per-command timeout via this path (#2460).
+    with FakeApp(bridge.port, dispatcher_like()):
+        driver = bridge.wait_for_app(timeout=5, request_timeout=LIVE_CONNECT_REQUEST_TIMEOUT)
+        assert driver._timeout == LIVE_CONNECT_REQUEST_TIMEOUT
+
+
+def test_per_call_timeout_override_is_honored(bridge):
+    # A slow handler lets a tight per-call timeout fire while the driver default
+    # comfortably outlasts it — the mechanism the failure-artifact probes use to
+    # capture evidence with a longer timeout than the live path (#2460).
+    def slow_handler(command):
+        time.sleep(0.4)
+        return {"ok": True, "action": command.get("action"), "value": {}}
+
+    with FakeApp(bridge.port, slow_handler):
+        driver = bridge.wait_for_app(timeout=5)
+        with pytest.raises(BridgeError):
+            driver.get_state(timeout=0.05)
+        # The generous default (10s) rides out the same slow handler.
+        assert driver.get_state() == {}

--- a/tests/system/tests/test_ssh.py
+++ b/tests/system/tests/test_ssh.py
@@ -16,6 +16,7 @@ import time
 import pytest
 
 from termihub_harness import (
+    LIVE_CONNECT_REQUEST_TIMEOUT,
     ConnectionsUi,
     MonitoringUi,
     PasswordPromptUi,
@@ -38,6 +39,10 @@ HOST = "127.0.0.1"
 @pytest.mark.usefixtures("ssh_fixtures")
 class TestSshPasswordAuth(TerminalUi, TabsUi, ConnectionsUi, PasswordPromptUi, SystemTest):
     """SSH-01: password authentication opens a working terminal tab."""
+
+    # Live SSH connect: the WKWebView JS thread is starved by the always-on
+    # Docker/krunkit VMs during negotiation, so raise the command timeout (#2460).
+    request_timeout = LIVE_CONNECT_REQUEST_TIMEOUT
 
     def test_connects_with_password_and_opens_a_tab(self):
         name = unique_name("ssh-pass")
@@ -243,6 +248,10 @@ class TestSshServerDisconnect(TerminalUi, TabsUi, ConnectionsUi, PasswordPromptU
     (``terminal-exit`` with ``reason: "dropped"``) and shows the disconnect
     overlay rather than entering the calmer clean-exit / view-mode path.
     """
+
+    # Live SSH connect + disconnect: raise the command timeout to ride out the
+    # WKWebView JS-thread starvation under the always-on Docker/krunkit VMs (#2460).
+    request_timeout = LIVE_CONNECT_REQUEST_TIMEOUT
 
     def test_handles_server_disconnect(self):
         control = SshServerControl()

--- a/tests/system/tests/test_transfer_queue.py
+++ b/tests/system/tests/test_transfer_queue.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import pytest
 
 from termihub_harness import (
+    LIVE_CONNECT_REQUEST_TIMEOUT,
     ConnectionsUi,
     FilesUi,
     PasswordPromptUi,
@@ -149,6 +150,11 @@ class TestTransferQueueLiveTransfer(
     so it does not pull in the ``ssh-keys`` image the broader ``ssh_fixtures``
     would build.
     """
+
+    # Live SFTP connect + transfer: raise the command timeout so a WKWebView
+    # JS thread starved by the always-on Docker/krunkit VMs still completes each
+    # verb instead of tripping the default 10s mid-negotiation (#2460).
+    request_timeout = LIVE_CONNECT_REQUEST_TIMEOUT
 
     # A size that is big enough for the 256 KiB chunk loop to emit several
     # throttled (~10 Hz) progress updates, but small enough that the paste


### PR DESCRIPTION
Part of #2460 — harness robustness improvements from the live-connect investigation. Does **not** close #2460 (the live suite is still blocked by a distinct, now-characterized bug — see below and the new follow-up).

## What this lands
- **Raised the live-connect bridge verb timeout** so live-connect/SFTP verbs no longer false-fail at the 10s default under WKWebView JS-thread stalls. This alone changed the failure signature from `command timed out after 10.0s` to a real, fast (123s) assertion, proving the webview is **not hung** — bridge commands return.
- **Capture webview evidence (console + screenshot) on timeout** via a separate longer timeout on the failure path, so future live-connect failures produce real diagnostics instead of an opaque 10s timeout.
- Supporting artifact/roundtrip harness plumbing + tests.

## What is NOT fixed (follow-up filed)
With the raised timeout, the live SSH-**password** suites still fail — but now at a specific, real step: the connection editor's password field never renders when auth is switched to `password` via the harness, so the form never validates. Root-caused to `isFieldVisible(f, watchedValues)` (RHF watched state) not updating when `selectRadixOption` drives the authMethod dropdown in the live WKWebView. Filed as a dedicated Ready2Implement follow-up (referenced on #2460). Blocks the live half of #2398 and #2447.