### PR TITLE
feat(terminal): optimistic client-side folding for projection intents (Closes #2533)

### DIFF
--- a/src/services/transport/ProjectionClient.test.ts
+++ b/src/services/transport/ProjectionClient.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { ProjectionClient, type ProjectionCacheState } from "./ProjectionClient";
 import type { FrameHandler, Subscription, Transport } from "./Transport";
-import type { DiffFrame, DiffOp, IntentAck, ProjectionFrame, SnapshotFrame } from "./types";
+import type { DiffFrame, DiffOp, Intent, IntentAck, ProjectionFrame, SnapshotFrame } from "./types";
 
 const clone = <T>(v: T): T => JSON.parse(JSON.stringify(v)) as T;
 
@@ -28,7 +28,14 @@ class FakeTransport implements Transport {
     this.view = initial;
   }
 
-  async dispatch(): Promise<IntentAck> {
+  /** Intents seen by {@link dispatch}, newest last. */
+  dispatched: Intent[] = [];
+  /** Optional stub for {@link dispatch}; unset ⇒ dispatch is not exercised. */
+  dispatchHandler?: (intent: Intent) => IntentAck | Promise<IntentAck>;
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (this.dispatchHandler) return this.dispatchHandler(intent);
     throw new Error("dispatch not exercised in these tests");
   }
 
@@ -176,5 +183,157 @@ describe("ProjectionClient", () => {
     transport.publish(next);
     expect(client.state.version).toBe(0);
     expect(states).toHaveLength(1);
+  });
+});
+
+// ── Optimistic client-side folding (#2533) ─────────────────────────────────────
+
+/** A tiny region view used for the overlay tests: `{ items: { <id>: value } }`. */
+const itemsView = (items: Record<string, string> = {}) => ({ items });
+
+/** A fold that optimistically sets `items[id] = value`, immutably. */
+const setItem =
+  (id: string, value: string) =>
+  (view: unknown): unknown => {
+    const v = (view ?? { items: {} }) as { items: Record<string, string> };
+    return { ...v, items: { ...v.items, [id]: value } };
+  };
+
+const intentFor = (id: string): Intent => ({
+  intentId: `intent-${id}`,
+  kind: "test.set",
+  payload: { id },
+  clientId: "client-test",
+});
+
+const accepted = (region: string, version: number): IntentAck => ({
+  intentId: "ignored",
+  status: "accepted",
+  produced: [{ region, version }],
+});
+
+describe("ProjectionClient · optimistic folding (#2533)", () => {
+  let transport: FakeTransport;
+  let client: ProjectionClient;
+  let states: ProjectionCacheState[];
+
+  beforeEach(async () => {
+    transport = new FakeTransport(itemsView({ a: "base" }), "items");
+    client = new ProjectionClient(transport, "items");
+    states = [];
+    client.onChange((s) => states.push(clone(s)));
+    await client.start();
+  });
+
+  it("applies the optimistic fold synchronously, before the ack resolves", () => {
+    transport.dispatchHandler = () => accepted("items", 1);
+    // Do NOT await: the overlay must be visible the moment dispatch returns.
+    void client.dispatchOptimistic(intentFor("b"), setItem("b", "optimistic"));
+
+    expect(client.state.view).toEqual(itemsView({ a: "base", b: "optimistic" }));
+    // The version is untouched — the overlay is not an authoritative advance.
+    expect(client.state.version).toBe(0);
+    expect(transport.dispatched).toHaveLength(1);
+  });
+
+  it("keeps the overlay until the confirming version, then the authoritative diff supersedes it", async () => {
+    transport.dispatchHandler = () => accepted("items", 1);
+    const ack = await client.dispatchOptimistic(intentFor("b"), setItem("b", "optimistic"));
+    expect(ack.status).toBe("accepted");
+
+    // Backend has not reached v1 yet ⇒ the overlay still stands.
+    expect(client.state.view).toEqual(itemsView({ a: "base", b: "optimistic" }));
+
+    // The authoritative diff lands at v1 — with the backend's OWN value, which
+    // may differ from the optimistic guess. It supersedes the overlay exactly
+    // (no double-apply, no leftover optimistic value).
+    transport.publish(itemsView({ a: "base", b: "authoritative" }));
+
+    expect(client.state.version).toBe(1);
+    expect(client.state.view).toEqual(itemsView({ a: "base", b: "authoritative" }));
+  });
+
+  it("rolls the overlay back cleanly when the intent is rejected (divergence)", async () => {
+    transport.dispatchHandler = () => ({
+      intentId: "ignored",
+      status: "rejected",
+      error: { code: "denied", message: "nope" },
+    });
+    const p = client.dispatchOptimistic(intentFor("b"), setItem("b", "optimistic"));
+    // Synchronously overlaid…
+    expect(client.state.view).toEqual(itemsView({ a: "base", b: "optimistic" }));
+
+    const ack = await p;
+    expect(ack.status).toBe("rejected");
+    // …then rolled back to the authoritative baseline once the rejection lands.
+    expect(client.state.view).toEqual(itemsView({ a: "base" }));
+    expect(client.state.version).toBe(0);
+  });
+
+  it("rolls back when the intent produced no change on this region (no-op divergence)", async () => {
+    // Accepted, but the change (if any) lands on a different region — nothing
+    // authoritative will ever confirm the overlay here.
+    transport.dispatchHandler = () => accepted("other-region", 7);
+    const ack = await client.dispatchOptimistic(intentFor("b"), setItem("b", "optimistic"));
+
+    expect(ack.status).toBe("accepted");
+    expect(client.state.view).toEqual(itemsView({ a: "base" }));
+  });
+
+  it("reconciles when the authoritative diff races AHEAD of the ack", async () => {
+    // Hold the ack open so the diff can land first.
+    let resolveAck!: (ack: IntentAck) => void;
+    transport.dispatchHandler = () => new Promise<IntentAck>((r) => (resolveAck = r));
+
+    const p = client.dispatchOptimistic(intentFor("b"), setItem("b", "optimistic"));
+    expect(client.state.view).toEqual(itemsView({ a: "base", b: "optimistic" }));
+
+    // The confirming diff arrives before the ack: the overlay is still layered
+    // over the new baseline (transient) since its confirm version is unknown.
+    transport.publish(itemsView({ a: "base", b: "authoritative" }));
+    expect(client.state.version).toBe(1);
+    expect(client.state.view).toEqual(itemsView({ a: "base", b: "optimistic" }));
+
+    // Ack resolves with the produced version the diff already reached ⇒ prune.
+    resolveAck(accepted("items", 1));
+    await p;
+    expect(client.state.view).toEqual(itemsView({ a: "base", b: "authoritative" }));
+  });
+
+  it("rolls back when the dispatch transport throws, and rethrows", async () => {
+    transport.dispatchHandler = () => {
+      throw new Error("transport down");
+    };
+    const p = client.dispatchOptimistic(intentFor("b"), setItem("b", "optimistic"));
+    // Overlay is applied synchronously even though the dispatch will fail.
+    expect(client.state.view).toEqual(itemsView({ a: "base", b: "optimistic" }));
+
+    await expect(p).rejects.toThrow("transport down");
+    // Rolled back so the caller's fallback path sees an un-diverged view.
+    expect(client.state.view).toEqual(itemsView({ a: "base" }));
+  });
+
+  it("keeps independent overlays; confirming one leaves the other standing", async () => {
+    transport.dispatchHandler = (intent) =>
+      // b confirms at v1, c at v2.
+      accepted("items", intent.intentId === "intent-b" ? 1 : 2);
+
+    await client.dispatchOptimistic(intentFor("b"), setItem("b", "opt-b"));
+    await client.dispatchOptimistic(intentFor("c"), setItem("c", "opt-c"));
+    expect(client.state.view).toEqual(itemsView({ a: "base", b: "opt-b", c: "opt-c" }));
+
+    // Backend reaches v1: b's fold is pruned; c's (confirm v2) still stands.
+    transport.publish(itemsView({ a: "base", b: "srv-b" }));
+    expect(client.state.view).toEqual(itemsView({ a: "base", b: "srv-b", c: "opt-c" }));
+
+    // Backend reaches v2: c's fold is pruned too.
+    transport.publish(itemsView({ a: "base", b: "srv-b", c: "srv-c" }));
+    expect(client.state.view).toEqual(itemsView({ a: "base", b: "srv-b", c: "srv-c" }));
+  });
+
+  it("leaves the effective view reference-identical to the baseline with no overlay", () => {
+    // Regions that never dispatch optimistically are unaffected: the emitted
+    // view IS the authoritative baseline object (the 8 inverted domains).
+    expect(client.state.view).toBe((client as unknown as { baseView: unknown }).baseView);
   });
 });

