### PR TITLE
feat(session): re-attach the live agent session on reconnect (Part of #2512)

### DIFF
--- a/docs/changes/dev0/feature/2512-agent-live-reattach-backend.md
+++ b/docs/changes/dev0/feature/2512-agent-live-reattach-backend.md
@@ -1,0 +1,12 @@
+### Added
+
+- Resilient **agent**-hosted terminal tabs now re-attach to the **same live
+  session** when their connection drops and reconnects, so a long-running
+  process (e.g. a compile) keeps running across the disconnect and simply
+  continues on reconnect — instead of the desktop starting a fresh shell and
+  orphaning the recovered session. When the live agent session genuinely cannot
+  be recovered (the agent restarted, or the session aged out), the tab now
+  surfaces an explicit **session-lost** state rather than silently opening a new
+  shell. Backend groundwork, gated behind the default-off `sessionBackendReattach`
+  flag (no user-visible change yet; the frontend notice and "start new shell"
+  action follow separately) (part of #2512).

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -810,6 +810,12 @@ impl SessionManager {
             spawned,
         };
 
+        // Capture the agent's live session id before `remote_session_id` moves
+        // into the `SessionEntry` below, so the resilient-reconnect retention can
+        // record it for the redrive to re-attach to (#2512). `None` for a direct
+        // (non-agent) session.
+        let retained_agent_session_id = remote_session_id.clone();
+
         // Store session.
         {
             let mut sessions = self.sessions.lock().await;
@@ -865,6 +871,14 @@ impl SessionManager {
                         type_id: type_id.to_string(),
                         settings: settings.clone(),
                         agent_id: agent_id.map(|s| s.to_string()),
+                        // The live agent session id to re-attach to on reconnect
+                        // (#2512), captured from the proxy's `remote_session_id()`
+                        // after the initial agent connect. `None` for a direct tab
+                        // (no agent session). The redrive attaches to *this* live
+                        // session (running process continues) rather than minting a
+                        // new one, and emits session-lost when the agent no longer
+                        // lists it.
+                        agent_session_id: retained_agent_session_id.clone(),
                         resilient: true,
                         // The client's `sessionBackendReattach` determination
                         // (#2454): the sole gate on whether the backend reconnect
@@ -1489,6 +1503,113 @@ impl SessionManager {
         self.persistent()
             .attach_persistent_tab(connection_id, tab_id, emitter)
             .await
+    }
+
+    /// Re-attach a reconnecting resilient tab to an **existing live agent
+    /// session** — the running process continues (#2512).
+    ///
+    /// The backend reconnect redrive calls this after it re-establishes the
+    /// agent's SSH transport and confirms (via `connection.list`) that the live
+    /// agent session id it retained for the tab (`remote_session_id`) is still
+    /// present. Rather than `create_connection` minting a **new** agent session
+    /// (which would orphan the recovered process), it re-establishes the
+    /// desktop-side proxy against the surviving daemon via
+    /// [`RemoteProxy::reconnect_existing`] (which registers a fresh output channel
+    /// and issues `connection.attach` for a buffer replay), inserts it under a
+    /// fresh desktop `session_id`, records the identity bridge for that id keyed by
+    /// the stable `tab_id`, and streams output — mirroring the post-connect
+    /// bookkeeping of [`create_connection`](Self::create_connection). Returns the
+    /// new desktop `session_id` so the redrive can publish it via
+    /// `set_backend_session_id` for the frontend to re-attach terminal I/O to.
+    ///
+    /// Only ever called for a resilient agent tab, so the identity bridge is
+    /// recorded with `resilient: true`. The retained request is left untouched:
+    /// the same live agent session id remains valid for the next drop.
+    pub async fn reattach_agent_session<E: EventEmitter>(
+        &self,
+        tab_id: &str,
+        agent_id: &str,
+        remote_session_id: &str,
+        emitter: E,
+    ) -> Result<String, TerminalError> {
+        let session_id = uuid::Uuid::new_v4().to_string();
+
+        // Re-establish the desktop side against the surviving daemon.
+        // `reconnect_existing` calls `register_session_output` + `attach_session`
+        // synchronously; the latter internally parks on `blocking_recv`, so run it
+        // on the blocking pool to keep the tokio worker free to drive
+        // `agent_io_task` and deliver the reply.
+        let agent_mgr = self.agent_manager.clone();
+        let agent_id_owned = agent_id.to_string();
+        let remote_sid_owned = remote_session_id.to_string();
+        let proxy = tokio::task::spawn_blocking(move || {
+            RemoteProxy::reconnect_existing(agent_id_owned, remote_sid_owned, agent_mgr)
+        })
+        .await
+        .map_err(|e| TerminalError::SpawnFailed(format!("spawn_blocking join: {e}")))?
+        .map_err(|e| TerminalError::SpawnFailed(e.to_string()))?;
+
+        let output_rx = proxy.subscribe_output();
+
+        // Insert under the fresh desktop session id.
+        {
+            let mut sessions = self.sessions.lock().await;
+            sessions.insert(
+                session_id.clone(),
+                SessionEntry {
+                    connection: Box::new(proxy),
+                    info: SessionInfo {
+                        id: session_id.clone(),
+                        title: "Remote".to_string(),
+                        connection_type: "remote".to_string(),
+                        alive: true,
+                        agent_id: Some(agent_id.to_string()),
+                        spawned: false,
+                    },
+                    remote_session_id: Some(remote_session_id.to_string()),
+                    line_ending: LineEnding::default(),
+                },
+            );
+        }
+
+        // Record the identity bridge for the new desktop session id, keyed by the
+        // stable tab id, so a future drop of this re-attached session folds
+        // `reconnect`/`dropped` at the `terminal-exit` source (#2431/#2439).
+        self.session_tab_ids
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(
+                session_id.clone(),
+                TabBinding {
+                    tab_id: tab_id.to_string(),
+                    resilient: true,
+                },
+            );
+
+        // Stream output for the re-attached session (buffer replay is already
+        // in-flight from `attach_session`).
+        let sessions_clone = self.sessions.clone();
+        let capture = self.ensure_output_buffer(&session_id);
+        let output_buffers = self.output_buffers.clone();
+        let session_loggers = self.session_loggers.clone();
+        let session_tab_ids = self.session_tab_ids.clone();
+        let sid = session_id.clone();
+        tokio::spawn(async move {
+            Self::run_output_reader(
+                sid,
+                output_rx,
+                emitter,
+                sessions_clone,
+                false,
+                capture,
+                output_buffers,
+                session_loggers,
+                session_tab_ids,
+            )
+            .await;
+        });
+
+        Ok(session_id)
     }
 
     /// Unregister `tab_id` from the persistent session identified by `session_id`.
@@ -3039,6 +3160,58 @@ mod tests {
             "the retained request carries the agent_id the redrive re-connects through"
         );
         assert!(req.backend_reattach, "the redrive gate is recorded");
+    }
+
+    #[tokio::test]
+    async fn create_connection_records_agent_session_id_on_the_retained_request() {
+        // #2512: a resilient AGENT tab must retain the live agent session id it is
+        // attached to (from the proxy's `remote_session_id()` after the initial
+        // connect), so the redrive can re-attach to *that same* live session on
+        // reconnect instead of minting a new one. A resilient DIRECT tab has no
+        // agent session, so it retains `None`.
+        let (manager, _cleared) = make_test_manager_with_retain_agent();
+
+        manager
+            .create_connection(
+                "mock",
+                serde_json::json!({ "password": "secret" }),
+                Some("agent-1"), // resilient AGENT session
+                Some("tab-a:0"),
+                false,
+                true, // resilient
+                true, // backend_reattach opted in
+                MockEventEmitter::new(),
+            )
+            .await
+            .expect("agent session should open");
+        let agent_req = manager
+            .retained_request("tab-a")
+            .expect("a resilient agent session retains its connection request");
+        assert!(
+            agent_req.agent_session_id.is_some(),
+            "the retained request carries the live agent session id to re-attach to (#2512)"
+        );
+
+        manager
+            .create_connection(
+                "mock",
+                serde_json::json!({ "password": "secret" }),
+                None, // resilient DIRECT session
+                Some("tab-d:0"),
+                false,
+                true,
+                true,
+                MockEventEmitter::new(),
+            )
+            .await
+            .expect("direct session should open");
+        let direct_req = manager
+            .retained_request("tab-d")
+            .expect("a resilient direct session retains its connection request");
+        assert!(
+            direct_req.agent_session_id.is_none(),
+            "a direct (non-agent) tab has no agent session id to retain (#2512)"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/session/retained_request.rs
+++ b/src-tauri/src/session/retained_request.rs
@@ -65,6 +65,16 @@ pub(crate) struct RetainedConnectionRequest {
     /// direct connections this retention currently covers (#2454); kept so the
     /// agent redrive (#2455) can reuse the same store.
     pub(crate) agent_id: Option<String>,
+    /// The **live agent session id** this resilient agent tab is attached to, if
+    /// any (#2512). Populated in `create_connection` from the proxy's
+    /// `remote_session_id()` after the initial agent connect; always `None` for a
+    /// **direct** (non-agent) tab, which has no agent session. On reconnect the
+    /// backend redrive re-attaches to *this same* live session (the running
+    /// process continues) via `connection.attach` instead of minting a new one
+    /// with `connection.create` — and, when the agent no longer lists it, emits an
+    /// explicit session-lost state rather than a silent new shell. Not a secret,
+    /// but zeroized on drop alongside the other fields for uniformity.
+    pub(crate) agent_session_id: Option<String>,
     /// The tab's resilient-reconnect determination at connect time.
     pub(crate) resilient: bool,
     /// Whether the owning tab opted into the **backend-driven** reconnect redrive
@@ -84,6 +94,9 @@ impl Drop for RetainedConnectionRequest {
         self.type_id.zeroize();
         if let Some(agent_id) = self.agent_id.as_mut() {
             agent_id.zeroize();
+        }
+        if let Some(agent_session_id) = self.agent_session_id.as_mut() {
+            agent_session_id.zeroize();
         }
         zeroize_json(&mut self.settings);
     }
@@ -211,6 +224,7 @@ mod tests {
                 type_id: "ssh".to_string(),
                 settings: json!({ "host": "h", "password": "p" }),
                 agent_id: None,
+                agent_session_id: None,
                 resilient: true,
                 backend_reattach: false,
             },
@@ -246,6 +260,7 @@ mod tests {
                 type_id: "ssh".to_string(),
                 settings: json!({ "host": "h", "password": "p" }),
                 agent_id: Some("agent-1".to_string()),
+                agent_session_id: None,
                 resilient: true,
                 backend_reattach: true,
             },
@@ -286,6 +301,7 @@ mod tests {
                 type_id: "ssh".to_string(),
                 settings: json!({ "password": "old" }),
                 agent_id: None,
+                agent_session_id: None,
                 resilient: true,
                 backend_reattach: false,
             },
@@ -296,6 +312,7 @@ mod tests {
                 type_id: "ssh".to_string(),
                 settings: json!({ "password": "new" }),
                 agent_id: None,
+                agent_session_id: None,
                 resilient: true,
                 backend_reattach: false,
             },
@@ -317,6 +334,7 @@ mod tests {
                 type_id: "ssh".to_string(),
                 settings: json!({ "password": "p" }),
                 agent_id: None,
+                agent_session_id: None,
                 resilient: true,
                 backend_reattach: true,
             },
@@ -327,6 +345,7 @@ mod tests {
                 type_id: "ssh".to_string(),
                 settings: json!({ "password": "p" }),
                 agent_id: Some("agent-1".to_string()),
+                agent_session_id: None,
                 resilient: true,
                 backend_reattach: true,
             },
@@ -347,6 +366,7 @@ mod tests {
             type_id: "ssh".to_string(),
             settings: json!({ "password": "p" }),
             agent_id: Some(agent.to_string()),
+            agent_session_id: None,
             resilient: true,
             backend_reattach: true,
         };

--- a/src-tauri/src/session_projection/redrive.rs
+++ b/src-tauri/src/session_projection/redrive.rs
@@ -98,6 +98,11 @@ impl<R: Runtime> ReconnectRedrive for AppReconnectRedrive<R> {
         let type_id = request.type_id.clone();
         let settings = request.settings.clone();
         let agent_id = request.agent_id.clone();
+        // The live agent session id this tab is attached to (#2512). `Some` for a
+        // resilient agent tab: the redrive re-attaches to *this* live session
+        // (running process continues) instead of minting a new one, and emits
+        // session-lost if the agent no longer lists it. `None` for a direct tab.
+        let agent_session_id = request.agent_session_id.clone();
         drop(request);
 
         // A unique per-attempt connect id in the `${tabId}:${retry}` form so the
@@ -142,6 +147,18 @@ impl<R: Runtime> ReconnectRedrive for AppReconnectRedrive<R> {
                     });
                     sync_timer(&app, &tab_id);
                     clear_retained_on_giveup(&app, &tab_id);
+                    return;
+                }
+
+                // #2512: for a resilient **agent** tab whose live agent session id
+                // we retained, re-attach to *that same* live session (the running
+                // process continues) rather than minting a new one — or emit an
+                // explicit session-lost state when the agent no longer lists it.
+                // The transport is up (checked above), so the agent can answer
+                // `connection.list`. Direct tabs and agent tabs with no retained
+                // session id fall through to the create path below.
+                if let Some(remote_sid) = agent_session_id.as_deref() {
+                    reattach_or_lose(&app, &manager, &tab_id, aid, remote_sid).await;
                     return;
                 }
             }
@@ -197,6 +214,103 @@ impl<R: Runtime> ReconnectRedrive for AppReconnectRedrive<R> {
             }
         });
     }
+}
+
+/// Re-attach a reconnecting resilient agent tab to its retained **live** agent
+/// session, or emit an explicit session-lost state when the agent no longer
+/// lists it (#2512). The caller has already re-established the agent transport,
+/// so `connection.list` can answer.
+///
+/// Never mints a new agent session (maintainer decision): a recovered live
+/// session is re-attached so the **running process continues**; an unrecoverable
+/// one surfaces [`SessionLifecycleStore::session_lost`] so the frontend renders a
+/// "session lost" notice + manual "start new shell", never a silent replacement.
+async fn reattach_or_lose<R: Runtime>(
+    app: &AppHandle<R>,
+    manager: &SessionManager,
+    tab_id: &str,
+    agent_id: &str,
+    remote_session_id: &str,
+) {
+    // Ask the agent which sessions are live/recovered. Runs on the blocking pool
+    // (the client parks on `blocking_recv`), like the transport re-establish.
+    let client = manager.agent_client();
+    let aid = agent_id.to_string();
+    let listed = tauri::async_runtime::spawn_blocking(move || client.list_sessions(&aid)).await;
+
+    let recoverable = matches!(&listed, Ok(Ok(sessions))
+        if sessions
+            .iter()
+            .any(|s| s.session_id == remote_session_id && is_recoverable_status(&s.status)));
+
+    if !recoverable {
+        // The live session is gone. Guard the cancel race, then fold the terminal
+        // session-lost state and scrub the retained secrets — never a silent new
+        // shell.
+        if still_connecting(app, tab_id) {
+            fold_session_transition(app, |store| {
+                store.session_lost(
+                    tab_id,
+                    Some("the live agent session could not be recovered".to_string()),
+                );
+            });
+            sync_timer(app, tab_id);
+            manager.clear_retained_request_with_agent_scrub(tab_id);
+        }
+        return;
+    }
+
+    match manager
+        .reattach_agent_session(tab_id, agent_id, remote_session_id, app.clone())
+        .await
+    {
+        Ok(new_session_id) => {
+            // Guard the cancel race exactly as the create path does: a user cancel
+            // / give-up that landed while attaching moved the loop off
+            // `Connecting` — tear the freshly re-attached desktop session down
+            // rather than settling it live.
+            if !still_connecting(app, tab_id) {
+                let _ = manager.close_session(&new_session_id).await;
+                return;
+            }
+            // Settle the tab live and hand the frontend the new backend session id
+            // to re-attach terminal I/O to (#2457); the live process continues.
+            let sid = new_session_id.clone();
+            fold_session_transition(app, |store| {
+                store.connected(tab_id);
+                store.set_backend_session_id(tab_id, Some(sid.clone()));
+            });
+            sync_timer(app, tab_id);
+        }
+        Err(e) => {
+            // A transient attach failure re-arms the next backoff window (or gives
+            // up), exactly like a failed create — a transport hiccup, distinct
+            // from a gone session (which folds session-lost above).
+            fold_session_transition(app, |store| {
+                store.reconnect_failed(tab_id, Some(e.to_string()));
+            });
+            sync_timer(app, tab_id);
+            clear_retained_on_giveup(app, tab_id);
+        }
+    }
+}
+
+/// Whether the tab's reconnect loop is still in its `Connecting` sub-phase — the
+/// guard the redrive uses to avoid settling (or stomping) an outcome after a user
+/// cancel / give-up raced the in-flight attempt.
+fn still_connecting<R: Runtime>(app: &AppHandle<R>, tab_id: &str) -> bool {
+    app.try_state::<Arc<SessionLifecycleStore>>()
+        .and_then(|store| store.reconnect_state(tab_id))
+        .map(|s| s.phase)
+        == Some(ReconnectPhase::Connecting)
+}
+
+/// Whether an agent-reported session status means the live session is still there
+/// to re-attach to (#2512). The agent reports `running` for both live and
+/// **recovered** sessions (a recovered daemon is set back to `Running`); a
+/// naturally-exited session reports `exited` and must not be re-attached.
+fn is_recoverable_status(status: &str) -> bool {
+    status == "running"
 }
 
 /// On a reconnect give-up (terminal `Failed`), scrub the secrets the loop

