### PR TITLE
fix(agent): harden registry-daemon spawn off-thread + initialize/handshake diagnostics (Part of #2480)

### DIFF
--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -17,7 +17,7 @@ use jsonrpsee::types::ErrorObjectOwned;
 use semver::Version as SemverVersion;
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use termihub_core::tool::{CollectingHost, ToolRegistry};
 use tokio_util::sync::CancellationToken;
@@ -483,6 +483,16 @@ fn register_initialize(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::R
             .parse()
             .map_err(|e| invalid_params("initialize", e))?;
 
+        // Diagnostic for #2480: INFO-level bookend so a full-app display run can
+        // see the `initialize` request arrive on the agent (the transport loop's
+        // "Received:" line is DEBUG-gated and hidden at the default INFO filter).
+        // Pairs with "initialize: responding" below — a gap between the two
+        // localises a stall to the agent's initialize handler.
+        info!(
+            "initialize: request received from client={} version={} protocol={}",
+            p.client, p.client_version, p.protocol_version
+        );
+
         // Negotiate the version both sides will speak: the highest version the
         // agent supports that does not exceed the client's request, sharing the
         // agent's major (docs/remote-protocol.md → Version Negotiation). An
@@ -519,6 +529,13 @@ fn register_initialize(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::R
             // an agent binary swap would otherwise kill without warning.
             // Fire-and-forget: a missing registry must never fail `initialize`.
             if let Some(registry) = s.registry_client.get() {
+                // Diagnostic for #2480: this call is fire-and-forget (it only
+                // hands a command to the background supervisor), so it must never
+                // be where `initialize` stalls — the log confirms it returns.
+                debug!(
+                    "initialize: announcing client {} to host registry",
+                    client_id
+                );
                 registry.register(ClientRecord {
                     client_id: entry.client_id.clone(),
                     client: entry.client.clone(),
@@ -557,6 +574,10 @@ fn register_initialize(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::R
             Vec::new()
         };
         let connection_types = session_manager.registry().available_types();
+
+        // Diagnostic for #2480: the handler has finished all its work and is
+        // handing the result back to the transport loop to serialise + flush.
+        info!("initialize: responding to client (docker_available={docker_available})");
 
         Ok::<_, ErrorObjectOwned>(
             serde_json::to_value(InitializeResult {

--- a/agent/src/handler/dispatch.rs
+++ b/agent/src/handler/dispatch.rs
@@ -554,16 +554,28 @@ fn register_initialize(module: &mut RpcModule<Mutex<HandlerState>>) -> anyhow::R
             )
         };
 
+        // Diagnostic step-trace for #2480: the local repro proves the registry
+        // path never blocks `initialize` (fresh spawn, fd-clean daemon, and even
+        // a wedged registry all respond in ~2 ms), so if a full-app run stalls
+        // between "request received" and "responding" it is one of the awaits
+        // below. These per-step logs localise which one on the next display run.
+        debug!("initialize: applying persistent buffer size");
         session_manager
             .set_persistent_buffer_size_bytes(buffer_size)
             .await;
 
         if !p.external_connection_files.is_empty() {
+            info!(
+                "initialize: loading {} external connection file(s)",
+                p.external_connection_files.len()
+            );
             connection_store
                 .load_external_files(&p.external_connection_files)
                 .await;
+            debug!("initialize: external connection files loaded");
         }
 
+        debug!("initialize: probing docker availability");
         let docker_available = detect_docker_available().await;
         // Only enumerate images when the daemon already answered the probe
         // quickly — this keeps `initialize` from blocking on `docker images`

--- a/agent/src/registry_daemon/client.rs
+++ b/agent/src/registry_daemon/client.rs
@@ -75,6 +75,39 @@ const CONNECT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 /// trying again. Bounds the respawn rate when a registry cannot start at all.
 const RECONNECT_DELAY: Duration = Duration::from_secs(2);
 
+/// Env var that suppresses the detached registry-daemon spawn (#2480).
+///
+/// A `--stdio` agent serving a **single** desktop client does not need the
+/// ADR-11 cross-worker "who is attached" registry — that only matters when
+/// several agent processes on one host must see each other. The system-test
+/// harness stands up exactly one throwaway-sshd agent per session, so it sets
+/// this to opt that session out of spawning the detached registry daemon.
+///
+/// When set to a truthy value (`1` / `true` / `yes`) [`RegistryConfig::default`]
+/// disables [`auto_spawn`](RegistryConfig::auto_spawn): the worker still connects
+/// to a registry that already happens to be listening, but it never *spawns* one,
+/// and [`list`](RegistryClient::list) falls back to the per-process view — the
+/// same behaviour as a host where no registry is reachable. Unset (the
+/// production default) the behaviour is byte-identical to before this flag
+/// existed.
+pub const SKIP_REGISTRY_DAEMON_ENV: &str = "TERMIHUB_AGENT_SKIP_REGISTRY_DAEMON";
+
+/// Parse a [`SKIP_REGISTRY_DAEMON_ENV`]-style value into a skip decision.
+///
+/// Truthy (`1` / `true` / `yes`) → skip the spawn. Anything else — absent,
+/// empty, or any other string — means "do not skip", so production (env unset)
+/// is byte-identical to the pre-flag behaviour. Pulled out as a pure function so
+/// the decision is unit-testable without mutating the process environment.
+fn skip_from_env(raw: Option<&str>) -> bool {
+    matches!(raw, Some("1") | Some("true") | Some("yes"))
+}
+
+/// Whether this process should suppress the registry-daemon spawn, read from
+/// [`SKIP_REGISTRY_DAEMON_ENV`].
+fn skip_registry_daemon() -> bool {
+    skip_from_env(std::env::var(SKIP_REGISTRY_DAEMON_ENV).ok().as_deref())
+}
+
 /// How the worker reaches its registry.
 #[derive(Debug, Clone)]
 pub struct RegistryConfig {
@@ -82,9 +115,11 @@ pub struct RegistryConfig {
     pub endpoint: String,
     /// Whether a failed connect may spawn a registry daemon.
     ///
-    /// Always `true` in production. Tests that run the registry in-process set
-    /// it to `false` so a failure surfaces as a failure rather than silently
-    /// spawning a real detached process from the test binary.
+    /// `true` in production by default. Tests that run the registry in-process
+    /// set it to `false` so a failure surfaces as a failure rather than silently
+    /// spawning a real detached process from the test binary. It is also forced
+    /// to `false` when [`SKIP_REGISTRY_DAEMON_ENV`] is set (single-client
+    /// sessions that do not need the ADR-11 registry — see that constant).
     pub auto_spawn: bool,
 }
 
@@ -92,7 +127,10 @@ impl Default for RegistryConfig {
     fn default() -> Self {
         Self {
             endpoint: registry_endpoint(),
-            auto_spawn: true,
+            // A single-client session (the system-test harness) opts out of the
+            // detached registry-daemon spawn via the env var; production leaves
+            // it unset, so this is `true` exactly as before (#2480).
+            auto_spawn: !skip_registry_daemon(),
         }
     }
 }
@@ -128,6 +166,16 @@ impl RegistryClient {
         notification_tx: NotificationSender,
         shutdown: CancellationToken,
     ) -> Self {
+        // Diagnostic for #2480: make the single-client opt-out visible at INFO in
+        // the agent's stderr so a full-app display run can confirm the harness
+        // env reached the agent and the registry-daemon spawn was suppressed.
+        if !config.auto_spawn {
+            info!(
+                "Registry-daemon auto-spawn disabled ({} set) — single-client session, \
+                 not spawning the host-wide registry",
+                SKIP_REGISTRY_DAEMON_ENV
+            );
+        }
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
         tokio::spawn(supervise(config, cmd_rx, notification_tx, shutdown));
         Self { cmd_tx }
@@ -532,6 +580,43 @@ mod tests {
         );
 
         assert_eq!(client.list().await, None);
+    }
+
+    /// The single-client opt-out (#2480): a truthy [`SKIP_REGISTRY_DAEMON_ENV`]
+    /// value disables the spawn, everything else leaves it enabled — so an unset
+    /// env (production) is byte-identical to the pre-flag default.
+    #[test]
+    fn skip_from_env_only_trips_on_truthy_values() {
+        for truthy in ["1", "true", "yes"] {
+            assert!(
+                skip_from_env(Some(truthy)),
+                "{truthy:?} should suppress the registry-daemon spawn"
+            );
+        }
+        for falsy in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("false"),
+            Some("no"),
+            Some("on"),
+        ] {
+            assert!(
+                !skip_from_env(falsy),
+                "{falsy:?} must not suppress the spawn (production default is unset)"
+            );
+        }
+    }
+
+    /// With the skip env unset, [`RegistryConfig::default`] must keep
+    /// `auto_spawn` on — the production path is unchanged by the new flag.
+    #[test]
+    fn default_config_keeps_auto_spawn_on_without_the_skip_env() {
+        // This test process does not set the env var, so the default must spawn.
+        assert!(
+            RegistryConfig::default().auto_spawn,
+            "production default (env unset) must still auto-spawn the registry"
+        );
     }
 
     #[test]

--- a/agent/src/registry_daemon/client.rs
+++ b/agent/src/registry_daemon/client.rs
@@ -306,8 +306,18 @@ async fn connect_or_spawn(config: &RegistryConfig) -> std::io::Result<(BoxedRead
     // Nothing listening — start one. Several workers may reach this at once;
     // the losers' daemons exit on `AddrInUse` and everyone connects to the
     // winner, so no locking is needed (see `process::run_registry_daemon`).
-    if let Err(e) = spawn_registry_daemon() {
-        warn!("Failed to spawn registry daemon: {e}");
+    //
+    // The spawn is a synchronous `fork`+`exec` of a full binary; on a loaded
+    // host that can take non-trivial time (copy-on-write page-table setup), so
+    // it runs on the blocking pool rather than occupying a runtime worker thread
+    // the transport loop shares. This supervisor already runs on its own task
+    // off the `initialize` critical path, but keeping the fork off the async
+    // workers entirely is cheap insurance that a slow spawn can never add
+    // latency to request handling (#2480 hardening).
+    match tokio::task::spawn_blocking(spawn_registry_daemon).await {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => warn!("Failed to spawn registry daemon: {e}"),
+        Err(e) => warn!("Registry daemon spawn task panicked: {e}"),
     }
     ipc::connect_with_retry(
         &config.endpoint,

--- a/agent/tests/registry_daemon_integration.rs
+++ b/agent/tests/registry_daemon_integration.rs
@@ -93,10 +93,26 @@ impl Drop for RegistryProcess {
 /// assertion. Binding `:0` in the agent itself closes the window completely:
 /// the port cannot be taken because it is never free.
 fn spawn_agent(registry_endpoint: &str) -> AgentProcess {
-    let mut child = Command::new(agent_binary())
+    spawn_agent_inner(registry_endpoint, false)
+}
+
+/// Like [`spawn_agent`] but with `TERMIHUB_AGENT_SKIP_REGISTRY_DAEMON=1`, the
+/// single-client opt-out the system-test harness sets (#2480). The agent must
+/// still serve `initialize`/RPC, but must never spawn a registry daemon.
+fn spawn_agent_skipping_registry(registry_endpoint: &str) -> AgentProcess {
+    spawn_agent_inner(registry_endpoint, true)
+}
+
+fn spawn_agent_inner(registry_endpoint: &str, skip_registry_daemon: bool) -> AgentProcess {
+    let mut command = Command::new(agent_binary());
+    command
         .arg("--listen")
         .arg("127.0.0.1:0")
-        .env("TERMIHUB_REGISTRY_ENDPOINT", registry_endpoint)
+        .env("TERMIHUB_REGISTRY_ENDPOINT", registry_endpoint);
+    if skip_registry_daemon {
+        command.env("TERMIHUB_AGENT_SKIP_REGISTRY_DAEMON", "1");
+    }
+    let mut child = command
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
@@ -460,6 +476,55 @@ fn a_worker_spawns_the_registry_when_none_is_running() {
     );
     // The auto-spawned registry is not ours to kill — it exits on its own once
     // idle. Its endpoint is unique to this test, so it can affect nothing else.
+}
+
+/// The single-client opt-out (#2480): with `TERMIHUB_AGENT_SKIP_REGISTRY_DAEMON`
+/// set, a worker that finds no registry must **not** spawn one, yet must still
+/// serve the desktop — `initialize` succeeds and the per-process fallback view
+/// reports the client. This is the headless proof (over a direct TCP transport,
+/// no SSH) that suppressing the ADR-11 registry-daemon spawn leaves the connect
+/// path intact; it is the exact inverse of
+/// [`a_worker_spawns_the_registry_when_none_is_running`].
+#[test]
+fn a_worker_with_the_skip_env_never_spawns_the_registry_but_still_serves() {
+    let dir = TempDir::new().expect("temp dir");
+    let endpoint = unique_endpoint(&dir, "skip");
+    assert!(
+        !endpoint_reachable(&endpoint),
+        "test must start with no registry"
+    );
+
+    // A single agent with the opt-out env set — the harness's single-client shape.
+    let agent = spawn_agent_skipping_registry(&endpoint);
+    let mut desktop = Client::connect(&agent.addr);
+
+    // The connect path is unaffected: initialize completes and returns a client_id.
+    let client_id = desktop.initialize("skip-desktop");
+    assert!(
+        !client_id.is_empty(),
+        "initialize must still succeed with the registry-daemon spawn suppressed"
+    );
+
+    // The host-wide registry never answers (none was spawned), so
+    // `list_connections` falls back to this worker's per-process view — which
+    // still includes the connected desktop.
+    assert_eq!(
+        wait_for_connections(&mut desktop, &["skip-desktop"]),
+        vec!["skip-desktop"],
+        "the per-process fallback must still report the connected client"
+    );
+
+    // The decisive assertion: nothing ever bound the registry endpoint. Poll a
+    // short window so a (buggy) delayed spawn would still be caught, then confirm
+    // the endpoint stayed unreachable the whole time.
+    let watch_deadline = Instant::now() + Duration::from_secs(3);
+    while Instant::now() < watch_deadline {
+        assert!(
+            !endpoint_reachable(&endpoint),
+            "the skip env must prevent any registry-daemon spawn ({endpoint} became reachable)"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
 }
 
 /// A desktop that disconnects must stop being reported host-wide — otherwise

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -17,7 +17,7 @@ use tauri::{AppHandle, Emitter};
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use termihub_core::backends::ssh::handler::SshSession;
 use termihub_core::monitoring::{MonitoringSender, SystemStats};
@@ -1738,6 +1738,16 @@ async fn read_handshake_line(
         }
         match channel.wait().await {
             Some(ChannelMsg::Data { ref data }) => {
+                // Diagnostic for #2480: confirms the desktop is actually
+                // receiving the agent's stdout (the initialize response) over the
+                // SSH channel. A run that logs "awaiting response" but never this
+                // means the bytes are not arriving — a transport/channel issue,
+                // not the agent's initialize handler.
+                info!(
+                    "Agent {}: handshake received {} stdout byte(s) over the channel",
+                    agent_id,
+                    data.len()
+                );
                 buf.push_str(&String::from_utf8_lossy(data));
             }
             Some(ChannelMsg::ExtendedData { ref data, ext: 1 }) => {
@@ -1748,7 +1758,10 @@ async fn read_handshake_line(
                     String::from_utf8_lossy(data)
                 );
             }
-            Some(ChannelMsg::Eof) | None => return None,
+            Some(ChannelMsg::Eof) | None => {
+                info!("Agent {}: channel EOF/closed during handshake", agent_id);
+                return None;
+            }
             Some(ChannelMsg::ExitStatus { exit_status }) => {
                 warn!(
                     "Agent {}: process exited with status {} during handshake",
@@ -1756,7 +1769,11 @@ async fn read_handshake_line(
                 );
                 return None;
             }
-            _ => {}
+            other => {
+                // Any other channel message (window adjust, success, etc.). Logged
+                // at DEBUG so a stalled handshake still shows what russh delivered.
+                debug!("Agent {}: handshake channel message: {:?}", agent_id, other);
+            }
         }
     }
 }

--- a/src-tauri/src/terminal/agent_manager.rs
+++ b/src-tauri/src/terminal/agent_manager.rs
@@ -684,10 +684,22 @@ impl AgentConnectionManager {
                     TerminalError::RemoteError(format!("Serialize initialize failed: {}", e))
                 })?;
 
+            // Diagnostic for #2480: bookend the handshake at INFO so a full-app
+            // display run can see whether the stall is before the `initialize`
+            // write, or while awaiting the response line from the agent. Pairs
+            // with the "initialize response received" log after the loop below.
+            info!(
+                "Agent {}: exec launched, sending initialize over the SSH channel",
+                agent_id_str
+            );
             channel.data(req_line.as_bytes()).await.map_err(|e| {
                 emit_agent_state(&app_handle_clone, &agent_id_str, "disconnected");
                 TerminalError::RemoteError(format!("Write initialize failed: {}", e))
             })?;
+            info!(
+                "Agent {}: initialize written, awaiting response line from agent",
+                agent_id_str
+            );
 
             // Read the initialize response from the channel. The agent may emit
             // notifications before it answers (e.g. output from a session it
@@ -754,6 +766,14 @@ impl AgentConnectionManager {
                             .to_string();
                         // Copy agent_version into capabilities so the UI can read it.
                         capabilities.agent_version = agent_version.clone();
+                        // Diagnostic for #2480: the handshake completed — the
+                        // agent's initialize response reached the desktop. If a
+                        // display run reaches this line the transport round-trip
+                        // is healthy and any remaining stall is downstream.
+                        info!(
+                            "Agent {}: initialize response received (agent v{}, protocol {}); marking connected",
+                            agent_id_str, agent_version, protocol_version
+                        );
                         break (capabilities, agent_version, protocol_version, client_id);
                     }
                     jsonrpc::HandshakeOutcome::Rejected(message) => {

--- a/tests/system/termihub_harness/local_agent.py
+++ b/tests/system/termihub_harness/local_agent.py
@@ -212,14 +212,10 @@ class LocalAgentSshd:
         # Mirrors scripts/dev.sh: loopback-only, key auth only, no PAM/strict-modes
         # so it runs unprivileged.
         #
-        # SetEnv injects TERMIHUB_AGENT_SKIP_REGISTRY_DAEMON into every session so
-        # the `termihub-agent --stdio` the desktop execs opts out of spawning the
-        # ADR-11 host-wide registry daemon (#2480). This session serves exactly
-        # one desktop client, which never needs the cross-worker "who is attached"
-        # registry, and suppressing its detached spawn keeps the agent-over-
-        # throwaway-sshd connect path clean. sshd builds its session environment
-        # from scratch (it does not pass its own env through), so SetEnv — not the
-        # launcher's env — is what actually reaches the exec'd agent.
+        # The agent runs with the ADR-11 host-wide registry daemon ON here (the
+        # default), so post-drop session recovery is genuinely exercised — the
+        # single-client skip option (#2480) exists but is deliberately NOT wired
+        # in, because recovery must work with the registry present.
         self._config.write_text(
             "\n".join(
                 [
@@ -232,7 +228,6 @@ class LocalAgentSshd:
                     "PasswordAuthentication no",
                     "PubkeyAuthentication yes",
                     "StrictModes no",
-                    "SetEnv TERMIHUB_AGENT_SKIP_REGISTRY_DAEMON=1",
                     "LogLevel ERROR",
                     "",
                 ]

--- a/tests/system/termihub_harness/local_agent.py
+++ b/tests/system/termihub_harness/local_agent.py
@@ -211,6 +211,15 @@ class LocalAgentSshd:
     def _write_config(self) -> None:
         # Mirrors scripts/dev.sh: loopback-only, key auth only, no PAM/strict-modes
         # so it runs unprivileged.
+        #
+        # SetEnv injects TERMIHUB_AGENT_SKIP_REGISTRY_DAEMON into every session so
+        # the `termihub-agent --stdio` the desktop execs opts out of spawning the
+        # ADR-11 host-wide registry daemon (#2480). This session serves exactly
+        # one desktop client, which never needs the cross-worker "who is attached"
+        # registry, and suppressing its detached spawn keeps the agent-over-
+        # throwaway-sshd connect path clean. sshd builds its session environment
+        # from scratch (it does not pass its own env through), so SetEnv — not the
+        # launcher's env — is what actually reaches the exec'd agent.
         self._config.write_text(
             "\n".join(
                 [
@@ -223,6 +232,7 @@ class LocalAgentSshd:
                     "PasswordAuthentication no",
                     "PubkeyAuthentication yes",
                     "StrictModes no",
+                    "SetEnv TERMIHUB_AGENT_SKIP_REGISTRY_DAEMON=1",
                     "LogLevel ERROR",
                     "",
                 ]


### PR DESCRIPTION
Part of #2480.

## What changed since the first revision

The first revision skipped the registry daemon in the harness. Live-run feedback: that made connect fast but broke post-drop **session recovery**, and suggested the registry-spawn path was blocking `initialize`. I re-investigated with a **local repro** (real throwaway sshd + the built agent) and the mechanism turned out to be different — see findings. This revision keeps the registry **ON**, hardens the spawn, and adds the diagnostics needed to pinpoint the true stall on a display run.

## Empirical root-cause findings (local repro over a real throwaway sshd)

Three controlled tests, all against a throwaway loopback sshd running `termihub-agent --stdio` (isolated registry endpoint via `TERMIHUB_REGISTRY_ENDPOINT`):

1. **Fresh registry spawn** (registry ON, none running): the agent logs `Spawned registry daemon` **and** responds to `initialize` in **~2 ms**; the openssh client receives the full response; the registry daemon binds its socket.
2. **fd inspection of the spawned registry daemon** (`lsof`): its fds are `0→/dev/null`, `1→/dev/null`, `2→registry.log`, plus its **own** kqueues and registry socket. It holds **no** sshd channel pipe/socket. The fd-inheritance hypothesis is disproven.
3. **Wedged/contended registry** (a listener that accepts but never replies, simulating the shared per-user socket): `initialize` **still** responds in ~2 ms.

Conclusion: the registry (spawn, fd inheritance, or contention) is **not** on the `initialize` critical path. `RegistryClient::register` is genuinely fire-and-forget (an unbounded channel send to a background supervisor task), and `recover_sessions` reconnects to persisted **session-daemon** sockets from `state.json` — it does **not** use the registry daemon. So neither "spawn blocks initialize" nor "skip breaks recovery" is explained by the registry code itself; the full-app stall differs in some other variable (russh vs openssh, the reconnect recovery path, or environment). The added diagnostics are designed to isolate it on the next display run.

## Changes

1. **Keep the registry ON; harden the spawn** — the synchronous `fork`+`exec` now runs on the blocking pool via `spawn_blocking`, so a slow fork on a loaded host can never occupy a runtime worker the transport loop shares. (Defensive; the supervisor already runs off the `initialize` path.)
2. **Harness no longer wires the skip** — `local_agent.py` runs with the registry ON so post-drop recovery is genuinely exercised. The `TERMIHUB_AGENT_SKIP_REGISTRY_DAEMON` env option remains as an **inert, off-by-default** capability (covered by a headless test).
3. **Granular diagnostics (kept):**
   - Agent `initialize` handler: `initialize: request received …`, per-step logs (`applying persistent buffer size`, `loading N external connection file(s)`, `probing docker availability`), and `initialize: responding …`.
   - Desktop handshake read loop: logs each russh `ChannelMsg` — `handshake received N stdout byte(s)`, `channel EOF/closed`, and other messages at DEBUG — plus `sending initialize` / `awaiting response` / `initialize response received … marking connected`.

## What to grep for on the next display run

- Agent side: does it log `initialize: responding`? If `request received` appears but not `responding`, note the **last** per-step log (`applying persistent buffer size` / `loading N external connection file(s)` / `probing docker availability`) — that pinpoints the blocking await. My repro shows all of these complete in ~2 ms, so a stall here would be a full-app-only difference (e.g. `load_external_files` — the app sends real external connection files; the repro sends none).
- Desktop side: after `awaiting response`, does `handshake received N stdout byte(s)` appear? If the agent logged `responding` but the desktop never logs received bytes, the stall is in the **transport/channel** (russh), not the agent.

## Verification

- `cargo build -p termihub-agent -p termihub`, `cargo clippy -p termihub-agent -p termihub --tests -- -D warnings`, `cargo fmt --check` all green.
- `cargo test -p termihub-agent --test registry_daemon_integration` — 13/13 (incl. the inert skip-option test).
- Local repro: agent responds + registry binds with the hardened spawn.
- **Cannot verify the full-app connect+recovery here** (needs a display session). The diagnostics above are built to localise the true stall on the maintainer's `launchctl asuser` run.