### PR TITLE
feat(backend): make layout store authoritative for tab groups + tab lifecycle (Part of #2283)

### DIFF
--- a/src-tauri/src/layout/mod.rs
+++ b/src-tauri/src/layout/mod.rs
@@ -25,4 +25,4 @@
 pub mod projection;
 pub mod store;
 
-pub use store::{ClientLayout, GroupLayout, LayoutStore};
+pub use store::LayoutStore;

--- a/src-tauri/src/layout/mod.rs
+++ b/src-tauri/src/layout/mod.rs
@@ -25,4 +25,4 @@
 pub mod projection;
 pub mod store;
 
-pub use store::LayoutStore;
+pub use store::{ClientLayout, GroupLayout, LayoutStore};

--- a/src-tauri/src/layout/projection.rs
+++ b/src-tauri/src/layout/projection.rs
@@ -68,7 +68,7 @@ use tauri::{AppHandle, Manager};
 
 use termihub_core::layout::panel_tree::{PanelNode, Tab};
 
-use crate::layout::store::{ClientLayout, GroupLayout, LayoutError, LayoutStore};
+use crate::layout::store::{GroupLayout, LayoutError, LayoutStore};
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
 
 /// The projection region id for a client's layout (`layout@<clientId>`).
@@ -350,9 +350,7 @@ fn parse_tab(intent: &Intent) -> Result<Tab, (String, String)> {
 }
 
 /// Parse a `layout.replaceGroups` payload `{ activeGroupId, groups: [GroupLayout] }`.
-fn parse_replace_groups(
-    intent: &Intent,
-) -> Result<(Vec<GroupLayout>, String), (String, String)> {
+fn parse_replace_groups(intent: &Intent) -> Result<(Vec<GroupLayout>, String), (String, String)> {
     let groups_value = intent
         .payload
         .get("groups")
@@ -364,7 +362,12 @@ fn parse_replace_groups(
         .get("activeGroupId")
         .and_then(Value::as_str)
         .map(str::to_string)
-        .ok_or_else(|| ("bad_payload".to_string(), "missing 'activeGroupId'".to_string()))?;
+        .ok_or_else(|| {
+            (
+                "bad_payload".to_string(),
+                "missing 'activeGroupId'".to_string(),
+            )
+        })?;
     Ok((groups, active_group_id))
 }
 

--- a/src-tauri/src/layout/projection.rs
+++ b/src-tauri/src/layout/projection.rs
@@ -12,8 +12,13 @@
 //! **Client-scoped** (per Open Design Decision #1/#6: multi-client is in scope,
 //! and layout is per-window view arrangement — moving a tab on one client need
 //! not move it on another). Each client gets its own region, seeded lazily and
-//! mutated via `intent.client_id`. Its render-ready view model is the panel tree
-//! plus the focused panel:
+//! mutated via `intent.client_id`.
+//!
+//! The store is authoritative for the **full** multi-group layout
+//! ([`LayoutStore::snapshot_full`] → `{ activeGroupId, groups: [...] }`), but the
+//! published region keeps the **back-compat active-group** shape (#2283 slice A)
+//! so the current render path is unaffected until a later slice flips the
+//! frontend:
 //!
 //! ```json
 //! { "root": <PanelNode>, "activePanelId": "panel-…" }
@@ -21,17 +26,30 @@
 //!
 //! # Intents
 //!
-//! | kind                        | payload                                  | effect                                        |
-//! | --------------------------- | ---------------------------------------- | --------------------------------------------- |
-//! | `layout.split`              | `{ panelId, direction, position }`       | split a leaf, inserting a new empty leaf       |
-//! | `layout.merge`              | `{ sourcePanelId, targetPanelId }`       | move all tabs into the target, drop the source |
-//! | `layout.moveTab`            | `{ tabId, targetPanelId, edge }`         | move a tab (center = merge; edge = split)      |
-//! | `layout.closeTabStructure`  | `{ tabId }`                              | remove a tab; drop its leaf if left empty      |
-//! | `layout.removePanel`        | `{ panelId }`                            | drop a whole leaf panel, then simplify         |
-//! | `layout.reorderTabs`        | `{ panelId, oldIndex, newIndex }`        | reorder a tab within its leaf                   |
-//! | `layout.setActivePanel`     | `{ panelId }`                            | repoint the focused panel                       |
-//! | `layout.resize`             | `{ splitId, sizes }`                     | persist a split's child percentage sizes        |
-//! | `layout.replace`            | `{ root, activePanelId }`                | install a whole tree (the bridge's seed path)  |
+//! Every structural intent accepts an optional `groupId` (defaulting to the
+//! active group). The group-level intents mutate the group set itself.
+//!
+//! | kind                        | payload                                        | effect                                        |
+//! | --------------------------- | ---------------------------------------------- | --------------------------------------------- |
+//! | `layout.split`              | `{ groupId?, panelId, direction, position }`   | split a leaf, inserting a new empty leaf       |
+//! | `layout.merge`              | `{ groupId?, sourcePanelId, targetPanelId }`   | move all tabs into the target, drop the source |
+//! | `layout.moveTab`            | `{ groupId?, tabId, targetPanelId, edge }`     | move a tab (center = merge; edge = split)      |
+//! | `layout.closeTabStructure`  | `{ groupId?, tabId }`                          | remove a tab; drop its leaf if left empty      |
+//! | `layout.addTab`             | `{ groupId?, panelId, tab }`                   | insert a minimal tab into a panel, focus it     |
+//! | `layout.removePanel`        | `{ groupId?, panelId }`                        | drop a whole leaf panel, then simplify         |
+//! | `layout.reorderTabs`        | `{ groupId?, panelId, oldIndex, newIndex }`    | reorder a tab within its leaf                   |
+//! | `layout.setActivePanel`     | `{ groupId?, panelId }`                        | repoint the focused panel                       |
+//! | `layout.resize`             | `{ groupId?, splitId, sizes }`                 | persist a split's child percentage sizes        |
+//! | `layout.replace`            | `{ root, activePanelId }`                      | install a tree over the active group (seed path)|
+//! | `layout.addGroup`           | `{ name? }`                                    | append a fresh group, make it active            |
+//! | `layout.closeGroup`         | `{ groupId }`                                  | remove a group (rejects the last one)           |
+//! | `layout.renameGroup`        | `{ groupId, name }`                            | rename a group                                  |
+//! | `layout.setGroupColor`      | `{ groupId, color? }`                          | set/clear a group's accent colour               |
+//! | `layout.setActiveGroup`     | `{ groupId }`                                  | switch the active group                         |
+//! | `layout.reorderGroups`      | `{ fromIndex, toIndex }`                       | reorder the group set                           |
+//! | `layout.moveTabToGroup`     | `{ tabId, fromPanelId, targetGroupId }`        | move a tab from the active group to another     |
+//! | `layout.addGroupWithTab`    | `{ tabId, fromPanelId }`                       | pull a tab into a brand-new active group        |
+//! | `layout.replaceGroups`      | `{ activeGroupId, groups }`                    | install a whole multi-group layout              |
 //!
 //! # Shadow mode
 //!
@@ -48,9 +66,9 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use tauri::{AppHandle, Manager};
 
-use termihub_core::layout::panel_tree::PanelNode;
+use termihub_core::layout::panel_tree::{PanelNode, Tab};
 
-use crate::layout::store::{LayoutError, LayoutStore};
+use crate::layout::store::{ClientLayout, GroupLayout, LayoutError, LayoutStore};
 use crate::projection::{HandlerRegistry, Intent, ProducedRegion, Projector};
 
 /// The projection region id for a client's layout (`layout@<clientId>`).
@@ -84,11 +102,18 @@ pub fn register_layout_intents(registry: &mut HandlerRegistry, app_handle: AppHa
     let handle = app_handle.clone();
     registry.route("layout.split", move |intent, projector| {
         let store = store_of(&handle)?;
+        let group = optional_str(intent, "groupId");
         let panel_id = required_str(intent, "panelId")?;
         let direction = required_enum(intent, "direction")?;
         let position = required_enum(intent, "position")?;
         store
-            .split(&intent.client_id, &panel_id, direction, position)
+            .split(
+                &intent.client_id,
+                group.as_deref(),
+                &panel_id,
+                direction,
+                position,
+            )
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &store, &intent.client_id))
     });
@@ -96,10 +121,11 @@ pub fn register_layout_intents(registry: &mut HandlerRegistry, app_handle: AppHa
     let handle = app_handle.clone();
     registry.route("layout.merge", move |intent, projector| {
         let store = store_of(&handle)?;
+        let group = optional_str(intent, "groupId");
         let source = required_str(intent, "sourcePanelId")?;
         let target = required_str(intent, "targetPanelId")?;
         store
-            .merge(&intent.client_id, &source, &target)
+            .merge(&intent.client_id, group.as_deref(), &source, &target)
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &store, &intent.client_id))
     });
@@ -107,11 +133,12 @@ pub fn register_layout_intents(registry: &mut HandlerRegistry, app_handle: AppHa
     let handle = app_handle.clone();
     registry.route("layout.moveTab", move |intent, projector| {
         let store = store_of(&handle)?;
+        let group = optional_str(intent, "groupId");
         let tab_id = required_str(intent, "tabId")?;
         let target = required_str(intent, "targetPanelId")?;
         let edge = required_enum(intent, "edge")?;
         store
-            .move_tab(&intent.client_id, &tab_id, &target, edge)
+            .move_tab(&intent.client_id, group.as_deref(), &tab_id, &target, edge)
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &store, &intent.client_id))
     });
@@ -119,9 +146,22 @@ pub fn register_layout_intents(registry: &mut HandlerRegistry, app_handle: AppHa
     let handle = app_handle.clone();
     registry.route("layout.closeTabStructure", move |intent, projector| {
         let store = store_of(&handle)?;
+        let group = optional_str(intent, "groupId");
         let tab_id = required_str(intent, "tabId")?;
         store
-            .close_tab_structure(&intent.client_id, &tab_id)
+            .close_tab_structure(&intent.client_id, group.as_deref(), &tab_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.addTab", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let group = optional_str(intent, "groupId");
+        let panel_id = required_str(intent, "panelId")?;
+        let tab = parse_tab(intent)?;
+        store
+            .add_tab(&intent.client_id, group.as_deref(), &panel_id, tab)
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &store, &intent.client_id))
     });
@@ -129,9 +169,10 @@ pub fn register_layout_intents(registry: &mut HandlerRegistry, app_handle: AppHa
     let handle = app_handle.clone();
     registry.route("layout.removePanel", move |intent, projector| {
         let store = store_of(&handle)?;
+        let group = optional_str(intent, "groupId");
         let panel_id = required_str(intent, "panelId")?;
         store
-            .remove_panel(&intent.client_id, &panel_id)
+            .remove_panel(&intent.client_id, group.as_deref(), &panel_id)
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &store, &intent.client_id))
     });
@@ -139,11 +180,18 @@ pub fn register_layout_intents(registry: &mut HandlerRegistry, app_handle: AppHa
     let handle = app_handle.clone();
     registry.route("layout.reorderTabs", move |intent, projector| {
         let store = store_of(&handle)?;
+        let group = optional_str(intent, "groupId");
         let panel_id = required_str(intent, "panelId")?;
         let old_index = required_usize(intent, "oldIndex")?;
         let new_index = required_usize(intent, "newIndex")?;
         store
-            .reorder_tabs(&intent.client_id, &panel_id, old_index, new_index)
+            .reorder_tabs(
+                &intent.client_id,
+                group.as_deref(),
+                &panel_id,
+                old_index,
+                new_index,
+            )
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &store, &intent.client_id))
     });
@@ -151,9 +199,10 @@ pub fn register_layout_intents(registry: &mut HandlerRegistry, app_handle: AppHa
     let handle = app_handle.clone();
     registry.route("layout.setActivePanel", move |intent, projector| {
         let store = store_of(&handle)?;
+        let group = optional_str(intent, "groupId");
         let panel_id = required_str(intent, "panelId")?;
         store
-            .set_active_panel(&intent.client_id, &panel_id)
+            .set_active_panel(&intent.client_id, group.as_deref(), &panel_id)
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &store, &intent.client_id))
     });
