### PR TITLE
activate backend-driven agent reconnect under the flag (part of #2476)

### DIFF
--- a/docs/changes/dev0/feature/2476-agent-reconnect-activation.md
+++ b/docs/changes/dev0/feature/2476-agent-reconnect-activation.md
@@ -1,0 +1,11 @@
+### Changed
+
+- Agent-hosted terminal sessions now reconnect **backend-driven** when the
+  `sessionBackendReattach` flag is on (#2476). On a dropped agent transport the
+  backend redrive re-establishes the connection, parks and retries for as long as
+  the drop lasts, mints a fresh session, and the tab re-attaches to it — the
+  client no longer runs its own agent reconnect engine in parallel (which would
+  double-drive the transport). A backend give-up settles the tab as disconnected;
+  the client per-attempt connect deadline no longer force-fails a prolonged
+  backend-driven reconnect. The flag is default-off, so agent reconnect behavior
+  is unchanged until it is enabled.

--- a/src-tauri/src/utils/test_bridge.rs
+++ b/src-tauri/src/utils/test_bridge.rs
@@ -20,14 +20,54 @@ use tauri::Runtime;
 /// Env var holding the runner's WebSocket port the app should connect out to.
 pub const TEST_BRIDGE_PORT_ENV: &str = "TERMIHUB_TEST_BRIDGE_PORT";
 
+/// Env-var prefix for injecting a runtime feature-flag global into the webview
+/// under the test bridge (#2476). `TERMIHUB_TEST_FLAG_<NAME>=<bool>` injects
+/// `window.__TERMIHUB_<NAME>__ = <bool>` before boot, so the harness can flip a
+/// `window.__TERMIHUB_*__`-gated flag for a live run (e.g. the agent reconnect
+/// activation reads `__TERMIHUB_SESSION_BACKEND_REATTACH__`) without a bridge
+/// protocol round-trip. Only active in test-bridge mode; production injects none.
+pub const TEST_FLAG_ENV_PREFIX: &str = "TERMIHUB_TEST_FLAG_";
+
+/// Whether a `TERMIHUB_TEST_FLAG_*` value reads as truthy (`1`/`true`, any case).
+fn flag_is_truthy(raw: &str) -> bool {
+    matches!(raw.trim().to_ascii_lowercase().as_str(), "1" | "true")
+}
+
+/// Whether an env-var suffix is a safe JS identifier fragment (`[A-Za-z0-9_]+`),
+/// so the injected `window.__TERMIHUB_<NAME>__` can never be a script-injection
+/// vector. Env-var names are already restricted to this set, so this is a
+/// belt-and-suspenders guard.
+fn is_safe_flag_name(name: &str) -> bool {
+    !name.is_empty() && name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}
+
+/// JavaScript that sets each `TERMIHUB_TEST_FLAG_<NAME>` env var as the boolean
+/// global `window.__TERMIHUB_<NAME>__`. Empty when none are set. Names are sorted
+/// so the emitted script is deterministic (stable across runs / for tests).
+fn feature_flag_init_script() -> String {
+    let mut pairs: Vec<(String, bool)> = std::env::vars()
+        .filter_map(|(key, val)| {
+            let name = key.strip_prefix(TEST_FLAG_ENV_PREFIX)?;
+            is_safe_flag_name(name).then(|| (name.to_string(), flag_is_truthy(&val)))
+        })
+        .collect();
+    pairs.sort();
+    pairs
+        .into_iter()
+        .map(|(name, value)| format!(" window.__TERMIHUB_{name}__ = {value};"))
+        .collect()
+}
+
 /// JavaScript that opts the in-app bridge into WebSocket test mode.
 ///
 /// Mirrors the keys read by `src/testbridge/testMode.ts`
 /// (`TEST_BRIDGE_GLOBAL_KEY` and `TEST_BRIDGE_PORT_GLOBAL_KEY`). Assigns to
-/// `window` explicitly since the script runs in its own function scope.
+/// `window` explicitly since the script runs in its own function scope. Any
+/// `TERMIHUB_TEST_FLAG_*` feature-flag globals are appended (#2476).
 fn test_bridge_init_script(port: u16) -> String {
     format!(
-        "window.__TERMIHUB_TEST_BRIDGE__ = true; window.__TERMIHUB_TEST_BRIDGE_PORT__ = {port};"
+        "window.__TERMIHUB_TEST_BRIDGE__ = true; window.__TERMIHUB_TEST_BRIDGE_PORT__ = {port};{}",
+        feature_flag_init_script()
     )
 }
 
@@ -66,6 +106,45 @@ mod tests {
         let script = test_bridge_init_script(48123);
         assert!(script.contains("window.__TERMIHUB_TEST_BRIDGE__ = true"));
         assert!(script.contains("window.__TERMIHUB_TEST_BRIDGE_PORT__ = 48123"));
+    }
+
+    #[test]
+    fn flag_truthiness_matches_common_forms() {
+        assert!(flag_is_truthy("1"));
+        assert!(flag_is_truthy("true"));
+        assert!(flag_is_truthy(" TRUE "));
+        assert!(!flag_is_truthy("0"));
+        assert!(!flag_is_truthy("false"));
+        assert!(!flag_is_truthy(""));
+    }
+
+    #[test]
+    fn safe_flag_name_rejects_injection() {
+        assert!(is_safe_flag_name("SESSION_BACKEND_REATTACH"));
+        assert!(is_safe_flag_name("A1_B2"));
+        assert!(!is_safe_flag_name(""));
+        assert!(!is_safe_flag_name("A;window.x=1"));
+        assert!(!is_safe_flag_name("A-B"));
+    }
+
+    #[test]
+    fn feature_flag_script_injects_env_flags_sorted_and_typed() {
+        // Mutates process-global env vars under unique keys no other test reads.
+        let on = "TERMIHUB_TEST_FLAG_ZZZ_ON";
+        let off = "TERMIHUB_TEST_FLAG_AAA_OFF";
+        unsafe {
+            std::env::set_var(on, "1");
+            std::env::set_var(off, "false");
+        }
+        let script = feature_flag_init_script();
+        assert_eq!(
+            script,
+            " window.__TERMIHUB_AAA_OFF__ = false; window.__TERMIHUB_ZZZ_ON__ = true;"
+        );
+        unsafe {
+            std::env::remove_var(on);
+            std::env::remove_var(off);
+        }
     }
 
     #[test]

--- a/src/components/Terminal/Terminal.agent-reconnect.test.tsx
+++ b/src/components/Terminal/Terminal.agent-reconnect.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * Component tests for the backend-driven AGENT reconnect activation (#2476).
+ *
+ * When the default-off `sessionBackendReattach` flag is ON, a reconnect of an
+ * agent-hosted tab must be driven **entirely by the backend redrive** — the
+ * client agent engine (`createTerminal` → `connectRemoteAgent` + park + bounded
+ * spawn retries) must NOT run, or it double-drives the very agent transport the
+ * redrive is re-establishing. Instead the Terminal:
+ *   • re-attaches terminal I/O to the backend-published session id on success, or
+ *   • settles the tab disconnected when the backend give-up folds into the region,
+ * never calling `createTerminal` on either path.
+ *
+ * With the flag OFF the reconnect drives the client engine exactly as on develop
+ * (a fresh `createTerminal`), pinning byte-identical flag-off parity.
+ *
+ * Mirrors Terminal.backend-reattach.test.tsx (the direct-SSH #2457 analog).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Terminal } from "./Terminal";
+import { TerminalPortalProvider } from "./TerminalRegistry";
+import { useAppStore } from "@/store/appStore";
+import {
+  setSessionBackendReattachEnabled,
+  setSessionTransportForTest,
+  stopSessionSubscription,
+} from "@/store/sessionBridge";
+import {
+  FakeSessionTransport,
+  connected as connectedLifecycle,
+} from "@/test/sessionLifecycleRegionTestHarness";
+
+// --- Mocks (mirror Terminal.backend-reattach.test.tsx) ---
+
+vi.mock("@xterm/xterm", () => {
+  class MockXTerm {
+    open = vi.fn();
+    dispose = vi.fn();
+    loadAddon = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn(() => ({ dispose: vi.fn() }));
+    onScroll = vi.fn(() => ({ dispose: vi.fn() }));
+    onCursorMove = vi.fn(() => ({ dispose: vi.fn() }));
+    onWriteParsed = vi.fn(() => ({ dispose: vi.fn() }));
+    write = vi.fn((_data: unknown, cb?: () => void) => cb?.());
+    writeln = vi.fn();
+    reset = vi.fn();
+    scrollToBottom = vi.fn();
+    scrollLines = vi.fn();
+    selectAll = vi.fn();
+    hasSelection = vi.fn(() => false);
+    getSelection = vi.fn(() => "");
+    attachCustomKeyEventHandler = vi.fn();
+    unicode = { activeVersion: "6" };
+    cols = 80;
+    rows = 24;
+    resize = vi.fn();
+    focus = vi.fn();
+    element = document.createElement("div");
+    buffer = { active: { viewportY: 0, baseY: 0, length: 0, getLine: vi.fn() } };
+    parser = { registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })) };
+    options = {};
+  }
+  return { Terminal: MockXTerm };
+});
+
+vi.mock("@xterm/addon-fit", () => {
+  class MockFitAddon {
+    fit = vi.fn();
+    proposeDimensions = vi.fn(() => ({ cols: 80, rows: 24 }));
+    dispose = vi.fn();
+  }
+  return { FitAddon: MockFitAddon };
+});
+
+vi.mock("@xterm/addon-unicode11", () => {
+  class MockUnicode11Addon {
+    dispose = vi.fn();
+  }
+  return { Unicode11Addon: MockUnicode11Addon };
+});
+
+vi.mock("@xterm/addon-search", () => {
+  class MockSearchAddon {
+    dispose = vi.fn();
+  }
+  return { SearchAddon: MockSearchAddon };
+});
+
+vi.mock("@/themes", () => ({
+  getXtermTheme: vi.fn(() => ({})),
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+const mockCreateTerminal = vi.fn().mockResolvedValue("fresh-session");
+const mockGetAgentSessionBuffer = vi.fn().mockResolvedValue(new Uint8Array());
+
+vi.mock("@/services/api", () => ({
+  createTerminal: (...args: unknown[]) => mockCreateTerminal(...args),
+  sendInput: vi.fn().mockResolvedValue(undefined),
+  resizeTerminal: vi.fn().mockResolvedValue(undefined),
+  closeTerminal: vi.fn().mockResolvedValue(undefined),
+  detachPersistentTab: vi.fn().mockResolvedValue(0),
+  getAgentSessionBuffer: (...args: unknown[]) => mockGetAgentSessionBuffer(...args),
+  sessionGetCapabilities: vi.fn().mockResolvedValue({}),
+}));
+
+const mockSubscribeOutput = vi.fn(() => vi.fn());
+const mockSubscribeExit = vi.fn(() => vi.fn());
+
+vi.mock("@/services/events", () => ({
+  terminalDispatcher: {
+    init: vi.fn().mockResolvedValue(undefined),
+    subscribeOutput: (...args: unknown[]) => mockSubscribeOutput(...(args as [])),
+    subscribeExit: (...args: unknown[]) => mockSubscribeExit(...(args as [])),
+    clearPendingExit: vi.fn(),
+    clearPendingOutput: vi.fn(),
+  },
+}));
+
+vi.mock("@/services/keybindings", () => ({
+  processKeyEvent: vi.fn(() => null),
+  isAppShortcut: vi.fn(() => false),
+  isChordPending: vi.fn(() => false),
+}));
+
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  readText: vi.fn().mockResolvedValue(""),
+}));
+
+globalThis.ResizeObserver = class {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+} as unknown as typeof ResizeObserver;
+
+let container: HTMLDivElement;
+let root: Root;
+let transport: FakeSessionTransport;
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  mockCreateTerminal.mockClear();
+  mockCreateTerminal.mockResolvedValue("fresh-session");
+  mockGetAgentSessionBuffer.mockClear();
+  mockSubscribeOutput.mockClear();
+  mockSubscribeExit.mockClear();
+  transport = new FakeSessionTransport();
+  setSessionTransportForTest(transport);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  stopSessionSubscription();
+  setSessionTransportForTest(null);
+  setSessionBackendReattachEnabled(null);
+});
+
+const AGENT_CONFIG = {
+  type: "remote-session" as const,
+  config: { agentId: "agent-1", sessionType: "shell" },
+};
+
+/** Add a live agent (remote-session) tab to the store and return its id. */
+function addAgentTab(sessionId: string): string {
+  return useAppStore.getState().addTab("Agent Shell", "remote-session", AGENT_CONFIG, {
+    contentType: "terminal",
+    sessionId,
+  });
+}
+
+const mount = (tabId: string, existingSessionId: string) => {
+  act(() => {
+    root.render(
+      <TerminalPortalProvider>
+        <Terminal
+          tabId={tabId}
+          config={AGENT_CONFIG}
+          isVisible={true}
+          existingSessionId={existingSessionId}
+        />
+      </TerminalPortalProvider>
+    );
+  });
+};
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("Terminal — backend-driven agent reconnect (#2476)", () => {
+  it("flag ON: re-attaches to the backend-published id, never calling the client engine", async () => {
+    setSessionBackendReattachEnabled(true);
+    const tabId = addAgentTab("initial-session");
+    // The redrive re-established the transport and published the fresh backend id.
+    transport.setSession(tabId, { ...connectedLifecycle(), sessionId: "agent-new" });
+
+    mount(tabId, "initial-session");
+    await act(async () => {
+      await wait(50);
+    });
+    expect(mockCreateTerminal).not.toHaveBeenCalled(); // initial mount reattaches
+
+    act(() => {
+      useAppStore.getState().reconnectTerminal(tabId);
+    });
+    await act(async () => {
+      await wait(80);
+    });
+
+    // The client agent engine is suppressed — no createTerminal on the reconnect.
+    expect(mockCreateTerminal).not.toHaveBeenCalled();
+    // Terminal I/O re-attaches to the backend-chosen id.
+    expect(mockSubscribeOutput).toHaveBeenCalledWith("agent-new", expect.any(Function));
+    expect(mockSubscribeExit).toHaveBeenCalledWith("agent-new", expect.any(Function));
+  });
+
+  it("flag ON: settles disconnected on backend give-up, never calling the client engine", async () => {
+    setSessionBackendReattachEnabled(true);
+    const tabId = addAgentTab("initial-session");
+    mount(tabId, "initial-session");
+    await act(async () => {
+      await wait(50);
+    });
+
+    act(() => {
+      useAppStore.getState().reconnectTerminal(tabId);
+    });
+    // Backend park/retry exhausts → folds Failed/gaveup into the region.
+    await act(async () => {
+      await wait(30);
+      transport.setSession(tabId, {
+        status: "failed",
+        reconnect: { phase: "gaveup", attempt: 3, delayMs: 0 },
+        error: "agent unreachable after 3 attempts",
+      });
+      await wait(80);
+    });
+
+    expect(mockCreateTerminal).not.toHaveBeenCalled();
+    const state = useAppStore.getState();
+    expect(state.terminalDisconnectErrors[tabId]).toBe("agent unreachable after 3 attempts");
+    expect(state.terminalExitedTabs[tabId]).toBe(true);
+    expect(state.terminalAutoReconnect[tabId]).toBeUndefined();
+  });
+
+  it("flag OFF: reconnect drives the client engine (createTerminal) — develop parity", async () => {
+    setSessionBackendReattachEnabled(false);
+    const tabId = addAgentTab("initial-session");
+    // Even with a backend id available, the flag-off path ignores it.
+    transport.setSession(tabId, { ...connectedLifecycle(), sessionId: "agent-new" });
+
+    mount(tabId, "initial-session");
+    await act(async () => {
+      await wait(50);
+    });
+    expect(mockCreateTerminal).not.toHaveBeenCalled();
+
+    act(() => {
+      useAppStore.getState().reconnectTerminal(tabId);
+    });
+    await act(async () => {
+      await wait(80);
+    });
+
+    // develop behavior: an agent reconnect re-creates the session via the client.
+    expect(mockCreateTerminal).toHaveBeenCalledTimes(1);
+    expect(mockSubscribeOutput).not.toHaveBeenCalledWith("agent-new", expect.any(Function));
+  });
+});

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -22,7 +22,11 @@ import {
 } from "@/services/api";
 import { terminalDispatcher } from "@/services/events";
 import { useTerminalRegistry } from "./TerminalRegistry";
