### PR TITLE
fix(session): stop reconnect timer SIGABRT by spawning on the managed runtime (Closes #2503)

### DIFF
--- a/docs/changes/dev0/fix/2503-reconnect-scheduler-offruntime-spawn.md
+++ b/docs/changes/dev0/fix/2503-reconnect-scheduler-offruntime-spawn.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Fixed a hard crash (SIGABRT) that could occur when a session's backend-driven
+  reconnect timer was armed. The reconnect scheduler spawned its one-shot timer
+  with the free `tokio::spawn`, but it is reached synchronously from a sync Tauri
+  command that runs off the Tokio runtime — so the spawn panicked ("must be
+  called from the context of a Tokio 1.x runtime") and aborted the app on the
+  reconnect path. It now spawns onto Tauri's managed async runtime, which is safe
+  from any thread (#2503).

--- a/src-tauri/src/session_projection/timer.rs
+++ b/src-tauri/src/session_projection/timer.rs
@@ -93,10 +93,18 @@ pub trait ReconnectScheduler: Send + Sync {
 }
 
 /// Production [`ReconnectScheduler`] backed by `tokio::time::sleep`. Each armed
-/// timer is a spawned task; cancelling aborts it. Requires a Tokio runtime
-/// (always present in the Tauri app).
+/// timer is a spawned task; cancelling aborts it.
+///
+/// Spawns onto Tauri's **managed** async runtime via
+/// [`tauri::async_runtime::spawn`] rather than the free `tokio::spawn`. This is
+/// load-bearing (#2503): `schedule` is reached **synchronously** from the sync
+/// Tauri command `intent_dispatch`, which runs on the main/webview thread
+/// *outside* any Tokio runtime context — the free `tokio::spawn` panics there
+/// ("must be called from the context of a Tokio 1.x runtime") and aborts the
+/// process on the reconnect hot path. The managed handle is thread-agnostic, so
+/// arming is safe from the sync-command thread (and from a plain unit test).
 pub struct TokioReconnectScheduler {
-    handles: Mutex<HashMap<String, tokio::task::JoinHandle<()>>>,
+    handles: Mutex<HashMap<String, tauri::async_runtime::JoinHandle<()>>>,
 }
 
 impl TokioReconnectScheduler {
@@ -106,7 +114,7 @@ impl TokioReconnectScheduler {
         }
     }
 
-    fn lock(&self) -> MutexGuard<'_, HashMap<String, tokio::task::JoinHandle<()>>> {
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, tauri::async_runtime::JoinHandle<()>>> {
         self.handles.lock().unwrap_or_else(|e| e.into_inner())
     }
 }
@@ -121,7 +129,10 @@ impl ReconnectScheduler for TokioReconnectScheduler {
     fn schedule(&self, key: String, delay_ms: u64, task: FireTask) {
         // Replace any prior timer for this key so a re-arm never leaves two live.
         self.cancel(&key);
-        let handle = tokio::spawn(async move {
+        // Managed runtime (not the free `tokio::spawn`): this is reached from a
+        // sync Tauri command that runs off the Tokio runtime — see the struct
+        // doc and #2503.
+        let handle = tauri::async_runtime::spawn(async move {
             tokio::time::sleep(Duration::from_millis(delay_ms)).await;
             task();
         });

--- a/src-tauri/src/session_projection/timer_tests.rs
+++ b/src-tauri/src/session_projection/timer_tests.rs
@@ -367,6 +367,94 @@ fn backend_redrive_giveup_settles_failed_error_distinct_from_user_cancel_disconn
     );
 }
 
+// ── Production scheduler off the Tokio runtime (#2503) ──────────────────────
+
+use super::TokioReconnectScheduler;
+
+/// #2503 regression: the production [`TokioReconnectScheduler`] is reached
+/// **synchronously** from the sync Tauri command `intent_dispatch`, which runs
+/// on the main/webview thread *outside* any Tokio runtime. The old free
+/// `tokio::spawn` panicked there ("must be called from the context of a Tokio
+/// 1.x runtime") → `abort()` → the app SIGABRT-crashed on agent reconnect.
+/// Spawning onto Tauri's managed runtime makes arming safe from any thread.
+///
+/// This is a plain `#[test]` (NOT `#[tokio::test]`) so it runs with no ambient
+/// runtime, reproducing the crash context exactly. On `develop` it aborts; with
+/// the fix it arms and the one-shot fires through the managed runtime.
+#[test]
+fn scheduling_from_a_non_runtime_thread_arms_and_fires_without_panicking() {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let scheduler = TokioReconnectScheduler::new();
+    let (tx, rx) = mpsc::channel();
+
+    // Arm from this plain-test thread (no Tokio runtime in scope). The old free
+    // `tokio::spawn` would panic/abort right here.
+    scheduler.schedule(
+        "s1".to_string(),
+        0,
+        Box::new(move || {
+            let _ = tx.send(());
+        }),
+    );
+
+    rx.recv_timeout(Duration::from_secs(5))
+        .expect("the armed timer fired via the managed runtime");
+}
+
+/// A pending timer armed off the runtime can still be cancelled off the runtime:
+/// `cancel` aborts the managed handle, so the task never runs. Guards against a
+/// regression where the abort path also needs the ambient runtime.
+#[test]
+fn cancelling_a_pending_timer_from_a_non_runtime_thread_stops_it() {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let scheduler = TokioReconnectScheduler::new();
+    let (tx, rx) = mpsc::channel();
+
+    // Arm far in the future, then cancel before it can elapse.
+    scheduler.schedule(
+        "s1".to_string(),
+        60_000,
+        Box::new(move || {
+            let _ = tx.send(());
+        }),
+    );
+    scheduler.cancel("s1");
+
+    assert!(
+        rx.recv_timeout(Duration::from_millis(200)).is_err(),
+        "a cancelled timer never fires"
+    );
+}
+
+/// End-to-end shape of the crash: drive the real [`ReconnectTimerDriver::sync`]
+/// with the production [`TokioReconnectScheduler`] from a plain (non-runtime)
+/// thread — the exact `intent_dispatch → register_session_intents → sync_timer →
+/// sync → schedule` path that aborted on `develop`. Arming must not panic.
+#[test]
+fn driver_sync_with_the_production_scheduler_arms_off_runtime_without_panicking() {
+    let store = Arc::new(SessionLifecycleStore::new());
+    store.set_rand_for_test(Box::new(|| 0.5));
+    let scheduler = Arc::new(TokioReconnectScheduler::new());
+    let driver = Arc::new(ReconnectTimerDriver::new(
+        store.clone(),
+        scheduler.clone(),
+        Arc::new(|| {}),
+    ));
+
+    // Drop → Waiting arms a real backoff one-shot via `tauri::async_runtime`.
+    store.connect("s1");
+    store.reconnect("s1");
+    driver.sync("s1"); // panicked/aborted here on develop
+
+    // A subsequent settle cancels the pending timer — also off-runtime.
+    store.connected("s1");
+    driver.sync("s1");
+}
+
 #[test]
 fn remove_disarms_any_pending_timer() {
     let (store, _projector, scheduler, driver, _pub) = harness();


### PR DESCRIPTION
## Summary

Fixes the hard crash (SIGABRT) on the backend-driven agent reconnect path found during the #2476 live grade.

`TokioReconnectScheduler::schedule` (`src-tauri/src/session_projection/timer.rs`) armed its one-shot timer with the **free `tokio::spawn`**. But `schedule` is reached **synchronously** from the sync Tauri command `intent_dispatch` (`commands/projection.rs`, a `pub fn`) → `register_session_intents` → `sync_timer` → `ReconnectTimerDriver::sync` → `schedule`. Sync Tauri commands run on the main/webview thread, **outside the Tokio runtime**, so `tokio::spawn` panics ("must be called from the context of a Tokio 1.x runtime") → `abort()` → the app dies on reconnect.

## Fix

Spawn onto Tauri's **managed** async runtime via `tauri::async_runtime::spawn` instead of the free `tokio::spawn`. It is thread-agnostic (works from any thread, including the sync-command thread), returns a `tauri::async_runtime::JoinHandle<T>` that also has `.abort()`. The `handles` map field type and the `lock()`/`cancel()` abort site are updated accordingly, and the struct doc explains why the managed runtime is load-bearing here. **The change is confined to `timer.rs`** (no `lib.rs` edit, avoiding the parallel PR #2504).

## Tests

Three new **plain `#[test]`** regressions (NOT `#[tokio::test]`) drive the real `TokioReconnectScheduler` / `ReconnectTimerDriver::sync` from a non-runtime thread — reproducing the crash context:

- `scheduling_from_a_non_runtime_thread_arms_and_fires_without_panicking`
- `cancelling_a_pending_timer_from_a_non_runtime_thread_stops_it`
- `driver_sync_with_the_production_scheduler_arms_off_runtime_without_panicking`

On `develop` all three **panic** with "there is no reactor running, must be called from the context of a Tokio 1.x runtime"; with the fix they pass. All existing (ManualScheduler) timer tests stay green — 12/12, stable across 5 stress runs.

Verified locally: `cargo build -p termihub`, `cargo test -p termihub session_projection::timer`, `cargo clippy -p termihub --tests -- -D warnings`, `cargo fmt --check`.

Closes #2503