### PR TITLE
fix(backend): scrub retained request on non-loop drop (part of #2455)

### DIFF
--- a/src-tauri/src/session/retained_request.rs
+++ b/src-tauri/src/session/retained_request.rs
@@ -210,6 +210,53 @@ mod tests {
     }
 
     #[test]
+    fn retain_and_clear_agent_request_carries_and_scrubs_agent_id() {
+        // #2455: the same store retains a resilient **agent** request (agent_id
+        // Some) so the backend redrive can re-establish the transport through the
+        // agent. The store must round-trip the agent_id (for the redrive) and
+        // clear must drop + zeroize it just like a direct request — an agent-tab
+        // drop mirrors `session.dropped`, whose scrub now routes through `clear`,
+        // so a leaked agent request there would regress Model A's secret
+        // guarantee.
+        let store = RetainedRequestStore::new();
+        store.retain(
+            "tab-agent",
+            RetainedConnectionRequest {
+                type_id: "ssh".to_string(),
+                settings: json!({ "host": "h", "password": "p" }),
+                agent_id: Some("agent-1".to_string()),
+                resilient: true,
+                backend_reattach: true,
+            },
+        );
+
+        let got = store.get("tab-agent").expect("retained agent request");
+        assert_eq!(
+            got.agent_id.as_deref(),
+            Some("agent-1"),
+            "the store round-trips the agent_id the redrive re-connects through"
+        );
+        assert_eq!(got.settings["password"], json!("p"));
+        assert!(got.backend_reattach);
+
+        store.clear("tab-agent");
+        assert!(
+            !store.contains("tab-agent"),
+            "clearing an agent request drops + zeroizes it (the `session.dropped` scrub point)"
+        );
+    }
+
+    #[test]
+    fn drop_zeroizes_agent_id() {
+        // The retained request's Drop must scrub the agent_id string in place, the
+        // same way it scrubs the settings secrets. Assert the mechanism `Drop`
+        // uses (`Zeroize` on the owned string) empties it.
+        let mut agent_id = "agent-secret-id".to_string();
+        agent_id.zeroize();
+        assert_eq!(agent_id, "");
+    }
+
+    #[test]
     fn retain_replaces_prior_request() {
         let store = RetainedRequestStore::new();
         store.retain(

--- a/src-tauri/src/session_projection/projection.rs
+++ b/src-tauri/src/session_projection/projection.rs
@@ -169,6 +169,17 @@ pub fn register_session_intents(registry: &mut HandlerRegistry, app_handle: AppH
         store.dropped(&id, optional_str(intent, "error"));
         let produced = publish_sessions(projector, &store);
         sync_timer(&handle, &id);
+        // A `session.dropped` is a terminal, **non-loop** drop: the tab did not
+        // arm the resilient-reconnect loop (a resilient drop folds
+        // `session.reconnect` instead, which keeps the request for the redrive).
+        // So the session is neither active nor reconnecting — scrub its retained
+        // request so no resolved secret outlives it (#2454 Model A mitigation).
+        // A no-op today (only resilient *direct* tabs retain, and they never fold
+        // `dropped`), but the mandatory scrub point once #2455 lets resilient
+        // **agent** tabs retain: an agent-tab drop mirrors `session.dropped`, so
+        // without this the agent request's resolved secret would outlive the
+        // session and regress Model A's guarantee.
+        clear_retained_request(&handle, &id);
         Ok(produced)
     });
 


### PR DESCRIPTION
Part of #2455 (Part 2 of #2446, retention Model A). Lands the **safe subset** — the secret-lifetime hardening (blocker 3 / decomposition step D) — and defers the rest to sequenced follow-ups after a design decision. Does **not** close #2455.

## Why the safe subset (and not the full agent redrive)

Moving agent silent-retry server-side cannot land as one clean, verifiable, byte-identical-flag-off PR that also keeps flag-ON correct, because the core blocker is a genuine **architecture decision**, not a mechanical port:

- The backend redrive (`redrive.rs`, #2464) already forwards `agent_id` into `create_connection`, but `create_connection(agent_id=Some)` → `RemoteProxy::connect` → `create_session` → `send_request` **fails with "Agent not connected" when the agent transport itself is down** — it never re-establishes the transport, so the reconnect can't succeed while it's down.
- The backend **does not retain agent config/credentials**: `RemoteAgentConfig`/`AgentSettings` are captured by value into the live per-agent I/O task (`agent_manager.rs:1708-1709`) and dropped on reap (~line 2004). The frontend store owns agent configs. So the hot path can't cold-re-establish a reaped agent transport without new infra or frontend involvement.
- `agent_manager` already runs its own server-side transport-reconnect loop; a session-level redrive loop must be **coordinated** with it to avoid double-reconnect/races.

`sessionBackendReattach` is already flippable (#2205 PR-B will flip it), so any *partial* agent wiring under the flag would make flag-ON a **broken, half-inverted hot path** for agents — explicitly what must not ship. Full details + the Option A/B fork are in the follow-ups.

## What this PR lands (byte-identical, flag-independent)

- **`session.dropped` now scrubs the retained connection request** (`session_projection/projection.rs`), matching the disconnect / cancel / remove / give-up routes. A `session.dropped` is a terminal, non-loop drop (a resilient drop folds `session.reconnect` instead), so the session is neither active nor reconnecting → drop + **zeroize** its retained request. This is a **no-op today** (only resilient *direct* tabs retain, and they never fold `dropped`) so behavior is byte-identical, but it is the **mandatory scrub point** for #2455: once resilient **agent** tabs retain, an agent-tab drop mirrors `session.dropped`, and without this the agent request's resolved secret would outlive the session and regress Model A's guarantee.
- **Store tests** proving `RetainedRequestStore` round-trips a resilient agent request's `agent_id` (which the redrive re-connects through) and that `clear`/`Drop` scrub it and its secret settings.

No flag is added; the existing default-off `sessionBackendReattach` is unchanged. Flag-ON semantics are unchanged (direct = backend-driven per #2454, agents = client-driven as before).

## Verification

- `cargo test --lib session::retained_request` (6/6) and `session_projection::projection` (17/17) green; `cargo fmt --check` and `cargo clippy --lib -- -D warnings` clean.
- Rust-only change; no TS/api surface touched.
- The `session.dropped` route validated by the same-pattern parity with the four sibling clearing routes (#2454) plus the manager-level `close_session_clears_the_retained_request` / `clear_retained_request_is_idempotent` tests and the new store-level agent-request scrub tests. (Live agent-drop verification is scoped into #2473, where the behavior it verifies actually lands.)

## Deferred (Ready2Implement follow-ups)

- **#2472** — backend agent-transport re-establishment for the redrive (the critical-path blocker + the Option A/B config-retention design decision + coordination with `agent_manager`'s transport loop).
- **#2473** — route resilient agent tabs into the backend redrive (`isResilientReconnectTab` flag-gated inclusion, `create_connection` retention for agents, server-side park, client silent-retry + mirror suppression under the flag) and the live agent-drop verification. Depends on #2472.

Once #2454 + #2473 verify, #2446 closes and #2205 PR-B can flip `sessionBackendReattach` and delete the client reconnect engine.
