### PR TITLE
fix(agent): faithful reconnect-drop harness + cross-agent recovery test (Closes #2508)

### DIFF
--- a/agent/tests/local_agent_integration.rs
+++ b/agent/tests/local_agent_integration.rs
@@ -1764,3 +1764,159 @@ fn persistent_shell_buffer_replayed_after_tcp_reconnect() {
         client.close(&setup.session_id);
     }
 }
+
+/// A **fresh agent process** must recover a session daemon spawned under a
+/// **prior, now-dead** agent process and re-attach the *original* session —
+/// not fall back to a brand-new one.
+///
+/// This is the headless analog of the live #2476 agent-reconnect recovery path,
+/// and the exact positive case that had no automated coverage and that failed in
+/// the live grade (because the drop harness was killing the detached daemon; see
+/// #2508). The real reconnect flow is:
+///
+///   1. an agent process is attached to a detached, `setsid`'d session daemon;
+///   2. the SSH transport drops and takes the agent process with it (its stdio
+///      hits EOF and it exits) — but the daemon, reparented to PID 1, survives;
+///   3. the reconnect stands up a *fresh* agent process against the same per-user
+///      state/socket dir, which calls `recover_sessions()` and re-attaches the
+///      surviving daemon, replaying its ring buffer.
+///
+/// The test reproduces that with an agent-process swap over a genuinely surviving
+/// daemon: agent A recovers the daemon session and writes a marker into it; agent
+/// A's **process** is then killed (like [`LocalAgent`]/[`IsolatedAgent`]'s `Drop`
+/// — leaving the separately-spawned daemon alive); a fresh agent B, pointed at the
+/// same config/state dir, must recover the **same** session id and replay the
+/// marker on re-attach. A regression that reaped the daemon with the agent (the
+/// #2508 drop-harness bug) fails here: agent B would find a dead endpoint, drop
+/// the session from state, and expose no session to re-attach.
+#[cfg(unix)]
+#[test]
+#[cfg_attr(
+    windows,
+    ignore = "flaky under Windows-runner oversubscription; see #2495"
+)]
+fn fresh_agent_recovers_daemon_session_from_dead_prior_agent() {
+    // ── Shared, agent-independent state: a temp dir + a manually-spawned daemon.
+    // The daemon stands in for the detached, `setsid`'d session daemon that
+    // outlives any single agent process. Because it is spawned by the *test*
+    // (not a child of either agent), killing an agent process never touches it —
+    // exactly the invariant a faithful transport drop preserves.
+    let tmp = TempDir::new().expect("failed to create temp dir");
+    let tmp_path = tmp.path().to_path_buf();
+    let session_id = test_session_id();
+    let socket_path = tmp_path.join(format!("session-{session_id}.sock"));
+
+    let (mut daemon, daemon_stderr) = spawn_daemon_for_local_shell(&session_id, &socket_path);
+    wait_for_socket(
+        &mut daemon,
+        &socket_path,
+        daemon_stderr.path(),
+        ready_timeout(),
+    );
+
+    // Persist the daemon session so every agent that starts against this config
+    // dir recovers it on startup (`recover_sessions()`), the same record a real
+    // persistent session's `connection.create` writes.
+    let state_dir = tmp_path.join("termihub-agent");
+    std::fs::create_dir_all(&state_dir).expect("create state dir");
+    let state_json = json!({
+        "sessions": {
+            &session_id: {
+                "type_id": "local",
+                "title": "reconnect-recovery-shell",
+                "created_at": "2024-01-01T00:00:00+00:00",
+                "daemon_socket": socket_path.to_str().expect("socket path not UTF-8"),
+                "settings": {}
+            }
+        }
+    });
+    std::fs::write(state_dir.join("state.json"), state_json.to_string()).expect("write state.json");
+
+    let marker = "termihub-agent-swap-marker-2508";
+
+    // ── Agent A: recover the daemon session, attach, write a marker ───────────
+    {
+        let agent_a = IsolatedAgent::spawn(&tmp_path);
+        let mut client = AgentClient::connect(&agent_a.addr);
+        client.initialize();
+
+        // The session recovered from state must be present and match our id.
+        let entry = client
+            .list_sessions()
+            .into_iter()
+            .find(|s| s["session_id"].as_str() == Some(session_id.as_str()))
+            .expect("agent A did not recover the daemon session from state.json");
+        assert_eq!(
+            entry["status"], "running",
+            "recovered session not running under agent A: {entry}"
+        );
+
+        let ar = client.attach(&session_id);
+        assert!(ar["result"].is_object(), "agent A attach failed: {ar}");
+
+        let wr = client.write_input(&session_id, &format!("echo {marker}\n"));
+        assert!(wr["result"].is_object(), "agent A write failed: {wr}");
+        assert!(
+            client.wait_for_output(marker),
+            "agent A never saw its marker echoed — precondition (a live daemon \
+             session under the prior agent) not met"
+        );
+
+        // `agent_a` drops here: its process is killed (SIGKILL, as
+        // `IsolatedAgent::Drop` does), modelling the transport drop that takes
+        // the remote agent process with it. The separately-spawned daemon is
+        // untouched and stays alive.
+    }
+
+    // The daemon must have survived the agent process that was attached to it —
+    // otherwise this would not exercise the "fresh agent recovers a *surviving*
+    // daemon" case, and would instead be the #2508 false-failure it guards against.
+    assert!(
+        socket_path.exists() && matches!(daemon.try_wait(), Ok(None)),
+        "session daemon did not survive agent A's death — cannot exercise \
+         cross-agent recovery (this is the #2508 drop-harness bug's signature)"
+    );
+
+    // ── Agent B: a *fresh* process recovers the surviving daemon ──────────────
+    let agent_b = IsolatedAgent::spawn(&tmp_path);
+    let mut client = AgentClient::connect(&agent_b.addr);
+    client.initialize();
+
+    // Agent B must re-attach the ORIGINAL session, not create a new one: the
+    // recovered list must hold exactly the same id agent A used.
+    let sessions = client.list_sessions();
+    let recovered_ids: Vec<&str> = sessions
+        .iter()
+        .filter_map(|s| s["session_id"].as_str())
+        .collect();
+    assert!(
+        recovered_ids.contains(&session_id.as_str()),
+        "fresh agent B did not recover the original session {session_id} — \
+         recovery fell back to a new session instead of re-attaching the \
+         surviving daemon (the live 'stuck Reconnecting -> new shell' symptom); \
+         recovered ids: {recovered_ids:?}"
+    );
+    assert_eq!(
+        recovered_ids.len(),
+        1,
+        "expected exactly the one surviving session after cross-agent recovery, \
+         got {recovered_ids:?}"
+    );
+
+    // Re-attach over the fresh agent: the daemon replays its ring buffer, which
+    // must still contain the marker agent A wrote before it died — proving the
+    // ORIGINAL session state survived the agent-process swap.
+    let ar = client.attach(&session_id);
+    assert!(ar["result"].is_object(), "agent B re-attach failed: {ar}");
+    assert!(
+        client.wait_for_output(marker),
+        "buffer replay after cross-agent recovery did not contain '{marker}' — \
+         the fresh agent did not re-attach the original daemon session's state"
+    );
+
+    client.close(&session_id);
+
+    // Explicitly reap the daemon (the test owns it; no scaffold Drop does it).
+    daemon.kill().ok();
+    daemon.wait().ok();
+}