--- a/src-tauri/src/session_projection/redrive_resume_tests.rs
+++ b/src-tauri/src/session_projection/redrive_resume_tests.rs
@@ -75,6 +75,13 @@ struct FakeAgent {
     /// Whether a cold reconnect (reconnect_retained_agent) can re-establish.
     reattach_ok: AtomicBool,
     create_count: AtomicUsize,
+    /// The live agent session ids `create_session` minted, so `list_sessions` can
+    /// report them as recoverable on reconnect (#2512).
+    created_ids: Mutex<Vec<String>>,
+    /// Whether the live agent session survived the drop and is recoverable. When
+    /// `false`, `list_sessions` returns empty (the agent hard-restarted / the
+    /// session aged out) so the redrive must fold session-lost, not create-new.
+    session_recoverable: AtomicBool,
     /// Keep output senders alive so create_connection's reader does not end
     /// (which would tear the session down + fold a drop).
     senders: Mutex<Vec<OutputSender>>,
@@ -85,6 +92,8 @@ impl FakeAgent {
             connected: AtomicBool::new(true),
             reattach_ok: AtomicBool::new(true),
             create_count: AtomicUsize::new(0),
+            created_ids: Mutex::new(Vec::new()),
+            session_recoverable: AtomicBool::new(true),
             senders: Mutex::new(Vec::new()),
         }
     }
