### PR TITLE
test(agent): retry client connect with bounded backoff to fix Windows 10060 flake (Closes #2490)

### DIFF
--- a/agent/tests/local_agent_integration.rs
+++ b/agent/tests/local_agent_integration.rs
@@ -14,7 +14,7 @@
 //! The binary is built automatically by cargo before the tests run.
 
 use std::io::{BufRead, BufReader, Read, Write};
-use std::net::{Shutdown, TcpListener, TcpStream};
+use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::path::Path;
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicU16, Ordering};
@@ -374,10 +374,75 @@ fn spawn_ready_listener(
     );
 }
 
+// ── Client connect with bounded retry ────────────────────────────────────────
+
+/// Per-attempt connect timeout for [`connect_with_retry`] and [`probe_once`].
+///
+/// A bare `TcpStream::connect` uses the OS default connect timeout, which on
+/// **Windows** is a long, unforgiving SYN-retransmit sequence (~21s). Under
+/// heavy parallel CI load a *ready* loopback listener's accept backlog can fill
+/// for a beat, so Windows silently drops the client SYN and a single `connect`
+/// hangs the whole way to that default — surfacing as
+/// `Os { code: 10060, kind: TimedOut }`, the #2490 / #1579 flake that reds a
+/// random agent-integration test each run. Capping each attempt short turns that
+/// one long hang into a fast poll: abandon a stalled SYN quickly and re-attempt
+/// on the backoff schedule. On unix a bare connect refuses fast, so the cap is
+/// only ever exercised there in pathological cases; it is harmless.
+const CONNECT_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(750);
+
+/// Resolve a `host:port` string to a single `SocketAddr` for `connect_timeout`.
+///
+/// A malformed address is a test bug, not a transient condition, so this panics
+/// rather than feeding a retry loop that could never succeed.
+fn resolve_addr(addr: &str) -> SocketAddr {
+    addr.to_socket_addrs()
+        .unwrap_or_else(|e| panic!("could not parse agent addr {addr}: {e}"))
+        .next()
+        .unwrap_or_else(|| panic!("agent addr {addr} resolved to no socket address"))
+}
+
+/// Connect a client to a *ready* agent listener, retrying short-timeout connects
+/// with bounded backoff until the listener accepts or [`ready_timeout`] elapses.
+///
+/// [`spawn_ready_listener`] already proves the accept loop is live before a test
+/// runs, so this normally succeeds on the first attempt and never sleeps. Its job
+/// is to survive the transient Windows-CI window described on
+/// [`CONNECT_ATTEMPT_TIMEOUT`]: it polls on **connect success** (per the #2459
+/// hardening lesson — never a fixed sleep-then-assume-ready) instead of betting
+/// the whole test on one `connect` that can hang for ~21s.
+///
+/// The deadline is bounded and the **read side is untouched**: a listener that
+/// never accepts still fails the test once the budget elapses — this only widens
+/// the connect window, it does not mask a genuine hang or weaken any readiness
+/// assertion.
+fn connect_with_retry(addr: &str) -> TcpStream {
+    let socket_addr = resolve_addr(addr);
+    let deadline = Instant::now() + ready_timeout();
+    let mut backoff = readiness_backoff();
+    loop {
+        match TcpStream::connect_timeout(&socket_addr, CONNECT_ATTEMPT_TIMEOUT) {
+            Ok(stream) => return stream,
+            Err(e) => {
+                if Instant::now() >= deadline {
+                    panic!(
+                        "could not connect to agent at {addr} within {:?} — last error: {e}",
+                        ready_timeout()
+                    );
+                }
+            }
+        }
+        std::thread::sleep(backoff.next_delay().unwrap_or(READINESS_BACKOFF_CAP));
+    }
+}
+
 /// One FIN-readiness probe. Returns `None` on success (EOF observed), or
 /// `Some(reason)` describing a transient failure so the caller can retry.
 fn probe_once(addr: &str, deadline: &Instant) -> Option<String> {
-    let mut stream = match TcpStream::connect(addr) {
+    // Use a short per-attempt connect timeout (see [`CONNECT_ATTEMPT_TIMEOUT`]):
+    // a bare `connect` here would hang ~21s on a Windows SYN drop, stalling the
+    // whole readiness backoff loop before it could retry.
+    let mut stream = match TcpStream::connect_timeout(&resolve_addr(addr), CONNECT_ATTEMPT_TIMEOUT)
+    {
         Ok(stream) => stream,
         Err(e) => return Some(format!("connect: {e}")),
     };
@@ -466,7 +531,7 @@ fn agent_starts_and_accepts_connections() {
 #[test]
 fn agent_responds_to_initialize() {
     let agent = LocalAgent::spawn();
-    let mut stream = TcpStream::connect(&agent.addr).expect("connect failed");
+    let mut stream = connect_with_retry(&agent.addr);
     stream.set_read_timeout(Some(RPC_READ_TIMEOUT)).unwrap();
 
     let response = rpc(
@@ -488,7 +553,7 @@ fn agent_responds_to_initialize() {
 #[test]
 fn agent_returns_error_for_unknown_method_before_initialize() {
     let agent = LocalAgent::spawn();
-    let mut stream = TcpStream::connect(&agent.addr).expect("connect failed");
+    let mut stream = connect_with_retry(&agent.addr);
     stream.set_read_timeout(Some(RPC_READ_TIMEOUT)).unwrap();
 
     let response = rpc(
@@ -512,7 +577,7 @@ fn agent_handles_multiple_sequential_connections() {
     let agent = LocalAgent::spawn();
 
     for i in 0..3 {
-        let mut stream = TcpStream::connect(&agent.addr).expect("connect failed");
+        let mut stream = connect_with_retry(&agent.addr);
         stream.set_read_timeout(Some(RPC_READ_TIMEOUT)).unwrap();
 
         let response = rpc(
@@ -561,7 +626,10 @@ struct AgentClient {
 
 impl AgentClient {
     fn connect(addr: &str) -> Self {
-        let stream = TcpStream::connect(addr).expect("connect failed");
+        // Retry the connect with bounded backoff so a transient Windows-CI SYN
+        // drop against a ready listener does not 10060 the test (#2490/#1579);
+        // see [`connect_with_retry`].
+        let stream = connect_with_retry(addr);
         // Match the simple `rpc()` helper's generous per-round-trip budget: a
         // loaded CI runner can momentarily take several seconds to answer an
         // RPC, and a 10s ceiling flaked under that load (#1398). The read still

--- a/agent/tests/tcp_listener_readiness.rs
+++ b/agent/tests/tcp_listener_readiness.rs
@@ -19,12 +19,64 @@
 //! the whole delay.
 
 use std::io::{BufRead, BufReader, Read, Write};
-use std::net::TcpStream;
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
+use termihub_core::monitoring::BackoffSchedule;
+
 fn agent_binary() -> &'static str {
     env!("CARGO_BIN_EXE_termihub-agent")
+}
+
+/// Per-attempt connect timeout for [`connect_with_retry`].
+///
+/// A bare `TcpStream::connect` uses the OS default connect timeout, ~21s of
+/// unforgiving SYN retransmits on **Windows**. Under heavy parallel CI load a
+/// *ready* loopback listener's accept backlog can fill for a beat, Windows drops
+/// the SYN, and a single connect hangs the whole way to that default —
+/// `Os { code: 10060, kind: TimedOut }`, the #2490 / #1579 flake. Capping each
+/// attempt short lets us abandon a stalled SYN and re-attempt quickly.
+const CONNECT_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(750);
+/// Overall budget for establishing the client connection once the agent has
+/// announced readiness. Matches [`STARTUP_TIMEOUT`]'s generosity for a loaded
+/// runner; a listener that never accepts still fails the test after it elapses.
+const CONNECT_DEADLINE: Duration = Duration::from_secs(30);
+
+/// Connect to the agent's listener, retrying short-timeout connects with bounded
+/// backoff until it accepts or [`CONNECT_DEADLINE`] elapses.
+///
+/// Polls on **connect success** (per the #2459 hardening lesson — not a fixed
+/// sleep) so the transient Windows-CI SYN-drop window (see
+/// [`CONNECT_ATTEMPT_TIMEOUT`]) cannot 10060 this test. The `initialize`
+/// read-timing assertion below — the actual #1579 readiness check — is left
+/// entirely untouched: this hardens the transport, it does not weaken the test.
+fn connect_with_retry(addr: &str) -> TcpStream {
+    let socket_addr: SocketAddr = addr
+        .to_socket_addrs()
+        .unwrap_or_else(|e| panic!("could not parse agent addr {addr}: {e}"))
+        .next()
+        .unwrap_or_else(|| panic!("agent addr {addr} resolved to no socket address"));
+    let deadline = Instant::now() + CONNECT_DEADLINE;
+    let mut backoff = BackoffSchedule::new(
+        Duration::from_millis(20),
+        Duration::from_millis(500),
+        u32::MAX,
+    );
+    loop {
+        match TcpStream::connect_timeout(&socket_addr, CONNECT_ATTEMPT_TIMEOUT) {
+            Ok(stream) => return stream,
+            Err(e) => {
+                if Instant::now() >= deadline {
+                    panic!(
+                        "could not connect to agent at {addr} within {CONNECT_DEADLINE:?} \
+                         — last error: {e}"
+                    );
+                }
+            }
+        }
+        std::thread::sleep(backoff.next_delay().unwrap_or(Duration::from_millis(500)));
+    }
 }
 
 /// How long the agent's startup path is stretched before it binds.
@@ -85,7 +137,10 @@ fn listening_log_is_a_true_readiness_signal() {
     );
 
     // Connect the instant we see the readiness signal and send `initialize`.
-    let stream = TcpStream::connect(&addr).expect("connect to agent");
+    // Retry the connect with bounded backoff so a transient Windows-CI SYN drop
+    // does not 10060 before the read-timing assertion runs (#2490); the
+    // `initialize` read budget below is unchanged and remains the #1579 check.
+    let stream = connect_with_retry(&addr);
     stream
         .set_read_timeout(Some(INITIALIZE_READ_TIMEOUT))
         .expect("set read timeout");


### PR DESCRIPTION
## Problem

The agent-integration suites (`agent/tests/local_agent_integration.rs`, `agent/tests/tcp_listener_readiness.rs`) connect a TCP client to a freshly `--listen`-bound agent on loopback and `read_line` the first response. On a loaded **Windows** CI runner a *ready* listener's accept backlog fills for a beat; Windows silently drops the client SYN and a single bare `TcpStream::connect` hangs on the OS default connect timeout (~21s of SYN retransmits), surfacing as `Os { code: 10060, kind: TimedOut }` ("the connected party did not properly respond").

This reds a **random** agent-integration test each run (observed on `shell_session_persists_across_client_disconnect`, `agent_handles_multiple_sequential_connections`, and `listening_log_is_a_true_readiness_signal`) — a **timing flake, not a logic defect** — and now blocks the Windows leg of essentially every agent-reconnect PR. ubuntu + macos pass the same tests because a not-yet-accepting loopback connect refuses/completes fast there.

`Closes #2490`
`Closes #1579` — same root cause (its `listening_log_is_a_true_readiness_signal` connect is one of the flaking sites).

## Fix

A shared `connect_with_retry` helper that polls short-timeout `TcpStream::connect_timeout` attempts (750ms each) on bounded exponential backoff until the listener accepts or a generous deadline elapses. This turns one long unforgiving `connect` hang into a fast **poll on connect success** — per the #2459 hardening lesson, never a fixed sleep-then-assume-ready.

Applied to every client connect site:
- `local_agent_integration.rs`: the `AgentClient` client connect (covers all stateful-client tests incl. the persistent/reconnect ones), the three raw-connect tests, and the readiness `probe_once` (so a Windows SYN drop no longer stalls the readiness backoff loop itself).
- `tcp_listener_readiness.rs`: the post-`Listening on` client connect.

## Readiness assertions stay genuine

- The deadline is **bounded** — a listener that never accepts still fails the test; this widens the connect window, it does not mask a hang.
- The **read side is untouched**. In particular `tcp_listener_readiness`'s `initialize` read-timing check (the actual #1579 assertion that the agent answers promptly once it advertises readiness) is unchanged — only the connect that precedes it is hardened.

## Verification

- `cargo fmt -p termihub-agent --check` and `cargo clippy -p termihub-agent --tests -- -D warnings`: clean.
- **Local macOS stress loop: 20/20 consecutive green** runs of both suites (`local_agent_integration` + `tcp_listener_readiness`), no `10060`/`TimedOut`, no regression.
- The real Windows proof is this PR's Windows CI leg.