--- a/scripts/internal/agent-reconnect-transport.sh
+++ b/scripts/internal/agent-reconnect-transport.sh
@@ -4,10 +4,23 @@
 #
 # The dev agent is a loopback sshd on this checkout's `dev_agent_port` (from
 # dev.local.json), started by `scripts/dev.sh`. "Dropping" the transport means
-# killing that sshd — the master listener AND every established-connection child —
-# so an in-flight agent session is severed at once (killing only the listener
-# leaves the established connection alive; see tests' LocalAgentSshd.stop). With
-# the listener gone, backend reconnect attempts fail, which is exactly the
+# severing ONLY the SSH transport: kill the sshd master listener AND its
+# per-connection `sshd:` child handlers, but do NOT touch the `termihub-agent`
+# process or the detached session daemon it spawned. Killing sshd is enough — the
+# SSH channel closes, the agent's stdio hits EOF and it exits on its own, and the
+# `setsid`'d session daemon (reparented to PID 1) survives, exactly as it does in
+# a real transport drop. That surviving daemon is the whole point of the recovery
+# grade: on `restore`, the backend re-establishes the transport and the fresh
+# agent re-attaches it.
+#
+# This is deliberately NOT a recursive PPID-tree reap of the sshd master. At the
+# instant of the drop the agent's session daemon is still a PPID-child of the live
+# `termihub-agent` (setsid changed its session/pgroup, NOT its PPID), so a
+# descendants() walk would kill the daemon too — the #2508 bug that made recovery
+# find a dead socket and fall back to a NEW shell, a false failure that invalidated
+# the #2476 grade. `setsid` protects the daemon from sshd's SIGHUP-on-teardown, not
+# from an explicit PPID-tree kill, so the kill list is restricted to sshd processes.
+# With the listener gone, backend reconnect attempts fail, which is exactly the
 # prolonged outage that forces the backend park/retry loop under the
 # `sessionBackendReattach` flag.
 #
@@ -69,13 +82,42 @@ is_listening() {
 }
 
 # Every descendant PID of $1, depth-first (children before parents), so a kill
