### PR TITLE
feat(terminal): render agent session-lost state + start-new-shell action (Closes #2514)

### DIFF
--- a/docs/changes/dev0/feature/2514-session-lost-frontend.md
+++ b/docs/changes/dev0/feature/2514-session-lost-frontend.md
@@ -1,0 +1,10 @@
+### Added
+
+- Resilient agent shell tabs now show an explicit **"Session lost"** notice when a
+  reconnect restores the transport but the live agent session could not be
+  recovered (agent restarted, aged out, or the daemon died). Instead of silently
+  opening a replacement shell, the tab preserves its scrollback and offers a clear
+  **"Start New Shell"** action to open a fresh session on demand, alongside "View
+  Scrollback". This is the frontend half of the agent live-reattach feature and is
+  gated behind the default-off `sessionBackendReattach` experimental flag, so
+  there is no change unless it is enabled (#2514, part of #2512).

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -446,9 +446,26 @@ export function Terminal({
         // we start fresh: a persistent tab restarts its background session and
         // reattaches to the new live id; any other tab creates a new session.
         const isReconnect = (useAppStore.getState().terminalRetryCounters[tabId] ?? 0) > 0;
+        // "Start new shell" (#2512): the one-shot force-fresh flag makes this
+        // reconnect create a brand-new session instead of re-attaching an
+        // unrecoverable one. Consumed here so a later reconnect re-attaches as
+        // usual.
+        const forceFresh = useAppStore.getState().terminalForceFreshReconnect[tabId] ?? false;
+        if (forceFresh) {
+          useAppStore.setState((s) => {
+            const next = { ...s.terminalForceFreshReconnect };
+            delete next[tabId];
+            return { terminalForceFreshReconnect: next };
+          });
+        }
         let reattachSessionId: string | null;
         if (isReconnect) {
-          if (persistentConnectionId) {
+          if (forceFresh) {
+            // Skip every re-attach branch: a fresh `create_connection` below opens
+            // a new shell for the tab (an explicit user choice on the session-lost
+            // notice, where auto re-attach is deliberately suppressed).
+            reattachSessionId = null;
+          } else if (persistentConnectionId) {
             // Persistent/agent tab: restart the background session and reattach
             // to its (possibly new) live id — never to the dead mount-time id.
             reattachSessionId = await useAppStore.getState().restartPersistentSessionForTab(tabId);
@@ -474,6 +491,14 @@ export function Terminal({
               useAppStore
                 .getState()
                 .settleBackendReconnectGaveUp(tabId, outcome.error ?? "Agent reconnect failed.");
+              return;
+            }
+            if (outcome.kind === "sessionLost") {
+              // The transport came back but the live agent session was
+              // unrecoverable (#2512). Never silently mint a replacement: settle
+              // the tab into the terminal session-lost state, whose overlay offers
+              // an explicit "start new shell" action.
+              useAppStore.getState().settleSessionLost(tabId);
               return;
             }
             reattachSessionId = outcome.sessionId;

--- a/src/components/Terminal/TerminalDisconnectOverlay.projection.test.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.projection.test.tsx
@@ -25,6 +25,8 @@ vi.mock("lucide-react", () => ({
   AlertTriangle: () => null,
   Loader2: () => null,
   CheckCircle2: () => null,
+  Unplug: () => null,
+  Plus: () => null,
 }));
 
 const TAB = "tab-1";

--- a/src/components/Terminal/TerminalDisconnectOverlay.sessionLost.test.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.sessionLost.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { TerminalDisconnectOverlay } from "./TerminalDisconnectOverlay";
+import { withTooltip } from "@/test/tooltip";
+import { useAppStore } from "@/store/appStore";
+import {
+  setSessionIntentsEnabled,
+  setSessionRenderFromProjectionEnabled,
+  setSessionTransportForTest,
+  stopSessionSubscription,
+} from "@/store/sessionBridge";
+import {
+  connected,
+  FakeSessionTransport,
+  sessionLost,
+} from "@/test/sessionLifecycleRegionTestHarness";
+
+// Stub lucide-react icons used in the overlay (incl. the session-lost variant's
+// Unplug + Plus).
+vi.mock("lucide-react", () => ({
+  WifiOff: () => null,
+  RefreshCw: () => null,
+  X: () => null,
+  AlertTriangle: () => null,
+  Loader2: () => null,
+  CheckCircle2: () => null,
+  Unplug: () => null,
+  Plus: () => null,
+}));
+
+const TAB = "tab-1";
+
+/** Flush the bridge's async subscribe + fan-out so the projected snapshot lands. */
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("TerminalDisconnectOverlay — session-lost variant (#2512)", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+  let transport: FakeSessionTransport;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    transport = new FakeSessionTransport();
+    setSessionTransportForTest(transport);
+    setSessionRenderFromProjectionEnabled(true);
+    setSessionIntentsEnabled(true);
+    useAppStore.setState({
+      terminalExitedTabs: { [TAB]: true },
+      terminalDisconnectErrors: {},
+      terminalViewMode: {},
+      terminalReconnectingTabs: {},
+      terminalReconnectTriggerErrors: {},
+      terminalAutoReconnect: {},
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    stopSessionSubscription();
+    setSessionTransportForTest(null);
+    setSessionRenderFromProjectionEnabled(null);
+    setSessionIntentsEnabled(null);
+  });
+
+  it("renders the session-lost notice with the backend error from the region", async () => {
+    transport.setSession(TAB, sessionLost("the live agent session could not be recovered"));
+
+    act(() => root.render(withTooltip(<TerminalDisconnectOverlay tabId={TAB} />)));
+    await flush();
+
+    expect(transport.subscribeCount).toBeGreaterThan(0);
+    const body = container.querySelector("[data-testid='terminal-session-lost']");
+    expect(body).not.toBeNull();
+    expect(body?.textContent).toContain("Session lost");
+    const errorBox = container.querySelector("[data-testid='terminal-session-lost-error-box']");
+    expect(errorBox?.textContent).toContain("could not be recovered");
+    // The explicit "start new shell" action is offered; no auto-reconnect.
+    expect(
+      container.querySelector("[data-testid='terminal-session-lost-new-shell-btn']")
+    ).not.toBeNull();
+  });
+
+  it("renders the notice without an error box when the region carries no message", async () => {
+    transport.setSession(TAB, sessionLost());
+
+    act(() => root.render(withTooltip(<TerminalDisconnectOverlay tabId={TAB} />)));
+    await flush();
+
+    expect(container.querySelector("[data-testid='terminal-session-lost']")).not.toBeNull();
+    expect(container.querySelector("[data-testid='terminal-session-lost-error-box']")).toBeNull();
+  });
+
+  it("'start new shell' triggers startFreshShellForTab for the tab", async () => {
+    const startFreshShellForTab = vi.fn();
+    useAppStore.setState({ startFreshShellForTab });
+    transport.setSession(TAB, sessionLost("gone"));
+
+    act(() => root.render(withTooltip(<TerminalDisconnectOverlay tabId={TAB} />)));
+    await flush();
+
+    const btn = container.querySelector<HTMLButtonElement>(
+      "[data-testid='terminal-session-lost-new-shell-btn']"
+    );
+    expect(btn).not.toBeNull();
+    act(() => btn!.click());
+
+    expect(startFreshShellForTab).toHaveBeenCalledWith(TAB);
+  });
+
+  it("does not render the session-lost variant for a non-lost (connected) session", async () => {
+    transport.setSession(TAB, connected());
+
+    act(() => root.render(withTooltip(<TerminalDisconnectOverlay tabId={TAB} />)));
+    await flush();
+
+    // The exited tab still shows the standard disconnect overlay, but not the
+    // session-lost variant.
+    expect(container.querySelector("[data-testid='terminal-session-lost']")).toBeNull();
+    expect(
+      container.querySelector("[data-testid='terminal-session-lost-new-shell-btn']")
+    ).toBeNull();
+  });
+});

--- a/src/components/Terminal/TerminalDisconnectOverlay.tsx
+++ b/src/components/Terminal/TerminalDisconnectOverlay.tsx
@@ -1,5 +1,14 @@
 import { useCallback, useEffect, useState } from "react";
-import { WifiOff, RefreshCw, X, AlertTriangle, Loader2, CheckCircle2 } from "lucide-react";
+import {
+  WifiOff,
+  RefreshCw,
+  X,
+  AlertTriangle,
+  Loader2,
+  CheckCircle2,
+  Unplug,
+  Plus,
+} from "lucide-react";
 import { useAppStore } from "@/store/appStore";
 import { useProjectedSessionLifecycle, useSessionAutoReconnect } from "@/store/useSessionLifecycle";
 import { Button, Tooltip } from "@/components/ui";
@@ -128,6 +137,8 @@ function AutoReconnectingOverlay({ tabId }: { tabId: string }) {
  * exits unexpectedly or while a reconnect is in progress.
  *
  * Variants (determined from store state, in priority order):
+ *   - "session-lost"   — terminal: live agent session unrecoverable, "start new
+ *                        shell" + view-scrollback buttons (#2512)
  *   - "auto-reconnect" — agentless resilient-reconnect countdown + Cancel (#1962)
  *   - "reconnecting"   — spinner, optional trigger error, Stop button
  *   - "error"          — error box, "Reconnect failed" heading, retry + view buttons
@@ -139,6 +150,7 @@ export function TerminalDisconnectOverlay({ tabId }: TerminalDisconnectOverlayPr
   const reconnectTerminal = useAppStore((s) => s.reconnectTerminal);
   const dismissTerminalDisconnect = useAppStore((s) => s.dismissTerminalDisconnect);
   const setTerminalExited = useAppStore((s) => s.setTerminalExited);
+  const startFreshShellForTab = useAppStore((s) => s.startFreshShellForTab);
   // Render cut (#2205 PR-A / #2442): the disconnect error, reconnect flag and the
   // reconnect-trigger error are all sourced from the projected `session-lifecycle`
   // region (falls back to appStore when it does not mirror). #2442 added the
@@ -148,6 +160,11 @@ export function TerminalDisconnectOverlay({ tabId }: TerminalDisconnectOverlayPr
   const disconnectError = lifecycle.disconnectError;
   const isReconnecting = lifecycle.reconnecting;
   const reconnectTriggerError = lifecycle.reconnectTriggerError;
+  // Terminal session-lost state (#2512): a resilient agent tab reconnected its
+  // transport but its live agent session could not be recovered. Sourced from the
+  // projected region (no appStore twin) and gated behind `sessionBackendReattach`.
+  const isSessionLost = lifecycle.sessionLost;
+  const sessionLostError = lifecycle.sessionLostError;
   // The auto-reconnect gate reads the same projected-with-fallback loop detail as
   // the countdown overlay itself, so the region drives which variant shows (#2204).
   const autoReconnectWaiting = useSessionAutoReconnect(tabId)?.phase === "waiting";
@@ -164,6 +181,75 @@ export function TerminalDisconnectOverlay({ tabId }: TerminalDisconnectOverlayPr
   const handleStop = useCallback(() => {
     setTerminalExited(tabId);
   }, [tabId, setTerminalExited]);
+
+  const handleStartNewShell = useCallback(() => {
+    startFreshShellForTab(tabId);
+  }, [tabId, startFreshShellForTab]);
+
+  // Session-lost (#2512) is terminal and takes precedence over every other
+  // variant: the live agent session could not be recovered, so the tab offers an
+  // explicit "start new shell" rather than a reconnect — never a silent new shell.
+  if (isSessionLost) {
+    return (
+      <div
+        className="terminal-disconnect-overlay terminal-disconnect-overlay--error"
+        data-testid="terminal-disconnect-overlay"
+      >
+        <Tooltip content="View scrollback" side="bottom">
+          <button
+            className="terminal-disconnect-overlay__dismiss"
+            onClick={handleDismiss}
+            aria-label="Dismiss and view scrollback"
+            data-testid="terminal-disconnect-dismiss-btn"
+          >
+            <X size={14} />
+          </button>
+        </Tooltip>
+
+        <div className="terminal-disconnect-overlay__body" data-testid="terminal-session-lost">
+          <Unplug
+            size={32}
+            className="terminal-disconnect-overlay__icon terminal-disconnect-overlay__icon--error"
+          />
+
+          <p className="terminal-disconnect-overlay__heading">Session lost</p>
+          <p className="terminal-disconnect-overlay__subheading">
+            The connection was restored, but the live session could not be recovered. Its process
+            has ended. Scrollback is preserved below.
+          </p>
+
+          {sessionLostError && (
+            <div
+              className="terminal-disconnect-overlay__error-box"
+              data-testid="terminal-session-lost-error-box"
+            >
+              <span className="terminal-disconnect-overlay__error-text">{sessionLostError}</span>
+            </div>
+          )}
+
+          <div className="terminal-disconnect-overlay__actions">
+            <Button
+              variant="primary"
+              size="sm"
+              icon={<Plus size={14} />}
+              onClick={handleStartNewShell}
+              data-testid="terminal-session-lost-new-shell-btn"
+            >
+              Start New Shell
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleDismiss}
+              data-testid="terminal-disconnect-view-btn"
+            >
+              View Scrollback
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   // Agentless resilient reconnect (#1962) takes precedence: while the backoff
   // loop is counting down, show the countdown/Cancel variant instead of the

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1052,6 +1052,15 @@ export interface AppState
 
   // Per-tab terminal session disconnects (runtime-only, cleared on reconnect, dismiss, or tab close)
   terminalExitedTabs: Record<string, boolean>;
+  /**
+   * Tabs whose next reconnect must start a **fresh** session rather than
+   * re-attach to a retained one (#2512). Set by {@link startFreshShellForTab} when
+   * the user picks "start new shell" on the session-lost notice: the reconnect
+   * effect consumes the flag and skips the backend re-attach / persistent-restart
+   * branches, going straight to a fresh `create_connection`. Runtime-only,
+   * one-shot (consumed by the effect).
+   */
+  terminalForceFreshReconnect: Record<string, boolean>;
   /** How each exited tab's session ended — drives the disconnect overlay wording (#1121). */
   terminalExitInfo: Record<string, TerminalExitInfo>;
   /**
@@ -1104,6 +1113,26 @@ export interface AppState
    * possibly divergent, second signal).
    */
   settleBackendReconnectGaveUp: (tabId: string, error: string) => void;
+
+  /**
+   * Settle a resilient agent tab into the terminal **session-lost** state (#2512):
+   * the backend re-established the transport on reconnect but the live agent
+   * session could not be recovered, so it folded `session.sessionLost` into the
+   * region. This reflects that locally — clearing the loop record + every in-flight
+   * connect flag and marking the tab exited so the disconnect overlay mounts and
+   * renders the projected session-lost notice (its "start new shell" action). Does
+   * NOT set a disconnect error (the notice sources its message from the region) and
+   * does NOT re-mirror any `session.*` intent (the backend already folded it).
+   */
+  settleSessionLost: (tabId: string) => void;
+
+  /**
+   * Start a fresh shell for a tab from the session-lost notice (#2512): arm the
+   * one-shot {@link terminalForceFreshReconnect} flag and drive a reconnect, so the
+   * effect creates a brand-new session (an explicit `create_connection`) instead of
+   * attempting to re-attach the unrecoverable one.
+   */
+  startFreshShellForTab: (tabId: string) => void;
 
   /**
    * Register the cohort of tabs placed by a restore/launch (#1146, audit G4).
@@ -5570,6 +5599,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
 
     // Per-tab terminal session disconnects (runtime-only)
     terminalExitedTabs: {},
+    terminalForceFreshReconnect: {},
     terminalExitInfo: {},
     intentionallyKilledSessions: {},
     terminalDisconnectErrors: {},
@@ -5686,6 +5716,43 @@ export const useAppStore = create<AppState>((set, get, store) => {
       if (deadKey && currentMonitorsView().monitors[deadKey]) {
         get().disconnectMonitoring(deadKey);
       }
+    },
+
+    settleSessionLost: (tabId) => {
+      // The backend folded `session.sessionLost` into the region (the live agent
+      // session was unrecoverable). Reflect it locally without re-mirroring an
+      // intent: clear the loop record + every in-flight connect flag so no
+      // competing overlay lingers, and mark the tab exited so the disconnect
+      // overlay mounts. Deliberately no `terminalDisconnectErrors` write — the
+      // session-lost variant sources its message from the projected region, and a
+      // disconnect error would otherwise drive the generic "Reconnect failed"
+      // variant.
+      set((state) => ({
+        terminalAutoReconnect: omitKey(state.terminalAutoReconnect, tabId),
+        terminalConnecting: omitKey(state.terminalConnecting, tabId),
+        terminalConnectDeadline: omitKey(state.terminalConnectDeadline, tabId),
+        terminalWaitingForAgent: omitKey(state.terminalWaitingForAgent, tabId),
+        terminalAutoRetryCount: omitKey(state.terminalAutoRetryCount, tabId),
+        terminalSpawnErrors: omitKey(state.terminalSpawnErrors, tabId),
+        terminalReconnectingTabs: omitKey(state.terminalReconnectingTabs, tabId),
+        terminalReconnectTriggerErrors: omitKey(state.terminalReconnectTriggerErrors, tabId),
+        terminalExitedTabs: { ...state.terminalExitedTabs, [tabId]: true },
+      }));
+      get().settleRestoreTab(tabId, "failed");
+      const deadKey = monitorKeyForTab(collectLiveTabs(get()).find((t) => t.id === tabId));
+      if (deadKey && currentMonitorsView().monitors[deadKey]) {
+        get().disconnectMonitoring(deadKey);
+      }
+    },
+
+    startFreshShellForTab: (tabId) => {
+      // Arm the one-shot force-fresh flag first so the reconnect effect (re-run by
+      // reconnectTerminal bumping the retry counter) reads it and skips the
+      // re-attach branch, creating a brand-new session instead.
+      set((state) => ({
+        terminalForceFreshReconnect: { ...state.terminalForceFreshReconnect, [tabId]: true },
+      }));
+      get().reconnectTerminal(tabId);
     },
 
     // Aggregate partial-restore feedback (#1146, audit G4) + bulk retry (#1227,

--- a/src/store/sessionBridge.agentReconnect.test.ts
+++ b/src/store/sessionBridge.agentReconnect.test.ts
@@ -91,6 +91,13 @@ const gaveUp = (error?: string): ProjectedSessionLifecycle => ({
   error,
 });
 
+const lost = (error?: string): ProjectedSessionLifecycle => ({
+  status: "sessionLost",
+  reconnect: { phase: "idle", attempt: 0, delayMs: 0 },
+  endReason: "unexpected",
+  error,
+});
+
 const flush = () => new Promise((r) => setTimeout(r, 0));
 
 let transport: FakeTransport;
@@ -174,5 +181,24 @@ describe("waitForBackendAgentReconnectOutcome", () => {
   it("resolves canceled when the effect is torn down", async () => {
     const outcome = await waitForBackendAgentReconnectOutcome("tab-7", null, () => true);
     expect(outcome).toEqual({ kind: "canceled" });
+  });
+
+  it("reports session-lost when the live agent session is unrecoverable (#2512)", async () => {
+    const pending = waitForBackendAgentReconnectOutcome("tab-8", "agent-old", never);
+    await flush();
+    transport.setSession("tab-8", reconnecting()); // parking — no resolution yet
+    await flush();
+    transport.setSession("tab-8", lost("the live agent session could not be recovered"));
+    expect(await pending).toEqual({
+      kind: "sessionLost",
+      error: "the live agent session could not be recovered",
+    });
+  });
+
+  it("reports session-lost with no error when the region carries none (#2512)", async () => {
+    transport.setSession("tab-9", lost());
+    await flush();
+    const outcome = await waitForBackendAgentReconnectOutcome("tab-9", "agent-old", never);
+    expect(outcome).toEqual({ kind: "sessionLost", error: undefined });
   });
 });

--- a/src/store/sessionBridge.ts
+++ b/src/store/sessionBridge.ts
@@ -60,7 +60,14 @@ export type ProjectedSessionStatus =
   | "connected"
   | "disconnected"
   | "reconnecting"
-  | "failed";
+  | "failed"
+  /** A resilient **agent** tab re-established its transport on reconnect, but the
+   * live agent session it was attached to could not be recovered (agent
+   * hard-restart / aged out / daemon died). Terminal state: the frontend renders
+   * an explicit "session lost" notice + a manual "start new shell" action rather
+   * than silently minting a replacement shell (#2512). Twin of Rust
+   * `SessionStatus::SessionLost`. */
+  | "sessionLost";
 
 /** Why a session left `connected` (twin of Rust `EndReason`). */
 export type ProjectedEndReason = "user" | "unexpected" | "error";
@@ -647,6 +654,10 @@ export type BackendAgentReconnectOutcome =
   /** The backend park/retry loop exhausted / the session was folded terminal —
    * settle the tab as disconnected (never fall through to the client engine). */
   | { kind: "giveup"; error?: string }
+  /** The transport was re-established but the live agent session could not be
+   * recovered (#2512): the tab folds to the explicit session-lost notice with a
+   * manual "start new shell" action — never a silent replacement shell. */
+  | { kind: "sessionLost"; error?: string }
   /** The effect was torn down (`isCanceled`) — abandon the wait, drive nothing. */
   | { kind: "canceled" };
 
@@ -692,6 +703,10 @@ export function waitForBackendAgentReconnectOutcome(
     // Success takes precedence: a fresh backend session id means the transport is
     // back, even if a stale phase field has not yet been recomputed.
     if (acceptId(life.sessionId)) return { kind: "reattach", sessionId: life.sessionId };
+    // The transport came back but the live agent session was unrecoverable
+    // (#2512): a distinct terminal outcome from a plain give-up — the frontend
+    // renders the explicit session-lost notice, never a silent new shell.
+    if (life.status === "sessionLost") return { kind: "sessionLost", error: life.error };
     if (life.reconnect.phase === "gaveup" || life.status === "failed") {
       return { kind: "giveup", error: life.error };
     }

--- a/src/store/useSessionLifecycle.ts
+++ b/src/store/useSessionLifecycle.ts
@@ -113,6 +113,14 @@ export interface ProjectedSessionLifecycleSlice {
   /** The reconnect-trigger cause shown while reconnecting, if any (mirrors
    * `terminalReconnectTriggerErrors`, #2442). */
   reconnectTriggerError: string | undefined;
+  /** True when the projected status is the terminal `sessionLost` state (#2512):
+   * a resilient agent tab reconnected its transport but its live agent session
+   * could not be recovered. Sourced directly from the region (no `appStore` twin —
+   * the state is only ever emitted server-side, behind `sessionBackendReattach`). */
+  sessionLost: boolean;
+  /** The backend-supplied "why the session could not be recovered" message shown
+   * in the session-lost notice, if any (#2512). `undefined` unless `sessionLost`. */
+  sessionLostError: string | undefined;
 }
 
 /**
@@ -166,11 +174,18 @@ export function useProjectedSessionLifecycle(tabId: string): ProjectedSessionLif
   }, [enabled, tabId]);
 
   const p = enabled ? projected : undefined;
+  // `sessionLost` has no `appStore` twin to gate against (it is emitted only
+  // server-side, behind `sessionBackendReattach`), so it is read straight from the
+  // region: present ⇒ terminal session-lost, absent ⇒ false. When the render cut
+  // is off `p` is `undefined`, so it stays `false` — inert on the pre-cut path.
+  const lost = p?.status === "sessionLost";
   return {
     connecting: effectiveConnecting(connectingLocal, p),
     reconnecting: effectiveReconnecting(reconnectingLocal, p),
     disconnectError: effectiveDisconnectError(disconnectErrorLocal, p),
     reconnectTriggerError: effectiveReconnectTriggerError(reconnectTriggerErrorLocal, p),
+    sessionLost: lost,
+    sessionLostError: lost ? p?.error : undefined,
   };
 }
 

--- a/src/test/sessionLifecycleRegionTestHarness.ts
+++ b/src/test/sessionLifecycleRegionTestHarness.ts
@@ -184,6 +184,21 @@ export function failed(
   return { status: "failed", reconnect: idleReconnect(), endReason, error };
 }
 
+/**
+ * A terminal `sessionLost` projected lifecycle (#2512): a resilient agent tab
+ * re-established its transport but the live agent session could not be recovered.
+ * Carries the backend "why" message; the reconnect loop is idle and there is no
+ * backend session id to re-attach to.
+ */
+export function sessionLost(error?: string): ProjectedSessionLifecycle {
+  return {
+    status: "sessionLost",
+    reconnect: idleReconnect(),
+    endReason: "unexpected",
+    ...(error !== undefined ? { error } : {}),
+  };
+}
+
 /** The idle reconnect detail (no loop active). */
 export function idleReconnect(): ProjectedReconnect {
   return { phase: "idle", attempt: 0, delayMs: 0 };


### PR DESCRIPTION
Frontend half of the agent live-reattach feature. Follow-up to #2512; builds on the backend core merged in #2513.

## What
When a resilient agent-hosted shell tab reconnects its transport but its **live agent session cannot be recovered** (agent hard-restart / aged out / daemon died), the backend now emits a terminal `sessionLost` state (#2513). This PR renders that state on the frontend:

- **Session-lost notice** — a clear "Session lost" overlay (highest-priority variant of `TerminalDisconnectOverlay`) with the backend `error` message and preserved scrollback, composed from the `ui/Button` primitive and existing overlay tokens.
- **"Start New Shell" action** — an explicit user-driven create (never a silent replacement shell). It arms a one-shot `terminalForceFreshReconnect` flag and drives a reconnect that skips every re-attach branch and does a fresh `create_connection`.
- **Wiring** — `waitForBackendAgentReconnectOutcome` now classifies `sessionLost` as a distinct terminal outcome (previously it would park forever); `Terminal.tsx` routes it to the new `settleSessionLost` store action (marks the tab exited, clears in-flight connect flags, deliberately sets no disconnect error so the notice sources its message from the region).

## Happy-path / item 4
Confirmed the happy-path re-attach is unchanged: on a successful reattach the backend mints a **fresh** desktop session id (`session/manager.rs:1535`, `uuid::Uuid::new_v4()`), so `waitForBackendReattachSessionId` / `waitForBackendAgentReconnectOutcome`'s exclude-prior-id guard is always satisfied — the id is never actually reused, so nothing needed changing there.

## Flag safety
All new behavior is gated behind the default-off `sessionBackendReattach` flag (the `sessionLost` status is only ever emitted server-side under it, and the projected slice reads `false` when the render cut is off). Flag OFF: byte-identical to develop.

## Tests
- `waitForBackendAgentReconnectOutcome` reports `sessionLost` (with and without an error message).
- Session-lost overlay render: notice + backend error box + "Start New Shell" button; no error box when the region carries none; the action calls `startFreshShellForTab`; the variant does not show for a non-lost session.
- Full frontend suite green (4935 tests), `pnpm build`, `pnpm run lint`, and prettier all pass.

Closes #2514

🤖 Generated with [Claude Code](https://claude.com/claude-code)