### PR TITLE
feat(agent): backend agent-transport re-establishment for reconnect redrive (part of #2472)

### DIFF
--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -74,19 +74,33 @@ fn to_store_session(info: &AgentSessionInfo) -> StoreAgentSession {
 /// Async because SSH authentication + JSON-RPC handshake are blocking
 /// network operations that must not run on the main thread (which would
 /// freeze the WebView).
+///
+/// `backend_reattach` carries the client's default-off `sessionBackendReattach`
+/// flag (#2472). When `Some(true)`, the manager retains this agent's SSH
+/// transport config so the server-side reconnect redrive can cold-re-establish
+/// the transport after a reap; when absent/`false` (the develop path) nothing is
+/// retained and no agent secret survives a reap — byte-identical. The frontend
+/// does not thread this yet; it is wired with the agent-tab routing (#2473).
 #[tauri::command]
 pub async fn connect_agent(
     agent_id: String,
     config: RemoteAgentConfig,
     agent_settings: Option<AgentSettings>,
+    backend_reattach: Option<bool>,
     agent_manager: State<'_, Arc<dyn AgentRpcClient>>,
 ) -> Result<AgentConnectResult, String> {
     info!(agent_id, host = %config.host, "Connecting to remote agent");
     let manager = agent_manager.inner().clone();
     tauri::async_runtime::spawn_blocking(move || {
-        manager
+        let result = manager
             .connect_agent(&agent_id, &config, agent_settings.as_ref())
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string())?;
+        // Only an opted-in connect retains the reattach config (#2472); the
+        // default-off path leaves the store untouched.
+        if backend_reattach == Some(true) {
+            manager.retain_agent_config(&agent_id, &config, agent_settings.as_ref());
+        }
+        Ok(result)
     })
     .await
     .unwrap_or_else(|e| Err(e.to_string()))

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -1076,6 +1076,14 @@ impl SessionManager {
         self.retained_requests.get(tab_id)
     }
 
+    /// The agent RPC client, for the backend reconnect redrive to cold-re-establish
+    /// a reaped **agent** transport before re-creating the session (#2472). The
+    /// redrive lives in `session_projection`, so it reaches the client through
+    /// this accessor rather than the crate-private field.
+    pub(crate) fn agent_client(&self) -> Arc<dyn AgentRpcClient> {
+        self.agent_manager.clone()
+    }
+
     /// The frontend `tab_id` that owns a backend `session_id`, or `None` for a
     /// session created without a `connect_id` (no tab) or already removed (#2431).
     ///

--- a/src-tauri/src/session_projection/redrive.rs
+++ b/src-tauri/src/session_projection/redrive.rs
@@ -90,8 +90,11 @@ impl<R: Runtime> ReconnectRedrive for AppReconnectRedrive<R> {
             .unwrap_or(0);
 
         // Clone out the fields to forward before the secret-bearing request drops
-        // (its `Drop` zeroizes the clone). `agent_id` is always `None` for the
-        // direct connections this covers; the field is forwarded for #2455.
+        // (its `Drop` zeroizes the clone). `agent_id` is `Some` for a resilient
+        // **agent** tab (once #2473 routes them + retains the request): the redrive
+        // must cold-re-establish that agent's transport before re-creating the
+        // session, since `create_connection` → `create_session` fails "Agent not
+        // connected" when the SSH transport was reaped (#2472).
         let type_id = request.type_id.clone();
         let settings = request.settings.clone();
         let agent_id = request.agent_id.clone();
@@ -108,6 +111,41 @@ impl<R: Runtime> ReconnectRedrive for AppReconnectRedrive<R> {
         let manager = (*manager).clone();
         let tab_id = tab_id.to_string();
         tauri::async_runtime::spawn(async move {
+            // For a resilient **agent** tab, cold-re-establish the agent SSH
+            // transport from the backend-retained config (#2472) before minting
+            // the session. This models the client engine's "park while the agent
+            // reconnects": one loop attempt = one (re-establish + create) try, so
+            // the reconnect loop's own bounded backoff subsumes the client's
+            // `MAX_AGENT_SPAWN_ATTEMPTS`. The re-establish is a blocking SSH
+            // connect, so it runs on the blocking pool (as the connect command
+            // does). No-op when the agent is already connected — the in-task
+            // reconnect loop owns transient breaks, so the redrive never
+            // double-drives the transport.
+            if let Some(aid) = agent_id.as_deref() {
+                let client = manager.agent_client();
+                let aid_owned = aid.to_string();
+                let established = tauri::async_runtime::spawn_blocking(move || {
+                    client.reconnect_retained_agent(&aid_owned)
+                })
+                .await;
+                let transport_up = matches!(established, Ok(Ok(())));
+                if !transport_up {
+                    // Could not re-establish the agent transport this attempt:
+                    // fold a reconnect failure so the engine arms the next backoff
+                    // window or gives up, exactly as a failed session create would.
+                    let err = match established {
+                        Ok(Err(e)) => e.to_string(),
+                        _ => "agent transport re-establishment failed".to_string(),
+                    };
+                    fold_session_transition(&app, |store| {
+                        store.reconnect_failed(&tab_id, Some(err));
+                    });
+                    sync_timer(&app, &tab_id);
+                    clear_retained_on_giveup(&app, &tab_id, agent_id.as_deref());
+                    return;
+                }
+            }
+
             let result = manager
                 .create_connection(
                     &type_id,
@@ -154,21 +192,39 @@ impl<R: Runtime> ReconnectRedrive for AppReconnectRedrive<R> {
                         store.reconnect_failed(&tab_id, Some(e.to_string()));
                     });
                     sync_timer(&app, &tab_id);
-                    // On give-up the loop is over: drop + zeroize the retained
-                    // request so no resolved secret outlives it (#2454 mitigation).
-                    let gave_up = app
-                        .try_state::<Arc<SessionLifecycleStore>>()
-                        .and_then(|store| store.reconnect_state(&tab_id))
-                        .map(|s| s.phase)
-                        == Some(ReconnectPhase::Gaveup);
-                    if gave_up {
-                        if let Some(manager) = app.try_state::<SessionManager>() {
-                            manager.clear_retained_request(&tab_id);
-                        }
-                    }
+                    clear_retained_on_giveup(&app, &tab_id, agent_id.as_deref());
                 }
             }
         });
+    }
+}
+
+/// On a reconnect give-up (terminal `Failed`), scrub the secrets the loop
+/// retained so none outlives it: the per-tab connection request (#2454) and —
+/// for a resilient **agent** tab — the per-agent transport config (#2472). A
+/// no-op unless the store reports the tab actually gave up (a mere backoff stays
+/// `Waiting` and keeps the retained secrets for the next attempt).
+///
+/// The agent-config scrub is conservative: it clears the agent's config on this
+/// tab's give-up without ref-counting sibling tabs on the same agent. That is
+/// safe here because agent tabs do not retain a request until #2473 wires the
+/// routing; #2473 owns any multi-tab-per-agent refinement.
+fn clear_retained_on_giveup<R: Runtime>(app: &AppHandle<R>, tab_id: &str, agent_id: Option<&str>) {
+    let gave_up = app
+        .try_state::<Arc<SessionLifecycleStore>>()
+        .and_then(|store| store.reconnect_state(tab_id))
+        .map(|s| s.phase)
+        == Some(ReconnectPhase::Gaveup);
+    if !gave_up {
+        return;
+    }
+    if let Some(manager) = app.try_state::<SessionManager>() {
+        manager.clear_retained_request(tab_id);
+    }
+    if let Some(aid) = agent_id {
+        if let Some(store) = app.try_state::<SessionManager>() {
+            store.agent_client().clear_retained_agent_config(aid);
+        }
     }
 }
 

