### PR TITLE
refactor(layout): render every tab group from the group-aware region (Part of #2283)

### DIFF
--- a/src-tauri/src/layout/projection.rs
+++ b/src-tauri/src/layout/projection.rs
@@ -85,7 +85,11 @@ pub fn publish_layout(
     client_id: &str,
 ) -> Vec<ProducedRegion> {
     let region = layout_region(client_id);
-    match projector.publish(&region, store.snapshot(client_id)) {
+    // Group-aware widening (#2283 slice C): the region carries the full
+    // multi-group view `{ groups, activeGroupId }` so the frontend renders every
+    // tab group (composing the active one). Was the back-compat active-group
+    // `{ root, activePanelId }` through slice A/B.
+    match projector.publish(&region, store.snapshot_full(client_id)) {
         Some(version) => vec![ProducedRegion { region, version }],
         None => Vec::new(),
     }

--- a/src-tauri/src/layout/projection_tests.rs
+++ b/src-tauri/src/layout/projection_tests.rs
@@ -480,7 +480,8 @@ fn replace_seeds_a_tree_then_a_structural_intent_round_trips() {
         "cache converges on authority"
     );
     // t1 landed in b; a is left with t2 — tab count is conserved across the seed.
-    let root: PanelNode = serde_json::from_value(store.snapshot_full("A")["groups"][0]["root"].clone()).unwrap();
+    let root: PanelNode =
+        serde_json::from_value(store.snapshot_full("A")["groups"][0]["root"].clone()).unwrap();
     assert_eq!(
         termihub_core::layout::panel_tree::count_tabs_in_tree(&root),
         3
@@ -549,7 +550,8 @@ fn the_step2b_intents_round_trip_and_converge_on_authority() {
     );
 
     // Final assertions on the authoritative tree.
-    let root: PanelNode = serde_json::from_value(store.snapshot_full("A")["groups"][0]["root"].clone()).unwrap();
+    let root: PanelNode =
+        serde_json::from_value(store.snapshot_full("A")["groups"][0]["root"].clone()).unwrap();
     let a = termihub_core::layout::panel_tree::find_leaf(&root, "a").unwrap();
     assert_eq!(
         a.tabs.iter().map(|t| t.id.as_str()).collect::<Vec<_>>(),
@@ -701,7 +703,8 @@ fn add_tab_route_inserts_a_tab_and_converges() {
         "cache converges on authority"
     );
 
-    let root: PanelNode = serde_json::from_value(store.snapshot_full("A")["groups"][0]["root"].clone()).unwrap();
+    let root: PanelNode =
+        serde_json::from_value(store.snapshot_full("A")["groups"][0]["root"].clone()).unwrap();
     let b = termihub_core::layout::panel_tree::find_leaf(&root, "b").unwrap();
     assert!(
         b.tabs.iter().any(|t| t.id == "new"),

--- a/src-tauri/src/layout/projection_tests.rs
+++ b/src-tauri/src/layout/projection_tests.rs
@@ -336,7 +336,7 @@ fn subscribe_returns_the_seeded_snapshot_identically_to_every_subscriber() {
     let region = layout_region("A");
 
     let projector = Arc::new(Projector::new());
-    projector.register_region(&region, store.snapshot("A"));
+    projector.register_region(&region, store.snapshot_full("A"));
 
     let snap_a = projector.subscribe(&region, "sub-a", "A", Arc::new(VecSink::new()));
     let snap_b = projector.subscribe(&region, "sub-b", "A", Arc::new(VecSink::new()));
@@ -344,9 +344,13 @@ fn subscribe_returns_the_seeded_snapshot_identically_to_every_subscriber() {
     assert_eq!(snap_a.version, 0);
     assert_eq!(snap_a, snap_b, "a late joiner gets an identical baseline");
     assert_eq!(snap_a.region, "layout@A");
-    // The view model is the panel tree + focused panel.
-    assert_eq!(snap_a.view["activePanelId"], json!("a"));
-    assert_eq!(snap_a.view["root"]["type"], json!("split"));
+    // The view model is the full multi-group view: one group holding the panel
+    // tree + focused panel, and the active-group id (#2283 slice C).
+    let groups = snap_a.view["groups"].as_array().expect("groups array");
+    assert_eq!(groups.len(), 1);
+    assert_eq!(groups[0]["activePanelId"], json!("a"));
+    assert_eq!(groups[0]["root"]["type"], json!("split"));
+    assert_eq!(snap_a.view["activeGroupId"], groups[0]["id"]);
 }
 
 #[test]
@@ -354,7 +358,7 @@ fn split_intent_produces_one_diff_fanned_to_two_subscribers() {
     let store = seeded_store("A");
     let region = layout_region("A");
     let projector = Arc::new(Projector::new());
-    projector.register_region(&region, store.snapshot("A"));
+    projector.register_region(&region, store.snapshot_full("A"));
     let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
 
     let sink_a = Arc::new(VecSink::new());
@@ -388,7 +392,7 @@ fn split_intent_produces_one_diff_fanned_to_two_subscribers() {
     cache_a.apply(&diffs_a[0]);
     assert_eq!(
         cache_a.view,
-        store.snapshot("A"),
+        store.snapshot_full("A"),
         "cache converges on authority"
     );
 }
@@ -398,7 +402,7 @@ fn move_and_close_intents_advance_the_region_monotonically() {
     let store = seeded_store("A");
     let region = layout_region("A");
     let projector = Arc::new(Projector::new());
-    projector.register_region(&region, store.snapshot("A"));
+    projector.register_region(&region, store.snapshot_full("A"));
     let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
 
     let sink = Arc::new(VecSink::new());
@@ -427,7 +431,7 @@ fn move_and_close_intents_advance_the_region_monotonically() {
     assert_eq!(cache.version, 2);
     assert_eq!(
         cache.view,
-        store.snapshot("A"),
+        store.snapshot_full("A"),
         "cache converges on authority"
     );
 }
@@ -441,7 +445,7 @@ fn replace_seeds_a_tree_then_a_structural_intent_round_trips() {
     let region = layout_region("A");
     let projector = Arc::new(Projector::new());
     // Lazily seeds an empty leaf; the region exists before the first replace.
-    projector.register_region(&region, store.snapshot("A"));
+    projector.register_region(&region, store.snapshot_full("A"));
     let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
 
     let sink = Arc::new(VecSink::new());
@@ -472,11 +476,11 @@ fn replace_seeds_a_tree_then_a_structural_intent_round_trips() {
     assert_eq!(cache.version, 2);
     assert_eq!(
         cache.view,
-        store.snapshot("A"),
+        store.snapshot_full("A"),
         "cache converges on authority"
     );
     // t1 landed in b; a is left with t2 — tab count is conserved across the seed.
-    let root: PanelNode = serde_json::from_value(store.snapshot("A")["root"].clone()).unwrap();
+    let root: PanelNode = serde_json::from_value(store.snapshot_full("A")["groups"][0]["root"].clone()).unwrap();
     assert_eq!(
         termihub_core::layout::panel_tree::count_tabs_in_tree(&root),
         3
@@ -504,7 +508,7 @@ fn the_step2b_intents_round_trip_and_converge_on_authority() {
     store.seed_for_test("A", tree, Some("a".to_string()));
     let region = layout_region("A");
     let projector = Arc::new(Projector::new());
-    projector.register_region(&region, store.snapshot("A"));
+    projector.register_region(&region, store.snapshot_full("A"));
     let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
 
     let sink = Arc::new(VecSink::new());
@@ -540,12 +544,12 @@ fn the_step2b_intents_round_trip_and_converge_on_authority() {
     assert_eq!(cache.version, 4);
     assert_eq!(
         cache.view,
-        store.snapshot("A"),
+        store.snapshot_full("A"),
         "cache converges on authority"
     );
 
     // Final assertions on the authoritative tree.
-    let root: PanelNode = serde_json::from_value(store.snapshot("A")["root"].clone()).unwrap();
+    let root: PanelNode = serde_json::from_value(store.snapshot_full("A")["groups"][0]["root"].clone()).unwrap();
     let a = termihub_core::layout::panel_tree::find_leaf(&root, "a").unwrap();
     assert_eq!(
         a.tabs.iter().map(|t| t.id.as_str()).collect::<Vec<_>>(),
@@ -557,7 +561,7 @@ fn the_step2b_intents_round_trip_and_converge_on_authority() {
         "removePanel dropped b"
     );
     assert_eq!(
-        store.snapshot("A")["activePanelId"],
+        store.snapshot_full("A")["groups"][0]["activePanelId"],
         json!("c"),
         "focus folded into the projection"
     );
@@ -568,7 +572,7 @@ fn a_bad_reorder_index_is_rejected_without_advancing() {
     let store = seeded_store("A");
     let region = layout_region("A");
     let projector = Arc::new(Projector::new());
-    projector.register_region(&region, store.snapshot("A"));
+    projector.register_region(&region, store.snapshot_full("A"));
     let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
     let sink = Arc::new(VecSink::new());
     projector.subscribe(&region, "sub", "A", sink.clone());
@@ -593,8 +597,8 @@ fn intents_are_client_scoped_across_regions() {
     store.seed_for_test("B", two_panel_tree(), Some("a".to_string()));
 
     let projector = Arc::new(Projector::new());
-    projector.register_region(&layout_region("A"), store.snapshot("A"));
-    projector.register_region(&layout_region("B"), store.snapshot("B"));
+    projector.register_region(&layout_region("A"), store.snapshot_full("A"));
+    projector.register_region(&layout_region("B"), store.snapshot_full("B"));
     let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
 
     let sink_a = Arc::new(VecSink::new());
@@ -619,7 +623,7 @@ fn a_rejected_intent_advances_nothing() {
     let store = seeded_store("A");
     let region = layout_region("A");
     let projector = Arc::new(Projector::new());
-    projector.register_region(&region, store.snapshot("A"));
+    projector.register_region(&region, store.snapshot_full("A"));
     let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
 
     let sink = Arc::new(VecSink::new());
@@ -642,7 +646,7 @@ fn a_dead_subscriber_is_reaped_and_others_keep_receiving() {
     let store = seeded_store("A");
     let region = layout_region("A");
     let projector = Arc::new(Projector::new());
-    projector.register_region(&region, store.snapshot("A"));
+    projector.register_region(&region, store.snapshot_full("A"));
     let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
 
     let live = Arc::new(VecSink::new());
@@ -668,7 +672,7 @@ fn a_dead_subscriber_is_reaped_and_others_keep_receiving() {
 fn harness_for(store: Arc<LayoutStore>) -> (Dispatcher, String, Arc<VecSink>, ClientCache) {
     let region = layout_region("A");
     let projector = Arc::new(Projector::new());
-    projector.register_region(&region, store.snapshot("A"));
+    projector.register_region(&region, store.snapshot_full("A"));
     let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
     let sink = Arc::new(VecSink::new());
     let snap = projector.subscribe(&region, "sub", "A", sink.clone());
@@ -693,11 +697,11 @@ fn add_tab_route_inserts_a_tab_and_converges() {
     }
     assert_eq!(
         cache.view,
-        store.snapshot("A"),
+        store.snapshot_full("A"),
         "cache converges on authority"
     );
 
-    let root: PanelNode = serde_json::from_value(store.snapshot("A")["root"].clone()).unwrap();
+    let root: PanelNode = serde_json::from_value(store.snapshot_full("A")["groups"][0]["root"].clone()).unwrap();
     let b = termihub_core::layout::panel_tree::find_leaf(&root, "b").unwrap();
     assert!(
         b.tabs.iter().any(|t| t.id == "new"),
@@ -706,7 +710,7 @@ fn add_tab_route_inserts_a_tab_and_converges() {
 }
 
 #[test]
-fn add_group_route_appends_a_group_and_switches_the_back_compat_view() {
+fn add_group_route_appends_a_group_and_widens_the_full_view() {
     let store = seeded_store("A");
     let (dispatcher, region, sink, mut cache) = harness_for(store.clone());
 
@@ -720,27 +724,30 @@ fn add_group_route_appends_a_group_and_switches_the_back_compat_view() {
     assert_eq!(full["activeGroupId"], groups[1]["id"]);
     assert_eq!(groups[1]["name"], json!("Extra"));
 
-    // The back-compat region followed the active group (now an empty leaf).
+    // The multi-group region carries every group, so adding one moves the view:
+    // one diff, and the cache converges on the widened authority (#2283 slice C).
     let _ = region;
     for diff in &sink.diffs() {
         cache.apply(diff);
     }
     assert_eq!(
         cache.view,
-        store.snapshot("A"),
-        "region tracks the active group"
+        store.snapshot_full("A"),
+        "region carries the full multi-group view"
     );
+    assert_eq!(cache.view["groups"].as_array().unwrap().len(), 2);
 }
 
 #[test]
-fn rename_group_route_is_accepted_and_updates_authority() {
+fn rename_group_route_moves_the_full_view_and_updates_authority() {
     let store = seeded_store("A");
     let region = layout_region("A");
     let projector = Arc::new(Projector::new());
-    projector.register_region(&region, store.snapshot("A"));
+    projector.register_region(&region, store.snapshot_full("A"));
     let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
     let sink = Arc::new(VecSink::new());
-    projector.subscribe(&region, "sub", "A", sink.clone());
+    let snap = projector.subscribe(&region, "sub", "A", sink.clone());
+    let mut cache = ClientCache::from_snapshot(&snap);
 
     let group_id = store.snapshot_full("A")["activeGroupId"]
         .as_str()
@@ -752,13 +759,14 @@ fn rename_group_route_is_accepted_and_updates_authority() {
         json!({ "groupId": group_id, "name": "Renamed" }),
     ));
     assert_eq!(ack.status, IntentStatus::Accepted);
-    // A metadata-only change: the back-compat region view is unchanged, so no diff.
-    assert_eq!(
-        sink.diffs().len(),
-        0,
-        "rename does not move the back-compat view"
-    );
-    assert_eq!(projector.region_version(&region), Some(0));
+    // The full view carries group metadata, so a rename now moves the region:
+    // exactly one diff, and the cache converges on the renamed authority.
+    assert_eq!(sink.diffs().len(), 1, "rename moves the full view");
+    assert_eq!(projector.region_version(&region), Some(1));
+    for diff in &sink.diffs() {
+        cache.apply(diff);
+    }
+    assert_eq!(cache.view, store.snapshot_full("A"));
     assert_eq!(
         store.snapshot_full("A")["groups"][0]["name"],
         json!("Renamed")
@@ -823,7 +831,7 @@ fn close_group_route_rejects_the_last_group() {
     let store = seeded_store("A");
     let region = layout_region("A");
     let projector = Arc::new(Projector::new());
-    projector.register_region(&region, store.snapshot("A"));
+    projector.register_region(&region, store.snapshot_full("A"));
     let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
     let sink = Arc::new(VecSink::new());
     projector.subscribe(&region, "sub", "A", sink.clone());

--- a/src-tauri/src/layout/store.rs
+++ b/src-tauri/src/layout/store.rs
@@ -137,9 +137,9 @@ impl ClientLayout {
 
     /// The full render-ready view model: `{ activeGroupId, groups: [...] }`.
     ///
-    /// The authoritative shape a later slice flips the region and frontend onto;
-    /// not yet consumed by production wiring this slice (only [`snapshot_full`]).
-    #[allow(dead_code)]
+    /// The authoritative shape the live `layout@<clientId>` region carries since
+    /// the group-aware widening (#2283 slice C): [`publish_layout`] publishes it
+    /// via [`snapshot_full`] so the frontend renders every tab group.
     fn full_view(&self) -> Value {
         serde_json::to_value(self).unwrap_or(Value::Null)
     }
@@ -189,12 +189,14 @@ impl LayoutStore {
         Self::default()
     }
 
-    /// The current **back-compat** render-ready view for a client (seeding it if
+    /// The **back-compat** render-ready view for a client (seeding it if
     /// unknown): the active group's `{ root, activePanelId }`.
     ///
-    /// Pure with respect to layout structure — it never mutates an existing
-    /// client — so the projector can safely diff two consecutive snapshots. This
-    /// keeps the live `layout@<clientId>` region shape unchanged this slice.
+    /// Retained accessor: since the group-aware widening (#2283 slice C) the live
+    /// `layout@<clientId>` region carries [`snapshot_full`] instead, so this is no
+    /// longer published — kept (and unit-tested) as the documented back-compat
+    /// active-group shape / a rollback seam. Pure with respect to layout structure.
+    #[allow(dead_code)]
     pub fn snapshot(&self, client_id: &str) -> Value {
         self.lock()
             .entry(client_id.to_string())
@@ -203,9 +205,9 @@ impl LayoutStore {
     }
 
     /// The full multi-group view for a client: `{ activeGroupId, groups: [...] }`.
-    /// The authoritative shape a later slice flips the region and frontend onto;
-    /// exercised by the group-transform tests this slice, not yet by live wiring.
-    #[allow(dead_code)]
+    /// The authoritative shape the live `layout@<clientId>` region carries since
+    /// the group-aware widening (#2283 slice C): [`publish_layout`] publishes it so
+    /// the frontend renders every tab group (composing the active one).
     pub fn snapshot_full(&self, client_id: &str) -> Value {
         self.lock()
             .entry(client_id.to_string())

--- a/src/store/appStore.layoutBridge.test.ts
+++ b/src/store/appStore.layoutBridge.test.ts
@@ -31,6 +31,20 @@ interface RegionState {
   view: unknown;
 }
 
+/** One group in the simulated full multi-group region view (#2283 slice C). */
+interface MinimalGroupView {
+  id: string;
+  name: string;
+  color?: string;
+  root: PanelNode;
+  activePanelId: string | null;
+}
+/** The full region view the simulated backend publishes. */
+interface FullView {
+  groups: MinimalGroupView[];
+  activeGroupId: string;
+}
+
 const { backend, dispatched } = vi.hoisted(() => ({
   backend: {
     version: -1,
@@ -79,30 +93,47 @@ vi.mock("@/services/transport", () => ({
           error: { code: "x", message: "nope" },
         };
       }
-      if (intent.kind === "layout.replace") {
-        backend.push({ root: intent.payload.root, activePanelId: intent.payload.activePanelId });
+      // The region carries the full multi-group view `{ groups, activeGroupId }`
+      // (#2283 slice C). Structural intents operate on the ACTIVE group; these
+      // helpers read/write the active group's tree while keeping the others.
+      const active = (): MinimalGroupView => {
+        const v = backend.view as FullView;
+        return v.groups.find((g) => g.id === v.activeGroupId) ?? v.groups[0];
+      };
+      const pushActive = (root: PanelNode, activePanelId: string | null): void => {
+        const v = backend.view as FullView;
+        const activeId = active().id;
+        const groups = v.groups.map((g) => (g.id === activeId ? { ...g, root, activePanelId } : g));
+        backend.push({ groups, activeGroupId: v.activeGroupId });
+      };
+
+      if (intent.kind === "layout.replaceGroups") {
+        backend.push({
+          groups: intent.payload.groups as MinimalGroupView[],
+          activeGroupId: intent.payload.activeGroupId as string,
+        });
       } else if (intent.kind === "layout.split") {
-        const view = backend.view as { root: PanelNode };
+        const g = active();
         const newLeaf = createLeafPanel();
         let root = splitLeaf(
-          view.root,
+          g.root,
           intent.payload.panelId as string,
           newLeaf,
           intent.payload.direction as "horizontal" | "vertical",
           intent.payload.position as "before" | "after"
         );
         root = simplifyTree(root);
-        backend.push({ root, activePanelId: newLeaf.id });
+        pushActive(root, newLeaf.id);
       } else if (intent.kind === "layout.moveTab") {
         // Mirrors the Rust store's move_tab: detach (positional active fallback),
         // place (center = append / edge = split), prune emptied source, simplify.
         // It does NOT repoint the active panel — the frontend bridge does.
-        const view = backend.view as { root: PanelNode; activePanelId: string | null };
+        const g = active();
         const tabId = intent.payload.tabId as string;
         const target = intent.payload.targetPanelId as string;
-        const src = findLeafByTab(view.root, tabId)!;
+        const src = findLeafByTab(g.root, tabId)!;
         const theTab = src.tabs.find((t) => t.id === tabId)!;
-        let root = updateLeaf(view.root, src.id, (leaf) => removeTabMinimal(leaf, tabId));
+        let root = updateLeaf(g.root, src.id, (leaf) => removeTabMinimal(leaf, tabId));
         const splitInfo = edgeToSplit(intent.payload.edge as never);
         if (!splitInfo) {
           root = updateLeaf(root, target, (leaf) => ({
@@ -125,40 +156,40 @@ vi.mock("@/services/transport", () => ({
           root = removed ?? root;
         }
         root = simplifyTree(root);
-        backend.push({ root, activePanelId: view.activePanelId });
+        pushActive(root, g.activePanelId);
       } else if (intent.kind === "layout.removePanel") {
         // Mirrors the Rust store's remove_panel: drop the whole leaf, simplify,
         // repoint focus onto the first survivor when the removed panel held it.
-        const view = backend.view as { root: PanelNode; activePanelId: string | null };
+        const g = active();
         const panelId = intent.payload.panelId as string;
-        const removed = removeLeaf(view.root, panelId);
-        const root = removed ? simplifyTree(removed) : view.root;
-        let active = view.activePanelId;
-        if (!active || !findLeaf(root, active)) {
-          active = getAllLeaves(root)[0]?.id ?? null;
+        const removed = removeLeaf(g.root, panelId);
+        const root = removed ? simplifyTree(removed) : g.root;
+        let focus = g.activePanelId;
+        if (!focus || !findLeaf(root, focus)) {
+          focus = getAllLeaves(root)[0]?.id ?? null;
         }
-        backend.push({ root, activePanelId: active });
+        pushActive(root, focus);
       } else if (intent.kind === "layout.reorderTabs") {
         // Mirrors the Rust store's reorder_tabs: move a tab within its leaf,
         // leaving focus untouched.
-        const view = backend.view as { root: PanelNode; activePanelId: string | null };
+        const g = active();
         const panelId = intent.payload.panelId as string;
         const oldIndex = intent.payload.oldIndex as number;
         const newIndex = intent.payload.newIndex as number;
-        const root = updateLeaf(view.root, panelId, (leaf) => {
+        const root = updateLeaf(g.root, panelId, (leaf) => {
           const tabs = [...leaf.tabs];
           const [moved] = tabs.splice(oldIndex, 1);
           tabs.splice(newIndex, 0, moved);
           return { ...leaf, tabs };
         });
-        backend.push({ root, activePanelId: view.activePanelId });
+        pushActive(root, g.activePanelId);
       } else if (intent.kind === "layout.setActivePanel") {
         // Mirrors the Rust store's set_active_panel: repoint focus, tree unchanged.
-        const view = backend.view as { root: PanelNode };
-        backend.push({ root: view.root, activePanelId: intent.payload.panelId as string });
+        const g = active();
+        pushActive(g.root, intent.payload.panelId as string);
       } else if (intent.kind === "layout.resize") {
         // Mirrors the Rust store's resize: set the split's normalized sizes.
-        const view = backend.view as { root: PanelNode; activePanelId: string | null };
+        const g = active();
         const splitId = intent.payload.splitId as string;
         const sizes = normalizeSizes(intent.payload.sizes as number[]);
         const setSizes = (n: PanelNode): PanelNode => {
@@ -166,7 +197,7 @@ vi.mock("@/services/transport", () => ({
           const children = n.children.map(setSizes);
           return n.id === splitId ? { ...n, children, sizes } : { ...n, children };
         };
-        backend.push({ root: setSizes(view.root), activePanelId: view.activePanelId });
+        pushActive(setSizes(g.root), g.activePanelId);
       }
       return {
         intentId: "intent-test",
@@ -190,7 +221,10 @@ vi.mock("@/services/transport", () => ({
       return () => backend.listeners.delete(listener);
     }
     async start() {
-      backend.push({ root: createLeafPanel(), activePanelId: null });
+      backend.push({
+        groups: [{ id: "seed-group", name: "Main", root: createLeafPanel(), activePanelId: null }],
+        activeGroupId: "seed-group",
+      });
     }
     stop() {}
   },
@@ -285,8 +319,9 @@ describe("appStore layout bridge — splitPanel cut (#2151)", () => {
     useAppStore.getState().splitPanel("vertical");
     await flush();
 
-    // Seed-before-mutate: replace precedes the structural intent.
-    expect(dispatched.map((d) => d.kind)).toEqual(["layout.replace", "layout.split"]);
+    // Seed-before-mutate: the whole multi-group layout is installed before the
+    // structural intent (#2283 slice C).
+    expect(dispatched.map((d) => d.kind)).toEqual(["layout.replaceGroups", "layout.split"]);
     expect(dispatched[1].payload).toMatchObject({
       panelId: "a",
       direction: "vertical",
@@ -409,9 +444,14 @@ describe("appStore layout bridge — cut ↔ local parity (#2151)", () => {
     useAppStore.getState().setActivePanel("b");
     expect(useAppStore.getState().activePanelId).toBe("b");
     await flush();
-    expect(dispatched.map((d) => d.kind)).toEqual(["layout.replace", "layout.setActivePanel"]);
-    // The projection now tracks the folded focus.
-    expect((backend.view as { activePanelId: string }).activePanelId).toBe("b");
+    expect(dispatched.map((d) => d.kind)).toEqual([
+      "layout.replaceGroups",
+      "layout.setActivePanel",
+    ]);
+    // The projection's active group now tracks the folded focus.
+    const folded = backend.view as FullView;
+    const activeGroup = folded.groups.find((g) => g.id === folded.activeGroupId)!;
+    expect(activeGroup.activePanelId).toBe("b");
   });
 
   it("setActivePanel preserves zoom-follow both ways (#2188)", async () => {

--- a/src/store/appStore.tabContent.test.ts
+++ b/src/store/appStore.tabContent.test.ts
@@ -94,10 +94,14 @@ function allTabs(): TerminalTab[] {
   return getAllLeaves(useAppStore.getState().rootPanel).flatMap((l) => l.tabs);
 }
 
-/** The projected (minimal) view of the current tree, focused on the active panel. */
+/** The projected (multi-group) view of the current tree — a single active group
+ * holding the current panel tree (#2283 slice C). */
 function currentView(): LayoutView {
   const { rootPanel, activePanelId } = useAppStore.getState();
-  return { root: toMinimalNode(rootPanel), activePanelId };
+  return {
+    groups: [{ id: "g", name: "Main", root: toMinimalNode(rootPanel), activePanelId }],
+    activeGroupId: "g",
+  };
 }
 
 describe("appStore — tabContent by-id map (#2283)", () => {

--- a/src/store/appStore.tabContent.test.ts
+++ b/src/store/appStore.tabContent.test.ts
@@ -169,7 +169,7 @@ describe("appStore — tabContent by-id map (#2283)", () => {
   });
 
   it("render parity: composing from the map equals composing from the in-tree tab", () => {
-    // A mix of a terminal tab (mapped) and an editor tab (not mapped → fallback).
+    // A mix of a terminal tab and an editor tab — both mapped since slice C.
     useAppStore.getState().addTab("Shell", "local", LOCAL_CONFIG);
     useAppStore.getState().openScratchEditorTab("Notes", "notes.md", "hello");
     useAppStore.getState().addTab("Shell 2", "local", LOCAL_CONFIG);
@@ -195,6 +195,98 @@ describe("appStore — tabContent by-id map (#2283)", () => {
     expect(composeRenderTree(view, rootPanel, tabContent)).toEqual(
       composeRenderTree(view, rootPanel)
     );
+    expect(composeRenderTree(view, rootPanel, tabContent)).toEqual(rootPanel);
+  });
+});
+
+describe("appStore — comprehensive tabContent map for every tab type (#2283 slice C)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+    vi.clearAllMocks();
+  });
+
+  /** Open a tab of each instrumented content type into the active panel. */
+  function openOneOfEach(): void {
+    const s = useAppStore.getState();
+    s.addTab("Shell", "local", LOCAL_CONFIG);
+    s.openSettingsTab();
+    s.openLogViewerTab();
+    s.openNetworkDiagnosticTab("ping");
+    s.openScratchEditorTab("Notes", "notes.md", "hi");
+    s.openConnectionEditorTab("new");
+    s.openTunnelEditorTab(null);
+    s.openWorkspaceEditorTab(null);
+    s.selectPlugin("p1");
+  }
+
+  it("every rendered tab resolves its content from the map (no fallback needed)", () => {
+    openOneOfEach();
+    const { rootPanel, tabContent } = useAppStore.getState();
+
+    for (const leaf of getAllLeaves(rootPanel)) {
+      for (const t of leaf.tabs) {
+        // The map holds a content-identical entry for EVERY tab in the tree.
+        expect(tabContent[t.id]).toBeDefined();
+        expect(tabContent[t.id]).toEqual(extractTabContent(t));
+      }
+    }
+
+    // Composing from the map is byte-identical to the in-tree fallback and to the
+    // authoritative tree — so the in-tree fallback is now belt-and-suspenders.
+    const view = currentView();
+    expect(composeRenderTree(view, rootPanel, tabContent)).toEqual(
+      composeRenderTree(view, rootPanel)
+    );
+    expect(composeRenderTree(view, rootPanel, tabContent)).toEqual(rootPanel);
+  });
+
+  it.each([
+    ["settings", () => useAppStore.getState().openSettingsTab()],
+    ["log-viewer", () => useAppStore.getState().openLogViewerTab()],
+    ["network-diagnostic", () => useAppStore.getState().openNetworkDiagnosticTab("ping")],
+    ["editor", () => useAppStore.getState().openScratchEditorTab("N", "n.md", "x")],
+    ["connection-editor", () => useAppStore.getState().openConnectionEditorTab("new")],
+    ["tunnel-editor", () => useAppStore.getState().openTunnelEditorTab(null)],
+    ["workspace-editor", () => useAppStore.getState().openWorkspaceEditorTab(null)],
+    ["plugin-detail", () => useAppStore.getState().selectPlugin("p1")],
+  ])("%s: open tracks content, close prunes it", (type, open) => {
+    open();
+    const tab = allTabs().find((t) => t.contentType === type)!;
+    expect(tab).toBeDefined();
+    expect(useAppStore.getState().tabContent[tab.id]).toEqual(extractTabContent(tab));
+
+    useAppStore.getState().closeTab(tab.id, tab.panelId);
+    expect(useAppStore.getState().tabContent[tab.id]).toBeUndefined();
+  });
+
+  it("selectPlugin reuse re-points meta and keeps the map in sync", () => {
+    useAppStore.getState().selectPlugin("p1");
+    const first = allTabs().find((t) => t.contentType === "plugin-detail")!;
+    expect(useAppStore.getState().tabContent[first.id]).toEqual(extractTabContent(first));
+
+    // Selecting another plugin REUSES the single plugin-detail tab (re-points its
+    // meta) rather than opening a second — the map entry must follow.
+    useAppStore.getState().selectPlugin("p2");
+    const reused = allTabs().find((t) => t.contentType === "plugin-detail")!;
+    expect(reused.id).toBe(first.id);
+    expect((reused as { pluginDetailMeta?: { pluginId: string } }).pluginDetailMeta?.pluginId).toBe(
+      "p2"
+    );
+    expect(useAppStore.getState().tabContent[reused.id]).toEqual(extractTabContent(reused));
+  });
+
+  it("openScratchEditorTab tracks editorMeta; render parity holds", () => {
+    useAppStore.getState().openScratchEditorTab("Notes", "notes.md", "content");
+    const tab = allTabs().find((t) => t.contentType === "editor")!;
+    // The editorMeta rides in the map entry (content, not structure).
+    expect(useAppStore.getState().tabContent[tab.id]).toEqual(extractTabContent(tab));
+    expect(
+      (useAppStore.getState().tabContent[tab.id] as { editorMeta?: { scratch?: boolean } })
+        .editorMeta?.scratch
+    ).toBe(true);
+
+    const { rootPanel, tabContent } = useAppStore.getState();
+    const view = currentView();
     expect(composeRenderTree(view, rootPanel, tabContent)).toEqual(rootPanel);
   });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -4071,7 +4071,13 @@ export const useAppStore = create<AppState>((set, get, store) => {
           tabs.push(newTab);
           return { ...leaf, tabs, activeTabId: newTab.id };
         });
-        return { ...nav, rootPanel, activePanelId: targetPanelId };
+        return {
+          ...nav,
+          rootPanel,
+          activePanelId: targetPanelId,
+          // Track the new tab's content in the by-id map (part of #2283).
+          tabContent: setTabContentEntry(state.tabContent, newTab),
+        };
       }),
 
     openLogViewerTab: () =>
@@ -4102,7 +4108,12 @@ export const useAppStore = create<AppState>((set, get, store) => {
           tabs.push(newTab);
           return { ...leaf, tabs, activeTabId: newTab.id };
         });
-        return { rootPanel, activePanelId: targetPanelId };
+        return {
+          rootPanel,
+          activePanelId: targetPanelId,
+          // Track the new tab's content in the by-id map (part of #2283).
+          tabContent: setTabContentEntry(state.tabContent, newTab),
+        };
       }),
 
     openNetworkDiagnosticTab: (tool, prefillHost, connectionId) =>
@@ -4133,7 +4144,13 @@ export const useAppStore = create<AppState>((set, get, store) => {
           tabs.push(newTab);
           return { ...leaf, tabs, activeTabId: newTab.id };
         });
-        return { rootPanel, activePanelId: targetPanelId };
+        return {
+          rootPanel,
+          activePanelId: targetPanelId,
+          // Track the new tab's content (incl. its diagnostic meta) in the by-id
+          // map (part of #2283).
+          tabContent: setTabContentEntry(state.tabContent, newTab),
+        };
       }),
 
     openEditorTab: (filePath, isRemote, permissions, sessionBrowser) =>
@@ -4155,24 +4172,32 @@ export const useAppStore = create<AppState>((set, get, store) => {
               t.editorMeta?.sessionKey === sessionKey
           );
           if (existing) {
+            // Refresh the backing session so a reconnected session works.
+            let refreshedMeta = existing.editorMeta;
+            if (isRemote && existing.editorMeta && sessionBrowser) {
+              refreshedMeta = {
+                ...existing.editorMeta,
+                sessionBrowser,
+                sessionKey,
+              };
+            }
             const rootPanel = updateLeaf(state.rootPanel, leaf.id, (l) => ({
               ...l,
-              tabs: l.tabs.map((t) => {
-                if (t.id !== existing.id) return { ...t, isActive: false };
-                // Refresh the backing session so a reconnected session works.
-                let updatedMeta = t.editorMeta;
-                if (isRemote && t.editorMeta && sessionBrowser) {
-                  updatedMeta = {
-                    ...t.editorMeta,
-                    sessionBrowser,
-                    sessionKey,
-                  };
-                }
-                return { ...t, isActive: true, editorMeta: updatedMeta };
-              }),
+              tabs: l.tabs.map((t) =>
+                t.id === existing.id
+                  ? { ...t, isActive: true, editorMeta: refreshedMeta }
+                  : { ...t, isActive: false }
+              ),
               activeTabId: existing.id,
             }));
-            return { rootPanel, activePanelId: leaf.id };
+            return {
+              rootPanel,
+              activePanelId: leaf.id,
+              // Keep the mapped content in sync with the refreshed meta (#2283).
+              tabContent: patchTabContentEntry(state.tabContent, existing.id, {
+                editorMeta: refreshedMeta,
+              }),
+            };
           }
         }
 
@@ -4197,7 +4222,12 @@ export const useAppStore = create<AppState>((set, get, store) => {
           tabs.push(newTab);
           return { ...leaf, tabs, activeTabId: newTab.id };
         });
-        return { rootPanel, activePanelId: targetPanelId };
+        return {
+          rootPanel,
+          activePanelId: targetPanelId,
+          // Track the new tab's content (incl. editorMeta) in the by-id map (#2283).
+          tabContent: setTabContentEntry(state.tabContent, newTab),
+        };
       }),
 
     openScratchEditorTab: (title, fileName, content) =>
@@ -4221,7 +4251,12 @@ export const useAppStore = create<AppState>((set, get, store) => {
           tabs.push(newTab);
           return { ...leaf, tabs, activeTabId: newTab.id };
         });
-        return { rootPanel, activePanelId: targetPanelId };
+        return {
+          rootPanel,
+          activePanelId: targetPanelId,
+          // Track the scratch editor's content (incl. editorMeta) in the map (#2283).
+          tabContent: setTabContentEntry(state.tabContent, newTab),
+        };
       }),
 
     openConnectionEditorTab: (connectionId, folderId) =>
@@ -4273,7 +4308,12 @@ export const useAppStore = create<AppState>((set, get, store) => {
           tabs.push(newTab);
           return { ...leaf, tabs, activeTabId: newTab.id };
         });
-        return { rootPanel, activePanelId: targetPanelId };
+        return {
+          rootPanel,
+          activePanelId: targetPanelId,
+          // Track the new tab's content (incl. connectionEditorMeta) in the map (#2283).
+          tabContent: setTabContentEntry(state.tabContent, newTab),
+        };
       }),
 
     openAgentDefinitionEditorTab: (agentId, definitionId, folderId) =>
@@ -4324,7 +4364,12 @@ export const useAppStore = create<AppState>((set, get, store) => {
           tabs.push(newTab);
           return { ...leaf, tabs, activeTabId: newTab.id };
         });
-        return { rootPanel, activePanelId: targetPanelId };
+        return {
+          rootPanel,
+          activePanelId: targetPanelId,
+          // Track the new tab's content (incl. connectionEditorMeta) in the map (#2283).
+          tabContent: setTabContentEntry(state.tabContent, newTab),
+        };
       }),
 
     editorDirtyTabs: {},
@@ -6804,7 +6849,12 @@ export const useAppStore = create<AppState>((set, get, store) => {
           tabs.push(newTab);
           return { ...leaf, tabs, activeTabId: newTab.id };
         });
-        return { rootPanel, activePanelId: targetPanelId };
+        return {
+          rootPanel,
+          activePanelId: targetPanelId,
+          // Track the new tab's content (incl. tunnelEditorMeta) in the map (#2283).
+          tabContent: setTabContentEntry(state.tabContent, newTab),
+        };
       }),
 
     // Embedded Servers — data + lifecycle provided by createEmbeddedServersSlice (#2113).
@@ -6835,7 +6885,16 @@ export const useAppStore = create<AppState>((set, get, store) => {
               ),
               activeTabId: existing.id,
             }));
-            return { rootPanel, activePanelId: leaf.id, selectedPluginId: pluginId };
+            return {
+              rootPanel,
+              activePanelId: leaf.id,
+              selectedPluginId: pluginId,
+              // Keep the mapped content in sync with the re-pointed title/meta (#2283).
+              tabContent: patchTabContentEntry(state.tabContent, existing.id, {
+                title,
+                pluginDetailMeta: { pluginId },
+              }),
+            };
           }
         }
 
@@ -6852,7 +6911,13 @@ export const useAppStore = create<AppState>((set, get, store) => {
           tabs.push(newTab);
           return { ...leaf, tabs, activeTabId: newTab.id };
         });
-        return { rootPanel, activePanelId: targetPanelId, selectedPluginId: pluginId };
+        return {
+          rootPanel,
+          activePanelId: targetPanelId,
+          selectedPluginId: pluginId,
+          // Track the new tab's content (incl. pluginDetailMeta) in the map (#2283).
+          tabContent: setTabContentEntry(state.tabContent, newTab),
+        };
       }),
 
     // Macro recording (#1674) + playback (#1675) provided by createMacrosSlice (#2114).
@@ -7381,7 +7446,12 @@ export const useAppStore = create<AppState>((set, get, store) => {
           tabs.push(newTab);
           return { ...leaf, tabs, activeTabId: newTab.id };
         });
-        return { rootPanel, activePanelId: targetPanelId };
+        return {
+          rootPanel,
+          activePanelId: targetPanelId,
+          // Track the new tab's content (incl. workspaceEditorMeta) in the map (#2283).
+          tabContent: setTabContentEntry(state.tabContent, newTab),
+        };
       }),
 
     launchWorkspace: async (workspaceId) => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -245,6 +245,8 @@ import {
   normalizeSizes,
 } from "@/utils/panelTree";
 import {
+  buildLayoutSnapshot,
+  type LayoutSnapshot,
   layoutIntentsEnabled,
   logBridgeFallback,
   moveTabPayload,
@@ -2582,6 +2584,26 @@ function patchTabContentEntry(
 }
 
 /**
+ * The rich multi-group {@link LayoutSnapshot} of `appStore`'s current layout —
+ * the seed-before-mutate payload passed to {@link runLayoutIntent} (#2283 slice
+ * C). The active group's live tree is the top-level `rootPanel`/`activePanelId`;
+ * every other group comes from its `tabGroups` entry.
+ */
+function currentLayoutSnapshot(state: {
+  tabGroups: TabGroup[];
+  activeTabGroupId: string;
+  rootPanel: PanelNode;
+  activePanelId: string | null;
+}): LayoutSnapshot {
+  return buildLayoutSnapshot(
+    state.tabGroups,
+    state.activeTabGroupId,
+    state.rootPanel,
+    state.activePanelId
+  );
+}
+
+/**
  * Serialize a tab into the view-model carried across a native-window boundary
  * (#1900). Placement (`panelId`/`isActive`) is dropped — the destination window
  * re-assigns it on hydrate — while `sessionId` anchors the re-attach to the same
@@ -4544,12 +4566,10 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // tree. Focus is unchanged, so only `rootPanel` is applied. Any failure
       // falls back to the local reducer.
       if (!layoutIntentsEnabled()) return applyLocal();
-      const { rootPanel, activePanelId } = get();
       void runLayoutIntent(
         "layout.reorderTabs",
         { panelId, oldIndex, newIndex },
-        rootPanel,
-        activePanelId
+        currentLayoutSnapshot(get())
       )
         .then((res) => set({ rootPanel: res.rootPanel }))
         .catch((err) => {
@@ -4582,13 +4602,12 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // reconcileNode is the authoritative writer of the reconciled tree. On any
       // failure fall back to the local reducer so layout never breaks.
       if (!layoutIntentsEnabled()) return applyLocal();
-      const { rootPanel, activePanelId } = get();
+      const { activePanelId } = get();
       if (!activePanelId) return applyLocal();
       void runLayoutIntent(
         "layout.split",
         { panelId: activePanelId, direction: direction ?? "horizontal", position: "after" },
-        rootPanel,
-        activePanelId
+        currentLayoutSnapshot(get())
       )
         .then((res) => set(res))
         .catch((err) => {
@@ -4621,9 +4640,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // panel". The sole-leaf case is a no-op both here and in the store. Any
       // failure falls back to the local reducer.
       if (!layoutIntentsEnabled()) return applyLocal();
-      const { rootPanel, activePanelId } = get();
+      const { rootPanel } = get();
       if (getAllLeaves(rootPanel).length <= 1) return;
-      void runLayoutIntent("layout.removePanel", { panelId }, rootPanel, activePanelId)
+      void runLayoutIntent("layout.removePanel", { panelId }, currentLayoutSnapshot(get()))
         .then((res) => set(res))
         .catch((err) => {
           logBridgeFallback("layout.removePanel", err);
@@ -4654,10 +4673,11 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // logged (the projection catches up on the next seed).
       applyLocal();
       if (!layoutIntentsEnabled()) return;
-      const { rootPanel, activePanelId } = get();
-      void runLayoutIntent("layout.setActivePanel", { panelId }, rootPanel, activePanelId).catch(
-        (err) => logBridgeFallback("layout.setActivePanel", err)
-      );
+      void runLayoutIntent(
+        "layout.setActivePanel",
+        { panelId },
+        currentLayoutSnapshot(get())
+      ).catch((err) => logBridgeFallback("layout.setActivePanel", err));
     },
 
     setPanelSizes: (splitId, sizes) => {
@@ -4671,8 +4691,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // the normalized sizes and reconcileNode writes the reconciled tree. Only
       // `rootPanel` changes. Any failure falls back to the local reducer.
       if (!layoutIntentsEnabled()) return applyLocal();
-      const { rootPanel, activePanelId } = get();
-      void runLayoutIntent("layout.resize", { splitId, sizes }, rootPanel, activePanelId)
+      void runLayoutIntent("layout.resize", { splitId, sizes }, currentLayoutSnapshot(get()))
         .then((res) => set({ rootPanel: res.rootPanel }))
         .catch((err) => {
           logBridgeFallback("layout.resize", err);
@@ -4763,7 +4782,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // local path to preserve exact parity; everything else routes through the
       // store, with reconcileNode as the authoritative writer.
       if (!layoutIntentsEnabled()) return applyLocal();
-      const { rootPanel, activePanelId } = get();
+      const { rootPanel } = get();
       const sourceLeaf = findLeaf(rootPanel, fromPanelId);
       const selfEdgeSingleTab =
         edge !== "center" && fromPanelId === targetPanelId && (sourceLeaf?.tabs.length ?? 0) <= 1;
@@ -4772,8 +4791,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
       void runLayoutIntent(
         "layout.moveTab",
         moveTabPayload(tabId, targetPanelId, edge),
-        rootPanel,
-        activePanelId,
+        currentLayoutSnapshot(get()),
         tabId
       )
         .then((res) => set(res))

--- a/src/store/layoutBridge.test.ts
+++ b/src/store/layoutBridge.test.ts
@@ -9,8 +9,10 @@ import { describe, it, expect, afterEach } from "vitest";
 import type { PanelNode, TabContent, TerminalTab } from "@/types/terminal";
 
 import {
+  buildLayoutSnapshot,
   collectTabs,
   composeRenderTree,
+  type LayoutSnapshot,
   type LayoutView,
   layoutIntentsEnabled,
   layoutRenderFromProjectionEnabled,
@@ -21,6 +23,7 @@ import {
   toMinimalNode,
   viewMatchesTree,
 } from "./layoutBridge";
+import type { TabGroup } from "@/types/terminal";
 
 function tab(id: string, extra: Partial<TerminalTab> = {}): TerminalTab {
   return {
@@ -142,13 +145,23 @@ describe("layoutBridge — tree mapping", () => {
 });
 
 describe("layoutBridge — render-from-projection helpers (#2151 step 3)", () => {
-  /** The projected (minimal) view of `tree()`, focused on panel `a`. */
+  /** The projected multi-group view of `tree()`: a single active group `g1`
+   * holding the tree, focused on panel `a` (#2283 slice C). */
   function view(): LayoutView {
-    return { root: toMinimalNode(tree()), activePanelId: "a" };
+    return {
+      groups: [{ id: "g1", name: "Main", root: toMinimalNode(tree()), activePanelId: "a" }],
+      activeGroupId: "g1",
+    };
+  }
+
+  /** A single-group `appStore` snapshot mirroring `view()`. */
+  function snapshot(root: PanelNode = tree(), activePanelId: string | null = "a"): LayoutSnapshot {
+    const groups: TabGroup[] = [{ id: "g1", name: "Main", rootPanel: root, activePanelId }];
+    return buildLayoutSnapshot(groups, "g1", root, activePanelId);
   }
 
   it("minimalNodesEqual: a tree equals its own minimal projection", () => {
-    expect(minimalNodesEqual(toMinimalNode(tree()), view().root)).toBe(true);
+    expect(minimalNodesEqual(toMinimalNode(tree()), toMinimalNode(tree()))).toBe(true);
   });
 
   it("minimalNodesEqual: sensitive to tab order, active tab, sizes, and direction", () => {
@@ -179,25 +192,104 @@ describe("layoutBridge — render-from-projection helpers (#2151 step 3)", () =>
   });
 
   it("viewMatchesTree: true only when structure AND active panel align", () => {
-    expect(viewMatchesTree(view(), tree(), "a")).toBe(true);
+    expect(viewMatchesTree(view(), snapshot())).toBe(true);
     // Active panel differs.
-    expect(viewMatchesTree(view(), tree(), "b")).toBe(false);
+    expect(viewMatchesTree(view(), snapshot(tree(), "b"))).toBe(false);
     // A view missing a tab appStore still has (local add not yet in the region).
     const stale: LayoutView = {
-      root: toMinimalNode({
-        type: "split",
-        id: "root",
-        direction: "horizontal",
-        sizes: [50, 50],
-        children: [
-          { type: "leaf", id: "a", tabs: [tab("t1")], activeTabId: "t1" },
-          { type: "leaf", id: "b", tabs: [tab("t3")], activeTabId: "t3" },
-        ],
-      }),
-      activePanelId: "a",
+      groups: [
+        {
+          id: "g1",
+          name: "Main",
+          root: toMinimalNode({
+            type: "split",
+            id: "root",
+            direction: "horizontal",
+            sizes: [50, 50],
+            children: [
+              { type: "leaf", id: "a", tabs: [tab("t1")], activeTabId: "t1" },
+              { type: "leaf", id: "b", tabs: [tab("t3")], activeTabId: "t3" },
+            ],
+          }),
+          activePanelId: "a",
+        },
+      ],
+      activeGroupId: "g1",
     };
-    expect(viewMatchesTree(stale, tree(), "a")).toBe(false);
-    expect(viewMatchesTree(null, tree(), "a")).toBe(false);
+    expect(viewMatchesTree(stale, snapshot())).toBe(false);
+    expect(viewMatchesTree(null, snapshot())).toBe(false);
+  });
+
+  it("viewMatchesTree (multi-group): all groups must match, in order (#2283)", () => {
+    // Two groups: g1 active holding the tree, g2 a single leaf.
+    const g2Root: PanelNode = { type: "leaf", id: "z", tabs: [tab("t9")], activeTabId: "t9" };
+    const groups: TabGroup[] = [
+      { id: "g1", name: "Main", rootPanel: tree(), activePanelId: "a" },
+      { id: "g2", name: "Second", rootPanel: g2Root, activePanelId: "z" },
+    ];
+    const snap = buildLayoutSnapshot(groups, "g1", tree(), "a");
+    const mirror: LayoutView = {
+      groups: [
+        { id: "g1", name: "Main", root: toMinimalNode(tree()), activePanelId: "a" },
+        { id: "g2", name: "Second", root: toMinimalNode(g2Root), activePanelId: "z" },
+      ],
+      activeGroupId: "g1",
+    };
+    expect(viewMatchesTree(mirror, snap)).toBe(true);
+
+    // A non-active group's tree drifts → the whole gate fails (forces a reseed).
+    const drifted: LayoutView = {
+      ...mirror,
+      groups: [
+        mirror.groups[0],
+        { id: "g2", name: "Second", root: toMinimalNode(tree()), activePanelId: "a" },
+      ],
+    };
+    expect(viewMatchesTree(drifted, snap)).toBe(false);
+
+    // Group metadata (name) drifts → fails.
+    const renamed: LayoutView = {
+      ...mirror,
+      groups: [{ ...mirror.groups[0], name: "Renamed" }, mirror.groups[1]],
+    };
+    expect(viewMatchesTree(renamed, snap)).toBe(false);
+
+    // activeGroupId differs → fails.
+    expect(viewMatchesTree({ ...mirror, activeGroupId: "g2" }, snap)).toBe(false);
+
+    // Group order / count differs → fails.
+    expect(viewMatchesTree({ ...mirror, groups: [mirror.groups[1], mirror.groups[0]] }, snap)).toBe(
+      false
+    );
+    expect(viewMatchesTree({ ...mirror, groups: [mirror.groups[0]] }, snap)).toBe(false);
+  });
+
+  it("composeRenderTree (multi-group): composes the active group whichever it is (#2283)", () => {
+    // g1 = tree(); g2 = a single-leaf tree. The composed output tracks the active
+    // group, and tab/panel ids are preserved (xterm reparents, never remounts).
+    const g2Root: PanelNode = {
+      type: "leaf",
+      id: "z",
+      tabs: [tab("t9")],
+      activeTabId: "t9",
+    };
+    const two: LayoutView = {
+      groups: [
+        { id: "g1", name: "Main", root: toMinimalNode(tree()), activePanelId: "a" },
+        { id: "g2", name: "Second", root: toMinimalNode(g2Root), activePanelId: "z" },
+      ],
+      activeGroupId: "g1",
+    };
+    // Active = g1 → composes tree() from g1's rich root (structure preserved;
+    // reconcile re-derives panelId/isActive).
+    expect(toMinimalNode(composeRenderTree(two, tree()))).toEqual(toMinimalNode(tree()));
+    // Switch active to g2 → composes the g2 tree from g2's rich root, ids intact.
+    const g2 = composeRenderTree({ ...two, activeGroupId: "g2" }, g2Root) as Extract<
+      PanelNode,
+      { type: "leaf" }
+    >;
+    expect(g2.id).toBe("z");
+    expect(g2.tabs.map((t) => t.id)).toEqual(["t9"]);
   });
 
   it("composeRenderTree: structure from the view, rich content from appStore by id", () => {

--- a/src/store/layoutBridge.ts
+++ b/src/store/layoutBridge.ts
@@ -60,6 +60,7 @@ import type {
   PanelNode,
   SplitContainer,
   TabContent,
+  TabGroup,
   TerminalTab,
 } from "@/types/terminal";
 import { frontendLog } from "@/utils/frontendLog";
@@ -94,10 +95,92 @@ interface MinimalSplit {
 }
 export type MinimalNode = MinimalLeaf | MinimalSplit;
 
-/** The `layout@<clientId>` region view model: tree + focused panel. */
-export interface LayoutView {
+/**
+ * One projected tab group (twin of the Rust `GroupLayout`): its panel tree plus
+ * metadata and focused panel. `color` is omitted when unset.
+ */
+export interface MinimalGroup {
+  id: string;
+  name: string;
+  color?: string;
   root: MinimalNode;
   activePanelId: string | null;
+}
+
+/**
+ * The `layout@<clientId>` region view model — the full multi-group view emitted
+ * by `LayoutStore::snapshot_full()` (#2283 slice C): every tab group plus the
+ * active group id. The renderer composes the **active** group; the rest are
+ * carried so the region is a faithful mirror of `appStore`'s groups.
+ */
+export interface LayoutView {
+  groups: MinimalGroup[];
+  activeGroupId: string;
+}
+
+/**
+ * One tab group in the rich `appStore`-side snapshot: the authoritative panel
+ * tree (rich {@link PanelNode}) plus metadata and focused panel. Built by
+ * {@link buildLayoutSnapshot} from `appStore.tabGroups` with the active group's
+ * live tree overlaid.
+ */
+export interface GroupSnapshot {
+  id: string;
+  name: string;
+  color?: string;
+  root: PanelNode;
+  activePanelId: string | null;
+}
+
+/** The rich `appStore`-side multi-group snapshot: the seed/gate input. */
+export interface LayoutSnapshot {
+  groups: GroupSnapshot[];
+  activeGroupId: string;
+}
+
+/**
+ * Build the rich {@link LayoutSnapshot} from `appStore`'s group state. Only the
+ * **active** group's live tree lives at the top-level `rootPanel`/`activePanelId`
+ * (the matching `tabGroups` entry is stale until a switch), so the active group
+ * is overlaid from those while the rest come from their `tabGroups` entries.
+ */
+export function buildLayoutSnapshot(
+  tabGroups: TabGroup[],
+  activeGroupId: string,
+  activeRoot: PanelNode,
+  activeRootActivePanelId: string | null
+): LayoutSnapshot {
+  return {
+    groups: tabGroups.map((g) => {
+      const isActive = g.id === activeGroupId;
+      const snap: GroupSnapshot = {
+        id: g.id,
+        name: g.name,
+        root: isActive ? activeRoot : g.rootPanel,
+        activePanelId: isActive ? activeRootActivePanelId : g.activePanelId,
+      };
+      if (g.color != null) snap.color = g.color;
+      return snap;
+    }),
+    activeGroupId,
+  };
+}
+
+/** Project a rich {@link GroupSnapshot} to its minimal wire form (for seeding). */
+export function toMinimalGroup(group: GroupSnapshot): MinimalGroup {
+  const minimal: MinimalGroup = {
+    id: group.id,
+    name: group.name,
+    root: toMinimalNode(group.root),
+    activePanelId: group.activePanelId,
+  };
+  if (group.color != null) minimal.color = group.color;
+  return minimal;
+}
+
+/** The active group of a projected view (falls back to the first group). */
+export function activeGroupOf(view: LayoutView): MinimalGroup | undefined {
+  return view.groups.find((g) => g.id === view.activeGroupId) ?? view.groups[0];
 }
 
 // ── Feature flag (runtime-flippable so a dev build can verify the ON path) ─────
@@ -365,29 +448,44 @@ function awaitVersion(client: ProjectionClient, version: number, timeoutMs = 400
  * when `focusTabId` is given, the reconciled `activePanelId` is re-derived as
  * the panel that now holds that tab — reproducing the old focus behaviour.
  *
+ * # Group-aware seed (#2283 slice C)
+ *
+ * Seed-before-mutate installs **every** tab group via `layout.replaceGroups`
+ * (not just the active tree), so the region is a faithful multi-group mirror
+ * before the transform runs. The structural intent still operates on the active
+ * group (its `groupId` is omitted → the store's active group), and the active
+ * group is read back out of the full view for reconcile.
+ *
  * @param kind        the `layout.*` intent kind
  * @param payload     the intent payload
- * @param root        `appStore`'s current `rootPanel` (authoritative structure)
- * @param active      `appStore`'s current `activePanelId`
+ * @param snapshot    `appStore`'s current multi-group snapshot (authority)
  * @param focusTabId  when set, focus the panel this tab landed in
- * @returns the reconciled `{ rootPanel, activePanelId }` to apply to `appStore`
+ * @returns the reconciled `{ rootPanel, activePanelId }` for the **active** group
  * @throws  on a rejected/failed intent or an unreconcilable diff (caller falls
  *          back to the local mutation)
  */
 export async function runLayoutIntent(
   kind: string,
   payload: Record<string, unknown>,
-  root: PanelNode,
-  active: string | null,
+  snapshot: LayoutSnapshot,
   focusTabId?: string
 ): Promise<LayoutStructuralResult> {
   const client = await ensureSubscribed();
-  const tabsById = collectTabs(root);
+  const activeGroup =
+    snapshot.groups.find((g) => g.id === snapshot.activeGroupId) ?? snapshot.groups[0];
+  if (!activeGroup) {
+    throw new Error("layout snapshot has no active group");
+  }
+  const tabsById = collectTabs(activeGroup.root);
 
-  // Seed the store with appStore's authoritative tree, then transform it.
+  // Seed the store with appStore's authoritative multi-group layout, then
+  // transform the active group.
   throwIfRejected(
-    await dispatch("layout.replace", { root: toMinimalNode(root), activePanelId: active }),
-    "replace"
+    await dispatch("layout.replaceGroups", {
+      groups: snapshot.groups.map(toMinimalGroup),
+      activeGroupId: snapshot.activeGroupId,
+    }),
+    "replaceGroups"
   );
   const ack = await dispatch(kind, payload);
   throwIfRejected(ack, kind);
@@ -398,13 +496,14 @@ export async function runLayoutIntent(
   }
 
   const view = client.state.view as LayoutView | undefined;
-  if (!view || !view.root) {
-    throw new Error("layout region has no view after intent");
+  const projectedGroup = view ? activeGroupOf(view) : undefined;
+  if (!projectedGroup || !projectedGroup.root) {
+    throw new Error("layout region has no active group after intent");
   }
-  const rootPanel = reconcileNode(view.root, tabsById);
+  const rootPanel = reconcileNode(projectedGroup.root, tabsById);
   const activePanelId = focusTabId
-    ? (findLeafByTab(rootPanel, focusTabId)?.id ?? view.activePanelId)
-    : view.activePanelId;
+    ? (findLeafByTab(rootPanel, focusTabId)?.id ?? projectedGroup.activePanelId)
+    : projectedGroup.activePanelId;
   return { rootPanel, activePanelId };
 }
 
@@ -483,35 +582,57 @@ function sizesEqual(a: number[] | undefined, b: number[] | undefined): boolean {
 }
 
 /**
- * Whether a projected `view` is a faithful structural mirror of `root` +
- * `activePanelId` — the gate that decides if the renderer may source structure
- * from the projection (true) or must fall back to `appStore` (false).
+ * Whether one projected {@link MinimalGroup} faithfully mirrors a rich
+ * {@link GroupSnapshot} — same id, metadata, focused panel, and panel tree.
  */
-export function viewMatchesTree(
-  view: LayoutView | null | undefined,
-  root: PanelNode,
-  activePanelId: string | null
-): boolean {
-  if (!view || !view.root) return false;
-  if ((view.activePanelId ?? null) !== (activePanelId ?? null)) return false;
-  return minimalNodesEqual(toMinimalNode(root), view.root);
+function minimalGroupMatches(view: MinimalGroup, snap: GroupSnapshot): boolean {
+  return (
+    view.id === snap.id &&
+    view.name === snap.name &&
+    (view.color ?? null) === (snap.color ?? null) &&
+    (view.activePanelId ?? null) === (snap.activePanelId ?? null) &&
+    minimalNodesEqual(toMinimalNode(snap.root), view.root)
+  );
 }
 
 /**
- * Compose the rich render tree from a projected view: **structure** from
- * `view.root`, **content** re-attached by tab id — preferring the flat
- * `contentById` {@link TabContent} map (part of #2283), and falling back to
- * `contentRoot`'s in-tree rich tabs for any id the map does not yet hold. Throws
- * (via {@link reconcileNode}) if the view references a tab absent from **both**;
- * callers gate with {@link viewMatchesTree} first so this never throws on the
- * happy path.
+ * Whether a projected `view` is a faithful structural mirror of the whole
+ * `snapshot` — **every** group matches in order (id, metadata, focused panel and
+ * tree) and the active group id agrees (#2283 slice C). This is the gate that
+ * decides if the renderer may source structure from the projection (true) or
+ * must fall back to `appStore` (false). Widened from the single active tree so a
+ * group add/close/rename/color/reorder (still local) reseeds the region.
+ */
+export function viewMatchesTree(
+  view: LayoutView | null | undefined,
+  snapshot: LayoutSnapshot
+): boolean {
+  if (!view || !Array.isArray(view.groups)) return false;
+  if ((view.activeGroupId ?? null) !== (snapshot.activeGroupId ?? null)) return false;
+  if (view.groups.length !== snapshot.groups.length) return false;
+  return view.groups.every((vg, i) => minimalGroupMatches(vg, snapshot.groups[i]));
+}
+
+/**
+ * Compose the rich render tree for the **active** group of a projected view:
+ * **structure** from the active group's `root`, **content** re-attached by tab
+ * id — preferring the flat `contentById` {@link TabContent} map (part of #2283),
+ * and falling back to `activeContentRoot`'s in-tree rich tabs for any id the map
+ * does not yet hold. `activeContentRoot` is `appStore`'s active-group rich tree
+ * (its `rootPanel`). Throws (via {@link reconcileNode}) if the view references a
+ * tab absent from **both**; callers gate with {@link viewMatchesTree} first so
+ * this never throws on the happy path.
  */
 export function composeRenderTree(
   view: LayoutView,
-  contentRoot: PanelNode,
+  activeContentRoot: PanelNode,
   contentById?: Record<string, TabContent>
 ): PanelNode {
-  return reconcileNode(view.root, collectTabs(contentRoot), contentById);
+  const group = activeGroupOf(view);
+  if (!group) {
+    throw new Error("layout view has no active group");
+  }
+  return reconcileNode(group.root, collectTabs(activeContentRoot), contentById);
 }
 
 /** Ensure the layout region client is subscribed; the renderer's entry point.
@@ -522,19 +643,37 @@ export async function ensureLayoutRegionClient(): Promise<ProjectionClient> {
 }
 
 /**
- * Seed the layout region with a whole tree so the projection tracks
- * `appStore`'s current structure (the render-side counterpart to the mutation
- * bridge's seed-before-mutate). Idempotent server-side: replacing with the same
- * tree yields no diff.
+ * Seed the layout region with the whole multi-group layout so the projection
+ * tracks `appStore`'s current structure (the render-side counterpart to the
+ * mutation bridge's seed-before-mutate). Installs every group via
+ * `layout.replaceGroups` (#2283 slice C). Idempotent server-side: replacing with
+ * the same layout yields no diff.
  */
-export async function seedLayoutRegion(
-  root: PanelNode,
-  activePanelId: string | null
-): Promise<void> {
+export async function seedLayoutRegion(snapshot: LayoutSnapshot): Promise<void> {
   throwIfRejected(
-    await dispatch("layout.replace", { root: toMinimalNode(root), activePanelId }),
-    "replace"
+    await dispatch("layout.replaceGroups", {
+      groups: snapshot.groups.map(toMinimalGroup),
+      activeGroupId: snapshot.activeGroupId,
+    }),
+    "replaceGroups"
   );
+}
+
+/** Structural equality over two rich {@link LayoutSnapshot}s — used to de-dupe
+ * reseeds (a settled layout is not reseeded on every render). */
+export function layoutSnapshotsEqual(a: LayoutSnapshot, b: LayoutSnapshot): boolean {
+  if ((a.activeGroupId ?? null) !== (b.activeGroupId ?? null)) return false;
+  if (a.groups.length !== b.groups.length) return false;
+  return a.groups.every((g, i) => {
+    const o = b.groups[i];
+    return (
+      g.id === o.id &&
+      g.name === o.name &&
+      (g.color ?? null) === (o.color ?? null) &&
+      (g.activePanelId ?? null) === (o.activePanelId ?? null) &&
+      minimalNodesEqual(toMinimalNode(g.root), toMinimalNode(o.root))
+    );
+  });
 }
 
 /** Log a render-path fallback so the projection-cut recovery is visible. */

--- a/src/store/useLayoutRenderTree.test.tsx
+++ b/src/store/useLayoutRenderTree.test.tsx
@@ -62,8 +62,11 @@ vi.mock("@/services/transport", () => ({
   createTransport: () => ({
     async dispatch(intent: { kind: string; payload: Record<string, unknown> }) {
       dispatched.push({ kind: intent.kind, payload: intent.payload });
-      if (intent.kind === "layout.replace" && backend.applyReplace) {
-        backend.push({ root: intent.payload.root, activePanelId: intent.payload.activePanelId });
+      if (intent.kind === "layout.replaceGroups" && backend.applyReplace) {
+        backend.push({
+          groups: intent.payload.groups,
+          activeGroupId: intent.payload.activeGroupId,
+        });
       }
       return {
         intentId: "intent-test",
@@ -87,10 +90,18 @@ vi.mock("@/services/transport", () => ({
       return () => backend.listeners.delete(listener);
     }
     async start() {
-      // The store seeds an unknown client's region to a single empty leaf.
+      // The store seeds an unknown client's region to a single "Main" group with
+      // one empty leaf (the full multi-group view — #2283 slice C).
       backend.push({
-        root: { type: "leaf", id: "seed", tabs: [], activeTabId: null },
-        activePanelId: "seed",
+        groups: [
+          {
+            id: "seed-group",
+            name: "Main",
+            root: { type: "leaf", id: "seed", tabs: [], activeTabId: null },
+            activePanelId: "seed",
+          },
+        ],
+        activeGroupId: "seed-group",
       });
     }
     stop() {}
@@ -186,7 +197,7 @@ describe("useLayoutRenderTree (#2151 step 3)", () => {
 
     // The initial snapshot was a single empty leaf (not a mirror) → the hook
     // seeded the region with appStore's tree.
-    expect(dispatched.map((d) => d.kind)).toContain("layout.replace");
+    expect(dispatched.map((d) => d.kind)).toContain("layout.replaceGroups");
 
     // Composed from the projection: structurally identical to appStore's tree.
     const store = useAppStore.getState().rootPanel;
@@ -207,8 +218,38 @@ describe("useLayoutRenderTree (#2151 step 3)", () => {
     await mount();
 
     // Seed was attempted, but the region did not advance to a mirror.
-    expect(dispatched.map((d) => d.kind)).toContain("layout.replace");
+    expect(dispatched.map((d) => d.kind)).toContain("layout.replaceGroups");
     // Renderer fell back to appStore's tree rather than showing the stale leaf.
     expect(latest).toBe(useAppStore.getState().rootPanel);
+  });
+
+  it("multi-group: seeds every group and composes the active one (#2283)", async () => {
+    // Two groups: the active one holds seedTree(), a second holds a single leaf.
+    const secondRoot: PanelNode = {
+      type: "leaf",
+      id: "z",
+      tabs: [tab("t9")],
+      activeTabId: "t9",
+    };
+    const groups = useAppStore.getState().tabGroups;
+    const activeId = useAppStore.getState().activeTabGroupId;
+    useAppStore.setState({
+      tabGroups: [
+        { ...groups[0] },
+        { id: "group-2", name: "Second", rootPanel: secondRoot, activePanelId: "z" },
+      ],
+      activeTabGroupId: activeId,
+    });
+    setLayoutRenderFromProjectionEnabled(true);
+    await mount();
+
+    // The seed installs BOTH groups via replaceGroups.
+    const seed = dispatched.find((d) => d.kind === "layout.replaceGroups");
+    expect(seed).toBeDefined();
+    expect((seed!.payload.groups as unknown[]).length).toBe(2);
+
+    // The renderer composes the ACTIVE group's tree (seedTree), not the second.
+    expect(latest).not.toBeNull();
+    expect(toMinimalNode(latest!)).toEqual(toMinimalNode(useAppStore.getState().rootPanel));
   });
 });

--- a/src/store/useLayoutRenderTree.ts
+++ b/src/store/useLayoutRenderTree.ts
@@ -35,15 +35,15 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useAppStore } from "@/store/appStore";
 import {
+  buildLayoutSnapshot,
   composeRenderTree,
   ensureLayoutRegionClient,
+  type LayoutSnapshot,
   type LayoutView,
   layoutRenderFromProjectionEnabled,
+  layoutSnapshotsEqual,
   logRenderFallback,
-  type MinimalNode,
-  minimalNodesEqual,
   seedLayoutRegion,
-  toMinimalNode,
   viewMatchesTree,
 } from "@/store/layoutBridge";
 import type { ProjectionCacheState, ProjectionClient } from "@/services/transport";
@@ -58,6 +58,12 @@ import type { PanelNode } from "@/types/terminal";
 export function useLayoutRenderTree(): PanelNode {
   const storeRoot = useAppStore((s) => s.rootPanel);
   const storeActivePanelId = useAppStore((s) => s.activePanelId);
+  // The full group model: `tabGroups` + the active group id, with the active
+  // group's live tree carried at top-level `rootPanel`/`activePanelId` (#2283
+  // slice C). The region mirrors all groups; the renderer composes the active
+  // one.
+  const tabGroups = useAppStore((s) => s.tabGroups);
+  const activeTabGroupId = useAppStore((s) => s.activeTabGroupId);
   // The authoritative by-id tab-content map (part of #2283). Render composition
   // sources each tab's content from here, falling back to the in-tree tab for
   // any id the map does not yet hold (editor/settings/etc.). Behaviour-preserving
@@ -70,7 +76,14 @@ export function useLayoutRenderTree(): PanelNode {
 
   const [regionState, setRegionState] = useState<ProjectionCacheState | null>(null);
   const clientRef = useRef<ProjectionClient | null>(null);
-  const lastSeeded = useRef<{ root: MinimalNode; activePanelId: string | null } | null>(null);
+  const lastSeeded = useRef<LayoutSnapshot | null>(null);
+
+  // The rich multi-group snapshot appStore is authoritative for — the seed
+  // payload and the faithful-mirror gate's reference.
+  const snapshot = useMemo<LayoutSnapshot>(
+    () => buildLayoutSnapshot(tabGroups, activeTabGroupId, storeRoot, storeActivePanelId),
+    [tabGroups, activeTabGroupId, storeRoot, storeActivePanelId]
+  );
 
   // Subscribe to the layout region while enabled; a transport that cannot
   // subscribe (non-Tauri without a socket) just leaves the renderer on the
@@ -95,32 +108,27 @@ export function useLayoutRenderTree(): PanelNode {
   }, [enabled]);
 
   const view = regionState?.view as LayoutView | undefined;
-  const matches = enabled && viewMatchesTree(view, storeRoot, storeActivePanelId);
+  const matches = enabled && viewMatchesTree(view, snapshot);
 
-  // Keep the region a faithful mirror of appStore's structure. When the view is
-  // not a mirror (initial single-leaf snapshot, or a local non-intent edit),
-  // seed it with the current tree so composing can resume. De-duped so a settled
-  // tree is not reseeded on every render.
+  // Keep the region a faithful mirror of appStore's multi-group structure. When
+  // the view is not a mirror (initial single-leaf snapshot, or a local non-intent
+  // edit — including a group add/close/rename/color/reorder), seed the whole
+  // layout so composing can resume. De-duped so a settled layout is not reseeded
+  // on every render.
   useEffect(() => {
     if (!enabled || !clientRef.current || matches) return;
-    const minimal = toMinimalNode(storeRoot);
     const prev = lastSeeded.current;
-    if (
-      prev &&
-      prev.activePanelId === storeActivePanelId &&
-      minimalNodesEqual(prev.root, minimal)
-    ) {
-      return;
-    }
-    lastSeeded.current = { root: minimal, activePanelId: storeActivePanelId };
-    seedLayoutRegion(storeRoot, storeActivePanelId).catch((err) => logRenderFallback(err));
+    if (prev && layoutSnapshotsEqual(prev, snapshot)) return;
+    lastSeeded.current = snapshot;
+    seedLayoutRegion(snapshot).catch((err) => logRenderFallback(err));
     // `regionState` is a dep so the seed re-evaluates once the region snapshot
     // first arrives (which sets `clientRef` but may leave `matches` false).
-  }, [enabled, matches, storeRoot, storeActivePanelId, regionState]);
+  }, [enabled, matches, snapshot, regionState]);
 
   return useMemo(() => {
     if (matches && view) {
       try {
+        // Content fallback comes from the active group's rich tree (`storeRoot`).
         return composeRenderTree(view, storeRoot, tabContent);
       } catch (err) {
         // A tab referenced by the view but absent from appStore — treat as a


### PR DESCRIPTION
Slice C of the layout data-flow inversion (`#2283`). Makes the frontend
**group-aware**: it renders all tab groups from the widened multi-group region
view, still seed-based (no fold/removal yet). **Behavior-preserving.**

Builds on slice A (backend `snapshot_full()` + group transforms) and slice B
(`tabContent` by-id map).

## What changed

**Backend — widen the region (`snapshot_full`)**
- `publish_layout` now publishes the full multi-group view `{ groups,
  activeGroupId }` instead of the back-compat active-group `{ root,
  activePanelId }`, so the frontend can render every group. `snapshot()` is
  retained as a documented back-compat / rollback accessor (still unit-tested).
- `projection_tests` assert the full-view contract (seed + convergence read
  `snapshot_full`; add/rename-group now move the region as metadata rides the
  widened view).

**Frontend — render the active group from the region (part a)**
- `LayoutView` becomes the multi-group shape; new `GroupSnapshot`/`LayoutSnapshot`
  + `buildLayoutSnapshot` / `toMinimalGroup` / `activeGroupOf` /
  `layoutSnapshotsEqual`.
- `viewMatchesTree` is widened to a multi-group faithful-mirror gate: **every**
  group must match in order (id, metadata, focused panel, tree) and the active
  group id must agree — so a local group add/close/rename/color/reorder reseeds.
- `composeRenderTree` composes the active group's tree; tab/panel ids are
  preserved so xterm reparents, never remounts.
- Seed-before-mutate installs the whole layout via `layout.replaceGroups`
  (render-side seed + `runLayoutIntent`), which reads the active group back out.
- Group reducers stay local + seed (no fold yet).

**Frontend — comprehensiveness prep (part b)**
- Bring the remaining tab creators into `tabContent` (settings, log-viewer,
  network-diagnostic, editor, scratch-editor, connection-editor,
  agent-definition-editor, tunnel-editor, workspace-editor, plugin-detail),
  plus the two content-mutating reuse sites (editor `editorMeta` refresh,
  plugin single-tab re-point). Every rendered tab now resolves content from the
  map; the in-tree fallback becomes belt-and-suspenders.
- `agent-error` tabs are deliberately left on the in-tree fallback (tangled
  in-place conversion to a terminal tab) — follow-up `#2539`.

## Parity & tests
- The active group's composed tree is byte-identical to the prior single-group
  render.
- Multi-group mirror-gate tests; group-switch compose keeps tab/panel ids;
  comprehensive open→(mutate)→close map parity for every newly-instrumented
  type + plugin reuse re-point.
- Full frontend suite green (4988), backend `layout::` tests green (74),
  `tsc` / prettier / eslint / cargo fmt clean.

## Not in scope (later slices)
- No `rootPanel`/reducer/flag removal; no `dispatchOptimistic` switch (slice D).

Part of `#2283`. Follow-up: `#2539` (agent-error tab-content tracking).