### PR TITLE
fix(agent): render newly created agent folders/connections reliably (Closes #2486)

### DIFF
--- a/docs/changes/dev3/fix/2486-agent-create-renders.md
+++ b/docs/changes/dev3/fix/2486-agent-create-renders.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- Creating a new folder (connection group) or connection on a connected remote
+  agent now reliably appears in the Remote Agents sidebar. Two races in the
+  authoritative `agents` projection could silently drop the new item even though
+  the create succeeded: a create folded against an agent whose region entry had
+  not landed yet was discarded, and a once-per-connect refresh snapshot taken
+  before the create was persisted could clobber it when delivered afterwards. The
+  agents store now records optimistic creates until a server snapshot confirms
+  them, so a create survives a racing stale snapshot and renders as soon as the
+  agent entry exists — while a locally deleted item still stays deleted. (#2486)

--- a/src-tauri/src/agents_projection/store.rs
+++ b/src-tauri/src/agents_projection/store.rs
@@ -175,12 +175,102 @@ struct Inner {
     sessions: HashMap<String, Vec<AgentSession>>,
     definitions: HashMap<String, Vec<AgentDefinition>>,
     folders: HashMap<String, Vec<AgentFolder>>,
+    /// Per-agent folders/definitions that were created optimistically on the client
+    /// but not yet confirmed by a server snapshot (#2486). They protect a fresh
+    /// create from being clobbered by a **stale** whole-list snapshot
+    /// (`set_folders` / `set_definitions` / `refresh`) that was taken *before* the
+    /// create was persisted but delivered *after* it. An entry is dropped the moment
+    /// a snapshot confirms it (the snapshot now contains it), or the user deletes it
+    /// locally, or the agent is removed/disconnected — so a genuinely deleted item
+    /// is never resurrected.
+    pending_folders: HashMap<String, Vec<AgentFolder>>,
+    pending_definitions: HashMap<String, Vec<AgentDefinition>>,
 }
 
 impl Inner {
     /// Find one agent by id for in-place mutation.
     fn agent_mut(&mut self, id: &str) -> Option<&mut AgentEntry> {
         self.agents.iter_mut().find(|a| a.id == id)
+    }
+
+    /// Record a folder as an unconfirmed local create so a later stale snapshot
+    /// cannot drop it (upsert by id — a re-create of the same id replaces it).
+    fn track_pending_folder(&mut self, id: &str, folder: &AgentFolder) {
+        let list = self.pending_folders.entry(id.to_string()).or_default();
+        list.retain(|f| f.id != folder.id);
+        list.push(folder.clone());
+    }
+
+    /// Stop protecting a folder (confirmed by a snapshot, deleted locally, …).
+    fn untrack_pending_folder(&mut self, id: &str, folder_id: &str) {
+        if let Some(list) = self.pending_folders.get_mut(id) {
+            list.retain(|f| f.id != folder_id);
+            if list.is_empty() {
+                self.pending_folders.remove(id);
+            }
+        }
+    }
+
+    /// Record a definition as an unconfirmed local create (see
+    /// [`Self::track_pending_folder`]).
+    fn track_pending_definition(&mut self, id: &str, definition: &AgentDefinition) {
+        let list = self.pending_definitions.entry(id.to_string()).or_default();
+        list.retain(|d| d.id != definition.id);
+        list.push(definition.clone());
+    }
+
+    /// Stop protecting a definition.
+    fn untrack_pending_definition(&mut self, id: &str, definition_id: &str) {
+        if let Some(list) = self.pending_definitions.get_mut(id) {
+            list.retain(|d| d.id != definition_id);
+            if list.is_empty() {
+                self.pending_definitions.remove(id);
+            }
+        }
+    }
+
+    /// Reconcile a server folder snapshot with the agent's unconfirmed local
+    /// creates (#2486): take the snapshot as the authoritative base, confirm-and-drop
+    /// any pending folder the snapshot now contains, and append any pending folder
+    /// the snapshot is missing (a create the snapshot predates) so it survives. The
+    /// snapshot's own ordering is preserved; preserved creates follow it.
+    fn reconcile_folders(&mut self, id: &str, snapshot: Vec<AgentFolder>) -> Vec<AgentFolder> {
+        let snapshot_ids: HashSet<String> = snapshot.iter().map(|f| f.id.clone()).collect();
+        let mut merged = snapshot;
+        if let Some(pending) = self.pending_folders.get_mut(id) {
+            pending.retain(|f| !snapshot_ids.contains(&f.id));
+            merged.extend(pending.iter().cloned());
+            if pending.is_empty() {
+                self.pending_folders.remove(id);
+            }
+        }
+        merged
+    }
+
+    /// Reconcile a server definition snapshot with the agent's unconfirmed local
+    /// creates (see [`Self::reconcile_folders`]).
+    fn reconcile_definitions(
+        &mut self,
+        id: &str,
+        snapshot: Vec<AgentDefinition>,
+    ) -> Vec<AgentDefinition> {
+        let snapshot_ids: HashSet<String> = snapshot.iter().map(|d| d.id.clone()).collect();
+        let mut merged = snapshot;
+        if let Some(pending) = self.pending_definitions.get_mut(id) {
+            pending.retain(|d| !snapshot_ids.contains(&d.id));
+            merged.extend(pending.iter().cloned());
+            if pending.is_empty() {
+                self.pending_definitions.remove(id);
+            }
+        }
+        merged
+    }
+
+    /// Forget every unconfirmed local create for an agent (removal / disconnect /
+    /// whole-slice replace — the live view is being reset from an authority).
+    fn clear_pending(&mut self, id: &str) {
+        self.pending_folders.remove(id);
+        self.pending_definitions.remove(id);
     }
 }
 
@@ -282,10 +372,13 @@ impl AgentsStore {
             }
         }
         inner.agents = next;
-        // Drop the sub-state of agents no longer in the persisted list.
+        // Drop the sub-state of agents no longer in the persisted list (self-cleaning
+        // for any orphan folder/definition map created before its entry existed, #2486).
         inner.sessions.retain(|id, _| kept.contains(id));
         inner.definitions.retain(|id, _| kept.contains(id));
         inner.folders.retain(|id, _| kept.contains(id));
+        inner.pending_folders.retain(|id, _| kept.contains(id));
+        inner.pending_definitions.retain(|id, _| kept.contains(id));
     }
 
     /// `agent.update` — update one agent's persisted fields (name, config,