--- a/src/services/transport/ProjectionClient.ts
+++ b/src/services/transport/ProjectionClient.ts
@@ -156,9 +156,7 @@ export class ProjectionClient {
     }
 
     const produced =
-      ack.status === "accepted"
-        ? ack.produced?.find((p) => p.region === this.region)
-        : undefined;
+      ack.status === "accepted" ? ack.produced?.find((p) => p.region === this.region) : undefined;
     if (!produced) {
       // Rejected, or a no-op / divergence that produced no change on this
       // region: no confirming version will ever arrive, so roll back now.

--- a/src/services/transport/ProjectionClient.ts
+++ b/src/services/transport/ProjectionClient.ts
@@ -3,17 +3,41 @@
  *
  * Holds `{ version, view }` for one region, applies ordered diffs, detects
  * gaps (`baseVersion !== version`) and re-baselines via `resync`, and notifies
- * listeners on every change. It computes and decides nothing about the view —
- * the backend is the single authoritative writer; this is a dumb cache.
+ * listeners on every change. The backend is the single authoritative writer;
+ * the cache computes nothing about the authoritative view.
+ *
+ * # Optimistic client-side folding (#2533)
+ *
+ * On top of the authoritative baseline the cache carries an **optimistic
+ * overlay**: a dispatching client can apply its own intent to its local view
+ * *synchronously* via {@link ProjectionClient.dispatchOptimistic}, so a
+ * component reading the projection sees its own intent immediately instead of
+ * only after a full backend round-trip. This closes the hot-path overlay gap
+ * that the appStore local writes cover today (#2205 / #2283).
+ *
+ * The overlay is a list of pending {@link OptimisticFold}s applied over the
+ * authoritative `baseView` to produce the effective view. Reconcile is
+ * **version-gated**: the intent's ack reports the region version its change
+ * lands at, and the fold is dropped once the cache reaches that version — at
+ * which point the authoritative diff/snapshot already carries the real change,
+ * so the authoritative state supersedes the optimistic one with no double-apply
+ * and no drift. Divergence is handled the same way: a rejected intent, or one
+ * that produced no change on this region, is rolled back at once (there is no
+ * confirming version to wait for), so an optimistic entry is never stranded.
+ *
+ * Regions that never call {@link dispatchOptimistic} keep an empty overlay, so
+ * their effective view is reference-identical to the authoritative baseline —
+ * the already-inverted domains are unaffected.
  *
  * Diffs are applied with the maintained `fast-json-patch` package (RFC 6902),
- * the mirror of the Rust reference applier `projection::apply_ops`.
+ * the mirror of the Rust reference applier `projection::apply_ops`. Diffs and
+ * snapshots always target the authoritative `baseView`, never the overlay.
  */
 
 import { applyPatch, type Operation } from "fast-json-patch";
 
 import type { FrameHandler, Subscription, Transport } from "./Transport";
-import type { DiffFrame, ProjectionFrame, SnapshotFrame } from "./types";
+import type { DiffFrame, Intent, IntentAck, ProjectionFrame, SnapshotFrame } from "./types";
 
 /** The cache's public state for one region. */
 export interface ProjectionCacheState {
@@ -25,9 +49,40 @@ export interface ProjectionCacheState {
 /** Notified with the new cache state on every change. */
 export type CacheListener = (state: ProjectionCacheState) => void;
 
+/**
+ * A pure optimistic transform of a region view (#2533): given the current
+ * effective view, return the view as it should appear once the dispatched
+ * intent has been applied — the client-side twin of the backend reducer for
+ * that intent.
+ *
+ * **Must not mutate its input** (the authoritative baseline is shared) and
+ * should be **idempotent / last-writer** in shape: while the intent is in
+ * flight the fold may briefly be layered over a baseline that already carries
+ * the backend's own application of it, until the confirming version prunes it.
+ * A full-entry replace (as the session-lifecycle folds use) satisfies this.
+ */
+export type OptimisticFold = (view: unknown) => unknown;
+
+/** One in-flight optimistic overlay awaiting its authoritative confirmation. */
+interface PendingFold {
+  intentId: string;
+  fold: OptimisticFold;
+  /** The region version at which the backend applied this intent (from the
+   * ack's `produced`); `undefined` until the ack resolves. The fold is dropped
+   * once `version >= confirmVersion`. */
+  confirmVersion?: number;
+}
+
 export class ProjectionClient {
   private version = -1;
-  private view: unknown = undefined;
+  /** The authoritative baseline; diffs and snapshots apply here. */
+  private baseView: unknown = undefined;
+  /** The overlaid view emitted to listeners: `baseView` with the pending
+   * optimistic folds applied. Reference-identical to `baseView` when there is
+   * no overlay. */
+  private effective: unknown = undefined;
+  /** In-flight optimistic overlays, in dispatch order (#2533). */
+  private pending: PendingFold[] = [];
   private subscription?: Subscription;
   private readonly listeners = new Set<CacheListener>();
   private closed = false;
@@ -38,9 +93,9 @@ export class ProjectionClient {
     public readonly region: string
   ) {}
 
-  /** Current cached `{ version, view }`. */
+  /** Current cached `{ version, view }` (the effective, overlaid view). */
   get state(): ProjectionCacheState {
-    return { version: this.version, view: this.view };
+    return { version: this.version, view: this.effective };
   }
 
   /** Subscribe a listener; returns an unsubscribe function. */
@@ -66,6 +121,57 @@ export class ProjectionClient {
     this.subscription = undefined;
   }
 
+  /**
+   * Dispatch an intent and apply its optimistic {@link OptimisticFold} to the
+   * local view **synchronously**, so a subscriber reading the projection sees
+   * this client's own intent immediately — before the authoritative
+   * diff/snapshot arrives (#2533).
+   *
+   * The overlay is reconciled against the authoritative stream:
+   * - **accepted** with a produced version on this region → the fold is kept
+   *   until the cache reaches that version (the diff/snapshot then carries the
+   *   real change), then dropped — the authoritative state supersedes it.
+   * - **accepted with no change on this region**, or **rejected** → nothing
+   *   authoritative will confirm the fold, so it is rolled back at once
+   *   (divergence handling; the overlay is never stranded).
+   * - the **dispatch throwing** → the fold is rolled back and the error
+   *   rethrown, so the caller's fallback path runs on a clean view.
+   *
+   * Resolves with the ack (a receipt; the result rides the region diff).
+   */
+  async dispatchOptimistic(intent: Intent, fold: OptimisticFold): Promise<IntentAck> {
+    const entry: PendingFold = { intentId: intent.intentId, fold };
+    this.pending.push(entry);
+    this.recompute();
+    this.emit();
+
+    let ack: IntentAck;
+    try {
+      ack = await this.transport.dispatch(intent);
+    } catch (err) {
+      // The intent never reached the backend; roll the overlay back so the
+      // caller's fallback path sees an un-diverged view.
+      this.dropPending(entry);
+      throw err;
+    }
+
+    const produced =
+      ack.status === "accepted"
+        ? ack.produced?.find((p) => p.region === this.region)
+        : undefined;
+    if (!produced) {
+      // Rejected, or a no-op / divergence that produced no change on this
+      // region: no confirming version will ever arrive, so roll back now.
+      this.dropPending(entry);
+    } else {
+      entry.confirmVersion = produced.version;
+      // The confirming diff may already have landed (it raced the ack); prune
+      // immediately if so.
+      if (this.pruneConfirmed()) this.emit();
+    }
+    return ack;
+  }
+
   private onFrame(frame: ProjectionFrame): void {
     if (this.closed) return;
     if (frame.kind === "snapshot") {
@@ -77,7 +183,9 @@ export class ProjectionClient {
 
   private adoptSnapshot(snapshot: SnapshotFrame): void {
     this.version = snapshot.version;
-    this.view = snapshot.view;
+    this.baseView = snapshot.view;
+    this.pruneConfirmed();
+    this.recompute();
     this.emit();
   }
 
@@ -94,9 +202,12 @@ export class ProjectionClient {
       void this.resync();
       return;
     }
-    const result = applyPatch(this.view, diff.ops as Operation[], false, false);
-    this.view = result.newDocument;
+    // Authoritative diffs always apply to the baseline, never the overlay.
+    const result = applyPatch(this.baseView, diff.ops as Operation[], false, false);
+    this.baseView = result.newDocument;
     this.version = diff.version;
+    this.pruneConfirmed();
+    this.recompute();
     this.emit();
   }
 
@@ -116,6 +227,39 @@ export class ProjectionClient {
     } finally {
       this.resyncing = false;
     }
+  }
+
+  /** Recompute the effective (overlaid) view from `baseView` + `pending`. */
+  private recompute(): void {
+    this.effective =
+      this.pending.length === 0
+        ? this.baseView
+        : this.pending.reduce((view, p) => p.fold(view), this.baseView);
+  }
+
+  /** Drop a single pending overlay (rollback) and re-emit. */
+  private dropPending(entry: PendingFold): void {
+    const index = this.pending.indexOf(entry);
+    if (index === -1) return;
+    this.pending.splice(index, 1);
+    this.recompute();
+    this.emit();
+  }
+
+  /**
+   * Drop every pending overlay whose confirming version the cache has now
+   * reached — the authoritative view already carries the change. Recomputes
+   * the effective view; returns whether anything was dropped (the caller emits).
+   */
+  private pruneConfirmed(): boolean {
+    if (this.pending.length === 0) return false;
+    const before = this.pending.length;
+    this.pending = this.pending.filter(
+      (p) => p.confirmVersion === undefined || this.version < p.confirmVersion
+    );
+    const changed = this.pending.length !== before;
+    if (changed) this.recompute();
+    return changed;
   }
 
   private emit(): void {

--- a/src/services/transport/index.ts
+++ b/src/services/transport/index.ts
@@ -27,6 +27,7 @@ export { WebSocketTransport, type JsonRpcSocket } from "./WebSocketTransport";
 export {
   ProjectionClient,
   type CacheListener,
+  type OptimisticFold,
   type ProjectionCacheState,
 } from "./ProjectionClient";
 export { newClientId, newIntentId } from "./ids";

--- a/src/store/sessionBridge.test.ts
+++ b/src/store/sessionBridge.test.ts
@@ -19,8 +19,10 @@ import {
 } from "@/utils/reconnectBackoff";
 
 import {
+  currentSessionView,
   dispatchSessionIntent,
   effectiveAutoReconnect,
+  ensureSessionSubscribed,
   mirrorSessionIntent,
   onSessionView,
   projectedReconnectMirrors,
@@ -383,5 +385,82 @@ describe("effectiveAutoReconnect — render-cut source selection (#2204)", () =>
   it("preserves the fixed countdown deadline (never re-anchors nextAttemptAt)", () => {
     const composed = effectiveAutoReconnect(record, mirror);
     expect(composed?.nextAttemptAt).toBe(record.nextAttemptAt);
+  });
+});
+
+describe("optimistic client-side folding (#2533)", () => {
+  const connecting: ProjectedSessionLifecycle = {
+    status: "connecting",
+    reconnect: initialReconnectState,
+  };
+
+  /** Let the dispatch + reconcile microtasks settle. */
+  const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+  it("applies session.connect optimistically so the connecting state is gap-free — synchronously, before any await", () => {
+    // The backend also records the connect (realistic path), but the assertion
+    // fires synchronously, before the dispatch promise resolves: the overlay
+    // alone makes the projection connecting, so there is NO local write needed.
+    transport.onDispatch = (intent, sessions) => {
+      const id = (intent.payload as { sessionId: string }).sessionId;
+      sessions[id] = { status: "connecting", reconnect: initialReconnectState };
+    };
+
+    const seen: Array<Record<string, ProjectedSessionLifecycle>> = [];
+    onSessionView((next) => seen.push(structuredClone(next)));
+
+    mirrorSessionIntent("session.connect", "tab-1");
+
+    // Gap-free: the projected read reflects the intent immediately.
+    expect(currentSessionView()["tab-1"]).toEqual(connecting);
+    expect(seen[seen.length - 1]?.["tab-1"]).toEqual(connecting);
+    expect(transport.dispatched).toHaveLength(1);
+    expect(transport.dispatched[0].kind).toBe("session.connect");
+  });
+
+  it("reconciles the overlay against the authoritative diff (no double-apply, overlay pruned)", async () => {
+    transport.onDispatch = (intent, sessions) => {
+      const id = (intent.payload as { sessionId: string }).sessionId;
+      sessions[id] = { status: "connecting", reconnect: initialReconnectState };
+    };
+
+    mirrorSessionIntent("session.connect", "tab-1");
+    expect(currentSessionView()["tab-1"]).toEqual(connecting);
+
+    await flush();
+
+    // Still connecting — but now sourced from the authoritative view, with the
+    // overlay pruned (the value is exactly the backend's, not folded twice).
+    expect(currentSessionView()["tab-1"]).toEqual(connecting);
+    // A later authoritative transition wins with no stale optimistic residue.
+    transport.setSession("tab-1", { status: "connected", reconnect: initialReconnectState });
+    await flush();
+    expect(currentSessionView()["tab-1"]).toEqual({
+      status: "connected",
+      reconnect: initialReconnectState,
+    });
+  });
+
+  it("rolls the overlay back cleanly when the intent diverges (backend produced no change)", async () => {
+    // No onDispatch ⇒ the fake acks `accepted` with an empty `produced`: nothing
+    // authoritative will confirm the overlay, so it must be rolled back.
+    await ensureSessionSubscribed();
+
+    mirrorSessionIntent("session.connect", "tab-1");
+    // Synchronously overlaid…
+    expect(currentSessionView()["tab-1"]).toEqual(connecting);
+
+    await flush();
+
+    // …then rolled back to the authoritative (empty) view — never stranded.
+    expect(currentSessionView()["tab-1"]).toBeUndefined();
+  });
+
+  it("does not overlay non-folded intents (minimal blast radius)", () => {
+    // `session.disconnect` has no registered fold, so it dispatches without any
+    // synchronous overlay: the projected view is untouched for an unknown tab.
+    mirrorSessionIntent("session.disconnect", "tab-x");
+    expect(currentSessionView()["tab-x"]).toBeUndefined();
+    expect(transport.dispatched[transport.dispatched.length - 1]?.kind).toBe("session.disconnect");
   });
 });

--- a/src/store/sessionBridge.ts
+++ b/src/store/sessionBridge.ts
@@ -41,11 +41,19 @@ import {
   newClientId,
   newIntentId,
   ProjectionClient,
+  type Intent,
   type IntentAck,
+  type OptimisticFold,
+  type ProjectionCacheState,
   type Transport,
 } from "@/services/transport";
 import type { TerminalAutoReconnectState } from "@/types/terminal";
-import { DEFAULT_BACKOFF, type BackoffConfig, type ReconnectPhase } from "@/utils/reconnectBackoff";
+import {
+  DEFAULT_BACKOFF,
+  initialReconnectState,
+  type BackoffConfig,
+  type ReconnectPhase,
+} from "@/utils/reconnectBackoff";
 import { frontendLog } from "@/utils/frontendLog";
 
 /** The projection region id for the session-lifecycle domain (twin of the Rust
@@ -279,7 +287,12 @@ export function sessionBackendReattachEnabled(): boolean {
 // ── Transport + region client (lazy, mirrors the tunnel slice) ─────────────────
 
 let transportInstance: Transport | null = null;
+/** The region client once its subscription has started (its snapshot adopted). */
 let regionClient: ProjectionClient | null = null;
+/** The region client instance the moment it is created — before `start()`
+ * resolves — so an optimistic dispatch can overlay on it synchronously (#2533).
+ * Same object as {@link regionClient} once started. */
+let creatingClient: ProjectionClient | null = null;
 let startPromise: Promise<ProjectionClient> | null = null;
 
 // A stable per-session client identity for dispatched intents (fan-out / audit
@@ -290,8 +303,9 @@ const clientId = newClientId();
 /** Inject a transport for tests; `null` restores the lazily-created real one and
  * drops any active subscription. */
 export function setSessionTransportForTest(t: Transport | null): void {
-  regionClient?.stop();
+  (regionClient ?? creatingClient)?.stop();
   regionClient = null;
+  creatingClient = null;
   startPromise = null;
   transportInstance = t;
 }
@@ -316,13 +330,109 @@ export async function dispatchSessionIntent(
 
 /** Fire a `session.*` intent, swallowing and logging any failure so the local
  * lifecycle path is never disrupted by a bridge hiccup (the resilience
- * fallback). Never throws. */
+ * fallback). Never throws.
+ *
+ * When the intent kind carries a synchronous-feedback requirement (it has a
+ * registered {@link OPTIMISTIC_SESSION_FOLDS} entry, e.g. `session.connect`), the
+ * dispatch is routed through the region client's optimistic-folding path so the
+ * projected view reflects the intent immediately — closing the hot-path overlay
+ * gap (#2533). Unregistered kinds dispatch without an overlay. */
 export function mirrorSessionIntent(
   kind: SessionIntentKind,
   sessionId: string,
   error?: string
 ): void {
+  const fold = OPTIMISTIC_SESSION_FOLDS[kind];
+  if (fold) {
+    mirrorOptimisticSessionIntent(kind, sessionId, fold, error);
+    return;
+  }
   void dispatchSessionIntent(kind, sessionId, error)
+    .then((ack) => {
+      if (ack.status === "rejected") {
+        logSessionBridgeFallback(kind, new Error(ack.error?.message ?? "rejected"));
+      }
+    })
+    .catch((err) => logSessionBridgeFallback(kind, err));
+}
+
+// ── Optimistic client-side folding (#2533) ─────────────────────────────────────
+//
+// A dispatching client applies its own `session.*` intent to the local
+// projection view synchronously, so the projected read is gap-free — closing the
+// hot-path window appStore's synchronous `terminalConnecting` write covers today
+// (removed by #2205 PR-B / #2283). ProjectionClient owns the general overlay +
+// version-gated reconcile machinery; this file supplies the faithful per-intent
+// transform (the client-side twin of the Rust `SessionLifecycleStore` reducer).
+// Only the `connecting`-feedback intents are folded — the rest dispatch without
+// an overlay, keeping the blast radius minimal.
+
+/** The projected lifecycle for a session entering its initial connect — the twin
+ * of the Rust `SessionLifecycle::connecting()` serialisation (every `Option`
+ * field is skipped, so only `status` + `reconnect` are present). */
+function projectedConnecting(): ProjectedSessionLifecycle {
+  return { status: "connecting", reconnect: { ...initialReconnectState } };
+}
+
+/** A session-intent optimistic transform: `(view, sessionId, error) => view`,
+ * pure and immutable (never mutates the shared baseline). */
+type SessionOptimisticFold = (
+  view: SessionLifecycleView,
+  sessionId: string,
+  error: string | undefined
+) => SessionLifecycleView;
+
+/**
+ * Intents that carry a synchronous-feedback requirement, folded optimistically.
+ *
+ * `session.connect` sets the tab's lifecycle to `connecting`, matching
+ * `SessionLifecycleStore::connect` (a fresh connect resets any prior record) —
+ * so the "Connecting…" overlay is gap-free the instant the intent is dispatched,
+ * with no local `terminalConnecting` write. Extend this map to add
+ * `file-browser` / `layout`-style folds; unregistered kinds dispatch without an
+ * overlay (the minimal blast radius on the already-inverted domains).
+ */
+const OPTIMISTIC_SESSION_FOLDS: Partial<Record<SessionIntentKind, SessionOptimisticFold>> = {
+  "session.connect": (view, sessionId) => ({
+    ...view,
+    sessions: { ...view.sessions, [sessionId]: projectedConnecting() },
+  }),
+};
+
+/** Dispatch a folded `session.*` intent through the region client so its overlay
+ * is applied to the projected view synchronously, then reconciled against the
+ * authoritative diff. Never throws (the resilience contract). */
+function mirrorOptimisticSessionIntent(
+  kind: SessionIntentKind,
+  sessionId: string,
+  fold: SessionOptimisticFold,
+  error?: string
+): void {
+  let client: ProjectionClient;
+  try {
+    client = sessionRegionClient();
+  } catch (err) {
+    // No transport (e.g. non-Tauri without a socket): the optimistic overlay is
+    // a hot-path nicety, never a correctness requirement — the plain dispatch
+    // path would swallow the same failure. Log and skip.
+    logSessionBridgeFallback(kind, err);
+    return;
+  }
+
+  // Ensure the region is subscribed so the authoritative diff arrives to
+  // reconcile (prune) the overlay; a subscribe failure is logged and does not
+  // strand the overlay — a later resync/snapshot reconciles it.
+  void ensureSessionSubscribed().catch((err) => logSessionBridgeFallback("subscribe", err));
+
+  const payload: Record<string, unknown> = { sessionId };
+  if (error !== undefined) payload.error = error;
+  const intent: Intent = { intentId: newIntentId(), kind, payload, clientId };
+
+  const overlay: OptimisticFold = (view) =>
+    fold((view ?? { sessions: {} }) as SessionLifecycleView, sessionId, error);
+
+  void client
+    .dispatchOptimistic(intent, overlay)
     .then((ack) => {
       if (ack.status === "rejected") {
         logSessionBridgeFallback(kind, new Error(ack.error?.message ?? "rejected"));
@@ -350,6 +460,38 @@ export function onSessionView(listener: SessionViewListener): () => void {
   return () => viewListeners.delete(listener);
 }
 
+/** Fan a region-client change out to the {@link onSessionView} listeners as the
+ * reconciled `sessions` map (and the previous one). */
+function fanOutSessionView(state: ProjectionCacheState): void {
+  const view = (state.view ?? {}) as Partial<SessionLifecycleView>;
+  const next = view.sessions ?? {};
+  const prev = lastSessions;
+  lastSessions = next;
+  for (const listener of viewListeners) {
+    try {
+      listener(next, prev);
+    } catch (err) {
+      logSessionBridgeFallback("reconcile", err);
+    }
+  }
+}
+
+/**
+ * The region client instance, created (and its change fan-out registered) on
+ * first use — **synchronously**, before its subscription has started — so an
+ * optimistic dispatch can overlay on it at once (#2533). Returns the started
+ * {@link regionClient} once available, else the {@link creatingClient}. Throws
+ * only if the transport itself cannot be built (non-Tauri without a socket).
+ */
+function sessionRegionClient(): ProjectionClient {
+  if (regionClient) return regionClient;
+  if (!creatingClient) {
+    creatingClient = new ProjectionClient(transport(), SESSION_LIFECYCLE_REGION);
+    creatingClient.onChange(fanOutSessionView);
+  }
+  return creatingClient;
+}
+
 /**
  * Ensure the `session-lifecycle` region client is subscribed so projected diffs
  * are received and fanned out to the {@link onSessionView} listeners. Idempotent
@@ -359,20 +501,7 @@ export function onSessionView(listener: SessionViewListener): () => void {
 export function ensureSessionSubscribed(): Promise<ProjectionClient> {
   if (regionClient) return Promise.resolve(regionClient);
   if (!startPromise) {
-    const client = new ProjectionClient(transport(), SESSION_LIFECYCLE_REGION);
-    client.onChange((state) => {
-      const view = (state.view ?? {}) as Partial<SessionLifecycleView>;
-      const next = view.sessions ?? {};
-      const prev = lastSessions;
-      lastSessions = next;
-      for (const listener of viewListeners) {
-        try {
-          listener(next, prev);
-        } catch (err) {
-          logSessionBridgeFallback("reconcile", err);
-        }
-      }
-    });
+    const client = sessionRegionClient();
     startPromise = client
       .start()
       .then(() => {
@@ -390,8 +519,9 @@ export function ensureSessionSubscribed(): Promise<ProjectionClient> {
 
 /** Drop the region subscription (tests / re-init). */
 export function stopSessionSubscription(): void {
-  regionClient?.stop();
+  (regionClient ?? creatingClient)?.stop();
   regionClient = null;
+  creatingClient = null;
   startPromise = null;
   lastSessions = {};
 }


### PR DESCRIPTION
## What & why

The remaining appStore reducer removals (#2205 session-lifecycle, #2283 layout + file-browser) are **not** the mechanical deletes the pure-state domains were: they carry a **synchronous UI-feedback** requirement the projection read path can't yet satisfy. A dispatching client sees its own `session.*` intent only after a full backend round-trip, because `ProjectionClient` updates its view only when a backend diff/snapshot arrives. Today appStore covers that window with a synchronous `terminalConnecting: true` write, keeping the "Connecting…" overlay gap-free. Deleting that local write (the #2205/#2283 goal) exposes the async round-trip as a **visible overlay flash on every connect/reconnect** — the common hot path.

This PR adds **optimistic client-side folding** so a dispatching client applies its own intent to its local projection view **synchronously**, then reconciles when the authoritative backend frame arrives.

## Design

**General mechanism in `ProjectionClient`, faithful per-region fold supplied by the caller.** A new `ProjectionClient.dispatchOptimistic(intent, fold)`:

1. **Synchronous apply.** Pushes the caller's pure `fold` onto a pending overlay applied over the authoritative `baseView`, and emits at once — a subscriber sees its own intent immediately.
2. **Version-gated reconcile.** The intent's ack reports the region version its change lands at (`produced`). The overlay is dropped once the cache reaches that version, at which point the authoritative diff/snapshot already carries the real change — so the authoritative state supersedes the optimistic one with **no double-apply and no drift**.
3. **Divergence handling.** A **rejected** intent, one that **produced no change on this region**, or a **throwing dispatch** is rolled back at once (there is no confirming version to wait for) — an overlay is never stranded.

**Why this shape:** putting the overlay + reconcile machinery in `ProjectionClient` (which every region already uses) makes it reusable for `file-browser`/`layout` by construction — each region just supplies its own fold — while keeping the cache's authoritative version-tracking as the single reconcile point. **Minimal blast radius:** a region that never calls `dispatchOptimistic` keeps an empty overlay, so its effective view is reference-identical to the authoritative baseline. The 8 already-inverted domains are untouched.

**Faithful session fold.** `session.connect` is routed through `dispatchOptimistic` with a fold that is the client-side twin of the Rust `SessionLifecycleStore::connect` (status `connecting`, initial reconnect state, all optional fields omitted — byte-identical to the backend snapshot/diff). Only the `connecting`-feedback intent is folded; every other `session.*` intent stays on the plain dispatch path. The region client is now created synchronously on first use (before its subscription starts) so the overlay applies immediately.

No appStore reducer is removed here — this PR **only** adds the capability. #2205/#2283 build on it.

## Reconcile / divergence

| Ack outcome | Handling |
| --- | --- |
| accepted, produced version V on region | keep overlay until cache version ≥ V, then prune (authoritative supersedes) |
| accepted, no change on this region | roll back immediately (no-op divergence) |
| rejected | roll back immediately |
| dispatch throws | roll back and rethrow (caller's local fallback runs on a clean view) |
| diff races ahead of the ack | overlay stays until the ack sets the confirm version, then prunes |

## Tests (TDD, test commit before impl)

- **`ProjectionClient.test.ts`** (generic): synchronous apply before the ack; keep-until-confirm then authoritative supersedes (no double-apply); rollback on rejection / no-op / transport throw; diff racing ahead of the ack; independent multi-overlay pruning; effective view reference-identical to baseline with no overlay.
- **`sessionBridge.test.ts`** (integration): `session.connect` makes the projected `connecting` state gap-free **synchronously** with no local write; reconciles against the authoritative diff; rolls back on divergence; non-folded intents (`session.disconnect`) dispatch without an overlay.

## Verification

- Full frontend suite green (4960 tests), `pnpm build` (tsc + vite) clean, `prettier --check src/**` clean, ESLint clean on changed files.

## Reuse for file-browser / layout

Yes as-is: the mechanism is region-agnostic. Those domains only need to register their own faithful fold in the same pattern (a per-region fold map like `OPTIMISTIC_SESSION_FOLDS`), routed through `dispatchOptimistic`. No further `ProjectionClient` change required.

Closes #2533. Follow-up to #2205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)