### PR TITLE
feat(backend): retain resilient agent sessions + refcount-scrub the agent config (Part of #2473)

### DIFF
--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -829,21 +829,25 @@ impl SessionManager {
                 );
 
             // Retain the connection request for the resilient-reconnect loop
-            // (#2454, retention Model A) so the backend redrive (follow-up) can
-            // re-establish the transport itself. Scoped to **resilient DIRECT**
-            // (non-agent) sessions — agent silent-retry is #2455 and a
-            // non-resilient tab never reconnects, so neither retains a secret.
-            // Refreshed on every (re)connect of the tab; dropped + zeroized on
-            // any terminal-loop / session-end path (see the module docs and the
-            // `clear_retained_request` call sites). A no-op for the internal
-            // agent-setup session, which carries no `connect_id` / tab id.
-            if resilient_reconnect && agent_id.is_none() {
+            // (#2454, retention Model A) so the backend redrive re-establishes the
+            // transport itself. Covers **resilient DIRECT** (non-agent, #2454) and
+            // **resilient AGENT** (#2473) sessions alike: the redrive
+            // cold-re-establishes the agent transport from the retained `agent_id`
+            // + per-agent config (#2472) before re-creating the session. A
+            // non-resilient tab never reconnects, so it retains no secret; only a
+            // tab that opted into resilient reconnect (the frontend's
+            // `isResilientReconnectTab`) does. Refreshed on every (re)connect of
+            // the tab; dropped + zeroized on any terminal-loop / session-end path
+            // (see the module docs and the `clear_retained_request` call sites). A
+            // no-op for the internal agent-setup session, which carries no
+            // `connect_id` / tab id.
+            if resilient_reconnect {
                 self.retained_requests.retain(
                     &tab_id,
                     RetainedConnectionRequest {
                         type_id: type_id.to_string(),
                         settings: settings.clone(),
-                        agent_id: None,
+                        agent_id: agent_id.map(|s| s.to_string()),
                         resilient: true,
                         // The client's `sessionBackendReattach` determination
                         // (#2454): the sole gate on whether the backend reconnect
@@ -1049,13 +1053,41 @@ impl SessionManager {
     }
 
     /// Drop + zeroize the retained connection request for a tab (#2454, retention
-    /// Model A). The security-mitigation scrub point invoked by every
-    /// terminal-loop / session-end path that the manager itself does not observe
-    /// — the give-up, user-cancel, graceful-disconnect and remove lifecycle
-    /// transitions (routed through [`crate::session_projection::projection`]).
-    /// Idempotent: clearing a tab with no retained request is a no-op.
+    /// Model A) — the per-tab primitive, without the per-agent transport-config
+    /// scrub. The lifecycle scrub points now route through
+    /// [`Self::clear_retained_request_with_agent_scrub`] so a resilient agent tab's
+    /// shared transport config is refcount-scrubbed too (#2473); this narrower form
+    /// stays as the direct-only building block. Idempotent: clearing a tab with no
+    /// retained request is a no-op.
+    #[allow(dead_code)] // building block for the agent-scrub variant + the idempotency test
     pub fn clear_retained_request(&self, tab_id: &str) {
         self.retained_requests.clear(tab_id);
+    }
+
+    /// Clear a tab's retained request and, when it was the **last** tab on its
+    /// agent, scrub that agent's retained transport config too (#2473).
+    ///
+    /// The per-tab request (#2454) and the per-agent transport config (#2472) have
+    /// different lifetimes: one SSH transport is shared by every session on an
+    /// agent, so its secret-bearing config must survive until the last tab on that
+    /// agent releases it. This clears the tab's own request first, then — only if
+    /// no sibling tab still routes through the same agent — drops + zeroizes the
+    /// per-agent config. A direct (non-agent) tab has no agent config to scrub, so
+    /// this behaves exactly like [`Self::clear_retained_request`] for it; idempotent
+    /// throughout. This is the tab-close / non-loop-drop scrub point (routed
+    /// through [`crate::session_projection::projection`]); the reconnect give-up
+    /// point applies the same refcount in
+    /// [`crate::session_projection::redrive`].
+    pub fn clear_retained_request_with_agent_scrub(&self, tab_id: &str) {
+        // Read the agent id before clearing (the request is about to drop), then
+        // clear this tab so the sibling check below does not count itself.
+        let agent_id = self.retained_requests.agent_id_for(tab_id);
+        self.retained_requests.clear(tab_id);
+        if let Some(agent_id) = agent_id {
+            if !self.retained_requests.any_for_agent(&agent_id) {
+                self.agent_manager.clear_retained_agent_config(&agent_id);
+            }
+        }
     }
 
     /// Whether a resilient-reconnect connection request is currently retained for
@@ -2789,6 +2821,282 @@ mod tests {
         assert!(
             manager.has_retained_request("tab-r"),
             "a resilient direct session retains its connection request (#2454 Model A)"
+        );
+    }
+
+    /// A mock `AgentRpcClient` that satisfies the `create_connection` agent
+    /// handshake (create → register output → attach → capability query) and
+    /// **records** every `clear_retained_agent_config` call, so the #2473
+    /// retention + refcount-scrub tests can drive a real agent session through the
+    /// manager without a live SSH transport.
+    struct RetainAgent {
+        cleared: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    impl RetainAgent {
+        fn new() -> (Self, std::sync::Arc<std::sync::Mutex<Vec<String>>>) {
+            let cleared = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            (
+                Self {
+                    cleared: cleared.clone(),
+                },
+                cleared,
+            )
+        }
+    }
+
+    impl AgentRpcClient for RetainAgent {
+        fn connect_agent(
+            &self,
+            _: &str,
+            _: &RemoteAgentConfig,
+            _: Option<&AgentSettings>,
+        ) -> Result<AgentConnectResult, TerminalError> {
+            unimplemented!()
+        }
+        fn cancel_connect(&self, _: &str) -> bool {
+            false
+        }
+        fn disconnect_agent(&self, _: &str) -> Result<(), TerminalError> {
+            Ok(())
+        }
+        fn is_connected(&self, _: &str) -> bool {
+            true
+        }
+        fn get_capabilities(&self, _: &str) -> Option<AgentCapabilities> {
+            None
+        }
+        fn clear_retained_agent_config(&self, agent_id: &str) {
+            self.cleared
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(agent_id.to_string());
+        }
+        fn shutdown_agent(&self, _: &str, _: Option<&str>) -> Result<u32, TerminalError> {
+            unimplemented!()
+        }
+        fn send_request(&self, _: &str, _: &str, _: Value) -> Result<Value, TerminalError> {
+            // The handshake queries `connection.types`; an empty list is fine (no
+            // file-browser / monitoring proxies wired for the test session).
+            Ok(serde_json::json!({ "types": [] }))
+        }
+        fn create_session(
+            &self,
+            _: &str,
+            session_type: &str,
+            _: Value,
+            title: Option<&str>,
+            definition_id: Option<&str>,
+        ) -> Result<AgentSessionInfo, TerminalError> {
+            Ok(AgentSessionInfo {
+                session_id: uuid::Uuid::new_v4().to_string(),
+                title: title.unwrap_or("mock").to_string(),
+                session_type: session_type.to_string(),
+                status: "running".to_string(),
+                attached: true,
+                definition_id: definition_id.map(str::to_string),
+            })
+        }
+        fn attach_session(&self, _: &str, _: &str) -> Result<(), TerminalError> {
+            Ok(())
+        }
+        fn close_session(&self, _: &str, _: &str) -> Result<(), TerminalError> {
+            Ok(())
+        }
+        fn list_sessions(&self, _: &str) -> Result<Vec<AgentSessionInfo>, TerminalError> {
+            Ok(Vec::new())
+        }
+        fn list_connections_and_folders(
+            &self,
+            _: &str,
+        ) -> Result<AgentConnectionsData, TerminalError> {
+            unimplemented!()
+        }
+        fn list_definitions(&self, _: &str) -> Result<Vec<AgentDefinitionInfo>, TerminalError> {
+            unimplemented!()
+        }
+        fn save_definition(&self, _: &str, _: Value) -> Result<AgentDefinitionInfo, TerminalError> {
+            unimplemented!()
+        }
+        fn update_definition(
+            &self,
+            _: &str,
+            _: Value,
+        ) -> Result<AgentDefinitionInfo, TerminalError> {
+            unimplemented!()
+        }
+        fn delete_definition(&self, _: &str, _: &str) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+        fn create_folder(
+            &self,
+            _: &str,
+            _: &str,
+            _: Option<&str>,
+        ) -> Result<AgentFolderInfo, TerminalError> {
+            unimplemented!()
+        }
+        fn update_folder(&self, _: &str, _: Value) -> Result<AgentFolderInfo, TerminalError> {
+            unimplemented!()
+        }
+        fn delete_folder(&self, _: &str, _: &str) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+        fn register_session_output(
+            &self,
+            _: &str,
+            _: &str,
+            _: OutputSender,
+        ) -> Result<(), TerminalError> {
+            Ok(())
+        }
+        fn unregister_session_output(&self, _: &str, _: &str) -> Result<(), TerminalError> {
+            Ok(())
+        }
+        fn register_monitoring_output(
+            &self,
+            _: &str,
+            _: &str,
+            _: MonitoringSender,
+        ) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+        fn unregister_monitoring_output(&self, _: &str, _: &str) -> Result<(), TerminalError> {
+            Ok(())
+        }
+        fn send_session_input(&self, _: &str, _: &str, _: &[u8]) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+        fn resize_session(&self, _: &str, _: &str, _: u16, _: u16) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+        fn apply_agent_settings(&self, _: &str, _: &AgentSettings) -> Result<(), TerminalError> {
+            unimplemented!()
+        }
+    }
+
+    /// Build a manager whose agent client is a [`RetainAgent`], returning the
+    /// recorded-clears handle alongside it.
+    fn make_test_manager_with_retain_agent() -> (
+        SessionManager,
+        std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    ) {
+        let mut registry = termihub_core::connection::ConnectionTypeRegistry::new();
+        registry.register(
+            "mock",
+            "Mock",
+            "mock",
+            Box::new(|| Box::new(MockConnection::default())),
+        );
+        let (agent, cleared) = RetainAgent::new();
+        (SessionManager::new(registry, Arc::new(agent)), cleared)
+    }
+
+    #[tokio::test]
+    async fn create_connection_retains_request_for_resilient_agent_session() {
+        // #2473: a resilient **agent** session now retains its request (with the
+        // agent_id the redrive cold-re-establishes the transport through), the same
+        // way a resilient direct session does (#2454). Before this, retention was
+        // guarded to `agent_id.is_none()`, so agent tabs never entered the backend
+        // redrive.
+        let (manager, _cleared) = make_test_manager_with_retain_agent();
+        manager
+            .create_connection(
+                "mock",
+                serde_json::json!({ "password": "secret" }),
+                Some("agent-1"), // resilient AGENT session
+                Some("tab-a:0"),
+                false,
+                true, // resilient
+                true, // backend_reattach opted in
+                MockEventEmitter::new(),
+            )
+            .await
+            .expect("agent session should open");
+        let req = manager
+            .retained_request("tab-a")
+            .expect("a resilient agent session retains its connection request");
+        assert_eq!(
+            req.agent_id.as_deref(),
+            Some("agent-1"),
+            "the retained request carries the agent_id the redrive re-connects through"
+        );
+        assert!(req.backend_reattach, "the redrive gate is recorded");
+    }
+
+    #[tokio::test]
+    async fn clear_retained_request_scrubs_agent_config_only_for_the_last_tab() {
+        // #2473 refcount: one SSH transport is shared by every session on an agent,
+        // so the per-agent transport config (#2472) must survive until the LAST tab
+        // on that agent releases its retained request. Clearing one of two sibling
+        // tabs must NOT scrub the config; clearing the last one must.
+        let (manager, cleared) = make_test_manager_with_retain_agent();
+        for tab in ["tab-x:0", "tab-y:0"] {
+            manager
+                .create_connection(
+                    "mock",
+                    serde_json::json!({ "password": "secret" }),
+                    Some("agent-1"),
+                    Some(tab),
+                    false,
+                    true,
+                    true,
+                    MockEventEmitter::new(),
+                )
+                .await
+                .expect("agent session should open");
+        }
+
+        // First sibling clears: a tab on agent-1 still holds it → no scrub.
+        manager.clear_retained_request_with_agent_scrub("tab-x");
+        assert!(
+            cleared
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .is_empty(),
+            "a sibling tab still holds agent-1, so its transport config must not be scrubbed"
+        );
+
+        // Last sibling clears: nothing left on agent-1 → scrub exactly once.
+        manager.clear_retained_request_with_agent_scrub("tab-y");
+        assert_eq!(
+            &*cleared
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            &["agent-1".to_string()],
+            "the last tab on agent-1 releasing it scrubs the per-agent transport config once"
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_retained_request_with_agent_scrub_is_a_noop_for_direct_tabs() {
+        // A direct (non-agent) tab has no per-agent config, so the refcounted scrub
+        // must behave exactly like the plain per-tab clear and never touch the
+        // agent config store.
+        let (manager, cleared) = make_test_manager_with_retain_agent();
+        manager
+            .create_connection(
+                "mock",
+                serde_json::json!({ "password": "secret" }),
+                None, // direct
+                Some("tab-d:0"),
+                false,
+                true,
+                true,
+                MockEventEmitter::new(),
+            )
+            .await
+            .expect("direct session should open");
+        assert!(manager.has_retained_request("tab-d"));
+
+        manager.clear_retained_request_with_agent_scrub("tab-d");
+        assert!(!manager.has_retained_request("tab-d"));
+        assert!(
+            cleared
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .is_empty(),
+            "a direct tab has no agent config to scrub"
         );
     }
 

--- a/src-tauri/src/session/retained_request.rs
+++ b/src-tauri/src/session/retained_request.rs
@@ -152,6 +152,27 @@ impl RetainedRequestStore {
     pub(crate) fn get(&self, tab_id: &str) -> Option<RetainedConnectionRequest> {
         self.lock().get(tab_id).cloned()
     }
+
+    /// The `agent_id` a tab's retained request routes through, if any. Reads only
+    /// the (non-secret) agent id, so it does **not** clone the secret-bearing
+    /// `settings` the way [`Self::get`] does — the per-agent transport-config
+    /// refcount scrub (#2473) needs the agent id, not the settings.
+    pub(crate) fn agent_id_for(&self, tab_id: &str) -> Option<String> {
+        self.lock().get(tab_id).and_then(|r| r.agent_id.clone())
+    }
+
+    /// Whether **any** retained request currently routes through `agent_id`.
+    ///
+    /// The refcount behind the per-agent transport-config scrub (#2473): one SSH
+    /// transport is shared by every session on an agent, so its retained config
+    /// must survive until the *last* tab on that agent stops needing it. A caller
+    /// clears its own tab's request first, then asks this — a `false` answer means
+    /// no sibling tab still holds the agent, so its config can be scrubbed.
+    pub(crate) fn any_for_agent(&self, agent_id: &str) -> bool {
+        self.lock()
+            .values()
+            .any(|r| r.agent_id.as_deref() == Some(agent_id))
+    }
 }
 
 #[cfg(test)]
@@ -283,6 +304,73 @@ mod tests {
             store.get("tab-1").unwrap().settings["password"],
             json!("new")
         );
+    }
+
+    #[test]
+    fn agent_id_for_reads_the_agent_without_cloning_settings() {
+        let store = RetainedRequestStore::new();
+        assert_eq!(store.agent_id_for("missing"), None);
+
+        store.retain(
+            "tab-direct",
+            RetainedConnectionRequest {
+                type_id: "ssh".to_string(),
+                settings: json!({ "password": "p" }),
+                agent_id: None,
+                resilient: true,
+                backend_reattach: true,
+            },
+        );
+        store.retain(
+            "tab-agent",
+            RetainedConnectionRequest {
+                type_id: "ssh".to_string(),
+                settings: json!({ "password": "p" }),
+                agent_id: Some("agent-1".to_string()),
+                resilient: true,
+                backend_reattach: true,
+            },
+        );
+
+        assert_eq!(store.agent_id_for("tab-direct"), None);
+        assert_eq!(store.agent_id_for("tab-agent").as_deref(), Some("agent-1"));
+    }
+
+    #[test]
+    fn any_for_agent_tracks_the_last_tab_on_an_agent() {
+        // The refcount behind the per-agent transport-config scrub (#2473): the
+        // agent config must survive until the last tab on that agent releases it.
+        let store = RetainedRequestStore::new();
+        assert!(!store.any_for_agent("agent-1"));
+
+        let agent_req = |agent: &str| RetainedConnectionRequest {
+            type_id: "ssh".to_string(),
+            settings: json!({ "password": "p" }),
+            agent_id: Some(agent.to_string()),
+            resilient: true,
+            backend_reattach: true,
+        };
+        store.retain("tab-a", agent_req("agent-1"));
+        store.retain("tab-b", agent_req("agent-1"));
+        store.retain("tab-c", agent_req("agent-2"));
+
+        assert!(store.any_for_agent("agent-1"));
+        assert!(store.any_for_agent("agent-2"));
+
+        // Clearing one of two siblings on agent-1 keeps the agent referenced.
+        store.clear("tab-a");
+        assert!(
+            store.any_for_agent("agent-1"),
+            "a sibling tab still holds agent-1, so its config must not be scrubbed"
+        );
+
+        // Clearing the last tab on agent-1 releases it; agent-2 is unaffected.
+        store.clear("tab-b");
+        assert!(
+            !store.any_for_agent("agent-1"),
+            "the last tab on agent-1 released it — its config can now be scrubbed"
+        );
+        assert!(store.any_for_agent("agent-2"));
     }
 
     #[test]

--- a/src-tauri/src/session_projection/projection.rs
+++ b/src-tauri/src/session_projection/projection.rs
@@ -262,9 +262,14 @@ pub fn register_session_intents(registry: &mut HandlerRegistry, app_handle: AppH
 /// session. `tab_id` is the region key (the intent's `sessionId`, which the
 /// bridge keys by tab id). Off-path no-op when the manager is not managed (e.g. a
 /// headless projection unit-test app), matching [`sync_timer`].
+///
+/// For a resilient **agent** tab (#2473) this also scrubs the per-agent transport
+/// config (#2472) — but only when this was the last tab on that agent, so a
+/// sibling session still reconnecting over the shared transport keeps it. A direct
+/// tab has no agent config, so this is exactly the per-tab request scrub for it.
 fn clear_retained_request(app_handle: &AppHandle, tab_id: &str) {
     if let Some(manager) = app_handle.try_state::<SessionManager>() {
-        manager.clear_retained_request(tab_id);
+        manager.clear_retained_request_with_agent_scrub(tab_id);
     }
 }
 

--- a/src-tauri/src/session_projection/redrive.rs
+++ b/src-tauri/src/session_projection/redrive.rs
@@ -141,7 +141,7 @@ impl<R: Runtime> ReconnectRedrive for AppReconnectRedrive<R> {
                         store.reconnect_failed(&tab_id, Some(err));
                     });
                     sync_timer(&app, &tab_id);
-                    clear_retained_on_giveup(&app, &tab_id, agent_id.as_deref());
+                    clear_retained_on_giveup(&app, &tab_id);
                     return;
                 }
             }
@@ -192,7 +192,7 @@ impl<R: Runtime> ReconnectRedrive for AppReconnectRedrive<R> {
                         store.reconnect_failed(&tab_id, Some(e.to_string()));
                     });
                     sync_timer(&app, &tab_id);
-                    clear_retained_on_giveup(&app, &tab_id, agent_id.as_deref());
+                    clear_retained_on_giveup(&app, &tab_id);
                 }
             }
         });
