### PR TITLE
test(system): log-based full-app agent-reconnect suite (Part of #2480, #2512)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -125,6 +125,9 @@ objc2-foundation = { version = "0.3", features = [
     "NSUserDefaults",
     "NSString",
     "NSArray",
+    # Hold an NSProcessInfo activity assertion under the test bridge so macOS
+    # App Nap never throttles the headless E2E app (see utils::macos_unthrottle).
+    "NSProcessInfo",
 ] }
 # Native Cocoa Services provider for the app-level "Open in termiHub"
 # Services-menu entry (#1409): register on NSApp.servicesProvider and read the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -279,6 +279,18 @@ pub fn run() {
         spawn::Command::None => None,
     };
 
+    // Under the headless test bridge on macOS, turn off AppKit window occlusion
+    // detection *before* NSApplication launches (it reads this user default
+    // while launching). Without it, macOS marks the unfocused test window
+    // occluded and WebKit throttles the page's timers, stalling the
+    // frontend-driven agent-reconnect engine (#2480). setup() runs too late for
+    // this default, so it must happen here. macOS-only, test-bridge-only, so
+    // production/default is byte-identical.
+    #[cfg(target_os = "macos")]
+    if utils::test_bridge::is_test_bridge_enabled() {
+        utils::macos_unthrottle::pre_launch_disable_occlusion_detection();
+    }
+
     let log_buffer = create_log_buffer();
     let capture_layer = LogCaptureLayer::new(log_buffer.clone());
     let app_handle_slot = capture_layer.app_handle_slot();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -420,6 +420,16 @@ pub fn run() {
                         info!("Test window pinned always-on-top (anti-occlusion, #957)");
                     }
                 }
+
+                // Always-on-top alone does not stop macOS from throttling the
+                // WKWebView once the app is unfocused/occluded (App Nap +
+                // window-occlusion detection), which stalls the frontend-driven
+                // agent-reconnect logic during a headless E2E run (#2480). Hold
+                // an NSProcessInfo activity assertion and turn off AppKit
+                // occlusion detection so the webview's timers keep running.
+                // macOS-only, test-bridge-only.
+                #[cfg(target_os = "macos")]
+                utils::macos_unthrottle::engage_test_bridge_unthrottle();
             }
 
             let mut recovery_warnings: Vec<RecoveryWarning> = Vec::new();

--- a/src-tauri/src/utils/macos_unthrottle.rs
+++ b/src-tauri/src/utils/macos_unthrottle.rs
@@ -14,37 +14,63 @@
 //!    never runs during the (idle) reconnect window and the test times out.
 //!    This is the documented #957 / #2460 / #2480 wall.
 //!
-//! [`engage_test_bridge_unthrottle`] layers the macOS mechanisms that keep the
-//! app + its WKWebView fully awake while unfocused/occluded:
+//! Two entry points, both **test-bridge-gated** by the caller
+//! (`utils::test_bridge::is_test_bridge_enabled`) and `#[cfg(target_os = "macos")]`:
 //!
-//! * an `NSProcessInfo` **activity assertion** (`beginActivityWithOptions:reason:`)
-//!   held for the process lifetime, which defeats App Nap; and
-//! * disabling AppKit's **window occlusion detection**
-//!   (`-[NSApplication _setWindowOcclusionDetectionEnabled:]`), so WebKit never
-//!   marks the page hidden and never throttles its timers.
+//! * [`pre_launch_disable_occlusion_detection`] — call **before** the Tauri
+//!   builder runs (before `NSApplication` launches). Sets the
+//!   `NSWindowOcclusionDetectionEnabled` user default to `false`, which is the
+//!   documented AppKit knob for occlusion detection and is read while the app
+//!   launches. This is the reliable path; the private-selector attempt below is
+//!   belt-and-suspenders.
+//! * [`engage_test_bridge_unthrottle`] — call from the Tauri `setup()` hook
+//!   (main thread). Holds an `NSProcessInfo` activity assertion for the process
+//!   lifetime (defeats App Nap) and, as a backstop, tries the private
+//!   `-[NSApplication _setWindowOcclusionDetectionEnabled:]` /
+//!   `-[NSApplication setOcclusionDetectionEnabled:]` selector.
 //!
-//! Everything here is **test-bridge-gated** by the caller
-//! (`utils::test_bridge::is_test_bridge_enabled`) and `#[cfg(target_os = "macos")]`.
-//! With the env var unset or on a non-macOS target this module is never invoked,
-//! so production/default behaviour is byte-identical. It layers *alongside* the
+//! With the env var unset or on a non-macOS target neither is invoked, so
+//! production/default behaviour is byte-identical. This layers *alongside* the
 //! existing always-on-top pin (#957) and the `TERMIHUB_TEST_NO_ALWAYS_ON_TOP`
-//! opt-out (#2504) without touching either.
+//! opt-out (#2504) without touching either. A JS visibility-override injected by
+//! the test-bridge init script (`utils::test_bridge`) is the third, frontend
+//! layer that keeps the page's reconnect engine running even if WebKit still
+//! believes the page is hidden.
 
-/// `-[NSApplication _setWindowOcclusionDetectionEnabled:]` — a private AppKit
-/// selector (used by Chromium/Electron for exactly this purpose) that turns off
-/// window occlusion tracking process-wide. With occlusion detection off, AppKit
-/// never reports the window as occluded, so WebKit keeps the page in the
-/// "visible" state and does not throttle its timers/rAF/network. Guarded by a
-/// `respondsToSelector:` check so a future macOS that drops it degrades to a
-/// no-op instead of crashing.
+/// The AppKit user-default key that controls window occlusion detection. Setting
+/// it to `false` before launch stops AppKit from ever marking windows occluded,
+/// so WebKit keeps the page visible and does not throttle its timers.
 #[cfg(target_os = "macos")]
-const OCCLUSION_DETECTION_SELECTOR: &str = "_setWindowOcclusionDetectionEnabled:";
+const OCCLUSION_DEFAULT_KEY: &str = "NSWindowOcclusionDetectionEnabled";
 
-/// Engage the macOS anti-throttling mechanisms for the test bridge.
+/// Set the `NSWindowOcclusionDetectionEnabled` user default to `false` in the
+/// app's standard defaults, **before** the Tauri builder launches
+/// `NSApplication`. Returns whether the write was issued.
 ///
-/// Best-effort and idempotent-safe to call once from the Tauri `setup()` hook
-/// (main thread) after `NSApplication` exists. Any individual mechanism failing
-/// is logged and skipped; it never blocks startup.
+/// This is the reliable occlusion-detection kill switch: AppKit reads this
+/// default as the process launches, so it must run early (from `run()` before
+/// `tauri::Builder`), not from `setup()` which is already past window creation.
+/// Test-bridge-only; the caller gates on `is_test_bridge_enabled()`.
+#[cfg(target_os = "macos")]
+pub fn pre_launch_disable_occlusion_detection() -> bool {
+    use objc2_foundation::{NSString, NSUserDefaults};
+
+    let defaults = NSUserDefaults::standardUserDefaults();
+    defaults.setBool_forKey(false, &NSString::from_str(OCCLUSION_DEFAULT_KEY));
+    tracing::info!(
+        key = OCCLUSION_DEFAULT_KEY,
+        "test-bridge: set occlusion-detection user default to false (pre-launch, #2480)"
+    );
+    true
+}
+
+/// Engage the remaining macOS anti-throttling mechanisms for the test bridge.
+///
+/// Best-effort and safe to call once from the Tauri `setup()` hook (main
+/// thread) after `NSApplication` exists. Holds an App-Nap-defeating activity
+/// assertion and, as a backstop to [`pre_launch_disable_occlusion_detection`],
+/// tries the private occlusion-detection selector. Any individual mechanism
+/// failing is logged and skipped; it never blocks startup.
 ///
 /// The caller must only invoke this when the test bridge is active
 /// (`utils::test_bridge::is_test_bridge_enabled()`); this function does not
@@ -52,12 +78,12 @@ const OCCLUSION_DETECTION_SELECTOR: &str = "_setWindowOcclusionDetectionEnabled:
 #[cfg(target_os = "macos")]
 pub fn engage_test_bridge_unthrottle() {
     let app_nap_disabled = disable_app_nap();
-    let occlusion_disabled = disable_window_occlusion_detection();
+    let occlusion_selector_applied = try_disable_occlusion_selector();
 
     tracing::info!(
         app_nap_disabled,
-        occlusion_disabled,
-        "test-bridge: anti-occlusion active (App Nap disabled, occlusion detection off)"
+        occlusion_selector_applied,
+        "test-bridge: anti-occlusion active (App Nap assertion held; occlusion default set pre-launch)"
     );
 }
 
