### PR TITLE
fix(ui): agent/session stale-green state + agent-node two-row header (Closes #2524)

### DIFF
--- a/docs/changes/dev0/fix/2524-agent-node-state-layout.md
+++ b/docs/changes/dev0/fix/2524-agent-node-state-layout.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **Remote Agents sidebar & terminal tabs no longer show a stale "connected"
+  green indicator after a drop.** A terminal tab whose live agent session was
+  lost on reconnect (the transport came back but the session could not be
+  recovered) kept a green connection dot as if healthy; its status dot now
+  reflects the disconnected/lost state (#2524, #2512).
+- **The remote-agent header no longer hides the agent name.** The state bubble,
+  agent name and version badge now sit on the first row and the action buttons
+  drop to a second row, so a connected agent's action buttons can no longer
+  crowd the name off the row (#2524).

--- a/src/components/Sidebar/AgentNode.header.test.tsx
+++ b/src/components/Sidebar/AgentNode.header.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * Agent-header presentation (#2524):
+ *
+ *  1. The connection state dot tracks the real `connectionState` — a
+ *     disconnected / reconnecting / connecting agent never shows the green
+ *     "connected" dot (regression guard for the stale-green bug).
+ *  2. The header stacks into two rows: the agent name lives on row 1 alongside
+ *     the state bubble + version badge (inside the toggle), while the action
+ *     buttons live in a *sibling* container (row 2) so they can never crowd the
+ *     name off the row.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, Root } from "react-dom/client";
+import { useAppStore } from "@/store/appStore";
+import { AgentNode } from "./AgentNode";
+import { DEFAULT_AGENT_SETTINGS, type RemoteAgentDefinition } from "@/types/connection";
+import { setupAgentsRegion, seedAgentsRegion } from "@/test/agentsRegionTestHarness";
+
+// --- mocks required by AgentNode --------------------------------------------
+
+vi.mock("@dnd-kit/sortable", () => ({
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  useDraggable: () => ({ attributes: {}, listeners: {}, setNodeRef: vi.fn(), isDragging: false }),
+  useDroppable: () => ({ setNodeRef: vi.fn(), isOver: false }),
+  useDndContext: () => ({ active: null }),
+  useDndMonitor: () => {},
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: () => "" } },
+}));
+
+vi.mock("@/services/api", () => ({
+  removeCredential: vi.fn(() => Promise.resolve()),
+  storeCredential: vi.fn(() => Promise.resolve()),
+  cancelConnectAgent: vi.fn(() => Promise.resolve()),
+  listAgentDefinitions: vi.fn(() => Promise.resolve([])),
+  listAgentConnections: vi.fn(() => Promise.resolve({ connections: [], folders: [] })),
+  saveAgentDefinition: vi.fn(),
+  updateAgentDefinition: vi.fn(),
+  deleteAgentDefinition: vi.fn(() => Promise.resolve()),
+  createAgentFolder: vi.fn(),
+  updateAgentFolder: vi.fn(),
+  deleteAgentFolder: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("@/utils/frontendLog", () => ({ frontendLog: vi.fn() }));
+vi.mock("@/utils/resolveConnectionCredential", () => ({
+  resolveConnectionCredential: vi.fn(() =>
+    Promise.resolve({ usedStoredCredential: false, password: null })
+  ),
+}));
+vi.mock("@/utils/ensureCredentialStoreUnlocked", () => ({
+  ensureCredentialStoreUnlocked: vi.fn(() => Promise.resolve(true)),
+}));
+vi.mock("./AgentSetupDialog", () => ({ AgentSetupDialog: () => null }));
+vi.mock("./ConnectionErrorDialog", () => ({ ConnectionErrorDialog: () => null }));
+vi.mock("./InlineFolderInput", () => ({ InlineFolderInput: () => null }));
+vi.mock("@/components/AgentUpdateBanner", () => ({ AgentUpdateBanner: () => null }));
+
+// The header's action buttons wrap their icons in the Radix-backed Tooltip, which
+// needs a TooltipProvider. Stub it to a passthrough so isolated renders don't
+// require the app-root provider.
+vi.mock("@/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/ui")>();
+  return { ...actual, Tooltip: ({ children }: { children: React.ReactNode }) => children };
+});
+
+// --- helpers -----------------------------------------------------------------
+
+const AGENT_ID = "agent-header-test";
+
+function makeAgent(overrides: Partial<RemoteAgentDefinition> = {}): RemoteAgentDefinition {
+  return {
+    id: AGENT_ID,
+    name: "Production Box",
+    config: {
+      host: "host.example.com",
+      port: 22,
+      username: "user",
+      authMethod: "password",
+      password: "secret",
+    },
+    connectionState: "connected",
+    isExpanded: true,
+    agentSettings: DEFAULT_AGENT_SETTINGS,
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderAgent(agent: RemoteAgentDefinition) {
+  seedAgentsRegion({
+    agentDefinitions: { [AGENT_ID]: [] },
+    agentFolders: { [AGENT_ID]: [] },
+    agentSessions: { [AGENT_ID]: [] },
+    remoteAgents: [agent],
+  });
+  act(() => {
+    root.render(React.createElement(AgentNode, { agent }));
+  });
+}
+
+function stateDot(): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="agent-state-${AGENT_ID}"]`);
+}
+
+function header(): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="agent-header-${AGENT_ID}"]`);
+}
+
+setupAgentsRegion();
+
+describe("AgentNode — header presentation (#2524)", () => {
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  describe("state dot tracks connectionState (never stale green)", () => {
+    it("shows the connected modifier when connected", () => {
+      renderAgent(makeAgent({ connectionState: "connected" }));
+      expect(stateDot()?.className).toContain("agent-node__state-dot--connected");
+    });
+
+    it("shows the disconnected modifier — not connected — when disconnected", () => {
+      renderAgent(makeAgent({ connectionState: "disconnected" }));
+      const cls = stateDot()?.className ?? "";
+      expect(cls).toContain("agent-node__state-dot--disconnected");
+      expect(cls).not.toContain("agent-node__state-dot--connected");
+    });
+
+    it("shows the reconnecting modifier — not connected — while reconnecting", () => {
+      renderAgent(makeAgent({ connectionState: "reconnecting" }));
+      const cls = stateDot()?.className ?? "";
+      expect(cls).toContain("agent-node__state-dot--reconnecting");
+      expect(cls).not.toContain("agent-node__state-dot--connected");
+    });
+
+    it("shows the connecting modifier — not connected — while connecting", () => {
+      renderAgent(makeAgent({ connectionState: "connecting" }));
+      const cls = stateDot()?.className ?? "";
+      expect(cls).toContain("agent-node__state-dot--connecting");
+      expect(cls).not.toContain("agent-node__state-dot--connected");
+    });
+  });
+
+  describe("two-row layout keeps the agent name visible", () => {
+    it("marks the agent header with the two-row modifier", () => {
+      renderAgent(makeAgent());
+      expect(header()?.className).toContain("connection-list__group-header--agent");
+    });
+
+    it("keeps the name + state dot on row 1 (the toggle) and buttons in a sibling row", () => {
+      renderAgent(makeAgent());
+
+      const toggle = container.querySelector<HTMLElement>(".connection-list__group-toggle");
+      const actions = container.querySelector<HTMLElement>(".connection-list__group-actions");
+      const title = container.querySelector<HTMLElement>(".connection-list__group-title");
+
+      expect(toggle).not.toBeNull();
+      expect(actions).not.toBeNull();
+      expect(title?.textContent).toBe("Production Box");
+
+      // Row 1: the state bubble and the agent name live inside the toggle.
+      expect(toggle!.contains(stateDot())).toBe(true);
+      expect(toggle!.contains(title)).toBe(true);
+
+      // Row 2: the action buttons are a *sibling* of the toggle, never nested
+      // inside it — so they can never crowd the name off its row.
+      expect(toggle!.contains(actions)).toBe(false);
+      expect(actions!.parentElement).toBe(header());
+    });
+  });
+});

--- a/src/components/Sidebar/AgentNode.tsx
+++ b/src/components/Sidebar/AgentNode.tsx
@@ -1201,7 +1201,7 @@ export function AgentNode({ agent, style, sectionRef, filterQuery = "" }: AgentN
       <ContextMenu.Root>
         <ContextMenu.Trigger asChild>
           <div
-            className="connection-list__group-header"
+            className="connection-list__group-header connection-list__group-header--agent"
             data-testid={`agent-header-${agent.id}`}
             title={`Remote agent: ${agent.name}`}
             {...attributes}

--- a/src/components/Sidebar/ConnectionList.css
+++ b/src/components/Sidebar/ConnectionList.css
@@ -126,6 +126,27 @@
   flex-shrink: 0;
 }
 
+/*
+ * Per-agent header stacks into two rows (#2524): row 1 = state bubble + agent
+ * name + version badge (the toggle), row 2 = the action buttons. On the single
+ * shared row the buttons crowded the row and pushed the agent name out of view;
+ * a column keeps the toggle full-width so the name is always visible and free to
+ * ellipsize. Scoped to the agent header so the LOCAL / REMOTE AGENTS section
+ * headers keep their single-row layout.
+ */
+.connection-list__group-header--agent {
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: var(--spacing-xxs);
+}
+
+/* Row 2: indent the buttons to sit under the agent name (past chevron + state
+   dot + server icon) so they read as belonging to the agent above them. */
+.connection-list__group-header--agent .connection-list__group-actions {
+  padding-left: calc(var(--spacing-2xl) + var(--spacing-lg));
+}
+
 .connection-list__tree {
   flex: 1;
   overflow-y: auto;

--- a/src/components/Terminal/TabBar.tsx
+++ b/src/components/Terminal/TabBar.tsx
@@ -46,8 +46,12 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
   // / disconnect errors) are sourced from the projected region (falls back to
   // appStore per key when not mirrored); spawn errors and exited tabs stay on
   // appStore (not part of the session-lifecycle region).
-  const { terminalConnecting, terminalReconnectingTabs, terminalDisconnectErrors } =
-    useProjectedSessionLifecycleMaps();
+  const {
+    terminalConnecting,
+    terminalReconnectingTabs,
+    terminalDisconnectErrors,
+    terminalSessionLost,
+  } = useProjectedSessionLifecycleMaps();
   const terminalSpawnErrors = useAppStore((s) => s.terminalSpawnErrors);
   const terminalExitedTabs = useAppStore((s) => s.terminalExitedTabs);
   // Broadcast participation (#1957): the badge shows on every tab in the target
@@ -230,6 +234,7 @@ export function TabBar({ panelId, tabs }: TabBarProps) {
                         terminalSpawnErrors,
                         terminalDisconnectErrors,
                         terminalExitedTabs,
+                        terminalSessionLost,
                       },
                       tab.id
                     )

--- a/src/store/useProjectedSessionLifecycle.test.tsx
+++ b/src/store/useProjectedSessionLifecycle.test.tsx
@@ -18,6 +18,7 @@ import {
   flushSessionRegion,
   installSessionLifecycleHarness,
   reconnecting,
+  sessionLost,
 } from "@/test/sessionLifecycleRegionTestHarness";
 
 import {
@@ -153,5 +154,16 @@ describe("useProjectedSessionLifecycleMaps (list consumers)", () => {
     expect(latest?.terminalConnecting).toEqual({ a: true });
     expect(latest?.terminalReconnectingTabs).toEqual({ b: true });
     expect(latest?.terminalDisconnectErrors).toEqual({ c: "boom" });
+  });
+
+  it("exposes a terminalSessionLost map from the region (#2524)", async () => {
+    // The tab-strip dot reads this so a session-lost tab never stays green (#2512).
+    harness.transport.setSession("d", sessionLost("process ended"));
+    harness.transport.setSession("e", connected());
+    let latest: ProjectedSessionLifecycleMaps | undefined;
+    mount(<Probe onValue={(v) => (latest = v)} />);
+    await flushSessionRegion();
+
+    expect(latest?.terminalSessionLost).toEqual({ d: true });
   });
 });