--- a/src-tauri/src/terminal/agent_config_store.rs
+++ b/src-tauri/src/terminal/agent_config_store.rs
@@ -1,0 +1,306 @@
+//! Backend retention of a connected agent's SSH transport config — the agent
+//! counterpart to session retention **Model A** ([`crate::session::retained_request`]),
+//! and the foundation for the server-side agent-transport re-establishment in the
+//! reconnect redrive (#2472, agent half of #2446; unblocks #2473 + #2205 PR-B).
+//!
+//! # Why retain the agent config
+//!
+//! When a resilient **agent** session drops because the agent's SSH transport
+//! itself went down and the in-task reconnect loop
+//! ([`crate::terminal::agent_manager`]) exhausted its budget and *reaped* the
+//! connection, the desktop no longer holds anything to re-establish it with — the
+//! [`RemoteAgentConfig`]/[`AgentSettings`] were captured by value in the reaped
+//! I/O task and dropped with it. To let the reconnect redrive **cold-re-establish
+//! the agent transport itself** (call `connect_agent` again on the fired attempt
+//! edge), the backend must own that config past the reap. This store is that
+//! ownership.
+//!
+//! It is keyed by **`agent_id`** (not tab id): one SSH transport is multiplexed
+//! by every session on that agent, so the transport config is per-agent, whereas
+//! the per-tab [`crate::session::retained_request`] owns the session request.
+//!
+//! # Security: the agent password must not outlive the loop
+//!
+//! [`RemoteAgentConfig::password`] is a **resolved secret** (an SSH password
+//! after credential-store resolution). Surviving the reap extends its in-memory
+//! lifetime, so — exactly as Model A does for the session request — a retained
+//! agent config is **zeroized on drop** and scrubbed at every terminal point:
+//! user disconnect / shutdown / prune (the "agent is gone" points, in
+//! [`crate::terminal::agent_manager`]) and reconnect give-up (the loop-terminal
+//! point, in the redrive). Zeroizing uses the same [`zeroize`] crate the
+//! credential store uses.
+//!
+//! # Byte-identical when the flag is off
+//!
+//! Nothing populates this store unless the agent connect opted into
+//! backend-reattach (the client's default-off `sessionBackendReattach` flag,
+//! threaded through the `connect_agent` command). With the flag off the store is
+//! never written, so no agent config survives a reap — byte-identical to
+//! `develop`, and no new secret lifetime is introduced.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use zeroize::Zeroize;
+
+use crate::connection::config::AgentSettings;
+use crate::terminal::backend::RemoteAgentConfig;
+
+/// A retained agent SSH transport config for one agent's reconnect redrive.
+///
+/// Zeroized on drop: [`RemoteAgentConfig::password`] may hold a resolved secret
+/// (see the module docs), so [`Drop`] scrubs it rather than leaving it for the
+/// allocator to reuse. `key_path` is a filesystem path, not a secret, and is left
+/// as-is; [`AgentSettings`] carries no secrets.
+#[derive(Debug, Clone)]
+pub(crate) struct RetainedAgentConfig {
+    /// The agent's SSH transport config — **`password` may be a secret**.
+    pub(crate) config: RemoteAgentConfig,
+    /// The agent runtime settings sent on `initialize`.
+    pub(crate) settings: AgentSettings,
+}
+
+impl Drop for RetainedAgentConfig {
+    fn drop(&mut self) {
+        if let Some(password) = self.config.password.as_mut() {
+            password.zeroize();
+        }
+    }
+}
+
+/// Per-agent store of [`RetainedAgentConfig`]s, keyed by `agent_id`.
+///
+/// Cloneable (`Arc`-backed) so it can be a field on the
+/// [`crate::terminal::agent_manager::AgentConnectionManager`] and shared with the
+/// detached tasks / redrive that re-establish a reaped transport.
+#[derive(Clone, Default)]
+pub(crate) struct AgentConfigStore {
+    inner: Arc<Mutex<HashMap<String, RetainedAgentConfig>>>,
+}
+
+impl AgentConfigStore {
+    /// An empty store.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, RetainedAgentConfig>> {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Retain (replacing any prior) the transport config for `agent_id`. A
+    /// re-connect overwrites the previous config; the replaced value is zeroized
+    /// as it drops.
+    pub(crate) fn retain(&self, agent_id: &str, config: RemoteAgentConfig, settings: AgentSettings) {
+        self.lock()
+            .insert(agent_id.to_string(), RetainedAgentConfig { config, settings });
+    }
+
+    /// Drop and zeroize the retained config for `agent_id`, if any. Idempotent —
+    /// clearing an agent with no retained config is a no-op. This is the security
+    /// mitigation's scrub point: every terminal (agent-gone / loop-give-up) path
+    /// calls it.
+    pub(crate) fn clear(&self, agent_id: &str) {
+        // `remove` returns the value; dropping it runs the zeroizing `Drop`.
+        drop(self.lock().remove(agent_id));
+    }
+
+    /// A clone of the retained config for `agent_id`, for the redrive to
+    /// re-establish the transport. Cloning copies the secret-bearing password;
+    /// the returned [`RetainedAgentConfig`]'s `Drop` zeroizes the clone, so the
+    /// caller must hold it only as long as the re-connect needs it.
+    pub(crate) fn get(&self, agent_id: &str) -> Option<RetainedAgentConfig> {
+        self.lock().get(agent_id).cloned()
+    }
+
+    /// Whether a config is currently retained for `agent_id`.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn contains(&self, agent_id: &str) -> bool {
+        self.lock().contains_key(agent_id)
+    }
+}
+
+/// What the reconnect redrive should do to re-establish an agent's transport,
+/// decided from whether the agent is already connected and whether a reattach
+/// config is retained. Split out from
+/// [`crate::terminal::agent_manager::AgentConnectionManager::reconnect_retained_agent`]
+/// so the single-owner coordination is unit-testable without a live SSH connect
+/// or a Tauri runtime.
+pub(crate) enum ReattachDecision {
+    /// The agent is already connected — either genuinely, or mid in-task
+    /// reconnect (the map entry is still alive). Do not double-drive: no-op.
+    AlreadyConnected,
+    /// The transport is down and a config is retained: cold-re-establish it.
+    Reconnect(RetainedAgentConfig),
+    /// The transport is down and nothing is retained (the connect did not opt in,
+    /// or the config was already scrubbed): the redrive folds a reconnect failure.
+    NoRetainedConfig,
+}
+
+/// Decide how the redrive should re-establish `agent_id`'s transport.
+///
+/// `connected` is the caller's `is_connected(agent_id)` reading, threaded in so
+/// this stays a pure function over the store.
+pub(crate) fn decide_reattach(
+    store: &AgentConfigStore,
+    connected: bool,
+    agent_id: &str,
+) -> ReattachDecision {
+    if connected {
+        return ReattachDecision::AlreadyConnected;
+    }
+    match store.get(agent_id) {
+        Some(retained) => ReattachDecision::Reconnect(retained),
+        None => ReattachDecision::NoRetainedConfig,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_with_password(password: Option<&str>) -> RemoteAgentConfig {
+        RemoteAgentConfig {
+            host: "example.com".to_string(),
+            port: 22,
+            username: "user".to_string(),
+            auth_method: "password".to_string(),
+            password: password.map(|s| s.to_string()),
+            key_path: Some("~/.ssh/id_ed25519".to_string()),
+            save_password: None,
+            agent_path: None,
+            external_connection_files: Vec::new(),
+            allow_self_update: false,
+            update_strategy: Default::default(),
+        }
+    }
+
+    #[test]
+    fn retain_and_get_roundtrip() {
+        let store = AgentConfigStore::new();
+        assert!(!store.contains("agent-1"));
+
+        store.retain(
+            "agent-1",
+            config_with_password(Some("secret")),
+            AgentSettings::default(),
+        );
+        assert!(store.contains("agent-1"));
+
+        let got = store.get("agent-1").expect("retained config");
+        assert_eq!(got.config.host, "example.com");
+        assert_eq!(got.config.password.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn clear_drops_and_is_idempotent() {
+        let store = AgentConfigStore::new();
+        store.retain(
+            "agent-1",
+            config_with_password(Some("secret")),
+            AgentSettings::default(),
+        );
+        assert!(store.contains("agent-1"));
+
+        store.clear("agent-1");
+        assert!(!store.contains("agent-1"));
+        // Clearing an absent agent is a no-op.
+        store.clear("agent-1");
+        assert!(!store.contains("agent-1"));
+    }
+
+    #[test]
+    fn retain_replaces_prior_config() {
+        let store = AgentConfigStore::new();
+        store.retain(
+            "agent-1",
+            config_with_password(Some("old")),
+            AgentSettings::default(),
+        );
+        store.retain(
+            "agent-1",
+            config_with_password(Some("new")),
+            AgentSettings::default(),
+        );
+        assert_eq!(
+            store.get("agent-1").unwrap().config.password.as_deref(),
+            Some("new")
+        );
+    }
+
+    #[test]
+    fn drop_zeroizes_the_password() {
+        // The retained config's Drop must scrub the secret password in place. We
+        // assert the observable contract via the mechanism Drop uses (`Zeroize`
+        // on the owned string): after scrubbing, the secret does not survive.
+        let mut retained = RetainedAgentConfig {
+            config: config_with_password(Some("super-secret")),
+            settings: AgentSettings::default(),
+        };
+        // Mimic Drop's scrub and assert it empties the secret.
+        if let Some(password) = retained.config.password.as_mut() {
+            password.zeroize();
+        }
+        assert_eq!(retained.config.password.as_deref(), Some(""));
+    }
+
+    #[test]
+    fn get_is_none_when_absent() {
+        let store = AgentConfigStore::new();
+        assert!(store.get("nope").is_none());
+    }
+
+    #[test]
+    fn decide_reattach_no_ops_when_already_connected() {
+        // Never double-drive against the in-task reconnect loop: a connected (or
+        // mid-reconnect, still-alive) agent means the transport is owned already.
+        let store = AgentConfigStore::new();
+        store.retain(
+            "agent-1",
+            config_with_password(Some("secret")),
+            AgentSettings::default(),
+        );
+        assert!(matches!(
+            decide_reattach(&store, true, "agent-1"),
+            ReattachDecision::AlreadyConnected
+        ));
+    }
+
+    #[test]
+    fn decide_reattach_reconnects_when_down_with_a_retained_config() {
+        let store = AgentConfigStore::new();
+        store.retain(
+            "agent-1",
+            config_with_password(Some("secret")),
+            AgentSettings::default(),
+        );
+        match decide_reattach(&store, false, "agent-1") {
+            ReattachDecision::Reconnect(retained) => {
+                assert_eq!(retained.config.password.as_deref(), Some("secret"));
+            }
+            _ => panic!("expected a cold re-establish from the retained config"),
+        }
+    }
+
+    #[test]
+    fn decide_reattach_reports_no_config_when_down_and_nothing_retained() {
+        // Flag-off (or already-scrubbed) tabs retain nothing: the redrive must
+        // fold a reconnect failure rather than block on a phantom transport.
+        let store = AgentConfigStore::new();
+        assert!(matches!(
+            decide_reattach(&store, false, "agent-none"),
+            ReattachDecision::NoRetainedConfig
+        ));
+    }
+
+    #[test]
+    fn a_config_without_a_password_retains_and_clears_cleanly() {
+        // Key-auth agents carry no password; Drop must tolerate `None`.
+        let store = AgentConfigStore::new();
+        store.retain("agent-key", config_with_password(None), AgentSettings::default());
+        let got = store.get("agent-key").expect("retained config");
+        assert!(got.config.password.is_none());
+        store.clear("agent-key");
+        assert!(!store.contains("agent-key"));
+    }
+}

--- a/src-tauri/src/terminal/agent_config_store.rs
+++ b/src-tauri/src/terminal/agent_config_store.rs
@@ -91,9 +91,16 @@ impl AgentConfigStore {
     /// Retain (replacing any prior) the transport config for `agent_id`. A
     /// re-connect overwrites the previous config; the replaced value is zeroized
     /// as it drops.
-    pub(crate) fn retain(&self, agent_id: &str, config: RemoteAgentConfig, settings: AgentSettings) {
-        self.lock()
-            .insert(agent_id.to_string(), RetainedAgentConfig { config, settings });
+    pub(crate) fn retain(
+        &self,
+        agent_id: &str,
+        config: RemoteAgentConfig,
+        settings: AgentSettings,
+    ) {
+        self.lock().insert(
+            agent_id.to_string(),
+            RetainedAgentConfig { config, settings },
+        );
     }
 
     /// Drop and zeroize the retained config for `agent_id`, if any. Idempotent —
@@ -131,7 +138,9 @@ pub(crate) enum ReattachDecision {
     /// reconnect (the map entry is still alive). Do not double-drive: no-op.
     AlreadyConnected,
     /// The transport is down and a config is retained: cold-re-establish it.
-    Reconnect(RetainedAgentConfig),
+    /// Boxed to keep the enum small (the config is far larger than the unit
+    /// variants).
+    Reconnect(Box<RetainedAgentConfig>),
     /// The transport is down and nothing is retained (the connect did not opt in,
     /// or the config was already scrubbed): the redrive folds a reconnect failure.
     NoRetainedConfig,
@@ -150,7 +159,7 @@ pub(crate) fn decide_reattach(
         return ReattachDecision::AlreadyConnected;
     }
     match store.get(agent_id) {
-        Some(retained) => ReattachDecision::Reconnect(retained),
+        Some(retained) => ReattachDecision::Reconnect(Box::new(retained)),
         None => ReattachDecision::NoRetainedConfig,
     }
 }
@@ -297,7 +306,11 @@ mod tests {
     fn a_config_without_a_password_retains_and_clears_cleanly() {
         // Key-auth agents carry no password; Drop must tolerate `None`.
         let store = AgentConfigStore::new();
-        store.retain("agent-key", config_with_password(None), AgentSettings::default());
+        store.retain(
+            "agent-key",
+            config_with_password(None),
+            AgentSettings::default(),
+        );
         let got = store.get("agent-key").expect("retained config");
         assert!(got.config.password.is_none());
         store.clear("agent-key");

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -25,6 +25,7 @@ use termihub_core::monitoring::{MonitoringSender, SystemStats};
 use crate::agents_projection::projection::fold_agent_transition;
 use crate::agents_projection::store::AgentConnectionState;
 use crate::connection::config::AgentSettings;
+use crate::terminal::agent_config_store::{decide_reattach, AgentConfigStore, ReattachDecision};
 use crate::terminal::agent_deploy::ConnectedHost;
 use crate::terminal::agent_forward::DesktopAgentForward;
 use crate::terminal::backend::{OutputSender, RemoteAgentConfig, RemoteStateChangeEvent};
@@ -251,6 +252,31 @@ pub trait AgentRpcClient: Send + Sync + 'static {
 
     /// Get the capabilities of a connected agent.
     fn get_capabilities(&self, agent_id: &str) -> Option<AgentCapabilities>;
+
+    /// Retain an agent's SSH transport config for backend-driven reconnect
+    /// reattach (#2472). Default no-op so mock clients need not implement it; the
+    /// production [`AgentConnectionManager`] stores it for the redrive.
+    fn retain_agent_config(
+        &self,
+        _agent_id: &str,
+        _config: &RemoteAgentConfig,
+        _agent_settings: Option<&AgentSettings>,
+    ) {
+    }
+
+    /// Drop and zeroize the retained reattach config for an agent (#2472).
+    /// Default no-op; the production manager scrubs it.
+    fn clear_retained_agent_config(&self, _agent_id: &str) {}
+
+    /// Cold-re-establish a reaped agent transport from its retained config for
+    /// the reconnect redrive (#2472). Default errors so mocks that do not model
+    /// reattach fall through to a folded reconnect failure; the production
+    /// [`AgentConnectionManager`] re-establishes from its retained config.
+    fn reconnect_retained_agent(&self, agent_id: &str) -> Result<(), TerminalError> {
+        Err(TerminalError::RemoteError(format!(
+            "Agent {agent_id} reattach not supported"
+        )))
+    }
 
     /// Gracefully shut down a remote agent and disconnect.
     fn shutdown_agent(&self, agent_id: &str, reason: Option<&str>) -> Result<u32, TerminalError>;
@@ -514,6 +540,13 @@ pub struct AgentConnectionManager {
     agents: AgentMap,
     /// Cancellation tokens for in-flight connects, keyed by agent id (G1, #1235).
     connecting: ConnectingRegistry,
+    /// Retained SSH transport configs for agents that opted into backend-driven
+    /// reconnect reattach, keyed by agent id (#2472). Survives a transport reap
+    /// so the reconnect redrive can cold-re-establish the transport itself; only
+    /// ever populated when the connect opted in (default-off flag), so it is
+    /// never written on the `develop`/flag-off path. See
+    /// [`crate::terminal::agent_config_store`].
+    agent_configs: AgentConfigStore,
     app_handle: AppHandle,
 }
 
@@ -522,6 +555,7 @@ impl AgentConnectionManager {
         Self {
             agents: Arc::new(Mutex::new(HashMap::new())),
             connecting: Arc::new(Mutex::new(HashMap::new())),
+            agent_configs: AgentConfigStore::new(),
             app_handle,
         }
     }
@@ -531,7 +565,14 @@ impl AgentConnectionManager {
     /// already safe because `is_connected()` reports `false` for such entries
     /// (G6, #1239).
     pub fn prune_dead_agents(&self) -> Vec<String> {
-        prune_dead_agents_from_map(&self.agents)
+        let pruned = prune_dead_agents_from_map(&self.agents);
+        // Scrub the reattach config of every pruned agent: a manual prune of a
+        // dead agent is a terminal point, so its retained secret must not linger
+        // (#2472).
+        for agent_id in &pruned {
+            self.agent_configs.clear(agent_id);
+        }
+        pruned
     }
 
     /// Cancel an in-flight (still connecting) agent by its `agent_id`.
@@ -842,7 +883,16 @@ impl AgentConnectionManager {
             .lock()
             .map_err(|e| TerminalError::RemoteError(format!("Lock failed: {}", e)))?;
 
-        if let Some(conn) = agents.remove(agent_id) {
+        let live = agents.remove(agent_id);
+        // Scrub the reattach config unconditionally, before returning either arm:
+        // a user disconnect is a terminal point, and the agent may already have
+        // been *reaped* (no live entry) while its reattach config lingers — that
+        // config must not survive the user's disconnect (#2472). The agents lock
+        // is dropped first so the config-store lock is never held nested under it.
+        drop(agents);
+        self.agent_configs.clear(agent_id);
+
+        if let Some(conn) = live {
             let _ = conn.command_tx.send(AgentIoCommand::Disconnect);
             conn.alive.store(false, Ordering::SeqCst);
             emit_agent_state(&self.app_handle, agent_id, "disconnected");
@@ -868,6 +918,82 @@ impl AgentConnectionManager {
     pub fn get_capabilities(&self, agent_id: &str) -> Option<AgentCapabilities> {
         let agents = self.agents.lock().unwrap_or_else(|e| e.into_inner());
         agents.get(agent_id).map(|c| c.capabilities.clone())
+    }
+
+    /// Retain an agent's SSH transport config for backend-driven reconnect
+    /// reattach (#2472), so the redrive can cold-re-establish the transport after
+    /// a reap. Called by the `connect_agent` command **only** when the connect
+    /// opted into backend reattach (the client's default-off `sessionBackendReattach`
+    /// flag); with the flag off this is never called, so no agent config survives
+    /// a reap and the path stays byte-identical to `develop`. The retained
+    /// secret is zeroized on drop and scrubbed at every terminal point (user
+    /// disconnect / shutdown / prune here, reconnect give-up in the redrive).
+    pub fn retain_agent_config(
+        &self,
+        agent_id: &str,
+        config: &RemoteAgentConfig,
+        agent_settings: Option<&AgentSettings>,
+    ) {
+        self.agent_configs.retain(
+            agent_id,
+            config.clone(),
+            agent_settings.cloned().unwrap_or_default(),
+        );
+    }
+
+    /// Drop and zeroize the retained reattach config for an agent (#2472). The
+    /// loop-terminal scrub point: the redrive calls it when a tab's reconnect
+    /// loop gives up. Idempotent.
+    pub fn clear_retained_agent_config(&self, agent_id: &str) {
+        self.agent_configs.clear(agent_id);
+    }
+
+    /// Cold-re-establish a **reaped** agent transport from its retained config
+    /// for the reconnect redrive (#2472).
+    ///
+    /// Single-owner coordination with the in-task reconnect loop
+    /// ([`agent_io_task`]'s [`reconnect_agent`]): that loop owns *transient*
+    /// transport breaks while the I/O task is alive, keeping the agent map entry
+    /// present. This method therefore:
+    ///
+    /// - **no-ops** (`Ok`) when the agent is already connected — either genuinely,
+    ///   or mid in-task reconnect (the entry is still `alive`), so it never
+    ///   double-drives against that loop;
+    /// - otherwise cold-re-establishes from the retained config via
+    ///   [`Self::connect_agent`], which locks the agent map for the whole connect,
+    ///   so two concurrent redrives serialize and the loser observes the winner's
+    ///   entry as "already connected" (mapped back to `Ok` here);
+    /// - returns `Err` when nothing is retained (the connect did not opt in, or
+    ///   the config was already scrubbed) so the redrive folds a reconnect
+    ///   failure and arms the next backoff / gives up.
+    ///
+    /// Synchronous (wraps a blocking SSH connect); callers on an async runtime
+    /// must invoke it via `spawn_blocking`, exactly as the `connect_agent`
+    /// command does.
+    pub fn reconnect_retained_agent(&self, agent_id: &str) -> Result<(), TerminalError> {
+        // The decision (no-op / reconnect / no-config) is a pure function over the
+        // config store + the connected reading, unit-tested in `agent_config_store`.
+        // `Reconnect` clones the config out (its `Drop` zeroizes the copied
+        // password) so the config-store lock is not held across the blocking
+        // connect.
+        match decide_reattach(&self.agent_configs, self.is_connected(agent_id), agent_id) {
+            ReattachDecision::AlreadyConnected => Ok(()),
+            ReattachDecision::NoRetainedConfig => Err(TerminalError::RemoteError(format!(
+                "No retained config to re-establish agent {agent_id}"
+            ))),
+            ReattachDecision::Reconnect(retained) => {
+                match self.connect_agent(agent_id, &retained.config, Some(&retained.settings)) {
+                    Ok(_) => Ok(()),
+                    // A concurrent redrive won the connect race and already
+                    // re-established the transport — treat that as success, not a
+                    // failure to fold.
+                    Err(TerminalError::RemoteError(msg)) if msg.contains("already connected") => {
+                        Ok(())
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+        }
     }
 
     /// Send `agent.shutdown` to a connected agent and disconnect it.
@@ -1347,6 +1473,23 @@ impl AgentRpcClient for AgentConnectionManager {
 
     fn get_capabilities(&self, agent_id: &str) -> Option<AgentCapabilities> {
         AgentConnectionManager::get_capabilities(self, agent_id)
+    }
+
+    fn retain_agent_config(
+        &self,
+        agent_id: &str,
+        config: &RemoteAgentConfig,
+        agent_settings: Option<&AgentSettings>,
+    ) {
+        AgentConnectionManager::retain_agent_config(self, agent_id, config, agent_settings)
+    }
+
+    fn clear_retained_agent_config(&self, agent_id: &str) {
+        AgentConnectionManager::clear_retained_agent_config(self, agent_id)
+    }
+
+    fn reconnect_retained_agent(&self, agent_id: &str) -> Result<(), TerminalError> {
+        AgentConnectionManager::reconnect_retained_agent(self, agent_id)
     }
 
     fn shutdown_agent(&self, agent_id: &str, reason: Option<&str>) -> Result<u32, TerminalError> {

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_binary;
 pub mod agent_cancel;
+pub mod agent_config_store;
 pub mod agent_deploy;
 pub mod agent_forward;
 pub mod agent_install;


### PR DESCRIPTION
Part of #2472 (agent half of #2446; unblocks #2473 and #2205 PR-B). Implements the **Option B** backend agent-transport re-establishment: the backend now owns the agent SSH transport config so the reconnect redrive can cold-re-establish a *reaped* agent transport itself. Default-off flag; **byte-identical to develop when off, and inert in every production configuration reachable today** (see below).

## What the backend now owns
- **`AgentConfigStore`** (`src-tauri/src/terminal/agent_config_store.rs`) — a per-`agent_id` store of `RemoteAgentConfig`/`AgentSettings`, the agent counterpart to session retention **Model A**. It survives a transport reap (the in-task reconnect loop exhausting + `reap_agent`), which is what previously dropped the config with the reaped I/O task and left the desktop nothing to re-establish with.
- **`AgentConnectionManager::reconnect_retained_agent`** — cold-re-establishes a down transport from the retained config via `connect_agent`; **no-ops when the agent is already connected**; folds a concurrent winner's "already connected". The decision (no-op / reconnect / no-config) is a pure, unit-tested helper (`decide_reattach`).
- **Redrive wiring** (`session_projection/redrive.rs`) — for a resilient **agent** tab, the redrive re-establishes the transport (on the blocking pool, modeling the client engine's *park*) before minting the session; a failed re-establish folds a reconnect failure so the loop arms the next backoff or gives up. **One loop attempt = one (re-establish + create) try**, so the reconnect loop's own bounded backoff subsumes the client's `MAX_AGENT_SPAWN_ATTEMPTS`.

## Coordination with agent_manager's own reconnect loop (single owner)
The I/O task's in-task `reconnect_agent` loop owns **transient** breaks while the task is alive (the map entry stays `alive`). `reconnect_retained_agent` therefore **no-ops when `is_connected`**, so it never double-drives that loop; it only cold-re-establishes once the transport has been **reaped** (entry gone). Two concurrent redrives serialize on `connect_agent`'s map lock and the loser sees "already connected" (mapped to success). The redrive only drives a reap when the tab is in the backend loop under the flag.

## Zeroize / scrub audit (the crux)
`RemoteAgentConfig.password` is the only secret; `RetainedAgentConfig` **zeroizes it on drop**. Scrub points:
- **Populate:** `connect_agent` command **only** when `backend_reattach == Some(true)`. The frontend does not thread this yet, so the store is **never populated in production** — no new secret lifetime, byte-identical off.
- **Scrub:** user disconnect (**unconditional — even when already reaped**), shutdown (routes through disconnect), prune, redrive give-up, and replace-on-reconnect. Every drop zeroizes.
- **Not scrubbed on plain reap** — deliberate (that is the survival point for reattach); harmless because nothing survives a reap unless it opted in.
- **Deferred to #2473:** multi-tab-per-agent refcounting on give-up, and the tab-close/removal scrub of the agent config, both only reachable once #2473 routes agent tabs to retain requests. Noted inline.

## Verification
- **Unit (primary proof):** `agent_config_store` — zeroize on drop, scrub/replace round-trips, and the `decide_reattach` coordination (no-op-when-connected / reconnect-with-config / no-config). Full backend suite green (1735 lib tests), `clippy --all-targets` clean, `cargo fmt --check` clean.
- **Not headlessly testable here:** `AppReconnectRedrive` needs a live `AppHandle` and `AgentConnectionManager` needs the concrete Wry runtime (not `MockRuntime`), so the end-to-end redrive+manager glue is integration-level (consistent with the existing redrive having no unit tests). The pure decision seam is extracted and tested instead.
- **Live agent-drop verification is deferred to #2473**, which owns the activation (see below) — a real drop cannot be exercised until the frontend routes agent tabs and threads the flag.

## Remaining work (all #2473, now unblocked)
#2473 activates this: flag-gate `isResilientReconnectTab` for agent tabs, extend `create_connection` retention to agent sessions, thread `sessionBackendReattach` into the `connect_agent` invoke, the server-side park model, client silent-retry + mirror suppression for agent tabs, parity tests, and **live agent-drop verification**. With #2454 + #2473 verified, #2446 closes and #2205 PR-B can flip the flag + delete the client reconnect engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