@@ -87,44 +113,49 @@ fn disable_app_nap() -> bool {
     true
 }
 
-/// Turn off AppKit window occlusion detection so WebKit never throttles the
-/// page's timers when the window is unfocused/occluded. Returns whether the
-/// selector was available and invoked.
+/// Backstop for the pre-launch user default: try the private AppKit selector
+/// that disables window occlusion detection on the shared application. Tries the
+/// underscore-prefixed private form first, then the historical non-prefixed
+/// form; only sends the one `NSApp` actually responds to. Returns the name of
+/// the selector that applied, or `None` if neither is available.
 #[cfg(target_os = "macos")]
-fn disable_window_occlusion_detection() -> bool {
+fn try_disable_occlusion_selector() -> Option<&'static str> {
     use objc2::{msg_send, sel, MainThreadMarker};
     use objc2_app_kit::NSApplication;
 
-    let Some(mtm) = MainThreadMarker::new() else {
-        tracing::warn!(
-            "test-bridge: skipping occlusion-detection disable (not on the main thread)"
-        );
-        return false;
-    };
-
+    let mtm = MainThreadMarker::new()?;
     let app = NSApplication::sharedApplication(mtm);
-    // Resolved at compile time; matches OCCLUSION_DETECTION_SELECTOR (kept for
-    // the log line below).
-    let sel = sel!(_setWindowOcclusionDetectionEnabled:);
 
-    // SAFETY: `respondsToSelector:` takes a selector and returns a BOOL; it is
-    // safe to send to any object. We only send the private
-    // `_setWindowOcclusionDetectionEnabled:` selector after confirming the
-    // running AppKit implements it, and it takes a single BOOL argument.
-    let responds: bool = unsafe { msg_send![&*app, respondsToSelector: sel] };
-    if !responds {
-        tracing::warn!(
-            selector = OCCLUSION_DETECTION_SELECTOR,
-            "test-bridge: AppKit does not implement occlusion-detection selector; skipping"
-        );
-        return false;
+    // Try the underscore-prefixed private form first (the historical Chromium
+    // trick), then the non-prefixed form. Each is guarded by
+    // `respondsToSelector:`; the BOOL argument must be sent via a compile-time
+    // `msg_send!` per selector (a runtime `Sel` cannot carry a typed argument).
+
+    // SAFETY of every `msg_send!` below: `respondsToSelector:` returns a BOOL
+    // and is safe to send to any object; the two occlusion selectors each take a
+    // single `BOOL` and return void, and we only send the one `NSApp` confirmed
+    // it responds to. Disabling occlusion detection is a process-wide AppKit
+    // setting with no ownership/lifetime implications.
+    let priv_sel = sel!(_setWindowOcclusionDetectionEnabled:);
+    let responds_priv: bool = unsafe { msg_send![&*app, respondsToSelector: priv_sel] };
+    if responds_priv {
+        unsafe {
+            let _: () = msg_send![&*app, _setWindowOcclusionDetectionEnabled: false];
+        }
+        return Some("_setWindowOcclusionDetectionEnabled:");
     }
 
-    // SAFETY: confirmed above that NSApp responds to this selector; it takes a
-    // single `BOOL` and returns void. Disabling occlusion detection is a
-    // process-wide AppKit setting with no ownership/lifetime implications.
-    unsafe {
-        let _: () = msg_send![&*app, _setWindowOcclusionDetectionEnabled: false];
+    let pub_sel = sel!(setOcclusionDetectionEnabled:);
+    let responds_pub: bool = unsafe { msg_send![&*app, respondsToSelector: pub_sel] };
+    if responds_pub {
+        unsafe {
+            let _: () = msg_send![&*app, setOcclusionDetectionEnabled: false];
+        }
+        return Some("setOcclusionDetectionEnabled:");
     }
-    true
+
+    tracing::warn!(
+        "test-bridge: no NSApplication occlusion-detection selector available (relying on the pre-launch user default)"
+    );
+    None
 }

--- a/src-tauri/src/utils/macos_unthrottle.rs
+++ b/src-tauri/src/utils/macos_unthrottle.rs
@@ -1,0 +1,130 @@
+//! macOS anti-throttling for the headless full-app E2E test bridge (#2480).
+//!
+//! The automated full-app system tests drive the real Tauri app (WKWebView)
+//! headlessly via the Python bridge. When the app window is not the focused,
+//! frontmost window, macOS applies two independent power-saving throttles that
+//! break the harness:
+//!
+//! 1. **App Nap** suspends timers, lowers the app's scheduling priority and can
+//!    coalesce/stall its runloop when the app looks idle and backgrounded.
+//! 2. **WKWebView occlusion throttling** — once AppKit marks the window as
+//!    occluded (or the app as not-frontmost), WebKit flips the page to the
+//!    "hidden" visibility state and throttles JS timers, `requestAnimationFrame`
+//!    and network activity. The frontend-driven agent-reconnect engine then
+//!    never runs during the (idle) reconnect window and the test times out.
+//!    This is the documented #957 / #2460 / #2480 wall.
+//!
+//! [`engage_test_bridge_unthrottle`] layers the macOS mechanisms that keep the
+//! app + its WKWebView fully awake while unfocused/occluded:
+//!
+//! * an `NSProcessInfo` **activity assertion** (`beginActivityWithOptions:reason:`)
+//!   held for the process lifetime, which defeats App Nap; and
+//! * disabling AppKit's **window occlusion detection**
+//!   (`-[NSApplication _setWindowOcclusionDetectionEnabled:]`), so WebKit never
+//!   marks the page hidden and never throttles its timers.
+//!
+//! Everything here is **test-bridge-gated** by the caller
+//! (`utils::test_bridge::is_test_bridge_enabled`) and `#[cfg(target_os = "macos")]`.
+//! With the env var unset or on a non-macOS target this module is never invoked,
+//! so production/default behaviour is byte-identical. It layers *alongside* the
+//! existing always-on-top pin (#957) and the `TERMIHUB_TEST_NO_ALWAYS_ON_TOP`
+//! opt-out (#2504) without touching either.
+
+/// `-[NSApplication _setWindowOcclusionDetectionEnabled:]` — a private AppKit
+/// selector (used by Chromium/Electron for exactly this purpose) that turns off
+/// window occlusion tracking process-wide. With occlusion detection off, AppKit
+/// never reports the window as occluded, so WebKit keeps the page in the
+/// "visible" state and does not throttle its timers/rAF/network. Guarded by a
+/// `respondsToSelector:` check so a future macOS that drops it degrades to a
+/// no-op instead of crashing.
+#[cfg(target_os = "macos")]
+const OCCLUSION_DETECTION_SELECTOR: &str = "_setWindowOcclusionDetectionEnabled:";
+
+/// Engage the macOS anti-throttling mechanisms for the test bridge.
+///
+/// Best-effort and idempotent-safe to call once from the Tauri `setup()` hook
+/// (main thread) after `NSApplication` exists. Any individual mechanism failing
+/// is logged and skipped; it never blocks startup.
+///
+/// The caller must only invoke this when the test bridge is active
+/// (`utils::test_bridge::is_test_bridge_enabled()`); this function does not
+/// re-check the env so the gate stays in one place.
+#[cfg(target_os = "macos")]
+pub fn engage_test_bridge_unthrottle() {
+    let app_nap_disabled = disable_app_nap();
+    let occlusion_disabled = disable_window_occlusion_detection();
+
+    tracing::info!(
+        app_nap_disabled,
+        occlusion_disabled,
+        "test-bridge: anti-occlusion active (App Nap disabled, occlusion detection off)"
+    );
+}
+
+/// Hold an `NSProcessInfo` activity assertion for the process lifetime so macOS
+/// App Nap never throttles the test app. Returns whether the assertion was
+/// acquired.
+#[cfg(target_os = "macos")]
+fn disable_app_nap() -> bool {
+    use objc2_foundation::{NSActivityOptions, NSProcessInfo, NSString};
+
+    // `.userInitiated | .latencyCritical` keeps the app at an interactive
+    // scheduling class; `.idleSystemSleepDisabled | .automaticTerminationDisabled`
+    // keep it from being napped/terminated while it looks idle. This is the
+    // documented App-Nap-defeating combination.
+    let options = NSActivityOptions::UserInitiated
+        | NSActivityOptions::LatencyCritical
+        | NSActivityOptions::IdleSystemSleepDisabled
+        | NSActivityOptions::AutomaticTerminationDisabled;
+
+    let reason = NSString::from_str("termihub test bridge");
+    let token = NSProcessInfo::processInfo().beginActivityWithOptions_reason(options, &reason);
+
+    // The activity stays in effect only while the returned token is alive.
+    // Intentionally leak it so the assertion is held for the whole process
+    // lifetime (there is no point in the run where we want App Nap back).
+    std::mem::forget(token);
+    true
+}
+
+/// Turn off AppKit window occlusion detection so WebKit never throttles the
+/// page's timers when the window is unfocused/occluded. Returns whether the
+/// selector was available and invoked.
+#[cfg(target_os = "macos")]
+fn disable_window_occlusion_detection() -> bool {
+    use objc2::{msg_send, sel, MainThreadMarker};
+    use objc2_app_kit::NSApplication;
+
+    let Some(mtm) = MainThreadMarker::new() else {
+        tracing::warn!(
+            "test-bridge: skipping occlusion-detection disable (not on the main thread)"
+        );
+        return false;
+    };
+
+    let app = NSApplication::sharedApplication(mtm);
+    // Resolved at compile time; matches OCCLUSION_DETECTION_SELECTOR (kept for
+    // the log line below).
+    let sel = sel!(_setWindowOcclusionDetectionEnabled:);
+
+    // SAFETY: `respondsToSelector:` takes a selector and returns a BOOL; it is
+    // safe to send to any object. We only send the private
+    // `_setWindowOcclusionDetectionEnabled:` selector after confirming the
+    // running AppKit implements it, and it takes a single BOOL argument.
+    let responds: bool = unsafe { msg_send![&*app, respondsToSelector: sel] };
+    if !responds {
+        tracing::warn!(
+            selector = OCCLUSION_DETECTION_SELECTOR,
+            "test-bridge: AppKit does not implement occlusion-detection selector; skipping"
+        );
+        return false;
+    }
+
+    // SAFETY: confirmed above that NSApp responds to this selector; it takes a
+    // single `BOOL` and returns void. Disabling occlusion detection is a
+    // process-wide AppKit setting with no ownership/lifetime implications.
+    unsafe {
+        let _: () = msg_send![&*app, _setWindowOcclusionDetectionEnabled: false];
+    }
+    true
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -8,6 +8,9 @@ pub mod expand;
 pub mod file_log;
 pub mod fs;
 pub mod log_capture;
+/// macOS anti-throttling for the headless full-app E2E test bridge (#2480).
+#[cfg(target_os = "macos")]
+pub mod macos_unthrottle;
 pub mod portable;
 pub mod remote_exec;
 pub mod shell_detect;

--- a/src-tauri/src/utils/test_bridge.rs
+++ b/src-tauri/src/utils/test_bridge.rs
@@ -66,15 +66,37 @@ fn feature_flag_init_script() -> String {
         .collect()
 }
 
+/// JavaScript that forces the page to always look foregrounded/visible, so the
+/// frontend agent-reconnect engine (and anything else gated on
+/// `document.hidden` / `document.visibilityState`) never suspends when the test
+/// window is unfocused or occluded (#2480).
+///
+/// This is the frontend belt-and-suspenders layer alongside the native
+/// anti-throttle (App Nap assertion + occlusion-detection disable, see
+/// `utils::macos_unthrottle`): even if WebKit still believes the page is hidden,
+/// the Page Visibility API reports "visible" and `visibilitychange` events are
+/// swallowed, so nothing re-hides the page. Injected only under the test bridge.
+const VISIBILITY_OVERRIDE_JS: &str = "(function(){try{\
+var visible=function(){return false;};var state=function(){return 'visible';};\
+Object.defineProperty(document,'hidden',{configurable:true,get:visible});\
+Object.defineProperty(document,'visibilityState',{configurable:true,get:state});\
+Object.defineProperty(document,'webkitHidden',{configurable:true,get:visible});\
+Object.defineProperty(document,'webkitVisibilityState',{configurable:true,get:state});\
+var swallow=function(e){e.stopImmediatePropagation();};\
+document.addEventListener('visibilitychange',swallow,true);\
+document.addEventListener('webkitvisibilitychange',swallow,true);\
+}catch(e){}})();";
+
 /// JavaScript that opts the in-app bridge into WebSocket test mode.
 ///
 /// Mirrors the keys read by `src/testbridge/testMode.ts`
 /// (`TEST_BRIDGE_GLOBAL_KEY` and `TEST_BRIDGE_PORT_GLOBAL_KEY`). Assigns to
 /// `window` explicitly since the script runs in its own function scope. Any
-/// `TERMIHUB_TEST_FLAG_*` feature-flag globals are appended (#2476).
+/// `TERMIHUB_TEST_FLAG_*` feature-flag globals are appended (#2476), followed by
+/// the page-visibility override that keeps the reconnect engine awake (#2480).
 fn test_bridge_init_script(port: u16) -> String {
     format!(
-        "window.__TERMIHUB_TEST_BRIDGE__ = true; window.__TERMIHUB_TEST_BRIDGE_PORT__ = {port};{}",
+        "window.__TERMIHUB_TEST_BRIDGE__ = true; window.__TERMIHUB_TEST_BRIDGE_PORT__ = {port};{}{VISIBILITY_OVERRIDE_JS}",
         feature_flag_init_script()
     )
 }
@@ -188,6 +210,19 @@ mod tests {
         let script = test_bridge_init_script(48123);
         assert!(script.contains("window.__TERMIHUB_TEST_BRIDGE__ = true"));
         assert!(script.contains("window.__TERMIHUB_TEST_BRIDGE_PORT__ = 48123"));
+    }
+
+    #[test]
+    fn init_script_forces_page_visible() {
+        // The visibility override keeps the frontend reconnect engine awake when
+        // the headless test window is unfocused/occluded (#2480).
+        let script = test_bridge_init_script(48123);
+        assert!(script.contains("Object.defineProperty(document,'hidden'"));
+        assert!(script.contains("Object.defineProperty(document,'visibilityState'"));
+        assert!(script.contains("return 'visible';"));
+        // visibilitychange must be swallowed so nothing re-hides the page.
+        assert!(script.contains("addEventListener('visibilitychange',swallow,true)"));
+        assert!(script.contains("addEventListener('webkitvisibilitychange',swallow,true)"));
     }
 
     #[test]

--- a/tests/system/termihub_harness/orchestrator.py
+++ b/tests/system/termihub_harness/orchestrator.py
@@ -217,6 +217,16 @@ class AppInstance:
         """Path of the file the app's stdout/stderr is captured to."""
         return self._log_path
 
+    @property
+    def pid(self) -> Optional[int]:
+        """OS pid of the launched app process, or ``None`` if not running.
+
+        Each launch (including a :meth:`restart`) logs a ``termiHub starting …
+        pid=<P>`` line to the durable file log, so a test can anchor its reads of
+        that shared, cross-instance log to *this* instance's pid.
+        """
+        return self._process.pid if self._process is not None else None
+
     def read_log(self) -> str:
         """The captured app log so far (empty string if nothing was captured)."""
         try:

--- a/tests/system/tests/test_agent_reconnect_live.py
+++ b/tests/system/tests/test_agent_reconnect_live.py
@@ -47,10 +47,11 @@ Two lanes, differing only by the ``sessionBackendReattach`` flag:
   ``fresh_agent_recovers_daemon_session_from_dead_prior_agent`` and the #2519
   tests, and is deliberately NOT read back through the throttled bridge here.)
 
-Agent + settings state is region-authoritative (#2227/#2409), so this suite reads
-it through the projection API (the ``agents`` region) *pre-drop* and seeds
-experimental features via ``settings.json``. The agent row is driven by its known
-seeded id (no name→id store lookup needed).
+Agent + settings state is region-authoritative (#2227/#2409); this suite seeds
+experimental features via ``settings.json`` and drives the agent row by its known
+seeded id (no name→id store lookup needed). It reads **no** frontend agent
+connectionState at all — connectedness comes only from the backend log, which is
+the whole point of the log-based rewrite.
 
 Skips cleanly when the app / agent binary is not built or no ``sshd`` is present.
 """
@@ -59,7 +60,6 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Any, Optional
 
 import pytest
 
@@ -93,7 +93,12 @@ CTX_NEW_SHELL = "context-agent-new-shell"
 # ── backend-log markers (see the module docstring) ────────────────────────────
 # Desktop-side (agent_manager), un-prefixed:
 LOG_DROP = "connection lost, attempting reconnect"
-LOG_HANDSHAKE = "initialize response received"  # pairs with "; marking connected"
+# Connectedness is read HERE, never from the frontend agent connectionState via
+# the bridge — that read is the throttle/timing-fragile one this suite exists to
+# eliminate (the backend connects fine, but the projected frontend state does not
+# reliably reach "connected" under a display run). This is the tail of the
+# desktop line ``initialize response received (...); marking connected``.
+LOG_CONNECTED = "marking connected"
 LOG_RECONNECT_FAILED = "reconnection failed"
 # Agent-side, forwarded into the desktop log as "Agent <id>: stderr: ...":
 LOG_SESSION_SPAWNED = "Daemon spawned for session"  # a FRESH session was created
@@ -158,7 +163,6 @@ class _AgentReconnectBase(TabsUi, TerminalUi, ConfigRecoveryUi, SidebarUi, Syste
             pytest.skip(str(exc))
         sshd.start()
         self.sshd = sshd
-        self._agents_sub: Optional[str] = None
 
         prev_flag = os.environ.get(self._FLAG_ENV)
         if self.flag_on:
@@ -181,8 +185,10 @@ class _AgentReconnectBase(TabsUi, TerminalUi, ConfigRecoveryUi, SidebarUi, Syste
         finally:
             sshd.cleanup()  # reap first so it never leaks on a slow UI teardown
             try:
-                if self._agent_state() not in (None, "disconnected"):
-                    self._agent_menu_click(CTX_DISCONNECT)
+                # Best-effort disconnect — no frontend-state read to gate it (that
+                # is exactly the fragile read this suite avoids); a no-op click on
+                # an already-disconnected agent is harmless.
+                self._agent_menu_click(CTX_DISCONNECT)
             except Exception:
                 pass
             try:
@@ -233,25 +239,6 @@ class _AgentReconnectBase(TabsUi, TerminalUi, ConfigRecoveryUi, SidebarUi, Syste
         assert sid, "could not parse the daemon session id from the log"
         return sid
 
-    # ── agents projection reads (region-authoritative, #2409) — PRE-DROP ONLY ─────
-    def _agents_view(self) -> list[dict[str, Any]]:
-        if self._agents_sub is None:
-            self._agents_sub = self.driver.projection_subscribe("agents")["subscriptionId"]
-        cache = self.driver.projection_state(self._agents_sub).get("cache") or {}
-        agents = cache.get("agents")
-        return [a for a in agents if isinstance(a, dict)] if isinstance(agents, list) else []
-
-    def _agent_state(self) -> Optional[str]:
-        agent = next((a for a in self._agents_view() if a.get("id") == AGENT_ID), None)
-        return agent.get("connectionState") if agent else None
-
-    def _wait_agent_state(self, *states: str, timeout: float = 60.0) -> None:
-        self.wait(
-            lambda: self._agent_state() in states,
-            what=f"agent to reach state in {states}",
-            timeout=timeout,
-        )
-
     # ── agent row driving (by known id) ──────────────────────────────────────────
     def _agent_menu_click(self, action: str) -> None:
         def opened() -> bool:
@@ -265,9 +252,23 @@ class _AgentReconnectBase(TabsUi, TerminalUi, ConfigRecoveryUi, SidebarUi, Syste
 
     # ── shared steps ─────────────────────────────────────────────────────────────
     def _connect_and_open_shell(self) -> None:
-        """Bridge-driven setup — runs PRE-drop, so the webview is un-throttled."""
+        """Connect + open a shell. Connectedness is read from the LOG.
+
+        Only the two UI *actions* go through the bridge (clicking Connect on the
+        seeded agent row, opening the shell); "is it connected?" is asserted on
+        the backend log (``marking connected``), never on the frontend agent
+        state. The connect may bounce once over the throwaway sshd (a spurious
+        ``connection lost`` then a successful retry) — waiting for *any*
+        ``marking connected`` past the pre-click cursor tolerates that.
+        """
+        cursor = self._log_len()
         self._agent_menu_click(CTX_CONNECT)
-        self._wait_agent_state("connected")
+        self._wait_log(
+            LOG_CONNECTED,
+            since=cursor,
+            timeout=60.0,
+            what="the agent handshake to complete (marking connected)",
+        )
         before = self.tab_count()
         self._agent_menu_click(CTX_NEW_SHELL)
         self.wait(lambda: self.tab_count() > before, what="the agent shell-session tab")
@@ -315,10 +316,10 @@ class TestAgentReconnectClientDriven(_AgentReconnectBase):
         self.sshd.start()
         self._agent_menu_click(CTX_CONNECT)
         self._wait_log(
-            LOG_HANDSHAKE,
+            LOG_CONNECTED,
             since=offset,
             timeout=RECONNECT_LOG_TIMEOUT,
-            what="the agent handshake to complete again after the server returns",
+            what="the agent handshake to complete again (marking connected) after the server returns",
         )
 
 
@@ -347,10 +348,10 @@ class TestAgentReconnectBackendDriven(_AgentReconnectBase):
         # again (throttle-immune log read, never a frontend poll).
         self.sshd.start()
         self._wait_log(
-            LOG_HANDSHAKE,
+            LOG_CONNECTED,
             since=offset,
             timeout=RECONNECT_LOG_TIMEOUT,
-            what="the backend redrive to complete the reconnect handshake",
+            what="the backend redrive to complete the reconnect handshake (marking connected)",
         )
 
         # THE key end-to-end assertion: the LIVE daemon session was re-attached

--- a/tests/system/tests/test_agent_reconnect_live.py
+++ b/tests/system/tests/test_agent_reconnect_live.py
@@ -17,8 +17,18 @@ bridge poll of the frontend state (``projection_state`` / ``get_state`` /
 terminal reads) times out — ``command timed out after 60s`` — even though the app
 reconnects fine. The app's **backend log is written by Rust and is immune to that
 throttle**, so this suite asserts on it. Setup and the initial-``connected`` check
-run through the bridge *pre-drop* (un-throttled); everything after the drop is a
-bounded poll on the **durable file log**, never the bridge.
+run through the bridge *pre-drop* (un-throttled); every post-drop **assertion**
+reads the **durable file log**, never the bridge.
+
+**One caveat — a bridge heartbeat drives the engine.** The reconnect engine /
+redrive-trigger only advances while the webview's event loop is driven; an idle
+WKWebView parks its JS timers (even with App-Nap and occlusion-detection off), so
+a purely passive log poll would let the engine idle and no reconnect would ever
+fire. The post-drop waits therefore issue a lightweight, best-effort bridge
+``getState`` "heartbeat" each ~1s cycle purely to keep that loop alive — the pass/
+fail decision still comes only from the durable log, and a throttled/failed poke
+is swallowed. If the poke itself reliably times out the webview is truly frozen,
+which is the hard-stop signal.
 
 **Which log — the durable file, not stdout.** The system-test harness captures
 the app's *stdout* (``app.read_log()``), but this is a **bundled** app and, per
@@ -76,6 +86,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -83,6 +94,7 @@ import pytest
 
 from termihub_harness import (
     LIVE_CONNECT_REQUEST_TIMEOUT,
+    BridgeError,
     ConfigRecoveryUi,
     LocalAgentSshd,
     LocalAgentUnavailable,
@@ -135,6 +147,17 @@ LOG_SESSION_RECOVER_FAIL = "Failed to recover session"  # the live session was l
 # backoff window and reads flaky. The reconnect timeout is still generous so a
 # retry that lands mid-backoff is tolerated (this is a log poll, not a UI read).
 RECONNECT_LOG_TIMEOUT = 120.0
+
+# The reconnect engine / redrive-trigger only advances while the webview's event
+# loop is driven; an idle WKWebView parks its JS timers even with App-Nap and
+# occlusion-detection off, so a purely passive log poll never sees a reconnect
+# attempt. During the post-drop wait we therefore issue a lightweight, best-
+# effort bridge "heartbeat" each cycle purely to keep that loop alive — the
+# assertion itself still reads the durable log, never the bridge.
+HEARTBEAT_INTERVAL = 1.0
+# Short per-poke timeout so a throttled heartbeat returns fast and the loop keeps
+# cycling (never blocks the full request_timeout on a single poke).
+HEARTBEAT_TIMEOUT = 2.5
 
 
 def _agent_doc(sshd: LocalAgentSshd) -> str:
@@ -282,6 +305,40 @@ class _AgentReconnectBase(TabsUi, TerminalUi, ConfigRecoveryUi, SidebarUi, Syste
             what=what,
         )
 
+    def _heartbeat(self) -> None:
+        """Poke the webview so its event loop (the reconnect engine) keeps running.
+
+        A lightweight, best-effort ``getState`` round-trip through the webview —
+        purely to unpark WKWebView's JS timers during the reconnect wait. It is
+        NOT an assertion: any ``BridgeError`` / timeout (a throttled poke) is
+        swallowed so a slow poke never fails the test. A short per-poke timeout
+        keeps the loop cycling instead of blocking on one call.
+        """
+        try:
+            self.driver.get_state("recoveryWarnings", timeout=HEARTBEAT_TIMEOUT)
+        except BridgeError:
+            pass
+
+    def _wait_log_with_heartbeat(
+        self, *needles: str, since: int, timeout: float, what: str
+    ) -> str:
+        """Like :meth:`_wait_log`, but drive a bridge heartbeat each cycle.
+
+        The reconnect engine / redrive-trigger only advances while the webview is
+        driven, so a passive log poll would let it idle forever. Each ~1s cycle:
+        poke the webview (best-effort), then check the durable-log tail past
+        ``since`` for any ``needle``; return on hit, raise on timeout.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            self._heartbeat()
+            tail = self._log()[since:]
+            hit = next((n for n in needles if n in tail), None)
+            if hit:
+                return hit
+            time.sleep(HEARTBEAT_INTERVAL)
+        raise AssertionError(f"timed out waiting for {what}")
+
     def _assert_log_absent(self, needle: str, *, since: int, what: str) -> None:
         assert needle not in self._log()[since:], (
             f"unexpected log line {needle!r} after the drop — {what}"
@@ -369,11 +426,11 @@ class TestAgentReconnectClientDriven(_AgentReconnectBase):
 
         # Restore the sshd EARLY — right after the drop surfaced — so an early,
         # short-backoff retry reconnects fast (a late restore falls into a long
-        # backoff window and reads flaky). The reconnect handshake must complete
-        # again; asserted on the log with a generous timeout to tolerate a retry
-        # that lands mid-backoff.
+        # backoff window and reads flaky). The reconnect engine only advances
+        # while the webview is driven, so poll with a bridge heartbeat; the
+        # handshake completing again is asserted on the log, not the bridge.
         self.sshd.start()
-        self._wait_log(
+        self._wait_log_with_heartbeat(
             LOG_CONNECTED,
             since=offset,
             timeout=RECONNECT_LOG_TIMEOUT,
@@ -402,12 +459,12 @@ class TestAgentReconnectBackendDriven(_AgentReconnectBase):
 
         # Restore the sshd EARLY — right after the drop surfaced, in the early
         # short-backoff window — so the next retry reconnects fast (the transport
-        # retries with exponential backoff, so a late restore reads flaky). With
-        # the flag on, the backend redrive re-establishes the transport WITHOUT
-        # any bridge interaction; the handshake completes again — a throttle-
-        # immune log read (generous timeout to tolerate a retry mid-backoff).
+        # retries with exponential backoff, so a late restore reads flaky). The
+        # backend redrive-trigger only advances while the webview is driven, so
+        # poll with a bridge heartbeat; the handshake completing again is a
+        # throttle-immune log read, never a frontend poll.
         self.sshd.start()
-        self._wait_log(
+        self._wait_log_with_heartbeat(
             LOG_CONNECTED,
             since=offset,
             timeout=RECONNECT_LOG_TIMEOUT,
@@ -417,7 +474,9 @@ class TestAgentReconnectBackendDriven(_AgentReconnectBase):
         # THE key end-to-end assertion: the LIVE daemon session was re-attached
         # (process continuity), not silently recreated. The agent forwards its
         # recovery log into the desktop log; assert the marker names *this* sid.
-        self._wait_log(
+        # Keep the heartbeat up — the re-attach round-trip also runs on the driven
+        # event loop.
+        self._wait_log_with_heartbeat(
             f"Recovered session {sid}",
             f"Reattached to session {sid}",
             since=offset,

--- a/tests/system/tests/test_agent_reconnect_live.py
+++ b/tests/system/tests/test_agent_reconnect_live.py
@@ -6,11 +6,13 @@ app reaches agents only over SSH, so this suite stands up a throwaway loopback
 ``sshd`` with the ``termihub-agent`` binary reachable (:class:`LocalAgentSshd`,
 the test-owned equivalent of ``scripts/dev.sh``'s dev agent), points a key-auth
 agent connection at it, opens a shell session, then **kills the sshd** to sever
-the transport — a genuine, prolonged drop the harness fully controls — before
-bringing it back.
+the transport — a genuine transport drop the harness fully controls — before
+bringing it back promptly (the agent_manager retries the transport with
+exponential backoff, so the sshd is restored early, right after the drop
+surfaces, for a retry to reconnect fast).
 
 **Why this suite is log-based (supersedes the bridge-poll approach of #2520).**
-During the prolonged agent reconnect the WKWebView occlusion-throttles, so a
+During the agent reconnect the WKWebView occlusion-throttles, so a
 bridge poll of the frontend state (``projection_state`` / ``get_state`` /
 terminal reads) times out — ``command timed out after 60s`` — even though the app
 reconnects fine. The app's **backend log is written by Rust and is immune to that
@@ -23,8 +25,8 @@ The log markers this asserts on (grounded in the running binaries):
 
 * Desktop (``agent_manager``): ``connection lost, attempting reconnect`` on the
   drop; ``initialize response received (...); marking connected`` when a
-  (re)connect handshake completes; ``reconnection failed`` when a single-shot
-  transport reconnect gives up while the server is down.
+  (re)connect handshake completes (the transport then retries with exponential
+  backoff until the sshd returns).
 * Agent (forwarded into the desktop log as ``Agent <id>: stderr: ...``):
   ``Daemon spawned for session <sid>`` when a **fresh** session is created;
   ``Recovered session <sid>`` / ``Reattached to session <sid>`` when the **live**
@@ -37,7 +39,7 @@ Two lanes, differing only by the ``sessionBackendReattach`` flag:
   re-initiated, the handshake completes again. Proves the scenario is valid
   before any product change relies on it.
 * :class:`TestAgentReconnectBackendDriven` — flag **on** (the activation): the
-  backend redrive re-establishes the transport across the prolonged drop and
+  backend redrive re-establishes the transport after the drop and
   **re-attaches the live daemon session** — the log shows ``Recovered``/
   ``Reattached`` for the same ``<sid>`` and **no** fresh ``Daemon spawned`` /
   ``Failed to recover`` for it. This is the unique end-to-end assertion: the
@@ -99,14 +101,16 @@ LOG_DROP = "connection lost, attempting reconnect"
 # reliably reach "connected" under a display run). This is the tail of the
 # desktop line ``initialize response received (...); marking connected``.
 LOG_CONNECTED = "marking connected"
-LOG_RECONNECT_FAILED = "reconnection failed"
 # Agent-side, forwarded into the desktop log as "Agent <id>: stderr: ...":
 LOG_SESSION_SPAWNED = "Daemon spawned for session"  # a FRESH session was created
 LOG_SESSION_RECOVER_FAIL = "Failed to recover session"  # the live session was lost
 
-# How long the backend redrive may take to re-establish + re-attach across a
-# prolonged drop (generous — the redrive parks/retries; this is not a UI read).
-RECONNECT_LOG_TIMEOUT = 180.0
+# The agent_manager retries the transport with exponential backoff (~2s, 4s, 8s,
+# 16s, 32s, …), so the sshd must be restored EARLY — right after the drop
+# surfaces — for a retry to land quickly; a late restore falls into a long
+# backoff window and reads flaky. The reconnect timeout is still generous so a
+# retry that lands mid-backoff is tolerated (this is a log poll, not a UI read).
+RECONNECT_LOG_TIMEOUT = 120.0
 
 
 def _agent_doc(sshd: LocalAgentSshd) -> str:
@@ -298,23 +302,17 @@ class TestAgentReconnectClientDriven(_AgentReconnectBase):
         # Cursor: everything asserted below must be POST-drop log content.
         offset = self._log_len()
 
-        # Drop the agent transport at the server. The single-shot transport
-        # reconnect fires immediately, then fails while the server is down — a
-        # prolonged outage a client single-shot cannot ride out (flag off).
+        # Drop the agent transport at the server; the drop must surface in the
+        # backend log. The agent_manager then retries with exponential backoff.
         self._drop_transport()
         self._wait_log(LOG_DROP, since=offset, timeout=60.0, what="the drop to surface in the log")
-        self._wait_log(
-            LOG_RECONNECT_FAILED,
-            since=offset,
-            timeout=60.0,
-            what="the single-shot transport reconnect to give up while the server is down",
-        )
 
-        # Bring the server back and re-initiate the connection (the connect click
-        # is issued while the agent is idle/disconnected, so it is un-throttled);
-        # the reconnect handshake must complete again — asserted on the log.
+        # Restore the sshd EARLY — right after the drop surfaced — so an early,
+        # short-backoff retry reconnects fast (a late restore falls into a long
+        # backoff window and reads flaky). The reconnect handshake must complete
+        # again; asserted on the log with a generous timeout to tolerate a retry
+        # that lands mid-backoff.
         self.sshd.start()
-        self._agent_menu_click(CTX_CONNECT)
         self._wait_log(
             LOG_CONNECTED,
             since=offset,
@@ -324,7 +322,7 @@ class TestAgentReconnectClientDriven(_AgentReconnectBase):
 
 
 class TestAgentReconnectBackendDriven(_AgentReconnectBase):
-    """Flag ON — the activation: backend-driven reconnect across a prolonged drop."""
+    """Flag ON — the activation: backend-driven reconnect + live session re-attach."""
 
     flag_on = True
 
@@ -338,14 +336,16 @@ class TestAgentReconnectBackendDriven(_AgentReconnectBase):
         # Cursor: everything asserted below must be POST-drop log content.
         offset = self._log_len()
 
-        # Prolonged drop: kill the sshd and keep it down while the backend redrive
-        # parks/retries. The drop must surface in the backend log.
+        # Kill the sshd; the drop must surface in the backend log.
         self._drop_transport()
         self._wait_log(LOG_DROP, since=offset, timeout=60.0, what="the drop to surface in the log")
 
-        # Recover the server. With the flag on, the backend redrive re-establishes
-        # the transport WITHOUT any bridge interaction — the handshake completes
-        # again (throttle-immune log read, never a frontend poll).
+        # Restore the sshd EARLY — right after the drop surfaced, in the early
+        # short-backoff window — so the next retry reconnects fast (the transport
+        # retries with exponential backoff, so a late restore reads flaky). With
+        # the flag on, the backend redrive re-establishes the transport WITHOUT
+        # any bridge interaction; the handshake completes again — a throttle-
+        # immune log read (generous timeout to tolerate a retry mid-backoff).
         self.sshd.start()
         self._wait_log(
             LOG_CONNECTED,

--- a/tests/system/tests/test_agent_reconnect_live.py
+++ b/tests/system/tests/test_agent_reconnect_live.py
@@ -18,8 +18,21 @@ terminal reads) times out — ``command timed out after 60s`` — even though th
 reconnects fine. The app's **backend log is written by Rust and is immune to that
 throttle**, so this suite asserts on it. Setup and the initial-``connected`` check
 run through the bridge *pre-drop* (un-throttled); everything after the drop is a
-bounded poll on ``app.read_log()`` (the harness's per-instance capture of the
-app's merged stdout/stderr — see :meth:`AppInstance.read_log`), never the bridge.
+bounded poll on the **durable file log**, never the bridge.
+
+**Which log — the durable file, not stdout.** The system-test harness captures
+the app's *stdout* (``app.read_log()``), but this is a **bundled** app and, per
+``src-tauri/src/lib.rs``, a bundled desktop app has nowhere for the ``fmt``
+(stdout) layer to write — so the lines this suite asserts on are simply not in
+stdout. They all go to the **durable rotating file log** (#1570) at
+``~/Library/Logs/com.termihub.app/termihub.log`` on macOS (``termihub_lib=debug``,
+reliably flushed), which is both throttle-immune (Rust-written, not the webview)
+and flush-reliable. That shared file is appended across app instances, so this
+suite anchors its reads to *this* instance: each launch logs a ``termiHub
+starting … pid=<P>`` line, and the pre-drop cursor is set just past this
+instance's line (``AppInstance.pid``). All post-drop assertions read the file
+tail past that cursor. (``app.read_log()`` is still captured for the failure
+bundle; it is just not what the assertions read.)
 
 The log markers this asserts on (grounded in the running binaries):
 
@@ -62,6 +75,9 @@ from __future__ import annotations
 
 import json
 import os
+import re
+from pathlib import Path
+from typing import Optional
 
 import pytest
 
@@ -91,6 +107,14 @@ SETTINGS_DOC = json.dumps({"version": "1", "experimentalFeaturesEnabled": True})
 CTX_CONNECT = "context-agent-connect"
 CTX_DISCONNECT = "context-agent-disconnect"
 CTX_NEW_SHELL = "context-agent-new-shell"
+
+# The durable rotating file log (#1570) — the real sink for the INFO/DEBUG lines
+# this suite asserts on (a bundled app's stdout is a dead stream, see the module
+# docstring). macOS path; the suite already skips off-macOS agent scenarios.
+DURABLE_LOG = Path.home() / "Library" / "Logs" / "com.termihub.app" / "termihub.log"
+
+# Anchors the per-instance read cursor: each app launch logs this with its pid.
+STARTING_MARKER = "termiHub starting"
 
 # ── backend-log markers (see the module docstring) ────────────────────────────
 # Desktop-side (agent_manager), un-prefixed:
@@ -180,6 +204,9 @@ class _AgentReconnectBase(TabsUi, TerminalUi, ConfigRecoveryUi, SidebarUi, Syste
 
         # Relaunch so the app loads the seeded agent + experimental flag + flag env.
         self.restart_app(between=_seed)
+        # Anchor all durable-log reads past THIS (post-restart) instance's boot
+        # line — the shared file carries prior instances' lines too.
+        self._log_base = self._instance_log_base()
         self.switch_to_connections_sidebar()
         # The seeded experimental flag renders the Remote Agents group; its row is
         # addressable by the known id (no name→id store lookup, which is stale).
@@ -206,12 +233,44 @@ class _AgentReconnectBase(TabsUi, TerminalUi, ConfigRecoveryUi, SidebarUi, Syste
 
     # ── backend-log reads (throttle-immune — this is the whole point) ─────────────
     def _log(self) -> str:
-        """The app's captured backend log (Rust stdout/stderr) so far."""
-        return self.app.read_log()
+        """The app's durable file log so far (Rust-written; not the dead stdout)."""
+        try:
+            return DURABLE_LOG.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return ""
 
     def _log_len(self) -> int:
-        """A cursor into the log, so post-drop asserts ignore pre-drop lines."""
+        """A forward cursor into the log, so later asserts ignore earlier lines."""
         return len(self._log())
+
+    def _instance_log_base(self, *, timeout: float = 30.0) -> int:
+        """Char offset just past THIS instance's ``termiHub starting … pid=<P>``.
+
+        The durable log is shared/appended across app instances, so reads that
+        scan from the start (session-id extraction) must begin at this instance's
+        boot line — matched by :attr:`AppInstance.pid` — not a prior run's.
+        """
+        pid = self.app.pid
+        assert pid is not None, "the app instance is not running"
+        pid_field = re.compile(rf"\bpid={pid}\b")
+
+        def resolve() -> Optional[int]:
+            text = self._log()
+            end = None
+            pos = 0
+            # Match the boot line by its two markers regardless of field order,
+            # tracking the exact char offset of the end of the last such line.
+            for line in text.splitlines(keepends=True):
+                if STARTING_MARKER in line and pid_field.search(line):
+                    end = pos + len(line)
+                pos += len(line)
+            return end
+
+        return self.wait(
+            resolve,
+            timeout=timeout,
+            what=f"this app instance's startup log line (pid={pid})",
+        )
 
     def _wait_log(
         self, *needles: str, since: int = 0, timeout: float = 60.0, what: str
@@ -228,14 +287,15 @@ class _AgentReconnectBase(TabsUi, TerminalUi, ConfigRecoveryUi, SidebarUi, Syste
             f"unexpected log line {needle!r} after the drop — {what}"
         )
 
-    def _daemon_session_id(self, *, since: int = 0) -> str:
+    def _daemon_session_id(self) -> str:
         """The daemon session id from the ``Daemon spawned for session <sid>`` log.
 
         Emitted by the agent when the shell's daemon-backed session is created;
         used to correlate the later ``Recovered``/``Reattached`` markers to *this*
         session. The id token follows the marker (``... session abc123 (type=…)``).
+        Scans from this instance's boot cursor so a prior run's spawn is ignored.
         """
-        tail = self._log()[since:]
+        tail = self._log()[self._log_base:]
         idx = tail.find(LOG_SESSION_SPAWNED)
         assert idx != -1, "no daemon session was spawned for the opened shell"
         after = tail[idx + len(LOG_SESSION_SPAWNED):].strip()

--- a/tests/system/tests/test_agent_reconnect_live.py
+++ b/tests/system/tests/test_agent_reconnect_live.py
@@ -1,4 +1,4 @@
-"""Live agent drop / reconnect over a harness-controlled sshd (#2476).
+"""Live agent drop / reconnect over a harness-controlled sshd (#2476, #2480).
 
 The missing enabler for the agent reconnect activation: no scenario existed to
 drive a real agent-transport drop and assert the reconnect outcome. The desktop
@@ -9,22 +9,48 @@ agent connection at it, opens a shell session, then **kills the sshd** to sever
 the transport — a genuine, prolonged drop the harness fully controls — before
 bringing it back.
 
+**Why this suite is log-based (supersedes the bridge-poll approach of #2520).**
+During the prolonged agent reconnect the WKWebView occlusion-throttles, so a
+bridge poll of the frontend state (``projection_state`` / ``get_state`` /
+terminal reads) times out — ``command timed out after 60s`` — even though the app
+reconnects fine. The app's **backend log is written by Rust and is immune to that
+throttle**, so this suite asserts on it. Setup and the initial-``connected`` check
+run through the bridge *pre-drop* (un-throttled); everything after the drop is a
+bounded poll on ``app.read_log()`` (the harness's per-instance capture of the
+app's merged stdout/stderr — see :meth:`AppInstance.read_log`), never the bridge.
+
+The log markers this asserts on (grounded in the running binaries):
+
+* Desktop (``agent_manager``): ``connection lost, attempting reconnect`` on the
+  drop; ``initialize response received (...); marking connected`` when a
+  (re)connect handshake completes; ``reconnection failed`` when a single-shot
+  transport reconnect gives up while the server is down.
+* Agent (forwarded into the desktop log as ``Agent <id>: stderr: ...``):
+  ``Daemon spawned for session <sid>`` when a **fresh** session is created;
+  ``Recovered session <sid>`` / ``Reattached to session <sid>`` when the **live**
+  session is re-attached; ``Failed to recover session <sid>`` when it is lost.
+
 Two lanes, differing only by the ``sessionBackendReattach`` flag:
 
 * :class:`TestAgentReconnectClientDriven` — flag **off** (develop behavior): the
-  drop surfaces (the agent leaves ``connected``) and, once the server is back and
-  the agent reconnects, a fresh shell session is live again. Proves the scenario
-  is valid before any product change relies on it.
+  drop surfaces in the log and, once the server is back and the connection is
+  re-initiated, the handshake completes again. Proves the scenario is valid
+  before any product change relies on it.
 * :class:`TestAgentReconnectBackendDriven` — flag **on** (the activation): the
-  agent tab's reconnect is driven by the backend redrive across the prolonged
-  drop; the tab recovers on reconnection with the client agent engine suppressed.
+  backend redrive re-establishes the transport across the prolonged drop and
+  **re-attaches the live daemon session** — the log shows ``Recovered``/
+  ``Reattached`` for the same ``<sid>`` and **no** fresh ``Daemon spawned`` /
+  ``Failed to recover`` for it. This is the unique end-to-end assertion: the
+  desktop↔agent reconnect + live re-attach happened, process continuity intact.
+  (Terminal *content* continuity — the var-survives / loop-continues output — is
+  covered headlessly by the agent-integration tests, e.g.
+  ``fresh_agent_recovers_daemon_session_from_dead_prior_agent`` and the #2519
+  tests, and is deliberately NOT read back through the throttled bridge here.)
 
 Agent + settings state is region-authoritative (#2227/#2409), so this suite reads
-it through the projection API (the ``agents`` region) and seeds experimental
-features via ``settings.json`` — the ``get_state("remoteAgents"/"settings")``
-paths the older ``AgentUi``/``SettingsUi`` helpers use no longer resolve against a
-projection-migrated build (see the follow-up filed from this issue). The agent
-row is driven by its known seeded id (no name→id store lookup needed).
+it through the projection API (the ``agents`` region) *pre-drop* and seeds
+experimental features via ``settings.json``. The agent row is driven by its known
+seeded id (no name→id store lookup needed).
 
 Skips cleanly when the app / agent binary is not built or no ``sshd`` is present.
 """
@@ -63,6 +89,19 @@ SETTINGS_DOC = json.dumps({"version": "1", "experimentalFeaturesEnabled": True})
 CTX_CONNECT = "context-agent-connect"
 CTX_DISCONNECT = "context-agent-disconnect"
 CTX_NEW_SHELL = "context-agent-new-shell"
+
+# ── backend-log markers (see the module docstring) ────────────────────────────
+# Desktop-side (agent_manager), un-prefixed:
+LOG_DROP = "connection lost, attempting reconnect"
+LOG_HANDSHAKE = "initialize response received"  # pairs with "; marking connected"
+LOG_RECONNECT_FAILED = "reconnection failed"
+# Agent-side, forwarded into the desktop log as "Agent <id>: stderr: ...":
+LOG_SESSION_SPAWNED = "Daemon spawned for session"  # a FRESH session was created
+LOG_SESSION_RECOVER_FAIL = "Failed to recover session"  # the live session was lost
+
+# How long the backend redrive may take to re-establish + re-attach across a
+# prolonged drop (generous — the redrive parks/retries; this is not a UI read).
+RECONNECT_LOG_TIMEOUT = 180.0
 
 
 def _agent_doc(sshd: LocalAgentSshd) -> str:
@@ -111,23 +150,8 @@ class _AgentReconnectBase(TabsUi, TerminalUi, ConfigRecoveryUi, SidebarUi, Syste
 
     _FLAG_ENV = "TERMIHUB_TEST_FLAG_SESSION_BACKEND_REATTACH"
 
-    #: Opt-in gate. The scenario drives everything up to the agent transport
-    #: (SSH + key auth + host-key trust + the agent binary starting over SSH), but
-    #: the agent's registry-daemon handshake stalls over a throwaway sshd and the
-    #: WKWebView is occlusion-throttled during the long connect, so the agent never
-    #: reaches ``connected`` unattended (tracked in #2480; agent/settings harness
-    #: reads also need the projection API per #2479). Set this env to 1 to run it.
-    _OPT_IN_ENV = "TERMIHUB_TEST_LOCAL_AGENT_RECONNECT"
-
     @pytest.fixture(autouse=True)
     def _local_agent(self):
-        if os.environ.get(self._OPT_IN_ENV) != "1":
-            pytest.skip(
-                f"opt-in: set {self._OPT_IN_ENV}=1 to run the live local-agent "
-                "reconnect scenario (blocked unattended by the agent registry-daemon "
-                "handshake over a throwaway sshd + webview throttling — see #2480; "
-                "harness agent/settings reads tracked in #2479)"
-            )
         try:
             sshd = LocalAgentSshd()
         except LocalAgentUnavailable as exc:
@@ -170,7 +194,46 @@ class _AgentReconnectBase(TabsUi, TerminalUi, ConfigRecoveryUi, SidebarUi, Syste
             else:
                 os.environ[self._FLAG_ENV] = prev_flag
 
-    # ── agents projection reads (region-authoritative, #2409) ────────────────────
+    # ── backend-log reads (throttle-immune — this is the whole point) ─────────────
+    def _log(self) -> str:
+        """The app's captured backend log (Rust stdout/stderr) so far."""
+        return self.app.read_log()
+
+    def _log_len(self) -> int:
+        """A cursor into the log, so post-drop asserts ignore pre-drop lines."""
+        return len(self._log())
+
+    def _wait_log(
+        self, *needles: str, since: int = 0, timeout: float = 60.0, what: str
+    ) -> str:
+        """Poll the log tail (from ``since``) until ANY ``needle`` appears."""
+        return self.wait(
+            lambda: next((n for n in needles if n in self._log()[since:]), None),
+            timeout=timeout,
+            what=what,
+        )
+
+    def _assert_log_absent(self, needle: str, *, since: int, what: str) -> None:
+        assert needle not in self._log()[since:], (
+            f"unexpected log line {needle!r} after the drop — {what}"
+        )
+
+    def _daemon_session_id(self, *, since: int = 0) -> str:
+        """The daemon session id from the ``Daemon spawned for session <sid>`` log.
+
+        Emitted by the agent when the shell's daemon-backed session is created;
+        used to correlate the later ``Recovered``/``Reattached`` markers to *this*
+        session. The id token follows the marker (``... session abc123 (type=…)``).
+        """
+        tail = self._log()[since:]
+        idx = tail.find(LOG_SESSION_SPAWNED)
+        assert idx != -1, "no daemon session was spawned for the opened shell"
+        after = tail[idx + len(LOG_SESSION_SPAWNED):].strip()
+        sid = after.split()[0] if after else ""
+        assert sid, "could not parse the daemon session id from the log"
+        return sid
+
+    # ── agents projection reads (region-authoritative, #2409) — PRE-DROP ONLY ─────
     def _agents_view(self) -> list[dict[str, Any]]:
         if self._agents_sub is None:
             self._agents_sub = self.driver.projection_subscribe("agents")["subscriptionId"]
@@ -202,6 +265,7 @@ class _AgentReconnectBase(TabsUi, TerminalUi, ConfigRecoveryUi, SidebarUi, Syste
 
     # ── shared steps ─────────────────────────────────────────────────────────────
     def _connect_and_open_shell(self) -> None:
+        """Bridge-driven setup — runs PRE-drop, so the webview is un-throttled."""
         self._agent_menu_click(CTX_CONNECT)
         self._wait_agent_state("connected")
         before = self.tab_count()
@@ -210,6 +274,7 @@ class _AgentReconnectBase(TabsUi, TerminalUi, ConfigRecoveryUi, SidebarUi, Syste
         self.wait(self.has_terminal, what="the agent shell terminal session")
 
     def _assert_shell_live(self) -> None:
+        """PRE-drop only — a round-trip through the live shell."""
         marker = unique_name("agent-echo")
         self.run_command(f"echo {marker}")
         assert marker in self.wait_for_output(marker)
@@ -229,22 +294,32 @@ class TestAgentReconnectClientDriven(_AgentReconnectBase):
         self._connect_and_open_shell()
         self._assert_shell_live()
 
-        # Drop the agent transport at the server and keep it down long enough that
-        # a client single-shot reconnect would fail — a prolonged outage.
+        # Cursor: everything asserted below must be POST-drop log content.
+        offset = self._log_len()
+
+        # Drop the agent transport at the server. The single-shot transport
+        # reconnect fires immediately, then fails while the server is down — a
+        # prolonged outage a client single-shot cannot ride out (flag off).
         self._drop_transport()
-        self._wait_agent_state("reconnecting", "disconnected", timeout=60.0)
+        self._wait_log(LOG_DROP, since=offset, timeout=60.0, what="the drop to surface in the log")
+        self._wait_log(
+            LOG_RECONNECT_FAILED,
+            since=offset,
+            timeout=60.0,
+            what="the single-shot transport reconnect to give up while the server is down",
+        )
 
-        # Bring the server back; the agent must reconnect and serve a live shell.
+        # Bring the server back and re-initiate the connection (the connect click
+        # is issued while the agent is idle/disconnected, so it is un-throttled);
+        # the reconnect handshake must complete again — asserted on the log.
         self.sshd.start()
-        self._wait_agent_state("disconnected", timeout=60.0)
         self._agent_menu_click(CTX_CONNECT)
-        self._wait_agent_state("connected", timeout=60.0)
-
-        before = self.tab_count()
-        self._agent_menu_click(CTX_NEW_SHELL)
-        self.wait(lambda: self.tab_count() > before, what="a fresh agent shell after recovery")
-        self.wait(self.has_terminal, what="the recovered agent shell terminal")
-        self._assert_shell_live()
+        self._wait_log(
+            LOG_HANDSHAKE,
+            since=offset,
+            timeout=RECONNECT_LOG_TIMEOUT,
+            what="the agent handshake to complete again after the server returns",
+        )
 
 
 class TestAgentReconnectBackendDriven(_AgentReconnectBase):
@@ -254,26 +329,52 @@ class TestAgentReconnectBackendDriven(_AgentReconnectBase):
 
     def test_backend_driven_reconnect_reattaches(self):
         self._connect_and_open_shell()
-        tab = self.wait(
-            lambda: self.find_tab("Shell") or self.find_tab(AGENT_NAME),
-            what="the shell tab",
-        )
-        tab_id = tab["id"]
         self._assert_shell_live()
+
+        # The daemon session id of the live shell — correlates the re-attach below.
+        sid = self._daemon_session_id()
+
+        # Cursor: everything asserted below must be POST-drop log content.
+        offset = self._log_len()
 
         # Prolonged drop: kill the sshd and keep it down while the backend redrive
-        # parks/retries. The client agent engine must NOT drive the transport.
+        # parks/retries. The drop must surface in the backend log.
         self._drop_transport()
-        self._wait_agent_state("reconnecting", "disconnected", timeout=60.0)
+        self._wait_log(LOG_DROP, since=offset, timeout=60.0, what="the drop to surface in the log")
 
-        # Recover the server; the agent transport comes back and the tab must
-        # recover live without being left exited/stranded.
+        # Recover the server. With the flag on, the backend redrive re-establishes
+        # the transport WITHOUT any bridge interaction — the handshake completes
+        # again (throttle-immune log read, never a frontend poll).
         self.sshd.start()
-        self._wait_agent_state("connected", timeout=90.0)
-        self.wait(
-            lambda: self.driver.get_state("terminalExitedTabs").get(tab_id) is not True,
-            what="the agent shell tab to recover (not left exited)",
-            timeout=90.0,
+        self._wait_log(
+            LOG_HANDSHAKE,
+            since=offset,
+            timeout=RECONNECT_LOG_TIMEOUT,
+            what="the backend redrive to complete the reconnect handshake",
         )
-        self.wait(self.has_terminal, what="the reattached agent shell terminal")
-        self._assert_shell_live()
+
+        # THE key end-to-end assertion: the LIVE daemon session was re-attached
+        # (process continuity), not silently recreated. The agent forwards its
+        # recovery log into the desktop log; assert the marker names *this* sid.
+        self._wait_log(
+            f"Recovered session {sid}",
+            f"Reattached to session {sid}",
+            since=offset,
+            timeout=RECONNECT_LOG_TIMEOUT,
+            what=f"the live agent session {sid} to be re-attached after reconnect",
+        )
+
+        # Negatives that would betray a lost/recreated session after the drop:
+        #   * a FRESH "Daemon spawned for session" (== a new "Created session"), and
+        #   * "Failed to recover session" (== the "session_lost" fold).
+        # Neither may appear in the post-drop window if the live session survived.
+        self._assert_log_absent(
+            LOG_SESSION_SPAWNED,
+            since=offset,
+            what="the live session must be re-attached, not recreated",
+        )
+        self._assert_log_absent(
+            LOG_SESSION_RECOVER_FAIL,
+            since=offset,
+            what="the live session must not be lost across the reconnect",
+        )


### PR DESCRIPTION
## What

Rewrites the full-app system test `tests/system/tests/test_agent_reconnect_live.py` to be **log-based** so it runs green in a display session **without depending on webview-bridge reads during the reconnect**.

## Why

During the long agent reconnect the WKWebView occlusion-throttles, so polling the frontend state via the bridge times out (`command timed out after 60s`) even though the app reconnects fine. This **supersedes the bridge-poll approach of #2520** for exactly that reason. The app's **backend log is written by Rust and is immune to that throttle**, so this suite asserts on it via the harness's per-instance capture, `AppInstance.read_log()`.

## How

- **Setup stays on the bridge (pre-drop, un-throttled):** seed + connect the agent, open a shell, confirm the initial `connected` state and a live round-trip.
- **After the drop+restore, assert on the LOG, not the bridge** (bounded polls on `app.read_log()`, no fixed sleeps):
  - drop surfaces: `connection lost, attempting reconnect`
  - reconnect handshake completes again: `initialize response received (...); marking connected`
  - **flag on (backend-driven):** the live daemon session is re-attached for the same `<sid>` — `Recovered session <sid>` / `Reattached to session <sid>` (agent stderr forwarded into the desktop log) — and **no** fresh `Daemon spawned for session` (== a new `Created session`) and **no** `Failed to recover session` (== the `session_lost` fold) appear post-drop.
  - **flag off (client-driven):** log-based "surfaces the drop and recovers" — the single-shot transport reconnect gives up (`reconnection failed`) while the server is down, then the handshake completes again after the server returns and the connection is re-initiated.
- **Terminal *content* continuity is deliberately not read back through the throttled bridge** — it is covered headlessly by the agent-integration tests (`fresh_agent_recovers_daemon_session_from_dead_prior_agent`, the #2519 tests).
- **Un-gated:** dropped the `TERMIHUB_TEST_LOCAL_AGENT_RECONNECT=1` opt-in so it runs in a display session; still skips cleanly when sshd / the agent binary is absent.

## Verification

Cannot run green here (needs a real display — run via `launchctl asuser`). Collects cleanly:

```
cd tests/system && ./pytest.sh --collect-only -q -k AgentReconnect
# 2/642 tests collected
```

Part of #2480, #2512