### PR TITLE
test(agent): make agent-integration response reads robust to slow windows CI (Closes #2493)

### DIFF
--- a/agent/tests/local_agent_integration.rs
+++ b/agent/tests/local_agent_integration.rs
@@ -463,6 +463,82 @@ fn probe_once(addr: &str, deadline: &Instant) -> Option<String> {
     }
 }
 
+// ── Response reads robust to slow Windows-CI responses ────────────────────────
+
+/// Short per-read socket timeout used inside [`read_line_until_deadline`].
+///
+/// Kept small so the read loop re-checks its wall-clock deadline promptly. Each
+/// expiry is a `WouldBlock` (unix) / `WSAETIMEDOUT` os error 10060 (Windows)
+/// that the loop simply retries; it is never the budget that fails a test.
+const READ_POLL_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// A fresh total budget for reading a single response line.
+///
+/// Reuses the same generous, env-overridable ([`TERMIHUB_TEST_READY_TIMEOUT_SECS`])
+/// ceiling as the other readiness waits — a loaded Windows runner's first or
+/// reconnect/replay response can arrive several seconds late without the agent
+/// being unhealthy.
+fn read_deadline() -> Instant {
+    Instant::now() + ready_timeout()
+}
+
+/// Read one NDJSON line from `reader`, retrying transient per-read timeouts until
+/// `deadline`.
+///
+/// # Why this exists (#2493)
+///
+/// A socket read timeout (`SO_RCVTIMEO`) is a hard cutoff: a single `read_line`
+/// fails the instant that timeout expires. On **Windows** the expiry maps to
+/// `WSAETIMEDOUT` — `Os { code: 10060, kind: TimedOut }` — so a loaded Windows CI
+/// runner that answers an RPC (or replays a reconnect buffer) slower than one
+/// tight timeout would 10060 the whole test even though the agent is healthy and
+/// the response is merely late. The connect facet was fixed by
+/// [`connect_with_retry`] (#2492); this is its read-side mirror, covering every
+/// response read in the suite (the [`AgentClient`] and the simple [`rpc`] helper).
+///
+/// Instead of one tight cutoff this loops a *short* per-read timeout
+/// ([`READ_POLL_TIMEOUT`]) up to a generous total `deadline`: every
+/// `WouldBlock`/`TimedOut` expiry just re-checks the clock and retries. Partial
+/// bytes already appended by a timed-out `read_line` are preserved by
+/// `BufRead::read_until` (the wire is ASCII JSON, so a per-read boundary never
+/// splits a multi-byte char), so a retry resumes the same line rather than losing
+/// it.
+///
+/// The deadline is **bounded**, so the assertion stays genuine: a genuinely
+/// stalled or never-responding agent still fails once `deadline` elapses — the
+/// read never blocks forever and no real hang is swallowed. Returns the bytes
+/// appended (`0` = clean EOF), or the last timeout error once the deadline passes.
+fn read_line_until_deadline(
+    reader: &mut BufReader<TcpStream>,
+    line: &mut String,
+    deadline: Instant,
+) -> std::io::Result<usize> {
+    reader
+        .get_ref()
+        .set_read_timeout(Some(READ_POLL_TIMEOUT))
+        .expect("set_read_timeout");
+    let start_len = line.len();
+    loop {
+        match reader.read_line(line) {
+            // `read_line` returns `Ok` only at a newline or EOF — either way this
+            // line is complete (or the stream ended). Report total bytes read.
+            Ok(_) => return Ok(line.len() - start_len),
+            Err(e)
+                if e.kind() == std::io::ErrorKind::WouldBlock
+                    || e.kind() == std::io::ErrorKind::TimedOut =>
+            {
+                // Slow-but-responding agent: the per-read window lapsed with the
+                // line not yet complete. Retry until the bounded deadline, then
+                // surface the timeout so a real hang still fails the test.
+                if Instant::now() >= deadline {
+                    return Err(e);
+                }
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
+
 /// Send a single NDJSON line and return the first response line.
 fn rpc(stream: &mut TcpStream, msg: &str) -> String {
     let mut line = msg.trim().to_string();
@@ -471,8 +547,46 @@ fn rpc(stream: &mut TcpStream, msg: &str) -> String {
 
     let mut reader = BufReader::new(stream.try_clone().expect("clone failed"));
     let mut response = String::new();
-    reader.read_line(&mut response).expect("read_line failed");
+    read_line_until_deadline(&mut reader, &mut response, read_deadline())
+        .expect("read_line failed");
     response.trim().to_string()
+}
+
+/// The bounded read must still FAIL on a genuinely non-responding peer once its
+/// deadline elapses — it widens the window for a slow-but-live agent, it does not
+/// turn a real hang into a pass (#2493). Uses a raw listener that accepts but
+/// never answers, so no agent binary is involved.
+#[test]
+fn read_line_until_deadline_fails_fast_on_silent_peer() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    // Accept the connection and hold it open without ever writing a byte.
+    let server = std::thread::spawn(move || {
+        if let Ok((sock, _)) = listener.accept() {
+            std::thread::sleep(Duration::from_secs(5));
+            drop(sock);
+        }
+    });
+
+    let stream = TcpStream::connect(addr).expect("connect");
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    let started = Instant::now();
+    let deadline = started + Duration::from_millis(750);
+    let result = read_line_until_deadline(&mut reader, &mut line, deadline);
+    let elapsed = started.elapsed();
+
+    assert!(
+        result.is_err(),
+        "a silent peer must time out at the deadline, not read a line: {result:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(3),
+        "bounded read must fail near its deadline, not block indefinitely — took {elapsed:?}"
+    );
+
+    drop(reader);
+    server.join().ok();
 }
 
 /// A dead agent process must be reported immediately, not waited out.
@@ -659,9 +773,15 @@ impl AgentClient {
     }
 
     /// Read and parse one NDJSON line from the agent.
+    ///
+    /// Uses the bounded, timeout-retrying [`read_line_until_deadline`] so a slow
+    /// Windows-CI response — the reconnect/replay read is the slowest — does not
+    /// 10060 the test on a single `SO_RCVTIMEO` expiry (#2493), while a genuinely
+    /// stalled agent still fails once the deadline elapses.
     fn read_one(&mut self) -> Value {
         let mut line = String::new();
-        self.reader.read_line(&mut line).expect("read_line failed");
+        read_line_until_deadline(&mut self.reader, &mut line, read_deadline())
+            .expect("read_line failed");
         serde_json::from_str(line.trim()).expect("invalid JSON from agent")
     }
 

--- a/agent/tests/tcp_listener_readiness.rs
+++ b/agent/tests/tcp_listener_readiness.rs
@@ -80,13 +80,22 @@ fn connect_with_retry(addr: &str) -> TcpStream {
 }
 
 /// How long the agent's startup path is stretched before it binds.
-const STARTUP_DELAY: Duration = Duration::from_millis(3000);
+///
+/// Widened (was 3000ms) alongside [`INITIALIZE_READ_TIMEOUT`] so the readiness
+/// check tolerates a loaded Windows CI runner (#2493): the honest `initialize`
+/// reply now has a 3s window, while this delay stays comfortably longer so a
+/// still-in-startup agent (the #1579 bug) still cannot answer inside that window.
+const STARTUP_DELAY: Duration = Duration::from_millis(5000);
 /// Time allowed to observe the `Listening on …` line.
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 /// Read budget for `initialize` once we have connected. Deliberately shorter
 /// than `STARTUP_DELAY`: if the agent were still in its startup delay when we
 /// connected (the #1579 bug), the reply could not arrive inside this window.
-const INITIALIZE_READ_TIMEOUT: Duration = Duration::from_millis(1500);
+///
+/// Widened (was 1500ms) to absorb a slow-but-honest response on a loaded Windows
+/// runner without 10060-flaking (#2493) — it stays well under [`STARTUP_DELAY`],
+/// so the #1579 assertion (a stalled listener cannot answer in time) stays real.
+const INITIALIZE_READ_TIMEOUT: Duration = Duration::from_millis(3000);
 
 /// A spawned agent process, killed on drop so a failing assertion never leaks it.
 struct AgentProcess {


### PR DESCRIPTION
## Summary

Fixes the **read facet** of the Windows agent-integration `10060` flake (#2493). The connect facet was fixed by `connect_with_retry` (#2492, merged); this is its read-side mirror. Blocks the Windows leg of #2489 and #2491.

Windows maps an `SO_RCVTIMEO` (read-timeout) expiry to `WSAETIMEDOUT` — `Os { code: 10060, kind: TimedOut }`. A single `read_line` with one tight socket timeout therefore 10060s the whole test the moment a loaded Windows runner answers an RPC (or replays a reconnect buffer) slower than that timeout, even though the agent is healthy and the response is merely late. Observed on the slowest paths — `shell_session_persists_across_client_disconnect` and `persistent_shell_buffer_replayed_after_tcp_reconnect` (the reconnect/replay reads).

## Approach — robust bounded read

- New shared helper `read_line_until_deadline(reader, line, deadline)` (mirrors `connect_with_retry`): loops a **short per-read timeout** (`READ_POLL_TIMEOUT` = 500ms) up to a **generous, bounded, env-overridable** total deadline (`ready_timeout()`, 60s default, `TERMIHUB_TEST_READY_TIMEOUT_SECS`). Every `WouldBlock`/`TimedOut` expiry just re-checks the clock and retries. Partial bytes already appended by a timed-out `read_line` are preserved by `BufRead::read_until` (the wire is ASCII JSON, so a per-read boundary never splits a multi-byte char), so a retry resumes the same line.
- **All response read sites** now route through it: `AgentClient::read_one` (used by `rpc`, `initialize`, and the reconnect/replay reads) and the simple `rpc()` helper. `wait_for_output` already had the equivalent poll-with-deadline pattern and is unchanged.

## Assertions stay genuine (no swallowed hangs)

- The deadline is **bounded**: a genuinely stalled/never-responding agent still fails once it elapses — reads never block forever.
- New regression test `read_line_until_deadline_fails_fast_on_silent_peer` connects to a raw listener that accepts but never writes, and asserts the bounded read **errors near its deadline** (fails fast, does not block).
- `tcp_listener_readiness`'s `initialize` read-timing check (the #1579 readiness assertion) is **kept, not weakened**: its read budget is widened for CI load (1500 -> 3000ms) *together with* the startup delay (3000 -> 5000ms), so the read budget stays well under the delay — a listener still in startup (the bug) still cannot answer in time.

## Verification

Cannot run Windows CI locally (flake is Windows-specific). Verified logic soundness + no regression via a **20x local macOS stress loop** of `cargo test -p termihub-agent --test local_agent_integration --test tcp_listener_readiness`: **20/20 iterations stable green, no hangs**, and the silent-peer test confirms fast failure at the deadline. `cargo fmt --check` + `cargo clippy --tests -- -D warnings` clean on the agent crate. Windows proof is this PR's Windows leg.

Closes #2493

🤖 Generated with [Claude Code](https://claude.com/claude-code)