### PR TITLE
fix(ui): accept null for optional connection form fields (part of #2467)

### DIFF
--- a/docs/changes/dev0/fix/2467-radix-select-rhf-propagation.md
+++ b/docs/changes/dev0/fix/2467-radix-select-rhf-propagation.md
@@ -5,7 +5,7 @@
   field is reset to `null` so a shared-name field cannot leak the previous
   type's value (#1820) — but the client-side form validator (zod) treated a
   `null` optional field as invalid input. Any optional field left at its default
-  (e.g. an SSH connection's Advanced *Shell* or *Connect timeout*) then reported
+  (e.g. an SSH connection's Advanced _Shell_ or _Connect timeout_) then reported
   a spurious "Invalid input", so the form never became valid and both save
   buttons remained greyed out. Optional fields now accept `null` as "empty", so
   a connection with untouched optional fields validates and saves as expected

--- a/docs/changes/dev0/fix/2467-radix-select-rhf-propagation.md
+++ b/docs/changes/dev0/fix/2467-radix-select-rhf-propagation.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- The connection editor's **Save** / **Save & Connect** could stay disabled for
+  a fully valid connection. When you switched the connection **Type**, every
+  field is reset to `null` so a shared-name field cannot leak the previous
+  type's value (#1820) — but the client-side form validator (zod) treated a
+  `null` optional field as invalid input. Any optional field left at its default
+  (e.g. an SSH connection's Advanced *Shell* or *Connect timeout*) then reported
+  a spurious "Invalid input", so the form never became valid and both save
+  buttons remained greyed out. Optional fields now accept `null` as "empty", so
+  a connection with untouched optional fields validates and saves as expected
+  (#2467).

--- a/src/components/DynamicForm/settingsSchemaToZod.test.ts
+++ b/src/components/DynamicForm/settingsSchemaToZod.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { settingsSchemaToZod } from "./settingsSchemaToZod";
-import type { SettingsSchema } from "@/types/schema";
+import type { FieldType, SettingsSchema } from "@/types/schema";
 
 function makeSchema(fields: SettingsSchema["groups"][0]["fields"]): SettingsSchema {
   return { groups: [{ key: "g", label: "Group", fields }] };
@@ -165,6 +165,64 @@ describe("settingsSchemaToZod", () => {
       expect(zod.safeParse({ volumes: [{ host: "/a", container: "/b" }] }).success).toBe(true);
       expect(zod.safeParse({ volumes: [] }).success).toBe(true);
       expect(zod.safeParse({}).success).toBe(true);
+    });
+  });
+
+  // Regression for #2467: when the connection type changes, ConnectionSettingsForm
+  // clears every field to `null` (not `undefined`) so react-hook-form's per-name
+  // value cache cannot leak the previous type's value (#1820). A bare
+  // `.optional()` accepts only `undefined`, so those `null`-cleared optional
+  // fields (e.g. SSH Advanced `shell` / `connectTimeoutSecs`) failed validation
+  // as "Invalid input", leaving Save & Connect permanently disabled for SSH.
+  // Optional fields must therefore also accept `null`.
+  describe("optional fields accept null (type-switch clears to null, #2467)", () => {
+    it("optional text/password/filePath/serialPort accept null", () => {
+      const types: FieldType["type"][] = ["text", "password", "filePath", "serialPort"];
+      for (const type of types) {
+        const zod = settingsSchemaToZod(
+          makeSchema([{ key: "f", label: "F", fieldType: { type } as FieldType, required: false }])
+        );
+        expect(zod.safeParse({ f: null }).success).toBe(true);
+      }
+    });
+
+    it("optional number accepts null", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([
+          { key: "n", label: "N", fieldType: { type: "number", min: 0 }, required: false },
+        ])
+      );
+      expect(zod.safeParse({ n: null }).success).toBe(true);
+    });
+
+    it("optional port accepts null", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([{ key: "port", label: "Port", fieldType: { type: "port" }, required: false }])
+      );
+      expect(zod.safeParse({ port: null }).success).toBe(true);
+    });
+
+    it("boolean/keyValueList/objectList accept null", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([
+          { key: "flag", label: "Flag", fieldType: { type: "boolean" }, required: false },
+          { key: "env", label: "Env", fieldType: { type: "keyValueList" }, required: false },
+          {
+            key: "vols",
+            label: "Vols",
+            fieldType: { type: "objectList", fields: [] },
+            required: false,
+          },
+        ])
+      );
+      expect(zod.safeParse({ flag: null, env: null, vols: null }).success).toBe(true);
+    });
+
+    it("a required field still rejects null", () => {
+      const zod = settingsSchemaToZod(
+        makeSchema([{ key: "host", label: "Host", fieldType: { type: "text" }, required: true }])
+      );
+      expect(zod.safeParse({ host: null }).success).toBe(false);
     });
   });
 

