### PR TITLE
feat(backend): opt-out env for test-bridge always-on-top pin (Closes #2504)

### DIFF
--- a/scripts/internal/verify-agent-reconnect.sh
+++ b/scripts/internal/verify-agent-reconnect.sh
@@ -7,9 +7,10 @@
 #   2. Turns the `sessionBackendReattach` flag ON without you editing anything,
 #      via the #2481 test-bridge env->window injection
 #      (TERMIHUB_TEST_FLAG_SESSION_BACKEND_REATTACH -> window.__TERMIHUB_SESSION_BACKEND_REATTACH__).
-#      Test-bridge mode also pins the window always-on-top, which stops macOS from
-#      occlusion-throttling the WebView during the long reconnect (#957) — the very
-#      reason this grade cannot run headlessly and needs a real display.
+#      This is an operator-watched grade on a real display, so the window is left
+#      as a NORMAL, backgroundable window (TERMIHUB_TEST_NO_ALWAYS_ON_TOP=1, #2504)
+#      — you keep it visible yourself, so occlusion-throttling isn't a concern and
+#      you can freely background it to read this checklist / use a second terminal.
 #   3. Launches this checkout's dev agent + the app via `scripts/dev.sh` (builds if
 #      stale; the dev agent sshd + connection are set up for you). The window stays
 #      in the foreground so you can watch the reconnect.
@@ -90,7 +91,8 @@ PYEOF
 
 # ── A free loopback port to trigger the test-bridge init-script (flag inject) ──
 # Nothing needs to listen there — the port's only job is to register the bridge
-# plugin so the flag global is injected and the window is pinned always-on-top.
+# plugin so the flag global is injected (the window is NOT pinned always-on-top
+# here; see TERMIHUB_TEST_NO_ALWAYS_ON_TOP below, #2504).
 pick_bridge_port() {
     local port
     for port in 47600 47601 47602 47603 47604; do
@@ -118,6 +120,9 @@ cat <<CHECKLIST
 The app is about to launch (first run BUILDS — this can take a few minutes).
 Keep THIS terminal open (it runs the app). Do the drop/restore in a SECOND
 terminal with the one-liners below.
+
+The termiHub window is a NORMAL, backgroundable window (not pinned on top) — you
+can freely switch to this terminal / another app to read these steps.
 
   DROP transport (sever the dev-agent SSH):
       $TRANSPORT drop
@@ -159,11 +164,15 @@ Disconnected) both hold. Close the window / press Ctrl-C here to tear down
 
 CHECKLIST
 
-# The flag injection + always-on-top require the test-bridge plugin, which the
-# backend registers only when TERMIHUB_TEST_BRIDGE_PORT parses. Nothing listens
-# on BRIDGE_PORT — the app's bridge client just logs a failed connect (harmless).
+# The flag injection requires the test-bridge plugin, which the backend registers
+# only when TERMIHUB_TEST_BRIDGE_PORT parses. Nothing listens on BRIDGE_PORT — the
+# app's bridge client just logs a failed connect (harmless).
 export TERMIHUB_TEST_BRIDGE_PORT="$BRIDGE_PORT"
 export TERMIHUB_TEST_FLAG_SESSION_BACKEND_REATTACH=1
+# Opt out of the test-bridge always-on-top pin (#2504): this is an operator-watched
+# grade on a real display, so the operator keeps the window visible themselves —
+# leaving it a normal, backgroundable window instead of forcing it above everything.
+export TERMIHUB_TEST_NO_ALWAYS_ON_TOP=1
 
 # Not `exec`: run as a child so the EXIT trap (state-file cleanup) still fires
 # when the app closes. scripts/dev.sh owns stopping its own dev-agent sshd.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -405,9 +405,15 @@ pub fn run() {
             // throttles WKWebView rendering, which hangs the harness (xterm stops
             // painting, screenshots time out) once a guided-manual test hands off
             // to an external app like VS Code (#957). Best-effort and test-only;
-            // production windows are untouched.
+            // production windows are untouched. An operator can opt out via
+            // TERMIHUB_TEST_NO_ALWAYS_ON_TOP so the window stays backgroundable
+            // during a guided-manual grade (#2504).
             if utils::test_bridge::is_test_bridge_enabled() {
-                if let Some(window) = app.get_webview_window("main") {
+                if utils::test_bridge::always_on_top_opt_out() {
+                    info!(
+                        "Test window always-on-top skipped by request (TERMIHUB_TEST_NO_ALWAYS_ON_TOP, #2504)"
+                    );
+                } else if let Some(window) = app.get_webview_window("main") {
                     if let Err(e) = window.set_always_on_top(true) {
                         tracing::warn!("Failed to set test window always-on-top: {e}");
                     } else {

--- a/src-tauri/src/utils/test_bridge.rs
+++ b/src-tauri/src/utils/test_bridge.rs
@@ -20,6 +20,13 @@ use tauri::Runtime;
 /// Env var holding the runner's WebSocket port the app should connect out to.
 pub const TEST_BRIDGE_PORT_ENV: &str = "TERMIHUB_TEST_BRIDGE_PORT";
 
+/// Env var to opt out of pinning the test window always-on-top under the test
+/// bridge (#2504). When set to a truthy value (`1`/`true`, any case), the
+/// anti-occlusion pin (#957) is skipped so an operator can background the
+/// window during a guided-manual grade (read the checklist, use a second
+/// terminal). Unset → behaviour is unchanged (the window is still pinned).
+pub const TEST_NO_ALWAYS_ON_TOP_ENV: &str = "TERMIHUB_TEST_NO_ALWAYS_ON_TOP";
+
 /// Env-var prefix for injecting a runtime feature-flag global into the webview
 /// under the test bridge (#2476). `TERMIHUB_TEST_FLAG_<NAME>=<bool>` injects
 /// `window.__TERMIHUB_<NAME>__ = <bool>` before boot, so the harness can flip a
@@ -97,6 +104,15 @@ pub fn is_test_bridge_enabled() -> bool {
     parse_port(std::env::var(TEST_BRIDGE_PORT_ENV).ok()).is_some()
 }
 
+/// Whether the operator has opted out of pinning the test window always-on-top
+/// (`TERMIHUB_TEST_NO_ALWAYS_ON_TOP` set to a truthy value). See #2504. Used only
+/// in test-bridge mode; production launches never pin the window regardless.
+pub fn always_on_top_opt_out() -> bool {
+    std::env::var(TEST_NO_ALWAYS_ON_TOP_ENV)
+        .ok()
+        .is_some_and(|raw| flag_is_truthy(&raw))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -160,6 +176,30 @@ mod tests {
         assert_eq!(parse_port(Some("0".to_string())), None);
         assert_eq!(parse_port(Some("70000".to_string())), None);
         assert_eq!(parse_port(Some("not-a-port".to_string())), None);
+    }
+
+    #[test]
+    fn always_on_top_opt_out_tracks_truthy_env_var() {
+        // Mutates a process-global env var; no other test reads this key.
+        let key = TEST_NO_ALWAYS_ON_TOP_ENV;
+        let saved = std::env::var(key).ok();
+        unsafe { std::env::remove_var(key) };
+        assert!(
+            !always_on_top_opt_out(),
+            "unset → do not opt out (pin stays)"
+        );
+        unsafe { std::env::set_var(key, "1") };
+        assert!(always_on_top_opt_out());
+        unsafe { std::env::set_var(key, "true") };
+        assert!(always_on_top_opt_out());
+        unsafe { std::env::set_var(key, "0") };
+        assert!(!always_on_top_opt_out());
+        unsafe { std::env::set_var(key, "") };
+        assert!(!always_on_top_opt_out());
+        match saved {
+            Some(v) => unsafe { std::env::set_var(key, v) },
+            None => unsafe { std::env::remove_var(key) },
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

The test-bridge always-on-top window pin (`window.set_always_on_top(true)`, added by #957 as anti-occlusion for headless harness runs) also fires during **operator-watched manual grades**, forcing the window above everything. That blocks the operator from backgrounding the window to read the checklist or use a second terminal.

This adds an **opt-out env var `TERMIHUB_TEST_NO_ALWAYS_ON_TOP`**:

- **`src-tauri/src/utils/test_bridge.rs`** — new `TEST_NO_ALWAYS_ON_TOP_ENV` const + `always_on_top_opt_out()` helper, using the existing `flag_is_truthy` (`1`/`true`, any case) env-parsing style. Unit test added.
- **`src-tauri/src/lib.rs`** (setup, ~L403) — the pin is skipped (and logged) when the opt-out is truthy. Everything else in test-bridge mode (flag injection, bridge transport) is untouched.
- **`scripts/internal/verify-agent-reconnect.sh`** — exports `TERMIHUB_TEST_NO_ALWAYS_ON_TOP=1` (operator-watched grade on a real display keeps the window visible itself) and the printed checklist now notes the window is a normal, backgroundable window.

## Behaviour

- Env **unset** → byte-identical to today (window still pinned always-on-top in test-bridge mode).
- Env **truthy** → pin skipped, window is a normal backgroundable window.
- **Production** launches are unaffected either way (the pin only ever runs under test-bridge mode).

## Verification

- `cargo build -p termihub` ✓
- `cargo clippy -p termihub --all-targets -- -D warnings` ✓
- `cargo fmt --check` ✓
- `cargo test -p termihub always_on_top` ✓ (new opt-out test)
- `bash -n scripts/internal/verify-agent-reconnect.sh` ✓

Closes #2504