### PR TITLE
test(system): live-verify SSH host-key + disconnect + transfer-queue harness (Closes #2447)

### DIFF
--- a/tests/system/termihub_harness/ui/passwordprompt.py
+++ b/tests/system/termihub_harness/ui/passwordprompt.py
@@ -8,6 +8,8 @@ password-auth suites drive it directly.
 
 from __future__ import annotations
 
+import time
+
 from ..bridge import BridgeError
 from ..fixtures import SSH_PASSWORD
 from .base import HarnessMixin
@@ -19,6 +21,49 @@ class PasswordPromptUi(HarnessMixin):
     def password_prompt_open(self) -> bool:
         """Whether the SSH password prompt modal is currently open."""
         return bool(self.driver.get_state("passwordPromptOpen"))
+
+    def accept_host_key_prompt(self, *, remember: bool = True, timeout: float = 20.0) -> bool:
+        """Accept the interactive SSH host-key trust prompt (#1959) if one appears.
+
+        Since #1959 the SSH handshake blocks on an ``ssh-host-key-prompt`` the
+        first time a connection sees an untrusted host key — which every fresh
+        test app instance is, connecting to a throwaway config dir with no
+        remembered keys. The prompt (``ssh-hostkey-prompt``) is a global modal the
+        user must answer; nothing else does, so an un-answered prompt leaves the
+        connection hung mid-handshake: no server-side session is ever created and
+        an auto-connecting SFTP browser never reaches ``connected``. That is what
+        stalled the live transfer-queue and server-disconnect suites (#2398 /
+        #2447) — the terminal's xterm still mounts (so ``has_terminal`` passes),
+        masking that the connection never actually completed.
+
+        Prompt ordering on a password connect is: password prompt (to gather the
+        secret) → TCP connect → **host-key** prompt during the handshake. So this
+        is answered *after* :meth:`handle_password_prompt`, not before.
+
+        ``remember`` clicks "Accept for host" (persist to this instance's trust
+        store) so the terminal, its SFTP session, and any reconnect within the
+        same app instance are not re-prompted; ``remember=False`` clicks "Accept
+        once". Tolerant by design: a host already trusted this run raises no
+        prompt, so this returns ``False`` instead of failing — and it short-circuits
+        as soon as the active terminal has printed real output (the connection
+        completed without a prompt). Returns ``True`` when it accepted one.
+        """
+        button = "ssh-hostkey-accept-remember" if remember else "ssh-hostkey-accept-once"
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                if self.driver.exists("ssh-hostkey-prompt"):
+                    self.driver.click(button)
+                    return True
+                # No prompt and the terminal already shows a shell prompt => the
+                # host was trusted, the handshake completed, nothing to accept.
+                if self.driver.read_terminal().strip():
+                    return False
+            except BridgeError:
+                # No active terminal yet / modal mounting — treat as "not ready".
+                pass
+            time.sleep(0.25)
+        return False
 
     def handle_password_prompt(self, password: str = SSH_PASSWORD) -> None:
         """Wait for the SSH password prompt, enter ``password``, and click Connect.

--- a/tests/system/termihub_harness/ui/ssh.py
+++ b/tests/system/termihub_harness/ui/ssh.py
@@ -23,13 +23,20 @@ class SshUi(HarnessMixin):
         def create_ssh_connection(self, name: str, *, host: str, port: int, username: str,
                                   auth_method: str = ..., key_path=..., connect: bool = ...) -> None: ...
         def handle_password_prompt(self, password: str = ...) -> None: ...
+        def accept_host_key_prompt(self, *, remember: bool = ..., timeout: float = ...) -> bool: ...
         def has_terminal(self) -> bool: ...
 
     def connect_ssh_password(self, name: str, *, port: int = SSH_PASSWORD_PORT) -> None:
         """Create + Save & Connect a password SSH connection, answer the prompt,
-        and wait for its terminal — the sequence nearly every SSH suite repeats."""
+        and wait for its terminal — the sequence nearly every SSH suite repeats.
+
+        Accepts the host-key trust prompt (#1959) that the first connect to a
+        fresh app instance's untrusted host raises mid-handshake: without it the
+        connection hangs and no session is ever established (#2398 / #2447).
+        """
         self.create_ssh_connection(
             name, host=SSH_HOST, port=port, username=SSH_USERNAME, connect=True
         )
         self.handle_password_prompt()
+        self.accept_host_key_prompt()
         self.wait(self.has_terminal, what="the SSH terminal session")

--- a/tests/system/tests/test_ssh.py
+++ b/tests/system/tests/test_ssh.py
@@ -271,13 +271,24 @@ class TestSshServerDisconnect(TerminalUi, TabsUi, ConnectionsUi, PasswordPromptU
             connect=True,
         )
         self.handle_password_prompt()
+        # Trust the server's host key so the handshake completes — otherwise the
+        # #1959 prompt blocks it and no server-side session is ever created (#2447).
+        self.accept_host_key_prompt()
         tab = self.wait(lambda: self.find_tab(name), what="the SSH tab")
         self.wait(self.has_terminal, what="the SSH terminal session")
         tab_id = tab["id"]
 
-        # Drop *only* this connection's sshd session at the server.
-        new_pids = control.session_pids() - pids_before
-        assert new_pids, "expected a new sshd session for the SSH connection"
+        # Drop *only* this connection's sshd session at the server. The server-side
+        # sshd session process appears asynchronously *after* the client initiates
+        # the connection, and ``has_terminal`` above only proves the xterm mounted
+        # and is readable — which happens while the tab is still ``terminalConnecting``,
+        # a moment before the SSH handshake registers the session on the server. A
+        # single-shot read therefore raced and saw an empty diff (#2447); poll until
+        # the new session PID appears instead.
+        new_pids = self.wait(
+            lambda: (control.session_pids() - pids_before) or False,
+            what="a new sshd session for the SSH connection",
+        )
         control.kill_sessions(new_pids)
 
         # The client must surface the disconnect: the tab's session is marked

--- a/tests/system/tests/test_transfer_queue.py
+++ b/tests/system/tests/test_transfer_queue.py
@@ -132,6 +132,17 @@ class TransferQueueReads(ProjectionHarness):
         )
 
 