@@ -161,19 +210,114 @@ pub fn register_layout_intents(registry: &mut HandlerRegistry, app_handle: AppHa
     let handle = app_handle.clone();
     registry.route("layout.resize", move |intent, projector| {
         let store = store_of(&handle)?;
+        let group = optional_str(intent, "groupId");
         let split_id = required_str(intent, "splitId")?;
         let sizes = required_sizes(intent, "sizes")?;
         store
-            .resize(&intent.client_id, &split_id, sizes)
+            .resize(&intent.client_id, group.as_deref(), &split_id, sizes)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.replace", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let (root, active_panel_id) = parse_replace(intent)?;
+        store.replace(&intent.client_id, root, active_panel_id);
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    // ── Group-level routes (twins of the frontend `*TabGroup*` reducers) ──
+
+    let handle = app_handle.clone();
+    registry.route("layout.addGroup", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let name = optional_str(intent, "name");
+        store.add_group(&intent.client_id, name);
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.closeGroup", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let group_id = required_str(intent, "groupId")?;
+        store
+            .close_group(&intent.client_id, &group_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.renameGroup", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let group_id = required_str(intent, "groupId")?;
+        let name = required_str(intent, "name")?;
+        store
+            .rename_group(&intent.client_id, &group_id, name)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.setGroupColor", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let group_id = required_str(intent, "groupId")?;
+        let color = optional_str(intent, "color");
+        store
+            .set_group_color(&intent.client_id, &group_id, color)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.setActiveGroup", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let group_id = required_str(intent, "groupId")?;
+        store
+            .set_active_group(&intent.client_id, &group_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.reorderGroups", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let from_index = required_usize(intent, "fromIndex")?;
+        let to_index = required_usize(intent, "toIndex")?;
+        store
+            .reorder_groups(&intent.client_id, from_index, to_index)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.moveTabToGroup", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let tab_id = required_str(intent, "tabId")?;
+        let from_panel_id = required_str(intent, "fromPanelId")?;
+        let target_group_id = required_str(intent, "targetGroupId")?;
+        store
+            .move_tab_to_group(&intent.client_id, &tab_id, &from_panel_id, &target_group_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.addGroupWithTab", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let tab_id = required_str(intent, "tabId")?;
+        let from_panel_id = required_str(intent, "fromPanelId")?;
+        store
+            .add_group_with_tab(&intent.client_id, &tab_id, &from_panel_id)
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &store, &intent.client_id))
     });
 
     let handle = app_handle;
-    registry.route("layout.replace", move |intent, projector| {
+    registry.route("layout.replaceGroups", move |intent, projector| {
         let store = store_of(&handle)?;
-        let (root, active_panel_id) = parse_replace(intent)?;
-        store.replace(&intent.client_id, root, active_panel_id);
+        let (groups, active_group_id) = parse_replace_groups(intent)?;
+        store.replace_groups(&intent.client_id, groups, active_group_id);
         Ok(publish_layout(projector, &store, &intent.client_id))
     });
 }
@@ -192,6 +336,36 @@ fn parse_replace(intent: &Intent) -> Result<(PanelNode, Option<String>), (String
         .and_then(Value::as_str)
         .map(str::to_string);
     Ok((root, active_panel_id))
+}
+
+/// Parse a `layout.addTab` payload's `tab` field into a minimal [`Tab`]
+/// (`{ id, sessionId?, contentType }`).
+fn parse_tab(intent: &Intent) -> Result<Tab, (String, String)> {
+    let tab_value = intent
+        .payload
+        .get("tab")
+        .ok_or_else(|| ("bad_payload".to_string(), "missing 'tab'".to_string()))?;
+    serde_json::from_value(tab_value.clone())
+        .map_err(|e| ("bad_payload".to_string(), format!("invalid 'tab': {e}")))
+}
+
+/// Parse a `layout.replaceGroups` payload `{ activeGroupId, groups: [GroupLayout] }`.
+fn parse_replace_groups(
+    intent: &Intent,
+) -> Result<(Vec<GroupLayout>, String), (String, String)> {
+    let groups_value = intent
+        .payload
+        .get("groups")
+        .ok_or_else(|| ("bad_payload".to_string(), "missing 'groups'".to_string()))?;
+    let groups: Vec<GroupLayout> = serde_json::from_value(groups_value.clone())
+        .map_err(|e| ("bad_payload".to_string(), format!("invalid 'groups': {e}")))?;
+    let active_group_id = intent
+        .payload
+        .get("activeGroupId")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| ("bad_payload".to_string(), "missing 'activeGroupId'".to_string()))?;
+    Ok((groups, active_group_id))
 }
 
 /// Resolve the managed layout store, or a rejectable error if it is absent.
@@ -220,6 +394,16 @@ fn required_str(intent: &Intent, key: &str) -> Result<String, (String, String)> 
         .and_then(Value::as_str)
         .map(str::to_string)
         .ok_or_else(|| ("bad_payload".to_string(), format!("missing '{key}'")))
+}
+
+/// Extract an optional string field (e.g. `groupId`, or a nullable `color`).
+/// Returns `None` when the key is absent or not a string.
+fn optional_str(intent: &Intent, key: &str) -> Option<String> {
+    intent
+        .payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
 }
 
 /// Extract a required non-negative integer field (e.g. a tab index).

--- a/src-tauri/src/layout/projection_tests.rs
+++ b/src-tauri/src/layout/projection_tests.rs
@@ -74,80 +74,186 @@ fn registry_for(store: Arc<LayoutStore>) -> HandlerRegistry {
 
     let s = store.clone();
     registry.route("layout.split", move |intent, projector| {
+        let group = optional_str(intent, "groupId");
         let panel_id = required_str(intent, "panelId")?;
         let direction: Direction = required_enum(intent, "direction")?;
         let position: Position = required_enum(intent, "position")?;
-        s.split(&intent.client_id, &panel_id, direction, position)
-            .map_err(to_ack_err)?;
+        s.split(
+            &intent.client_id,
+            group.as_deref(),
+            &panel_id,
+            direction,
+            position,
+        )
+        .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &s, &intent.client_id))
     });
 
     let s = store.clone();
     registry.route("layout.merge", move |intent, projector| {
+        let group = optional_str(intent, "groupId");
         let source = required_str(intent, "sourcePanelId")?;
         let target = required_str(intent, "targetPanelId")?;
-        s.merge(&intent.client_id, &source, &target)
+        s.merge(&intent.client_id, group.as_deref(), &source, &target)
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &s, &intent.client_id))
     });
 
     let s = store.clone();
     registry.route("layout.moveTab", move |intent, projector| {
+        let group = optional_str(intent, "groupId");
         let tab_id = required_str(intent, "tabId")?;
         let target = required_str(intent, "targetPanelId")?;
         let edge: DropEdge = required_enum(intent, "edge")?;
-        s.move_tab(&intent.client_id, &tab_id, &target, edge)
+        s.move_tab(&intent.client_id, group.as_deref(), &tab_id, &target, edge)
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &s, &intent.client_id))
     });
 
     let s = store.clone();
     registry.route("layout.closeTabStructure", move |intent, projector| {
+        let group = optional_str(intent, "groupId");
         let tab_id = required_str(intent, "tabId")?;
-        s.close_tab_structure(&intent.client_id, &tab_id)
+        s.close_tab_structure(&intent.client_id, group.as_deref(), &tab_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("layout.addTab", move |intent, projector| {
+        let group = optional_str(intent, "groupId");
+        let panel_id = required_str(intent, "panelId")?;
+        let tab = parse_tab(intent)?;
+        s.add_tab(&intent.client_id, group.as_deref(), &panel_id, tab)
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &s, &intent.client_id))
     });
 
     let s = store.clone();
     registry.route("layout.removePanel", move |intent, projector| {
+        let group = optional_str(intent, "groupId");
         let panel_id = required_str(intent, "panelId")?;
-        s.remove_panel(&intent.client_id, &panel_id)
+        s.remove_panel(&intent.client_id, group.as_deref(), &panel_id)
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &s, &intent.client_id))
     });
 
     let s = store.clone();
     registry.route("layout.reorderTabs", move |intent, projector| {
+        let group = optional_str(intent, "groupId");
         let panel_id = required_str(intent, "panelId")?;
         let old_index = required_usize(intent, "oldIndex")?;
         let new_index = required_usize(intent, "newIndex")?;
-        s.reorder_tabs(&intent.client_id, &panel_id, old_index, new_index)
-            .map_err(to_ack_err)?;
+        s.reorder_tabs(
+            &intent.client_id,
+            group.as_deref(),
+            &panel_id,
+            old_index,
+            new_index,
+        )
+        .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &s, &intent.client_id))
     });
 
     let s = store.clone();
     registry.route("layout.setActivePanel", move |intent, projector| {
+        let group = optional_str(intent, "groupId");
         let panel_id = required_str(intent, "panelId")?;
-        s.set_active_panel(&intent.client_id, &panel_id)
+        s.set_active_panel(&intent.client_id, group.as_deref(), &panel_id)
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &s, &intent.client_id))
     });
 
     let s = store.clone();
     registry.route("layout.resize", move |intent, projector| {
+        let group = optional_str(intent, "groupId");
         let split_id = required_str(intent, "splitId")?;
         let sizes = required_sizes(intent, "sizes")?;
-        s.resize(&intent.client_id, &split_id, sizes)
+        s.resize(&intent.client_id, group.as_deref(), &split_id, sizes)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("layout.replace", move |intent, projector| {
+        let (root, active_panel_id) = parse_replace(intent)?;
+        s.replace(&intent.client_id, root, active_panel_id);
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("layout.addGroup", move |intent, projector| {
+        let name = optional_str(intent, "name");
+        s.add_group(&intent.client_id, name);
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("layout.closeGroup", move |intent, projector| {
+        let group_id = required_str(intent, "groupId")?;
+        s.close_group(&intent.client_id, &group_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("layout.renameGroup", move |intent, projector| {
+        let group_id = required_str(intent, "groupId")?;
+        let name = required_str(intent, "name")?;
+        s.rename_group(&intent.client_id, &group_id, name)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("layout.setGroupColor", move |intent, projector| {
+        let group_id = required_str(intent, "groupId")?;
+        let color = optional_str(intent, "color");
+        s.set_group_color(&intent.client_id, &group_id, color)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("layout.setActiveGroup", move |intent, projector| {
+        let group_id = required_str(intent, "groupId")?;
+        s.set_active_group(&intent.client_id, &group_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("layout.reorderGroups", move |intent, projector| {
+        let from_index = required_usize(intent, "fromIndex")?;
+        let to_index = required_usize(intent, "toIndex")?;
+        s.reorder_groups(&intent.client_id, from_index, to_index)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("layout.moveTabToGroup", move |intent, projector| {
+        let tab_id = required_str(intent, "tabId")?;
+        let from_panel_id = required_str(intent, "fromPanelId")?;
+        let target_group_id = required_str(intent, "targetGroupId")?;
+        s.move_tab_to_group(&intent.client_id, &tab_id, &from_panel_id, &target_group_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
+    registry.route("layout.addGroupWithTab", move |intent, projector| {
+        let tab_id = required_str(intent, "tabId")?;
+        let from_panel_id = required_str(intent, "fromPanelId")?;
+        s.add_group_with_tab(&intent.client_id, &tab_id, &from_panel_id)
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &s, &intent.client_id))
     });
 
     let s = store;
-    registry.route("layout.replace", move |intent, projector| {
-        let (root, active_panel_id) = parse_replace(intent)?;
-        s.replace(&intent.client_id, root, active_panel_id);
+    registry.route("layout.replaceGroups", move |intent, projector| {
+        let (groups, active_group_id) = parse_replace_groups(intent)?;
+        s.replace_groups(&intent.client_id, groups, active_group_id);
         Ok(publish_layout(projector, &s, &intent.client_id))
     });
 

--- a/src-tauri/src/layout/projection_tests.rs
+++ b/src-tauri/src/layout/projection_tests.rs
@@ -660,3 +660,190 @@ fn a_dead_subscriber_is_reaped_and_others_keep_receiving() {
     assert_eq!(projector.subscriber_count(&region), 1, "dead reaped");
     assert_eq!(live.diffs().len(), 1, "live subscriber still receives");
 }
+
+// ── New route parity: addTab / group-level intents (#2283 slice A) ────────────
+
+/// Wire a projector + dispatcher over `store` for client `A`, returning the
+/// dispatcher, the region id, a subscribed sink, and the seeded client cache.
+fn harness_for(store: Arc<LayoutStore>) -> (Dispatcher, String, Arc<VecSink>, ClientCache) {
+    let region = layout_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    let snap = projector.subscribe(&region, "sub", "A", sink.clone());
+    let cache = ClientCache::from_snapshot(&snap);
+    (dispatcher, region, sink, cache)
+}
+
+#[test]
+fn add_tab_route_inserts_a_tab_and_converges() {
+    let store = seeded_store("A");
+    let (dispatcher, _region, sink, mut cache) = harness_for(store.clone());
+
+    let ack = dispatcher.dispatch(intent(
+        "layout.addTab",
+        "A",
+        json!({ "panelId": "b", "tab": { "id": "new", "contentType": "terminal" } }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    for diff in &sink.diffs() {
+        cache.apply(diff);
+    }
+    assert_eq!(
+        cache.view,
+        store.snapshot("A"),
+        "cache converges on authority"
+    );
+
+    let root: PanelNode = serde_json::from_value(store.snapshot("A")["root"].clone()).unwrap();
+    let b = termihub_core::layout::panel_tree::find_leaf(&root, "b").unwrap();
+    assert!(
+        b.tabs.iter().any(|t| t.id == "new"),
+        "tab inserted via route"
+    );
+}
+
+#[test]
+fn add_group_route_appends_a_group_and_switches_the_back_compat_view() {
+    let store = seeded_store("A");
+    let (dispatcher, region, sink, mut cache) = harness_for(store.clone());
+
+    let ack = dispatcher.dispatch(intent("layout.addGroup", "A", json!({ "name": "Extra" })));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    // The full authority now has two groups with the new one active.
+    let full = store.snapshot_full("A");
+    let groups = full["groups"].as_array().unwrap();
+    assert_eq!(groups.len(), 2);
+    assert_eq!(full["activeGroupId"], groups[1]["id"]);
+    assert_eq!(groups[1]["name"], json!("Extra"));
+
+    // The back-compat region followed the active group (now an empty leaf).
+    let _ = region;
+    for diff in &sink.diffs() {
+        cache.apply(diff);
+    }
+    assert_eq!(
+        cache.view,
+        store.snapshot("A"),
+        "region tracks the active group"
+    );
+}
+
+#[test]
+fn rename_group_route_is_accepted_and_updates_authority() {
+    let store = seeded_store("A");
+    let region = layout_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(&region, "sub", "A", sink.clone());
+
+    let group_id = store.snapshot_full("A")["activeGroupId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let ack = dispatcher.dispatch(intent(
+        "layout.renameGroup",
+        "A",
+        json!({ "groupId": group_id, "name": "Renamed" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    // A metadata-only change: the back-compat region view is unchanged, so no diff.
+    assert_eq!(
+        sink.diffs().len(),
+        0,
+        "rename does not move the back-compat view"
+    );
+    assert_eq!(projector.region_version(&region), Some(0));
+    assert_eq!(
+        store.snapshot_full("A")["groups"][0]["name"],
+        json!("Renamed")
+    );
+}
+
+#[test]
+fn replace_groups_route_installs_a_multi_group_layout_then_routes_operate() {
+    let store = Arc::new(LayoutStore::new());
+    let (dispatcher, _region, _sink, _cache) = harness_for(store.clone());
+
+    // Install two groups; g1 active holding two_panel_tree, g2 a single leaf.
+    let ack = dispatcher.dispatch(intent(
+        "layout.replaceGroups",
+        "A",
+        json!({
+            "activeGroupId": "g1",
+            "groups": [
+                { "id": "g1", "name": "Main", "root": two_panel_tree(), "activePanelId": "a" },
+                {
+                    "id": "g2",
+                    "name": "Second",
+                    "root": leaf_node("z", &["t9"]),
+                    "activePanelId": "z"
+                }
+            ]
+        }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+    assert_eq!(
+        store.snapshot_full("A")["groups"].as_array().unwrap().len(),
+        2
+    );
+
+    // Move t3 (panel b of active g1) into g2 via the route.
+    let ack = dispatcher.dispatch(intent(
+        "layout.moveTabToGroup",
+        "A",
+        json!({ "tabId": "t3", "fromPanelId": "b", "targetGroupId": "g2" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    let full = store.snapshot_full("A");
+    let g2_root: PanelNode = serde_json::from_value(
+        full["groups"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|g| g["id"] == json!("g2"))
+            .unwrap()["root"]
+            .clone(),
+    )
+    .unwrap();
+    assert!(
+        termihub_core::layout::panel_tree::find_leaf_by_tab(&g2_root, "t3").is_some(),
+        "t3 landed in g2 via the route"
+    );
+}
+
+#[test]
+fn close_group_route_rejects_the_last_group() {
+    let store = seeded_store("A");
+    let region = layout_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(&region, "sub", "A", sink.clone());
+
+    let group_id = store.snapshot_full("A")["activeGroupId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let ack = dispatcher.dispatch(intent(
+        "layout.closeGroup",
+        "A",
+        json!({ "groupId": group_id }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "last_group");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(&region), Some(0));
+}
+
+/// A leaf `PanelNode` value for JSON payload fixtures.
+fn leaf_node(id: &str, tab_ids: &[&str]) -> PanelNode {
+    PanelNode::Leaf(leaf(id, tab_ids))
+}

--- a/src-tauri/src/layout/store.rs
+++ b/src-tauri/src/layout/store.rs
@@ -1,17 +1,32 @@
-//! The authoritative, client-scoped panel-tree + tab model behind the shadow
-//! `layout@<clientId>` projection region (#2151).
+//! The authoritative, client-scoped layout model behind the shadow
+//! `layout@<clientId>` projection region (#2151, widened for #2283 slice A).
 //!
 //! Every structural transform delegates to the pure panel-tree algebra ported in
-//! #2143 (`termihub_core::layout::panel_tree`) — this module only owns the
-//! per-client authoritative trees and turns the four `layout.*` intents into
-//! algebra calls. It holds **only** the structure + minimal tab model
-//! (`{ id, sessionId, contentType }`, exactly the seam the ported `Tab` models);
-//! session status, tab colours, and broadcast membership stay in `appStore`
-//! under partial projection and migrate in later phases.
+//! #2143 (`termihub_core::layout::panel_tree`) — this module owns the per-client
+//! authoritative **multi-group** model and turns the `layout.*` intents into
+//! algebra calls. It holds the tab-group set (each with its own panel tree) plus
+//! the minimal tab model (`{ id, sessionId, contentType }`, exactly the seam the
+//! ported `Tab` model exposes); session status, tab colours, and broadcast
+//! membership stay in `appStore` under partial projection and migrate in later
+//! phases.
+//!
+//! # Multi-group authority + back-compat view (#2283 slice A)
+//!
+//! The store is now authoritative for the **full** layout: the ordered set of
+//! tab groups (`{ id, name, color, root, activePanelId }`) plus the active group.
+//! [`LayoutStore::snapshot_full`] emits `{ activeGroupId, groups: [...] }`. To
+//! keep the current render path unaffected until a later slice flips the
+//! frontend, [`LayoutStore::snapshot`] still emits the **active group's**
+//! back-compat view `{ root, activePanelId }` — the shape every existing
+//! `layout@<clientId>` consumer renders. Every structural transform takes an
+//! optional `group_id`, resolving to the active group when omitted.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, MutexGuard};
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use termihub_core::layout::panel_tree::{
@@ -24,12 +39,19 @@ use termihub_core::layout::panel_tree::{
 /// in [`super::projection`].
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum LayoutError {
-    /// A referenced leaf panel id is not present in the client's tree.
+    /// A referenced leaf panel id is not present in the target group's tree.
     #[error("panel not found: {0}")]
     PanelNotFound(String),
-    /// A referenced tab id is not present in the client's tree.
+    /// A referenced tab id is not present in the target group's tree.
     #[error("tab not found: {0}")]
     TabNotFound(String),
+    /// A referenced tab group id is not present in the client's layout.
+    #[error("group not found: {0}")]
+    GroupNotFound(String),
+    /// `closeGroup` was asked to close the sole remaining group — the app always
+    /// keeps at least one group, so this is rejected rather than silently no-op.
+    #[error("cannot close the last remaining group")]
+    LastGroup,
     /// A `moveTab` used the `center` edge where a real split edge was required,
     /// or vice versa — a malformed payload.
     #[error("invalid split edge")]
@@ -37,8 +59,8 @@ pub enum LayoutError {
     /// `merge` was asked to merge a panel into itself.
     #[error("source and target panels are the same")]
     SamePanel,
-    /// A `reorderTabs` index fell outside the target leaf's tab range.
-    #[error("tab index out of range")]
+    /// A `reorderTabs` / `reorderGroups` index fell outside the valid range.
+    #[error("index out of range")]
     IndexOutOfRange,
     /// A `resize` supplied a size array whose length did not match the split's
     /// child count.
@@ -52,6 +74,8 @@ impl LayoutError {
         match self {
             LayoutError::PanelNotFound(_) => "panel_not_found",
             LayoutError::TabNotFound(_) => "tab_not_found",
+            LayoutError::GroupNotFound(_) => "group_not_found",
+            LayoutError::LastGroup => "last_group",
             LayoutError::BadEdge
             | LayoutError::SamePanel
             | LayoutError::IndexOutOfRange
@@ -60,52 +84,127 @@ impl LayoutError {
     }
 }
 
-/// One client's authoritative layout: its panel tree plus the focused panel.
-#[derive(Clone, Debug, PartialEq)]
-struct LayoutState {
-    root: PanelNode,
-    active_panel_id: Option<String>,
+/// One tab group: an independent panel tree plus its metadata and focused panel.
+/// Serialises to the frontend `TabGroup` shape (`{ id, name, color?, root,
+/// activePanelId }`) — `color` is omitted when unset.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupLayout {
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub color: Option<String>,
+    pub root: PanelNode,
+    #[serde(default)]
+    pub active_panel_id: Option<String>,
 }
 
-impl LayoutState {
-    /// A freshly-seeded layout: a single empty leaf panel, focused.
-    fn seeded() -> Self {
+impl GroupLayout {
+    /// A freshly-seeded group: a single empty leaf panel, focused.
+    fn seeded(name: impl Into<String>) -> Self {
         let leaf = create_leaf_panel();
         let id = leaf.id.clone();
         Self {
+            id: generate_group_id(),
+            name: name.into(),
+            color: None,
             root: PanelNode::Leaf(leaf),
             active_panel_id: Some(id),
         }
     }
+}
 
-    /// The render-ready view model for this client's region.
-    fn view(&self) -> Value {
-        json!({ "root": self.root, "activePanelId": self.active_panel_id })
+/// One client's authoritative layout: its ordered tab groups plus the active
+/// group. Serialises to the full multi-group view `{ groups, activeGroupId }`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientLayout {
+    pub groups: Vec<GroupLayout>,
+    pub active_group_id: String,
+}
+
+impl ClientLayout {
+    /// A freshly-seeded client: one "Main" group with a single empty focused leaf.
+    fn seeded() -> Self {
+        let group = GroupLayout::seeded("Main");
+        let active_group_id = group.id.clone();
+        Self {
+            groups: vec![group],
+            active_group_id,
+        }
+    }
+
+    /// The full render-ready view model: `{ activeGroupId, groups: [...] }`.
+    fn full_view(&self) -> Value {
+        serde_json::to_value(self).unwrap_or(Value::Null)
+    }
+
+    /// The back-compat **active-group** view `{ root, activePanelId }` — the shape
+    /// the current `layout@<clientId>` consumers render, unchanged by the widening
+    /// so the live render path is unaffected until a later slice.
+    fn active_view(&self) -> Value {
+        match self.active_group() {
+            Some(g) => json!({ "root": g.root, "activePanelId": g.active_panel_id }),
+            None => json!({ "root": PanelNode::Leaf(create_leaf_panel()), "activePanelId": null }),
+        }
+    }
+
+    /// The active group, falling back to the first group when the active id is
+    /// somehow dangling (should not happen — transforms keep it valid).
+    fn active_group(&self) -> Option<&GroupLayout> {
+        self.groups
+            .iter()
+            .find(|g| g.id == self.active_group_id)
+            .or_else(|| self.groups.first())
+    }
+
+    /// A mutable borrow of the group `group_id` names, or the active group when
+    /// `group_id` is `None`. Rejects an unknown group.
+    fn group_mut(&mut self, group_id: Option<&str>) -> Result<&mut GroupLayout, LayoutError> {
+        let gid = group_id
+            .map(str::to_string)
+            .unwrap_or_else(|| self.active_group_id.clone());
+        self.groups
+            .iter_mut()
+            .find(|g| g.id == gid)
+            .ok_or(LayoutError::GroupNotFound(gid))
     }
 }
 
-/// The shadow layout authority. Owns one [`LayoutState`] per attached client,
+/// The shadow layout authority. Owns one [`ClientLayout`] per attached client,
 /// keyed by `clientId`; an unknown client is seeded lazily on first touch.
 #[derive(Default)]
 pub struct LayoutStore {
-    clients: Mutex<HashMap<String, LayoutState>>,
+    clients: Mutex<HashMap<String, ClientLayout>>,
 }
 
 impl LayoutStore {
-    /// A store with no clients yet. Regions are seeded lazily per `clientId`.
+    /// A store with no clients yet. Clients are seeded lazily per `clientId`.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// The current render-ready view model for a client (seeding it if unknown).
+    /// The current **back-compat** render-ready view for a client (seeding it if
+    /// unknown): the active group's `{ root, activePanelId }`.
     ///
     /// Pure with respect to layout structure — it never mutates an existing
-    /// client — so the projector can safely diff two consecutive snapshots.
+    /// client — so the projector can safely diff two consecutive snapshots. This
+    /// keeps the live `layout@<clientId>` region shape unchanged this slice.
     pub fn snapshot(&self, client_id: &str) -> Value {
         self.lock()
             .entry(client_id.to_string())
-            .or_insert_with(LayoutState::seeded)
-            .view()
+            .or_insert_with(ClientLayout::seeded)
+            .active_view()
+    }
+
+    /// The full multi-group view for a client: `{ activeGroupId, groups: [...] }`.
+    /// The authoritative shape a later slice flips the region and frontend onto.
+    pub fn snapshot_full(&self, client_id: &str) -> Value {
+        self.lock()
+            .entry(client_id.to_string())
+            .or_insert_with(ClientLayout::seeded)
+            .full_view()
     }
 
     /// `layout.split` — split a leaf panel, inserting a new empty leaf beside it
@@ -113,22 +212,24 @@ impl LayoutStore {
     pub fn split(
         &self,
         client_id: &str,
+        group_id: Option<&str>,
         panel_id: &str,
         direction: Direction,
         position: Position,
     ) -> Result<(), LayoutError> {
         let mut clients = self.lock();
-        let state = clients
+        let group = clients
             .entry(client_id.to_string())
-            .or_insert_with(LayoutState::seeded);
-        if find_leaf(&state.root, panel_id).is_none() {
+            .or_insert_with(ClientLayout::seeded)
+            .group_mut(group_id)?;
+        if find_leaf(&group.root, panel_id).is_none() {
             return Err(LayoutError::PanelNotFound(panel_id.to_string()));
         }
         let new_leaf = create_leaf_panel();
         let new_id = new_leaf.id.clone();
-        state.root = split_leaf(&state.root, panel_id, &new_leaf, direction, position);
-        state.active_panel_id = Some(new_id);
-        fix_active(state);
+        group.root = split_leaf(&group.root, panel_id, &new_leaf, direction, position);
+        group.active_panel_id = Some(new_id);
+        fix_active(group);
         Ok(())
     }
 
@@ -137,6 +238,7 @@ impl LayoutStore {
     pub fn merge(
         &self,
         client_id: &str,
+        group_id: Option<&str>,
         source_panel_id: &str,
         target_panel_id: &str,
     ) -> Result<(), LayoutError> {
@@ -144,23 +246,24 @@ impl LayoutStore {
             return Err(LayoutError::SamePanel);
         }
         let mut clients = self.lock();
-        let state = clients
+        let group = clients
             .entry(client_id.to_string())
-            .or_insert_with(LayoutState::seeded);
-        let tabs = find_leaf(&state.root, source_panel_id)
+            .or_insert_with(ClientLayout::seeded)
+            .group_mut(group_id)?;
+        let tabs = find_leaf(&group.root, source_panel_id)
             .ok_or_else(|| LayoutError::PanelNotFound(source_panel_id.to_string()))?
             .tabs
             .clone();
-        if find_leaf(&state.root, target_panel_id).is_none() {
+        if find_leaf(&group.root, target_panel_id).is_none() {
             return Err(LayoutError::PanelNotFound(target_panel_id.to_string()));
         }
-        let merged = update_leaf(&state.root, target_panel_id, |leaf| {
+        let merged = update_leaf(&group.root, target_panel_id, |leaf| {
             with_tabs_appended(leaf, &tabs)
         });
         let pruned = remove_leaf(&merged, source_panel_id).unwrap_or_else(single_empty_leaf);
-        state.root = simplify_tree(&pruned);
-        state.active_panel_id = Some(target_panel_id.to_string());
-        fix_active(state);
+        group.root = simplify_tree(&pruned);
+        group.active_panel_id = Some(target_panel_id.to_string());
+        fix_active(group);
         Ok(())
     }
 
@@ -171,15 +274,17 @@ impl LayoutStore {
     pub fn move_tab(
         &self,
         client_id: &str,
+        group_id: Option<&str>,
         tab_id: &str,
         target_panel_id: &str,
         edge: DropEdge,
     ) -> Result<(), LayoutError> {
         let mut clients = self.lock();
-        let state = clients
+        let group = clients
             .entry(client_id.to_string())
-            .or_insert_with(LayoutState::seeded);
-        let source_leaf = find_leaf_by_tab(&state.root, tab_id)
+            .or_insert_with(ClientLayout::seeded)
+            .group_mut(group_id)?;
+        let source_leaf = find_leaf_by_tab(&group.root, tab_id)
             .ok_or_else(|| LayoutError::TabNotFound(tab_id.to_string()))?;
         let source_id = source_leaf.id.clone();
         let tab = source_leaf
@@ -188,11 +293,11 @@ impl LayoutStore {
             .find(|t| t.id == tab_id)
             .cloned()
             .ok_or_else(|| LayoutError::TabNotFound(tab_id.to_string()))?;
-        if find_leaf(&state.root, target_panel_id).is_none() {
+        if find_leaf(&group.root, target_panel_id).is_none() {
             return Err(LayoutError::PanelNotFound(target_panel_id.to_string()));
         }
 
-        let detached = update_leaf(&state.root, &source_id, |leaf| {
+        let detached = update_leaf(&group.root, &source_id, |leaf| {
             with_tab_removed(leaf, tab_id)
         });
         let placed = match edge {
@@ -216,170 +321,470 @@ impl LayoutStore {
             }
         };
         let pruned = remove_leaf_if_empty(&placed, &source_id);
-        state.root = simplify_tree(&pruned);
-        fix_active(state);
+        group.root = simplify_tree(&pruned);
+        fix_active(group);
         Ok(())
     }
 
     /// `layout.closeTabStructure` — remove a tab from the tree, dropping its leaf
     /// if it becomes empty. Only the structural half of closing a tab; session
     /// teardown stays in `appStore` under partial projection (later phases).
-    pub fn close_tab_structure(&self, client_id: &str, tab_id: &str) -> Result<(), LayoutError> {
+    pub fn close_tab_structure(
+        &self,
+        client_id: &str,
+        group_id: Option<&str>,
+        tab_id: &str,
+    ) -> Result<(), LayoutError> {
         let mut clients = self.lock();
-        let state = clients
+        let group = clients
             .entry(client_id.to_string())
-            .or_insert_with(LayoutState::seeded);
-        let leaf_id = find_leaf_by_tab(&state.root, tab_id)
+            .or_insert_with(ClientLayout::seeded)
+            .group_mut(group_id)?;
+        let leaf_id = find_leaf_by_tab(&group.root, tab_id)
             .ok_or_else(|| LayoutError::TabNotFound(tab_id.to_string()))?
             .id
             .clone();
-        let detached = update_leaf(&state.root, &leaf_id, |leaf| with_tab_removed(leaf, tab_id));
+        let detached = update_leaf(&group.root, &leaf_id, |leaf| with_tab_removed(leaf, tab_id));
         let pruned = remove_leaf_if_empty(&detached, &leaf_id);
-        state.root = simplify_tree(&pruned);
-        fix_active(state);
+        group.root = simplify_tree(&pruned);
+        fix_active(group);
+        Ok(())
+    }
+
+    /// `layout.addTab` — insert a minimal tab into `(group, panel)` and focus it.
+    /// The structural half of opening a tab; the frontend session-creation flow
+    /// supplies the tab identity (`{ id, sessionId, contentType }`). Rejects an
+    /// unknown panel.
+    pub fn add_tab(
+        &self,
+        client_id: &str,
+        group_id: Option<&str>,
+        panel_id: &str,
+        tab: Tab,
+    ) -> Result<(), LayoutError> {
+        let mut clients = self.lock();
+        let group = clients
+            .entry(client_id.to_string())
+            .or_insert_with(ClientLayout::seeded)
+            .group_mut(group_id)?;
+        if find_leaf(&group.root, panel_id).is_none() {
+            return Err(LayoutError::PanelNotFound(panel_id.to_string()));
+        }
+        group.root = update_leaf(&group.root, panel_id, |leaf| with_tab_added(leaf, tab.clone()));
+        group.active_panel_id = Some(panel_id.to_string());
         Ok(())
     }
 
     /// `layout.removePanel` — drop a whole leaf panel (and every tab it holds)
     /// from the tree, then simplify and repoint focus. The structural half of the
-    /// close-panel action.
-    ///
-    /// Neither [`merge`](Self::merge) (which *preserves* the tabs by moving them
-    /// into a target) nor [`close_tab_structure`](Self::close_tab_structure)
-    /// (which removes a single tab) matches "discard the entire panel", so this is
-    /// its own transform over the shared `remove_leaf` algebra. Removing the sole
-    /// remaining leaf is a no-op — the app always keeps at least one panel —
-    /// mirroring the frontend `removePanel` reducer's `allLeaves.length <= 1`
-    /// guard, so the two paths stay parity-identical.
-    pub fn remove_panel(&self, client_id: &str, panel_id: &str) -> Result<(), LayoutError> {
+    /// close-panel action. Removing the sole remaining leaf is a no-op — the app
+    /// always keeps at least one panel — mirroring the frontend `removePanel`
+    /// reducer's `allLeaves.length <= 1` guard.
+    pub fn remove_panel(
+        &self,
+        client_id: &str,
+        group_id: Option<&str>,
+        panel_id: &str,
+    ) -> Result<(), LayoutError> {
         let mut clients = self.lock();
-        let state = clients
+        let group = clients
             .entry(client_id.to_string())
-            .or_insert_with(LayoutState::seeded);
-        if find_leaf(&state.root, panel_id).is_none() {
+            .or_insert_with(ClientLayout::seeded)
+            .group_mut(group_id)?;
+        if find_leaf(&group.root, panel_id).is_none() {
             return Err(LayoutError::PanelNotFound(panel_id.to_string()));
         }
-        if get_all_leaves(&state.root).len() <= 1 {
+        if get_all_leaves(&group.root).len() <= 1 {
             // Sole leaf: the frontend leaves the tree untouched; match it.
             return Ok(());
         }
-        let removed = remove_leaf(&state.root, panel_id).unwrap_or_else(single_empty_leaf);
-        state.root = simplify_tree(&removed);
-        // `fix_active` repoints focus onto the first surviving leaf when the
-        // removed panel held it — exactly the frontend `newLeaves[0]` fallback.
-        fix_active(state);
+        let removed = remove_leaf(&group.root, panel_id).unwrap_or_else(single_empty_leaf);
+        group.root = simplify_tree(&removed);
+        fix_active(group);
         Ok(())
     }
 
     /// `layout.reorderTabs` — move a tab within a single leaf from `old_index` to
-    /// `new_index`, leaving the active tab and every other panel untouched (a
-    /// same-panel drag-reorder). Mirrors the frontend `reorderTabs` reducer.
+    /// `new_index`, leaving the active tab and every other panel untouched.
     pub fn reorder_tabs(
         &self,
         client_id: &str,
+        group_id: Option<&str>,
         panel_id: &str,
         old_index: usize,
         new_index: usize,
     ) -> Result<(), LayoutError> {
         let mut clients = self.lock();
-        let state = clients
+        let group = clients
             .entry(client_id.to_string())
-            .or_insert_with(LayoutState::seeded);
-        let leaf = find_leaf(&state.root, panel_id)
+            .or_insert_with(ClientLayout::seeded)
+            .group_mut(group_id)?;
+        let leaf = find_leaf(&group.root, panel_id)
             .ok_or_else(|| LayoutError::PanelNotFound(panel_id.to_string()))?;
         let len = leaf.tabs.len();
         if old_index >= len || new_index >= len {
             return Err(LayoutError::IndexOutOfRange);
         }
-        state.root = update_leaf(&state.root, panel_id, |leaf| {
+        group.root = update_leaf(&group.root, panel_id, |leaf| {
             with_tabs_reordered(leaf, old_index, new_index)
         });
         Ok(())
     }
 
-    /// `layout.setActivePanel` — repoint the focused panel. Focus lives in the
-    /// projected view (`activePanelId`), so this makes the store authoritative for
-    /// it; zoom-follow stays a frontend concern under partial projection.
-    pub fn set_active_panel(&self, client_id: &str, panel_id: &str) -> Result<(), LayoutError> {
+    /// `layout.setActivePanel` — repoint the focused panel within a group.
+    pub fn set_active_panel(
+        &self,
+        client_id: &str,
+        group_id: Option<&str>,
+        panel_id: &str,
+    ) -> Result<(), LayoutError> {
         let mut clients = self.lock();
-        let state = clients
+        let group = clients
             .entry(client_id.to_string())
-            .or_insert_with(LayoutState::seeded);
-        if find_leaf(&state.root, panel_id).is_none() {
+            .or_insert_with(ClientLayout::seeded)
+            .group_mut(group_id)?;
+        if find_leaf(&group.root, panel_id).is_none() {
             return Err(LayoutError::PanelNotFound(panel_id.to_string()));
         }
-        state.active_panel_id = Some(panel_id.to_string());
+        group.active_panel_id = Some(panel_id.to_string());
         Ok(())
     }
 
     /// `layout.resize` — persist the child percentage `sizes` of the split
-    /// container `split_id` (normalized to sum to 100), so a user's drag of a
-    /// resize handle survives remounts and workspace save/restore. Rejects a size
-    /// array whose length does not match the split's child count.
+    /// container `split_id` (normalized to sum to 100). Rejects a size array whose
+    /// length does not match the split's child count.
     pub fn resize(
         &self,
         client_id: &str,
+        group_id: Option<&str>,
         split_id: &str,
         sizes: Vec<f64>,
     ) -> Result<(), LayoutError> {
         let mut clients = self.lock();
-        let state = clients
+        let group = clients
             .entry(client_id.to_string())
-            .or_insert_with(LayoutState::seeded);
-        let split = find_split(&state.root, split_id)
+            .or_insert_with(ClientLayout::seeded)
+            .group_mut(group_id)?;
+        let split = find_split(&group.root, split_id)
             .ok_or_else(|| LayoutError::PanelNotFound(split_id.to_string()))?;
         if sizes.len() != split.children.len() {
             return Err(LayoutError::SizeMismatch);
         }
         let normalized = normalize_sizes(&sizes);
-        state.root = set_split_sizes(&state.root, split_id, &normalized);
+        group.root = set_split_sizes(&group.root, split_id, &normalized);
         Ok(())
     }
 
-    /// `layout.replace` — install a complete tree for a client, replacing any
-    /// existing one.
-    ///
-    /// This is the **seed-before-mutate** entry point the step-2 frontend bridge
-    /// uses to keep the store authoritative for structure while tab *creation*
-    /// still lives in `appStore` (partial projection). Because tabs enter the
-    /// app via session creation — not a layout intent — the store would
-    /// otherwise never learn about them; the bridge pushes its current
-    /// structural tree (in the minimal `{ id, sessionId, contentType }` tab
-    /// form) here immediately before dispatching a structural intent, so the
-    /// four transforms operate on the real tree and project a diff the frontend
-    /// can reconcile back. The active panel is repointed at a real leaf when the
-    /// supplied id is absent.
+    // ── Group-level transforms (twins of the frontend `*TabGroup*` reducers) ──
+
+    /// `layout.addGroup` — append a fresh empty group and make it active. Returns
+    /// the new group's id. Mirrors the frontend `addTabGroup` reducer's default
+    /// `Group {count}` naming when no `name` is supplied.
+    pub fn add_group(&self, client_id: &str, name: Option<String>) -> String {
+        let mut clients = self.lock();
+        let client = clients
+            .entry(client_id.to_string())
+            .or_insert_with(ClientLayout::seeded);
+        let count = client.groups.len() + 1;
+        let group = GroupLayout::seeded(name.unwrap_or_else(|| format!("Group {count}")));
+        let new_id = group.id.clone();
+        client.groups.push(group);
+        client.active_group_id = new_id.clone();
+        new_id
+    }
+
+    /// `layout.closeGroup` — remove a group. Closing the sole remaining group is
+    /// rejected ([`LayoutError::LastGroup`]) — the app always keeps one group.
+    /// Closing the active group repoints the active group onto the adjacent one
+    /// (`max(0, idx-1)`), matching the frontend `closeTabGroup` reducer.
+    pub fn close_group(&self, client_id: &str, group_id: &str) -> Result<(), LayoutError> {
+        let mut clients = self.lock();
+        let client = clients
+            .entry(client_id.to_string())
+            .or_insert_with(ClientLayout::seeded);
+        if client.groups.len() <= 1 {
+            return Err(LayoutError::LastGroup);
+        }
+        let idx = client
+            .groups
+            .iter()
+            .position(|g| g.id == group_id)
+            .ok_or_else(|| LayoutError::GroupNotFound(group_id.to_string()))?;
+        let was_active = client.active_group_id == group_id;
+        client.groups.remove(idx);
+        if was_active {
+            let new_idx = idx.saturating_sub(1).min(client.groups.len() - 1);
+            client.active_group_id = client.groups[new_idx].id.clone();
+        }
+        Ok(())
+    }
+
+    /// `layout.renameGroup` — set a group's display name.
+    pub fn rename_group(
+        &self,
+        client_id: &str,
+        group_id: &str,
+        name: String,
+    ) -> Result<(), LayoutError> {
+        let mut clients = self.lock();
+        let group = clients
+            .entry(client_id.to_string())
+            .or_insert_with(ClientLayout::seeded)
+            .group_mut(Some(group_id))?;
+        group.name = name;
+        Ok(())
+    }
+
+    /// `layout.setGroupColor` — set (or clear, with `None`) a group's accent
+    /// colour.
+    pub fn set_group_color(
+        &self,
+        client_id: &str,
+        group_id: &str,
+        color: Option<String>,
+    ) -> Result<(), LayoutError> {
+        let mut clients = self.lock();
+        let group = clients
+            .entry(client_id.to_string())
+            .or_insert_with(ClientLayout::seeded)
+            .group_mut(Some(group_id))?;
+        group.color = color;
+        Ok(())
+    }
+
+    /// `layout.setActiveGroup` — switch the active group.
+    pub fn set_active_group(&self, client_id: &str, group_id: &str) -> Result<(), LayoutError> {
+        let mut clients = self.lock();
+        let client = clients
+            .entry(client_id.to_string())
+            .or_insert_with(ClientLayout::seeded);
+        if !client.groups.iter().any(|g| g.id == group_id) {
+            return Err(LayoutError::GroupNotFound(group_id.to_string()));
+        }
+        client.active_group_id = group_id.to_string();
+        Ok(())
+    }
+
+    /// `layout.reorderGroups` — move a group from `from_index` to `to_index`
+    /// (splice-out-then-splice-in), matching the frontend `reorderTabGroups`.
+    pub fn reorder_groups(
+        &self,
+        client_id: &str,
+        from_index: usize,
+        to_index: usize,
+    ) -> Result<(), LayoutError> {
+        let mut clients = self.lock();
+        let client = clients
+            .entry(client_id.to_string())
+            .or_insert_with(ClientLayout::seeded);
+        let len = client.groups.len();
+        if from_index >= len || to_index >= len {
+            return Err(LayoutError::IndexOutOfRange);
+        }
+        let moved = client.groups.remove(from_index);
+        client.groups.insert(to_index, moved);
+        Ok(())
+    }
+
+    /// `layout.moveTabToGroup` — move a tab from a panel in the **active** group
+    /// into the target group's first leaf, focusing it there. Prunes the emptied
+    /// source panel (unless it is the group's sole leaf). A no-op when the target
+    /// is the active group. Mirrors the frontend `moveTabToGroup` reducer.
+    pub fn move_tab_to_group(
+        &self,
+        client_id: &str,
+        tab_id: &str,
+        from_panel_id: &str,
+        target_group_id: &str,
+    ) -> Result<(), LayoutError> {
+        let mut clients = self.lock();
+        let client = clients
+            .entry(client_id.to_string())
+            .or_insert_with(ClientLayout::seeded);
+        if target_group_id == client.active_group_id {
+            return Ok(());
+        }
+        if !client.groups.iter().any(|g| g.id == target_group_id) {
+            return Err(LayoutError::GroupNotFound(target_group_id.to_string()));
+        }
+
+        // Detach the tab from the source (active) group first.
+        let tab = detach_tab_from_active_group(client, from_panel_id, tab_id)?;
+
+        // Add it to the target group's first leaf, focused.
+        let target = client
+            .groups
+            .iter_mut()
+            .find(|g| g.id == target_group_id)
+            .ok_or_else(|| LayoutError::GroupNotFound(target_group_id.to_string()))?;
+        let first_leaf_id = get_all_leaves(&target.root)
+            .first()
+            .map(|l| l.id.clone())
+            .ok_or_else(|| LayoutError::PanelNotFound(target_group_id.to_string()))?;
+        target.root = update_leaf(&target.root, &first_leaf_id, |leaf| {
+            with_tab_added(leaf, tab.clone())
+        });
+        Ok(())
+    }
+
+    /// `layout.addGroupWithTab` — move a tab out of a panel in the **active**
+    /// group into a brand-new group holding just that tab, made active. Returns
+    /// the new group's id. Mirrors the frontend `addTabGroupWithTab` reducer.
+    pub fn add_group_with_tab(
+        &self,
+        client_id: &str,
+        tab_id: &str,
+        from_panel_id: &str,
+    ) -> Result<String, LayoutError> {
+        let mut clients = self.lock();
+        let client = clients
+            .entry(client_id.to_string())
+            .or_insert_with(ClientLayout::seeded);
+
+        let tab = detach_tab_from_active_group(client, from_panel_id, tab_id)?;
+
+        let mut leaf = create_leaf_panel();
+        let panel_id = leaf.id.clone();
+        let tab_focus = tab.id.clone();
+        leaf.tabs = vec![tab];
+        leaf.active_tab_id = Some(tab_focus);
+        let count = client.groups.len() + 1;
+        let group = GroupLayout {
+            id: generate_group_id(),
+            name: format!("Group {count}"),
+            color: None,
+            root: PanelNode::Leaf(leaf),
+            active_panel_id: Some(panel_id),
+        };
+        let new_id = group.id.clone();
+        client.groups.push(group);
+        client.active_group_id = new_id.clone();
+        Ok(new_id)
+    }
+
+    /// `layout.replace` — install a complete tree for the **active group**,
+    /// replacing that group's tree. The seed-before-mutate entry point the
+    /// frontend bridge uses to keep the store authoritative for structure while
+    /// tab *creation* still lives in `appStore` (partial projection). The active
+    /// panel is repointed at a real leaf when the supplied id is absent.
     pub fn replace(&self, client_id: &str, root: PanelNode, active_panel_id: Option<String>) {
-        let mut state = LayoutState {
+        let mut clients = self.lock();
+        let client = clients
+            .entry(client_id.to_string())
+            .or_insert_with(ClientLayout::seeded);
+        let active_id = client.active_group_id.clone();
+        if let Ok(group) = client.group_mut(Some(&active_id)) {
+            group.root = root;
+            group.active_panel_id = active_panel_id;
+            fix_active(group);
+        }
+    }
+
+    /// `layout.replaceGroups` — install a complete multi-group layout for a
+    /// client, replacing any existing one. The whole-layout twin of [`replace`]
+    /// (workspace restore / multi-window install). Each group's active panel is
+    /// repointed at a real leaf when absent, and the active group id is repointed
+    /// at the first group when it does not name a present group. An empty install
+    /// falls back to a freshly-seeded client.
+    pub fn replace_groups(
+        &self,
+        client_id: &str,
+        groups: Vec<GroupLayout>,
+        active_group_id: String,
+    ) {
+        let client = if groups.is_empty() {
+            ClientLayout::seeded()
+        } else {
+            let mut client = ClientLayout {
+                groups,
+                active_group_id,
+            };
+            for group in client.groups.iter_mut() {
+                fix_active(group);
+            }
+            if !client.groups.iter().any(|g| g.id == client.active_group_id) {
+                client.active_group_id = client.groups[0].id.clone();
+            }
+            client
+        };
+        self.lock().insert(client_id.to_string(), client);
+    }
+
+    /// Install a single-group tree for a client — test-only seeding so intent
+    /// tests can start from a populated layout without a tab-creating intent.
+    #[cfg(test)]
+    pub fn seed_for_test(&self, client_id: &str, root: PanelNode, active_panel_id: Option<String>) {
+        let group = GroupLayout {
+            id: "group-test".to_string(),
+            name: "Main".to_string(),
+            color: None,
             root,
             active_panel_id,
         };
-        fix_active(&mut state);
-        self.lock().insert(client_id.to_string(), state);
-    }
-
-    /// Install a specific tree for a client — test-only seeding so intent tests
-    /// can start from a populated layout without a tab-creating intent (tabs
-    /// enter via session creation in `appStore`, out of this shadow's scope).
-    #[cfg(test)]
-    pub fn seed_for_test(&self, client_id: &str, root: PanelNode, active_panel_id: Option<String>) {
+        let active_group_id = group.id.clone();
         self.lock().insert(
             client_id.to_string(),
-            LayoutState {
-                root,
-                active_panel_id,
+            ClientLayout {
+                groups: vec![group],
+                active_group_id,
             },
         );
     }
 
-    fn lock(&self) -> MutexGuard<'_, HashMap<String, LayoutState>> {
+    /// Install a full multi-group layout for a client — test-only seeding.
+    #[cfg(test)]
+    pub fn seed_groups_for_test(&self, client_id: &str, client: ClientLayout) {
+        self.lock().insert(client_id.to_string(), client);
+    }
+
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, ClientLayout>> {
         // Short critical sections only; a poisoned lock means another thread
         // panicked mid-mutation (a bug) — recover rather than cascade.
         self.clients.lock().unwrap_or_else(|e| e.into_inner())
     }
 }
 
-// ── Pure leaf/tree helpers ───────────────────────────────────────────────────
+// ── Cross-group / pure leaf-tree helpers ─────────────────────────────────────
+
+/// Remove `tab_id` (held by `from_panel_id`) from the client's active group,
+/// pruning the emptied source panel unless it is the group's sole leaf, and
+/// repointing the group's focus. Returns the detached tab. Shared by
+/// [`LayoutStore::move_tab_to_group`] and [`LayoutStore::add_group_with_tab`],
+/// which both lift a tab out of the active group before re-homing it.
+fn detach_tab_from_active_group(
+    client: &mut ClientLayout,
+    from_panel_id: &str,
+    tab_id: &str,
+) -> Result<Tab, LayoutError> {
+    let active_id = client.active_group_id.clone();
+    let source = client
+        .groups
+        .iter_mut()
+        .find(|g| g.id == active_id)
+        .ok_or_else(|| LayoutError::GroupNotFound(active_id.clone()))?;
+    let source_leaf = find_leaf(&source.root, from_panel_id)
+        .ok_or_else(|| LayoutError::PanelNotFound(from_panel_id.to_string()))?;
+    let tab = source_leaf
+        .tabs
+        .iter()
+        .find(|t| t.id == tab_id)
+        .cloned()
+        .ok_or_else(|| LayoutError::TabNotFound(tab_id.to_string()))?;
+
+    let detached = update_leaf(&source.root, from_panel_id, |leaf| {
+        with_tab_removed(leaf, tab_id)
+    });
+    let now_empty = find_leaf(&detached, from_panel_id)
+        .map(|l| l.tabs.is_empty())
+        .unwrap_or(false);
+    source.root = if now_empty && get_all_leaves(&detached).len() > 1 {
+        simplify_tree(&remove_leaf(&detached, from_panel_id).unwrap_or_else(single_empty_leaf))
+    } else {
+        detached
+    };
+    fix_active(source);
+    Ok(tab)
+}
 
 /// A single empty leaf, the collapse target when a whole tree is emptied.
 fn single_empty_leaf() -> PanelNode {
@@ -389,8 +794,7 @@ fn single_empty_leaf() -> PanelNode {
 /// A copy of `leaf` with `tab_id` removed; when the removed tab was active, the
 /// active tab falls back **positionally** — the tab that shifts into the removed
 /// slot, or the new last tab. This matches the frontend `removeTabFromLeaf`
-/// reducer (`min(idx, len-1)`) exactly, so cutting a tab-moving mutation over to
-/// the store preserves which tab the source panel focuses (#2151 step 2).
+/// reducer (`min(idx, len-1)`) exactly.
 fn with_tab_removed(leaf: &LeafPanel, tab_id: &str) -> LeafPanel {
     let removed_idx = leaf.tabs.iter().position(|t| t.id == tab_id);
     let tabs: Vec<Tab> = leaf
@@ -446,8 +850,7 @@ fn with_tabs_appended(leaf: &LeafPanel, extra: &[Tab]) -> LeafPanel {
 }
 
 /// A copy of `leaf` with the tab at `old_index` moved to `new_index`, preserving
-/// the active tab. Mirrors the frontend `reorderTabs` splice-out-then-splice-in;
-/// callers validate the indices against the tab count first.
+/// the active tab. Callers validate the indices against the tab count first.
 fn with_tabs_reordered(leaf: &LeafPanel, old_index: usize, new_index: usize) -> LeafPanel {
     let mut tabs = leaf.tabs.clone();
     let moved = tabs.remove(old_index);
@@ -510,16 +913,28 @@ fn remove_leaf_if_empty(root: &PanelNode, leaf_id: &str) -> PanelNode {
     }
 }
 
-/// Repoint `active_panel_id` at an existing leaf when the current one is gone.
-fn fix_active(state: &mut LayoutState) {
-    let still_present = state
+/// Repoint a group's `active_panel_id` at an existing leaf when the current one
+/// is gone.
+fn fix_active(group: &mut GroupLayout) {
+    let still_present = group
         .active_panel_id
         .as_deref()
-        .map(|id| find_leaf(&state.root, id).is_some())
+        .map(|id| find_leaf(&group.root, id).is_some())
         .unwrap_or(false);
     if !still_present {
-        state.active_panel_id = get_all_leaves(&state.root).first().map(|l| l.id.clone());
+        group.active_panel_id = get_all_leaves(&group.root).first().map(|l| l.id.clone());
     }
+}
+
+/// Generate a unique tab-group id (mirrors the TS `group-<ts>-<n>` shape).
+fn generate_group_id() -> String {
+    static GROUP_COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = GROUP_COUNTER.fetch_add(1, Ordering::Relaxed) + 1;
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    format!("group-{millis}-{n}")
 }
 
 #[cfg(test)]

--- a/src-tauri/src/layout/store.rs
+++ b/src-tauri/src/layout/store.rs
@@ -136,6 +136,10 @@ impl ClientLayout {
     }
 
     /// The full render-ready view model: `{ activeGroupId, groups: [...] }`.
+    ///
+    /// The authoritative shape a later slice flips the region and frontend onto;
+    /// not yet consumed by production wiring this slice (only [`snapshot_full`]).
+    #[allow(dead_code)]
     fn full_view(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
@@ -199,7 +203,9 @@ impl LayoutStore {
     }
 
     /// The full multi-group view for a client: `{ activeGroupId, groups: [...] }`.
-    /// The authoritative shape a later slice flips the region and frontend onto.
+    /// The authoritative shape a later slice flips the region and frontend onto;
+    /// exercised by the group-transform tests this slice, not yet by live wiring.
+    #[allow(dead_code)]
     pub fn snapshot_full(&self, client_id: &str) -> Value {
         self.lock()
             .entry(client_id.to_string())
@@ -370,7 +376,9 @@ impl LayoutStore {
         if find_leaf(&group.root, panel_id).is_none() {
             return Err(LayoutError::PanelNotFound(panel_id.to_string()));
         }
-        group.root = update_leaf(&group.root, panel_id, |leaf| with_tab_added(leaf, tab.clone()));
+        group.root = update_leaf(&group.root, panel_id, |leaf| {
+            with_tab_added(leaf, tab.clone())
+        });
         group.active_panel_id = Some(panel_id.to_string());
         Ok(())
     }

--- a/src-tauri/src/layout/store_tests.rs
+++ b/src-tauri/src/layout/store_tests.rs
@@ -117,7 +117,7 @@ fn replace_installs_a_whole_tree_over_the_seeded_empty_leaf() {
 
     // A subsequent structural transform now operates on the installed tree.
     store
-        .move_tab("C", "t1", "b", DropEdge::Center)
+        .move_tab("C", None, "t1", "b", DropEdge::Center)
         .expect("move on the replaced tree");
     let root = root_of(&store, "C");
     assert_eq!(
@@ -144,7 +144,7 @@ fn split_inserts_a_new_empty_focused_leaf_and_preserves_tab_count() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
     store
-        .split("C", "b", Direction::Vertical, Position::After)
+        .split("C", None, "b", Direction::Vertical, Position::After)
         .unwrap();
 
     let root = root_of(&store, "C");
@@ -161,7 +161,7 @@ fn split_of_unknown_panel_is_rejected() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
     let err = store
-        .split("C", "nope", Direction::Horizontal, Position::After)
+        .split("C", None, "nope", Direction::Horizontal, Position::After)
         .unwrap_err();
     assert_eq!(err, LayoutError::PanelNotFound("nope".to_string()));
     assert_eq!(err.code(), "panel_not_found");
@@ -173,7 +173,7 @@ fn split_of_unknown_panel_is_rejected() {
 fn merge_moves_all_tabs_into_target_and_drops_the_source() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
-    store.merge("C", "a", "b").unwrap();
+    store.merge("C", None, "a", "b").unwrap();
 
     let root = root_of(&store, "C");
     // The tree simplifies to the single surviving leaf `b` holding all 3 tabs.
@@ -191,7 +191,7 @@ fn merge_into_self_is_rejected() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
     assert_eq!(
-        store.merge("C", "a", "a").unwrap_err(),
+        store.merge("C", None, "a", "a").unwrap_err(),
         LayoutError::SamePanel
     );
 }
@@ -201,7 +201,7 @@ fn merge_with_unknown_source_is_rejected() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
     assert_eq!(
-        store.merge("C", "ghost", "b").unwrap_err(),
+        store.merge("C", None, "ghost", "b").unwrap_err(),
         LayoutError::PanelNotFound("ghost".to_string()),
     );
 }
@@ -212,7 +212,7 @@ fn merge_with_unknown_source_is_rejected() {
 fn move_tab_center_drops_the_tab_into_the_target_stack() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
-    store.move_tab("C", "t1", "b", DropEdge::Center).unwrap();
+    store.move_tab("C", None, "t1", "b", DropEdge::Center).unwrap();
 
     let root = root_of(&store, "C");
     assert_eq!(count_tabs_in_tree(&root), 3, "tab count preserved");
@@ -227,7 +227,7 @@ fn move_tab_center_drops_the_tab_into_the_target_stack() {
 fn move_tab_edge_splits_the_target_into_a_new_leaf() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
-    store.move_tab("C", "t3", "a", DropEdge::Right).unwrap();
+    store.move_tab("C", None, "t3", "a", DropEdge::Right).unwrap();
 
     let root = root_of(&store, "C");
     // b held only t3; moving it out empties and prunes b. t3 lands in a fresh
@@ -251,7 +251,7 @@ fn move_tab_of_unknown_tab_is_rejected() {
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
     assert_eq!(
         store
-            .move_tab("C", "ghost", "b", DropEdge::Center)
+            .move_tab("C", None, "ghost", "b", DropEdge::Center)
             .unwrap_err(),
         LayoutError::TabNotFound("ghost".to_string()),
     );
@@ -271,7 +271,7 @@ fn removing_a_middle_active_tab_falls_back_positionally_like_the_frontend() {
         active_tab_id: Some("t2".to_string()),
     });
     store.seed_for_test("C", root, Some("a".to_string()));
-    store.close_tab_structure("C", "t2").unwrap();
+    store.close_tab_structure("C", None, "t2").unwrap();
 
     let root = root_of(&store, "C");
     let a = find_leaf(&root, "a").unwrap();
@@ -286,7 +286,7 @@ fn removing_a_middle_active_tab_falls_back_positionally_like_the_frontend() {
 fn close_tab_removes_one_tab_keeping_a_non_empty_leaf() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
-    store.close_tab_structure("C", "t1").unwrap();
+    store.close_tab_structure("C", None, "t1").unwrap();
 
     let root = root_of(&store, "C");
     assert_eq!(count_tabs_in_tree(&root), 2, "one tab removed");
@@ -300,7 +300,7 @@ fn close_tab_removes_one_tab_keeping_a_non_empty_leaf() {
 fn close_last_tab_in_a_leaf_prunes_and_simplifies() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("b".to_string()));
-    store.close_tab_structure("C", "t3").unwrap();
+    store.close_tab_structure("C", None, "t3").unwrap();
 
     let root = root_of(&store, "C");
     // b emptied → pruned → split simplified to just a.
@@ -317,7 +317,7 @@ fn close_of_unknown_tab_is_rejected() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
     assert_eq!(
-        store.close_tab_structure("C", "ghost").unwrap_err(),
+        store.close_tab_structure("C", None, "ghost").unwrap_err(),
         LayoutError::TabNotFound("ghost".to_string()),
     );
 }
@@ -328,7 +328,7 @@ fn close_of_unknown_tab_is_rejected() {
 fn remove_panel_drops_the_whole_leaf_and_simplifies() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
-    store.remove_panel("C", "a").unwrap();
+    store.remove_panel("C", None, "a").unwrap();
 
     let root = root_of(&store, "C");
     // a (and its two tabs) is gone; the split simplifies to the single leaf b.
@@ -344,7 +344,7 @@ fn remove_panel_drops_the_whole_leaf_and_simplifies() {
 fn remove_panel_keeps_focus_when_a_different_panel_is_removed() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
-    store.remove_panel("C", "b").unwrap();
+    store.remove_panel("C", None, "b").unwrap();
     // a was focused and survives → focus unchanged (frontend parity).
     assert_eq!(active_of(&store, "C").as_deref(), Some("a"));
 }
@@ -354,7 +354,7 @@ fn remove_panel_on_the_sole_leaf_is_a_no_op() {
     let store = LayoutStore::new();
     let root = PanelNode::Leaf(leaf("only", &["t1"]));
     store.seed_for_test("C", root, Some("only".to_string()));
-    store.remove_panel("C", "only").unwrap();
+    store.remove_panel("C", None, "only").unwrap();
 
     let root = root_of(&store, "C");
     // The app always keeps one panel; the sole leaf is untouched.
@@ -368,7 +368,7 @@ fn remove_panel_of_unknown_panel_is_rejected() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
     assert_eq!(
-        store.remove_panel("C", "ghost").unwrap_err(),
+        store.remove_panel("C", None, "ghost").unwrap_err(),
         LayoutError::PanelNotFound("ghost".to_string()),
     );
 }
@@ -385,7 +385,7 @@ fn reorder_tabs_moves_a_tab_within_its_leaf_keeping_active() {
     });
     store.seed_for_test("C", root, Some("a".to_string()));
     // Move t1 (index 0) to index 2.
-    store.reorder_tabs("C", "a", 0, 2).unwrap();
+    store.reorder_tabs("C", None, "a", 0, 2).unwrap();
 
     let root = root_of(&store, "C");
     let a = find_leaf(&root, "a").unwrap();
@@ -404,7 +404,7 @@ fn reorder_tabs_rejects_an_out_of_range_index() {
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
     // b holds one tab → index 1 is out of range.
     assert_eq!(
-        store.reorder_tabs("C", "b", 1, 0).unwrap_err(),
+        store.reorder_tabs("C", None, "b", 1, 0).unwrap_err(),
         LayoutError::IndexOutOfRange,
     );
     assert_eq!(LayoutError::IndexOutOfRange.code(), "bad_payload");
@@ -415,7 +415,7 @@ fn reorder_tabs_of_unknown_panel_is_rejected() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
     assert_eq!(
-        store.reorder_tabs("C", "ghost", 0, 0).unwrap_err(),
+        store.reorder_tabs("C", None, "ghost", 0, 0).unwrap_err(),
         LayoutError::PanelNotFound("ghost".to_string()),
     );
 }
@@ -427,7 +427,7 @@ fn set_active_panel_repoints_focus_without_touching_the_tree() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
     let before = root_of(&store, "C");
-    store.set_active_panel("C", "b").unwrap();
+    store.set_active_panel("C", None, "b").unwrap();
 
     assert_eq!(active_of(&store, "C").as_deref(), Some("b"), "focus moved");
     assert_eq!(root_of(&store, "C"), before, "tree unchanged");
@@ -438,7 +438,7 @@ fn set_active_panel_of_unknown_panel_is_rejected() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
     assert_eq!(
-        store.set_active_panel("C", "ghost").unwrap_err(),
+        store.set_active_panel("C", None, "ghost").unwrap_err(),
         LayoutError::PanelNotFound("ghost".to_string()),
     );
 }
@@ -450,7 +450,7 @@ fn resize_persists_normalized_sizes_on_the_split() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
     // Supply sizes that do not sum to 100 → stored normalized.
-    store.resize("C", "root", vec![30.0, 10.0]).unwrap();
+    store.resize("C", None, "root", vec![30.0, 10.0]).unwrap();
 
     let root = root_of(&store, "C");
     match root {
@@ -469,7 +469,7 @@ fn resize_rejects_a_mismatched_size_count() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
     assert_eq!(
-        store.resize("C", "root", vec![100.0]).unwrap_err(),
+        store.resize("C", None, "root", vec![100.0]).unwrap_err(),
         LayoutError::SizeMismatch,
     );
     assert_eq!(LayoutError::SizeMismatch.code(), "bad_payload");
@@ -480,7 +480,7 @@ fn resize_of_unknown_split_is_rejected() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
     assert_eq!(
-        store.resize("C", "ghost", vec![50.0, 50.0]).unwrap_err(),
+        store.resize("C", None, "ghost", vec![50.0, 50.0]).unwrap_err(),
         LayoutError::PanelNotFound("ghost".to_string()),
     );
 }
@@ -530,12 +530,12 @@ proptest! {
                 0 => {
                     let direction = if e % 2 == 0 { Direction::Horizontal } else { Direction::Vertical };
                     let position = if (e / 2) % 2 == 0 { Position::Before } else { Position::After };
-                    store.split(client, &src_id, direction, position).unwrap();
+                    store.split(client, None, &src_id, direction, position).unwrap();
                     prop_assert_eq!(count_tabs_in_tree(&root_of(&store, client)), before);
                 }
                 1 => {
                     if src_id != tgt_id {
-                        store.merge(client, &src_id, &tgt_id).unwrap();
+                        store.merge(client, None, &src_id, &tgt_id).unwrap();
                         prop_assert_eq!(count_tabs_in_tree(&root_of(&store, client)), before);
                     }
                 }
@@ -543,14 +543,14 @@ proptest! {
                     if let Some(t) = src.tabs.first() {
                         let tab_id = t.id.clone();
                         let edge = ALL_EDGES[e as usize % ALL_EDGES.len()];
-                        store.move_tab(client, &tab_id, &tgt_id, edge).unwrap();
+                        store.move_tab(client, None, &tab_id, &tgt_id, edge).unwrap();
                         prop_assert_eq!(count_tabs_in_tree(&root_of(&store, client)), before);
                     }
                 }
                 _ => {
                     if let Some(t) = src.tabs.first() {
                         let tab_id = t.id.clone();
-                        store.close_tab_structure(client, &tab_id).unwrap();
+                        store.close_tab_structure(client, None, &tab_id).unwrap();
                         prop_assert_eq!(count_tabs_in_tree(&root_of(&store, client)), before - 1);
                     }
                 }

--- a/src-tauri/src/layout/store_tests.rs
+++ b/src-tauri/src/layout/store_tests.rs
@@ -7,7 +7,7 @@
 //! assert the tree invariants hold after every step.
 
 use proptest::prelude::*;
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use super::*;
 use termihub_core::layout::panel_tree::{
@@ -212,7 +212,9 @@ fn merge_with_unknown_source_is_rejected() {
 fn move_tab_center_drops_the_tab_into_the_target_stack() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
-    store.move_tab("C", None, "t1", "b", DropEdge::Center).unwrap();
+    store
+        .move_tab("C", None, "t1", "b", DropEdge::Center)
+        .unwrap();
 
     let root = root_of(&store, "C");
     assert_eq!(count_tabs_in_tree(&root), 3, "tab count preserved");
@@ -227,7 +229,9 @@ fn move_tab_center_drops_the_tab_into_the_target_stack() {
 fn move_tab_edge_splits_the_target_into_a_new_leaf() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
-    store.move_tab("C", None, "t3", "a", DropEdge::Right).unwrap();
+    store
+        .move_tab("C", None, "t3", "a", DropEdge::Right)
+        .unwrap();
 
     let root = root_of(&store, "C");
     // b held only t3; moving it out empties and prunes b. t3 lands in a fresh
@@ -480,9 +484,548 @@ fn resize_of_unknown_split_is_rejected() {
     let store = LayoutStore::new();
     store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
     assert_eq!(
-        store.resize("C", None, "ghost", vec![50.0, 50.0]).unwrap_err(),
+        store
+            .resize("C", None, "ghost", vec![50.0, 50.0])
+            .unwrap_err(),
         LayoutError::PanelNotFound("ghost".to_string()),
     );
+}
+
+// ── Multi-group fixtures ─────────────────────────────────────────────────────
+
+fn group(id: &str, name: &str, root: PanelNode, active: Option<&str>) -> GroupLayout {
+    GroupLayout {
+        id: id.to_string(),
+        name: name.to_string(),
+        color: None,
+        root,
+        active_panel_id: active.map(str::to_string),
+    }
+}
+
+/// A two-group client: active `g1` holds `two_panel_tree`; `g2` holds a single
+/// leaf `z` with tab `t9`.
+fn two_group_client() -> ClientLayout {
+    ClientLayout {
+        groups: vec![
+            group("g1", "Main", two_panel_tree(), Some("a")),
+            group(
+                "g2",
+                "Second",
+                PanelNode::Leaf(leaf("z", &["t9"])),
+                Some("z"),
+            ),
+        ],
+        active_group_id: "g1".to_string(),
+    }
+}
+
+fn full_of(store: &LayoutStore, client: &str) -> Value {
+    store.snapshot_full(client)
+}
+
+fn group_root(store: &LayoutStore, client: &str, group_id: &str) -> PanelNode {
+    let full = store.snapshot_full(client);
+    let groups = full["groups"].as_array().expect("groups array");
+    let g = groups
+        .iter()
+        .find(|g| g["id"] == json!(group_id))
+        .expect("group present");
+    serde_json::from_value(g["root"].clone()).expect("group root deserializes")
+}
+
+// ── Back-compat + full view ──────────────────────────────────────────────────
+
+#[test]
+fn snapshot_is_the_active_groups_back_compat_view() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    // Back-compat shape is unchanged: { root, activePanelId } for the active group.
+    let snap = store.snapshot("C");
+    assert_eq!(snap["activePanelId"], json!("a"));
+    assert_eq!(count_tabs_in_tree(&root_of(&store, "C")), 3, "g1's tree");
+    assert!(snap.get("groups").is_none(), "no multi-group keys leak");
+
+    // Switching the active group re-points the back-compat view at g2.
+    store.set_active_group("C", "g2").unwrap();
+    assert_eq!(store.snapshot("C")["activePanelId"], json!("z"));
+    assert_eq!(count_tabs_in_tree(&root_of(&store, "C")), 1, "g2's tree");
+}
+
+#[test]
+fn snapshot_full_lists_every_group_and_the_active_id() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    let full = full_of(&store, "C");
+    assert_eq!(full["activeGroupId"], json!("g1"));
+    let groups = full["groups"].as_array().unwrap();
+    assert_eq!(groups.len(), 2);
+    assert_eq!(groups[0]["id"], json!("g1"));
+    assert_eq!(groups[0]["name"], json!("Main"));
+    assert_eq!(groups[1]["id"], json!("g2"));
+    // Unset colour is omitted, matching the frontend optional field.
+    assert!(groups[0].get("color").is_none());
+}
+
+#[test]
+fn a_never_touched_client_seeds_one_group() {
+    let store = LayoutStore::new();
+    let full = full_of(&store, "C");
+    let groups = full["groups"].as_array().unwrap();
+    assert_eq!(groups.len(), 1, "one seeded group");
+    assert_eq!(groups[0]["name"], json!("Main"));
+    assert_eq!(full["activeGroupId"], groups[0]["id"]);
+}
+
+// ── group_id scoping / isolation ─────────────────────────────────────────────
+
+#[test]
+fn an_omitted_group_id_targets_the_active_group() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    // None → active group g1 gains a leaf; g2 is untouched.
+    store
+        .split("C", None, "b", Direction::Vertical, Position::After)
+        .unwrap();
+    assert_eq!(get_all_leaves(&group_root(&store, "C", "g1")).len(), 3);
+    assert_eq!(get_all_leaves(&group_root(&store, "C", "g2")).len(), 1);
+}
+
+#[test]
+fn a_group_id_scopes_a_transform_to_that_group_only() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    let g1_before = group_root(&store, "C", "g1");
+    // Split inside the *inactive* group g2; g1 must be byte-identical afterwards.
+    store
+        .split("C", Some("g2"), "z", Direction::Horizontal, Position::After)
+        .unwrap();
+    assert_eq!(
+        get_all_leaves(&group_root(&store, "C", "g2")).len(),
+        2,
+        "g2 mutated"
+    );
+    assert_eq!(
+        group_root(&store, "C", "g1"),
+        g1_before,
+        "g1 never touched by a g2-scoped mutation"
+    );
+}
+
+#[test]
+fn a_transform_on_an_unknown_group_is_rejected() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    let err = store
+        .split(
+            "C",
+            Some("ghost"),
+            "a",
+            Direction::Horizontal,
+            Position::After,
+        )
+        .unwrap_err();
+    assert_eq!(err, LayoutError::GroupNotFound("ghost".to_string()));
+    assert_eq!(err.code(), "group_not_found");
+}
+
+// ── addTab ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn add_tab_inserts_and_focuses_a_minimal_tab() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    store.add_tab("C", None, "b", tab("new")).unwrap();
+
+    let root_g1 = group_root(&store, "C", "g1");
+    let b = find_leaf(&root_g1, "b").unwrap();
+    assert_eq!(
+        b.tabs.iter().map(|t| t.id.as_str()).collect::<Vec<_>>(),
+        vec!["t3", "new"]
+    );
+    assert_eq!(b.active_tab_id.as_deref(), Some("new"), "new tab focused");
+    assert_eq!(
+        store.snapshot("C")["activePanelId"],
+        json!("b"),
+        "panel focused"
+    );
+}
+
+#[test]
+fn add_tab_targets_a_named_group() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    store.add_tab("C", Some("g2"), "z", tab("new")).unwrap();
+    let root_g2 = group_root(&store, "C", "g2");
+    let z = find_leaf(&root_g2, "z").unwrap();
+    assert!(z.tabs.iter().any(|t| t.id == "new"));
+}
+
+#[test]
+fn add_tab_on_an_unknown_panel_is_rejected() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    assert_eq!(
+        store.add_tab("C", None, "ghost", tab("new")).unwrap_err(),
+        LayoutError::PanelNotFound("ghost".to_string()),
+    );
+}
+
+#[test]
+fn add_tab_then_close_tab_round_trips() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    let before = count_tabs_in_tree(&group_root(&store, "C", "g1"));
+    store.add_tab("C", None, "b", tab("ephemeral")).unwrap();
+    assert_eq!(
+        count_tabs_in_tree(&group_root(&store, "C", "g1")),
+        before + 1
+    );
+    store.close_tab_structure("C", None, "ephemeral").unwrap();
+    assert_eq!(
+        count_tabs_in_tree(&group_root(&store, "C", "g1")),
+        before,
+        "close undoes the add"
+    );
+}
+
+// ── addGroup ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn add_group_appends_an_empty_group_and_activates_it() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    let new_id = store.add_group("C", None);
+
+    let full = full_of(&store, "C");
+    let groups = full["groups"].as_array().unwrap();
+    assert_eq!(groups.len(), 3, "group appended");
+    assert_eq!(full["activeGroupId"], json!(new_id), "new group is active");
+    assert_eq!(
+        groups[2]["name"],
+        json!("Group 3"),
+        "default name uses count"
+    );
+    // The new group is a single empty focused leaf.
+    let root = group_root(&store, "C", &new_id);
+    let leaves = get_all_leaves(&root);
+    assert_eq!(leaves.len(), 1);
+    assert!(leaves[0].tabs.is_empty());
+}
+
+#[test]
+fn add_group_honours_an_explicit_name() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    let id = store.add_group("C", Some("Custom".to_string()));
+    let root_name = full_of(&store, "C")["groups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|g| g["id"] == json!(id))
+        .unwrap()["name"]
+        .clone();
+    assert_eq!(root_name, json!("Custom"));
+}
+
+// ── closeGroup ───────────────────────────────────────────────────────────────
+
+#[test]
+fn close_inactive_group_removes_only_it_and_keeps_active() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    store.close_group("C", "g2").unwrap();
+    let full = full_of(&store, "C");
+    assert_eq!(full["groups"].as_array().unwrap().len(), 1);
+    assert_eq!(full["activeGroupId"], json!("g1"), "active unchanged");
+}
+
+#[test]
+fn close_active_group_repoints_to_the_previous_group() {
+    let store = LayoutStore::new();
+    // Three groups g1,g2,g3; active g2 (index 1). Closing g2 → max(0,1-1)=0 → g1.
+    let client = ClientLayout {
+        groups: vec![
+            group("g1", "A", PanelNode::Leaf(leaf("a", &["t1"])), Some("a")),
+            group("g2", "B", PanelNode::Leaf(leaf("b", &["t2"])), Some("b")),
+            group("g3", "C", PanelNode::Leaf(leaf("c", &["t3"])), Some("c")),
+        ],
+        active_group_id: "g2".to_string(),
+    };
+    store.seed_groups_for_test("C", client);
+    store.close_group("C", "g2").unwrap();
+    assert_eq!(full_of(&store, "C")["activeGroupId"], json!("g1"));
+}
+
+#[test]
+fn closing_the_last_group_is_rejected() {
+    let store = LayoutStore::new();
+    // Fresh client → one seeded group.
+    let err = store
+        .close_group("C", &current_active_group(&store, "C"))
+        .unwrap_err();
+    assert_eq!(err, LayoutError::LastGroup);
+    assert_eq!(err.code(), "last_group");
+}
+
+#[test]
+fn closing_an_unknown_group_is_rejected() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    assert_eq!(
+        store.close_group("C", "ghost").unwrap_err(),
+        LayoutError::GroupNotFound("ghost".to_string()),
+    );
+}
+
+// ── rename / colour / setActive / reorder ────────────────────────────────────
+
+#[test]
+fn rename_group_sets_the_name() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    store
+        .rename_group("C", "g2", "Renamed".to_string())
+        .unwrap();
+    let name = full_of(&store, "C")["groups"].as_array().unwrap()[1]["name"].clone();
+    assert_eq!(name, json!("Renamed"));
+}
+
+#[test]
+fn set_group_color_sets_then_clears() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    store
+        .set_group_color("C", "g1", Some("#ff0000".to_string()))
+        .unwrap();
+    assert_eq!(
+        full_of(&store, "C")["groups"].as_array().unwrap()[0]["color"],
+        json!("#ff0000")
+    );
+    store.set_group_color("C", "g1", None).unwrap();
+    assert!(
+        full_of(&store, "C")["groups"].as_array().unwrap()[0]
+            .get("color")
+            .is_none(),
+        "cleared colour is omitted"
+    );
+}
+
+#[test]
+fn set_active_group_switches_and_rejects_unknown() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    store.set_active_group("C", "g2").unwrap();
+    assert_eq!(full_of(&store, "C")["activeGroupId"], json!("g2"));
+    assert_eq!(
+        store.set_active_group("C", "ghost").unwrap_err(),
+        LayoutError::GroupNotFound("ghost".to_string()),
+    );
+}
+
+#[test]
+fn reorder_groups_moves_a_group() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    // Move g1 (index 0) to index 1 → order becomes [g2, g1].
+    store.reorder_groups("C", 0, 1).unwrap();
+    let groups = full_of(&store, "C")["groups"].clone();
+    let ids: Vec<&str> = groups
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|g| g["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(ids, vec!["g2", "g1"]);
+    assert_eq!(
+        full_of(&store, "C")["activeGroupId"],
+        json!("g1"),
+        "active id stable"
+    );
+}
+
+#[test]
+fn reorder_groups_rejects_an_out_of_range_index() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    assert_eq!(
+        store.reorder_groups("C", 0, 5).unwrap_err(),
+        LayoutError::IndexOutOfRange,
+    );
+}
+
+// ── moveTabToGroup (cross-tree) ──────────────────────────────────────────────
+
+#[test]
+fn move_tab_to_group_moves_a_tab_across_trees() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    // Move t3 (sole tab of panel b in active g1) into g2.
+    store.move_tab_to_group("C", "t3", "b", "g2").unwrap();
+
+    // g1: b emptied → pruned → only a (t1,t2) survives.
+    let g1 = group_root(&store, "C", "g1");
+    assert_eq!(count_tabs_in_tree(&g1), 2, "t3 left g1");
+    assert!(find_leaf(&g1, "b").is_none(), "emptied source panel pruned");
+    // g2: t3 appended to z's stack and focused there.
+    let root_g2 = group_root(&store, "C", "g2");
+    let z = find_leaf(&root_g2, "z").unwrap();
+    assert_eq!(
+        z.tabs.iter().map(|t| t.id.as_str()).collect::<Vec<_>>(),
+        vec!["t9", "t3"]
+    );
+    assert_eq!(
+        z.active_tab_id.as_deref(),
+        Some("t3"),
+        "moved tab focused in target"
+    );
+}
+
+#[test]
+fn move_tab_to_group_keeps_a_shared_panel_when_it_still_has_tabs() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    // Move t1 out of panel a (which still holds t2) → a survives, not pruned.
+    store.move_tab_to_group("C", "t1", "a", "g2").unwrap();
+    let root_g1 = group_root(&store, "C", "g1");
+    let a = find_leaf(&root_g1, "a").unwrap();
+    assert_eq!(
+        a.tabs.iter().map(|t| t.id.as_str()).collect::<Vec<_>>(),
+        vec!["t2"]
+    );
+    assert_eq!(count_tabs_in_tree(&group_root(&store, "C", "g2")), 2);
+}
+
+#[test]
+fn move_tab_to_group_is_a_no_op_when_target_is_active() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    let before = full_of(&store, "C");
+    store.move_tab_to_group("C", "t1", "a", "g1").unwrap();
+    assert_eq!(
+        full_of(&store, "C"),
+        before,
+        "no change when target == active"
+    );
+}
+
+#[test]
+fn move_tab_to_group_rejects_unknown_target_and_tab() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    assert_eq!(
+        store
+            .move_tab_to_group("C", "t1", "a", "ghost")
+            .unwrap_err(),
+        LayoutError::GroupNotFound("ghost".to_string()),
+    );
+    assert_eq!(
+        store.move_tab_to_group("C", "nope", "a", "g2").unwrap_err(),
+        LayoutError::TabNotFound("nope".to_string()),
+    );
+}
+
+// ── addGroupWithTab (cross-tree) ─────────────────────────────────────────────
+
+#[test]
+fn add_group_with_tab_creates_a_new_active_group_holding_the_tab() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    let new_id = store.add_group_with_tab("C", "t1", "a").unwrap();
+
+    let full = full_of(&store, "C");
+    assert_eq!(
+        full["groups"].as_array().unwrap().len(),
+        3,
+        "group appended"
+    );
+    assert_eq!(full["activeGroupId"], json!(new_id), "new group active");
+    // Source g1 lost t1 (a still holds t2 — not pruned).
+    let root_g1 = group_root(&store, "C", "g1");
+    let a = find_leaf(&root_g1, "a").unwrap();
+    assert_eq!(
+        a.tabs.iter().map(|t| t.id.as_str()).collect::<Vec<_>>(),
+        vec!["t2"]
+    );
+    // The new group holds exactly t1, focused.
+    let root = group_root(&store, "C", &new_id);
+    let leaves = get_all_leaves(&root);
+    assert_eq!(leaves.len(), 1);
+    assert_eq!(
+        leaves[0]
+            .tabs
+            .iter()
+            .map(|t| t.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["t1"]
+    );
+    assert_eq!(leaves[0].active_tab_id.as_deref(), Some("t1"));
+}
+
+#[test]
+fn add_group_with_tab_rejects_an_unknown_tab() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    assert_eq!(
+        store.add_group_with_tab("C", "nope", "a").unwrap_err(),
+        LayoutError::TabNotFound("nope".to_string()),
+    );
+}
+
+// ── replaceGroups ────────────────────────────────────────────────────────────
+
+#[test]
+fn replace_groups_installs_a_whole_multi_group_layout() {
+    let store = LayoutStore::new();
+    // A fresh client (one group) is replaced by a two-group install.
+    store.replace_groups("C", two_group_client().groups, "g2".to_string());
+    let full = full_of(&store, "C");
+    assert_eq!(full["groups"].as_array().unwrap().len(), 2);
+    assert_eq!(full["activeGroupId"], json!("g2"));
+    // Back-compat view now reflects g2.
+    assert_eq!(store.snapshot("C")["activePanelId"], json!("z"));
+}
+
+#[test]
+fn replace_groups_repoints_a_dangling_active_group_and_active_panel() {
+    let store = LayoutStore::new();
+    // active_group_id names no present group; g1's active panel is a ghost.
+    let groups = vec![group("g1", "A", two_panel_tree(), Some("ghost"))];
+    store.replace_groups("C", groups, "nope".to_string());
+    let full = full_of(&store, "C");
+    assert_eq!(
+        full["activeGroupId"],
+        json!("g1"),
+        "active group repointed to first"
+    );
+    // The dangling active panel was repointed at a real leaf.
+    let active = store.snapshot("C")["activePanelId"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(find_leaf(&root_of(&store, "C"), &active).is_some());
+}
+
+#[test]
+fn replace_groups_with_no_groups_falls_back_to_a_seeded_client() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    store.replace_groups("C", Vec::new(), "whatever".to_string());
+    let full = full_of(&store, "C");
+    assert_eq!(
+        full["groups"].as_array().unwrap().len(),
+        1,
+        "seeded fallback"
+    );
+    assert_eq!(full["groups"].as_array().unwrap()[0]["name"], json!("Main"));
+}
+
+/// The active group id of a client (reads the full view).
+fn current_active_group(store: &LayoutStore, client: &str) -> String {
+    store.snapshot_full(client)["activeGroupId"]
+        .as_str()
+        .expect("active group id")
+        .to_string()
 }
 
 // ── Property tests over the transforms ───────────────────────────────────────


### PR DESCRIPTION
## Summary

Slice A of the layout data-flow inversion (`Part of #2283`): widens the backend
`LayoutStore` so it is authoritative for the **full** layout model — the ordered
set of tab groups plus tab lifecycle — while keeping the current render path
unaffected. **Backend Rust only; no `src/` change and no appStore reducer
removed.** Later slices flip the frontend onto this authority and delete the
reducers.

## What changed (`src-tauri/src/layout/`)

- **Multi-group model.** `LayoutState { root, active_panel_id }` is replaced by
  `GroupLayout { id, name, color, root, active_panel_id }` +
  `ClientLayout { groups, active_group_id }`. `snapshot_full()` emits
  `{ activeGroupId, groups: [...] }`.
- **Back-compat view preserved.** `snapshot()` still emits the active group's
  `{ root, activePanelId }` — the exact shape today's `layout@<clientId>`
  consumers render — so the live (shadow) region and every existing test are
  unaffected. The full view is available but not yet wired (a later slice flips
  the region + frontend onto it).
- **`group_id` on every structural transform** (split / merge / moveTab /
  closeTabStructure / removePanel / reorderTabs / setActivePanel / resize),
  resolving to the active group when `None`.
- **New group transforms** (twins of the frontend `*TabGroup*` reducers):
  `add_group`, `close_group` (rejects the last group via the new `LastGroup`),
  `rename_group`, `set_group_color`, `set_active_group`, `reorder_groups`,
  `move_tab_to_group` and `add_group_with_tab` (the genuine cross-tree algebra),
  plus `add_tab` and `replace_groups`.
- **New `LayoutError` variants** `GroupNotFound` / `LastGroup` with stable ack
  codes, and **intent routes** for every new transform (each existing route now
  reads an optional `groupId`).

## Tests (TDD)

- Per-transform unit tests; multi-group **isolation** (a mutation in one group
  never touches another); `add_tab`/`close_tab_structure` round-trip;
  `move_tab_to_group` / `add_group_with_tab` cross-tree correctness;
  `LastGroup` / `GroupNotFound` handling; back-compat active-group view parity;
  and projection **route-parity** tests for the new intents.
- `74 passed` across the layout module; `cargo fmt --check` and
  `cargo clippy --tests -D warnings` clean on the changed crate.

## Notes / design choices

- `move_tab_to_group` / `add_group_with_tab` take the **active** group as the
  source, mirroring the frontend reducers (which operate on the live tree).
- `replace` now targets the **active group's** tree (the existing seed path);
  `replace_groups` is the whole-layout twin for workspace-restore / multi-window.
- Group-metadata-only intents (rename / colour / reorder) produce no diff on the
  back-compat region this slice — that is expected until the region goes full.

Part of `#2283`.
