### PR TITLE
test(agent): quarantine flaky live-agent-tcp integration tests on windows

### DIFF
--- a/agent/tests/local_agent_integration.rs
+++ b/agent/tests/local_agent_integration.rs
@@ -12,6 +12,20 @@
 //! ```
 //!
 //! The binary is built automatically by cargo before the tests run.
+//!
+//! # Windows CI quarantine (#2495)
+//!
+//! The tests that spawn a live agent and drive it over a TCP client chronically
+//! flake **only on Windows CI** with `Os { code: 10060, kind: TimedOut }` — a
+//! *random* one each run — because the agent is genuinely slow to respond under
+//! the loaded Windows runner. Two targeted transport fixes (#2492 connect-retry,
+//! #2494 read-deadline) did not fully resolve the residual, so those tests carry
+//! `#[cfg_attr(windows, ignore = "…; see #2495")]`: they still run at full
+//! strength on ubuntu + macOS and only skip on the Windows leg, so this flake
+//! stops blocking unrelated PRs. The deep root-cause fix is tracked in #2495;
+//! remove the attribute when it lands. Tests that do not drive a live agent over
+//! TCP (the raw-socket read-deadline test, the dead-process fast-fail, and the
+//! `--version` check) are unaffected and stay enabled everywhere.
 
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
@@ -635,6 +649,10 @@ fn wait_for_agent_ready_reports_dead_process_fast() {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "flaky on Windows CI: agent slow-to-respond under load; see #2495"
+)]
 fn agent_starts_and_accepts_connections() {
     let agent = LocalAgent::spawn();
     // If we reach here, the agent bound a port and served the readiness probe
@@ -643,6 +661,10 @@ fn agent_starts_and_accepts_connections() {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "flaky on Windows CI: agent slow-to-respond under load; see #2495"
+)]
 fn agent_responds_to_initialize() {
     let agent = LocalAgent::spawn();
     let mut stream = connect_with_retry(&agent.addr);
@@ -665,6 +687,10 @@ fn agent_responds_to_initialize() {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "flaky on Windows CI: agent slow-to-respond under load; see #2495"
+)]
 fn agent_returns_error_for_unknown_method_before_initialize() {
     let agent = LocalAgent::spawn();
     let mut stream = connect_with_retry(&agent.addr);
@@ -687,6 +713,10 @@ fn agent_returns_error_for_unknown_method_before_initialize() {
 }
 
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "flaky on Windows CI: agent slow-to-respond under load; see #2495"
+)]
 fn agent_handles_multiple_sequential_connections() {
     let agent = LocalAgent::spawn();
 
@@ -943,6 +973,10 @@ impl AgentClient {
 /// Verify that creating a local shell session returns a valid session ID with
 /// status "running". This is the prerequisite for all other shell tests.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "flaky on Windows CI: agent slow-to-respond under load; see #2495"
+)]
 fn shell_session_create_returns_session_id() {
     let agent = LocalAgent::spawn();
     let mut client = AgentClient::connect(&agent.addr);
@@ -970,6 +1004,10 @@ fn shell_session_create_returns_session_id() {
 /// Verify that after attaching to a shell and writing a command, the agent
 /// delivers `connection.output` notifications containing the echoed text.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "flaky on Windows CI: agent slow-to-respond under load; see #2495"
+)]
 fn shell_session_attach_and_receive_output() {
     let agent = LocalAgent::spawn();
     let mut client = AgentClient::connect(&agent.addr);
@@ -1003,6 +1041,10 @@ fn shell_session_attach_and_receive_output() {
 /// alive in memory. A second client should see the same session in the list
 /// with `attached: false`.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "flaky on Windows CI: agent slow-to-respond under load; see #2495"
+)]
 fn shell_session_persists_across_client_disconnect() {
     let agent = LocalAgent::spawn();
     let session_id;
@@ -1053,6 +1095,10 @@ fn shell_session_persists_across_client_disconnect() {
 /// echo, then disconnects. A second client reconnects, re-attaches to the same
 /// session, and receives output — proving the shell process survived.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "flaky on Windows CI: agent slow-to-respond under load; see #2495"
+)]
 fn shell_session_reattach_after_reconnect() {
     let agent = LocalAgent::spawn();
     let session_id;
@@ -1350,6 +1396,10 @@ impl Drop for PersistentShellSetup {
 /// Flow: attach → run `ls`/`dir` → detach → attach → buffer replay contains output.
 #[cfg(unix)]
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "flaky on Windows CI: agent slow-to-respond under load; see #2495"
+)]
 fn persistent_shell_buffer_replayed_on_same_connection_reattach() {
     let setup = PersistentShellSetup::new();
     let mut client = setup.connect_client();
@@ -1413,6 +1463,10 @@ fn persistent_shell_buffer_replayed_on_same_connection_reattach() {
 /// buffer replay contains previous output.
 #[cfg(unix)]
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "flaky on Windows CI: agent slow-to-respond under load; see #2495"
+)]
 fn persistent_shell_buffer_replayed_after_tcp_reconnect() {
     let setup = PersistentShellSetup::new();
 

--- a/agent/tests/tcp_listener_readiness.rs
+++ b/agent/tests/tcp_listener_readiness.rs
@@ -113,6 +113,10 @@ impl Drop for AgentProcess {
 /// accept, and a client that connects on the strength of that log gets a timely
 /// `initialize` response rather than an accepted-then-stalled socket.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "flaky on Windows CI: agent slow-to-respond under load; see #2495"
+)]
 fn listening_log_is_a_true_readiness_signal() {
     let spawned_at = Instant::now();
     let mut child = Command::new(agent_binary())


### PR DESCRIPTION
## What

Quarantine the agent-integration tests that spawn a real `termihub-agent` and drive it over a TCP client **on the Windows leg only**, so their chronic Windows-CI flake stops blocking unrelated PRs. Coverage on **ubuntu + macOS stays full-strength**.

Part of **#2495** (Windows quarantine); the deep root-cause fix is tracked in **#2495**, which stays open. This PR does **not** close it.

## Why

`agent/tests/local_agent_integration.rs` and `agent/tests/tcp_listener_readiness.rs` chronically flake **only on Windows CI** with `Os { code: 10060, kind: TimedOut }` — a *random* test each run. The residual after the two targeted transport fixes (#2492 connect-retry, #2494 read-deadline) is the agent being genuinely slow-to-respond under the loaded Windows runner. Because the Windows `Run Tests` leg runs the whole workspace, this flake exposes **every** PR, not just agent-integration ones.

## Mechanism

Each affected test carries:

```rust
#[cfg_attr(windows, ignore = "flaky on Windows CI: agent slow-to-respond under load; see #2495")]
```

- `cfg_attr(windows, ignore)` skips **at runtime on Windows only** — the tests still compile and run at full strength on ubuntu + macOS. Not a bare `#[ignore]`.
- A module-level doc note in `local_agent_integration.rs` documents the quarantine and points to #2495 for un-quarantining when the deep fix lands.

## Quarantined (live agent + TCP client + read responses)

In `local_agent_integration.rs`:
- `agent_starts_and_accepts_connections`
- `agent_responds_to_initialize`
- `agent_returns_error_for_unknown_method_before_initialize`
- `agent_handles_multiple_sequential_connections`
- `shell_session_create_returns_session_id`
- `shell_session_attach_and_receive_output`
- `shell_session_persists_across_client_disconnect`
- `shell_session_reattach_after_reconnect`
- `persistent_shell_buffer_replayed_on_same_connection_reattach`
- `persistent_shell_buffer_replayed_after_tcp_reconnect`

In `tcp_listener_readiness.rs`:
- `listening_log_is_a_true_readiness_signal`

## Left enabled everywhere (do not drive a live agent over TCP)

- `read_line_until_deadline_fails_fast_on_silent_peer` — raw sockets, no agent binary
- `wait_for_agent_ready_reports_dead_process_fast` — dead-process fast-fail, no live listener/read
- `agent_version_flag_prints_version` — `--version` only

## Verification

`cargo test -p termihub-agent --test local_agent_integration --test tcp_listener_readiness` on macOS: **14 passed, 0 ignored** — confirming the ignore is Windows-only, not all-platform. `cargo fmt --check` and `cargo clippy --tests -- -D warnings` on the agent crate both clean.