+@pytest.mark.xfail(
+    reason=(
+        "#2469: an SSH SFTP session-to-session copy/paste is an unconditional "
+        "byte-based read/write round-trip (useSessionFileSystem.pasteEntry) that "
+        "registers no tracked transfer, so the region-fed Transfer Queue stays "
+        "empty. The connect/host-key/SFTP-open/navigation harness gaps this suite "
+        "hit are fixed (#2398); the remaining failure is the product gap in #2469. "
+        "Remove this marker once #2469 lands."
+    ),
+    strict=False,
+)
 @pytest.mark.usefixtures("ssh_password_fixtures")
 class TestTransferQueueLiveTransfer(
     TerminalUi,
@@ -162,22 +173,27 @@ class TestTransferQueueLiveTransfer(
     FILE_MB = 8
 
     def open_sftp_browser(self) -> str:
-        """Show the Files sidebar, clear any password prompt, await the listing."""
+        """Show the Files sidebar, clear any password prompt, await the listing.
+
+        Readiness is gated on the file-browser path bar rendering a path, not on a
+        ``sftpStatus`` store read: that top-level slice was retired when SFTP UI
+        state moved onto the projected file-browser region (the render-cut /
+        ``fileBrowser.*`` migration), so ``get_state("sftpStatus")`` no longer
+        resolves and the wait timed out immediately (#2398). The shared
+        ``SftpUi.connect_sftp_browser`` already gates on the same DOM signal — a
+        rendered path is the region-fed "SFTP connected and listing" signal — so
+        this mirrors it rather than reading a slice that no longer exists.
+        """
         self.switch_to_files_sidebar()
         self.wait(
             lambda: self.driver.exists("password-prompt-input")
-            or self.driver.get_state("sftpStatus") == "connected",
+            or self.driver.exists(self.CURRENT_PATH),
             what="the SFTP browser or its password prompt",
         )
-        # Gate on the store's liveness signal, not a stale DOM check: the SFTP
-        # session can auto-resolve the prompt from a cached credential, and
+        # The SFTP session can auto-resolve the prompt from a cached credential, and
         # ``handle_password_prompt`` then tolerates it closing under us (#1593).
         if self.password_prompt_open():
             self.handle_password_prompt()
-        self.wait(
-            lambda: self.driver.get_state("sftpStatus") == "connected",
-            what="the SFTP session to connect",
-        )
         return self.wait(lambda: self.file_browser_path() or False, what="the remote path")
 
     def test_real_sftp_paste_populates_the_transfer_queue(self):
@@ -194,13 +210,22 @@ class TestTransferQueueLiveTransfer(
         dest = f"destdir-{unique_name('tq')}"
 
         self.connect_ssh_password(unique_name("transfer-queue"))
-        source_dir = self.open_sftp_browser()
+        self.open_sftp_browser()
 
         # Seed a source file and an empty destination directory.
         self.run_command(f"dd if=/dev/zero of={name} bs=1M count={self.FILE_MB} 2>/dev/null")
         self.run_command(f"mkdir -p {dest}")
         self.run_command("sync")
         self.wait_for_file_row(name)
+
+        # Read the settled remote working directory only now, not from
+        # open_sftp_browser's return: a freshly-connected SFTP browser first
+        # renders the transient pre-cwd-follow root ("/") before it follows the
+        # terminal into the login directory, so capturing the path up front yielded
+        # "/" and every "<base>/<dest>" comparison below was built on the wrong base
+        # (#2398). Listing `name` proves the browser has settled on the directory
+        # that actually holds it, so the breadcrumb path is now the real base.
+        source_dir = self.file_browser_path()
 
         # Copy the source file, then paste it inside the destination directory.
         # Paste is driven from the toolbar button rather than the row context


### PR DESCRIPTION
Live verification of the #2467 / #2398 / #2447 fixes on `develop` (after #2468/#2466/#2464/#2462 landed), run against the always-on Docker `ssh-password` fixture on a quiet machine. Fixes the harness gaps found and reports one real product gap.

## Results (live, `./scripts/test-system-py.sh -m integration`)

`3 passed, 2 xfailed`

| Issue | Suite | Verdict |
| --- | --- | --- |
| **#2467** | `test_ssh.py::TestSshPasswordAuth` (both) | **PASS** — the SSH password connect flow is green live (the #2468 `.nullish()` form-validity fix). |
| **#2447** | `test_ssh.py::TestSshServerDisconnect::test_handles_server_disconnect` | **PASS** — a real server-side disconnect drives the Disconnected state. `Closes #2447`. |
| #2398 | `test_transfer_queue.py::TestTransferQueueLiveTransfer` (both) | **xfail** — blocked on a real product gap, #2469 (not a harness race). |

## Harness fixes

1. **Host-key trust prompt (the big one).** The interactive host-key trust prompt (#1959) blocks the SSH handshake the first time a fresh test app instance connects to an untrusted host, and nothing in the harness answered it — so every live SSH connection hung mid-handshake: no server session formed, SFTP never connected. The terminal's xterm still mounts, so `has_terminal` passed and masked it. Added `PasswordPromptUi.accept_host_key_prompt` (tolerant; "Accept for host") and wired it into `SshUi.connect_ssh_password` and the disconnect test. This is what unblocked both #2398 and #2447.
2. **Disconnect sshd-PID race.** Poll for the new server-side sshd session after connect instead of reading it once (it was read while the tab was still `terminalConnecting`).
3. **Transfer-queue SFTP open.** Gate on the file-browser path bar, not the retired `sftpStatus` store slice (removed in the SFTP region migration).
4. **Transfer-queue base path.** Read the remote base path only after the browser settles on the login dir — `open_sftp_browser` could return the transient pre-cwd-follow root `/`.

## Real product gap → #2469 (kept #2398 open)

With the harness gaps fixed, the live transfer-queue test now reaches its true limit: an **SSH SFTP session-to-session copy/paste** is an unconditional byte-based `session_read_file` + `session_write_file` round-trip (`useSessionFileSystem.pasteEntry`) that registers **no tracked transfer**, so the region-fed Transfer Queue never populates. The file copies correctly; only the queue tracking is missing. Filed as #2469 (`Ready2Implement`). The two `TestTransferQueueLiveTransfer` tests are `xfail (strict=False)` referencing #2469; remove the marker when it lands.

Part of #2398 (do not close — pending #2469).

Test-only changes; integration tests do not run in per-PR CI, so this was verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)