--- a/src/store/useSessionLifecycle.ts
+++ b/src/store/useSessionLifecycle.ts
@@ -200,6 +200,21 @@ export interface ProjectedSessionLifecycleMaps {
   terminalConnecting: Record<string, boolean>;
   terminalReconnectingTabs: Record<string, boolean>;
   terminalDisconnectErrors: Record<string, string>;
+  /**
+   * Tabs whose live session is terminally lost (#2512). Region-only (no `appStore`
+   * twin), so this is empty on the pre-cut path. It drives the tab-strip dot away
+   * from a stale-green "connected" when the session could not be recovered (#2524).
+   */
+  terminalSessionLost: Record<string, boolean>;
+}
+
+/** Build the `tabId → true` session-lost map from the projected region view. */
+function sessionLostMap(view: Record<string, ProjectedSessionLifecycle>): Record<string, boolean> {
+  const map: Record<string, boolean> = {};
+  for (const [tabId, life] of Object.entries(view)) {
+    if (life.status === "sessionLost") map[tabId] = true;
+  }
+  return map;
 }
 
 /**
@@ -251,12 +266,15 @@ export function useProjectedSessionLifecycleMaps(): ProjectedSessionLifecycleMap
         terminalConnecting: connectingLocal,
         terminalReconnectingTabs: reconnectingLocal,
         terminalDisconnectErrors: disconnectErrorsLocal,
+        // Session-lost is region-only; with the cut off there is nothing to read.
+        terminalSessionLost: {},
       };
     }
     return {
       terminalConnecting: effectiveConnectingMap(connectingLocal, view),
       terminalReconnectingTabs: effectiveReconnectingMap(reconnectingLocal, view),
       terminalDisconnectErrors: effectiveDisconnectErrorMap(disconnectErrorsLocal, view),
+      terminalSessionLost: sessionLostMap(view),
     };
   }, [enabled, connectingLocal, reconnectingLocal, disconnectErrorsLocal, view]);
 }

--- a/src/utils/tabStatus.test.ts
+++ b/src/utils/tabStatus.test.ts
@@ -39,6 +39,24 @@ describe("deriveTabStatus", () => {
     expect(deriveTabStatus(maps, "a")).toBe("disconnected");
   });
 
+  it("returns 'disconnected' when the live agent session is lost (#2524)", () => {
+    // #2512 session-lost: the transport came back but the live session could not
+    // be recovered. The dot must never stay green — regression for #2524 bug 2.
+    const maps = makeMaps({ terminalSessionLost: { a: true } });
+    expect(deriveTabStatus(maps, "a")).toBe("disconnected");
+  });
+
+  it("treats session-lost as terminal — it wins over an in-flight connecting flag (#2524)", () => {
+    // The region can report `sessionLost` while a stale connecting flag lingers
+    // (settleSessionLost has not folded yet). Session-lost is terminal, so the
+    // dot must show disconnected rather than a green-adjacent connecting pulse.
+    const maps = makeMaps({
+      terminalSessionLost: { a: true },
+      terminalConnecting: { a: true },
+    });
+    expect(deriveTabStatus(maps, "a")).toBe("disconnected");
+  });
+
   it("returns 'connected' when no lifecycle flags are set", () => {
     const maps = makeMaps();
     expect(deriveTabStatus(maps, "a")).toBe("connected");

--- a/src/utils/tabStatus.ts
+++ b/src/utils/tabStatus.ts
@@ -24,22 +24,39 @@ export interface TabStatusMaps {
   terminalDisconnectErrors: Record<string, string>;
   /** True when a tab's terminal session has exited. */
   terminalExitedTabs: Record<string, boolean>;
