### PR TITLE
harden backend-driven agent reconnect + add headless resume coverage (part of #2476, #2480)

### DIFF
--- a/docs/changes/dev1/fix/2476-agent-reconnect-resume.md
+++ b/docs/changes/dev1/fix/2476-agent-reconnect-resume.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- Backend-driven agent reconnect (`sessionBackendReattach`) now arms the reconnect
+  redrive from its own authoritative source. When a resilient agent session drops,
+  the server-side drop fold marked the tab "Reconnecting" but did not arm the
+  backend reconnect timer (every `session.*` intent route does; the source-side
+  fold did not), so the backend redrive relied solely on the client's
+  `session.reconnect` mirror to start its own loop. The drop fold now reconciles
+  the timer itself, so the backend is the sole driver of an agent reconnect as
+  designed and a resilient drop cannot leave a tab stuck "Reconnecting" with no
+  attempt ever driven.

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -192,9 +192,26 @@ impl<R: tauri::Runtime> EventEmitter for tauri::AppHandle<R> {
 
     fn fold_session_drop(&self, tab_id: &str, fold: DropFold) {
         use crate::session_projection::projection::fold_session_transition;
+        use crate::session_projection::ReconnectTimerDriver;
+        use tauri::Manager;
         match fold {
             DropFold::Reconnect => fold_session_transition(self, |store| store.reconnect(tab_id)),
             DropFold::Dropped => fold_session_transition(self, |store| store.dropped(tab_id, None)),
+        }
+        // Reconcile the backend reconnect timer at the **authoritative source**
+        // fold (#2476): a resilient drop (`Reconnect` → `Waiting`) must ARM the
+        // backend timer so the backend redrive drives the reconnect itself — it
+        // is the sole driver of an agent reconnect and must not depend on the
+        // client's `session.reconnect` mirror to start its own loop. Without this
+        // the source fold set the store to `Reconnecting` but left the timer
+        // unarmed (every `session.*` intent route calls `sync`, this fold did
+        // not), so if the client mirror did not fire/reach the backend the tab
+        // sat in `Reconnecting` forever with no attempt ever driven. `Dropped`
+        // (terminal) cancels any pending timer. Idempotent with the client
+        // mirror's own `sync` — a convergent double-arm. Off-path no-op when the
+        // driver is not managed (headless projection unit tests).
+        if let Some(driver) = self.try_state::<Arc<ReconnectTimerDriver>>() {
+            (*driver).sync(tab_id);
         }
     }
 

--- a/src-tauri/src/session_projection/mod.rs
+++ b/src-tauri/src/session_projection/mod.rs
@@ -25,6 +25,9 @@ pub mod redrive;
 pub mod store;
 pub mod timer;
 
+#[cfg(test)]
+mod redrive_resume_tests;
+
 pub use redrive::AppReconnectRedrive;
 pub use store::SessionLifecycleStore;
 pub use timer::{ReconnectRedrive, ReconnectTimerDriver, TokioReconnectScheduler};

--- a/src-tauri/src/session_projection/redrive_resume_tests.rs
+++ b/src-tauri/src/session_projection/redrive_resume_tests.rs
@@ -1,0 +1,461 @@
+//! Headless coverage for the **backend-driven agent reconnect redrive**
+//! resume-after-transport-restore path (#2476 / #2480).
+//!
+//! The live agent-reconnect grade cannot run headlessly (the WKWebView is
+//! occlusion-throttled and the real agent SSH handshake stalls over a throwaway
+//! sshd — see #2480), so the redrive's *coordination* had no automated coverage
+//! at all: nothing exercised "attempt fails while the transport is down → the
+//! loop re-arms → an attempt after the transport returns mints a fresh session
+//! and publishes its id for the frontend to re-attach to".
+//!
+//! This drives the **production** `AppReconnectRedrive`, `ReconnectTimerDriver`
+//! and `SessionManager` against a controllable fake agent (transport down, then
+//! up), with a deterministic manual scheduler, so the whole redrive resume
+//! sequence runs synchronously with no wall-clock, webview, or real SSH — the
+//! headless half of the #2480 lane. The frontend half (the reconcile → effect
+//! re-run → re-attach chain) is covered by `Terminal.agent-reconnect*.test.tsx`.
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use serde_json::Value;
+use tauri::Manager;
+
+use termihub_core::connection::ConnectionTypeRegistry;
+use termihub_core::reconnect_backoff::ReconnectPhase;
+
+use crate::commands::projection::ProjectionState;
+use crate::connection::config::AgentSettings;
+use crate::session::manager::SessionManager;
+use crate::session_projection::projection::{publish_sessions, SESSION_LIFECYCLE_REGION};
+use crate::session_projection::redrive::AppReconnectRedrive;
+use crate::session_projection::store::{SessionLifecycleStore, SessionStatus};
+use crate::session_projection::timer::{
+    ReconnectRedrive, ReconnectScheduler, ReconnectTimerDriver,
+};
+use crate::terminal::agent_manager::{
+    AgentCapabilities, AgentConnectResult, AgentConnectionsData, AgentDefinitionInfo,
+    AgentFolderInfo, AgentRpcClient, AgentSessionInfo,
+};
+use crate::terminal::backend::{OutputSender, RemoteAgentConfig};
+use crate::utils::errors::TerminalError;
+use termihub_core::monitoring::provider::MonitoringSender;
+
+/// The armed one-shots a [`ManualScheduler`] records: `key → (delay, task)`.
+type ArmedTasks = std::collections::HashMap<String, (u64, Box<dyn FnOnce() + Send>)>;
+
+/// A test scheduler that records armed one-shots and fires on command.
+#[derive(Default)]
+struct ManualScheduler {
+    tasks: Mutex<ArmedTasks>,
+}
+impl ManualScheduler {
+    fn armed(&self, key: &str) -> bool {
+        self.tasks.lock().unwrap().contains_key(key)
+    }
+    fn fire(&self, key: &str) {
+        let t = self.tasks.lock().unwrap().remove(key);
+        if let Some((_, task)) = t {
+            task();
+        }
+    }
+}
+impl ReconnectScheduler for ManualScheduler {
+    fn schedule(&self, key: String, delay_ms: u64, task: Box<dyn FnOnce() + Send>) {
+        self.tasks.lock().unwrap().insert(key, (delay_ms, task));
+    }
+    fn cancel(&self, key: &str) {
+        self.tasks.lock().unwrap().remove(key);
+    }
+}
+
+/// Controllable fake agent: models the transport being down then up.
+struct FakeAgent {
+    connected: AtomicBool,
+    /// Whether a cold reconnect (reconnect_retained_agent) can re-establish.
+    reattach_ok: AtomicBool,
+    create_count: AtomicUsize,
+    /// Keep output senders alive so create_connection's reader does not end
+    /// (which would tear the session down + fold a drop).
+    senders: Mutex<Vec<OutputSender>>,
+}
+impl FakeAgent {
+    fn new() -> Self {
+        Self {
+            connected: AtomicBool::new(true),
+            reattach_ok: AtomicBool::new(true),
+            create_count: AtomicUsize::new(0),
+            senders: Mutex::new(Vec::new()),
+        }
+    }
+}
+impl AgentRpcClient for FakeAgent {
+    fn disconnect_agent(&self, _agent_id: &str) -> Result<(), TerminalError> {
+        Ok(())
+    }
+    fn is_connected(&self, _agent_id: &str) -> bool {
+        self.connected.load(Ordering::SeqCst)
+    }
+    fn get_capabilities(&self, _agent_id: &str) -> Option<AgentCapabilities> {
+        None
+    }
+    fn reconnect_retained_agent(&self, _agent_id: &str) -> Result<(), TerminalError> {
+        if self.connected.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+        if self.reattach_ok.load(Ordering::SeqCst) {
+            self.connected.store(true, Ordering::SeqCst);
+            Ok(())
+        } else {
+            Err(TerminalError::RemoteError("transport down".into()))
+        }
+    }
+    fn shutdown_agent(&self, _agent_id: &str, _reason: Option<&str>) -> Result<u32, TerminalError> {
+        Ok(0)
+    }
+    fn send_request(
+        &self,
+        _agent_id: &str,
+        _method: &str,
+        _params: Value,
+    ) -> Result<Value, TerminalError> {
+        // "connection.types" → no types (capabilities parsing is skipped).
+        Ok(Value::Null)
+    }
+    fn create_session(
+        &self,
+        _agent_id: &str,
+        session_type: &str,
+        _config: Value,
+        _title: Option<&str>,
+        _definition_id: Option<&str>,
+    ) -> Result<AgentSessionInfo, TerminalError> {
+        if !self.connected.load(Ordering::SeqCst) {
+            return Err(TerminalError::RemoteError("Agent not connected".into()));
+        }
+        let n = self.create_count.fetch_add(1, Ordering::SeqCst);
+        Ok(AgentSessionInfo {
+            session_id: format!("remote-{n}"),
+            title: "Shell".into(),
+            session_type: session_type.into(),
+            status: "running".into(),
+            attached: false,
+            definition_id: None,
+        })
+    }
+    fn attach_session(
+        &self,
+        _agent_id: &str,
+        _remote_session_id: &str,
+    ) -> Result<(), TerminalError> {
+        Ok(())
+    }
+    fn close_session(
+        &self,
+        _agent_id: &str,
+        _remote_session_id: &str,
+    ) -> Result<(), TerminalError> {
+        Ok(())
+    }
+    fn list_sessions(&self, _agent_id: &str) -> Result<Vec<AgentSessionInfo>, TerminalError> {
+        Ok(vec![])
+    }
+    fn list_connections_and_folders(
+        &self,
+        _agent_id: &str,
+    ) -> Result<AgentConnectionsData, TerminalError> {
+        Ok(AgentConnectionsData {
+            connections: vec![],
+            folders: vec![],
+        })
+    }
+    fn list_definitions(&self, _agent_id: &str) -> Result<Vec<AgentDefinitionInfo>, TerminalError> {
+        Ok(vec![])
+    }
+    fn save_definition(
+        &self,
+        _agent_id: &str,
+        _definition: Value,
+    ) -> Result<AgentDefinitionInfo, TerminalError> {
+        unimplemented!()
+    }
+    fn update_definition(
+        &self,
+        _agent_id: &str,
+        _params: Value,
+    ) -> Result<AgentDefinitionInfo, TerminalError> {
+        unimplemented!()
+    }
+    fn delete_definition(&self, _agent_id: &str, _def_id: &str) -> Result<(), TerminalError> {
+        Ok(())
+    }
+    fn create_folder(
+        &self,
+        _agent_id: &str,
+        _name: &str,
+        _parent_id: Option<&str>,
+    ) -> Result<AgentFolderInfo, TerminalError> {
+        unimplemented!()
+    }
+    fn update_folder(
+        &self,
+        _agent_id: &str,
+        _params: Value,
+    ) -> Result<AgentFolderInfo, TerminalError> {
+        unimplemented!()
+    }
+    fn delete_folder(&self, _agent_id: &str, _folder_id: &str) -> Result<(), TerminalError> {
+        Ok(())
+    }
+    fn register_session_output(
+        &self,
+        _agent_id: &str,
+        _remote_session_id: &str,
+        output_tx: OutputSender,
+    ) -> Result<(), TerminalError> {
+        self.senders.lock().unwrap().push(output_tx);
+        Ok(())
+    }
+    fn unregister_session_output(
+        &self,
+        _agent_id: &str,
+        _remote_session_id: &str,
+    ) -> Result<(), TerminalError> {
+        Ok(())
+    }
+    fn register_monitoring_output(
+        &self,
+        _agent_id: &str,
+        _remote_session_id: &str,
+        _monitoring_tx: MonitoringSender,
+    ) -> Result<(), TerminalError> {
+        Ok(())
+    }
+    fn unregister_monitoring_output(
+        &self,
+        _agent_id: &str,
+        _remote_session_id: &str,
+    ) -> Result<(), TerminalError> {
+        Ok(())
+    }
+    fn send_session_input(
+        &self,
+        _agent_id: &str,
+        _remote_session_id: &str,
+        _data: &[u8],
+    ) -> Result<(), TerminalError> {
+        Ok(())
+    }
+    fn resize_session(
+        &self,
+        _agent_id: &str,
+        _remote_session_id: &str,
+        _cols: u16,
+        _rows: u16,
+    ) -> Result<(), TerminalError> {
+        Ok(())
+    }
+    fn apply_agent_settings(
+        &self,
+        _agent_id: &str,
+        _settings: &AgentSettings,
+    ) -> Result<(), TerminalError> {
+        Ok(())
+    }
+    fn connect_agent(
+        &self,
+        _agent_id: &str,
+        _config: &RemoteAgentConfig,
+        _agent_settings: Option<&AgentSettings>,
+    ) -> Result<AgentConnectResult, TerminalError> {
+        self.connected.store(true, Ordering::SeqCst);
+        Ok(AgentConnectResult {
+            capabilities: serde_json::from_value(serde_json::json!({
+                "connection_types": [],
+                "max_sessions": 10
+            }))
+            .unwrap(),
+            agent_version: "test".into(),
+            protocol_version: "1".into(),
+        })
+    }
+    fn cancel_connect(&self, _agent_id: &str) -> bool {
+        false
+    }
+    fn retain_agent_config(
+        &self,
+        _agent_id: &str,
+        _config: &RemoteAgentConfig,
+        _agent_settings: Option<&AgentSettings>,
+    ) {
+    }
+}
+
+fn poll_until<F: Fn() -> bool>(cond: F, label: &str) {
+    for _ in 0..200 {
+        if cond() {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    panic!("timed out waiting for: {label}");
+}
+
+#[test]
+fn agent_reconnect_resumes_after_transport_restore() {
+    let app = tauri::test::mock_app();
+    let handle = app.handle().clone();
+
+    let agent = Arc::new(FakeAgent::new());
+    let manager = SessionManager::new(
+        ConnectionTypeRegistry::new(),
+        agent.clone() as Arc<dyn AgentRpcClient>,
+    );
+    handle.manage(manager);
+
+    let store = Arc::new(SessionLifecycleStore::new());
+    store.set_rand_for_test(Box::new(|| 0.5));
+    handle.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let projector = projection.projector.clone();
+    let projector_seed = projection.projector.clone();
+    let store_for_publish = store.clone();
+    handle.manage(projection);
+
+    let scheduler = Arc::new(ManualScheduler::default());
+    let redrive: Arc<dyn ReconnectRedrive> = Arc::new(AppReconnectRedrive::new(handle.clone()));
+    let driver = Arc::new(
+        ReconnectTimerDriver::new(
+            store.clone(),
+            scheduler.clone(),
+            Arc::new(move || {
+                publish_sessions(&projector, &store_for_publish);
+            }),
+        )
+        .with_redrive(redrive),
+    );
+    handle.manage(driver.clone());
+
+    // Initial connect: agent up → session S1, request retained for the tab.
+    let manager_ref = handle.state::<SessionManager>();
+    let settings = serde_json::json!({ "config": {} });
+    let s1 = tauri::async_runtime::block_on(manager_ref.create_connection(
+        "shell",
+        settings.clone(),
+        Some("agent-1"),
+        Some("tab-1:0"),
+        false,
+        true, // resilient
+        true, // backend_reattach
+        handle.clone(),
+    ))
+    .expect("initial connect succeeds");
+    store.connect("tab-1");
+    store.connected("tab-1");
+    store.set_backend_session_id("tab-1", Some(s1.clone()));
+    publish_sessions(&projector_seed, &store);
+
+    // Drop: arm the loop (the client session.reconnect mirror does this in prod).
+    store.reconnect("tab-1");
+    driver.sync("tab-1");
+    assert!(scheduler.armed("tab-1"), "timer armed on drop");
+
+    // Transport is DOWN.
+    agent.connected.store(false, Ordering::SeqCst);
+    agent.reattach_ok.store(false, Ordering::SeqCst);
+
+    // Fire attempt 1: redrive can't re-establish → folds reconnect_failed → re-arms.
+    scheduler.fire("tab-1");
+    poll_until(
+        || store.get("tab-1").map(|s| s.reconnect.phase) == Some(ReconnectPhase::Waiting),
+        "redrive folds failure and re-arms Waiting",
+    );
+    assert!(
+        scheduler.armed("tab-1"),
+        "timer re-armed after failed attempt"
+    );
+    assert_eq!(
+        store.get("tab-1").map(|s| s.status),
+        Some(SessionStatus::Reconnecting)
+    );
+
+    // Transport RESTORED.
+    agent.reattach_ok.store(true, Ordering::SeqCst);
+
+    // Fire attempt 2: redrive re-establishes + creates a new session + publishes it.
+    scheduler.fire("tab-1");
+    poll_until(
+        || store.get("tab-1").map(|s| s.status) == Some(SessionStatus::Connected),
+        "redrive recovers to Connected after restore",
+    );
+    let life = store.get("tab-1").unwrap();
+    assert_eq!(life.status, SessionStatus::Connected);
+    assert!(
+        life.backend_session_id.is_some()
+            && life.backend_session_id.as_deref() != Some(s1.as_str()),
+        "a fresh backend session id is published for the frontend to re-attach"
+    );
+}
+
+/// The **authoritative source-side** drop fold ([`EventEmitter::fold_session_drop`],
+/// the exact call `SessionManager::emit_and_cleanup` makes at the `terminal-exit`
+/// source) must ARM the backend reconnect timer for a resilient drop, so the
+/// backend redrive drives the reconnect itself (#2476) rather than depending on
+/// the client's `session.reconnect` mirror to start the loop. Regression guard:
+/// before the fix the fold set the store to `Reconnecting` but left the timer
+/// unarmed (only the `session.*` intent routes called `sync`), so a tab whose
+/// client mirror did not reach the backend sat in `Reconnecting` forever with no
+/// attempt ever driven. A terminal (`Dropped`) fold cancels any pending timer.
+#[test]
+fn source_side_resilient_drop_fold_arms_the_reconnect_timer() {
+    use crate::session::manager::{DropFold, EventEmitter};
+
+    let app = tauri::test::mock_app();
+    let handle = app.handle().clone();
+
+    let store = Arc::new(SessionLifecycleStore::new());
+    store.set_rand_for_test(Box::new(|| 0.5));
+    store.connect("tab-1");
+    store.connected("tab-1");
+    handle.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let projector = projection.projector.clone();
+    let store_for_publish = store.clone();
+    handle.manage(projection);
+
+    let scheduler = Arc::new(ManualScheduler::default());
+    let driver = Arc::new(ReconnectTimerDriver::new(
+        store.clone(),
+        scheduler.clone(),
+        Arc::new(move || {
+            publish_sessions(&projector, &store_for_publish);
+        }),
+    ));
+    handle.manage(driver);
+
+    // A resilient drop at the source → store Reconnecting AND the timer armed.
+    handle.fold_session_drop("tab-1", DropFold::Reconnect);
+    assert_eq!(
+        store.get("tab-1").map(|s| s.status),
+        Some(SessionStatus::Reconnecting)
+    );
+    assert!(
+        scheduler.armed("tab-1"),
+        "the source-side resilient drop fold must arm the backend reconnect timer"
+    );
+
+    // A terminal drop at the source cancels any pending timer.
+    handle.fold_session_drop("tab-1", DropFold::Dropped);
+    assert!(
+        !scheduler.armed("tab-1"),
+        "a terminal (dropped) source fold cancels the reconnect timer"
+    );
+}

--- a/src/components/Terminal/Terminal.agent-reconnect-resume.test.tsx
+++ b/src/components/Terminal/Terminal.agent-reconnect-resume.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * Backend-driven AGENT reconnect **resume-after-restore** chain (#2476 / #2480),
+ * driven end-to-end by projected region diffs — the path a live agent drop takes.
+ *
+ * The sibling `Terminal.agent-reconnect.test.tsx` pins the outcome behaviour by
+ * calling `reconnectTerminal` directly. This covers the missing link: a resilient
+ * agent tab whose reconnect is driven **only** by the backend — the drop arms the
+ * loop, the backend reconnect timer fires the `Waiting → Connecting` edge (a
+ * region diff), the frontend reconcile re-runs the terminal effect, and the
+ * redrive's published fresh session id is re-attached — with the client agent
+ * engine never engaged. This is the exact scenario that regressed live: drop →
+ * Reconnecting worked, restore → re-attach did not.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { Terminal } from "./Terminal";
+import { TerminalPortalProvider } from "./TerminalRegistry";
+import { useAppStore } from "@/store/appStore";
+import {
+  setSessionBackendReattachEnabled,
+  setSessionTransportForTest,
+  setSessionIntentsEnabled,
+  setSessionRenderFromProjectionEnabled,
+  stopSessionSubscription,
+} from "@/store/sessionBridge";
+import {
+  FakeSessionTransport,
+  connected as connectedLifecycle,
+  reconnecting,
+} from "@/test/sessionLifecycleRegionTestHarness";
+
+vi.mock("@xterm/xterm", () => {
+  class MockXTerm {
+    open = vi.fn();
+    dispose = vi.fn();
+    loadAddon = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn(() => ({ dispose: vi.fn() }));
+    onScroll = vi.fn(() => ({ dispose: vi.fn() }));
+    onCursorMove = vi.fn(() => ({ dispose: vi.fn() }));
+    onWriteParsed = vi.fn(() => ({ dispose: vi.fn() }));
+    write = vi.fn((_d: unknown, cb?: () => void) => cb?.());
+    writeln = vi.fn();
+    reset = vi.fn();
+    scrollToBottom = vi.fn();
+    scrollLines = vi.fn();
+    selectAll = vi.fn();
+    hasSelection = vi.fn(() => false);
+    getSelection = vi.fn(() => "");
+    attachCustomKeyEventHandler = vi.fn();
+    unicode = { activeVersion: "6" };
+    cols = 80;
+    rows = 24;
+    resize = vi.fn();
+    focus = vi.fn();
+    element = document.createElement("div");
+    buffer = { active: { viewportY: 0, baseY: 0, length: 0, getLine: vi.fn() } };
+    parser = { registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })) };
+    options = {};
+  }
+  return { Terminal: MockXTerm };
+});
+vi.mock("@xterm/addon-fit", () => {
+  class M {
+    fit = vi.fn();
+    proposeDimensions = vi.fn(() => ({ cols: 80, rows: 24 }));
+    dispose = vi.fn();
+  }
+  return { FitAddon: M };
+});
+vi.mock("@xterm/addon-unicode11", () => ({
+  Unicode11Addon: class {
+    dispose = vi.fn();
+  },
+}));
+vi.mock("@xterm/addon-search", () => ({
+  SearchAddon: class {
+    dispose = vi.fn();
+  },
+}));
+vi.mock("@/themes", () => ({
+  getXtermTheme: vi.fn(() => ({})),
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+const mockCreateTerminal = vi.fn().mockResolvedValue("fresh-session");
+const mockGetAgentSessionBuffer = vi.fn().mockResolvedValue(new Uint8Array());
+vi.mock("@/services/api", () => ({
+  createTerminal: (...a: unknown[]) => mockCreateTerminal(...a),
+  sendInput: vi.fn().mockResolvedValue(undefined),
+  resizeTerminal: vi.fn().mockResolvedValue(undefined),
+  closeTerminal: vi.fn().mockResolvedValue(undefined),
+  detachPersistentTab: vi.fn().mockResolvedValue(0),
+  getAgentSessionBuffer: (...a: unknown[]) => mockGetAgentSessionBuffer(...a),
+  sessionGetCapabilities: vi.fn().mockResolvedValue({}),
+}));
+
+const mockSubscribeOutput = vi.fn(() => vi.fn());
+const mockSubscribeExit = vi.fn(() => vi.fn());
+vi.mock("@/services/events", () => ({
+  terminalDispatcher: {
+    init: vi.fn().mockResolvedValue(undefined),
+    subscribeOutput: (...a: unknown[]) => mockSubscribeOutput(...(a as [])),
+    subscribeExit: (...a: unknown[]) => mockSubscribeExit(...(a as [])),
+    clearPendingExit: vi.fn(),
+    clearPendingOutput: vi.fn(),
+  },
+}));
+vi.mock("@/services/keybindings", () => ({
+  processKeyEvent: vi.fn(() => null),
+  isAppShortcut: vi.fn(() => false),
+  isChordPending: vi.fn(() => false),
+}));
+vi.mock("@tauri-apps/plugin-clipboard-manager", () => ({
+  readText: vi.fn().mockResolvedValue(""),
+}));
+
+globalThis.ResizeObserver = class {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+} as unknown as typeof ResizeObserver;
+
+let container: HTMLDivElement;
+let root: Root;
+let transport: FakeSessionTransport;
+
+beforeEach(() => {
+  useAppStore.setState(useAppStore.getInitialState());
+  mockCreateTerminal.mockClear();
+  mockSubscribeOutput.mockClear();
+  mockSubscribeExit.mockClear();
+  transport = new FakeSessionTransport();
+  setSessionTransportForTest(transport);
+  setSessionIntentsEnabled(true);
+  setSessionRenderFromProjectionEnabled(true);
+  setSessionBackendReattachEnabled(true);
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  stopSessionSubscription();
+  setSessionTransportForTest(null);
+  setSessionBackendReattachEnabled(null);
+  setSessionIntentsEnabled(null);
+  setSessionRenderFromProjectionEnabled(null);
+});
+
+const AGENT_CONFIG = {
+  type: "remote-session" as const,
+  config: { agentId: "agent-1", sessionType: "shell" },
+};
+function addAgentTab(sessionId: string): string {
+  return useAppStore.getState().addTab("Agent Shell", "remote-session", AGENT_CONFIG, {
+    contentType: "terminal",
+    sessionId,
+  });
+}
+const mount = (tabId: string, existingSessionId: string) => {
+  act(() => {
+    root.render(
+      <TerminalPortalProvider>
+        <Terminal
+          tabId={tabId}
+          config={AGENT_CONFIG}
+          isVisible={true}
+          existingSessionId={existingSessionId}
+        />
+      </TerminalPortalProvider>
+    );
+  });
+};
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("Terminal — backend-driven agent reconnect RESUME via reconcile (#2476)", () => {
+  it("re-attaches to the redrive's fresh session id, driven only by region diffs", async () => {
+    const tabId = addAgentTab("S1");
+    transport.setSession(tabId, connectedLifecycle());
+    mount(tabId, "S1");
+    await act(async () => {
+      await wait(50);
+    });
+    expect(mockCreateTerminal).not.toHaveBeenCalled(); // initial mount reattaches
+
+    // Drop: arm the resilient loop + wire the backend-timer reconcile — exactly
+    // what setTerminalExited("dropped") does for a resilient agent tab.
+    act(() => {
+      useAppStore.getState().setTerminalExited(tabId, { code: null, reason: "dropped" });
+    });
+    await act(async () => {
+      await wait(20);
+    });
+
+    // Backend reconnect timer: Waiting, then it fires the attempt (→ Connecting).
+    act(() => {
+      transport.setSession(tabId, reconnecting({ phase: "waiting", attempt: 0, delayMs: 1000 }));
+    });
+    await act(async () => {
+      await wait(20);
+    });
+    act(() => {
+      transport.setSession(tabId, reconnecting({ phase: "connecting", attempt: 1, delayMs: 0 }));
+    });
+    await act(async () => {
+      await wait(50);
+    });
+
+    // Backend redrive minted S2 and published it (connected).
+    act(() => {
+      transport.setSession(tabId, { ...connectedLifecycle(), sessionId: "S2" });
+    });
+    await act(async () => {
+      await wait(80);
+    });
+
+    // Client agent engine stays suppressed; terminal I/O re-attaches to S2.
+    expect(mockCreateTerminal).not.toHaveBeenCalled();
+    expect(mockSubscribeOutput).toHaveBeenCalledWith("S2", expect.any(Function));
+    expect(mockSubscribeExit).toHaveBeenCalledWith("S2", expect.any(Function));
+  });
+});


### PR DESCRIPTION
## Summary

Hardens the backend-driven agent reconnect coordination (`sessionBackendReattach`) and adds the **headless automated coverage** the live grade lacked. Part of #2476 and #2480.

**Important — read before merging:** this does **not** claim to fully close the live failure the maintainer hit (agent tab stuck "Reconnecting" after transport restore). I could **not reproduce that exact symptom headlessly**, and the evidence localizes its remaining cause to the real agent-io-task transport layer, which needs the display-backed grade (#2480). Details below. So this is scoped as hardening + coverage, not `Closes #2476`.

## Root-cause investigation

Traced the whole resume-after-restore path (`agent_manager.rs` in-task `reconnect_agent`, `session_projection/redrive.rs`, `session/manager.rs` `emit_and_cleanup`/`fold_session_drop`, the `ReconnectTimerDriver`, and `Terminal.tsx` `waitForBackendAgentReconnectOutcome` + the appStore reconcile). I built two faithful reproductions:

- **Frontend chain** (`Terminal.agent-reconnect-resume.test.tsx`): given the backend region diffs (drop → `waiting` → `connecting` → `connected`+new id), the reconcile re-runs the terminal effect and re-attaches to the new session, client engine suppressed. **Recovers.**
- **Backend redrive** (`redrive_resume_tests.rs`): the production `AppReconnectRedrive` + `ReconnectTimerDriver` + `SessionManager` against a controllable fake agent (transport down → up). Attempt fails while down → loop re-arms → attempt after restore mints a fresh session and publishes its id. **Recovers.**

Both halves recover **in isolation**, which localizes the live "no connection came back" failure to the real agent-io-task integration that neither isolated repro (nor any headless test) can exercise: the in-task `reconnect_agent` transport reconnect not settling, or the fresh-after-reconnect agent's `connection.create` stalling over SSH (the ADR-11 registry-daemon handshake — the exact #2480 stall). Confirming/fixing that needs the live agent + display, i.e. the #2480 residual.

## The one concrete backend defect found and fixed

The authoritative **source-side** drop fold — `EventEmitter::fold_session_drop`, the call `emit_and_cleanup` makes at the `terminal-exit` source — set the tab to `Reconnecting` for a resilient drop but **never armed the backend reconnect timer**. Every `session.*` intent route calls `ReconnectTimerDriver::sync`; this fold did not. So the backend-driven agent reconnect redrive depended entirely on the client's `session.reconnect` mirror to start its own loop — contradicting #2476's "the backend is the sole driver". If that mirror did not fire/reach the backend, the tab sat in `Reconnecting` forever with no attempt driven and no give-up.

**Fix:** `fold_session_drop` now reconciles the timer itself (`Reconnect` → arm `Waiting`; `Dropped` → cancel). Idempotent with the client mirror (a convergent double-arm).

- **Before/after (reproduction test):** `source_side_resilient_drop_fold_arms_the_reconnect_timer` is **RED** without the fix (timer not armed) and **GREEN** with it (verified by reverting the fix).

## Automated-coverage status (#2480)

- Backend redrive resume path — now covered headless (`redrive_resume_tests.rs`), previously **zero** coverage.
- Frontend reconcile → re-attach path — now covered headless (`Terminal.agent-reconnect-resume.test.tsx`).
- Full live drop→restore E2E (`test_agent_reconnect_live.py`) — **still requires** a display-backed runner + the real-agent registry-daemon handshake fix. Unchanged residual, tracked in #2480.

## Tests

- Rust: `session_projection` (50) + `session::` (161) green; clippy clean; `cargo fmt --check` clean.
- Frontend: new resume test + existing `Terminal.agent-reconnect.test.tsx` (4 total) green; `api.test.ts` (81) green; prettier + eslint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
