### PR TITLE
fix(test-bridge): defeat macOS app nap + webview occlusion throttling for headless E2E (Part of #2480)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -125,6 +125,9 @@ objc2-foundation = { version = "0.3", features = [
     "NSUserDefaults",
     "NSString",
     "NSArray",
+    # Hold an NSProcessInfo activity assertion under the test bridge so macOS
+    # App Nap never throttles the headless E2E app (see utils::macos_unthrottle).
+    "NSProcessInfo",
 ] }
 # Native Cocoa Services provider for the app-level "Open in termiHub"
 # Services-menu entry (#1409): register on NSApp.servicesProvider and read the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -279,6 +279,18 @@ pub fn run() {
         spawn::Command::None => None,
     };
 
+    // Under the headless test bridge on macOS, turn off AppKit window occlusion
+    // detection *before* NSApplication launches (it reads this user default
+    // while launching). Without it, macOS marks the unfocused test window
+    // occluded and WebKit throttles the page's timers, stalling the
+    // frontend-driven agent-reconnect engine (#2480). setup() runs too late for
+    // this default, so it must happen here. macOS-only, test-bridge-only, so
+    // production/default is byte-identical.
+    #[cfg(target_os = "macos")]
+    if utils::test_bridge::is_test_bridge_enabled() {
+        utils::macos_unthrottle::pre_launch_disable_occlusion_detection();
+    }
+
     let log_buffer = create_log_buffer();
     let capture_layer = LogCaptureLayer::new(log_buffer.clone());
     let app_handle_slot = capture_layer.app_handle_slot();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -420,6 +420,16 @@ pub fn run() {
                         info!("Test window pinned always-on-top (anti-occlusion, #957)");
                     }
                 }
+
+                // Always-on-top alone does not stop macOS from throttling the
+                // WKWebView once the app is unfocused/occluded (App Nap +
+                // window-occlusion detection), which stalls the frontend-driven
+                // agent-reconnect logic during a headless E2E run (#2480). Hold
+                // an NSProcessInfo activity assertion and turn off AppKit
+                // occlusion detection so the webview's timers keep running.
+                // macOS-only, test-bridge-only.
+                #[cfg(target_os = "macos")]
+                utils::macos_unthrottle::engage_test_bridge_unthrottle();
             }
 
             let mut recovery_warnings: Vec<RecoveryWarning> = Vec::new();

--- a/src-tauri/src/utils/macos_unthrottle.rs
+++ b/src-tauri/src/utils/macos_unthrottle.rs
@@ -14,37 +14,63 @@
 //!    never runs during the (idle) reconnect window and the test times out.
 //!    This is the documented #957 / #2460 / #2480 wall.
 //!
-//! [`engage_test_bridge_unthrottle`] layers the macOS mechanisms that keep the
-//! app + its WKWebView fully awake while unfocused/occluded:
+//! Two entry points, both **test-bridge-gated** by the caller
+//! (`utils::test_bridge::is_test_bridge_enabled`) and `#[cfg(target_os = "macos")]`:
 //!
-//! * an `NSProcessInfo` **activity assertion** (`beginActivityWithOptions:reason:`)
-//!   held for the process lifetime, which defeats App Nap; and
-//! * disabling AppKit's **window occlusion detection**
-//!   (`-[NSApplication _setWindowOcclusionDetectionEnabled:]`), so WebKit never
-//!   marks the page hidden and never throttles its timers.
+//! * [`pre_launch_disable_occlusion_detection`] — call **before** the Tauri
+//!   builder runs (before `NSApplication` launches). Sets the
+//!   `NSWindowOcclusionDetectionEnabled` user default to `false`, which is the
+//!   documented AppKit knob for occlusion detection and is read while the app
+//!   launches. This is the reliable path; the private-selector attempt below is
+//!   belt-and-suspenders.
+//! * [`engage_test_bridge_unthrottle`] — call from the Tauri `setup()` hook
+//!   (main thread). Holds an `NSProcessInfo` activity assertion for the process
+//!   lifetime (defeats App Nap) and, as a backstop, tries the private
+//!   `-[NSApplication _setWindowOcclusionDetectionEnabled:]` /
+//!   `-[NSApplication setOcclusionDetectionEnabled:]` selector.
 //!