--- a/src/components/DynamicForm/settingsSchemaToZod.ts
+++ b/src/components/DynamicForm/settingsSchemaToZod.ts
@@ -7,6 +7,15 @@ import type { SettingsField, SettingsSchema } from "@/types/schema";
  * Maps each field type to its corresponding zod validator with appropriate
  * bounds. Backend validation in Agent.connect remains authoritative; this
  * schema is for UX feedback only.
+ *
+ * Optional fields use `.nullish()` (accepts `undefined` **and** `null`) rather
+ * than `.optional()` (which accepts only `undefined`): when the connection type
+ * changes, {@link import("./ConnectionSettingsForm")} clears every field to
+ * `null` — not `undefined` — so react-hook-form's per-name value cache cannot
+ * leak the previous type's value (#1820). A bare `.optional()` then rejected
+ * those `null`-cleared optional fields (e.g. SSH Advanced `shell` /
+ * `connectTimeoutSecs`) as "Invalid input", leaving the form invalid and Save &
+ * Connect permanently disabled for SSH (#2467).
  */
 export function settingsSchemaToZod(schema: SettingsSchema) {
   const shape: Record<string, z.ZodTypeAny> = {};
@@ -28,18 +37,18 @@ function fieldToZod(field: SettingsField): z.ZodTypeAny {
         .int("Must be an integer")
         .min(1, "Port must be between 1 and 65535")
         .max(65535, "Port must be between 1 and 65535");
-      return field.required ? portSchema : portSchema.optional();
+      return field.required ? portSchema : portSchema.nullish();
     }
 
     case "number": {
       let num = z.number();
       if (ft.min !== undefined) num = num.min(ft.min, `Must be at least ${ft.min}`);
       if (ft.max !== undefined) num = num.max(ft.max, `Must be at most ${ft.max}`);
-      return field.required ? num : num.optional();
+      return field.required ? num : num.nullish();
     }
 
     case "boolean":
-      return z.boolean().optional();
+      return z.boolean().nullish();
 
     case "select":
       return z.string();
@@ -50,13 +59,13 @@ function fieldToZod(field: SettingsField): z.ZodTypeAny {
     case "serialPort":
       return field.required
         ? z.string().min(1, `${field.label} is required`)
-        : z.string().optional();
+        : z.string().nullish();
 
     case "keyValueList":
-      return z.array(z.object({ key: z.string(), value: z.string() })).optional();
+      return z.array(z.object({ key: z.string(), value: z.string() })).nullish();
 
     case "objectList":
-      return z.array(z.record(z.string(), z.unknown())).optional();
+      return z.array(z.record(z.string(), z.unknown())).nullish();
 
     case "notice":
       // Display-only callout — carries no value, so it never affects validity.


### PR DESCRIPTION
## Summary

Part of `#2467`. The live SSH-**password** E2E suites could not be driven green
because the connection editor's **Save & Connect** stayed disabled
(`connection-editor-save data-invalid='true'`) after switching auth to
`password`.

**The diagnosed cause differs from the issue's hypothesis.** The issue guessed a
harness `select` → react-hook-form propagation bug (password field never
rendering). Live diagnosis on the current `develop` (after #2462/#2466) shows the
harness `select` propagates **correctly** — after selecting `password`,
`watch('authMethod')` and `getValues('authMethod')` are both `"password"`, the
key-path field hides, and (in credential-store `none` mode) the password field is
correctly absent by design.

The real blocker: `settingsSchemaToZod` mapped optional fields to zod's
`.optional()`, which accepts only `undefined` — **not `null`**. When the
connection **Type** changes, `ConnectionSettingsForm` resets every field to
`null` (not `undefined`) so react-hook-form's per-name value cache cannot leak
the previous type's value (#1820). Any optional field left at its default then
failed validation as `"Invalid input"`:

```
[diag after-select] watch="password" getValues="password" valid=false
  errors={"shell":"Invalid input","connectTimeoutSecs":"Invalid input"}
```

`shell` and `connectTimeoutSecs` (SSH Advanced) are visible, `null`, and optional
→ zod rejects `null` → `schemaValid=false` → `canSave=false` → both save buttons
stay disabled. This is a **user-facing** bug, not test-only: creating an SSH
connection with untouched Advanced fields could not be saved.

## Fix

Optional fields now use `.nullish()` (accepts `undefined` **and** `null`) instead
of `.optional()`. A `null`-cleared optional field is treated as empty; required
fields still reject `null`.

## Tests

- **Unit (per-PR-CI protected):** new regression in `settingsSchemaToZod.test.ts`
  — optional text/password/filePath/serialPort/number/port/boolean/list fields
  accept `null`; a required field still rejects it. Red before the fix, green
  after. This guards the regression without needing live E2E.
- **Live (bridge harness, macOS WKWebView):** with the fix,
  `TestSshPasswordAuth::test_connects_with_password_and_opens_a_tab`,
  `TestSshPasswordAuth::test_terminal_becomes_live_after_connect`, and
  `TestSshPasswordPromptFlow::test_prompt_appears_on_connect` **pass** — the form
  validates, Save & Connect enables, the password prompt appears, the connection
  opens, and the terminal goes live. This is the core of `#2467`.

## Live suites not fully green here — machine load, not this change

The broader live suites named on `#2467` / `#2398` / `#2447`
(`TestTransferQueueLiveTransfer`, `TestSshServerDisconnect`,
`TestSshKeyAuthUi`, some `TestSshPasswordPromptFlow`) still fail on this machine,
but **flakily and downstream of the form-validity gate this PR fixes** — they get
past Save & Connect, then time out in the live SSH/SFTP session or server-side
probes. Evidence it is load, not a defect:

- `TestSshPasswordPromptFlow::test_connects_after_entering_password` **flipped
  FAILED → PASSED** across two identical back-to-back runs.
- `TestSshServerDisconnect::test_handles_server_disconnect` connects, handles the
  password prompt, and opens the terminal, then fails only at the server-side
  `assert new_pids` sshd-session probe (`assert set()`).
- Transfer-queue failures are `sftpStatus does not resolve` / SFTP-connect
  timeouts.

Machine state during the runs (this is the #2460 WKWebView-starvation condition
the issue warns about — the machine was **not** actually quiet):

- `com.apple.Virtualization.VirtualMachine` pegged at **~98% CPU**.
- **31** running Docker containers (mostly 6–12-day-old orphan
  `termihub-<timestamp>-<pid>` session leftovers, plus another slot's fixtures).
- load average 15-min **~10** on 10 cores.

Per the shared-machine rules I did not kill any containers/processes I did not
start.

## Recommendation

Merge the fix + regression (root cause resolved, primary password-auth suite
green). Re-verify the `TestTransferQueueLiveTransfer` / `TestSshServerDisconnect`
live cases (`#2398` live half, `#2447` live disconnect) on a genuinely quiet
machine before closing those; a sweep of the ~27 orphan `termihub-*` containers
would remove the standing VM load.

Refs `#2467`, `#2398`, `#2447`, `#2460`.
