### PR TITLE
refactor(ui): introduce tabContent by-id seam for layout content (Part of #2283)

### DIFF
--- a/src/store/appStore.tabContent.test.ts
+++ b/src/store/appStore.tabContent.test.ts
@@ -1,0 +1,196 @@
+/**
+ * appStore `tabContent` by-id content map (part of #2283 — the layout data-flow
+ * inversion).
+ *
+ * Pins the seam that keeps rich tab **content** authoritative in `appStore`,
+ * keyed by tab id, as the layout projection region takes over panel-tree
+ * **structure**. Two guarantees:
+ *
+ *  1. **Maintenance parity** — after open / rename / session-update /
+ *     scrollback-replay-clear / close, the map entry reconstructs a tab that is
+ *     content-identical to the authoritative in-tree {@link TerminalTab}, and a
+ *     closed tab is pruned.
+ *  2. **Render parity** — composing the render tree from the projection yields
+ *     byte-identical output whether content is sourced from the map or from the
+ *     in-tree tab, so switching render composition onto the map cannot change
+ *     what the user sees.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockSaveSettings = vi.fn<(...args: any[]) => Promise<void>>(() => Promise.resolve());
+
+// Mock service modules before importing the store
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  persistConnection: vi.fn(() => Promise.resolve()),
+  removeConnection: vi.fn(() => Promise.resolve()),
+  persistFolder: vi.fn(() => Promise.resolve()),
+  removeFolder: vi.fn(() => Promise.resolve()),
+  getSettings: vi.fn(() =>
+    Promise.resolve({
+      version: "1",
+      externalConnectionFiles: [],
+      powerMonitoringEnabled: true,
+      fileBrowserEnabled: true,
+    })
+  ),
+  saveSettings: (...args: unknown[]) => mockSaveSettings(...args),
+  moveConnectionToFile: vi.fn(() => Promise.resolve()),
+  reloadExternalConnections: vi.fn(() => Promise.resolve([])),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({
+  applyTheme: vi.fn(),
+  onThemeChange: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@/services/api", () => ({
+  sftpOpen: vi.fn(),
+  sftpClose: vi.fn(),
+  sftpListDir: vi.fn(),
+  localListDir: vi.fn(),
+  vscodeAvailable: vi.fn(() => Promise.resolve(false)),
+  sessionGetCapabilities: vi.fn(() => Promise.resolve({ monitoring: false, fileBrowser: false })),
+  sessionMonitoringOpen: vi.fn(() => Promise.resolve()),
+  sessionMonitoringClose: vi.fn(() => Promise.resolve()),
+  listAvailableShells: vi.fn(() => Promise.resolve([])),
+  getDefaultShell: vi.fn(() => Promise.resolve(null)),
+  connectAgent: vi.fn(),
+  disconnectAgent: vi.fn(),
+  listAgentSessions: vi.fn(() => Promise.resolve([])),
+  listAgentDefinitions: vi.fn(() => Promise.resolve([])),
+  listAgentConnections: vi.fn(() => Promise.resolve({ connections: [], folders: [] })),
+  saveAgentDefinition: vi.fn(),
+  updateAgentDefinition: vi.fn(),
+  deleteAgentDefinition: vi.fn(),
+  createAgentFolder: vi.fn(),
+  updateAgentFolder: vi.fn(),
+  deleteAgentFolder: vi.fn(),
+  getCredentialStoreStatus: vi.fn(() => Promise.resolve({ mode: "none", status: "unavailable" })),
+}));
+
+vi.mock("@/services/tunnelApi", () => ({
+  getTunnels: vi.fn(() => Promise.resolve([])),
+  saveTunnel: vi.fn(),
+  deleteTunnel: vi.fn(),
+  startTunnel: vi.fn(),
+  stopTunnel: vi.fn(),
+  getTunnelStatuses: vi.fn(() => Promise.resolve([])),
+}));
+
+import type { ConnectionConfig, PanelNode, TerminalTab } from "@/types/terminal";
+import { getAllLeaves } from "@/utils/panelTree";
+import { composeRenderTree, toMinimalNode, type LayoutView } from "./layoutBridge";
+import { extractTabContent, useAppStore } from "./appStore";
+
+const LOCAL_CONFIG: ConnectionConfig = { type: "local", config: { shell: "zsh" } };
+
+/** Every tab currently in the active panel tree, flattened. */
+function allTabs(): TerminalTab[] {
+  return getAllLeaves(useAppStore.getState().rootPanel).flatMap((l) => l.tabs);
+}
+
+/** The projected (minimal) view of the current tree, focused on the active panel. */
+function currentView(): LayoutView {
+  const { rootPanel, activePanelId } = useAppStore.getState();
+  return { root: toMinimalNode(rootPanel), activePanelId };
+}
+
+describe("appStore — tabContent by-id map (#2283)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+  });
+
+  it("starts empty (the initial panel has no tabs)", () => {
+    expect(useAppStore.getState().tabContent).toEqual({});
+  });
+
+  it("addTab populates the map with the new tab's non-structural content", () => {
+    const id = useAppStore.getState().addTab("Shell", "local", LOCAL_CONFIG);
+    const tab = allTabs().find((t) => t.id === id)!;
+    // The map entry equals the in-tree tab projected to content (no panelId/isActive).
+    expect(useAppStore.getState().tabContent[id]).toEqual(extractTabContent(tab));
+    expect(useAppStore.getState().tabContent[id]).not.toHaveProperty("panelId");
+    expect(useAppStore.getState().tabContent[id]).not.toHaveProperty("isActive");
+  });
+
+  it("renameTab mirrors the new title into the map, in sync with the tree", () => {
+    const id = useAppStore.getState().addTab("Shell", "local", LOCAL_CONFIG);
+    useAppStore.getState().renameTab(id, "Renamed");
+    expect(useAppStore.getState().tabContent[id].title).toBe("Renamed");
+    const tab = allTabs().find((t) => t.id === id)!;
+    expect(useAppStore.getState().tabContent[id]).toEqual(extractTabContent(tab));
+  });
+
+  it("setTabSessionId mirrors the session id into the map, in sync with the tree", () => {
+    const id = useAppStore.getState().addTab("Shell", "local", LOCAL_CONFIG);
+    useAppStore.getState().setTabSessionId(id, "sess-42");
+    expect(useAppStore.getState().tabContent[id].sessionId).toBe("sess-42");
+    const tab = allTabs().find((t) => t.id === id)!;
+    expect(useAppStore.getState().tabContent[id]).toEqual(extractTabContent(tab));
+  });
+
+  it("clearPendingScrollbackReplay mirrors the cleared flag into the map", () => {
+    const id = useAppStore.getState().addTab("Shell", "local", LOCAL_CONFIG);
+    // Seed the flag on both the tree and the map, then clear it.
+    useAppStore.setState((s) => ({
+      rootPanel: {
+        ...s.rootPanel,
+        tabs: (s.rootPanel as Extract<PanelNode, { type: "leaf" }>).tabs.map((t) =>
+          t.id === id ? { ...t, pendingScrollbackReplay: true } : t
+        ),
+      } as PanelNode,
+      tabContent: {
+        ...s.tabContent,
+        [id]: { ...s.tabContent[id], pendingScrollbackReplay: true },
+      },
+    }));
+    useAppStore.getState().clearPendingScrollbackReplay(id);
+    expect(useAppStore.getState().tabContent[id].pendingScrollbackReplay).toBe(false);
+    const tab = allTabs().find((t) => t.id === id)!;
+    expect(useAppStore.getState().tabContent[id]).toEqual(extractTabContent(tab));
+  });
+
+  it("closeTab prunes the tab's entry from the map", () => {
+    const id = useAppStore.getState().addTab("Shell", "local", LOCAL_CONFIG);
+    const panelId = allTabs().find((t) => t.id === id)!.panelId;
+    expect(useAppStore.getState().tabContent[id]).toBeDefined();
+    useAppStore.getState().closeTab(id, panelId);
+    expect(useAppStore.getState().tabContent[id]).toBeUndefined();
+  });
+
+  it("render parity: composing from the map equals composing from the in-tree tab", () => {
+    // A mix of a terminal tab (mapped) and an editor tab (not mapped → fallback).
+    useAppStore.getState().addTab("Shell", "local", LOCAL_CONFIG);
+    useAppStore.getState().openScratchEditorTab("Notes", "notes.md", "hello");
+    useAppStore.getState().addTab("Shell 2", "local", LOCAL_CONFIG);
+
+    const { rootPanel, tabContent } = useAppStore.getState();
+    const view = currentView();
+
+    const fromTree = composeRenderTree(view, rootPanel);
+    const fromMap = composeRenderTree(view, rootPanel, tabContent);
+    // Sourcing content from the map is byte-identical to sourcing it from the tree.
+    expect(fromMap).toEqual(fromTree);
+    // ...and identical to the authoritative tree itself (structure + content).
+    expect(fromMap).toEqual(rootPanel);
+  });
+
+  it("render parity holds after rename + session update", () => {
+    const id = useAppStore.getState().addTab("Shell", "local", LOCAL_CONFIG);
+    useAppStore.getState().renameTab(id, "Renamed");
+    useAppStore.getState().setTabSessionId(id, "sess-7");
+
+    const { rootPanel, tabContent } = useAppStore.getState();
+    const view = currentView();
+    expect(composeRenderTree(view, rootPanel, tabContent)).toEqual(
+      composeRenderTree(view, rootPanel)
+    );
+    expect(composeRenderTree(view, rootPanel, tabContent)).toEqual(rootPanel);
+  });
+});

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import {
   TerminalTab,
+  TabContent,
   LeafPanel,
   PanelNode,
   ConnectionConfig,
@@ -510,6 +511,22 @@ export interface AppState
   // Panels & Tabs
   rootPanel: PanelNode;
   activePanelId: string | null;
+  /**
+   * Flat by-id map of non-structural tab content (part of #2283 — the layout
+   * data-flow inversion). As the layout projection region takes over the panel
+   * **tree structure**, each tab's rich **content** (title, config, connection
+   * metadata, session id, all `*Meta` editor state, …) stays authoritative in
+   * `appStore`, keyed by tab id — mirroring the deliberate content retention in
+   * the file-browser inversion. Render composition
+   * ({@link import("./useLayoutRenderTree").useLayoutRenderTree}) sources content
+   * from here, falling back to the in-tree {@link TerminalTab} for any id not yet
+   * present (editor/settings/etc. tabs). Populated for tabs opened via `addTab`
+   * (and hydrated window-handoff tabs) and maintained on the content mutations
+   * that touch those tabs (title, session id, scrollback-replay flag); pruned in
+   * `closeTab`. In this behavior-preserving slice it merely duplicates content
+   * the tree still holds.
+   */
+  tabContent: Record<string, TabContent>;
   /**
    * Open a new tab and make it active.
    * @param title Tab title.
@@ -2530,6 +2547,41 @@ function createTab(
 }
 
 /**
+ * Project a rich {@link TerminalTab} onto its {@link TabContent} — everything
+ * except the structural `panelId`/`isActive`, which belong to the panel tree.
+ * This is the shape stored in `appStore.tabContent` (part of #2283).
+ */
+export function extractTabContent(tab: TerminalTab): TabContent {
+  const { panelId: _panelId, isActive: _isActive, ...content } = tab;
+  return content;
+}
+
+/** Insert/replace a tab's entry in the by-id content map from its rich form. */
+function setTabContentEntry(
+  map: Record<string, TabContent>,
+  tab: TerminalTab
+): Record<string, TabContent> {
+  return { ...map, [tab.id]: extractTabContent(tab) };
+}
+
+/**
+ * Patch specific content fields of a tab **already tracked** in the map. A tab
+ * absent from the map (e.g. an editor/settings tab that renders via the in-tree
+ * fallback) is left untouched — this preserves the invariant that the map holds
+ * only tabs whose every content mutation is instrumented, so a tracked entry is
+ * never stale.
+ */
+function patchTabContentEntry(
+  map: Record<string, TabContent>,
+  tabId: string,
+  patch: Partial<TabContent>
+): Record<string, TabContent> {
+  const current = map[tabId];
+  if (!current) return map;
+  return { ...map, [tabId]: { ...current, ...patch } };
+}
+
+/**
  * Serialize a tab into the view-model carried across a native-window boundary
  * (#1900). Placement (`panelId`/`isActive`) is dropped — the destination window
  * re-assigns it on hydrate — while `sessionId` anchors the re-attach to the same
@@ -3172,6 +3224,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
           tabGroups,
           activePanelId: targetLeaf.id,
           releasedTransferSessions,
+          // Track the hydrated tab's content in the by-id map (part of #2283).
+          tabContent: setTabContentEntry(state.tabContent, newTab),
         };
       }),
 
@@ -3731,6 +3785,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
     // Panels & Tabs
     rootPanel: initialPanel,
     activePanelId: initialPanel.id,
+    // Flat by-id tab-content map (part of #2283). The initial panel is empty, so
+    // it starts empty and is populated as tabs open.
+    tabContent: {},
 
     getAllPanels: () => getAllLeaves(get().rootPanel),
 
@@ -3749,7 +3806,14 @@ export const useAppStore = create<AppState>((set, get, store) => {
         const tabGroups = state.tabGroups.map((g) =>
           g.id === state.activeTabGroupId ? { ...g, rootPanel } : g
         );
-        return { rootPanel, tabGroups };
+        return {
+          rootPanel,
+          tabGroups,
+          // Mirror the cleared replay flag into the content map (part of #2283).
+          tabContent: patchTabContentEntry(state.tabContent, tabId, {
+            pendingScrollbackReplay: false,
+          }),
+        };
       }),
 
     setTabSessionId: (tabId, sessionId) => {
@@ -3776,6 +3840,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
             ...l,
             tabs: l.tabs.map((t) => (t.id === tabId ? { ...t, sessionId } : t)),
           })),
+          // Mirror the session id into the content map (part of #2283).
+          tabContent: patchTabContentEntry(state.tabContent, tabId, { sessionId }),
         };
       });
 
@@ -3892,6 +3958,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
         return {
           rootPanel,
           activePanelId: targetPanelId,
+          // Duplicate the new tab's content into the by-id map (part of #2283).
+          tabContent: setTabContentEntry(state.tabContent, newTab),
           tabHorizontalScrolling: { ...state.tabHorizontalScrolling, [newTab.id]: hsEnabled },
           ...(tabColor ? { tabColors: { ...state.tabColors, [newTab.id]: tabColor } } : {}),
           ...(hasTabOpts
@@ -4277,6 +4345,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
         const remainingHs = omitKey(state.tabHorizontalScrolling, tabId);
         const remainingDirty = omitKey(state.editorDirtyTabs, tabId);
         const remainingColors = omitKey(state.tabColors, tabId);
+        // Prune the closed tab's content from the by-id map (part of #2283).
+        const remainingTabContent = omitKey(state.tabContent, tabId);
         const remainingOpts = omitKey(state.tabTerminalOptions, tabId);
         const remainingSearch = omitKey(state.terminalSearchVisible, tabId);
         const remainingSpawnErrors = omitKey(state.terminalSpawnErrors, tabId);
@@ -4330,6 +4400,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
             tabHorizontalScrolling: remainingHs,
             editorDirtyTabs: remainingDirty,
             tabColors: remainingColors,
+            tabContent: remainingTabContent,
             tabTerminalOptions: remainingOpts,
             terminalSearchVisible: remainingSearch,
             terminalSpawnErrors: remainingSpawnErrors,
@@ -4357,6 +4428,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
           tabHorizontalScrolling: remainingHs,
           editorDirtyTabs: remainingDirty,
           tabColors: remainingColors,
+          tabContent: remainingTabContent,
           tabTerminalOptions: remainingOpts,
           terminalSearchVisible: remainingSearch,
           terminalSpawnErrors: remainingSpawnErrors,
@@ -5469,6 +5541,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
             ...l,
             tabs: l.tabs.map((t) => (t.id === tabId ? { ...t, title: newTitle } : t)),
           })),
+          // Mirror the new title into the content map (part of #2283).
+          tabContent: patchTabContentEntry(state.tabContent, tabId, { title: newTitle }),
         };
       }),
 

--- a/src/store/layoutBridge.test.ts
+++ b/src/store/layoutBridge.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, it, expect, afterEach } from "vitest";
 
-import type { PanelNode, TerminalTab } from "@/types/terminal";
+import type { PanelNode, TabContent, TerminalTab } from "@/types/terminal";
 
 import {
   collectTabs,
@@ -34,6 +34,12 @@ function tab(id: string, extra: Partial<TerminalTab> = {}): TerminalTab {
     isActive: false,
     ...extra,
   } as TerminalTab;
+}
+
+/** The non-structural content of a `tab(id)` — its {@link TabContent} form. */
+function content(id: string, extra: Partial<TabContent> = {}): TabContent {
+  const { panelId: _p, isActive: _a, ...rest } = tab(id);
+  return { ...rest, ...extra };
 }
 
 /** Two-leaf split: `a` = [t1(active), t2], `b` = [t3]. */
@@ -203,6 +209,62 @@ describe("layoutBridge — render-from-projection helpers (#2151 step 3)", () =>
     expect(leafA.tabs[0].isActive).toBe(true);
     expect(leafA.tabs[0].panelId).toBe("a");
     expect(rich.sizes).toEqual([50, 50]);
+  });
+
+  it("composeRenderTree: content sourced from the tabContent map when present (#2283)", () => {
+    // The by-id content map wins over the in-tree tab: t1's title comes from the
+    // map, proving the render composition reads content from the map seam.
+    const contentById = {
+      t1: { ...content("t1"), title: "From map" },
+      t2: content("t2"),
+      t3: content("t3"),
+    };
+    const rich = composeRenderTree(view(), tree(), contentById) as Extract<
+      PanelNode,
+      { type: "split" }
+    >;
+    const leafA = rich.children[0] as Extract<PanelNode, { type: "leaf" }>;
+    expect(leafA.tabs[0].title).toBe("From map");
+    // Structure is still re-derived from the view, not the map.
+    expect(leafA.tabs[0].panelId).toBe("a");
+    expect(leafA.tabs[0].isActive).toBe(true);
+  });
+
+  it("composeRenderTree: falls back to the in-tree tab for ids absent from the map (#2283)", () => {
+    // Only t1 is in the map; t2/t3 must fall back to the in-tree TerminalTab so
+    // not-yet-mapped tabs render exactly as before.
+    const contentById = { t1: { ...content("t1"), title: "Mapped t1" } };
+    const rich = composeRenderTree(view(), tree(), contentById) as Extract<
+      PanelNode,
+      { type: "split" }
+    >;
+    const leafA = rich.children[0] as Extract<PanelNode, { type: "leaf" }>;
+    expect(leafA.tabs[0].title).toBe("Mapped t1"); // from map
+    expect(leafA.tabs[1].title).toBe("Tab t2"); // fallback to in-tree
+    const leafB = rich.children[1] as Extract<PanelNode, { type: "leaf" }>;
+    expect(leafB.tabs[0].title).toBe("Tab t3"); // fallback to in-tree
+  });
+
+  it("composeRenderTree output is identical whether content comes from the map or the tree (#2283)", () => {
+    // Parity: a map that faithfully mirrors the tree yields byte-identical output.
+    const contentById = { t1: content("t1"), t2: content("t2"), t3: content("t3") };
+    const fromTree = composeRenderTree(view(), tree());
+    const fromMap = composeRenderTree(view(), tree(), contentById);
+    expect(fromMap).toEqual(fromTree);
+  });
+
+  it("reconcileNode: falls back to the tree, then throws only when absent from BOTH sources (#2283)", () => {
+    const projected = {
+      type: "leaf" as const,
+      id: "a",
+      tabs: [{ id: "ghost", contentType: "terminal" }],
+      activeTabId: "ghost",
+    };
+    // Present in the content map (not the tree) → resolves via the map.
+    const viaMap = reconcileNode(projected, new Map(), { ghost: content("ghost") });
+    expect((viaMap as Extract<PanelNode, { type: "leaf" }>).tabs[0].title).toBe("Tab ghost");
+    // Absent from both an empty tree index and an empty map → throws.
+    expect(() => reconcileNode(projected, new Map(), {})).toThrow(/unknown tab ghost/);
   });
 });
 