@@ -134,8 +143,10 @@ impl AgentRpcClient for FakeAgent {
             return Err(TerminalError::RemoteError("Agent not connected".into()));
         }
         let n = self.create_count.fetch_add(1, Ordering::SeqCst);
+        let session_id = format!("remote-{n}");
+        self.created_ids.lock().unwrap().push(session_id.clone());
         Ok(AgentSessionInfo {
-            session_id: format!("remote-{n}"),
+            session_id,
             title: "Shell".into(),
             session_type: session_type.into(),
             status: "running".into(),
@@ -158,7 +169,23 @@ impl AgentRpcClient for FakeAgent {
         Ok(())
     }
     fn list_sessions(&self, _agent_id: &str) -> Result<Vec<AgentSessionInfo>, TerminalError> {
-        Ok(vec![])
+        if !self.session_recoverable.load(Ordering::SeqCst) {
+            return Ok(vec![]);
+        }
+        Ok(self
+            .created_ids
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|id| AgentSessionInfo {
+                session_id: id.clone(),
+                title: "Shell".into(),
+                session_type: "local".into(),
+                status: "running".into(),
+                attached: false,
+                definition_id: None,
+            })
+            .collect())
     }
     fn list_connections_and_folders(
         &self,
@@ -386,7 +413,9 @@ fn agent_reconnect_resumes_after_transport_restore() {
     // Transport RESTORED.
     agent.reattach_ok.store(true, Ordering::SeqCst);
 
-    // Fire attempt 2: redrive re-establishes + creates a new session + publishes it.
+    // Fire attempt 2: redrive re-establishes the transport and — since the live
+    // agent session (`remote-0`) is still listed — RE-ATTACHES to it (#2512)
+    // rather than minting a new one, publishing the new desktop session id.
     scheduler.fire("tab-1");
     poll_until(
         || store.get("tab-1").map(|s| s.status) == Some(SessionStatus::Connected),
@@ -397,7 +426,108 @@ fn agent_reconnect_resumes_after_transport_restore() {
     assert!(
         life.backend_session_id.is_some()
             && life.backend_session_id.as_deref() != Some(s1.as_str()),
-        "a fresh backend session id is published for the frontend to re-attach"
+        "a fresh desktop session id is published for the frontend to re-attach"
+    );
+    assert_eq!(
+        agent.create_count.load(Ordering::SeqCst),
+        1,
+        "the live agent session is re-attached, NOT re-created — only the initial \
+         create_session ran (#2512)"
+    );
+}
+
+/// #2512 session-lost: when the transport re-establishes but the live agent
+/// session is genuinely gone (agent hard-restarted / aged out), the redrive must
+/// fold the explicit terminal `SessionLost` state — never silently mint a new
+/// shell in its place.
+#[test]
+fn agent_reconnect_folds_session_lost_when_live_session_unrecoverable() {
+    let app = tauri::test::mock_app();
+    let handle = app.handle().clone();
+
+    let agent = Arc::new(FakeAgent::new());
+    let manager = SessionManager::new(
+        ConnectionTypeRegistry::new(),
+        agent.clone() as Arc<dyn AgentRpcClient>,
+    );
+    handle.manage(manager);
+
+    let store = Arc::new(SessionLifecycleStore::new());
+    store.set_rand_for_test(Box::new(|| 0.5));
+    handle.manage(store.clone());
+
+    let projection = ProjectionState::new();
+    projection
+        .projector
+        .register_region(SESSION_LIFECYCLE_REGION, store.snapshot());
+    let projector = projection.projector.clone();
+    let projector_seed = projection.projector.clone();
+    let store_for_publish = store.clone();
+    handle.manage(projection);
+
+    let scheduler = Arc::new(ManualScheduler::default());
+    let redrive: Arc<dyn ReconnectRedrive> = Arc::new(AppReconnectRedrive::new(handle.clone()));
+    let driver = Arc::new(
+        ReconnectTimerDriver::new(
+            store.clone(),
+            scheduler.clone(),
+            Arc::new(move || {
+                publish_sessions(&projector, &store_for_publish);
+            }),
+        )
+        .with_redrive(redrive),
+    );
+    handle.manage(driver.clone());
+
+    // Initial connect: agent up → session S1 (remote-0), request retained.
+    let manager_ref = handle.state::<SessionManager>();
+    let settings = serde_json::json!({ "config": {} });
+    let s1 = tauri::async_runtime::block_on(manager_ref.create_connection(
+        "shell",
+        settings.clone(),
+        Some("agent-1"),
+        Some("tab-1:0"),
+        false,
+        true, // resilient
+        true, // backend_reattach
+        handle.clone(),
+    ))
+    .expect("initial connect succeeds");
+    store.connect("tab-1");
+    store.connected("tab-1");
+    store.set_backend_session_id("tab-1", Some(s1.clone()));
+    publish_sessions(&projector_seed, &store);
+
+    // Drop: arm the loop.
+    store.reconnect("tab-1");
+    driver.sync("tab-1");
+    assert!(scheduler.armed("tab-1"), "timer armed on drop");
+
+    // Transport comes back, but the live agent session did NOT survive.
+    agent.session_recoverable.store(false, Ordering::SeqCst);
+
+    // Fire the attempt: transport re-establishes, `connection.list` no longer
+    // reports remote-0 → session-lost, and no new session is created.
+    scheduler.fire("tab-1");
+    poll_until(
+        || store.get("tab-1").map(|s| s.status) == Some(SessionStatus::SessionLost),
+        "redrive folds session-lost when the live session is unrecoverable",
+    );
+    let life = store.get("tab-1").unwrap();
+    assert_eq!(life.status, SessionStatus::SessionLost);
+    assert_eq!(
+        life.backend_session_id, None,
+        "a lost session leaves no backend id to re-attach to"
+    );
+    assert_eq!(
+        agent.create_count.load(Ordering::SeqCst),
+        1,
+        "session-lost must NOT mint a replacement shell — only the initial \
+         create_session ran (#2512)"
+    );
+    assert!(
+        !manager_ref.has_retained_request("tab-1"),
+        "the terminal session-lost state scrubs the retained request"
     );
 }
 

--- a/src-tauri/src/session_projection/store.rs
+++ b/src-tauri/src/session_projection/store.rs
@@ -60,6 +60,16 @@ pub enum SessionStatus {
     /// exhausted its attempts. `error` carries the message; the user may
     /// manually reconnect.
     Failed,
+    /// A distinct terminal state (#2512): a resilient **agent**-hosted tab
+    /// re-established its transport on reconnect, but the **live agent session**
+    /// it was attached to (its running process, e.g. a compile) could not be
+    /// recovered — the agent hard-restarted, the session aged out, or its daemon
+    /// died. The desktop deliberately does **not** silently mint a new shell in
+    /// its place (maintainer decision); it surfaces this explicit state so the
+    /// frontend can render a clear "session lost" notice plus a manual "start new
+    /// shell" action. Serialised as `sessionLost` for the frontend to key on.
+    #[serde(rename = "sessionLost")]
+    SessionLost,
 }
 
 /// Why a session left the `Connected` state — drives the disconnect-overlay
@@ -406,6 +416,32 @@ impl SessionLifecycleStore {
         if let Some(entry) = inner.sessions.get_mut(session_id) {
             entry.backend_session_id = backend_session_id;
         }
+    }
+
+    /// `session.sessionLost` (#2512) — a resilient **agent** tab re-established
+    /// its transport on reconnect, but the **live agent session** it was attached
+    /// to could not be recovered (agent hard-restart / aged out / daemon died).
+    /// Lands in the terminal [`SessionStatus::SessionLost`] state carrying
+    /// `error`, so the frontend renders an explicit "session lost" notice with a
+    /// manual "start new shell" action rather than the backend silently minting a
+    /// replacement shell. Resets the reconnect loop to idle, clears the
+    /// re-attach id (the backend session is gone), and records `Unexpected` as the
+    /// end reason (the live process was lost, not user-ended). Creates the entry
+    /// lazily so the redrive can fold it for a tab the store is already tracking.
+    pub fn session_lost(&self, session_id: &str, error: Option<String>) {
+        let mut inner = self.lock();
+        let entry = inner
+            .sessions
+            .entry(session_id.to_string())
+            .or_insert_with(SessionLifecycle::connecting);
+        entry.status = SessionStatus::SessionLost;
+        entry.reconnect = INITIAL_RECONNECT_STATE;
+        entry.end_reason = Some(EndReason::Unexpected);
+        entry.error = error;
+        entry.reconnect_error = None;
+        // The live agent session could not be recovered; there is no backend
+        // session to re-attach to (#2512).
+        entry.backend_session_id = None;
     }
 
     /// `session.remove` — the session/tab is gone; drop it from the region.

--- a/src-tauri/src/session_projection/store_tests.rs
+++ b/src-tauri/src/session_projection/store_tests.rs
@@ -370,3 +370,53 @@ fn a_fresh_connect_starts_without_a_stale_backend_session_id() {
     store.connect("s1");
     assert_eq!(store.get("s1").unwrap().backend_session_id, None);
 }
+
+#[test]
+fn session_lost_enters_the_terminal_session_lost_state() {
+    // #2512: when a resilient agent tab re-establishes its transport but the live
+    // agent session could not be recovered, `session_lost` folds a distinct
+    // terminal state — NOT a reconnect loop, NOT a silent new session. It carries
+    // the error, resets the loop to idle, and drops any stale re-attach id.
+    let store = deterministic_store();
+    store.connect("tab-1");
+    store.connected("tab-1");
+    store.set_backend_session_id("tab-1", Some("backend-live".to_string()));
+    // Arm a reconnect loop, as a real drop would.
+    store.reconnect("tab-1");
+    assert_eq!(
+        store.get("tab-1").unwrap().status,
+        SessionStatus::Reconnecting
+    );
+
+    store.session_lost(
+        "tab-1",
+        Some("the live agent session could not be recovered".to_string()),
+    );
+
+    let s = store.get("tab-1").unwrap();
+    assert_eq!(s.status, SessionStatus::SessionLost);
+    assert_eq!(s.reconnect.phase, ReconnectPhase::Idle);
+    assert_eq!(s.end_reason, Some(EndReason::Unexpected));
+    assert_eq!(
+        s.error.as_deref(),
+        Some("the live agent session could not be recovered")
+    );
+    assert_eq!(
+        s.backend_session_id, None,
+        "the lost live session leaves no backend id to re-attach to"
+    );
+}
+
+#[test]
+fn session_lost_serializes_as_session_lost_for_the_frontend() {
+    // The frontend keys off the serialized status string; pin it so the renderer
+    // and this backend state stay in agreement (#2512).
+    let store = deterministic_store();
+    store.connect("tab-1");
+    store.session_lost("tab-1", Some("gone".to_string()));
+    let snapshot = store.snapshot();
+    assert_eq!(
+        snapshot["sessions"]["tab-1"]["status"],
+        serde_json::json!("sessionLost")
+    );
+}


### PR DESCRIPTION
## What

Backend core for #2512: when a resilient **agent**-hosted terminal tab's transport drops and reconnects, re-attach the **same live agent session** (the running process — e.g. a compile — continues) instead of `create_connection` minting a new session and orphaning the recovered one. When the live session is genuinely unrecoverable, emit an **explicit session-lost state** rather than silently opening a new shell (maintainer decision).

Strictly additive behind the default-off `sessionBackendReattach` flag — the redrive still gates on `backend_reattach`, so **flag-off behavior is byte-identical to develop**.

## Changes

- **Retain the live agent session id** — `RetainedConnectionRequest.agent_session_id` (`session/retained_request.rs`), populated in `create_connection` from the proxy's `remote_session_id()` after the initial agent connect (`session/manager.rs`); `None` for direct tabs; zeroized on drop like the other fields.
- **Redrive attaches instead of creates** (`session_projection/redrive.rs`) — after re-establishing the agent transport, `connection.list` the agent's sessions; if the retained id is present + `running`, re-attach via `SessionManager::reattach_agent_session` (new helper wrapping `RemoteProxy::reconnect_existing`) and publish the new desktop session id via `set_backend_session_id`. Direct tabs keep the create path unchanged.
- **Explicit session-lost state** — new `SessionStatus::SessionLost` + `SessionLifecycleStore::session_lost` (`session_projection/store.rs`). **Emitted state name (serialized): `sessionLost`.** Terminal, resets the loop to idle, clears the re-attach id, scrubs the retained request.

## Session-lost state name

The backend folds `SessionStatus::SessionLost`, **serialized as `sessionLost`** in the `session-lifecycle` projection region, carrying an `error` message. The frontend can key on this.

## Tests

- `create_connection_records_agent_session_id_on_the_retained_request` — agent tab retains the live session id; direct tab retains `None`.
- `agent_reconnect_resumes_after_transport_restore` (updated) — redrive **re-attaches** the live session (`create_count == 1`, no new agent session).
- `agent_reconnect_folds_session_lost_when_live_session_unrecoverable` — folds `SessionLost` + scrubs retained request, no create-new.
- Store: `session_lost` terminal-state and `sessionLost` serialization tests.
- Full `cargo test -p termihub --lib` green (1761 passed); clippy `-D warnings` clean; fmt clean.

## Deferred (follow-up)

- **Frontend rendering** of the `sessionLost` state + the manual **"start new shell"** action. Tracked under #2512 (frontend piece); this PR only emits the backend state.

Part of #2512