@@ -205,11 +205,13 @@ impl<R: Runtime> ReconnectRedrive for AppReconnectRedrive<R> {
 /// no-op unless the store reports the tab actually gave up (a mere backoff stays
 /// `Waiting` and keeps the retained secrets for the next attempt).
 ///
-/// The agent-config scrub is conservative: it clears the agent's config on this
-/// tab's give-up without ref-counting sibling tabs on the same agent. That is
-/// safe here because agent tabs do not retain a request until #2473 wires the
-/// routing; #2473 owns any multi-tab-per-agent refinement.
-fn clear_retained_on_giveup<R: Runtime>(app: &AppHandle<R>, tab_id: &str, agent_id: Option<&str>) {
+/// The agent-config scrub is **refcounted** (#2473): one SSH transport is shared
+/// by every session on an agent, so this tab giving up must not scrub the config
+/// while a sibling tab on the same agent is still reconnecting over it.
+/// [`SessionManager::clear_retained_request_with_agent_scrub`] clears this tab's
+/// request first, then scrubs the per-agent config only when no sibling request
+/// still routes through the agent.
+fn clear_retained_on_giveup<R: Runtime>(app: &AppHandle<R>, tab_id: &str) {
     let gave_up = app
         .try_state::<Arc<SessionLifecycleStore>>()
         .and_then(|store| store.reconnect_state(tab_id))
@@ -219,12 +221,7 @@ fn clear_retained_on_giveup<R: Runtime>(app: &AppHandle<R>, tab_id: &str, agent_
         return;
     }
     if let Some(manager) = app.try_state::<SessionManager>() {
-        manager.clear_retained_request(tab_id);
-    }
-    if let Some(aid) = agent_id {
-        if let Some(store) = app.try_state::<SessionManager>() {
-            store.agent_client().clear_retained_agent_config(aid);
-        }
+        manager.clear_retained_request_with_agent_scrub(tab_id);
     }
 }
 


### PR DESCRIPTION
The **safe, inert backend foundation** for the agent reconnect activation (#2473, Part 2 of #2446). The risky frontend activation is split out to **#2476** and deliberately NOT landed here — see "Why this is the safe subset" below.

## What this lands (fully inert with the flag off)

1. **Retention for resilient AGENT sessions** — `create_connection` drops its `agent_id.is_none()` guard so a resilient agent session retains its request (Model A, #2454), carrying the `agent_id` the redrive re-connects through. `RetainedRequestStore` gains `agent_id_for` (reads the agent id without cloning the secret settings) and `any_for_agent` (the refcount).

2. **Per-agent transport-config refcount scrub** — `SessionManager::clear_retained_request_with_agent_scrub` clears a tab's request and scrubs the shared per-agent transport config (#2472) **only when it was the last tab on that agent** (one SSH transport is shared by every session on the agent). Wired into:
   - the lifecycle scrub points (`session_projection::projection`: disconnect / dropped / give-up / cancel / remove) — closing an agent tab mid-reconnect no longer leaves the agent password retained until the transport disconnects/prunes;
   - the reconnect give-up path (`session_projection::redrive`) — replaces the previous conservative *unconditional* agent-config clear, so a sibling tab still reconnecting over the shared transport keeps it.

## Why this is the safe subset (activation deferred to #2476)

`#2473` is an **all-or-nothing, ventilator-grade** activation of the agent reconnect hot path. This PR contains only the parts that are provably **byte-identical with the flag off AND unreachable until the frontend routes agent tabs as resilient**:

- With the flag off, `isResilientReconnectTab` still excludes agent tabs, so no agent session is resilient → nothing here retains.
- `createTerminal`'s `remote-session` branch still drops `resilientReconnect`/`backendReattach`, so the backend never sees them for agents.
- A direct tab has no per-agent config, so the refcounted scrub is a no-op for it.

The **frontend activation** (flag-gate `isResilientReconnectTab`, thread the flags through `createTerminal`, suppress the client agent silent-retry, resolve the client-wait vs backend-loop double-drive interplay) is the risky cut. It requires **live agent-drop verification** (blocker E) against a prolonged agent drop that I could not perform to ventilator grade here, so per the guardrail it is filed as **#2476** rather than shipped half-activated.

## Verification
- `cargo test` (session::retained_request, session::manager, session_projection): all green, incl. new tests:
  - `create_connection_retains_request_for_resilient_agent_session` (mock agent)
  - `clear_retained_request_scrubs_agent_config_only_for_the_last_tab` (refcount: 2 siblings → scrub only on the last)
  - `clear_retained_request_with_agent_scrub_is_a_noop_for_direct_tabs`
  - `agent_id_for_reads_the_agent_without_cloning_settings`, `any_for_agent_tracks_the_last_tab_on_an_agent`
- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- No frontend/docs changes → no change fragment (fully inert, no user-facing behavior).

## Per-issue status
- **#2473** — NOT closed. Backend foundation only; activation → #2476.
- **#2472** — mechanism already merged; this consumes it.
- **#2455 / #2446 / #2205 PR-B** — remain blocked on the activation (#2476).

Part of #2473. Follow-up (activation): #2476.