+  /**
+   * True when a tab is in the terminal `sessionLost` state (#2512): the transport
+   * came back but the live agent session could not be recovered. Sourced from the
+   * projected `session-lifecycle` region (it has no `appStore` twin), so it is
+   * optional — absent on the pre-cut path and for consumers that do not read the
+   * region. Without it a lost session falls through to `connected` and shows a
+   * stale-green dot (#2524).
+   */
+  terminalSessionLost?: Record<string, boolean>;
 }
 
 /**
  * Derive the connection-status dot for a single tab from the tab-id-keyed
  * lifecycle maps.
  *
- * Priority order (most transient / most severe first):
- *  1. `connecting`   — a connect or reconnect attempt is in flight.
- *  2. `failed`       — a spawn or reconnect attempt errored out.
- *  3. `disconnected` — the session exited without a recorded error.
- *  4. `connected`    — no lifecycle flags set (the live, healthy state).
+ * Priority order (most severe / most terminal first):
+ *  1. `disconnected` (session lost) — the live session is unrecoverable (#2512);
+ *     this is terminal, so it wins over a lingering in-flight connect flag.
+ *  2. `connecting`   — a connect or reconnect attempt is in flight.
+ *  3. `failed`       — a spawn or reconnect attempt errored out.
+ *  4. `disconnected` — the session exited without a recorded error.
+ *  5. `connected`    — no lifecycle flags set (the live, healthy state).
  *
  * @param maps  The tab-lifecycle maps (typically a slice of the app store).
  * @param tabId The tab whose status to derive.
  */
 export function deriveTabStatus(maps: TabStatusMaps, tabId: string): TabStatus {
+  // Session-lost is a terminal outcome: the transport recovered but the live
+  // session is gone (#2512). It takes precedence over the in-flight/error flags
+  // so the dot never lingers green (or pulses "connecting") after the loss (#2524).
+  if (maps.terminalSessionLost?.[tabId]) {
+    return "disconnected";
+  }
   if (maps.terminalConnecting[tabId] || maps.terminalReconnectingTabs[tabId]) {
     return "connecting";
   }


### PR DESCRIPTION
## Summary

Three related Remote Agents sidebar / agent-header UI defects found live during an agent drop/reconnect (#2524).

### 1. Agent state dot (sidebar) — already correct; locked with a regression test
Traced the dot end-to-end: `AgentNode`'s `STATE_DOT_CLASSES` maps all four `connectionState` values to distinct tokens (`connected`→green, `connecting`/`reconnecting`→yellow, `disconnected`→red), and the value propagates correctly — the backend `emit_agent_state_with_error` folds every `reconnecting`/`disconnected` transition into the authoritative `agents` projection region **and** emits `agent-state-change`, which the `useProjectedAgents` subscription re-renders on. On a real drop the agent dot flips to yellow/red. No view bug here; added a regression test so the mapping can never regress to stale-green.

### 2. Session-lost tab still showed a green dot — real fix
`deriveTabStatus` had no `sessionLost` case, so a terminal `sessionLost` tab (#2512: transport recovered but the live session was unrecoverable) fell through to `connected` → green dot. `sessionLost` lives only in the projected `session-lifecycle` region (no appStore twin), so:
- `useProjectedSessionLifecycleMaps` now also exposes a region-derived `terminalSessionLost` map.
- `deriveTabStatus` treats session-lost as terminal (wins over lingering in-flight flags) and returns `disconnected` (steady red) — matching `settleSessionLost`'s existing intent.
- `TabBar` feeds the new map in.

### 3. Agent-node header hid the name — restacked into two rows
The per-agent header shared a single `space-between` row, so a connected agent's action buttons crowded the name out of view. Added a `--agent` modifier that stacks it into two rows: **row 1 = state bubble + name + version badge** (the toggle), **row 2 = action buttons** (sibling container). Scoped to the agent header so the LOCAL / REMOTE AGENTS section headers keep their single-row layout. Token-only (no magic values).

## Tests
- `tabStatus.test.ts` — session-lost → `disconnected`, and it wins over an in-flight connecting flag.
- `useProjectedSessionLifecycle.test.tsx` — the maps hook exposes `terminalSessionLost` from the region.
- `AgentNode.header.test.tsx` — state dot tracks each `connectionState` (never stale green); name + bubble on row 1, buttons in a sibling row.
- Full `pnpm test`, `pnpm build`, `pnpm run lint`, and `prettier --check` green.

Closes #2524