--- a/src/store/layoutBridge.ts
+++ b/src/store/layoutBridge.ts
@@ -54,7 +54,14 @@ import {
   type IntentAck,
   type Transport,
 } from "@/services/transport";
-import type { DropEdge, LeafPanel, PanelNode, SplitContainer, TerminalTab } from "@/types/terminal";
+import type {
+  DropEdge,
+  LeafPanel,
+  PanelNode,
+  SplitContainer,
+  TabContent,
+  TerminalTab,
+} from "@/types/terminal";
 import { frontendLog } from "@/utils/frontendLog";
 import { findLeafByTab } from "@/utils/panelTree";
 
@@ -278,22 +285,36 @@ export function collectTabs(node: PanelNode): Map<string, TerminalTab> {
 
 /**
  * Rebuild a rich {@link PanelNode} from a projected minimal tree, re-attaching
- * each tab's rich fields by id from `tabsById` (partial projection: the region
- * carries only structure + minimal tab identity). Per-leaf, `panelId` and
- * `isActive` are re-derived from the projected structure — exactly what the old
- * local reducers set — so `SplitView`'s selectors see an identical shape.
+ * each tab's rich fields by id (partial projection: the region carries only
+ * structure + minimal tab identity). Per-leaf, `panelId` and `isActive` are
+ * re-derived from the projected structure — exactly what the old local reducers
+ * set — so `SplitView`'s selectors see an identical shape.
  *
- * Throws if the projection references a tab absent from `tabsById`; the caller
- * treats that as a bridge failure and falls back to the local mutation.
+ * **Content source (part of #2283).** A tab's non-structural content is read
+ * from `contentById` — the flat by-id {@link TabContent} map that is becoming
+ * the authoritative content store as the tree thins — and **falls back** to the
+ * in-tree rich {@link TerminalTab} in `tabsById` when the id is absent from the
+ * map. In this behavior-preserving slice the map merely *duplicates* content the
+ * tree still holds, so both sources agree; the fallback keeps tabs that are not
+ * yet in the map (e.g. editor/settings tabs) rendering exactly as before.
+ * `contentById` is optional so the structural write-back path
+ * ({@link runLayoutIntent}) keeps reconstructing straight from the tree.
+ *
+ * Throws if the projection references a tab absent from **both** sources; the
+ * caller treats that as a bridge failure and falls back to the local mutation.
  */
-export function reconcileNode(node: MinimalNode, tabsById: Map<string, TerminalTab>): PanelNode {
+export function reconcileNode(
+  node: MinimalNode,
+  tabsById: Map<string, TerminalTab>,
+  contentById?: Record<string, TabContent>
+): PanelNode {
   if (node.type === "leaf") {
     const tabs: TerminalTab[] = node.tabs.map((mt) => {
-      const rich = tabsById.get(mt.id);
-      if (!rich) {
+      const base = contentById?.[mt.id] ?? tabsById.get(mt.id);
+      if (!base) {
         throw new Error(`layout reconcile: unknown tab ${mt.id}`);
       }
-      return { ...rich, panelId: node.id, isActive: mt.id === node.activeTabId };
+      return { ...base, panelId: node.id, isActive: mt.id === node.activeTabId };
     });
     const leaf: LeafPanel = {
       type: "leaf",
@@ -307,7 +328,7 @@ export function reconcileNode(node: MinimalNode, tabsById: Map<string, TerminalT
     type: "split",
     id: node.id,
     direction: node.direction,
-    children: node.children.map((c) => reconcileNode(c, tabsById)),
+    children: node.children.map((c) => reconcileNode(c, tabsById, contentById)),
   };
   if (node.sizes) split.sizes = node.sizes;
   if (node.lastActiveLeafId) split.lastActiveLeafId = node.lastActiveLeafId;
@@ -478,13 +499,19 @@ export function viewMatchesTree(
 
 /**
  * Compose the rich render tree from a projected view: **structure** from
- * `view.root`, **content** re-attached by tab id from `contentRoot`'s rich tabs.
- * Throws (via {@link reconcileNode}) if the view references a tab absent from
- * `contentRoot`; callers gate with {@link viewMatchesTree} first so this never
- * throws on the happy path.
+ * `view.root`, **content** re-attached by tab id — preferring the flat
+ * `contentById` {@link TabContent} map (part of #2283), and falling back to
+ * `contentRoot`'s in-tree rich tabs for any id the map does not yet hold. Throws
+ * (via {@link reconcileNode}) if the view references a tab absent from **both**;
+ * callers gate with {@link viewMatchesTree} first so this never throws on the
+ * happy path.
  */
-export function composeRenderTree(view: LayoutView, contentRoot: PanelNode): PanelNode {
-  return reconcileNode(view.root, collectTabs(contentRoot));
+export function composeRenderTree(
+  view: LayoutView,
+  contentRoot: PanelNode,
+  contentById?: Record<string, TabContent>
+): PanelNode {
+  return reconcileNode(view.root, collectTabs(contentRoot), contentById);
 }
 
 /** Ensure the layout region client is subscribed; the renderer's entry point.

--- a/src/store/useLayoutRenderTree.ts
+++ b/src/store/useLayoutRenderTree.ts
@@ -58,6 +58,11 @@ import type { PanelNode } from "@/types/terminal";
 export function useLayoutRenderTree(): PanelNode {
   const storeRoot = useAppStore((s) => s.rootPanel);
   const storeActivePanelId = useAppStore((s) => s.activePanelId);
+  // The authoritative by-id tab-content map (part of #2283). Render composition
+  // sources each tab's content from here, falling back to the in-tree tab for
+  // any id the map does not yet hold (editor/settings/etc.). Behaviour-preserving
+  // while the tree still carries the full tab.
+  const tabContent = useAppStore((s) => s.tabContent);
 
   // Read the flag once at mount: it flips only via dev tooling, and the
   // subscription lifecycle is keyed off it below.
@@ -116,7 +121,7 @@ export function useLayoutRenderTree(): PanelNode {
   return useMemo(() => {
     if (matches && view) {
       try {
-        return composeRenderTree(view, storeRoot);
+        return composeRenderTree(view, storeRoot, tabContent);
       } catch (err) {
         // A tab referenced by the view but absent from appStore — treat as a
         // desync and fall back rather than throw in render.
@@ -125,5 +130,5 @@ export function useLayoutRenderTree(): PanelNode {
       }
     }
     return storeRoot;
-  }, [matches, view, storeRoot]);
+  }, [matches, view, storeRoot, tabContent]);
 }

--- a/src/types/terminal.ts
+++ b/src/types/terminal.ts
@@ -422,6 +422,20 @@ export interface TerminalTab {
 }
 
 /**
+ * The **non-structural** content of a {@link TerminalTab} — everything except
+ * its placement in the panel tree (`panelId`, `isActive`, which are derived from
+ * the layout structure). This is the shape stored in `appStore.tabContent`, the
+ * flat by-id content map that backs the layout data-flow inversion (part of
+ * #2283): as the layout projection region becomes authoritative for panel-tree
+ * **structure**, rich tab **content** (title, config, connection metadata,
+ * session id, all `*Meta` editor state, …) stays authoritative in `appStore`,
+ * keyed by tab id. `panelId`/`isActive` are intentionally omitted because they
+ * belong to the tree, not the content — the renderer re-derives them from the
+ * projected structure when it composes the render tree.
+ */
+export type TabContent = Omit<TerminalTab, "panelId" | "isActive">;
+
+/**
  * The minimal data needed to reopen a just-closed terminal tab from an
  * Undo/Reopen affordance — a fresh session is created, scrollback is not
  * restored. `null` reopen means the tab had no reconnectable config.


### PR DESCRIPTION
## What

Slice B of the layout data-flow inversion (\`Part of #2283\`): introduce the flat by-id **\`tabContent\`** map in \`appStore\` and switch render composition to read tab content from it, falling back to the in-tree tab. **Behavior-preserving** — de-risks the later tree-thinning.

As the layout projection region becomes authoritative for panel-tree **structure**, rich tab **content** (title, config, connectionType, contentType, all \`*Meta\`, sessionId, initialCommand, persistentConnectionId, connectionId, spawned, pendingScrollbackReplay) stays authoritative in \`appStore\`, keyed by tab id — mirroring the deliberate content retention in the just-merged file-browser inversion.

## Changes

- **\`src/types/terminal.ts\`** — add \`TabContent = Omit<TerminalTab, "panelId" | "isActive">\` (content minus the structural fields the tree owns).
- **\`src/store/appStore.ts\`** — add \`tabContent: Record<string, TabContent>\`; \`extractTabContent\` + insert/patch/prune helpers. Populate in \`addTab\` and \`hydrateHandoffTab\`; mirror content mutations that touch tracked tabs (\`renameTab\` → title, \`setTabSessionId\` → sessionId, \`clearPendingScrollbackReplay\` → flag); prune in \`closeTab\`.
- **\`src/store/layoutBridge.ts\`** — thread an optional \`contentById\` through \`reconcileNode\` / \`composeRenderTree\` that **prefers the map, falls back to the in-tree \`TerminalTab\`**. Tab/panel **ids are preserved exactly** (live xterm DOM reparents, never remounts). The structural write-back path (\`runLayoutIntent\`) keeps reconstructing from the tree.
- **\`src/store/useLayoutRenderTree.ts\`** — read \`tabContent\` and pass it to \`composeRenderTree\`.

Nothing removed: \`rootPanel\`, reducers, and flags are untouched. The tree still holds the full \`TerminalTab\`; the map merely duplicates content, and the fallback keeps not-yet-mapped tabs (editor/settings/etc.) rendering exactly as before. The map's non-staleness invariant is airtight: only tabs whose every content mutation is instrumented are tracked; all others render via the tree fallback.

## Tests (TDD)

- **\`layoutBridge.test.ts\`** — \`composeRenderTree\`/\`reconcileNode\` prefer the map, fall back to the in-tree tab, throw only when absent from both, and produce **identical output** when the map mirrors the tree.
- **\`appStore.tabContent.test.ts\`** (new) — open / rename / session-update / scrollback-replay-clear / close keep the map content-identical to the in-tree tab and prune on close; a mix of mapped (terminal) and unmapped (editor) tabs composes **byte-identical** whether content comes from the map or the tree.

## Verification

- \`pnpm test\` — 4974 passed (554 files)
- \`pnpm build\` (tsc + vite) — clean
- \`pnpm exec prettier --check "src/**"\` — clean
- \`pnpm run lint\` — clean

Relates to \`#2283\`.