### PR TITLE
test(agent): turnkey manual agent-reconnect verification + projection harness reads (Closes #2479)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1293,6 +1293,45 @@ a Unix agent host (the exec-replace is Unix-only). See PR #1352.
 5. **Dismiss.** Press **Dismiss** on the banner. Expect: the banner hides for the
    session and no update is requested.
 
+### Backend-driven agent reconnect across a prolonged transport drop (#2476)
+
+Verifies the backend-driven agent reconnect redrive under the
+`sessionBackendReattach` flag: an agent-hosted session whose transport is
+severed for a prolonged outage reconnects **backend-driven** (the terminal
+re-attaches to a new backend session, the client engine suppressed, no
+double-connect, never stranded), and a permanent drop settles Disconnected. This
+grade cannot run headlessly — macOS occlusion-throttles the WKWebView with no
+foreground display (#957, #2460) — so it is a turnkey manual test with a real
+display. Unix/macOS only (the dev agent is a loopback sshd). See PR for #2476;
+harness residual tracked in #2480.
+
+Run once (from a dev checkout — builds if stale, starts the dev agent + app with
+the flag on, prints the checklist):
+
+```bash
+scripts/internal/verify-agent-reconnect.sh
+```
+
+Then, in a **second terminal**, `scripts/internal/agent-reconnect-transport.sh
+{drop|restore}` severs / restores this checkout's dev-agent transport with one
+keystroke (kills the dev-agent sshd master + connection children by port, then
+relaunches it reusing the same host key so the reconnect is not blocked on a
+trust prompt).
+
+1. **Connect + open a session.** In the Connections sidebar, connect the
+   pre-registered dev agent (accept the host-key prompt if shown), then **New
+   Shell Session**; run `echo hello`. Expect: a live shell.
+2. **Drop.** Run `agent-reconnect-transport.sh drop`. Expect: within a few
+   seconds the agent tab shows **Reconnecting** — the terminal must not close,
+   exit, or vanish.
+3. **Prolonged outage + restore.** Wait ~30s (the backend parks + retries), then
+   run `agent-reconnect-transport.sh restore`. Expect: the agent reconnects
+   backend-driven and the **same** shell tab re-attaches to a fresh backend
+   session; `echo hello2` prints. No duplicate tab, no second connection.
+4. **Permanent drop.** Run `drop` again and do **not** restore. Expect: after the
+   backend gives up retrying, the agent/tab settles **Disconnected** — it must
+   not spin forever and must not be left stranded.
+
 ### Coordinated desktop-push Update deploy (#1616)
 
 Verifies that triggering an **Update** (the desktop-push deploy, not just the

--- a/scripts/internal/agent-reconnect-transport.sh
+++ b/scripts/internal/agent-reconnect-transport.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Drop / restore THIS checkout's dev-agent SSH transport for the #2476 manual
+# agent-reconnect grade. Companion to scripts/internal/verify-agent-reconnect.sh.
+#
+# The dev agent is a loopback sshd on this checkout's `dev_agent_port` (from
+# dev.local.json), started by `scripts/dev.sh`. "Dropping" the transport means
+# killing that sshd — the master listener AND every established-connection child —
+# so an in-flight agent session is severed at once (killing only the listener
+# leaves the established connection alive; see tests' LocalAgentSshd.stop). With
+# the listener gone, backend reconnect attempts fail, which is exactly the
+# prolonged outage that forces the backend park/retry loop under the
+# `sessionBackendReattach` flag.
+#
+# "Restoring" relaunches sshd from the SAME config file (hence the SAME host key),
+# so the app's trust store still trusts it and the backend-driven reconnect is not
+# blocked on a host-key prompt it cannot answer.
+#
+# Usage (run in a SECOND terminal while verify-agent-reconnect.sh runs):
+#   scripts/internal/agent-reconnect-transport.sh drop      # sever the transport
+#   scripts/internal/agent-reconnect-transport.sh restore   # bring it back
+#   scripts/internal/agent-reconnect-transport.sh status    # is it listening?
+#
+# Operates ONLY on this checkout's own dev-agent sshd (resolved by its dedicated
+# loopback port), never on shared Docker fixtures and never via pattern-pkill.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+STATE_DIR=".dev-agent"
+STATE_FILE="$STATE_DIR/agent-reconnect-transport.state"
+
+# ── Resolve this checkout's dev-agent port from dev.local.json ────────────────
+resolve_port() {
+    local port=""
+    if [ -f "dev.local.json" ]; then
+        port=$(grep -oE '"dev_agent_port"[[:space:]]*:[[:space:]]*[0-9]+' dev.local.json \
+            | grep -oE '[0-9]+$' || true)
+    fi
+    if [[ ! "$port" =~ ^[0-9]+$ ]]; then
+        echo "error: no dev_agent_port in dev.local.json — is this a dev checkout?" >&2
+        exit 1
+    fi
+    printf '%s' "$port"
+}
+
+PORT="$(resolve_port)"
+
+find_sshd_binary() {
+    local candidate
+    for candidate in /usr/sbin/sshd /sbin/sshd; do
+        [ -x "$candidate" ] && { printf '%s' "$candidate"; return; }
+    done
+    command -v sshd || true
+}
+
+# The PID of the sshd master listening on our loopback port (empty if none).
+listener_pid() {
+    lsof -nP -iTCP@127.0.0.1:"$PORT" -sTCP:LISTEN -t 2>/dev/null | head -1 || true
+}
+
+is_listening() {
+    [ -n "$(listener_pid)" ]
+}
+
+# Every descendant PID of $1, depth-first (children before parents), so a kill
+# list reaps leaves first — mirrors LocalAgentSshd.stop's recursive reap.
+descendants() {
+    local pid="$1" child
+    for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+        descendants "$child"
+        printf '%s\n' "$child"
+    done
+}
+
+# The sshd config path of a running master: prefer its own argv (`-f <path>`),
+# else fall back to the newest dev.sh-created sshd config dir.
+config_of() {
+    local pid="$1" cfg=""
+    if [ -n "$pid" ]; then
+        cfg=$(ps -o command= -p "$pid" 2>/dev/null \
+            | sed -n 's/.*-f \([^ ][^ ]*\).*/\1/p' || true)
+    fi
+    if [ -z "$cfg" ] || [ ! -f "$cfg" ]; then
+        # These are our own mktemp dirs (termihub-dev-sshd.XXXX) — safe names, so
+        # the SC2012 non-alphanumeric caveat cannot apply, and `ls -td` is portable
+        # across macOS/Linux where a `find -exec stat` mtime sort is not.
+        # shellcheck disable=SC2012
+        cfg=$(ls -td /tmp/termihub-dev-sshd.*/sshd_config 2>/dev/null | head -1 || true)
+    fi
+    printf '%s' "$cfg"
+}
+
+do_drop() {
+    local master
+    master="$(listener_pid)"
+    if [ -z "$master" ]; then
+        echo "[transport] already down — nothing listening on 127.0.0.1:$PORT."
+        return 0
+    fi
+
+    # Remember the config (host key) so restore relaunches an identical sshd.
+    local cfg
+    cfg="$(config_of "$master")"
+    mkdir -p "$STATE_DIR"
+    {
+        printf 'config=%s\n' "$cfg"
+        printf 'sshd=%s\n' "$(find_sshd_binary)"
+    } >"$STATE_FILE"
+
+    # Reap the master AND its per-connection children so the established agent
+    # transport is severed at once, not just the listener.
+    local victims
+    victims="$(descendants "$master") $master"
+    # shellcheck disable=SC2086 # word-splitting the PID list is intended.
+    kill -TERM $victims 2>/dev/null || true
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        is_listening || break
+        sleep 0.2
+    done
+    if is_listening; then
+        # shellcheck disable=SC2086
+        kill -KILL $victims 2>/dev/null || true
+        for _ in 1 2 3 4 5; do
+            is_listening || break
+            sleep 0.2
+        done
+    fi
+
+    if is_listening; then
+        echo "[transport] WARNING: sshd still listening on :$PORT after kill." >&2
+        return 1
+    fi
+    echo "[transport] DROPPED — dev-agent sshd on 127.0.0.1:$PORT is down."
+    echo "[transport] the agent tab should go Reconnecting; run 'restore' to bring it back,"
+    echo "[transport] or leave it down to watch the permanent-drop -> Disconnected case."
+}
+
+do_restore() {
+    if is_listening; then
+        echo "[transport] already up — sshd is listening on 127.0.0.1:$PORT."
+        return 0
+    fi
+
+    local cfg="" sshd_bin=""
+    if [ -f "$STATE_FILE" ]; then
+        # shellcheck disable=SC1090
+        cfg=$(sed -n 's/^config=//p' "$STATE_FILE")
+        sshd_bin=$(sed -n 's/^sshd=//p' "$STATE_FILE")
+    fi
+    [ -z "$cfg" ] || [ ! -f "$cfg" ] && cfg="$(config_of "")"
+    [ -x "$sshd_bin" ] || sshd_bin="$(find_sshd_binary)"
+
+    if [ -z "$cfg" ] || [ ! -f "$cfg" ]; then
+        echo "error: no dev-agent sshd config found to restore from." >&2
+        echo "       (run verify-agent-reconnect.sh first, then 'drop' before 'restore'.)" >&2
+        exit 1
+    fi
+    if [ -z "$sshd_bin" ]; then
+        echo "error: no sshd binary found." >&2
+        exit 1
+    fi
+
+    # Relaunch exactly as scripts/dev.sh does (daemonizes; reuses host key), so the
+    # restored transport is trusted and the backend reconnect just re-establishes.
+    "$sshd_bin" -f "$cfg"
+    for _ in $(seq 1 50); do
+        is_listening && break
+        sleep 0.1
+    done
+    if is_listening; then
+        echo "[transport] RESTORED — dev-agent sshd is listening on 127.0.0.1:$PORT again."
+        echo "[transport] the agent tab should reconnect (backend-driven) and re-attach live."
+    else
+        echo "[transport] WARNING: sshd did not come back up on :$PORT." >&2
+        return 1
+    fi
+}
+
+do_status() {
+    if is_listening; then
+        echo "[transport] UP — sshd listening on 127.0.0.1:$PORT (pid $(listener_pid))."
+    else
+        echo "[transport] DOWN — nothing listening on 127.0.0.1:$PORT."
+    fi
+}
+
+case "${1:-}" in
+    drop) do_drop ;;
+    restore) do_restore ;;
+    status) do_status ;;
+    *)
+        echo "usage: $0 {drop|restore|status}" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/internal/verify-agent-reconnect.sh
+++ b/scripts/internal/verify-agent-reconnect.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# TURNKEY manual test for the #2476 backend-driven agent-reconnect grade.
+#
+# ONE command, zero setup. It:
+#   1. Enables experimental features in the app's settings.json (so the dev
+#      agent's "Remote Agents" sidebar group renders), preserving other settings.
+#   2. Turns the `sessionBackendReattach` flag ON without you editing anything,
+#      via the #2481 test-bridge env->window injection
+#      (TERMIHUB_TEST_FLAG_SESSION_BACKEND_REATTACH -> window.__TERMIHUB_SESSION_BACKEND_REATTACH__).
+#      Test-bridge mode also pins the window always-on-top, which stops macOS from
+#      occlusion-throttling the WebView during the long reconnect (#957) — the very
+#      reason this grade cannot run headlessly and needs a real display.
+#   3. Launches this checkout's dev agent + the app via `scripts/dev.sh` (builds if
+#      stale; the dev agent sshd + connection are set up for you). The window stays
+#      in the foreground so you can watch the reconnect.
+#
+# Then follow the printed checklist (3-6 clicks, ~5 min). A companion command,
+# scripts/internal/agent-reconnect-transport.sh, drops/restores the dev-agent
+# transport with one keystroke — you never have to find a PID or a port.
+#
+# Unix/macOS only: the dev agent (a loopback sshd) is Unix-only, exactly as
+# scripts/dev.sh documents, so there is no .cmd sibling.
+#
+# Usage (run from anywhere in the repo):
+#   scripts/internal/verify-agent-reconnect.sh
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+if [[ "$(uname)" != "Darwin" && "$(uname)" != "Linux" ]]; then
+    echo "error: this manual test is Unix/macOS only (the dev agent is a loopback sshd)." >&2
+    exit 1
+fi
+
+TRANSPORT="$REPO_ROOT/scripts/internal/agent-reconnect-transport.sh"
+STATE_FILE="$REPO_ROOT/.dev-agent/agent-reconnect-transport.state"
+
+# ── This checkout's dev-agent port + label (from dev.local.json) ──────────────
+DEV_AGENT_PORT=""
+DEV_NAME=""
+if [ -f "dev.local.json" ]; then
+    DEV_AGENT_PORT=$(grep -oE '"dev_agent_port"[[:space:]]*:[[:space:]]*[0-9]+' dev.local.json \
+        | grep -oE '[0-9]+$' || true)
+    DEV_NAME=$(grep -oE '"dev_name"[[:space:]]*:[[:space:]]*"[^"]+"' dev.local.json \
+        | grep -oE '"[^"]+"$' | tr -d '"' || true)
+fi
+if [[ ! "$DEV_AGENT_PORT" =~ ^[0-9]+$ ]]; then
+    echo "error: no dev_agent_port in dev.local.json — scripts/dev.sh won't start a dev agent." >&2
+    exit 1
+fi
+AGENT_LABEL="Dev Agent (${DEV_NAME:-:$DEV_AGENT_PORT})"
+
+# ── App config dir (mirrors scripts/dev.sh) ──────────────────────────────────
+if [[ "$(uname)" == "Darwin" ]]; then
+    CFG_DIR="$HOME/Library/Application Support/com.termihub.app"
+else
+    CFG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/com.termihub.app"
+fi
+
+# ── Enable experimental features so the Remote Agents group renders ───────────
+# Region-authoritative settings are seeded from settings.json at startup (#2386),
+# so writing it before launch is enough. Read-modify-write preserves other keys.
+seed_experimental_features() {
+    python3 - "$CFG_DIR/settings.json" << 'PYEOF'
+import json, os, sys
+path = sys.argv[1]
+os.makedirs(os.path.dirname(path), exist_ok=True)
+data = {}
+if os.path.exists(path):
+    try:
+        loaded = json.load(open(path))
+        if isinstance(loaded, dict):
+            data = loaded
+    except (OSError, ValueError):
+        data = {}
+data.setdefault("version", "1")
+data["experimentalFeaturesEnabled"] = True
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+print(f"[setup] experimental features enabled in {path}")
+PYEOF
+}
+
+# ── A free loopback port to trigger the test-bridge init-script (flag inject) ──
+# Nothing needs to listen there — the port's only job is to register the bridge
+# plugin so the flag global is injected and the window is pinned always-on-top.
+pick_bridge_port() {
+    local port
+    for port in 47600 47601 47602 47603 47604; do
+        if ! lsof -nP -iTCP:"$port" -sTCP:LISTEN -t >/dev/null 2>&1; then
+            printf '%s' "$port"
+            return
+        fi
+    done
+    printf '%s' 47600
+}
+BRIDGE_PORT="$(pick_bridge_port)"
+
+cleanup() { rm -f "$STATE_FILE" 2>/dev/null || true; }
+trap cleanup EXIT
+
+seed_experimental_features
+rm -f "$STATE_FILE" 2>/dev/null || true
+
+cat <<CHECKLIST
+
+============================================================================
+  AGENT RECONNECT — TURNKEY MANUAL TEST (#2476)   flag: sessionBackendReattach ON
+============================================================================
+
+The app is about to launch (first run BUILDS — this can take a few minutes).
+Keep THIS terminal open (it runs the app). Do the drop/restore in a SECOND
+terminal with the one-liners below.
+
+  DROP transport (sever the dev-agent SSH):
+      $TRANSPORT drop
+  RESTORE transport (bring it back):
+      $TRANSPORT restore
+
+----------------------------------------------------------------------------
+FOLLOW THESE STEPS (each line states the expected result):
+----------------------------------------------------------------------------
+1. Wait for the termiHub window. In the Connections sidebar, expand
+   "Remote Agents" -> you should see "$AGENT_LABEL".
+
+2. Right-click "$AGENT_LABEL" -> Connect. If a host-key prompt appears, choose
+   Accept/trust it.
+   EXPECT: the agent's state becomes "Connected".
+
+3. Right-click the connected agent -> "New Shell Session". In the new tab type:
+      echo hello
+   EXPECT: a live shell that prints "hello".
+
+4. In the SECOND terminal run:  $TRANSPORT drop
+   EXPECT: within a few seconds the agent tab shows "Reconnecting..." (it must
+   NOT close, exit, or vanish — the terminal stays, backend-driven).
+
+5. Wait ~30s (let the backend park + retry a prolonged outage), then run:
+      $TRANSPORT restore
+   EXPECT: the agent reconnects BACKEND-DRIVEN and the SAME shell tab re-attaches
+   to a fresh backend session. Type:  echo hello2
+   -> it prints "hello2". No duplicate tab, no second connection.
+
+6. PERMANENT-DROP case: run  $TRANSPORT drop  again and DO NOT restore.
+   EXPECT: after the backend gives up retrying, the agent/tab settles
+   "Disconnected" (it must not spin forever and must not be left stranded).
+
+Done: PASS = steps 5 (reattach live, no double-connect) and 6 (clean
+Disconnected) both hold. Close the window / press Ctrl-C here to tear down
+(the dev agent sshd is stopped automatically).
+============================================================================
+
+CHECKLIST
+
+# The flag injection + always-on-top require the test-bridge plugin, which the
+# backend registers only when TERMIHUB_TEST_BRIDGE_PORT parses. Nothing listens
+# on BRIDGE_PORT — the app's bridge client just logs a failed connect (harmless).
+export TERMIHUB_TEST_BRIDGE_PORT="$BRIDGE_PORT"
+export TERMIHUB_TEST_FLAG_SESSION_BACKEND_REATTACH=1
+
+# Not `exec`: run as a child so the EXIT trap (state-file cleanup) still fires
+# when the app closes. scripts/dev.sh owns stopping its own dev-agent sshd.
+./scripts/dev.sh

--- a/tests/system/termihub_harness/ui/agent.py
+++ b/tests/system/termihub_harness/ui/agent.py
@@ -22,6 +22,13 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from .base import HarnessMixin
 
+#: Projection region id for the agents domain (region-authoritative since #2409;
+#: twin of the frontend ``AGENTS_REGION`` const). Its cache is the raw store
+#: snapshot keyed ``agents`` / ``sessions`` / ``definitions`` / ``folders`` —
+#: **not** the ``appStore``-named ``remoteAgents`` / ``agentSessions`` / … slices,
+#: which no longer exist on the store.
+AGENTS_REGION = "agents"
+
 
 class AgentUi(HarnessMixin):
     """Create remote agents and drive their menu, error dialog, and setup wizard."""
@@ -75,7 +82,10 @@ class AgentUi(HarnessMixin):
 
     # ── lookups ─────────────────────────────────────────────────────────────────
     def remote_agents(self) -> list[dict[str, Any]]:
-        value = self.driver.get_state("remoteAgents")
+        # Region-authoritative (#2409): read the `agents` projection region, whose
+        # raw cache lists the agents under the `agents` key (the old
+        # get_state("remoteAgents") path no longer resolves — #2479).
+        value = self.projection_region_cache(AGENTS_REGION).get("agents")
         return [a for a in value if isinstance(a, dict)] if isinstance(value, list) else []
 
     def find_agent(self, name: str) -> Optional[dict[str, Any]]:
@@ -201,21 +211,26 @@ class AgentUi(HarnessMixin):
         shells = capabilities.get("availableShells")
         return [s for s in shells if isinstance(s, str)] if isinstance(shells, list) else []
 
-    def _agent_keyed_dicts(self, state_key: str, agent_id: str) -> list[dict[str, Any]]:
-        """The dict entries of a ``Record<agentId, list>`` store keyed by ``agent_id``."""
-        value = self.driver.get_state(state_key)
+    def _agent_keyed_dicts(self, region_key: str, agent_id: str) -> list[dict[str, Any]]:
+        """The dict entries of a ``Record<agentId, list>`` map in the agents region.
+
+        Region-authoritative (#2409): the per-agent lists live under the raw
+        ``agents``-region keys (``sessions`` / ``definitions`` / ``folders``), not
+        the old ``appStore`` slices, so this reads the region cache (#2479).
+        """
+        value = self.projection_region_cache(AGENTS_REGION).get(region_key)
         items = value.get(agent_id) if isinstance(value, dict) else None
         return [i for i in items if isinstance(i, dict)] if isinstance(items, list) else []
 
     # ── agent-side sessions ──────────────────────────────────────────────────────
     def agent_sessions(self, agent_id: str) -> list[dict[str, Any]]:
-        """The live sessions the agent reports for ``agent_id`` (``agentSessions``)."""
-        return self._agent_keyed_dicts("agentSessions", agent_id)
+        """The live sessions the agent reports for ``agent_id`` (region ``sessions``)."""
+        return self._agent_keyed_dicts("sessions", agent_id)
 
     # ── saved definitions + persistent sessions ─────────────────────────────────
     def agent_definitions(self, agent_id: str) -> list[dict[str, Any]]:
-        """Saved connection definitions under ``agent_id`` (``agentDefinitions``)."""
-        return self._agent_keyed_dicts("agentDefinitions", agent_id)
+        """Saved connection definitions under ``agent_id`` (region ``definitions``)."""
+        return self._agent_keyed_dicts("definitions", agent_id)
 
     def create_agent_definition(
         self, agent_name: str, def_name: str, *, persistent: bool = False

--- a/tests/system/termihub_harness/ui/base.py
+++ b/tests/system/termihub_harness/ui/base.py
@@ -44,6 +44,30 @@ class HarnessMixin:
         """
         return self.driver.get_attribute(test_id, "disabled") is not None
 
+    def projection_region_cache(self, region: str) -> dict[str, Any]:
+        """The current projected cache of a ``region``, read through the substrate.
+
+        Some domains are **region-authoritative** — their state lives in a
+        projection region, not in ``appStore`` — so a ``get_state("<slice>")`` read
+        no longer resolves (agents since #2409, settings since #2227). This reads
+        the live region cache instead: it subscribes once per region (reused across
+        calls on the same test via a per-instance map) and returns the substrate's
+        current cache dict on every call, so a poll always sees the latest diff.
+
+        Returns ``{}`` when the region has no cache yet (never subscribed content),
+        so a ``.get(...)`` on the result is always safe.
+        """
+        subs = getattr(self, "_projection_region_subs", None)
+        if subs is None:
+            subs = {}
+            self._projection_region_subs = subs
+        sub_id = subs.get(region)
+        if sub_id is None:
+            sub_id = self.driver.projection_subscribe(region)["subscriptionId"]
+            subs[region] = sub_id
+        cache = self.driver.projection_state(sub_id).get("cache")
+        return cache if isinstance(cache, dict) else {}
+
     def open_named_context_menu(
         self,
         *,

--- a/tests/system/termihub_harness/ui/credential_store.py
+++ b/tests/system/termihub_harness/ui/credential_store.py
@@ -20,6 +20,7 @@ from typing import Any, Optional, TYPE_CHECKING
 
 from ..bridge import BridgeError
 from .base import HarnessMixin
+from .settings import SETTINGS_REGION
 
 #: Status-bar indicator that toggles lock state (lock when unlocked, open the
 #: unlock dialog when locked) — only rendered in master-password mode.
@@ -181,7 +182,10 @@ class CredentialStoreUi(HarnessMixin):
         )
         self.driver.select("auto-lock-timeout", str(minutes))
         self.wait(
-            lambda: self.driver.get_state("settings.credentialAutoLockMinutes") == minutes,
+            # Region-authoritative (#2227): the persisted value lives in the
+            # projected `settings` document, not an appStore `settings` slice (#2479).
+            lambda: self.projection_region_cache(SETTINGS_REGION).get("credentialAutoLockMinutes")
+            == minutes,
             what=f"the auto-lock timeout to persist as {minutes}",
         )
         self.switch_to_connections_sidebar()

--- a/tests/system/termihub_harness/ui/plugins.py
+++ b/tests/system/termihub_harness/ui/plugins.py
@@ -35,8 +35,8 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
 
-from ..bridge import BridgeError
 from .base import HarnessMixin
+from .settings import SETTINGS_REGION
 
 #: Id of the seeded fixture plugin (also its install directory name).
 SANDBOX_PLUGIN_ID = "termihub-sandbox-probe"
@@ -53,8 +53,9 @@ PARSER_OUTPUT_TOKEN = "sbxparserhit"
 #: The ``data-testid`` on the experimental frontend-plugin gate toggle
 #: (``FrontendPluginGateSettings.tsx``), under the *plugins* settings category.
 GATE_TOGGLE_TESTID = "settings-frontend-plugins-enabled"
-#: Store path of the gate setting (default-off; absent from the store until set).
-GATE_STATE_PATH = "settings.frontendPluginsEnabled"
+#: Key of the gate setting in the projected ``settings`` document (default-off;
+#: absent from the document until first set).
+GATE_SETTING_KEY = "frontendPluginsEnabled"
 
 #: The fixture's ``manifest.json`` (camelCase; ``deny_unknown_fields`` on the Rust
 #: side, so only known fields). ``apiVersion`` matches
@@ -184,13 +185,11 @@ class PluginsUi(HarnessMixin):
     def frontend_plugin_gate_enabled(self) -> bool:
         """Whether the experimental frontend-plugin gate is on.
 
-        The setting is absent from the store until first set, so a missing path
-        (``BridgeError``) means "off" — mirroring ``SettingsUi._experimental_enabled``.
+        Region-authoritative (#2227): read ``frontendPluginsEnabled`` from the
+        projected ``settings`` document — mirroring ``SettingsUi._experimental_enabled``.
+        The key is absent until first set, so a missing key reads as "off" (#2479).
         """
-        try:
-            return bool(self.driver.get_state(GATE_STATE_PATH))
-        except BridgeError:
-            return False
+        return bool(self.projection_region_cache(SETTINGS_REGION).get(GATE_SETTING_KEY))
 
     def write_gate_setting(self, enabled: bool) -> None:
         """Set ``frontendPluginsEnabled`` in the on-disk ``settings.json``.

--- a/tests/system/termihub_harness/ui/settings.py
+++ b/tests/system/termihub_harness/ui/settings.py
@@ -10,8 +10,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ..bridge import BridgeError
 from .base import HarnessMixin
+
+#: Projection region id for the settings domain (region-authoritative since #2227;
+#: twin of the frontend ``SETTINGS_REGION`` const). Its cache is the persisted
+#: ``AppSettings`` document one-to-one, so its fields are read directly — the old
+#: ``get_state("settings.…")`` path no longer resolves (``appStore`` has no
+#: ``settings`` slice).
+SETTINGS_REGION = "settings"
 
 
 class SettingsUi(HarnessMixin):
@@ -42,12 +48,12 @@ class SettingsUi(HarnessMixin):
         self.switch_to_connections_sidebar()
 
     def _experimental_enabled(self) -> bool:
-        # The setting is absent from the store until first set, so a missing path
-        # (BridgeError) means "off".
-        try:
-            return bool(self.driver.get_state("settings.experimentalFeaturesEnabled"))
-        except BridgeError:
-            return False
+        # Region-authoritative (#2227): read the flag from the projected `settings`
+        # document. It is absent until first set, so a missing key reads as "off"
+        # (the region cache always returns a dict, so no BridgeError to catch).
+        return bool(
+            self.projection_region_cache(SETTINGS_REGION).get("experimentalFeaturesEnabled")
+        )
 
     def open_settings_category(self, category: str) -> None:
         """Open Settings and select a category nav item (e.g. ``external-files``).


### PR DESCRIPTION
Two things, both in service of the #2476 backend-driven agent-reconnect live grade:

1. **Turnkey manual test for #2476** (primary) — the reconnect grade cannot run headlessly (macOS occlusion-throttles the WKWebView with no foreground display, #957/#2460), so this gives the maintainer a one-command setup + a short checklist for a real display.
2. **`Closes #2479`** — repoint the agent/settings harness reads at the projection regions they now live in.

## The one command the maintainer runs

```bash
scripts/internal/verify-agent-reconnect.sh
```

Run once from a dev checkout, it: seeds experimental features (so the dev agent's **Remote Agents** group renders), turns `sessionBackendReattach` **ON** via the #2481 test-bridge env→window injection (`TERMIHUB_TEST_FLAG_SESSION_BACKEND_REATTACH`), and launches this checkout's dev agent + the app via `scripts/dev.sh` (also pinned always-on-top, which defeats the occlusion throttle). First run builds — it can take a few minutes. Unix/macOS only (the dev agent is a loopback sshd), so there is no `.cmd` sibling.

Companion one-liner (run in a **second terminal**) drops/restores the dev-agent transport with one keystroke — no PID or port to find:

```bash
scripts/internal/agent-reconnect-transport.sh drop      # sever the transport
scripts/internal/agent-reconnect-transport.sh restore   # bring it back
```

`drop` kills this checkout's dev-agent sshd **master + established children** by port (a genuine transport drop that severs the in-flight session, not just the listener); `restore` relaunches sshd reusing the **same host key**, so the app's trust store still trusts it and the backend-driven reconnect is not blocked on a host-key prompt. It only ever touches this checkout's own dev-agent process — never Docker fixtures, never pattern-pkill.

## The checklist the maintainer follows (~5 min)

1. **Connect + open a session.** Connect the pre-registered dev agent (accept the host-key prompt if shown) → **New Shell Session**; run `echo hello`. Expect: a live shell.
2. **Drop.** Run `agent-reconnect-transport.sh drop`. Expect: within a few seconds the agent tab shows **Reconnecting** — the terminal must not close/exit/vanish.
3. **Prolonged outage + restore.** Wait ~30s (backend parks + retries), then `agent-reconnect-transport.sh restore`. Expect: the agent reconnects **backend-driven** and the **same** shell tab re-attaches to a fresh backend session; `echo hello2` prints. No duplicate tab, no second connection.
4. **Permanent drop.** Run `drop` again and do **not** restore. Expect: after the backend gives up, the agent/tab settles **Disconnected** — not spinning forever, not stranded.

PASS = steps 3 (reattach live, no double-connect) and 4 (clean Disconnected). Ctrl-C / close the window to tear down (the dev-agent sshd stops automatically).

## #2479 — projection harness reads

`AgentUi`/`SettingsUi` (and the plugin/credential helpers) read `get_state("remoteAgents" / "settings.*")` paths that no longer resolve — agents are region-authoritative since #2409, settings since #2227. Added a shared `HarnessMixin.projection_region_cache(region)` and repointed the reads at the `agents` / `settings` regions. This is what makes the agent test surface work again (and unblocks an automated version of the #2476 check).

## #2480 — automated lane residual

The opt-in `test_agent_reconnect_live.py` still cannot reach `connected` unattended (the WKWebView occlusion throttle needs a foreground/display-backed runner). Left as the residual per #2480; the turnkey **manual** test above is the accepted path for the #2476 grade.

## Verification done

- Both scripts shellcheck-clean; `bash -n` clean. `docs/testing.md` passes prettier + markdownlint. Harness modules import cleanly in the venv.
- Ran `verify-agent-reconnect.sh` for real: settings seeded, checklist printed with the resolved agent label + absolute paths, `scripts/dev.sh` built the agent and bound the dev-agent sshd on the checkout's port.
- Exercised `drop`/`restore`/`status` end-to-end against the **real** `dev.sh` daemon **and** a dev.sh-identical sshd with an established connection: drop severs the connection and reaps master + children; restore brings it back on the **same host key** (verified a strict-host-key reconnect still succeeds); idempotent drop/restore; clean teardown.

Closes #2479

🤖 Generated with [Claude Code](https://claude.com/claude-code)