### PR TITLE
fix(backend): permit test-bridge websocket via csp in test mode (Part of #2480)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1584,7 +1584,18 @@ pub fn run() {
             commands::xserver::x_server_install_dependency,
             commands::xserver::x_server_connect_consent_reply,
         ])
-        .build(tauri::generate_context!())
+        .build({
+            let mut context = tauri::generate_context!();
+            // In WebSocket test-bridge mode, widen `connect-src` so the in-app
+            // bridge's `ws://127.0.0.1:<port>` client (`src/testbridge/wsClient.ts`)
+            // is permitted by the built bundle's secure-origin (`tauri://localhost`)
+            // CSP — otherwise WebKit rejects the socket with `SecurityError` and the
+            // automated full-app system-test lane never connects (#2480). This is a
+            // no-op unless `TERMIHUB_TEST_BRIDGE_PORT` is set, so the production /
+            // release CSP is byte-identical to `tauri.conf.json`.
+            utils::test_bridge::relax_csp_if_test_bridge(&mut context.config_mut().app.security.csp);
+            context
+        })
         .expect("error while building tauri application")
         .run(|app_handle, event| {
             // Shutdown breadcrumbs (#1570). The 2026-07-17 post-mortem could only

--- a/src-tauri/src/utils/test_bridge.rs
+++ b/src-tauri/src/utils/test_bridge.rs
@@ -15,6 +15,7 @@
 //! builds inject nothing and the bridge stays inert.
 
 use tauri::plugin::{Builder, TauriPlugin};
+use tauri::utils::config::Csp;
 use tauri::Runtime;
 
 /// Env var holding the runner's WebSocket port the app should connect out to.
@@ -104,6 +105,70 @@ pub fn is_test_bridge_enabled() -> bool {
     parse_port(std::env::var(TEST_BRIDGE_PORT_ENV).ok()).is_some()
 }
 
+/// Extra `connect-src` sources injected into the CSP under test-bridge mode so
+/// the in-app WebSocket client (`ws://127.0.0.1:<port>`, `src/testbridge/wsClient.ts`)
+/// can reach the runner's bridge server. The built app bundle runs from the
+/// secure origin `tauri://localhost`, whose production CSP only allows
+/// `connect-src 'self' ipc: http://ipc.localhost` — so WebKit rejects the raw
+/// `ws://` socket with `SecurityError` and the automated full-app system-test
+/// lane never connects (#2480). Merged in *only* when test-bridge mode is
+/// active; the production/release CSP is untouched.
+pub const TEST_BRIDGE_CSP_CONNECT_SRC: &str = "ws://127.0.0.1:* ws://localhost:*";
+
+/// Return `csp` with the test-bridge WebSocket sources
+/// ([`TEST_BRIDGE_CSP_CONNECT_SRC`]) merged into its `connect-src` directive.
+///
+/// Pure string transform so it can be unit-tested in isolation. The `connect-src`
+/// directive is widened in place (order preserved); if the policy has no
+/// `connect-src` directive, one is appended as `connect-src 'self' <sources>`.
+/// Sources already present are not duplicated. Directives are trimmed and
+/// re-joined with `"; "`.
+///
+/// This is only ever applied when the app is launched with
+/// `TERMIHUB_TEST_BRIDGE_PORT` set (see [`relax_csp_if_test_bridge`]); with the
+/// env var unset the CSP is never passed through here, so production output is
+/// byte-identical to `tauri.conf.json`.
+pub fn relax_csp_policy(csp: &str) -> String {
+    let mut directives: Vec<String> = csp
+        .split(';')
+        .map(|directive| directive.trim().to_string())
+        .filter(|directive| !directive.is_empty())
+        .collect();
+
+    if let Some(connect_src) = directives
+        .iter_mut()
+        .find(|directive| directive.split_whitespace().next() == Some("connect-src"))
+    {
+        for source in TEST_BRIDGE_CSP_CONNECT_SRC.split_whitespace() {
+            if !connect_src.split_whitespace().any(|token| token == source) {
+                connect_src.push(' ');
+                connect_src.push_str(source);
+            }
+        }
+    } else {
+        directives.push(format!("connect-src 'self' {TEST_BRIDGE_CSP_CONNECT_SRC}"));
+    }
+
+    directives.join("; ")
+}
+
+/// Widen `csp` in place for the test bridge **only when test-bridge mode is
+/// active** (`TERMIHUB_TEST_BRIDGE_PORT` names a valid port). This is the single
+/// gate that keeps the relaxation test-only: when the env var is unset this is a
+/// no-op and the CSP is left exactly as declared in `tauri.conf.json`, so no
+/// production or release bundle can ever ship the relaxed policy.
+///
+/// A `None` CSP (no policy configured) is left as-is — Tauri's default applies
+/// and there is nothing to widen.
+pub fn relax_csp_if_test_bridge(csp: &mut Option<Csp>) {
+    if !is_test_bridge_enabled() {
+        return;
+    }
+    if let Some(policy) = csp.as_mut() {
+        *policy = Csp::Policy(relax_csp_policy(&policy.to_string()));
+    }
+}
+
 /// Whether the operator has opted out of pinning the test window always-on-top
 /// (`TERMIHUB_TEST_NO_ALWAYS_ON_TOP` set to a truthy value). See #2504. Used only
 /// in test-bridge mode; production launches never pin the window regardless.
@@ -116,6 +181,7 @@ pub fn always_on_top_opt_out() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn init_script_sets_both_globals() {
@@ -202,9 +268,115 @@ mod tests {
         }
     }
 
+    /// The exact production `connect-src` from `tauri.conf.json`. If the config
+    /// changes, this constant must change too — the assertion below is a guard
+    /// that the relaxation widens the *current* production directive, not a
+    /// stale one.
+    const PROD_CSP: &str = "default-src 'self'; script-src 'self' plugin://localhost http://plugin.localhost 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost; worker-src 'self' blob:; child-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'none'";
+
     #[test]
+    fn relax_csp_adds_ws_sources_to_connect_src() {
+        let relaxed = relax_csp_policy(PROD_CSP);
+        // The bridge WebSocket sources are now permitted.
+        assert!(relaxed.contains("ws://127.0.0.1:*"));
+        assert!(relaxed.contains("ws://localhost:*"));
+        // They land on connect-src, not some other directive.
+        let connect_src = relaxed
+            .split(';')
+            .map(str::trim)
+            .find(|d| d.starts_with("connect-src"))
+            .expect("connect-src directive present");
+        assert!(connect_src.contains("ws://127.0.0.1:*"));
+        assert!(connect_src.contains("ws://localhost:*"));
+        // The original sources are preserved.
+        assert!(connect_src.contains("'self'"));
+        assert!(connect_src.contains("ipc:"));
+        assert!(connect_src.contains("http://ipc.localhost"));
+        // Only connect-src is touched — other directives are unchanged.
+        assert!(relaxed.contains("default-src 'self'"));
+        assert!(relaxed.contains("object-src 'none'"));
+        // No ws:// leaks into any non-connect-src directive.
+        for directive in relaxed.split(';').map(str::trim) {
+            if !directive.starts_with("connect-src") {
+                assert!(
+                    !directive.contains("ws://"),
+                    "ws:// leaked into `{directive}`"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn relax_csp_is_idempotent() {
+        let once = relax_csp_policy(PROD_CSP);
+        let twice = relax_csp_policy(&once);
+        // Re-applying does not duplicate the sources.
+        assert_eq!(once.matches("ws://127.0.0.1:*").count(), 1);
+        assert_eq!(twice.matches("ws://127.0.0.1:*").count(), 1);
+        assert_eq!(twice.matches("ws://localhost:*").count(), 1);
+    }
+
+    #[test]
+    fn relax_csp_appends_connect_src_when_absent() {
+        let relaxed = relax_csp_policy("default-src 'self'; img-src 'self' data:");
+        let connect_src = relaxed
+            .split(';')
+            .map(str::trim)
+            .find(|d| d.starts_with("connect-src"))
+            .expect("connect-src directive appended");
+        assert!(connect_src.contains("'self'"));
+        assert!(connect_src.contains("ws://127.0.0.1:*"));
+        assert!(connect_src.contains("ws://localhost:*"));
+    }
+
+    #[test]
+    #[serial(test_bridge_port_env)]
+    fn relax_csp_if_test_bridge_only_widens_when_enabled() {
+        // Serialise on the process-global env var this and the enabled-tracker
+        // test both mutate.
+        let key = TEST_BRIDGE_PORT_ENV;
+        let saved = std::env::var(key).ok();
+
+        // Env unset → CSP left byte-identical to production.
+        unsafe { std::env::remove_var(key) };
+        let mut csp = Some(Csp::Policy(PROD_CSP.to_string()));
+        relax_csp_if_test_bridge(&mut csp);
+        assert_eq!(
+            csp,
+            Some(Csp::Policy(PROD_CSP.to_string())),
+            "unset env must leave the production CSP untouched"
+        );
+
+        // Env set → the ws:// sources are merged in.
+        unsafe { std::env::set_var(key, "48123") };
+        let mut csp = Some(Csp::Policy(PROD_CSP.to_string()));
+        relax_csp_if_test_bridge(&mut csp);
+        match csp {
+            Some(Csp::Policy(policy)) => {
+                assert!(policy.contains("ws://127.0.0.1:*"));
+                assert!(policy.contains("ws://localhost:*"));
+            }
+            other => panic!("expected a widened policy, got {other:?}"),
+        }
+
+        // A `None` CSP is never fabricated, even under the test bridge.
+        let mut none_csp: Option<Csp> = None;
+        relax_csp_if_test_bridge(&mut none_csp);
+        assert_eq!(none_csp, None);
+
+        match saved {
+            Some(v) => unsafe { std::env::set_var(key, v) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+    }
+
+    #[test]
+    #[serial(test_bridge_port_env)]
     fn is_test_bridge_enabled_tracks_the_env_var() {
-        // Mutates a process-global env var; no other test reads this key.
+        // Mutates a process-global env var; shared with
+        // `relax_csp_if_test_bridge_only_widens_when_enabled` — serialised via
+        // `#[serial(test_bridge_port_env)]` so the two never race under parallel
+        // `cargo test`.
         let key = TEST_BRIDGE_PORT_ENV;
         let saved = std::env::var(key).ok();
         unsafe { std::env::set_var(key, "48123") };


### PR DESCRIPTION
## Problem

The automated full-app system-test lane (`tests/system/`, e.g. `test_agent_reconnect_live.py`) launches the **built app bundle**, whose frontend runs from the secure origin `tauri://localhost`. The bundle CSP in `tauri.conf.json` is:

```
connect-src 'self' ipc: http://ipc.localhost
```

It does **not** permit `ws://`, so WebKit rejects the test bridge's raw browser WebSocket (`src/testbridge/wsClient.ts` → `new WebSocket("ws://127.0.0.1:<port>")`) with `SecurityError: The operation is insecure`, and `bridge.wait_for_app` times out. Dev mode (`http://localhost:1420`) relaxes CSP, which is why manual `scripts/dev.sh` runs connect but the bundle-based automated lane does not.

## Fix — test-only CSP relaxation

Widen `connect-src` with `ws://127.0.0.1:* ws://localhost:*` **only when the app is launched in test-bridge mode** (`TERMIHUB_TEST_BRIDGE_PORT` set — never in production/release). Mechanism:

- `src-tauri/src/utils/test_bridge.rs`: pure `relax_csp_policy(&str) -> String` (widens the `connect-src` directive in place, idempotent, no duplicates) + `relax_csp_if_test_bridge(&mut Option<Csp>)`, which is a **no-op unless `is_test_bridge_enabled()`** (the same `TERMIHUB_TEST_BRIDGE_PORT` gate already used for the init-script and always-on-top plumbing).
- `src-tauri/src/lib.rs`: applied to the generated context's CSP just before `.build(...)`.

**Env unset → CSP byte-identical to `tauri.conf.json`.** The gate never passes the CSP through the transform in normal use, so no production/release bundle can ship the relaxed policy. The transport (`wsClient.ts`) is unchanged — only CSP is widened, per the maintainer's chosen approach (not the IPC-reroute alternative).

## Tests

New `test_bridge`-module unit tests: ws sources land on `connect-src` (not elsewhere, no `ws://` leak into other directives), original sources preserved, idempotent, appended when absent, and the gate widens **only** when the env var is set / leaves the production CSP untouched when unset / never fabricates a `None` CSP. The two tests sharing `TERMIHUB_TEST_BRIDGE_PORT` are serialised via `#[serial(test_bridge_port_env)]`. `cargo test -p termihub test_bridge`, clippy `-D warnings`, and `cargo fmt --check` all green.

## Not covered here (coordinator/manual follow-up)

The end-to-end "app actually connects to the bridge" verification needs a real display session (the GUI won't run headless here). This PR proves the CSP is correctly conditional by unit test + reasoning; the live system-test-lane green run + `#2480` un-gating/close-out remain.

Part of #2480

🤖 Generated with [Claude Code](https://claude.com/claude-code)