@@ -318,6 +411,7 @@ impl AgentsStore {
         inner.sessions.remove(id);
         inner.definitions.remove(id);
         inner.folders.remove(id);
+        inner.clear_pending(id);
     }
 
     /// `agent.reorder` — move the agent at `old_index` to `new_index`
@@ -382,6 +476,10 @@ impl AgentsStore {
         if known {
             inner.sessions.insert(id.to_string(), Vec::new());
             inner.folders.insert(id.to_string(), Vec::new());
+            // The live folder view is reset; the next connect's refresh reloads it
+            // from the server (which by then includes any persisted create), so no
+            // unconfirmed create should be re-applied across a disconnect (#2486).
+            inner.clear_pending(id);
         }
     }
 
@@ -402,6 +500,10 @@ impl AgentsStore {
             return;
         }
         inner.sessions.insert(id.to_string(), sessions);
+        // Reconcile the once-per-connect snapshot with unconfirmed local creates so a
+        // create racing this refresh survives it (#2486).
+        let definitions = inner.reconcile_definitions(id, definitions);
+        let folders = inner.reconcile_folders(id, folders);
         inner.definitions.insert(id.to_string(), definitions);
         inner.folders.insert(id.to_string(), folders);
     }
@@ -446,6 +548,8 @@ impl AgentsStore {
     pub fn set_definitions(&self, id: &str, definitions: Vec<AgentDefinition>) {
         let mut inner = self.lock();
         if inner.agent_mut(id).is_some() {
+            // Preserve unconfirmed local creates a stale snapshot would drop (#2486).
+            let definitions = inner.reconcile_definitions(id, definitions);
             inner.definitions.insert(id.to_string(), definitions);
         }
     }
@@ -456,6 +560,8 @@ impl AgentsStore {
     pub fn set_folders(&self, id: &str, folders: Vec<AgentFolder>) {
         let mut inner = self.lock();
         if inner.agent_mut(id).is_some() {
+            // Preserve unconfirmed local creates a stale snapshot would drop (#2486).
+            let folders = inner.reconcile_folders(id, folders);
             inner.folders.insert(id.to_string(), folders);
         }
     }
@@ -464,12 +570,17 @@ impl AgentsStore {
 
     /// `agent.saveDefinition` — upsert a saved definition on an agent
     /// (`saveAgentDef`): replace any existing entry with the same id, else append.
-    /// A no-op for an unknown agent id.
+    ///
+    /// Applies even when the agent entry is not (yet) present (#2486): the create is
+    /// recorded in the per-agent definition map (and as an unconfirmed pending
+    /// create) so that if the entry lands moments later — via the persisted-list fold
+    /// or the client `agent.add` mirror — the definition is already there and
+    /// renders, instead of being silently dropped by a bare unknown-id no-op. The
+    /// map key is self-cleaning: `reflect_saved_agents` drops sub-state for any id
+    /// that is not a real persisted agent.
     pub fn save_definition(&self, id: &str, definition: AgentDefinition) {
         let mut inner = self.lock();
-        if inner.agent_mut(id).is_none() {
-            return;
-        }
+        inner.track_pending_definition(id, &definition);
         let list = inner.definitions.entry(id.to_string()).or_default();
         list.retain(|d| d.id != definition.id);
         list.push(definition);
@@ -479,6 +590,15 @@ impl AgentsStore {
     /// (`updateAgentDef`). A no-op if the agent or definition is unknown.
     pub fn update_definition(&self, id: &str, definition: AgentDefinition) {
         let mut inner = self.lock();
+        // Keep an unconfirmed create's pending copy current so an edit made before a
+        // snapshot confirms it is not lost when a stale snapshot is reconciled (#2486).
+        if inner
+            .pending_definitions
+            .get(id)
+            .is_some_and(|list| list.iter().any(|d| d.id == definition.id))
+        {
+            inner.track_pending_definition(id, &definition);
+        }
         if let Some(list) = inner.definitions.get_mut(id) {
             if let Some(slot) = list.iter_mut().find(|d| d.id == definition.id) {
                 *slot = definition;
@@ -490,6 +610,8 @@ impl AgentsStore {
     /// (`deleteAgentDef`). A no-op if the agent or definition is unknown.
     pub fn delete_definition(&self, id: &str, definition_id: &str) {
         let mut inner = self.lock();
+        // A locally deleted definition must stay deleted — stop protecting it (#2486).
+        inner.untrack_pending_definition(id, definition_id);
         if let Some(list) = inner.definitions.get_mut(id) {
             list.retain(|d| d.id != definition_id);
         }
@@ -507,11 +629,14 @@ impl AgentsStore {
     /// server-assigned folder id — converge on one entry instead of duplicating
     /// it. Folder ids are unique, so legitimate creates never collide and see no
     /// behavior change.
+    ///
+    /// Applies even when the agent entry is not (yet) present (#2486): the folder is
+    /// recorded in the per-agent folder map (and as an unconfirmed pending create) so
+    /// a create that races the agent's entry-creation fold is not silently dropped —
+    /// it renders as soon as the entry lands. See [`Self::save_definition`].
     pub fn create_folder(&self, id: &str, folder: AgentFolder) {
         let mut inner = self.lock();
-        if inner.agent_mut(id).is_none() {
-            return;
-        }
+        inner.track_pending_folder(id, &folder);
         let list = inner.folders.entry(id.to_string()).or_default();
         list.retain(|f| f.id != folder.id);
         list.push(folder);
@@ -521,6 +646,14 @@ impl AgentsStore {
     /// (`updateAgentFolder` / `toggleAgentFolder`). A no-op if unknown.
     pub fn update_folder(&self, id: &str, folder: AgentFolder) {
         let mut inner = self.lock();
+        // Keep an unconfirmed create's pending copy current (see update_definition, #2486).
+        if inner
+            .pending_folders
+            .get(id)
+            .is_some_and(|list| list.iter().any(|f| f.id == folder.id))
+        {
+            inner.track_pending_folder(id, &folder);
+        }
         if let Some(list) = inner.folders.get_mut(id) {
             if let Some(slot) = list.iter_mut().find(|f| f.id == folder.id) {
                 *slot = folder;
@@ -533,6 +666,8 @@ impl AgentsStore {
     /// no-op if the agent or folder is unknown.
     pub fn delete_folder(&self, id: &str, folder_id: &str) {
         let mut inner = self.lock();
+        // A locally deleted folder must stay deleted — stop protecting it (#2486).
+        inner.untrack_pending_folder(id, folder_id);
         if let Some(list) = inner.folders.get_mut(id) {
             list.retain(|f| f.id != folder_id);
         }
@@ -566,6 +701,10 @@ impl AgentsStore {
         inner.sessions = sessions;
         inner.definitions = definitions;
         inner.folders = folders;
+        // The whole slice is replaced from an authority; unconfirmed creates it does
+        // not carry are subsumed by it (#2486).
+        inner.pending_folders.clear();
+        inner.pending_definitions.clear();
     }
 
     /// Read one agent entry (test / diagnostics helper).

--- a/src-tauri/src/agents_projection/store_tests.rs
+++ b/src-tauri/src/agents_projection/store_tests.rs
@@ -424,15 +424,17 @@ fn per_slice_setters_on_an_unknown_agent_are_no_ops() {
 }
 
 #[test]
-fn transitions_on_an_unknown_agent_are_no_ops() {
+fn entry_transitions_on_an_unknown_agent_are_no_ops() {
     let store = AgentsStore::new();
-    // None of these should panic or create an agent / sub-state.
+    // None of these fabricate an agent entry or its sub-state for an unknown id.
     store.update("ghost", "x", config("h"), settings());
     store.apply_settings("ghost", settings());
     store.toggle_expanded("ghost");
     store.set_status("ghost", AgentConnectionState::Connected, None);
     store.set_capabilities("ghost", json!({}));
     store.disconnect("ghost");
+    // The whole-list snapshot setters still no-op on an unknown id (nothing to
+    // render under a missing agent node).
     store.refresh(
         "ghost",
         vec![session("s1")],
@@ -440,8 +442,8 @@ fn transitions_on_an_unknown_agent_are_no_ops() {
         vec![folder("f1")],
     );
     store.clear_sessions("ghost");
-    store.save_definition("ghost", definition("d1", None));
-    store.create_folder("ghost", folder("f1"));
+    store.set_definitions("ghost", vec![definition("d1", None)]);
+    store.set_folders("ghost", vec![folder("f1")]);
 
     assert!(store.get("ghost").is_none());
     assert!(store.definitions_of("ghost").is_empty());
@@ -450,6 +452,151 @@ fn transitions_on_an_unknown_agent_are_no_ops() {
         store.snapshot(),
         json!({ "agents": [], "sessions": {}, "definitions": {}, "folders": {} })
     );
+}
+
+// ── #2486: creates render reliably (both candidate mechanisms) ─────────────────
+
+/// Mechanism 1 (no-op on unknown id): a folder/definition created against an agent
+/// whose entry has not landed yet must not be silently dropped — it renders as soon
+/// as the entry arrives (persisted-list fold / client `agent.add` mirror).
+#[test]
+fn a_create_racing_entry_creation_renders_once_the_entry_lands() {
+    let store = AgentsStore::new();
+    // Create fires before the agent entry exists (the entry-creation fold has not
+    // run yet). Previously a bare unknown-id no-op silently dropped it.
+    store.create_folder("a1", folder("f1"));
+    store.save_definition("a1", definition("d1", None));
+    // Sub-state is recorded even though there is no agent node to render it under yet.
+    assert_eq!(store.folders_of("a1"), vec![folder("f1")]);
+    assert_eq!(store.definitions_of("a1"), vec![definition("d1", None)]);
+
+    // The entry lands via the persisted-list fold; the pre-created items survive and
+    // now render under the agent node.
+    store.reflect_saved_agents(vec![seed("a1", "One", "h1")]);
+    assert!(store.get("a1").is_some());
+    assert_eq!(store.folders_of("a1"), vec![folder("f1")]);
+    assert_eq!(store.definitions_of("a1"), vec![definition("d1", None)]);
+}
+
+/// An orphan sub-state map for an id that never becomes a real persisted agent is
+/// self-cleaning: `reflect_saved_agents` drops it (#2486).
+#[test]
+fn a_create_for_an_id_that_never_becomes_an_agent_is_dropped_by_reflect() {
+    let store = AgentsStore::new();
+    store.create_folder("ghost", folder("f1"));
+    store.save_definition("ghost", definition("d1", None));
+    // A reflect that does not include the id drops the orphan sub-state.
+    store.reflect_saved_agents(vec![seed("a1", "One", "h1")]);
+    assert!(store.folders_of("ghost").is_empty());
+    assert!(store.definitions_of("ghost").is_empty());
+}
+
+/// Mechanism 2 (source-fold vs optimistic-write race): a stale whole-list snapshot
+/// (`set_folders` / `set_definitions`) delivered *after* an optimistic create must
+/// not clobber it. The refresh snapshot was taken before the create was persisted.
+#[test]
+fn an_optimistic_create_survives_a_stale_whole_list_snapshot() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    // Existing, server-confirmed items plus the fresh optimistic create.
+    store.set_folders("a1", vec![folder("f1")]);
+    store.set_definitions("a1", vec![definition("d1", None)]);
+    store.create_folder("a1", folder("new"));
+    store.save_definition("a1", definition("newdef", None));
+
+    // A stale refresh snapshot (taken before the create persisted) lacks the new
+    // items. It must not drop them.
+    store.set_folders("a1", vec![folder("f1")]);
+    store.set_definitions("a1", vec![definition("d1", None)]);
+
+    let folder_ids: Vec<String> = store.folders_of("a1").into_iter().map(|f| f.id).collect();
+    let def_ids: Vec<String> = store
+        .definitions_of("a1")
+        .into_iter()
+        .map(|d| d.id)
+        .collect();
+    assert!(
+        folder_ids.contains(&"new".to_string()),
+        "create clobbered: {folder_ids:?}"
+    );
+    assert!(
+        def_ids.contains(&"newdef".to_string()),
+        "create clobbered: {def_ids:?}"
+    );
+    assert!(folder_ids.contains(&"f1".to_string()));
+    assert!(def_ids.contains(&"d1".to_string()));
+}
+
+/// The once-per-connect `refresh` (which replaces sessions + definitions + folders
+/// in one shot) must also preserve an unconfirmed local create it races (#2486).
+#[test]
+fn an_optimistic_create_survives_a_stale_refresh() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.create_folder("a1", folder("new"));
+    store.save_definition("a1", definition("newdef", None));
+
+    // A stale connect-refresh snapshot lacking the just-created items.
+    store.refresh("a1", vec![], vec![], vec![]);
+
+    assert_eq!(store.folders_of("a1"), vec![folder("new")]);
+    assert_eq!(store.definitions_of("a1"), vec![definition("newdef", None)]);
+}
+
+/// Once a snapshot confirms a create (it now contains it), the store stops
+/// protecting it — so a later snapshot that genuinely omits it (a delete on the
+/// server / another client) correctly drops it. No stale-item resurrection (#2486).
+#[test]
+fn a_confirmed_create_is_no_longer_protected_and_a_genuine_delete_sticks() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.create_folder("a1", folder("f1"));
+    store.save_definition("a1", definition("d1", None));
+
+    // A snapshot that includes the create confirms it (stops the protection).
+    store.set_folders("a1", vec![folder("f1")]);
+    store.set_definitions("a1", vec![definition("d1", None)]);
+    assert_eq!(store.folders_of("a1"), vec![folder("f1")]);
+
+    // A later authoritative snapshot omits it (deleted elsewhere) → it is dropped.
+    store.set_folders("a1", vec![]);
+    store.set_definitions("a1", vec![]);
+    assert!(store.folders_of("a1").is_empty());
+    assert!(store.definitions_of("a1").is_empty());
+}
+
+/// A create the user then deletes locally must stay deleted even if a stale snapshot
+/// (still lacking the delete) arrives afterwards — the protection is cleared on the
+/// local delete, so it is not resurrected (#2486).
+#[test]
+fn a_locally_deleted_create_is_not_resurrected_by_a_stale_snapshot() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.create_folder("a1", folder("f1"));
+    store.save_definition("a1", definition("d1", None));
+    store.delete_folder("a1", "f1");
+    store.delete_definition("a1", "d1");
+
+    // A stale snapshot (predating the create) — must not bring the deleted items back.
+    store.set_folders("a1", vec![]);
+    store.set_definitions("a1", vec![]);
+    assert!(store.folders_of("a1").is_empty());
+    assert!(store.definitions_of("a1").is_empty());
+}
+
+/// A disconnect resets the live view and forgets unconfirmed creates, so the next
+/// connect's refresh (which by then reflects any persisted create) is authoritative
+/// and nothing stale lingers (#2486).
+#[test]
+fn a_disconnect_forgets_unconfirmed_creates() {
+    let store = AgentsStore::new();
+    store.add("a1", "One", config("h1"), settings());
+    store.create_folder("a1", folder("f1"));
+    store.disconnect("a1");
+    assert!(store.folders_of("a1").is_empty());
+    // A post-reconnect snapshot without the folder is honoured (not resurrected).
+    store.set_folders("a1", vec![]);
+    assert!(store.folders_of("a1").is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## What & why

Creating a new folder (connection group) or connection on a **connected** remote agent could silently fail to appear in the Remote Agents sidebar — the create reported success (the "Created folder …" toast fired) but the item never rendered. The sidebar is region-authoritative (#2409, no `appStore` fallback), and both the optimistic client mirror (`agent.createFolder`/`agent.saveDefinition`) and the server-side folds (#2388/#2403) write to the same Rust `AgentsStore`, so the drop happens in the store.

## Which mechanisms fired

Both candidate mechanisms from the issue reproduce headlessly at the store level (confirmed with probe tests, then encoded as regression tests):

1. **No-op on unknown agent id.** `AgentsStore::create_folder` / `save_definition` early-returned when the agent entry was not yet in the region, discarding the sub-state instead of letting it render once the entry landed.
2. **Source-fold vs optimistic-write race (primary for a connected agent).** The once-per-connect refresh (`set_folders` / `set_definitions` / `refresh`) replaces the whole per-agent list from a server snapshot. A snapshot taken *before* the create was persisted but delivered *after* the optimistic create (at a higher region version) clobbered the just-added item — `commitAgentsView` only guards against *lower* versions, and the clobber is upstream of it in the store.

## The fix (store-level, `src-tauri/src/agents_projection/store.rs`)

- The store now tracks **unconfirmed optimistic creates** per agent (`pending_folders` / `pending_definitions`). A whole-list snapshot (`set_folders`/`set_definitions`/`refresh`) is reconciled against them: it stays authoritative for everything it contains, **confirms and drops** any pending create it now includes, and **preserves** any pending create it is missing (a create the snapshot predates).
- Protection is cleared on **local delete**, **agent removal/disconnect**, and **whole-slice replace** — so a genuinely deleted item stays deleted and is never resurrected.
- `create_folder` / `save_definition` no longer require the agent entry first; they upsert their sub-state so a create racing the entry-creation fold renders as soon as the entry lands. Orphan sub-state (an id that never becomes a real agent) is self-cleaning via `reflect_saved_agents`.

No frontend change was needed: with the store preserving the item, it publishes a snapshot containing it at a new (higher) version, which the frontend applies normally.

## Regression tests (`store_tests.rs`)

Verified RED without the fix, GREEN with it:

- `a_create_racing_entry_creation_renders_once_the_entry_lands` (mechanism 1)
- `a_create_for_an_id_that_never_becomes_an_agent_is_dropped_by_reflect`
- `an_optimistic_create_survives_a_stale_whole_list_snapshot` (mechanism 2)
- `an_optimistic_create_survives_a_stale_refresh` (mechanism 2, connect path)
- `a_confirmed_create_is_no_longer_protected_and_a_genuine_delete_sticks`
- `a_locally_deleted_create_is_not_resurrected_by_a_stale_snapshot`
- `a_disconnect_forgets_unconfirmed_creates`

`cargo test -p termihub agents_projection` (50 passed), `cargo clippy -p termihub --all-targets -- -D warnings`, and `cargo fmt --check` all pass; frontend agents-bridge tests unchanged and green.

Closes #2486

🤖 Generated with [Claude Code](https://claude.com/claude-code)