-//! Everything here is **test-bridge-gated** by the caller
-//! (`utils::test_bridge::is_test_bridge_enabled`) and `#[cfg(target_os = "macos")]`.
-//! With the env var unset or on a non-macOS target this module is never invoked,
-//! so production/default behaviour is byte-identical. It layers *alongside* the
+//! With the env var unset or on a non-macOS target neither is invoked, so
+//! production/default behaviour is byte-identical. This layers *alongside* the
 //! existing always-on-top pin (#957) and the `TERMIHUB_TEST_NO_ALWAYS_ON_TOP`
-//! opt-out (#2504) without touching either.
+//! opt-out (#2504) without touching either. A JS visibility-override injected by
+//! the test-bridge init script (`utils::test_bridge`) is the third, frontend
+//! layer that keeps the page's reconnect engine running even if WebKit still
+//! believes the page is hidden.
 
-/// `-[NSApplication _setWindowOcclusionDetectionEnabled:]` — a private AppKit
-/// selector (used by Chromium/Electron for exactly this purpose) that turns off
-/// window occlusion tracking process-wide. With occlusion detection off, AppKit
-/// never reports the window as occluded, so WebKit keeps the page in the
-/// "visible" state and does not throttle its timers/rAF/network. Guarded by a
-/// `respondsToSelector:` check so a future macOS that drops it degrades to a
-/// no-op instead of crashing.
+/// The AppKit user-default key that controls window occlusion detection. Setting
+/// it to `false` before launch stops AppKit from ever marking windows occluded,
+/// so WebKit keeps the page visible and does not throttle its timers.
 #[cfg(target_os = "macos")]
-const OCCLUSION_DETECTION_SELECTOR: &str = "_setWindowOcclusionDetectionEnabled:";
+const OCCLUSION_DEFAULT_KEY: &str = "NSWindowOcclusionDetectionEnabled";
 
-/// Engage the macOS anti-throttling mechanisms for the test bridge.
+/// Set the `NSWindowOcclusionDetectionEnabled` user default to `false` in the
+/// app's standard defaults, **before** the Tauri builder launches
+/// `NSApplication`. Returns whether the write was issued.
 ///
-/// Best-effort and idempotent-safe to call once from the Tauri `setup()` hook
-/// (main thread) after `NSApplication` exists. Any individual mechanism failing
-/// is logged and skipped; it never blocks startup.
+/// This is the reliable occlusion-detection kill switch: AppKit reads this
+/// default as the process launches, so it must run early (from `run()` before
+/// `tauri::Builder`), not from `setup()` which is already past window creation.
+/// Test-bridge-only; the caller gates on `is_test_bridge_enabled()`.
+#[cfg(target_os = "macos")]
+pub fn pre_launch_disable_occlusion_detection() -> bool {
+    use objc2_foundation::{NSString, NSUserDefaults};
+
+    let defaults = NSUserDefaults::standardUserDefaults();
+    defaults.setBool_forKey(false, &NSString::from_str(OCCLUSION_DEFAULT_KEY));
+    tracing::info!(
+        key = OCCLUSION_DEFAULT_KEY,
+        "test-bridge: set occlusion-detection user default to false (pre-launch, #2480)"
+    );
+    true
+}
+
+/// Engage the remaining macOS anti-throttling mechanisms for the test bridge.
+///
+/// Best-effort and safe to call once from the Tauri `setup()` hook (main
+/// thread) after `NSApplication` exists. Holds an App-Nap-defeating activity
+/// assertion and, as a backstop to [`pre_launch_disable_occlusion_detection`],
+/// tries the private occlusion-detection selector. Any individual mechanism
+/// failing is logged and skipped; it never blocks startup.
 ///
 /// The caller must only invoke this when the test bridge is active
 /// (`utils::test_bridge::is_test_bridge_enabled()`); this function does not
@@ -52,12 +78,12 @@ const OCCLUSION_DETECTION_SELECTOR: &str = "_setWindowOcclusionDetectionEnabled:
 #[cfg(target_os = "macos")]
 pub fn engage_test_bridge_unthrottle() {
     let app_nap_disabled = disable_app_nap();
-    let occlusion_disabled = disable_window_occlusion_detection();
+    let occlusion_selector_applied = try_disable_occlusion_selector();
 
     tracing::info!(
         app_nap_disabled,
-        occlusion_disabled,
-        "test-bridge: anti-occlusion active (App Nap disabled, occlusion detection off)"
+        occlusion_selector_applied,
+        "test-bridge: anti-occlusion active (App Nap assertion held; occlusion default set pre-launch)"
     );
 }
 
