### PR TITLE
fix(agent): thread reconnect flags through the agent create path (part of #2476)

### DIFF
--- a/src/services/api.test.ts
+++ b/src/services/api.test.ts
@@ -272,6 +272,35 @@ describe("api service", () => {
       expect(result).toBe("session-remote");
     });
 
+    it("createTerminal forwards resilientReconnect + backendReattach on the remote-session (agent) path (#2476)", async () => {
+      // The agent path used to DROP both flags (create_connection was called with
+      // only agentId + connectId), so the backend never saw them for an agent
+      // session and could not retain the request for the reconnect redrive. They
+      // are now threaded through — never spawn-origin, so `spawned` stays false.
+      mockedInvoke.mockResolvedValue("session-agent-resilient");
+      const config = {
+        type: "remote-session",
+        config: {
+          agentId: "agent-9",
+          sessionType: "shell",
+          shell: "/bin/bash",
+          persistent: false,
+        },
+      };
+
+      await createTerminal(config, "tab-agent", false, true, true);
+
+      expect(mockedInvoke).toHaveBeenCalledWith("create_connection", {
+        typeId: "shell",
+        settings: { shell: "/bin/bash", persistent: false },
+        agentId: "agent-9",
+        connectId: "tab-agent",
+        spawned: false,
+        resilientReconnect: true,
+        backendReattach: true,
+      });
+    });
+
     it("sendInput invokes with session ID and data", async () => {
       mockedInvoke.mockResolvedValue(undefined);
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -184,13 +184,22 @@ export async function importInventoryHosts(path: string): Promise<InventoryHost[
  *
  * `resilientReconnect` is the tab's resilient-reconnect determination (#2439),
  * forwarded to the backend so a genuine drop is folded server-side as
- * `session.reconnect` vs `session.dropped`. Only plain-SSH tabs opt in; the
- * `remote-session` (agent) path is never resilient, so it is not forwarded there.
+ * `session.reconnect` vs `session.dropped`. Both the direct and `remote-session`
+ * (agent) paths forward it: an agent tab becomes resilient once the agent
+ * reconnect redrive is activated (#2476), and the backend only retains a tab's
+ * request for the redrive when it is `resilient` (see `session/manager.rs`).
  *
- * `backendReattach` is the client's `sessionBackendReattach` flag (#2454), passed
- * on the direct path only so the backend records it on the retained request as the
- * redrive gate. The `remote-session` (agent) path is out of scope (#2455), so it
- * is not forwarded there.
+ * `backendReattach` is the client's `sessionBackendReattach` flag (#2454),
+ * forwarded on both paths so the backend records it on the retained request as
+ * the redrive gate — for a direct connection (#2457) and, once the agent reconnect
+ * frontend lands (#2476), for an agent session too. Agent sessions are never
+ * spawn-origin, so `spawned` is not forwarded on the `remote-session` path.
+ *
+ * NOTE: flag-off, both values resolve to `false` for agent tabs
+ * (`isResilientReconnectTabId` returns `false` and `sessionBackendReattach` is
+ * default-off), and the backend only retains-for-redrive when `resilient` is true,
+ * so forwarding them here is byte-identical to `develop` until the agent reconnect
+ * frontend (#2476) classifies agent tabs resilient under the flag.
  */
 export async function createTerminal(
   config: ConnectionConfig,
@@ -205,7 +214,15 @@ export async function createTerminal(
       sessionType: string;
       [key: string]: unknown;
     };
-    return await createConnection(sessionType, rest, agentId, connectId);
+    return await createConnection(
+      sessionType,
+      rest,
+      agentId,
+      connectId,
+      undefined,
+      resilientReconnect,
+      backendReattach
+    );
   }
   return await createConnection(
     config.type,


### PR DESCRIPTION
## Summary

Part of #2476 (agent reconnect redrive frontend activation). This lands **only the safe, inert plumbing** and **defers the risky activation** — the flag stays default-off and the change is byte-identical to `develop`.

`createTerminal`'s `remote-session` (agent) branch dropped `resilientReconnect` and `backendReattach` (it called `create_connection` with only `agentId` + `connectId`), so the backend never saw them for an agent session and could not retain the request for the reconnect redrive. This threads both through (agent sessions are never spawn-origin, so `spawned` stays `false`).

This is the prerequisite the scope flagged as required, and the exact payload the #2464 CI-round loss warned about — so it ships with a payload-assertion regression test.

## Why this is inert / byte-identical

- **Flag off** (default): `sessionBackendReattachEnabled()` is `false` and `isResilientReconnectTabId()` returns `false` for agent tabs, so both values resolve to `false` — identical to the old call.
- **Flag on, without the rest of #2476**: `isResilientReconnectTab` still returns `false` for agent tabs, and the backend only retains-for-redrive when `resilient` is true (`src-tauri/src/session/manager.rs:844`). So no retention, no redrive — develop behavior. Forwarding `backendReattach` alone changes nothing.

## Tests

- `pnpm vitest run src/services/api.test.ts` — 81 passed (new remote-session forwarding assertion included).
- `pnpm vitest run` — **545 files / 4905 tests passed**.
- `prettier --check` + `eslint` clean on touched files. No Rust touched.

## Why the full activation is DEFERRED (not live-verifiable here)

The mandatory live agent-drop + **prolonged-drop** verification cannot be performed by a headless agent (no GUI, and no existing harness assertion for the double-drive / connect-deadline / strand properties). Per the issue's own rule — *"if you cannot verify it live to grade, do NOT flip the activation; land only safe/inert parts"* — the remaining items are deferred. My design analysis of what they require, so a GUI-capable session can finish + live-verify:

1. **Item 1 — classify agent tabs resilient under the flag** (`isResilientReconnectTab`, `appStore.ts:2046`). This is the actual activation trigger: it enables backend retention (`manager.rs:844`) + the `session.reconnect` reconnecting fold. **Not safe alone** — with item 1 but not 3/4, a flag-on agent reconnect waits ~10s (`Terminal.tsx:461`) then **falls through to the client agent engine** (`connectRemoteAgent`) while the backend redrive is also re-establishing the transport → the double-drive.

2. **Items 3/4 — suppress the client agent engine on backend-driven reconnect + resolve the double-drive.** Confirmed complications that make this timing-sensitive and require live validation:
   - The render fold is **local-authoritative** — the `effective*` helpers in `sessionBridge.ts` are faithful-mirror gates that only echo the local store; a backend give-up does **not** surface on its own.
   - `reconnectTerminal` **arms a per-attempt connect-deadline** (`appStore.ts:5721`) that fires `failTerminalConnectTimeout`. A purely-backend-driven agent reconnect must therefore have the **reconcile propagate the backend's `connecting→waiting` backoff and `gaveup`** into the local loop (`ensureSessionReconcileWired`, `appStore.ts:2169`), or a prolonged drop is prematurely failed / stranded. That reconcile change touches shared machinery and is exactly what needs a real agent-drop to validate.
   - Backend contract confirmed: give-up folds `reconnect.phase == Gaveup` + `status = Failed` (`store.rs:342`); success folds `connected` + `set_backend_session_id(new)` (`redrive.rs:183`); redrive re-connects with `resilient=true, backend_reattach=true` and is gated on `req.backend_reattach` (`redrive.rs:77`).

## Per-issue status

- **#2476** — remains **open**. Only the create-path plumbing landed; frontend activation (items 1, 3, 4, 5) deferred pending live verification.
- **#2472 / #2473 / #2455 / #2446** — remain **open** (this PR does not complete them; the frontend activation they depend on is not landed).
- **#2205 PR-B** — still blocked (unchanged).

Part of #2476.