-import { useAppStore, isResilientReconnectTabId } from "@/store/appStore";
+import {
+  useAppStore,
+  isResilientReconnectTabId,
+  isBackendDrivenAgentReconnectTabId,
+} from "@/store/appStore";
 import { currentBroadcastView } from "@/store/broadcastBridge";
 import { currentAgentsView } from "@/store/agentsBridge";
 import { currentSettingsView } from "@/store/settingsBridge";
@@ -52,6 +56,7 @@ import { resolveHighlightingConfig, resolveActiveRules } from "@/services/syntax
 import {
   sessionBackendReattachEnabled,
   waitForBackendReattachSessionId,
+  waitForBackendAgentReconnectOutcome,
 } from "@/store/sessionBridge";
 
 const HORIZONTAL_SCROLL_COLS = 500;
@@ -447,6 +452,31 @@ export function Terminal({
             // Persistent/agent tab: restart the background session and reattach
             // to its (possibly new) live id — never to the dead mount-time id.
             reattachSessionId = await useAppStore.getState().restartPersistentSessionForTab(tabId);
+          } else if (isBackendDrivenAgentReconnectTabId(tabId)) {
+            // Backend-driven AGENT reconnect (#2476): the redrive re-establishes
+            // the agent transport and mints a new backend session, parking/
+            // retrying for however long the drop lasts. The client must NOT drive
+            // the transport in parallel — its agent engine (connectRemoteAgent +
+            // park + bounded spawn retries) is non-idempotent and would
+            // double-drive the very transport the backend is re-establishing. So
+            // this waits for the backend loop's terminal outcome and never falls
+            // through to the client create loop below:
+            //   • reattach → attach I/O to the fresh backend session id;
+            //   • giveup   → settle the tab disconnected (backend exhausted retries);
+            //   • canceled → the effect was torn down.
+            const outcome = await waitForBackendAgentReconnectOutcome(
+              tabId,
+              sessionIdRef.current,
+              isCanceled
+            );
+            if (isCanceled() || outcome.kind === "canceled") return;
+            if (outcome.kind === "giveup") {
+              useAppStore
+                .getState()
+                .settleBackendReconnectGaveUp(tabId, outcome.error ?? "Agent reconnect failed.");
+              return;
+            }
+            reattachSessionId = outcome.sessionId;
           } else if (sessionBackendReattachEnabled()) {
             // Backend-driven direct reconnect (#2457): with the flag on, the
             // reconnect redrive is server-side (#2454). The backend re-creates
@@ -629,6 +659,19 @@ export function Terminal({
               useAppStore.getState().setTerminalConnecting(tabId, false);
 
               if (isAgentSession && agentId) {
+                // Backend-driven agent reconnect (#2476): under the flag, a
+                // reconnect (retryCount>0) is owned entirely by the backend
+                // redrive. The client must NOT run its agent engine
+                // (connectRemoteAgent + park + bounded MAX_AGENT_SPAWN_ATTEMPTS)
+                // here — it would double-drive the transport the redrive is
+                // re-establishing. The backend-driven reconnect path above already
+                // reattaches or settles without reaching this create loop, so this
+                // is defense-in-depth: never engage the client engine on such a
+                // reconnect. Flag off / initial connect (retryCount 0) fall
+                // through to the engine unchanged.
+                if (isReconnect && isBackendDrivenAgentReconnectTabId(tabId)) {
+                  return;
+                }
                 // Check whether the agent transport itself is still connecting.
                 const agentState = currentAgentsView().remoteAgents.find(
                   (a) => a.id === agentId

--- a/src/store/appStore.agentReconnect.test.ts
+++ b/src/store/appStore.agentReconnect.test.ts
@@ -1,0 +1,191 @@
+/**
+ * appStore parity tests for the agent reconnect activation (#2476).
+ *
+ * The activation flag-gates the agent hot path behind `sessionBackendReattach`:
+ *
+ *  - {@link isResilientReconnectTabId} — an agent-hosted tab counts as resilient
+ *    ONLY when the flag is on (flag off ⇒ agents excluded, byte-identical to
+ *    develop). Direct-SSH classification is unchanged either way.
+ *  - {@link isBackendDrivenAgentReconnectTabId} — the discriminator that routes
+ *    an agent reconnect entirely to the backend (never the client agent engine)
+ *    and suppresses the client connect deadline. True only for a non-persistent
+ *    agent tab with the flag on.
+ *  - `reconnectTerminal` — skips the fixed 90 s "connecting" deadline for a
+ *    backend-driven agent reconnect (the backend park/retry legitimately
+ *    outlasts it), while every other tab keeps the safety-net deadline.
+ *  - `settleBackendReconnectGaveUp` — reflects a backend give-up as the
+ *    disconnect overlay without re-mirroring any intent.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  persistAgent: vi.fn(() => Promise.resolve()),
+  removeAgent: vi.fn(() => Promise.resolve()),
+  reorderAgents: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve()),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/services/api", () => ({
+  startPersistentSession: vi.fn(() => Promise.resolve("sid")),
+  stopPersistentSession: vi.fn(() => Promise.resolve()),
+  attachPersistentTab: vi.fn(() => Promise.resolve(1)),
+  connectAgent: vi.fn(() => Promise.resolve({ capabilities: {} })),
+  disconnectAgent: vi.fn(),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  listAgentConnections: vi.fn(() => Promise.resolve({ connections: [], folders: [] })),
+  saveAgentDefinition: vi.fn(),
+  updateAgentDefinition: vi.fn(),
+  deleteAgentDefinition: vi.fn(() => Promise.resolve()),
+  createAgentFolder: vi.fn(),
+  updateAgentFolder: vi.fn(() => Promise.resolve({})),
+  deleteAgentFolder: vi.fn(() => Promise.resolve()),
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  removeCredential: vi.fn(() => Promise.resolve()),
+  getConnectionTypes: vi.fn(() => Promise.resolve([])),
+  sessionGetCapabilities: vi.fn(() => Promise.resolve({})),
+}));
+
+import {
+  useAppStore,
+  isResilientReconnectTabId,
+  isBackendDrivenAgentReconnectTabId,
+} from "./appStore";
+import { setSessionBackendReattachEnabled, setSessionIntentsEnabled } from "./sessionBridge";
+
+/** A non-persistent agent (remote-session) shell tab. */
+function makeAgentTab(): string {
+  return useAppStore.getState().addTab(
+    "Agent Shell",
+    "remote-session",
+    {
+      type: "remote-session",
+      config: { agentId: "agent-1", sessionType: "shell" },
+    },
+    { contentType: "terminal", sessionId: "sess-agent" }
+  );
+}
+
+/** A plain, resilient-opt-in direct SSH tab. */
+function makeSshTab(): string {
+  return useAppStore.getState().addTab(
+    "web01",
+    "ssh",
+    {
+      type: "ssh",
+      config: { host: "web01.example.com", username: "deploy", resilientReconnect: true },
+    },
+    { contentType: "terminal", sessionId: "sess-ssh" }
+  );
+}
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  setSessionIntentsEnabled(true); // underlying cut default-on
+});
+
+afterEach(() => {
+  setSessionBackendReattachEnabled(null);
+  setSessionIntentsEnabled(null);
+});
+
+describe("agent tab resilient classification (#2476)", () => {
+  it("flag OFF: an agent tab is NOT resilient (byte-identical to develop)", () => {
+    setSessionBackendReattachEnabled(false);
+    const tabId = makeAgentTab();
+    expect(isResilientReconnectTabId(tabId)).toBe(false);
+    expect(isBackendDrivenAgentReconnectTabId(tabId)).toBe(false);
+  });
+
+  it("flag ON: an agent tab IS resilient and backend-driven", () => {
+    setSessionBackendReattachEnabled(true);
+    const tabId = makeAgentTab();
+    expect(isResilientReconnectTabId(tabId)).toBe(true);
+    expect(isBackendDrivenAgentReconnectTabId(tabId)).toBe(true);
+  });
+
+  it("a direct SSH tab is never backend-driven-agent, and its resilience is unchanged", () => {
+    setSessionBackendReattachEnabled(true);
+    const tabId = makeSshTab();
+    expect(isResilientReconnectTabId(tabId)).toBe(true); // opt-in, agentless #1962
+    expect(isBackendDrivenAgentReconnectTabId(tabId)).toBe(false);
+
+    setSessionBackendReattachEnabled(false);
+    expect(isResilientReconnectTabId(tabId)).toBe(true); // still opt-in, flag-independent
+    expect(isBackendDrivenAgentReconnectTabId(tabId)).toBe(false);
+  });
+});
+
+describe("reconnectTerminal connect-deadline reconciliation (#2476)", () => {
+  it("flag ON: a backend-driven agent reconnect arms NO connecting deadline", () => {
+    setSessionBackendReattachEnabled(true);
+    const tabId = makeAgentTab();
+    useAppStore.getState().reconnectTerminal(tabId);
+    expect(useAppStore.getState().terminalConnectDeadline[tabId]).toBeUndefined();
+    // The reconnect still fired (retry counter bumped, connecting overlay set).
+    expect(useAppStore.getState().terminalRetryCounters[tabId]).toBe(1);
+    expect(useAppStore.getState().terminalConnecting[tabId]).toBe(true);
+  });
+
+  it("flag OFF: an agent reconnect keeps the safety-net connecting deadline", () => {
+    setSessionBackendReattachEnabled(false);
+    const tabId = makeAgentTab();
+    useAppStore.getState().reconnectTerminal(tabId);
+    const deadline = useAppStore.getState().terminalConnectDeadline[tabId];
+    expect(deadline?.kind).toBe("connecting");
+    expect(deadline?.at).toBeGreaterThan(Date.now());
+  });
+
+  it("a direct SSH tab keeps the connecting deadline even with the flag on", () => {
+    setSessionBackendReattachEnabled(true);
+    const tabId = makeSshTab();
+    useAppStore.getState().reconnectTerminal(tabId);
+    expect(useAppStore.getState().terminalConnectDeadline[tabId]?.kind).toBe("connecting");
+  });
+});
+
+describe("settleBackendReconnectGaveUp (#2476)", () => {
+  it("clears the loop + connect flags and shows the disconnect overlay with the error", () => {
+    setSessionBackendReattachEnabled(true);
+    const tabId = makeAgentTab();
+    // Simulate a live backend-driven reconnect: connecting overlay up, loop record present.
+    useAppStore.getState().reconnectTerminal(tabId);
+    useAppStore.setState((s) => ({
+      terminalAutoReconnect: {
+        ...s.terminalAutoReconnect,
+        [tabId]: { phase: "connecting", attempt: 2, maxAttempts: 5, delayMs: 0, nextAttemptAt: 0 },
+      },
+    }));
+
+    useAppStore.getState().settleBackendReconnectGaveUp(tabId, "agent unreachable");
+
+    const state = useAppStore.getState();
+    expect(state.terminalAutoReconnect[tabId]).toBeUndefined();
+    expect(state.terminalConnecting[tabId]).toBeUndefined();
+    expect(state.terminalConnectDeadline[tabId]).toBeUndefined();
+    expect(state.terminalExitedTabs[tabId]).toBe(true);
+    expect(state.terminalDisconnectErrors[tabId]).toBe("agent unreachable");
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1091,6 +1091,19 @@ export interface AppState
   /** Return whether a session was intentionally killed, clearing the flag (#1121). */
   consumeSessionKilled: (sessionId: string) => boolean;
   setTerminalDisconnectWithError: (tabId: string, error: string) => void;
+  /**
+   * Settle a backend-driven agent reconnect (#2476) that the **backend** gave up
+   * on. The backend redrive owns the reconnect outcome under the
+   * `sessionBackendReattach` flag, so when its park/retry loop exhausts (folds
+   * `reconnectFailed` → `Failed`/`gaveup` in the region), the frontend must
+   * reflect that terminal state directly rather than routing through the client
+   * reconnect reducer (whose local attempt counter is not the authority here).
+   * Clears the loop record + every in-flight connect flag and shows the disconnect
+   * overlay with the give-up error, WITHOUT re-mirroring any `session.*` intent
+   * (the backend already folded the give-up — mirroring would be a redundant,
+   * possibly divergent, second signal).
+   */
+  settleBackendReconnectGaveUp: (tabId: string, error: string) => void;
 
   /**
    * Register the cohort of tabs placed by a restore/launch (#1146, audit G4).
@@ -2037,20 +2050,31 @@ function clearAutoReconnectTimer(tabId: string): void {
 const autoReconnectConfig: BackoffConfig = DEFAULT_BACKOFF;
 
 /**
- * Whether a tab is eligible for agentless resilient reconnect (#1962): a plain
- * SSH terminal whose saved connection opted in via the "Resilient Reconnect"
- * setting, and which is NOT agent-backed or a persistent session (those have
- * their own continuity machinery). Reads the opt-in from the tab's connection
- * config, where the SSH schema field persists it.
+ * Whether a tab is eligible for resilient reconnect. Two distinct populations,
+ * both excluding persistent sessions (those have their own continuity machinery):
+ *
+ * - **Agentless direct SSH (#1962):** a plain SSH terminal whose saved connection
+ *   opted in via the "Resilient Reconnect" setting. Client-driven backoff loop.
+ * - **Agent-hosted (#2476):** a shell session on a remote agent, resilient **only
+ *   when the `sessionBackendReattach` flag is on**. The agent reconnect is
+ *   backend-driven (park + retry + new-sessionId re-attach); the flag is its
+ *   master switch. With the flag OFF this returns `false` for every agent tab —
+ *   byte-identical to the pre-#2476 `if (cfg.agentId) return false` behavior.
+ *
+ * Reads the opt-in / agent marker from the tab's connection config.
  */
 function isResilientReconnectTab(tab: TerminalTab | undefined): boolean {
   if (!tab) return false;
   if (tab.contentType !== "terminal") return false;
-  if (tab.connectionType !== "ssh") return false;
   if (tab.persistentConnectionId) return false;
   const cfg = tab.config?.config as { resilientReconnect?: unknown; agentId?: unknown } | undefined;
   if (!cfg) return false;
-  if (cfg.agentId) return false;
+  if (cfg.agentId) {
+    // Agent-hosted tab (#2476): resilient iff the backend-reattach flag is on.
+    // Flag off ⇒ false ⇒ byte-identical to develop (agents were always excluded).
+    return sessionBackendReattachEnabled();
+  }
+  if (tab.connectionType !== "ssh") return false;
   return cfg.resilientReconnect === true;
 }
 
@@ -2065,6 +2089,33 @@ function isResilientReconnectTab(tab: TerminalTab | undefined): boolean {
 export function isResilientReconnectTabId(tabId: string): boolean {
   const tab = collectLiveTabs(useAppStore.getState()).find((t) => t.id === tabId);
   return isResilientReconnectTab(tab);
+}
+
+/**
+ * Whether `tabId` is an **agent-hosted** tab whose reconnect is driven entirely
+ * by the backend redrive under the `sessionBackendReattach` flag (#2476), as
+ * opposed to an agentless direct-SSH resilient tab (#1962/#2457) whose reconnect
+ * the client still drives (with the backend-reattach id as a fast path).
+ *
+ * This is the discriminator for the two agent-specific cuts of the activation:
+ *  - `Terminal.tsx` routes only these tabs through the give-up-aware wait that
+ *    stays deferred to the backend loop across a prolonged drop (never falling
+ *    through to the non-idempotent client agent engine — the double-drive fix);
+ *  - `reconnectTerminal` skips arming the fixed 90 s "connecting" deadline for
+ *    these tabs, since the backend park/retry legitimately outlasts it and the
+ *    give-up fold — not a client wall-clock timeout — is what settles the tab.
+ *
+ * Flag off ⇒ always `false` (no agent tab is resilient), so both cuts are inert
+ * and every path is byte-identical to develop.
+ */
+export function isBackendDrivenAgentReconnectTabId(tabId: string): boolean {
+  if (!sessionBackendReattachEnabled()) return false;
+  const tab = collectLiveTabs(useAppStore.getState()).find((t) => t.id === tabId);
+  if (!tab) return false;
+  if (tab.persistentConnectionId) return false;
+  const cfg = tab.config?.config as { agentId?: unknown } | undefined;
+  const isAgentTab = tab.config?.type === "remote-session" || !!cfg?.agentId;
+  return isAgentTab && isResilientReconnectTab(tab);
 }
 
 /**
@@ -5613,6 +5664,29 @@ export const useAppStore = create<AppState>((set, get, store) => {
         get().disconnectMonitoring(deadKey);
       }
     },
+    settleBackendReconnectGaveUp: (tabId, error) => {
+      // The backend already folded the give-up (region → Failed/gaveup); reflect
+      // it locally without re-mirroring an intent. Clear the auto-reconnect loop
+      // record and every in-flight connect flag (connecting / deadline / waiting /
+      // spawn-error) so no competing overlay lingers, then show the disconnect
+      // overlay with the give-up error (offering View Scrollback / Reconnect).
+      set((state) => ({
+        terminalAutoReconnect: omitKey(state.terminalAutoReconnect, tabId),
+        terminalConnecting: omitKey(state.terminalConnecting, tabId),
+        terminalConnectDeadline: omitKey(state.terminalConnectDeadline, tabId),
+        terminalWaitingForAgent: omitKey(state.terminalWaitingForAgent, tabId),
+        terminalAutoRetryCount: omitKey(state.terminalAutoRetryCount, tabId),
+        terminalSpawnErrors: omitKey(state.terminalSpawnErrors, tabId),
+        terminalReconnectingTabs: omitKey(state.terminalReconnectingTabs, tabId),
+        terminalExitedTabs: { ...state.terminalExitedTabs, [tabId]: true },
+        terminalDisconnectErrors: { ...state.terminalDisconnectErrors, [tabId]: error },
+      }));
+      get().settleRestoreTab(tabId, "failed");
+      const deadKey = monitorKeyForTab(collectLiveTabs(get()).find((t) => t.id === tabId));
+      if (deadKey && currentMonitorsView().monitors[deadKey]) {
+        get().disconnectMonitoring(deadKey);
+      }
+    },
 
     // Aggregate partial-restore feedback (#1146, audit G4) + bulk retry (#1227,
     // M2). Region-authoritative (#2206): the `restore-cohort@<clientId>` store
@@ -5701,32 +5775,49 @@ export const useAppStore = create<AppState>((set, get, store) => {
         terminalViewMode: { ...state.terminalViewMode, [tabId]: true },
       })),
     reconnectTerminal: (tabId) =>
-      set((state) => ({
-        terminalExitedTabs: omitKey(state.terminalExitedTabs, tabId),
-        terminalExitInfo: omitKey(state.terminalExitInfo, tabId),
-        terminalDisconnectErrors: omitKey(state.terminalDisconnectErrors, tabId),
-        terminalViewMode: omitKey(state.terminalViewMode, tabId),
-        terminalReconnectPrompt: omitKey(state.terminalReconnectPrompt, tabId),
-        terminalReconnectingTabs: omitKey(state.terminalReconnectingTabs, tabId),
-        terminalAutoRetryCount: omitKey(state.terminalAutoRetryCount, tabId),
-        terminalWaitingForAgent: omitKey(state.terminalWaitingForAgent, tabId),
-        terminalSpawnErrors: omitKey(state.terminalSpawnErrors, tabId),
-        terminalReconnectTriggerErrors: omitKey(state.terminalReconnectTriggerErrors, tabId),
-        // Set connecting immediately so the "Connecting…" overlay appears at once,
-        // without a gap between the disconnect overlay disappearing and the effect
-        // re-running to call setTerminalConnecting().
-        terminalConnecting: { ...state.terminalConnecting, [tabId]: true },
-        // Fresh reconnect attempt: arm a new connecting deadline (any prior one
-        // was cleared on disconnect) so the wall-clock timeout starts now.
-        terminalConnectDeadline: {
-          ...state.terminalConnectDeadline,
-          [tabId]: { kind: "connecting" as const, at: Date.now() + connectTimeoutMs("connecting") },
-        },
-        terminalRetryCounters: {
-          ...state.terminalRetryCounters,
-          [tabId]: (state.terminalRetryCounters[tabId] ?? 0) + 1,
-        },
-      })),
+      set((state) => {
+        // Backend-driven agent reconnect (#2476): the backend park/retry loop is
+        // the sole driver and legitimately outlasts the fixed 90 s "connecting"
+        // deadline on a prolonged agent drop. Arming it here would let the client
+        // wall-clock timeout force-fail a tab the backend is still recovering, so
+        // this reconnect leaves the deadline cleared — the backend give-up fold,
+        // not a client timer, is what settles the tab (the give-up-aware wait in
+        // Terminal.tsx resolves it). Every other tab keeps the safety-net deadline.
+        // Flag off ⇒ this is always false ⇒ byte-identical to develop.
+        const deferToBackendLoop = isBackendDrivenAgentReconnectTabId(tabId);
+        return {
+          terminalExitedTabs: omitKey(state.terminalExitedTabs, tabId),
+          terminalExitInfo: omitKey(state.terminalExitInfo, tabId),
+          terminalDisconnectErrors: omitKey(state.terminalDisconnectErrors, tabId),
+          terminalViewMode: omitKey(state.terminalViewMode, tabId),
+          terminalReconnectPrompt: omitKey(state.terminalReconnectPrompt, tabId),
+          terminalReconnectingTabs: omitKey(state.terminalReconnectingTabs, tabId),
+          terminalAutoRetryCount: omitKey(state.terminalAutoRetryCount, tabId),
+          terminalWaitingForAgent: omitKey(state.terminalWaitingForAgent, tabId),
+          terminalSpawnErrors: omitKey(state.terminalSpawnErrors, tabId),
+          terminalReconnectTriggerErrors: omitKey(state.terminalReconnectTriggerErrors, tabId),
+          // Set connecting immediately so the "Connecting…" overlay appears at once,
+          // without a gap between the disconnect overlay disappearing and the effect
+          // re-running to call setTerminalConnecting().
+          terminalConnecting: { ...state.terminalConnecting, [tabId]: true },
+          // Fresh reconnect attempt: arm a new connecting deadline (any prior one
+          // was cleared on disconnect) so the wall-clock timeout starts now —
+          // except for a backend-driven agent reconnect, which owns its own timing.
+          terminalConnectDeadline: deferToBackendLoop
+            ? omitKey(state.terminalConnectDeadline, tabId)
+            : {
+                ...state.terminalConnectDeadline,
+                [tabId]: {
+                  kind: "connecting" as const,
+                  at: Date.now() + connectTimeoutMs("connecting"),
+                },
+              },
+          terminalRetryCounters: {
+            ...state.terminalRetryCounters,
+            [tabId]: (state.terminalRetryCounters[tabId] ?? 0) + 1,
+          },
+        };
+      }),
     showTerminalReconnectPrompt: (tabId) =>
       set((state) => ({
         terminalReconnectPrompt: { ...state.terminalReconnectPrompt, [tabId]: true },

--- a/src/store/sessionBridge.agentReconnect.test.ts
+++ b/src/store/sessionBridge.agentReconnect.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for {@link waitForBackendAgentReconnectOutcome} — the give-up-aware
+ * wait that activates the backend-driven **agent** reconnect (#2476).
+ *
+ * Unlike {@link waitForBackendReattachSessionId} (direct SSH, #2457), this wait
+ * has no short fall-through timeout: it stays deferred to the backend park/retry
+ * loop for as long as the loop is active (a prolonged agent drop), resolving only
+ * on a genuine terminal outcome — a fresh backend session id (reattach), an
+ * exhausted-retry give-up, a server-side stop, or the effect being torn down.
+ * That is what keeps the client from ever double-driving the agent transport the
+ * backend redrive is re-establishing.
+ *
+ * The region is driven by an in-memory transport double so the round-trip runs
+ * without a backend (mirrors sessionBridge.backendReattach.test.ts).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  ProjectionFrame,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import {
+  SESSION_LIFECYCLE_REGION,
+  setSessionTransportForTest,
+  stopSessionSubscription,
+  waitForBackendAgentReconnectOutcome,
+  type ProjectedSessionLifecycle,
+} from "./sessionBridge";
+
+/** An in-memory `session-lifecycle` region double that fans a fresh snapshot to
+ * every subscriber on each mutation. */
+class FakeTransport implements Transport {
+  private view: { sessions: Record<string, ProjectedSessionLifecycle> } = { sessions: {} };
+  private version = 0;
+  private handlers: FrameHandler[] = [];
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    return { intentId: intent.intentId, status: "accepted", produced: [] };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.handlers.push(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => {
+        this.handlers = this.handlers.filter((h) => h !== onFrame);
+      },
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  setSession(id: string, life: ProjectedSessionLifecycle): void {
+    this.view.sessions[id] = life;
+    this.version += 1;
+    this.fan();
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private fan(): void {
+    const frame: ProjectionFrame = this.snapshot(SESSION_LIFECYCLE_REGION);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+const connectedWith = (sessionId: string): ProjectedSessionLifecycle => ({
+  status: "connected",
+  reconnect: { phase: "idle", attempt: 0, delayMs: 0 },
+  sessionId,
+});
+
+const reconnecting = (): ProjectedSessionLifecycle => ({
+  status: "reconnecting",
+  reconnect: { phase: "connecting", attempt: 1, delayMs: 0 },
+});
+
+const gaveUp = (error?: string): ProjectedSessionLifecycle => ({
+  status: "failed",
+  reconnect: { phase: "gaveup", attempt: 3, delayMs: 0 },
+  error,
+});
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+let transport: FakeTransport;
+
+beforeEach(() => {
+  transport = new FakeTransport();
+  setSessionTransportForTest(transport);
+});
+
+afterEach(() => {
+  stopSessionSubscription();
+  setSessionTransportForTest(null);
+});
+
+describe("waitForBackendAgentReconnectOutcome", () => {
+  const never = () => false;
+
+  it("reattaches to a fresh backend session id (fast path)", async () => {
+    transport.setSession("tab-1", connectedWith("agent-new"));
+    await flush();
+    const outcome = await waitForBackendAgentReconnectOutcome("tab-1", "agent-old", never);
+    expect(outcome).toEqual({ kind: "reattach", sessionId: "agent-new" });
+  });
+
+  it("reattaches once the redrive publishes the id after the wait starts", async () => {
+    const pending = waitForBackendAgentReconnectOutcome("tab-2", "agent-old", never);
+    await flush();
+    transport.setSession("tab-2", reconnecting()); // still parking — not terminal
+    await flush();
+    transport.setSession("tab-2", connectedWith("agent-fresh"));
+    expect(await pending).toEqual({ kind: "reattach", sessionId: "agent-fresh" });
+  });
+
+  it("excludes the prior (dead) session id so it never re-attaches to a corpse", async () => {
+    transport.setSession("tab-3", connectedWith("agent-old"));
+    await flush();
+    const pending = waitForBackendAgentReconnectOutcome("tab-3", "agent-old", never);
+    await flush();
+    transport.setSession("tab-3", connectedWith("agent-new"));
+    expect(await pending).toEqual({ kind: "reattach", sessionId: "agent-new" });
+  });
+
+  it("gives up when the backend exhausts retries (reconnect.phase gaveup / status failed)", async () => {
+    const pending = waitForBackendAgentReconnectOutcome("tab-4", "agent-old", never);
+    await flush();
+    transport.setSession("tab-4", reconnecting()); // parking — no resolution yet
+    await flush();
+    transport.setSession("tab-4", gaveUp("agent unreachable after 3 attempts"));
+    expect(await pending).toEqual({
+      kind: "giveup",
+      error: "agent unreachable after 3 attempts",
+    });
+  });
+
+  it("gives up (no error) when the loop is stopped server-side (status disconnected)", async () => {
+    const pending = waitForBackendAgentReconnectOutcome("tab-5", "agent-old", never);
+    await flush();
+    transport.setSession("tab-5", {
+      status: "disconnected",
+      reconnect: { phase: "idle", attempt: 0, delayMs: 0 },
+    });
+    expect(await pending).toEqual({ kind: "giveup" });
+  });
+
+  it("does NOT resolve while the backend is still parking (no fall-through timeout)", async () => {
+    let resolved: unknown = "pending";
+    const pending = waitForBackendAgentReconnectOutcome("tab-6", "agent-old", never).then((o) => {
+      resolved = o;
+      return o;
+    });
+    await flush();
+    transport.setSession("tab-6", reconnecting());
+    // Give any (nonexistent) short timeout ample room to fire — it must not.
+    await new Promise((r) => setTimeout(r, 60));
+    expect(resolved).toBe("pending");
+    // It still resolves once the backend reaches a terminal state.
+    transport.setSession("tab-6", connectedWith("agent-late"));
+    expect(await pending).toEqual({ kind: "reattach", sessionId: "agent-late" });
+  });
+
+  it("resolves canceled when the effect is torn down", async () => {
+    const outcome = await waitForBackendAgentReconnectOutcome("tab-7", null, () => true);
+    expect(outcome).toEqual({ kind: "canceled" });
+  });
+});

--- a/src/store/sessionBridge.ts
+++ b/src/store/sessionBridge.ts
@@ -639,6 +639,110 @@ export function waitForBackendReattachSessionId(
   });
 }
 
+/** The terminal outcome of a backend-driven **agent** reconnect wait (#2476). */
+export type BackendAgentReconnectOutcome =
+  /** The redrive re-established the transport and published a fresh backend
+   * session id — re-attach terminal I/O to it. */
+  | { kind: "reattach"; sessionId: string }
+  /** The backend park/retry loop exhausted / the session was folded terminal —
+   * settle the tab as disconnected (never fall through to the client engine). */
+  | { kind: "giveup"; error?: string }
+  /** The effect was torn down (`isCanceled`) — abandon the wait, drive nothing. */
+  | { kind: "canceled" };
+
+/**
+ * Wait for the terminal outcome of a **backend-driven agent reconnect** (#2476),
+ * reading the projected `session-lifecycle` region keyed by tab id.
+ *
+ * This is the agent counterpart to {@link waitForBackendReattachSessionId}, and
+ * the crux of the double-drive fix. The direct-SSH wait times out after ~10 s and
+ * the caller then falls through to the client redrive — safe for a direct
+ * connection, but for an **agent** tab that fall-through re-enters the
+ * non-idempotent client agent engine (`connectRemoteAgent` + park + bounded
+ * spawn retries), which double-drives the very transport the backend redrive is
+ * re-establishing. A prolonged agent drop (the backend park/retry running for
+ * minutes) makes that fall-through the common case, not an edge.
+ *
+ * So this wait instead **stays deferred to the backend loop for as long as the
+ * loop is active**, resolving only on a genuine terminal outcome:
+ *  - a fresh (non-excluded) `sessionId` appears  ⇒ `reattach` (success),
+ *  - `reconnect.phase === "gaveup"` or `status === "failed"`  ⇒ `giveup`
+ *    (the backend exhausted its retries),
+ *  - `status === "disconnected"` (the loop was cancelled/stopped server-side)
+ *    ⇒ `giveup` (settle the tab; no error banner),
+ *  - `isCanceled()` (the effect torn down)  ⇒ `canceled`.
+ *
+ * There is deliberately **no short fall-through timeout** — the tab is never
+ * stranded because the backend always reaches one of the terminal states above
+ * (success, exhausted-give-up, or user cancel, each folded into the region), and
+ * `isCanceled` polling frees the promise the instant the effect unmounts.
+ */
+export function waitForBackendAgentReconnectOutcome(
+  tabId: string,
+  excludeSessionId: string | null | undefined,
+  isCanceled: () => boolean
+): Promise<BackendAgentReconnectOutcome> {
+  const acceptId = (id: string | undefined): id is string =>
+    !!id && !(excludeSessionId != null && id === excludeSessionId);
+
+  const classify = (
+    life: ProjectedSessionLifecycle | undefined
+  ): BackendAgentReconnectOutcome | null => {
+    if (!life) return null;
+    // Success takes precedence: a fresh backend session id means the transport is
+    // back, even if a stale phase field has not yet been recomputed.
+    if (acceptId(life.sessionId)) return { kind: "reattach", sessionId: life.sessionId };
+    if (life.reconnect.phase === "gaveup" || life.status === "failed") {
+      return { kind: "giveup", error: life.error };
+    }
+    if (life.status === "disconnected") return { kind: "giveup" };
+    return null;
+  };
+
+  return new Promise<BackendAgentReconnectOutcome>((resolve) => {
+    let settled = false;
+    const cleanups: Array<() => void> = [];
+    const finish = (value: BackendAgentReconnectOutcome) => {
+      if (settled) return;
+      settled = true;
+      for (const c of cleanups) c();
+      resolve(value);
+    };
+
+    // Register the listener before the fast-path read so no diff in between is lost.
+    cleanups.push(
+      onSessionView((next) => {
+        const outcome = classify(next[tabId]);
+        if (outcome) finish(outcome);
+      })
+    );
+
+    // A subscribe failure leaves nothing to source the outcome — settle as
+    // give-up rather than hang, so the tab is never stranded.
+    ensureSessionSubscribed().catch((err) => {
+      logSessionBridgeFallback("subscribe", err);
+      finish({ kind: "giveup" });
+    });
+
+    const immediate = classify(currentSessionView()[tabId]);
+    if (immediate) {
+      finish(immediate);
+      return;
+    }
+    if (isCanceled()) {
+      finish({ kind: "canceled" });
+      return;
+    }
+
+    // No fall-through timeout: wait across the whole backend loop. Poll only for
+    // cancellation so a torn-down effect frees the promise promptly.
+    const cancelPoll = setInterval(() => {
+      if (isCanceled()) finish({ kind: "canceled" });
+    }, 100);
+    cleanups.push(() => clearInterval(cancelPoll));
+  });
+}
+
 /**
  * Effective `terminalConnecting[tabId]` for rendering: `true` when the projected
  * status is `connecting` and it mirrors the local `terminalConnecting` bool,

--- a/tests/system/termihub_harness/__init__.py
+++ b/tests/system/termihub_harness/__init__.py
@@ -56,6 +56,7 @@ from .manual import (
 from .clipboard import read_os_clipboard
 from .display import ensure_local_display
 from .orchestrator import AgentInstance, AppInstance, agent_binary_path, app_binary_path
+from .local_agent import LocalAgentSshd, LocalAgentUnavailable
 from .projection import ProjectionHarness
 from .ssh_agent import agent_has_key, key_fingerprint, sha256_fingerprints
 from .systemtest import SystemTest, unique_name
@@ -99,6 +100,8 @@ __all__ = [
     "screenshot_to_png_bytes",
     "AppInstance",
     "AgentInstance",
+    "LocalAgentSshd",
+    "LocalAgentUnavailable",
     "app_binary_path",
     "agent_binary_path",
     "SystemTest",

--- a/tests/system/termihub_harness/local_agent.py
+++ b/tests/system/termihub_harness/local_agent.py
@@ -1,0 +1,245 @@
+"""A harness-controlled local ``sshd`` with the ``termihub-agent`` reachable.
+
+The desktop app reaches remote agents **only over SSH** (see the orchestrator
+note / README), so a full app↔agent reconnection test needs an SSH endpoint the
+harness can (a) point an agent connection at and (b) kill and restart at will to
+drive a genuine transport drop. That is exactly what ``scripts/dev.sh`` sets up
+for interactive dev (a throwaway loopback ``sshd`` on ``dev_agent_port`` with the
+agent binary reachable); this class is the test-owned equivalent (#2476).
+
+Key-based auth against a throwaway host + client keypair, on a free loopback
+port, with ``UsePAM no`` / ``StrictModes no`` so it runs as the unprivileged test
+user (mirrors ``scripts/dev.sh``). ``start`` / ``stop`` / ``restart`` own the
+whole sshd process tree via ``psutil`` so a ``stop`` severs an established agent
+session at once — the "server-side drop" that forces the agent reconnect path.
+
+Skips cleanly (:class:`LocalAgentUnavailable`, turned into a ``pytest.skip`` at
+the call site) when no ``sshd`` binary is present or the agent binary is not
+built.
+"""
+
+from __future__ import annotations
+
+import getpass
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Optional
+
+import psutil
+
+from .orchestrator import agent_binary_path, free_port
+
+
+class LocalAgentUnavailable(Exception):
+    """No usable ``sshd`` (or agent binary) to stand up a local agent endpoint."""
+
+
+def _find_sshd() -> Optional[str]:
+    for candidate in ("/usr/sbin/sshd", "/sbin/sshd"):
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    found = shutil.which("sshd")
+    return found
+
+
+class LocalAgentSshd:
+    """A killable/restartable loopback ``sshd`` with the agent binary reachable.
+
+    Usage::
+
+        agent = LocalAgentSshd()   # raises LocalAgentUnavailable if unusable
+        agent.start()
+        ...                        # point a termiHub agent at agent.port (key auth)
+        agent.stop()               # abrupt transport drop
+        agent.start()              # transport recoverable again
+        agent.cleanup()
+    """
+
+    def __init__(self, port: Optional[int] = None) -> None:
+        self._sshd = _find_sshd()
+        if not self._sshd:
+            raise LocalAgentUnavailable("no sshd binary found (looked in /usr/sbin, /sbin, PATH)")
+        try:
+            self._agent_binary = agent_binary_path()
+        except FileNotFoundError as exc:
+            raise LocalAgentUnavailable(str(exc)) from exc
+
+        self._username = getpass.getuser()
+        self._port = port or free_port()
+        self._dir = Path(tempfile.mkdtemp(prefix="termihub-agent-sshd-"))
+        self._host_key = self._dir / "host_key"
+        self._client_key = self._dir / "client_key"
+        self._pid_file = self._dir / "sshd.pid"
+        self._config = self._dir / "sshd_config"
+        self._process: Optional[subprocess.Popen] = None
+        self._known_hosts = Path.home() / ".ssh" / "known_hosts"
+        self._known_hosts_added = False
+        self._generate_keys()
+        self._write_config()
+        self._register_known_host()
+
+    # ── properties the agent connection needs ────────────────────────────────────
+    @property
+    def port(self) -> int:
+        return self._port
+
+    @property
+    def username(self) -> str:
+        return self._username
+
+    @property
+    def client_key_path(self) -> str:
+        return str(self._client_key)
+
+    @property
+    def agent_binary_path(self) -> str:
+        return str(self._agent_binary)
+
+    # ── lifecycle ────────────────────────────────────────────────────────────────
+    def start(self, ready_timeout: float = 15.0) -> "LocalAgentSshd":
+        """Launch sshd and wait until the port accepts a TCP connection."""
+        if self._process is not None and self._process.poll() is None:
+            raise RuntimeError("local agent sshd already running")
+        # sshd daemonizes by default; -D keeps it in the foreground so we own the
+        # process (and its session children) as a subprocess tree we can reap.
+        self._process = subprocess.Popen(
+            [self._sshd, "-D", "-f", str(self._config)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self._wait_until_listening(ready_timeout)
+        return self
+
+    def stop(self) -> None:
+        """Kill the sshd process tree (SIGKILL) — an abrupt server-side drop.
+
+        Reaps the master *and* every session child so an established agent
+        connection is severed at once, not just the listener.
+        """
+        if self._process is None:
+            return
+        proc = self._process
+        self._process = None
+        if proc.poll() is not None:
+            return
+        try:
+            parent = psutil.Process(proc.pid)
+            victims = parent.children(recursive=True) + [parent]
+        except psutil.NoSuchProcess:
+            return
+        for victim in victims:
+            try:
+                victim.kill()
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+        psutil.wait_procs(victims, timeout=5.0)
+
+    def restart(self, ready_timeout: float = 15.0) -> None:
+        self.stop()
+        self.start(ready_timeout)
+
+    def is_listening(self) -> bool:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.5)
+            return sock.connect_ex(("127.0.0.1", self._port)) == 0
+
+    def cleanup(self) -> None:
+        self.stop()
+        self._unregister_known_host()
+        shutil.rmtree(self._dir, ignore_errors=True)
+
+    def __enter__(self) -> "LocalAgentSshd":
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.cleanup()
+
+    # ── internals ────────────────────────────────────────────────────────────────
+    def _generate_keys(self) -> None:
+        for path in (self._host_key, self._client_key):
+            subprocess.run(
+                ["ssh-keygen", "-t", "ed25519", "-f", str(path), "-N", "", "-q"],
+                check=True,
+                capture_output=True,
+            )
+        os.chmod(self._host_key, 0o600)
+        os.chmod(self._client_key, 0o600)
+        os.chmod(self._dir, 0o700)
+
+    @property
+    def _known_hosts_marker(self) -> str:
+        """The host token our known_hosts entry is keyed on (loopback + our port)."""
+        return f"[127.0.0.1]:{self._port}"
+
+    def _register_known_host(self) -> None:
+        """Pre-trust our host key in ``~/.ssh/known_hosts`` (strict verifier, #1969).
+
+        The app's default SSH host-key verifier is strict known_hosts-only, so a
+        throwaway sshd on an unknown host would otherwise block the agent connect
+        on a trust prompt. Seed our ``[127.0.0.1]:<port>`` entry so the connect
+        proceeds; :meth:`_unregister_known_host` removes exactly that line on
+        cleanup, leaving the user's file otherwise untouched.
+        """
+        pub = (self._host_key.with_suffix(".pub")).read_text().split()
+        # pub is: "<algo> <base64> [comment]"; build "[127.0.0.1]:<port> <algo> <base64>".
+        line = f"{self._known_hosts_marker} {pub[0]} {pub[1]}\n"
+        self._known_hosts.parent.mkdir(mode=0o700, exist_ok=True)
+        with open(self._known_hosts, "a", encoding="utf-8") as fh:
+            fh.write(line)
+        self._known_hosts_added = True
+
+    def _unregister_known_host(self) -> None:
+        if not self._known_hosts_added or not self._known_hosts.exists():
+            return
+        try:
+            kept = [
+                ln
+                for ln in self._known_hosts.read_text(encoding="utf-8").splitlines(keepends=True)
+                if self._known_hosts_marker not in ln
+            ]
+            self._known_hosts.write_text("".join(kept), encoding="utf-8")
+        except OSError:
+            pass
+        self._known_hosts_added = False
+
+    def _write_config(self) -> None:
+        # Mirrors scripts/dev.sh: loopback-only, key auth only, no PAM/strict-modes
+        # so it runs unprivileged.
+        self._config.write_text(
+            "\n".join(
+                [
+                    f"Port {self._port}",
+                    "ListenAddress 127.0.0.1",
+                    f"HostKey {self._host_key}",
+                    f"AuthorizedKeysFile {self._client_key}.pub",
+                    f"PidFile {self._pid_file}",
+                    "UsePAM no",
+                    "PasswordAuthentication no",
+                    "PubkeyAuthentication yes",
+                    "StrictModes no",
+                    "LogLevel ERROR",
+                    "",
+                ]
+            )
+        )
+
+    def _wait_until_listening(self, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self._process is not None and self._process.poll() is not None:
+                err = ""
+                if self._process.stderr is not None:
+                    err = self._process.stderr.read() or ""
+                raise LocalAgentUnavailable(
+                    f"sshd exited early (code {self._process.returncode}): {err.strip()}"
+                )
+            if self.is_listening():
+                return
+            time.sleep(0.1)
+        raise LocalAgentUnavailable(f"sshd did not listen on 127.0.0.1:{self._port} within {timeout}s")

--- a/tests/system/tests/test_agent_reconnect_live.py
+++ b/tests/system/tests/test_agent_reconnect_live.py
@@ -1,0 +1,279 @@
+"""Live agent drop / reconnect over a harness-controlled sshd (#2476).
+
+The missing enabler for the agent reconnect activation: no scenario existed to
+drive a real agent-transport drop and assert the reconnect outcome. The desktop
+app reaches agents only over SSH, so this suite stands up a throwaway loopback
+``sshd`` with the ``termihub-agent`` binary reachable (:class:`LocalAgentSshd`,
+the test-owned equivalent of ``scripts/dev.sh``'s dev agent), points a key-auth
+agent connection at it, opens a shell session, then **kills the sshd** to sever
+the transport — a genuine, prolonged drop the harness fully controls — before
+bringing it back.
+
+Two lanes, differing only by the ``sessionBackendReattach`` flag:
+
+* :class:`TestAgentReconnectClientDriven` — flag **off** (develop behavior): the
+  drop surfaces (the agent leaves ``connected``) and, once the server is back and
+  the agent reconnects, a fresh shell session is live again. Proves the scenario
+  is valid before any product change relies on it.
+* :class:`TestAgentReconnectBackendDriven` — flag **on** (the activation): the
+  agent tab's reconnect is driven by the backend redrive across the prolonged
+  drop; the tab recovers on reconnection with the client agent engine suppressed.
+
+Agent + settings state is region-authoritative (#2227/#2409), so this suite reads
+it through the projection API (the ``agents`` region) and seeds experimental
+features via ``settings.json`` — the ``get_state("remoteAgents"/"settings")``
+paths the older ``AgentUi``/``SettingsUi`` helpers use no longer resolve against a
+projection-migrated build (see the follow-up filed from this issue). The agent
+row is driven by its known seeded id (no name→id store lookup needed).
+
+Skips cleanly when the app / agent binary is not built or no ``sshd`` is present.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Optional
+
+import pytest
+
+from termihub_harness import (
+    LIVE_CONNECT_REQUEST_TIMEOUT,
+    ConfigRecoveryUi,
+    LocalAgentSshd,
+    LocalAgentUnavailable,
+    SidebarUi,
+    TabsUi,
+    TerminalUi,
+    SystemTest,
+    unique_name,
+)
+
+pytestmark = pytest.mark.integration
+
+AGENT_NAME = "Local Reconnect Agent"
+AGENT_ID = "test-local-reconnect-agent"
+AGENT_HEADER = f"agent-header-{AGENT_ID}"
+CONNECTIONS = "connections.json"
+SETTINGS = "settings.json"
+# Remote agents live behind the experimental-features flag; seed it on so the
+# Remote Agents sidebar renders (the UI reads it from the projected settings).
+SETTINGS_DOC = json.dumps({"version": "1", "experimentalFeaturesEnabled": True})
+
+CTX_CONNECT = "context-agent-connect"
+CTX_DISCONNECT = "context-agent-disconnect"
+CTX_NEW_SHELL = "context-agent-new-shell"
+
+
+def _agent_doc(sshd: LocalAgentSshd) -> str:
+    """A v2 nested connections store carrying one key-auth agent at ``sshd``."""
+    return json.dumps(
+        {
+            "version": "2",
+            "children": [],
+            "agents": [
+                {
+                    "id": AGENT_ID,
+                    "name": AGENT_NAME,
+                    "config": {
+                        "host": "127.0.0.1",
+                        "port": sshd.port,
+                        "username": sshd.username,
+                        "authMethod": "key",
+                        "keyPath": sshd.client_key_path,
+                        "agentPath": sshd.agent_binary_path,
+                    },
+                    "agentSettings": {
+                        "enableMonitoring": False,
+                        "enableFileBrowser": True,
+                        "enableDocker": False,
+                        "startingDirectory": "~",
+                        "logLevel": "info",
+                        "verboseTracing": False,
+                        "persistentScrollbackBufferSizeMb": 1,
+                    },
+                }
+            ],
+        }
+    )
+
+
+class _AgentReconnectBase(TabsUi, TerminalUi, ConfigRecoveryUi, SidebarUi, SystemTest):
+    """Shared setup: a controllable sshd + a seeded key-auth agent connection.
+
+    Subclasses set :attr:`flag_on` to choose the ``sessionBackendReattach`` lane;
+    the fixture injects the matching ``window.__TERMIHUB_*__`` global via the test
+    bridge (``TERMIHUB_TEST_FLAG_*``) before the app relaunches.
+    """
+
+    request_timeout = LIVE_CONNECT_REQUEST_TIMEOUT
+    flag_on: bool = False
+
+    _FLAG_ENV = "TERMIHUB_TEST_FLAG_SESSION_BACKEND_REATTACH"
+
+    #: Opt-in gate. The scenario drives everything up to the agent transport
+    #: (SSH + key auth + host-key trust + the agent binary starting over SSH), but
+    #: the agent's registry-daemon handshake stalls over a throwaway sshd and the
+    #: WKWebView is occlusion-throttled during the long connect, so the agent never
+    #: reaches ``connected`` unattended (tracked in #2480; agent/settings harness
+    #: reads also need the projection API per #2479). Set this env to 1 to run it.
+    _OPT_IN_ENV = "TERMIHUB_TEST_LOCAL_AGENT_RECONNECT"
+
+    @pytest.fixture(autouse=True)
+    def _local_agent(self):
+        if os.environ.get(self._OPT_IN_ENV) != "1":
+            pytest.skip(
+                f"opt-in: set {self._OPT_IN_ENV}=1 to run the live local-agent "
+                "reconnect scenario (blocked unattended by the agent registry-daemon "
+                "handshake over a throwaway sshd + webview throttling — see #2480; "
+                "harness agent/settings reads tracked in #2479)"
+            )
+        try:
+            sshd = LocalAgentSshd()
+        except LocalAgentUnavailable as exc:
+            pytest.skip(str(exc))
+        sshd.start()
+        self.sshd = sshd
+        self._agents_sub: Optional[str] = None
+
+        prev_flag = os.environ.get(self._FLAG_ENV)
+        if self.flag_on:
+            os.environ[self._FLAG_ENV] = "1"
+        else:
+            os.environ.pop(self._FLAG_ENV, None)
+
+        def _seed() -> None:
+            self.write_config(CONNECTIONS, _agent_doc(sshd))
+            self.write_config(SETTINGS, SETTINGS_DOC)
+
+        # Relaunch so the app loads the seeded agent + experimental flag + flag env.
+        self.restart_app(between=_seed)
+        self.switch_to_connections_sidebar()
+        # The seeded experimental flag renders the Remote Agents group; its row is
+        # addressable by the known id (no name→id store lookup, which is stale).
+        self.wait(lambda: self.driver.exists(AGENT_HEADER), what="the seeded agent row")
+        try:
+            yield
+        finally:
+            sshd.cleanup()  # reap first so it never leaks on a slow UI teardown
+            try:
+                if self._agent_state() not in (None, "disconnected"):
+                    self._agent_menu_click(CTX_DISCONNECT)
+            except Exception:
+                pass
+            try:
+                self.close_all_tabs()
+            except Exception:
+                pass
+            if prev_flag is None:
+                os.environ.pop(self._FLAG_ENV, None)
+            else:
+                os.environ[self._FLAG_ENV] = prev_flag
+
+    # ── agents projection reads (region-authoritative, #2409) ────────────────────
+    def _agents_view(self) -> list[dict[str, Any]]:
+        if self._agents_sub is None:
+            self._agents_sub = self.driver.projection_subscribe("agents")["subscriptionId"]
+        cache = self.driver.projection_state(self._agents_sub).get("cache") or {}
+        agents = cache.get("agents")
+        return [a for a in agents if isinstance(a, dict)] if isinstance(agents, list) else []
+
+    def _agent_state(self) -> Optional[str]:
+        agent = next((a for a in self._agents_view() if a.get("id") == AGENT_ID), None)
+        return agent.get("connectionState") if agent else None
+
+    def _wait_agent_state(self, *states: str, timeout: float = 60.0) -> None:
+        self.wait(
+            lambda: self._agent_state() in states,
+            what=f"agent to reach state in {states}",
+            timeout=timeout,
+        )
+
+    # ── agent row driving (by known id) ──────────────────────────────────────────
+    def _agent_menu_click(self, action: str) -> None:
+        def opened() -> bool:
+            if not self.driver.exists(AGENT_HEADER):
+                return False
+            self.driver.context_menu(AGENT_HEADER)
+            return self.driver.exists(action)
+
+        self.wait(opened, what=f"the agent context menu with {action}")
+        self.driver.click(action)
+
+    # ── shared steps ─────────────────────────────────────────────────────────────
+    def _connect_and_open_shell(self) -> None:
+        self._agent_menu_click(CTX_CONNECT)
+        self._wait_agent_state("connected")
+        before = self.tab_count()
+        self._agent_menu_click(CTX_NEW_SHELL)
+        self.wait(lambda: self.tab_count() > before, what="the agent shell-session tab")
+        self.wait(self.has_terminal, what="the agent shell terminal session")
+
+    def _assert_shell_live(self) -> None:
+        marker = unique_name("agent-echo")
+        self.run_command(f"echo {marker}")
+        assert marker in self.wait_for_output(marker)
+
+    def _drop_transport(self) -> None:
+        """Kill the sshd (and its session children) — a genuine transport drop."""
+        self.sshd.stop()
+        assert not self.sshd.is_listening()
+
+
+class TestAgentReconnectClientDriven(_AgentReconnectBase):
+    """Flag OFF — proves the drop/reconnect scenario against develop behavior."""
+
+    flag_on = False
+
+    def test_drop_surfaces_and_recovers(self):
+        self._connect_and_open_shell()
+        self._assert_shell_live()
+
+        # Drop the agent transport at the server and keep it down long enough that
+        # a client single-shot reconnect would fail — a prolonged outage.
+        self._drop_transport()
+        self._wait_agent_state("reconnecting", "disconnected", timeout=60.0)
+
+        # Bring the server back; the agent must reconnect and serve a live shell.
+        self.sshd.start()
+        self._wait_agent_state("disconnected", timeout=60.0)
+        self._agent_menu_click(CTX_CONNECT)
+        self._wait_agent_state("connected", timeout=60.0)
+
+        before = self.tab_count()
+        self._agent_menu_click(CTX_NEW_SHELL)
+        self.wait(lambda: self.tab_count() > before, what="a fresh agent shell after recovery")
+        self.wait(self.has_terminal, what="the recovered agent shell terminal")
+        self._assert_shell_live()
+
+
+class TestAgentReconnectBackendDriven(_AgentReconnectBase):
+    """Flag ON — the activation: backend-driven reconnect across a prolonged drop."""
+
+    flag_on = True
+
+    def test_backend_driven_reconnect_reattaches(self):
+        self._connect_and_open_shell()
+        tab = self.wait(
+            lambda: self.find_tab("Shell") or self.find_tab(AGENT_NAME),
+            what="the shell tab",
+        )
+        tab_id = tab["id"]
+        self._assert_shell_live()
+
+        # Prolonged drop: kill the sshd and keep it down while the backend redrive
+        # parks/retries. The client agent engine must NOT drive the transport.
+        self._drop_transport()
+        self._wait_agent_state("reconnecting", "disconnected", timeout=60.0)
+
+        # Recover the server; the agent transport comes back and the tab must
+        # recover live without being left exited/stranded.
+        self.sshd.start()
+        self._wait_agent_state("connected", timeout=90.0)
+        self.wait(
+            lambda: self.driver.get_state("terminalExitedTabs").get(tab_id) is not True,
+            what="the agent shell tab to recover (not left exited)",
+            timeout=90.0,
+        )
+        self.wait(self.has_terminal, what="the reattached agent shell terminal")
+        self._assert_shell_live()


### PR DESCRIPTION
Activates the backend-driven **agent** reconnect hot path behind the default-off `sessionBackendReattach` flag, plus the missing live-drop harness enabler. Part of **#2476** (umbrella #2446); relates to #2472/#2473/#2455/#2205 PR-B.

**Not** closing #2476: the flag-ON path is fully unit/component-verified but **not yet live-verified to grade** (the live harness reaches everything up to the agent transport but the agent registry-daemon handshake stalls over a throwaway sshd — details + follow-ups below). The flag is **default-off, so this is inert / byte-identical to develop** until #2205 PR-B flips it after live verification.

## The activation (all flag-gated; flag-off byte-identical)
- **`isResilientReconnectTab`** now counts a non-persistent **agent** tab as resilient **iff** `sessionBackendReattach` is on (flag-off ⇒ agents excluded exactly as before). Direct-SSH classification unchanged.
- **`isBackendDrivenAgentReconnectTabId`** — the discriminator that routes an agent reconnect to the backend and off the client engine.
- **`Terminal.tsx`** — on an agent reconnect, waits on the new give-up-aware `waitForBackendAgentReconnectOutcome`, and the client agent engine (`connectRemoteAgent` + park + `MAX_AGENT_SPAWN_ATTEMPTS`) is suppressed on the reconnect path.
- **`reconnectTerminal`** skips the fixed 90 s "connecting" deadline for a backend-driven agent reconnect (the backend park/retry legitimately outlasts it; the give-up fold settles the tab, not a client wall-clock timer).
- **`settleBackendReconnectGaveUp`** reflects a backend give-up as the disconnect overlay without re-mirroring an intent.

## The double-drive resolution (the crux) — approach + justification
`waitForBackendReattachSessionId` (direct SSH, #2457) times out after ~10 s and the caller **falls through to the client redrive** — safe for a direct connection, but for an **agent** tab that fall-through re-enters the non-idempotent client agent engine, which **double-drives** the transport the backend redrive is re-establishing. A prolonged agent drop makes that the common case.

Chosen fix — **extend the wait across the backend loop** (`waitForBackendAgentReconnectOutcome`): it has **no short fall-through timeout** and resolves only on a genuine terminal outcome read from the `session-lifecycle` region — a fresh `sessionId` (`reattach`), `reconnect.phase===gaveup` / `status===failed` (`giveup`), `status===disconnected` (stopped), or `isCanceled` (torn down). So the tab stays deferred to the backend loop however long the drop lasts, is **never stranded** (the backend always reaches one of those terminal states, and cancel-polling frees the promise on unmount), and there is exactly **one** client code path (attach on the published id) that never calls the agent engine.

Chosen over "reconcile re-drives connecting" because it is self-contained (one wait + caller + deadline change), reads the backend fold directly (matches "resolve connected on success / disconnected on give-up from the backend fold"), and avoids touching the shared `ensureSessionReconcileWired` guard that direct SSH also uses. Defense-in-depth guard also added so the client agent engine can never engage on a backend-driven reconnect even if the create loop were somehow reached.

## Verification
**Verified (unit + component, 17 new tests, full suite 4922 green; clippy/fmt/eslint/prettier clean):**
- `sessionBridge.agentReconnect.test.ts` — `waitForBackendAgentReconnectOutcome`: reattach / give-up (phase+status) / stopped / **no-fall-through-while-parking** / canceled.
- `appStore.agentReconnect.test.ts` — agent resilient classification flag-gating, connect-deadline reconciliation, `settleBackendReconnectGaveUp`.
- `Terminal.agent-reconnect.test.tsx` — flag-ON reattach **and** give-up both **never call the client engine** (double-drive suppression); flag-OFF drives the client engine (develop parity).

**NOT verified — live flag-ON prolonged-drop (why #2476 stays open):**
Added the live enabler — `LocalAgentSshd` (a harness-controlled throwaway loopback sshd with the agent binary reachable + host-key pre-trust) and `tests/system/tests/test_agent_reconnect_live.py` (flag-off + flag-on lanes; the flag is flipped live via a new `TERMIHUB_TEST_FLAG_*` → `window.__TERMIHUB_*__` test-bridge injection). The scenario drives app launch + seeded agent + experimental UI + agent connect (**SSH + key auth + host-key trust + the agent binary starting over SSH**), but the agent's **registry-daemon handshake stalls** over the minimal throwaway sshd (+ WKWebView occlusion throttling), so the agent never reaches `connected` unattended. It is therefore **opt-in-gated** (`TERMIHUB_TEST_LOCAL_AGENT_RECONNECT=1`) so it never reds CI. This is agent-infra/harness, **not** the reconnect product code.

Follow-ups filed: **#2479** (AgentUi/SettingsUi harness helpers read stale appStore paths — agents/settings are region-authoritative post-#2227/#2409), **#2480** (registry-daemon handshake stall + webview throttle blocking the live grade).

## Safety
Flag default-off ⇒ inert / byte-identical to develop; the activation code cannot affect agent reconnect until the flag is flipped (#2205 PR-B), which per the ventilator-grade guardrail requires the live grade in #2480 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)