-# list reaps leaves first — mirrors LocalAgentSshd.stop's recursive reap.
+# list reaps leaves first.
 descendants() {
     local pid="$1" child
     for child in $(pgrep -P "$pid" 2>/dev/null || true); do
         descendants "$child"
         printf '%s\n' "$child"
     done
+}
+
+# The basename of a PID's executable command (empty if the process is gone).
+# `ps -o comm=` returns the exec path on macOS (`/usr/sbin/sshd`) and the process
+# name on Linux (`sshd`); the basename normalises both.
+comm_of() {
+    local comm
+    comm=$(ps -o comm= -p "$1" 2>/dev/null | awk 'NR==1{print $1}')
+    printf '%s' "${comm##*/}"
+}
+
+# The SSH-transport kill list for a running sshd master $1: the master itself
+# plus only those of its descendants whose command is `sshd` — i.e. the
+# per-connection `sshd:` handlers and their privsep children. Leaves first, then
+# the master last, so the reap unwinds children before parents.
+#
+# Crucially this EXCLUDES the `termihub-agent --stdio` process the SSH session
+# runs and the `setsid`'d session daemon that agent spawned: at drop time the
+# daemon is still a PPID-child of the live agent (setsid changed its
+# session/pgroup, not its PPID), so a full `descendants()` reap would kill it and
+# reproduce the #2508 false failure. Filtering to `sshd` severs only the
+# transport; the agent then EOFs and exits on its own, and the detached daemon
+# survives for the recovery grade.
+sshd_transport_pids() {
+    local master="$1" pid
+    for pid in $(descendants "$master"); do
+        [ "$(comm_of "$pid")" = "sshd" ] && printf '%s\n' "$pid"
+    done
+    printf '%s\n' "$master"
 }
 
 # The sshd config path of a running master: prefer its own argv (`-f <path>`),
@@ -113,10 +155,12 @@ do_drop() {
         printf 'sshd=%s\n' "$(find_sshd_binary)"
     } >"$STATE_FILE"
 
-    # Reap the master AND its per-connection children so the established agent
-    # transport is severed at once, not just the listener.
+    # Reap the sshd master AND its per-connection `sshd:` handlers so the
+    # established SSH transport is severed at once — but NOT the agent process or
+    # its detached session daemon (see sshd_transport_pids / #2508). The agent
+    # then EOFs and exits on its own; the setsid'd daemon survives for recovery.
     local victims
-    victims="$(descendants "$master") $master"
+    victims="$(sshd_transport_pids "$master" | tr '\n' ' ')"
     # shellcheck disable=SC2086 # word-splitting the PID list is intended.
     kill -TERM $victims 2>/dev/null || true
     for _ in 1 2 3 4 5 6 7 8 9 10; do


### PR DESCRIPTION
## Problem

`scripts/internal/agent-reconnect-transport.sh`'s `do_drop()` reaped `descendants($sshd_master) + $sshd_master` via a recursive `pgrep -P` walk. Run while the agent was still alive, that walk caught the shell's detached **session daemon** — at that instant the daemon is still a PPID-child of the live `termihub-agent` (`setsid` changed its session/pgroup, **not** its PPID). A real transport drop leaves that daemon alive (`setsid` protects against sshd's SIGHUP-on-teardown, not an explicit PPID-tree kill), so the harness killed a process a real drop wouldn't. On reconnect, recovery found a dead socket and fell back to a **new** shell — a false failure that invalidated the #2476 recovery grade.

## Part 1 — faithful drop harness

`do_drop()` now severs **only the SSH transport**: it kills the sshd master listener plus its per-connection `sshd:` handlers (filtered by command == `sshd`), and never recurses into the `termihub-agent` process or its session daemon. The natural cascade reproduces a real drop — sshd dies, the SSH channel closes, the agent's stdio hits EOF and it exits on its own, and the `setsid`'d session daemon (reparented to PID 1) survives, re-attachable on `restore`. `restore`, the SIGTERM→SIGKILL escalation, the still-listening verification, and the per-checkout / loopback-port / no-pattern-pkill guarantees are unchanged. The header comment now documents the corrected behavior.

## Part 2 — missing automated recovery test

Adds `fresh_agent_recovers_daemon_session_from_dead_prior_agent` to `agent/tests/local_agent_integration.rs` — the headless analog of the live #2476 recovery path that had no coverage:

- Agent A recovers a daemon-backed session and writes a marker into the live shell.
- Agent A's **process** is killed (like `IsolatedAgent`/`LocalAgent`'s `Drop`), leaving the separately-spawned daemon alive.
- A **fresh** agent B, pointed at the same state/socket dir, calls `recover_sessions()` and must re-attach the **original** session id (asserted: exactly one recovered session, same id — not a new one), with the marker replayed from the daemon's ring buffer.

A regression that reaped the daemon with the agent (the #2508 bug) fails this test: agent B would find a dead endpoint and expose no session to re-attach.

## Verification

- `cargo build -p termihub-agent` ✅
- `cargo test -p termihub-agent --test local_agent_integration` ✅ (15 passed; new test run 5× for stability, all green)
- `cargo clippy -p termihub-agent --tests -- -D warnings` ✅
- `cargo fmt --check` ✅
- `bash -n` + `shellcheck` on the script ✅

Closes #2508

🤖 Generated with [Claude Code](https://claude.com/claude-code)