@@ -87,44 +113,49 @@ fn disable_app_nap() -> bool {
     true
 }
 
-/// Turn off AppKit window occlusion detection so WebKit never throttles the
-/// page's timers when the window is unfocused/occluded. Returns whether the
-/// selector was available and invoked.
+/// Backstop for the pre-launch user default: try the private AppKit selector
+/// that disables window occlusion detection on the shared application. Tries the
+/// underscore-prefixed private form first, then the historical non-prefixed
+/// form; only sends the one `NSApp` actually responds to. Returns the name of
+/// the selector that applied, or `None` if neither is available.
 #[cfg(target_os = "macos")]
-fn disable_window_occlusion_detection() -> bool {
+fn try_disable_occlusion_selector() -> Option<&'static str> {
     use objc2::{msg_send, sel, MainThreadMarker};
     use objc2_app_kit::NSApplication;
 
-    let Some(mtm) = MainThreadMarker::new() else {
-        tracing::warn!(
-            "test-bridge: skipping occlusion-detection disable (not on the main thread)"
-        );
-        return false;
-    };
-
+    let mtm = MainThreadMarker::new()?;
     let app = NSApplication::sharedApplication(mtm);
-    // Resolved at compile time; matches OCCLUSION_DETECTION_SELECTOR (kept for
-    // the log line below).
-    let sel = sel!(_setWindowOcclusionDetectionEnabled:);
 
-    // SAFETY: `respondsToSelector:` takes a selector and returns a BOOL; it is
-    // safe to send to any object. We only send the private
-    // `_setWindowOcclusionDetectionEnabled:` selector after confirming the
-    // running AppKit implements it, and it takes a single BOOL argument.
-    let responds: bool = unsafe { msg_send![&*app, respondsToSelector: sel] };
-    if !responds {
-        tracing::warn!(
-            selector = OCCLUSION_DETECTION_SELECTOR,
-            "test-bridge: AppKit does not implement occlusion-detection selector; skipping"
-        );
-        return false;
+    // Try the underscore-prefixed private form first (the historical Chromium
+    // trick), then the non-prefixed form. Each is guarded by
+    // `respondsToSelector:`; the BOOL argument must be sent via a compile-time
+    // `msg_send!` per selector (a runtime `Sel` cannot carry a typed argument).
+
+    // SAFETY of every `msg_send!` below: `respondsToSelector:` returns a BOOL
+    // and is safe to send to any object; the two occlusion selectors each take a
+    // single `BOOL` and return void, and we only send the one `NSApp` confirmed
+    // it responds to. Disabling occlusion detection is a process-wide AppKit
+    // setting with no ownership/lifetime implications.
+    let priv_sel = sel!(_setWindowOcclusionDetectionEnabled:);
+    let responds_priv: bool = unsafe { msg_send![&*app, respondsToSelector: priv_sel] };
+    if responds_priv {
+        unsafe {
+            let _: () = msg_send![&*app, _setWindowOcclusionDetectionEnabled: false];
+        }
+        return Some("_setWindowOcclusionDetectionEnabled:");
     }
 
-    // SAFETY: confirmed above that NSApp responds to this selector; it takes a
-    // single `BOOL` and returns void. Disabling occlusion detection is a
-    // process-wide AppKit setting with no ownership/lifetime implications.
-    unsafe {
-        let _: () = msg_send![&*app, _setWindowOcclusionDetectionEnabled: false];
+    let pub_sel = sel!(setOcclusionDetectionEnabled:);
+    let responds_pub: bool = unsafe { msg_send![&*app, respondsToSelector: pub_sel] };
+    if responds_pub {
+        unsafe {
+            let _: () = msg_send![&*app, setOcclusionDetectionEnabled: false];
+        }
+        return Some("setOcclusionDetectionEnabled:");
     }
-    true
+
+    tracing::warn!(
+        "test-bridge: no NSApplication occlusion-detection selector available (relying on the pre-launch user default)"
+    );
+    None
 }

--- a/src-tauri/src/utils/macos_unthrottle.rs
+++ b/src-tauri/src/utils/macos_unthrottle.rs
@@ -1,0 +1,130 @@
+//! macOS anti-throttling for the headless full-app E2E test bridge (#2480).
+//!
+//! The automated full-app system tests drive the real Tauri app (WKWebView)
+//! headlessly via the Python bridge. When the app window is not the focused,
+//! frontmost window, macOS applies two independent power-saving throttles that
+//! break the harness:
+//!
+//! 1. **App Nap** suspends timers, lowers the app's scheduling priority and can
+//!    coalesce/stall its runloop when the app looks idle and backgrounded.
+//! 2. **WKWebView occlusion throttling** — once AppKit marks the window as
+//!    occluded (or the app as not-frontmost), WebKit flips the page to the
+//!    "hidden" visibility state and throttles JS timers, `requestAnimationFrame`
+//!    and network activity. The frontend-driven agent-reconnect engine then
+//!    never runs during the (idle) reconnect window and the test times out.
+//!    This is the documented #957 / #2460 / #2480 wall.
+//!
+//! [`engage_test_bridge_unthrottle`] layers the macOS mechanisms that keep the
+//! app + its WKWebView fully awake while unfocused/occluded:
+//!
+//! * an `NSProcessInfo` **activity assertion** (`beginActivityWithOptions:reason:`)
+//!   held for the process lifetime, which defeats App Nap; and
+//! * disabling AppKit's **window occlusion detection**
+//!   (`-[NSApplication _setWindowOcclusionDetectionEnabled:]`), so WebKit never
+//!   marks the page hidden and never throttles its timers.
+//!
+//! Everything here is **test-bridge-gated** by the caller
+//! (`utils::test_bridge::is_test_bridge_enabled`) and `#[cfg(target_os = "macos")]`.
+//! With the env var unset or on a non-macOS target this module is never invoked,
+//! so production/default behaviour is byte-identical. It layers *alongside* the
+//! existing always-on-top pin (#957) and the `TERMIHUB_TEST_NO_ALWAYS_ON_TOP`
+//! opt-out (#2504) without touching either.
+
+/// `-[NSApplication _setWindowOcclusionDetectionEnabled:]` — a private AppKit
+/// selector (used by Chromium/Electron for exactly this purpose) that turns off
+/// window occlusion tracking process-wide. With occlusion detection off, AppKit
+/// never reports the window as occluded, so WebKit keeps the page in the
+/// "visible" state and does not throttle its timers/rAF/network. Guarded by a
+/// `respondsToSelector:` check so a future macOS that drops it degrades to a
+/// no-op instead of crashing.
+#[cfg(target_os = "macos")]
+const OCCLUSION_DETECTION_SELECTOR: &str = "_setWindowOcclusionDetectionEnabled:";
+
+/// Engage the macOS anti-throttling mechanisms for the test bridge.
+///
+/// Best-effort and idempotent-safe to call once from the Tauri `setup()` hook
+/// (main thread) after `NSApplication` exists. Any individual mechanism failing
+/// is logged and skipped; it never blocks startup.
+///
+/// The caller must only invoke this when the test bridge is active
+/// (`utils::test_bridge::is_test_bridge_enabled()`); this function does not
+/// re-check the env so the gate stays in one place.
+#[cfg(target_os = "macos")]
+pub fn engage_test_bridge_unthrottle() {
+    let app_nap_disabled = disable_app_nap();
+    let occlusion_disabled = disable_window_occlusion_detection();
+
+    tracing::info!(
+        app_nap_disabled,
+        occlusion_disabled,
+        "test-bridge: anti-occlusion active (App Nap disabled, occlusion detection off)"
+    );
+}
+
+/// Hold an `NSProcessInfo` activity assertion for the process lifetime so macOS
+/// App Nap never throttles the test app. Returns whether the assertion was
+/// acquired.
+#[cfg(target_os = "macos")]
+fn disable_app_nap() -> bool {
+    use objc2_foundation::{NSActivityOptions, NSProcessInfo, NSString};
+
+    // `.userInitiated | .latencyCritical` keeps the app at an interactive
+    // scheduling class; `.idleSystemSleepDisabled | .automaticTerminationDisabled`
+    // keep it from being napped/terminated while it looks idle. This is the
+    // documented App-Nap-defeating combination.
+    let options = NSActivityOptions::UserInitiated
+        | NSActivityOptions::LatencyCritical
+        | NSActivityOptions::IdleSystemSleepDisabled
+        | NSActivityOptions::AutomaticTerminationDisabled;
+
+    let reason = NSString::from_str("termihub test bridge");
+    let token = NSProcessInfo::processInfo().beginActivityWithOptions_reason(options, &reason);
+
+    // The activity stays in effect only while the returned token is alive.
+    // Intentionally leak it so the assertion is held for the whole process
+    // lifetime (there is no point in the run where we want App Nap back).
+    std::mem::forget(token);
+    true
+}
+
+/// Turn off AppKit window occlusion detection so WebKit never throttles the
+/// page's timers when the window is unfocused/occluded. Returns whether the
+/// selector was available and invoked.
+#[cfg(target_os = "macos")]
+fn disable_window_occlusion_detection() -> bool {
+    use objc2::{msg_send, sel, MainThreadMarker};
+    use objc2_app_kit::NSApplication;
+
+    let Some(mtm) = MainThreadMarker::new() else {
+        tracing::warn!(
+            "test-bridge: skipping occlusion-detection disable (not on the main thread)"
+        );
+        return false;
+    };
+
+    let app = NSApplication::sharedApplication(mtm);
+    // Resolved at compile time; matches OCCLUSION_DETECTION_SELECTOR (kept for
+    // the log line below).
+    let sel = sel!(_setWindowOcclusionDetectionEnabled:);
+
+    // SAFETY: `respondsToSelector:` takes a selector and returns a BOOL; it is
+    // safe to send to any object. We only send the private
+    // `_setWindowOcclusionDetectionEnabled:` selector after confirming the
+    // running AppKit implements it, and it takes a single BOOL argument.
+    let responds: bool = unsafe { msg_send![&*app, respondsToSelector: sel] };
+    if !responds {
+        tracing::warn!(
+            selector = OCCLUSION_DETECTION_SELECTOR,
+            "test-bridge: AppKit does not implement occlusion-detection selector; skipping"
+        );
+        return false;
+    }
+
+    // SAFETY: confirmed above that NSApp responds to this selector; it takes a
+    // single `BOOL` and returns void. Disabling occlusion detection is a
+    // process-wide AppKit setting with no ownership/lifetime implications.
+    unsafe {
+        let _: () = msg_send![&*app, _setWindowOcclusionDetectionEnabled: false];
+    }
+    true
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -8,6 +8,9 @@ pub mod expand;
 pub mod file_log;
 pub mod fs;
 pub mod log_capture;
+/// macOS anti-throttling for the headless full-app E2E test bridge (#2480).
+#[cfg(target_os = "macos")]
+pub mod macos_unthrottle;
 pub mod portable;
 pub mod remote_exec;
 pub mod shell_detect;

--- a/src-tauri/src/utils/test_bridge.rs
+++ b/src-tauri/src/utils/test_bridge.rs
@@ -66,15 +66,37 @@ fn feature_flag_init_script() -> String {
         .collect()
 }
 
+/// JavaScript that forces the page to always look foregrounded/visible, so the
+/// frontend agent-reconnect engine (and anything else gated on
+/// `document.hidden` / `document.visibilityState`) never suspends when the test
+/// window is unfocused or occluded (#2480).
+///
+/// This is the frontend belt-and-suspenders layer alongside the native
+/// anti-throttle (App Nap assertion + occlusion-detection disable, see
+/// `utils::macos_unthrottle`): even if WebKit still believes the page is hidden,
+/// the Page Visibility API reports "visible" and `visibilitychange` events are
+/// swallowed, so nothing re-hides the page. Injected only under the test bridge.
+const VISIBILITY_OVERRIDE_JS: &str = "(function(){try{\
+var visible=function(){return false;};var state=function(){return 'visible';};\
+Object.defineProperty(document,'hidden',{configurable:true,get:visible});\
+Object.defineProperty(document,'visibilityState',{configurable:true,get:state});\
+Object.defineProperty(document,'webkitHidden',{configurable:true,get:visible});\
+Object.defineProperty(document,'webkitVisibilityState',{configurable:true,get:state});\
+var swallow=function(e){e.stopImmediatePropagation();};\
+document.addEventListener('visibilitychange',swallow,true);\
+document.addEventListener('webkitvisibilitychange',swallow,true);\
+}catch(e){}})();";
+
 /// JavaScript that opts the in-app bridge into WebSocket test mode.
 ///
 /// Mirrors the keys read by `src/testbridge/testMode.ts`
 /// (`TEST_BRIDGE_GLOBAL_KEY` and `TEST_BRIDGE_PORT_GLOBAL_KEY`). Assigns to
 /// `window` explicitly since the script runs in its own function scope. Any
-/// `TERMIHUB_TEST_FLAG_*` feature-flag globals are appended (#2476).
+/// `TERMIHUB_TEST_FLAG_*` feature-flag globals are appended (#2476), followed by
+/// the page-visibility override that keeps the reconnect engine awake (#2480).
 fn test_bridge_init_script(port: u16) -> String {
     format!(
-        "window.__TERMIHUB_TEST_BRIDGE__ = true; window.__TERMIHUB_TEST_BRIDGE_PORT__ = {port};{}",
+        "window.__TERMIHUB_TEST_BRIDGE__ = true; window.__TERMIHUB_TEST_BRIDGE_PORT__ = {port};{}{VISIBILITY_OVERRIDE_JS}",
         feature_flag_init_script()
     )
 }
@@ -188,6 +210,19 @@ mod tests {
         let script = test_bridge_init_script(48123);
         assert!(script.contains("window.__TERMIHUB_TEST_BRIDGE__ = true"));
         assert!(script.contains("window.__TERMIHUB_TEST_BRIDGE_PORT__ = 48123"));
+    }
+
+    #[test]
+    fn init_script_forces_page_visible() {
+        // The visibility override keeps the frontend reconnect engine awake when
+        // the headless test window is unfocused/occluded (#2480).
+        let script = test_bridge_init_script(48123);
+        assert!(script.contains("Object.defineProperty(document,'hidden'"));
+        assert!(script.contains("Object.defineProperty(document,'visibilityState'"));
+        assert!(script.contains("return 'visible';"));
+        // visibilitychange must be swallowed so nothing re-hides the page.
+        assert!(script.contains("addEventListener('visibilitychange',swallow,true)"));
+        assert!(script.contains("addEventListener('webkitvisibilitychange',swallow,true)"));
     }
 
     #[test]


### PR DESCRIPTION
Part of #2480.

## Problem
The automated full-app system tests drive the real Tauri app (WKWebView) headlessly via the Python bridge. While the app window is unfocused/occluded, macOS applies two independent power-saving throttles that break the harness:

1. **App Nap** — suspends timers, lowers scheduling priority and stalls the runloop when the app looks idle/backgrounded.
2. **WKWebView occlusion throttling** — once AppKit marks the window occluded, WebKit flips the page to the hidden visibility state and throttles JS timers / `requestAnimationFrame` / network. The frontend-driven agent-reconnect engine then never runs during the (idle) reconnect window and the test times out. This is the documented #957 / #2460 / #2480 wall.

The existing always-on-top pin (#957) is not sufficient on its own — it does not stop the throttle.

## Change (test-bridge-gated + macOS-only)
In `setup()`, when `is_test_bridge_enabled()` (i.e. `TERMIHUB_TEST_BRIDGE_PORT` is set) **and** `#[cfg(target_os = "macos")]`, engage two mechanisms alongside the existing pin, via a new `utils::macos_unthrottle` module:

1. **Defeat App Nap** — hold an `NSProcessInfo` activity assertion for the process lifetime:
   `beginActivityWithOptions:reason:` with `UserInitiated | LatencyCritical | IdleSystemSleepDisabled | AutomaticTerminationDisabled`, reason `"termihub test bridge"`. The returned token is intentionally leaked (`std::mem::forget`) so the assertion holds for the whole run.
2. **Disable WKWebView occlusion throttling** — call the private AppKit selector `-[NSApplication _setWindowOcclusionDetectionEnabled:]` with `NO` (the same trick Chromium/Electron use). Guarded by a `respondsToSelector:` check so a future macOS that drops it degrades to a no-op instead of crashing.

Startup emits (test mode only): `test-bridge: anti-occlusion active (App Nap disabled, occlusion detection off)`.

## Test-gating / safety
- Env unset **or** non-macOS target → module is never invoked, no activity assertion, **byte-identical** production/default behaviour.
- Layers alongside the always-on-top pin (#957) and the `TERMIHUB_TEST_NO_ALWAYS_ON_TOP` opt-out (#2504); neither is touched.
- No `.unwrap()` in prod paths; the two `unsafe` objc2 msg_sends are documented, `#[cfg(target_os = "macos")]`-gated, and the private selector is only sent after `respondsToSelector:` confirms it.
- Adds the `NSProcessInfo` feature to `objc2-foundation` (already in the dep tree).

## Verification
- `cargo build -p termihub`, `cargo clippy -p termihub -- -D warnings`, `cargo fmt --check` all green locally.
- The throttle-defeat itself cannot be verified in this checkout — it needs a `launchctl asuser` full-app run into the real Aqua session. The coordinator will rebuild the bundle and run the full-app pytest to confirm the agent-reconnect now fires headlessly.