### PR TITLE
refactor(ui): optimistic-fold overlay for layout mutations (Part of #2283, Closes #2539)

### DIFF
--- a/src-tauri/src/layout/projection.rs
+++ b/src-tauri/src/layout/projection.rs
@@ -39,6 +39,7 @@
 //! | `layout.removePanel`        | `{ groupId?, panelId }`                        | drop a whole leaf panel, then simplify         |
 //! | `layout.reorderTabs`        | `{ groupId?, panelId, oldIndex, newIndex }`    | reorder a tab within its leaf                   |
 //! | `layout.setActivePanel`     | `{ groupId?, panelId }`                        | repoint the focused panel                       |
+//! | `layout.setActiveTab`       | `{ groupId?, tabId }`                          | focus a tab within its leaf                     |
 //! | `layout.resize`             | `{ groupId?, splitId, sizes }`                 | persist a split's child percentage sizes        |
 //! | `layout.replace`            | `{ root, activePanelId }`                      | install a tree over the active group (seed path)|
 //! | `layout.addGroup`           | `{ name? }`                                    | append a fresh group, make it active            |
@@ -207,6 +208,17 @@ pub fn register_layout_intents(registry: &mut HandlerRegistry, app_handle: AppHa
         let panel_id = required_str(intent, "panelId")?;
         store
             .set_active_panel(&intent.client_id, group.as_deref(), &panel_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &store, &intent.client_id))
+    });
+
+    let handle = app_handle.clone();
+    registry.route("layout.setActiveTab", move |intent, projector| {
+        let store = store_of(&handle)?;
+        let group = optional_str(intent, "groupId");
+        let tab_id = required_str(intent, "tabId")?;
+        store
+            .set_active_tab(&intent.client_id, group.as_deref(), &tab_id)
             .map_err(to_ack_err)?;
         Ok(publish_layout(projector, &store, &intent.client_id))
     });

--- a/src-tauri/src/layout/projection_tests.rs
+++ b/src-tauri/src/layout/projection_tests.rs
@@ -165,6 +165,15 @@ fn registry_for(store: Arc<LayoutStore>) -> HandlerRegistry {
     });
 
     let s = store.clone();
+    registry.route("layout.setActiveTab", move |intent, projector| {
+        let group = optional_str(intent, "groupId");
+        let tab_id = required_str(intent, "tabId")?;
+        s.set_active_tab(&intent.client_id, group.as_deref(), &tab_id)
+            .map_err(to_ack_err)?;
+        Ok(publish_layout(projector, &s, &intent.client_id))
+    });
+
+    let s = store.clone();
     registry.route("layout.resize", move |intent, projector| {
         let group = optional_str(intent, "groupId");
         let split_id = required_str(intent, "splitId")?;
@@ -850,6 +859,60 @@ fn close_group_route_rejects_the_last_group() {
     ));
     assert_eq!(ack.status, IntentStatus::Rejected);
     assert_eq!(ack.error.unwrap().code, "last_group");
+    assert_eq!(sink.diffs().len(), 0);
+    assert_eq!(projector.region_version(&region), Some(0));
+}
+
+#[test]
+fn set_active_tab_route_focuses_a_tab_and_converges() {
+    let store = seeded_store("A");
+    let (dispatcher, _region, sink, mut cache) = harness_for(store.clone());
+
+    // Activate t3 — it lives in panel b, so focus should repoint to b.
+    let ack = dispatcher.dispatch(intent("layout.setActiveTab", "A", json!({ "tabId": "t3" })));
+    assert_eq!(ack.status, IntentStatus::Accepted);
+
+    for diff in &sink.diffs() {
+        cache.apply(diff);
+    }
+    assert_eq!(
+        cache.view,
+        store.snapshot_full("A"),
+        "cache converges on authority"
+    );
+
+    let full = store.snapshot_full("A");
+    let root: PanelNode = serde_json::from_value(full["groups"][0]["root"].clone()).unwrap();
+    let b = termihub_core::layout::panel_tree::find_leaf(&root, "b").unwrap();
+    assert_eq!(
+        b.active_tab_id.as_deref(),
+        Some("t3"),
+        "tab focused via route"
+    );
+    assert_eq!(
+        full["groups"][0]["activePanelId"],
+        json!("b"),
+        "active panel repointed via route"
+    );
+}
+
+#[test]
+fn set_active_tab_route_rejects_an_unknown_tab() {
+    let store = seeded_store("A");
+    let region = layout_region("A");
+    let projector = Arc::new(Projector::new());
+    projector.register_region(&region, store.snapshot_full("A"));
+    let dispatcher = Dispatcher::new(projector.clone(), Arc::new(registry_for(store.clone())));
+    let sink = Arc::new(VecSink::new());
+    projector.subscribe(&region, "sub", "A", sink.clone());
+
+    let ack = dispatcher.dispatch(intent(
+        "layout.setActiveTab",
+        "A",
+        json!({ "tabId": "ghost" }),
+    ));
+    assert_eq!(ack.status, IntentStatus::Rejected);
+    assert_eq!(ack.error.unwrap().code, "tab_not_found");
     assert_eq!(sink.diffs().len(), 0);
     assert_eq!(projector.region_version(&region), Some(0));
 }

--- a/src-tauri/src/layout/store.rs
+++ b/src-tauri/src/layout/store.rs
@@ -460,6 +460,35 @@ impl LayoutStore {
         Ok(())
     }
 
+    /// `layout.setActiveTab` — focus a tab within its leaf. Finds the leaf holding
+    /// `tab_id` in the target group, sets that leaf's `active_tab_id` to `tab_id`,
+    /// and repoints the group's `active_panel_id` at that leaf. Rejects an unknown
+    /// tab. Mirrors the frontend `setActiveTab` reducer (and the "activate existing
+    /// tab" branch of every tab-opener).
+    pub fn set_active_tab(
+        &self,
+        client_id: &str,
+        group_id: Option<&str>,
+        tab_id: &str,
+    ) -> Result<(), LayoutError> {
+        let mut clients = self.lock();
+        let group = clients
+            .entry(client_id.to_string())
+            .or_insert_with(ClientLayout::seeded)
+            .group_mut(group_id)?;
+        let leaf_id = find_leaf_by_tab(&group.root, tab_id)
+            .ok_or_else(|| LayoutError::TabNotFound(tab_id.to_string()))?
+            .id
+            .clone();
+        group.root = update_leaf(&group.root, &leaf_id, |leaf| LeafPanel {
+            id: leaf.id.clone(),
+            tabs: leaf.tabs.clone(),
+            active_tab_id: Some(tab_id.to_string()),
+        });
+        group.active_panel_id = Some(leaf_id);
+        Ok(())
+    }
+
     /// `layout.resize` — persist the child percentage `sizes` of the split
     /// container `split_id` (normalized to sum to 100). Rejects a size array whose
     /// length does not match the split's child count.

--- a/src-tauri/src/layout/store_tests.rs
+++ b/src-tauri/src/layout/store_tests.rs
@@ -447,6 +447,86 @@ fn set_active_panel_of_unknown_panel_is_rejected() {
     );
 }
 
+// ── setActiveTab ─────────────────────────────────────────────────────────────
+
+#[test]
+fn set_active_tab_focuses_the_tab_and_its_leaf() {
+    let store = LayoutStore::new();
+    // Single leaf `a` = [t1(active), t2, t3]. Activate t3.
+    let root = PanelNode::Leaf(LeafPanel {
+        id: "a".to_string(),
+        tabs: vec![tab("t1"), tab("t2"), tab("t3")],
+        active_tab_id: Some("t1".to_string()),
+    });
+    store.seed_for_test("C", root, Some("a".to_string()));
+    store.set_active_tab("C", None, "t3").unwrap();
+
+    let root = root_of(&store, "C");
+    let a = find_leaf(&root, "a").unwrap();
+    assert_eq!(a.active_tab_id.as_deref(), Some("t3"), "tab focused");
+    assert_eq!(
+        active_of(&store, "C").as_deref(),
+        Some("a"),
+        "panel focused"
+    );
+}
+
+#[test]
+fn set_active_tab_in_a_non_active_leaf_repoints_active_panel() {
+    let store = LayoutStore::new();
+    // two_panel_tree: a=[t1,t2], b=[t3]; focus starts on a. Activating t3 (in b)
+    // repoints the active panel onto b.
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    store.set_active_tab("C", None, "t3").unwrap();
+
+    assert_eq!(
+        active_of(&store, "C").as_deref(),
+        Some("b"),
+        "active panel repointed to the leaf holding the tab"
+    );
+    let root = root_of(&store, "C");
+    let b = find_leaf(&root, "b").unwrap();
+    assert_eq!(b.active_tab_id.as_deref(), Some("t3"));
+    // The other leaf is untouched.
+    let a = find_leaf(&root, "a").unwrap();
+    assert_eq!(
+        a.active_tab_id.as_deref(),
+        Some("t1"),
+        "a's active tab kept"
+    );
+}
+
+#[test]
+fn set_active_tab_of_unknown_tab_is_rejected() {
+    let store = LayoutStore::new();
+    store.seed_for_test("C", two_panel_tree(), Some("a".to_string()));
+    let err = store.set_active_tab("C", None, "ghost").unwrap_err();
+    assert_eq!(err, LayoutError::TabNotFound("ghost".to_string()));
+    assert_eq!(err.code(), "tab_not_found");
+}
+
+#[test]
+fn set_active_tab_targets_a_named_group() {
+    let store = LayoutStore::new();
+    store.seed_groups_for_test("C", two_group_client());
+    // g2 holds leaf z = [t9]; activate t9 in the inactive group g2.
+    store.set_active_tab("C", Some("g2"), "t9").unwrap();
+
+    let root_g2 = group_root(&store, "C", "g2");
+    let z = find_leaf(&root_g2, "z").unwrap();
+    assert_eq!(z.active_tab_id.as_deref(), Some("t9"));
+    // g2's active panel repointed onto z; the active group itself is unchanged.
+    let full = full_of(&store, "C");
+    assert_eq!(full["activeGroupId"], json!("g1"), "active group unchanged");
+    let g2 = full["groups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|g| g["id"] == json!("g2"))
+        .unwrap();
+    assert_eq!(g2["activePanelId"], json!("z"));
+}
+
 // ── resize ───────────────────────────────────────────────────────────────────
 
 #[test]

--- a/src/store/appStore.agentErrorTabContent.test.ts
+++ b/src/store/appStore.agentErrorTabContent.test.ts
@@ -1,0 +1,152 @@
+/**
+ * agent-error tabs in the by-id `tabContent` map (#2539, folded into #2283 slice
+ * D').
+ *
+ * Slice C brought every tab type into `appStore.tabContent` **except**
+ * `agent-error` — those still rendered via the in-tree fallback. #2539 closes that
+ * gap: agent-error tabs are tracked in the map at their creation site (workspace
+ * restore) and every content mutation is instrumented — most notably the in-place
+ * `agent-error → terminal` conversion after reconnect — so a tracked entry is
+ * never stale. This pins that: the map holds a content-identical entry for an
+ * agent-error tab, the conversion updates it in sync with the tree, and close
+ * prunes it, with render parity throughout.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/services/storage", () => ({
+  loadConnections: vi.fn(() =>
+    Promise.resolve({ connections: [], folders: [], agents: [], externalErrors: [] })
+  ),
+  getSettings: vi.fn(() =>
+    Promise.resolve({ version: "1", externalConnectionFiles: [], powerMonitoringEnabled: true })
+  ),
+  saveSettings: vi.fn(() => Promise.resolve()),
+  getRecoveryWarnings: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn(() => vi.fn()) }));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
+  return { ...actual, toast: { loading: vi.fn(), success: vi.fn(), error: vi.fn() } };
+});
+
+import type { ConnectionConfig, PanelNode, TerminalTab } from "@/types/terminal";
+import { getAllLeaves } from "@/utils/panelTree";
+import { composeRenderTree, toMinimalNode, type LayoutView } from "./layoutBridge";
+import { extractTabContent, useAppStore } from "./appStore";
+import { __emitAgentsViewForTest, EMPTY_AGENTS_VIEW } from "./agentsBridge";
+
+function agentErrorTab(id: string): TerminalTab {
+  return {
+    id,
+    sessionId: null,
+    title: "Def (error)",
+    connectionType: "remote-session",
+    contentType: "agent-error",
+    config: {} as ConnectionConfig,
+    panelId: "a",
+    isActive: true,
+    agentErrorMeta: {
+      agentId: "ag1",
+      agentName: "Agent 1",
+      definitionId: "def1",
+      definitionName: "Def",
+      error: "agent offline",
+      initialCommand: "echo hi",
+    },
+  } as TerminalTab;
+}
+
+/** Install a single-group layout holding one agent-error tab, with the map
+ * populated exactly as workspace restore now does (#2539). */
+function seedAgentErrorLayout(): void {
+  const tab = agentErrorTab("ae1");
+  const root: PanelNode = { type: "leaf", id: "a", tabs: [tab], activeTabId: "ae1" };
+  useAppStore.setState(useAppStore.getInitialState());
+  useAppStore.setState({
+    rootPanel: root,
+    activePanelId: "a",
+    tabGroups: [{ id: "g1", name: "Main", rootPanel: root, activePanelId: "a" }],
+    activeTabGroupId: "g1",
+    tabContent: { ae1: extractTabContent(tab) },
+  });
+}
+
+function currentView(): LayoutView {
+  const { rootPanel, activePanelId } = useAppStore.getState();
+  return {
+    groups: [{ id: "g1", name: "Main", root: toMinimalNode(rootPanel), activePanelId }],
+    activeGroupId: "g1",
+  };
+}
+
+describe("appStore — agent-error tabs tracked in tabContent (#2539)", () => {
+  beforeEach(() => {
+    __emitAgentsViewForTest(EMPTY_AGENTS_VIEW, 0);
+  });
+
+  it("an agent-error tab resolves its content from the map (comprehensive)", () => {
+    seedAgentErrorLayout();
+    const { rootPanel, tabContent } = useAppStore.getState();
+    const tab = getAllLeaves(rootPanel)[0].tabs[0];
+    // The map holds a content-identical entry, carrying the agentErrorMeta.
+    expect(tabContent["ae1"]).toEqual(extractTabContent(tab));
+    expect(tabContent["ae1"].contentType).toBe("agent-error");
+    expect(
+      (tabContent["ae1"] as { agentErrorMeta?: { agentId: string } }).agentErrorMeta?.agentId
+    ).toBe("ag1");
+    // Render parity: composing from the map is byte-identical to the in-tree
+    // fallback and to the authoritative tree — so the fallback is redundant.
+    const view = currentView();
+    expect(composeRenderTree(view, rootPanel, tabContent)).toEqual(
+      composeRenderTree(view, rootPanel)
+    );
+    expect(composeRenderTree(view, rootPanel, tabContent)).toEqual(rootPanel);
+  });
+
+  it("the agent-error → terminal conversion updates the map in sync with the tree", () => {
+    seedAgentErrorLayout();
+    // Seed the agent definition so the error tab resolves to a live terminal.
+    __emitAgentsViewForTest(
+      {
+        ...EMPTY_AGENTS_VIEW,
+        agentDefinitions: {
+          ag1: [
+            {
+              id: "def1",
+              name: "Def",
+              sessionType: "local",
+              config: { shell: "zsh" },
+              persistent: false,
+              folderId: null,
+            },
+          ],
+        },
+      },
+      1
+    );
+
+    useAppStore.getState().resolveAgentErrorTabs("ag1");
+
+    const { rootPanel, tabContent } = useAppStore.getState();
+    const tab = getAllLeaves(rootPanel)[0].tabs[0];
+    // Tree converted in place (same tab id — no remount).
+    expect(tab.id).toBe("ae1");
+    expect(tab.contentType).toBe("terminal");
+    expect(tab.agentErrorMeta).toBeUndefined();
+    // The map followed the conversion (the #2539 instrumentation) — no stale entry.
+    expect(tabContent["ae1"]).toEqual(extractTabContent(tab));
+    expect(tabContent["ae1"].contentType).toBe("terminal");
+    // Render parity holds after the conversion.
+    const view = currentView();
+    expect(composeRenderTree(view, rootPanel, tabContent)).toEqual(rootPanel);
+  });
+
+  it("closing an agent-error tab prunes its map entry", () => {
+    seedAgentErrorLayout();
+    expect(useAppStore.getState().tabContent["ae1"]).toBeDefined();
+    useAppStore.getState().closeTab("ae1", "a");
+    expect(useAppStore.getState().tabContent["ae1"]).toBeUndefined();
+  });
+});

--- a/src/store/appStore.layoutBridge.test.ts
+++ b/src/store/appStore.layoutBridge.test.ts
@@ -1,71 +1,27 @@
 /**
- * appStore ↔ layout projection bridge wiring (#2151 step 2).
+ * appStore ↔ layout projection bridge wiring (#2283 slice D' — the un-gated
+ * optimistic-fold overlay).
  *
- * Drives the `splitPanel` mutation through a simulated backend (a fake transport
- * that applies the `layout.*` intent with the same panel-tree algebra the Rust
- * store uses, then pushes the diff to the region client) and asserts the
- * reconciled tree lands in `appStore.rootPanel` with the rich tabs preserved.
- * Also pins the strangler guarantees: flag-off keeps the local reducer, and a
- * rejected intent falls back to it.
+ * Drives the layout reducers through the **real**
+ * {@link import("./layoutBridge").mirrorLayoutIntent} path against an in-memory
+ * backend double ({@link FakeLayoutTransport}) that folds the granular `layout.*`
+ * intents like the Rust store. It pins the slice's contract:
+ *
+ * - the local reducer stays authoritative and **synchronous** — `appStore.rootPanel`
+ *   updates at once (the timing win: no seed→await→reconcile round-trip);
+ * - the same transition is mirrored into the region **synchronously** via an
+ *   optimistic overlay, then reconciled when the backend's diff lands;
+ * - a rejected dispatch rolls the overlay back while `appStore` keeps the local
+ *   result — the retained instant-revert fallback (#2283 removal stays gated);
+ * - tab **ids are preserved** across split / move / group-switch / tab-activation,
+ *   so the live xterm DOM (keyed by tab id) is never remounted.
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { flushMacrotask } from "@/test/flushAsync";
 
-import type { LeafPanel, PanelNode } from "@/types/terminal";
-import {
-  createLeafPanel,
-  edgeToSplit,
-  findLeaf,
-  findLeafByTab,
-  generatePanelId,
-  getAllLeaves,
-  normalizeSizes,
-  removeLeaf,
-  simplifyTree,
-  splitLeaf,
-  updateLeaf,
-} from "@/utils/panelTree";
-
-interface RegionState {
-  version: number;
-  view: unknown;
-}
-
-/** One group in the simulated full multi-group region view (#2283 slice C). */
-interface MinimalGroupView {
-  id: string;
-  name: string;
-  color?: string;
-  root: PanelNode;
-  activePanelId: string | null;
-}
-/** The full region view the simulated backend publishes. */
-interface FullView {
-  groups: MinimalGroupView[];
-  activeGroupId: string;
-}
-
-const { backend, dispatched } = vi.hoisted(() => ({
-  backend: {
-    version: -1,
-    view: undefined as unknown,
-    listeners: new Set<(s: RegionState) => void>(),
-    reject: false,
-    push(view: unknown) {
-      this.version += 1;
-      this.view = view;
-      const snapshot = { version: this.version, view: this.view };
-      this.listeners.forEach((l) => l(snapshot));
-    },
-    reset() {
-      this.version = -1;
-      this.view = undefined;
-      this.listeners.clear();
-      this.reject = false;
-    },
-  },
-  dispatched: [] as { kind: string; payload: Record<string, unknown> }[],
-}));
+import type { PanelNode, TerminalTab } from "@/types/terminal";
+import { findLeaf, getAllLeaves } from "@/utils/panelTree";
+import { FakeLayoutTransport, installLayoutHarness } from "@/test/layoutRegionTestHarness";
 
 vi.mock("@/services/storage", () => ({
   loadConnections: vi.fn(() =>
@@ -80,164 +36,17 @@ vi.mock("@/services/storage", () => ({
 
 vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn(() => vi.fn()) }));
 
-vi.mock("@/services/transport", () => ({
-  newClientId: () => "client-test",
-  newIntentId: () => "intent-test",
-  createTransport: () => ({
-    async dispatch(intent: { kind: string; payload: Record<string, unknown> }) {
-      dispatched.push({ kind: intent.kind, payload: intent.payload });
-      if (backend.reject) {
-        return {
-          intentId: "intent-test",
-          status: "rejected",
-          error: { code: "x", message: "nope" },
-        };
-      }
-      // The region carries the full multi-group view `{ groups, activeGroupId }`
-      // (#2283 slice C). Structural intents operate on the ACTIVE group; these
-      // helpers read/write the active group's tree while keeping the others.
-      const active = (): MinimalGroupView => {
-        const v = backend.view as FullView;
-        return v.groups.find((g) => g.id === v.activeGroupId) ?? v.groups[0];
-      };
-      const pushActive = (root: PanelNode, activePanelId: string | null): void => {
-        const v = backend.view as FullView;
-        const activeId = active().id;
-        const groups = v.groups.map((g) => (g.id === activeId ? { ...g, root, activePanelId } : g));
-        backend.push({ groups, activeGroupId: v.activeGroupId });
-      };
-
-      if (intent.kind === "layout.replaceGroups") {
-        backend.push({
-          groups: intent.payload.groups as MinimalGroupView[],
-          activeGroupId: intent.payload.activeGroupId as string,
-        });
-      } else if (intent.kind === "layout.split") {
-        const g = active();
-        const newLeaf = createLeafPanel();
-        let root = splitLeaf(
-          g.root,
-          intent.payload.panelId as string,
-          newLeaf,
-          intent.payload.direction as "horizontal" | "vertical",
-          intent.payload.position as "before" | "after"
-        );
-        root = simplifyTree(root);
-        pushActive(root, newLeaf.id);
-      } else if (intent.kind === "layout.moveTab") {
-        // Mirrors the Rust store's move_tab: detach (positional active fallback),
-        // place (center = append / edge = split), prune emptied source, simplify.
-        // It does NOT repoint the active panel — the frontend bridge does.
-        const g = active();
-        const tabId = intent.payload.tabId as string;
-        const target = intent.payload.targetPanelId as string;
-        const src = findLeafByTab(g.root, tabId)!;
-        const theTab = src.tabs.find((t) => t.id === tabId)!;
-        let root = updateLeaf(g.root, src.id, (leaf) => removeTabMinimal(leaf, tabId));
-        const splitInfo = edgeToSplit(intent.payload.edge as never);
-        if (!splitInfo) {
-          root = updateLeaf(root, target, (leaf) => ({
-            ...leaf,
-            tabs: [...leaf.tabs, { ...theTab }],
-            activeTabId: tabId,
-          }));
-        } else {
-          const newLeaf: LeafPanel = {
-            type: "leaf",
-            id: generatePanelId(),
-            tabs: [{ ...theTab }],
-            activeTabId: tabId,
-          };
-          root = splitLeaf(root, target, newLeaf, splitInfo.direction, splitInfo.position);
-        }
-        const src2 = findLeaf(root, src.id);
-        if (src2 && src2.tabs.length === 0) {
-          const removed = removeLeaf(root, src.id);
-          root = removed ?? root;
-        }
-        root = simplifyTree(root);
-        pushActive(root, g.activePanelId);
-      } else if (intent.kind === "layout.removePanel") {
-        // Mirrors the Rust store's remove_panel: drop the whole leaf, simplify,
-        // repoint focus onto the first survivor when the removed panel held it.
-        const g = active();
-        const panelId = intent.payload.panelId as string;
-        const removed = removeLeaf(g.root, panelId);
-        const root = removed ? simplifyTree(removed) : g.root;
-        let focus = g.activePanelId;
-        if (!focus || !findLeaf(root, focus)) {
-          focus = getAllLeaves(root)[0]?.id ?? null;
-        }
-        pushActive(root, focus);
-      } else if (intent.kind === "layout.reorderTabs") {
-        // Mirrors the Rust store's reorder_tabs: move a tab within its leaf,
-        // leaving focus untouched.
-        const g = active();
-        const panelId = intent.payload.panelId as string;
-        const oldIndex = intent.payload.oldIndex as number;
-        const newIndex = intent.payload.newIndex as number;
-        const root = updateLeaf(g.root, panelId, (leaf) => {
-          const tabs = [...leaf.tabs];
-          const [moved] = tabs.splice(oldIndex, 1);
-          tabs.splice(newIndex, 0, moved);
-          return { ...leaf, tabs };
-        });
-        pushActive(root, g.activePanelId);
-      } else if (intent.kind === "layout.setActivePanel") {
-        // Mirrors the Rust store's set_active_panel: repoint focus, tree unchanged.
-        const g = active();
-        pushActive(g.root, intent.payload.panelId as string);
-      } else if (intent.kind === "layout.resize") {
-        // Mirrors the Rust store's resize: set the split's normalized sizes.
-        const g = active();
-        const splitId = intent.payload.splitId as string;
-        const sizes = normalizeSizes(intent.payload.sizes as number[]);
-        const setSizes = (n: PanelNode): PanelNode => {
-          if (n.type === "leaf") return n;
-          const children = n.children.map(setSizes);
-          return n.id === splitId ? { ...n, children, sizes } : { ...n, children };
-        };
-        pushActive(setSizes(g.root), g.activePanelId);
-      }
-      return {
-        intentId: "intent-test",
-        status: "accepted",
-        produced: [{ region: "layout@client-test", version: backend.version }],
-      };
-    },
-    subscribe: vi.fn(),
-    resync: vi.fn(),
-  }),
-  ProjectionClient: class {
-    constructor(
-      _transport: unknown,
-      public readonly region: string
-    ) {}
-    get state(): RegionState {
-      return { version: backend.version, view: backend.view };
-    }
-    onChange(listener: (s: RegionState) => void) {
-      backend.listeners.add(listener);
-      return () => backend.listeners.delete(listener);
-    }
-    async start() {
-      backend.push({
-        groups: [{ id: "seed-group", name: "Main", root: createLeafPanel(), activePanelId: null }],
-        activeGroupId: "seed-group",
-      });
-    }
-    stop() {}
-  },
-}));
-
 vi.mock("@/components/ui", async () => {
   const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
   return { ...actual, toast: { loading: vi.fn(), success: vi.fn(), error: vi.fn() } };
 });
 
 import { useAppStore } from "./appStore";
-import { setLayoutIntentsEnabled } from "./layoutBridge";
-import type { TerminalTab } from "@/types/terminal";
+import {
+  currentLayoutView,
+  ensureLayoutRegionClient,
+  setLayoutIntentsEnabled,
+} from "./layoutBridge";
 
 function tab(id: string): TerminalTab {
   return {
@@ -252,33 +61,6 @@ function tab(id: string): TerminalTab {
   } as TerminalTab;
 }
 
-/** Minimal-view tab removal with the positional active fallback (Rust parity). */
-function removeTabMinimal(leaf: LeafPanel, tabId: string): LeafPanel {
-  const idx = leaf.tabs.findIndex((t) => t.id === tabId);
-  if (idx === -1) return leaf;
-  const tabs = leaf.tabs.filter((t) => t.id !== tabId);
-  let activeTabId = leaf.activeTabId;
-  if (activeTabId === tabId) {
-    activeTabId = tabs.length ? tabs[Math.min(idx, tabs.length - 1)].id : null;
-  }
-  return { ...leaf, tabs, activeTabId };
-}
-
-/**
- * A structural fingerprint of a tree, ignoring panel ids (which legitimately
- * differ between the local reducer and the store) but keeping tab id order and
- * per-leaf active tab — so two trees compare equal iff they place the same tabs
- * the same way. `activeTabs` records the tab ids of the focused panel.
- */
-function normalize(root: PanelNode, activePanelId: string | null): unknown {
-  const shape = (n: PanelNode): unknown =>
-    n.type === "leaf"
-      ? { leaf: n.tabs.map((t) => t.id), active: n.activeTabId }
-      : { split: n.direction, children: n.children.map(shape) };
-  const activeLeaf = activePanelId ? findLeaf(root, activePanelId) : null;
-  return { tree: shape(root), activeTabs: activeLeaf?.tabs.map((t) => t.id) ?? null };
-}
-
 function seedTree(): PanelNode {
   return {
     type: "split",
@@ -291,225 +73,244 @@ function seedTree(): PanelNode {
   };
 }
 
-async function flush() {
-  // Let the fire-and-forget bridge promise chain settle.
+/** Every tab id present anywhere in a tree, in leaf/order (id-preservation checks). */
+function tabIds(root: PanelNode): string[] {
+  return getAllLeaves(root).flatMap((l) => l.tabs.map((t) => t.id));
+}
+
+/**
+ * The active group's tree in a projected region view. Accepts both the client's
+ * effective {@link currentLayoutView} (minimal tabs) and the fake backend's
+ * {@link FakeLayoutTransport.regionView} (rich `PanelNode`) — both are read only
+ * for structure (`getAllLeaves` + tab ids), so a loose shape suffices.
+ */
+function regionActiveRoot(
+  view: { groups: { id: string; root: unknown }[]; activeGroupId: string } | undefined
+): PanelNode | undefined {
+  if (!view) return undefined;
+  const g = view.groups.find((x) => x.id === view.activeGroupId) ?? view.groups[0];
+  return g?.root as PanelNode | undefined;
+}
+
+async function flush(): Promise<void> {
   await flushMacrotask();
   await flushMacrotask();
 }
 
-describe("appStore layout bridge — splitPanel cut (#2151)", () => {
-  beforeEach(() => {
-    useAppStore.setState(useAppStore.getInitialState());
-    useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
-    backend.reset();
-    dispatched.length = 0;
-    setLayoutIntentsEnabled(null);
-  });
+let transport: FakeLayoutTransport;
+let teardown: () => void;
 
+async function resetStore(root: PanelNode = seedTree(), activePanelId = "a"): Promise<void> {
+  useAppStore.setState(useAppStore.getInitialState());
+  useAppStore.setState({ rootPanel: root, activePanelId });
+}
+
+beforeEach(async () => {
+  ({ transport, teardown } = installLayoutHarness());
+  setLayoutIntentsEnabled(null);
+  await resetStore();
+  // Pre-subscribe so the region's initial snapshot is adopted before any reducer
+  // dispatch — the fake fans snapshots synchronously, so subscribing first keeps
+  // versions monotonic (production's real transport is naturally ordered).
+  await ensureLayoutRegionClient();
+});
+
+afterEach(() => {
+  setLayoutIntentsEnabled(null);
+  teardown();
+});
+
+describe("slice D' — synchronous local authority + optimistic region overlay", () => {
   it("flag off: splitPanel mutates locally and dispatches nothing", () => {
     setLayoutIntentsEnabled(false);
     useAppStore.getState().splitPanel("vertical");
 
-    expect(dispatched).toHaveLength(0);
+    expect(transport.kinds()).toHaveLength(0);
     expect(getAllLeaves(useAppStore.getState().rootPanel)).toHaveLength(3);
   });
 
-  it("flag on: splitPanel seeds then dispatches layout.split and reconciles the diff", async () => {
+  it("flag on: splitPanel applies to rootPanel SYNCHRONOUSLY (no await)", () => {
+    setLayoutIntentsEnabled(true);
+    useAppStore.getState().splitPanel("vertical");
+    // No flush: the local reducer is the authoritative, synchronous writer.
+    expect(getAllLeaves(useAppStore.getState().rootPanel)).toHaveLength(3);
+  });
+
+  it("flag on: the region overlay reflects the split SYNCHRONOUSLY, before any ack", () => {
+    setLayoutIntentsEnabled(true);
+    useAppStore.getState().splitPanel("vertical");
+    // The optimistic overlay installs appStore's post-split tree at once.
+    const root = regionActiveRoot(currentLayoutView());
+    expect(root && getAllLeaves(root)).toHaveLength(3);
+  });
+
+  it("flag on: dispatches replaceGroups (seed) then the granular layout.split", async () => {
     setLayoutIntentsEnabled(true);
     useAppStore.getState().splitPanel("vertical");
     await flush();
-
-    // Seed-before-mutate: the whole multi-group layout is installed before the
-    // structural intent (#2283 slice C).
-    expect(dispatched.map((d) => d.kind)).toEqual(["layout.replaceGroups", "layout.split"]);
-    expect(dispatched[1].payload).toMatchObject({
+    expect(transport.kinds()).toEqual(["layout.replaceGroups", "layout.split"]);
+    expect(transport.dispatched[1].payload).toMatchObject({
       panelId: "a",
       direction: "vertical",
       position: "after",
     });
-
-    const root = useAppStore.getState().rootPanel;
-    const leaves = getAllLeaves(root);
-    expect(leaves).toHaveLength(3);
-    // The new empty leaf is focused.
-    const active = findLeaf(root, useAppStore.getState().activePanelId!);
-    expect(active?.tabs).toHaveLength(0);
-    // Existing rich tabs survived the round-trip (re-hydrated by id).
-    const a = findLeaf(root, "a")!;
-    expect(a.tabs.map((t) => t.id)).toEqual(["t1", "t2"]);
-    expect(a.tabs[0].title).toBe("Tab t1");
-    expect(a.tabs[0].sessionId).toBe("sess-t1");
   });
 
-  it("flag on but intent rejected: falls back to the local reducer", async () => {
+  it("reconcile: the backend converges to the same tab layout after the diff lands", async () => {
     setLayoutIntentsEnabled(true);
-    backend.reject = true;
-    useAppStore.getState().splitPanel("vertical");
+    useAppStore.getState().reorderTabs("a", 0, 1);
     await flush();
+    // Non-id-generating op: the backend's authoritative view matches appStore.
+    const backendRoot = regionActiveRoot(transport.regionView())!;
+    expect(tabIds(backendRoot)).toEqual(tabIds(useAppStore.getState().rootPanel));
+    // …and the client's effective view reconciled to it (overlay pruned).
+    expect(tabIds(regionActiveRoot(currentLayoutView())!)).toEqual(
+      tabIds(useAppStore.getState().rootPanel)
+    );
+  });
 
-    // Still ended up split — via the local fallback path.
+  it("rejected dispatch: overlay rolls back, appStore keeps the local result (fallback retained)", async () => {
+    setLayoutIntentsEnabled(true);
+    transport.reject = true;
+    useAppStore.getState().splitPanel("vertical");
+    // Local reducer already applied the split (authoritative + instant).
     expect(getAllLeaves(useAppStore.getState().rootPanel)).toHaveLength(3);
+    await flush();
+    // Still split locally — the retained fallback held through the rejection.
+    expect(getAllLeaves(useAppStore.getState().rootPanel)).toHaveLength(3);
+    // The optimistic overlay was rolled back (region did not adopt the change).
+    const root = regionActiveRoot(currentLayoutView());
+    expect(root && getAllLeaves(root).length).toBeLessThan(3);
   });
 });
 
-/**
- * Parity: the store-cut (flag on) path must place tabs identically to the local
- * reducer (flag off) for every operation cut in step 2. Runs the same operation
- * both ways from a fresh tree and compares the id-agnostic fingerprint.
- */
-describe("appStore layout bridge — cut ↔ local parity (#2151)", () => {
-  async function runBothWays(op: () => void): Promise<{ local: unknown; cut: unknown }> {
-    // Local (flag off).
-    useAppStore.setState(useAppStore.getInitialState());
-    useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
-    setLayoutIntentsEnabled(false);
-    op();
-    const s1 = useAppStore.getState();
-    const local = normalize(s1.rootPanel, s1.activePanelId);
+describe("slice D' — every listed op routes its granular intent", () => {
+  const cases: { name: string; run: () => void; kind: string }[] = [
+    {
+      name: "splitPanel",
+      run: () => useAppStore.getState().splitPanel("vertical"),
+      kind: "layout.split",
+    },
+    {
+      name: "removePanel",
+      run: () => useAppStore.getState().removePanel("b"),
+      kind: "layout.removePanel",
+    },
+    {
+      name: "setActivePanel",
+      run: () => useAppStore.getState().setActivePanel("b"),
+      kind: "layout.setActivePanel",
+    },
+    {
+      name: "setPanelSizes",
+      run: () => useAppStore.getState().setPanelSizes("root", [70, 30]),
+      kind: "layout.resize",
+    },
+    {
+      name: "reorderTabs",
+      run: () => useAppStore.getState().reorderTabs("a", 0, 1),
+      kind: "layout.reorderTabs",
+    },
+    {
+      name: "setActiveTab",
+      run: () => useAppStore.getState().setActiveTab("t2", "a"),
+      kind: "layout.setActiveTab",
+    },
+    {
+      name: "splitPanelWithTab (move)",
+      run: () => useAppStore.getState().splitPanelWithTab("t1", "a", "b", "center"),
+      kind: "layout.moveTab",
+    },
+    {
+      name: "addTabGroup",
+      run: () => useAppStore.getState().addTabGroup("Extra"),
+      kind: "layout.addGroup",
+    },
+    {
+      name: "renameTabGroup",
+      run: () => {
+        const gid = useAppStore.getState().activeTabGroupId;
+        useAppStore.getState().renameTabGroup(gid, "Renamed");
+      },
+      kind: "layout.renameGroup",
+    },
+    {
+      name: "setTabGroupColor",
+      run: () => {
+        const gid = useAppStore.getState().activeTabGroupId;
+        useAppStore.getState().setTabGroupColor(gid, "#abcdef");
+      },
+      kind: "layout.setGroupColor",
+    },
+  ];
 
-    // Cut (flag on) — same starting tree, backend simulated by the panel-tree algebra.
-    useAppStore.setState(useAppStore.getInitialState());
-    useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
-    backend.reset();
-    setLayoutIntentsEnabled(true);
-    op();
-    await flush();
-    const s2 = useAppStore.getState();
-    const cut = normalize(s2.rootPanel, s2.activePanelId);
-    return { local, cut };
+  for (const c of cases) {
+    it(`${c.name} dispatches ${c.kind}`, async () => {
+      setLayoutIntentsEnabled(true);
+      c.run();
+      await flush();
+      expect(transport.kinds()).toContain(c.kind);
+    });
   }
 
-  it("splitPanel produces an identical tree both ways", async () => {
-    const { local, cut } = await runBothWays(() => useAppStore.getState().splitPanel("vertical"));
-    expect(cut).toEqual(local);
-  });
-
-  it("drag-to-center (merge a tab into another panel) matches the local reducer", async () => {
-    const { local, cut } = await runBothWays(() =>
-      useAppStore.getState().splitPanelWithTab("t1", "a", "b", "center")
-    );
-    expect(cut).toEqual(local);
-  });
-
-  it("drag-to-edge (split a panel with a tab) matches the local reducer", async () => {
-    const { local, cut } = await runBothWays(() =>
-      useAppStore.getState().splitPanelWithTab("t3", "b", "a", "right")
-    );
-    expect(cut).toEqual(local);
-  });
-
-  it("removePanel drops the panel identically both ways (#2188)", async () => {
-    const { local, cut } = await runBothWays(() => useAppStore.getState().removePanel("a"));
-    expect(cut).toEqual(local);
-  });
-
-  it("removePanel keeps focus on a surviving panel identically both ways (#2188)", async () => {
-    // Focus starts on "a"; removing "b" must leave "a" focused on both paths.
-    const run = async (flag: boolean): Promise<unknown> => {
-      useAppStore.setState(useAppStore.getInitialState());
-      useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
-      backend.reset();
-      setLayoutIntentsEnabled(flag);
-      useAppStore.getState().removePanel("b");
-      await flush();
-      const s = useAppStore.getState();
-      return normalize(s.rootPanel, s.activePanelId);
-    };
-    expect(await run(true)).toEqual(await run(false));
-    expect(useAppStore.getState().activePanelId).toBe("a");
-  });
-
-  it("reorderTabs reorders within a leaf identically both ways (#2188)", async () => {
-    const { local, cut } = await runBothWays(() => useAppStore.getState().reorderTabs("a", 0, 1));
-    expect(cut).toEqual(local);
-  });
-
-  it("setActivePanel folds focus into the projection while applying locally (#2188)", async () => {
-    // Flag off (rollback): pure-local focus change, nothing dispatched.
-    useAppStore.setState(useAppStore.getInitialState());
-    useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
-    backend.reset();
-    dispatched.length = 0;
-    setLayoutIntentsEnabled(false);
-    useAppStore.getState().setActivePanel("b");
-    expect(useAppStore.getState().activePanelId).toBe("b");
-    expect(dispatched).toHaveLength(0);
-
-    // Flag on: focus applies synchronously (instant UX) AND folds into the region.
-    useAppStore.setState(useAppStore.getInitialState());
-    useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
-    backend.reset();
-    dispatched.length = 0;
+  it("addTab dispatches layout.addTab carrying the frontend-generated tab id", async () => {
     setLayoutIntentsEnabled(true);
-    useAppStore.getState().setActivePanel("b");
-    expect(useAppStore.getState().activePanelId).toBe("b");
+    const id = useAppStore.getState().addTab("New", "local", { type: "local", config: {} });
     await flush();
-    expect(dispatched.map((d) => d.kind)).toEqual([
-      "layout.replaceGroups",
-      "layout.setActivePanel",
-    ]);
-    // The projection's active group now tracks the folded focus.
-    const folded = backend.view as FullView;
-    const activeGroup = folded.groups.find((g) => g.id === folded.activeGroupId)!;
-    expect(activeGroup.activePanelId).toBe("b");
+    const add = transport.dispatched.find((d) => d.kind === "layout.addTab");
+    expect(add).toBeDefined();
+    expect((add!.payload as { tab: { id: string } }).tab.id).toBe(id);
   });
 
-  it("setActivePanel preserves zoom-follow both ways (#2188)", async () => {
-    const run = async (flag: boolean): Promise<string | null> => {
-      useAppStore.setState(useAppStore.getInitialState());
-      useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a", zoomedTabId: "t1" });
-      backend.reset();
-      setLayoutIntentsEnabled(flag);
-      // Switching focus to b, while zoomed, follows to b's active tab (t3).
-      useAppStore.getState().setActivePanel("b");
-      await flush();
-      return useAppStore.getState().zoomedTabId;
-    };
-    expect(await run(true)).toBe("t3");
-    expect(await run(false)).toBe("t3");
-  });
-
-  it("setPanelSizes persists identical split sizes both ways (#2188)", async () => {
-    const sizesOf = async (flag: boolean): Promise<number[] | undefined> => {
-      useAppStore.setState(useAppStore.getInitialState());
-      useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
-      backend.reset();
-      setLayoutIntentsEnabled(flag);
-      useAppStore.getState().setPanelSizes("root", [70, 30]);
-      await flush();
-      const root = useAppStore.getState().rootPanel;
-      return root.type === "split" ? root.sizes : undefined;
-    };
-    const cut = await sizesOf(true);
-    const local = await sizesOf(false);
-    expect(cut).toEqual(local);
-    expect(cut).toEqual([70, 30]);
-  });
-
-  it("dragging a middle active tab out preserves the source's focus both ways", async () => {
-    const threeTab = (): PanelNode => ({
-      type: "split",
-      id: "root",
-      direction: "horizontal",
-      children: [
-        { type: "leaf", id: "a", tabs: [tab("t1"), tab("t2"), tab("t3")], activeTabId: "t2" },
-        { type: "leaf", id: "b", tabs: [tab("t4")], activeTabId: "t4" },
-      ],
-    });
-    // Local.
-    useAppStore.setState(useAppStore.getInitialState());
-    useAppStore.setState({ rootPanel: threeTab(), activePanelId: "a" });
-    setLayoutIntentsEnabled(false);
-    useAppStore.getState().splitPanelWithTab("t2", "a", "b", "center");
-    const local = normalize(useAppStore.getState().rootPanel, useAppStore.getState().activePanelId);
-    // Cut.
-    useAppStore.setState(useAppStore.getInitialState());
-    useAppStore.setState({ rootPanel: threeTab(), activePanelId: "a" });
-    backend.reset();
+  it("closeTab dispatches layout.closeTabStructure", async () => {
     setLayoutIntentsEnabled(true);
-    useAppStore.getState().splitPanelWithTab("t2", "a", "b", "center");
+    useAppStore.getState().closeTab("t2", "a");
     await flush();
-    const cut = normalize(useAppStore.getState().rootPanel, useAppStore.getState().activePanelId);
-    expect(cut).toEqual(local);
+    expect(transport.kinds()).toContain("layout.closeTabStructure");
+  });
+
+  it("setActiveTab activates the tab in both appStore and the region", async () => {
+    setLayoutIntentsEnabled(true);
+    useAppStore.getState().setActiveTab("t2", "a");
+    await flush();
+    expect(findLeaf(useAppStore.getState().rootPanel, "a")!.activeTabId).toBe("t2");
+    const regionA = findLeaf(regionActiveRoot(transport.regionView())!, "a");
+    expect(regionA!.activeTabId).toBe("t2");
+  });
+});
+
+describe("slice D' — tab id preservation (no live-terminal remount)", () => {
+  it("split preserves every existing tab id", () => {
+    setLayoutIntentsEnabled(true);
+    const before = tabIds(useAppStore.getState().rootPanel);
+    useAppStore.getState().splitPanel("vertical");
+    expect(tabIds(useAppStore.getState().rootPanel)).toEqual(before);
+  });
+
+  it("drag-move (center) preserves the moved tab id and its stack neighbours", () => {
+    setLayoutIntentsEnabled(true);
+    useAppStore.getState().splitPanelWithTab("t1", "a", "b", "center");
+    const ids = tabIds(useAppStore.getState().rootPanel).sort();
+    expect(ids).toEqual(["t1", "t2", "t3"]);
+  });
+
+  it("group switch keeps each group's tab ids intact", async () => {
+    setLayoutIntentsEnabled(true);
+    // The seed tree lives in the first group. Add a fresh (empty) group — which
+    // becomes active — then switch back to the first and assert its tabs survived.
+    useAppStore.getState().addTabGroup("G2");
+    await flush();
+    const firstGroup = useAppStore.getState().tabGroups[0].id;
+    useAppStore.getState().setActiveTabGroup(firstGroup);
+    await flush();
+    expect(tabIds(useAppStore.getState().rootPanel).sort()).toEqual(["t1", "t2", "t3"]);
+  });
+
+  it("tab activation never changes tab ids, only the active flag", () => {
+    setLayoutIntentsEnabled(true);
+    const before = tabIds(useAppStore.getState().rootPanel);
+    useAppStore.getState().setActiveTab("t2", "a");
+    expect(tabIds(useAppStore.getState().rootPanel)).toEqual(before);
+    expect(findLeaf(useAppStore.getState().rootPanel, "a")!.activeTabId).toBe("t2");
   });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -248,9 +248,8 @@ import {
   buildLayoutSnapshot,
   type LayoutSnapshot,
   layoutIntentsEnabled,
-  logBridgeFallback,
+  mirrorLayoutIntent,
   moveTabPayload,
-  runLayoutIntent,
 } from "@/store/layoutBridge";
 import {
   ensureSessionSubscribed,
@@ -2567,6 +2566,30 @@ function setTabContentEntry(
 }
 
 /**
+ * Build a comprehensive by-id {@link TabContent} map from every tab across every
+ * group — the active group's live tree overriding its (stale) `tabGroups` entry
+ * (#2283 / #2539). Used where a whole layout is (re)built — workspace restore and
+ * the agent-error → terminal conversion — so **every** tab type, including
+ * `agent-error`, is tracked in the map rather than falling back to the in-tree
+ * copy. Tabs not present in any group are dropped, matching the map's invariant
+ * that it holds exactly the live tabs.
+ */
+function tabContentFromGroups(
+  tabGroups: TabGroup[],
+  activeGroupId?: string,
+  activeRoot?: PanelNode
+): Record<string, TabContent> {
+  const map: Record<string, TabContent> = {};
+  for (const g of tabGroups) {
+    const tree = activeRoot && g.id === activeGroupId ? activeRoot : g.rootPanel;
+    for (const leaf of getAllLeaves(tree)) {
+      for (const t of leaf.tabs) map[t.id] = extractTabContent(t);
+    }
+  }
+  return map;
+}
+
+/**
  * Patch specific content fields of a tab **already tracked** in the map. A tab
  * absent from the map (e.g. an editor/settings tab that renders via the in-tree
  * fallback) is left untouched — this preserves the invariant that the map holds
@@ -2585,8 +2608,8 @@ function patchTabContentEntry(
 
 /**
  * The rich multi-group {@link LayoutSnapshot} of `appStore`'s current layout —
- * the seed-before-mutate payload passed to {@link runLayoutIntent} (#2283 slice
- * C). The active group's live tree is the top-level `rootPanel`/`activePanelId`;
+ * the seed / overlay payload passed to {@link mirrorLayoutIntent} (#2283 slice
+ * D'). The active group's live tree is the top-level `rootPanel`/`activePanelId`;
  * every other group comes from its `tabGroups` entry.
  */
 function currentLayoutSnapshot(state: {
@@ -2884,11 +2907,14 @@ export const useAppStore = create<AppState>((set, get, store) => {
     addTabGroup: (name) => {
       const newGroupId = generateGroupId();
       const newPanel = createLeafPanel();
+      const pre = currentLayoutSnapshot(get());
+      let assignedName = name ?? "";
       set((state) => {
         const groupCount = state.tabGroups.length + 1;
+        assignedName = name ?? `Group ${groupCount}`;
         const newGroup: TabGroup = {
           id: newGroupId,
-          name: name ?? `Group ${groupCount}`,
+          name: assignedName,
           rootPanel: newPanel,
           activePanelId: newPanel.id,
         };
@@ -2905,13 +2931,24 @@ export const useAppStore = create<AppState>((set, get, store) => {
           activePanelId: newPanel.id,
         };
       });
+      // Optimistic-fold overlay (#2283 slice D'): mirror the new group into the
+      // region via `layout.addGroup`. The backend assigns its own group id; the
+      // overlay carries appStore's, so the region matches until the next reseed.
+      if (layoutIntentsEnabled()) {
+        mirrorLayoutIntent(
+          "layout.addGroup",
+          { name: assignedName },
+          pre,
+          currentLayoutSnapshot(get())
+        );
+      }
       return newGroupId;
     },
 
-    closeTabGroup: (groupId) =>
+    closeTabGroup: (groupId) => {
+      if (get().tabGroups.length <= 1) return; // sole group: no-op (backend rejects too)
+      const pre = currentLayoutSnapshot(get());
       set((state) => {
-        if (state.tabGroups.length <= 1) return state;
-
         const newGroups = state.tabGroups.filter((g) => g.id !== groupId);
 
         if (groupId !== state.activeTabGroupId) {
@@ -2929,23 +2966,52 @@ export const useAppStore = create<AppState>((set, get, store) => {
           rootPanel: newActiveGroup.rootPanel,
           activePanelId: newActiveGroup.activePanelId,
         };
-      }),
+      });
+      // Optimistic-fold overlay (#2283 slice D'): mirror the close into the region.
+      if (layoutIntentsEnabled()) {
+        mirrorLayoutIntent("layout.closeGroup", { groupId }, pre, currentLayoutSnapshot(get()));
+      }
+    },
 
-    renameTabGroup: (groupId, name) =>
+    renameTabGroup: (groupId, name) => {
+      const pre = currentLayoutSnapshot(get());
       set((state) => ({
         tabGroups: state.tabGroups.map((g) => (g.id === groupId ? { ...g, name } : g)),
-      })),
+      }));
+      if (layoutIntentsEnabled()) {
+        mirrorLayoutIntent(
+          "layout.renameGroup",
+          { groupId, name },
+          pre,
+          currentLayoutSnapshot(get())
+        );
+      }
+    },
 
-    setTabGroupColor: (groupId, color) =>
+    setTabGroupColor: (groupId, color) => {
+      const pre = currentLayoutSnapshot(get());
       set((state) => ({
         tabGroups: state.tabGroups.map((g) =>
           g.id === groupId ? { ...g, color: color ?? undefined } : g
         ),
-      })),
+      }));
+      // Omit `color` when clearing so the backend's `optional_str` resolves to
+      // `None` and drops the accent (matching the local `color ?? undefined`).
+      if (layoutIntentsEnabled()) {
+        mirrorLayoutIntent(
+          "layout.setGroupColor",
+          color != null ? { groupId, color } : { groupId },
+          pre,
+          currentLayoutSnapshot(get())
+        );
+      }
+    },
 
-    setActiveTabGroup: (groupId) =>
+    setActiveTabGroup: (groupId) => {
+      if (groupId === get().activeTabGroupId) return; // no-op
+      if (!get().tabGroups.some((g) => g.id === groupId)) return; // unknown group
+      const pre = currentLayoutSnapshot(get());
       set((state) => {
-        if (groupId === state.activeTabGroupId) return state;
         const targetGroup = state.tabGroups.find((g) => g.id === groupId);
         if (!targetGroup) return state;
         // Save current live state into the currently active group
@@ -2969,17 +3035,34 @@ export const useAppStore = create<AppState>((set, get, store) => {
           activePanelId: targetGroup.activePanelId,
           zoomedTabId: newZoomedTabId,
         };
-      }),
+      });
+      // Optimistic-fold overlay (#2283 slice D'): mirror the group switch into the
+      // region via `layout.setActiveGroup`.
+      if (layoutIntentsEnabled()) {
+        mirrorLayoutIntent("layout.setActiveGroup", { groupId }, pre, currentLayoutSnapshot(get()));
+      }
+    },
 
-    reorderTabGroups: (fromIndex, toIndex) =>
+    reorderTabGroups: (fromIndex, toIndex) => {
+      const pre = currentLayoutSnapshot(get());
       set((state) => {
         const groups = [...state.tabGroups];
         const [moved] = groups.splice(fromIndex, 1);
         groups.splice(toIndex, 0, moved);
         return { tabGroups: groups };
-      }),
+      });
+      if (layoutIntentsEnabled()) {
+        mirrorLayoutIntent(
+          "layout.reorderGroups",
+          { fromIndex, toIndex },
+          pre,
+          currentLayoutSnapshot(get())
+        );
+      }
+    },
 
     moveTabToGroup: (tabId, fromPanelId, targetGroupId) => {
+      const pre = currentLayoutSnapshot(get());
       set((state) => {
         if (targetGroupId === state.activeTabGroupId) return state;
 
@@ -3033,13 +3116,24 @@ export const useAppStore = create<AppState>((set, get, store) => {
           activePanelId: newActivePanelId,
         };
       });
+      // Optimistic-fold overlay (#2283 slice D'): mirror the cross-group move into
+      // the region via `layout.moveTabToGroup`.
+      if (layoutIntentsEnabled()) {
+        mirrorLayoutIntent(
+          "layout.moveTabToGroup",
+          { tabId, fromPanelId, targetGroupId },
+          pre,
+          currentLayoutSnapshot(get())
+        );
+      }
       // Moving a tab across groups changes broadcast membership when the source
       // or a target crosses the group boundary (#1980) — re-resolve so an
       // "all"/"panel" scope drops/adds it in the source's own group.
       get().refreshBroadcastMembership();
     },
 
-    addTabGroupWithTab: (tabId, fromPanelId) =>
+    addTabGroupWithTab: (tabId, fromPanelId) => {
+      const pre = currentLayoutSnapshot(get());
       set((state) => {
         // Find the tab in the active group's live rootPanel
         const sourceLeaf = getAllLeaves(state.rootPanel).find((l) => l.id === fromPanelId);
@@ -3096,7 +3190,19 @@ export const useAppStore = create<AppState>((set, get, store) => {
           rootPanel: newGroupRootPanel,
           activePanelId: newPanel.id,
         };
-      }),
+      });
+      // Optimistic-fold overlay (#2283 slice D'): mirror the "tab to new group"
+      // move into the region via `layout.addGroupWithTab`. The backend assigns its
+      // own group id; the overlay carries appStore's until the next reseed.
+      if (layoutIntentsEnabled()) {
+        mirrorLayoutIntent(
+          "layout.addGroupWithTab",
+          { tabId, fromPanelId },
+          pre,
+          currentLayoutSnapshot(get())
+        );
+      }
+    },
 
     // ── Multi-window foundation (#1900) ──
     movingSessionIds: [],
@@ -3320,6 +3426,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
         activeTabGroupId: firstGroup.id,
         rootPanel: firstGroup.rootPanel,
         activePanelId: firstGroup.activePanelId,
+        // Track every restored tab — including `agent-error` — in the by-id
+        // content map so it resolves from `tabContent` (#2539).
+        tabContent: tabContentFromGroups(builtGroups),
       });
       const { pendingTabIds, preFailedCount } = collectRestoreCohort(builtGroups);
       get().beginRestoreCohort(pendingTabIds, preFailedCount);
@@ -3935,7 +4044,11 @@ export const useAppStore = create<AppState>((set, get, store) => {
         spawned,
         initialCommand,
       } = options ?? {};
+      const pre = currentLayoutSnapshot(get());
       let createdTabId = "";
+      let addedPanelId = "";
+      let addedContentType = "terminal";
+      let addedSessionId: string | null = null;
       set((state) => {
         const allLeaves = getAllLeaves(state.rootPanel);
         const targetPanelId = panelId ?? state.activePanelId ?? allLeaves[0]?.id;
@@ -3958,6 +4071,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
         );
         const newTab: TerminalTab = connectionId ? { ...baseTab, connectionId } : baseTab;
         createdTabId = newTab.id;
+        addedPanelId = targetPanelId;
+        addedContentType = newTab.contentType;
+        addedSessionId = newTab.sessionId ?? null;
         const rootPanel = updateLeaf(state.rootPanel, targetPanelId, (leaf) => {
           const tabs = leaf.tabs.map((t) => ({ ...t, isActive: false }));
           tabs.push(newTab);
@@ -3989,6 +4105,23 @@ export const useAppStore = create<AppState>((set, get, store) => {
             : {}),
         };
       });
+      // Optimistic-fold overlay (#2283 slice D'): mirror the structural insert into
+      // the region via `layout.addTab`. The frontend-generated tab id is passed to
+      // the backend, so tab identity never diverges (the live xterm DOM, keyed by
+      // tab id, is never remounted). The tab's rich content stays in appStore's
+      // `tabContent` map / tree; the region carries only `{ id, sessionId,
+      // contentType }`.
+      if (layoutIntentsEnabled() && createdTabId && addedPanelId) {
+        mirrorLayoutIntent(
+          "layout.addTab",
+          {
+            panelId: addedPanelId,
+            tab: { id: createdTabId, sessionId: addedSessionId, contentType: addedContentType },
+          },
+          pre,
+          currentLayoutSnapshot(get())
+        );
+      }
       // Record real terminal connections in the session history (#1883). Only
       // genuine connections carry a config; settings/editor/etc. tabs (which
       // pass a non-terminal contentType) are skipped. Fire-and-forget so tab
@@ -4388,6 +4521,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
     setPendingAttachedTabCloseConfirm: (req) => set({ pendingAttachedTabCloseConfirm: req }),
 
     closeTab: (tabId, panelId) => {
+      // Snapshot the pre-close layout for the region seed (#2283 slice D').
+      const preLayout = currentLayoutSnapshot(get());
+
       // Session-intents cut (#2203): the tab is gone — drop its lifecycle record
       // from the shared region so the store does not leak a dead session. Any
       // pending backend reconnect timer is cancelled by `session.remove`.
@@ -4531,31 +4667,59 @@ export const useAppStore = create<AppState>((set, get, store) => {
           get().removeBroadcastTarget(tabId);
         }
       }
+
+      // Optimistic-fold overlay (#2283 slice D'): mirror the structural close into
+      // the region via `layout.closeTabStructure` (the structural half only —
+      // session teardown stayed above). appStore is authoritative; the overlay
+      // installs the post-close tree.
+      if (layoutIntentsEnabled()) {
+        mirrorLayoutIntent(
+          "layout.closeTabStructure",
+          { tabId },
+          preLayout,
+          currentLayoutSnapshot(get())
+        );
+      }
     },
 
-    setActiveTab: (tabId, panelId) =>
-      set((state) => {
-        const newRootPanel = updateLeaf(state.rootPanel, panelId, (leaf) => ({
-          ...leaf,
-          tabs: leaf.tabs.map((t) => ({ ...t, isActive: t.id === tabId })),
-          activeTabId: tabId,
-        }));
+    setActiveTab: (tabId, panelId) => {
+      // Local reducer — the authoritative, synchronous writer and the retained
+      // instant-revert fallback. Focuses `tabId` within its leaf and repoints the
+      // active panel, following the zoom overlay when it shows a tab of that leaf.
+      const applyLocal = () =>
+        set((state) => {
+          const newRootPanel = updateLeaf(state.rootPanel, panelId, (leaf) => ({
+            ...leaf,
+            tabs: leaf.tabs.map((t) => ({ ...t, isActive: t.id === tabId })),
+            activeTabId: tabId,
+          }));
 
-        // If the zoom overlay is showing a tab from the same panel, follow the switch
-        let newZoomedTabId = state.zoomedTabId;
-        if (state.zoomedTabId !== null) {
-          const panelLeaf = findLeaf(state.rootPanel, panelId);
-          if (panelLeaf?.tabs.some((t) => t.id === state.zoomedTabId)) {
-            newZoomedTabId = tabId;
+          // If the zoom overlay is showing a tab from the same panel, follow the switch
+          let newZoomedTabId = state.zoomedTabId;
+          if (state.zoomedTabId !== null) {
+            const panelLeaf = findLeaf(state.rootPanel, panelId);
+            if (panelLeaf?.tabs.some((t) => t.id === state.zoomedTabId)) {
+              newZoomedTabId = tabId;
+            }
           }
-        }
 
-        return {
-          rootPanel: newRootPanel,
-          activePanelId: panelId,
-          zoomedTabId: newZoomedTabId,
-        };
-      }),
+          return {
+            rootPanel: newRootPanel,
+            activePanelId: panelId,
+            zoomedTabId: newZoomedTabId,
+          };
+        });
+
+      // Optimistic-fold overlay (#2283 slice D'): apply locally (authoritative),
+      // then mirror the tab focus into the region via `layout.setActiveTab` — the
+      // structural "focus a tab within its leaf" primitive added for this slice.
+      // The backend derives the leaf from the tab id and repoints its active panel.
+      const pre = currentLayoutSnapshot(get());
+      applyLocal();
+      if (layoutIntentsEnabled()) {
+        mirrorLayoutIntent("layout.setActiveTab", { tabId }, pre, currentLayoutSnapshot(get()));
+      }
+    },
 
     moveTab: (tabId, fromPanelId, toPanelId, newIndex) =>
       set((state) => {
@@ -4594,8 +4758,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
       }),
 
     reorderTabs: (panelId, oldIndex, newIndex) => {
-      // Local reducer — the retained rollback/resilience fallback (see
-      // `splitPanel`). Reorders a tab within its leaf, leaving focus untouched.
+      // Local reducer — the authoritative, synchronous writer and the retained
+      // instant-revert fallback (see `splitPanel`). Reorders a tab within its
+      // leaf, leaving focus untouched.
       const applyLocal = () =>
         set((state) => ({
           rootPanel: updateLeaf(state.rootPanel, panelId, (leaf) => {
@@ -4606,30 +4771,28 @@ export const useAppStore = create<AppState>((set, get, store) => {
           }),
         }));
 
-      // Structural reorder cut (#2188): route through `layout.reorderTabs`; the
-      // backend LayoutStore reorders and reconcileNode writes the reconciled
-      // tree. Focus is unchanged, so only `rootPanel` is applied. Any failure
-      // falls back to the local reducer.
-      if (!layoutIntentsEnabled()) return applyLocal();
-      void runLayoutIntent(
-        "layout.reorderTabs",
-        { panelId, oldIndex, newIndex },
-        currentLayoutSnapshot(get())
-      )
-        .then((res) => set({ rootPanel: res.rootPanel }))
-        .catch((err) => {
-          logBridgeFallback("layout.reorderTabs", err);
-          applyLocal();
-        });
+      // Optimistic-fold overlay (#2283 slice D'): apply the authoritative local
+      // reorder synchronously, then mirror the same transition into the region
+      // via `layout.reorderTabs` so the projection stays in step without a
+      // seed→await round-trip. appStore stays authoritative and the fallback is
+      // retained (the #2283 reducer removal remains gated).
+      const pre = currentLayoutSnapshot(get());
+      applyLocal();
+      if (layoutIntentsEnabled()) {
+        mirrorLayoutIntent(
+          "layout.reorderTabs",
+          { panelId, oldIndex, newIndex },
+          pre,
+          currentLayoutSnapshot(get())
+        );
+      }
     },
 
     splitPanel: (direction) => {
-      // Local reducer. Since #2184 the intent path below is the default, so this
-      // is the retained resilience/rollback fallback: it runs when the flag is
-      // explicitly off (rollback) or an intent dispatch/reconcile fails, so a
-      // backend hiccup can never break layout. Not a duplicate algebra — it
+      // Local reducer — the authoritative, synchronous writer, and the retained
+      // instant-revert fallback (the #2283 reducer removal stays gated). It
       // orchestrates the shared `@/utils/panelTree` helpers (the same seam the
-      // Rust store ports), so keeping it costs no drift, only a safety net.
+      // Rust store ports), so it never drifts from the region's `layout.split`.
       const applyLocal = () =>
         set((state) => {
           const dir = direction ?? "horizontal";
@@ -4642,23 +4805,22 @@ export const useAppStore = create<AppState>((set, get, store) => {
           return { rootPanel, activePanelId: newLeaf.id };
         });
 
-      // Structural split cut (#2151 step 2, default-on since #2184): route
-      // through the `layout.split` intent; the backend LayoutStore mutates and
-      // reconcileNode is the authoritative writer of the reconciled tree. On any
-      // failure fall back to the local reducer so layout never breaks.
-      if (!layoutIntentsEnabled()) return applyLocal();
+      // Optimistic-fold overlay (#2283 slice D'): apply the authoritative local
+      // split synchronously, then mirror it into the region via `layout.split`.
+      // The split targets the pre-split active panel; the backend focuses its
+      // new leaf, matching the local reducer. appStore stays authoritative and
+      // the local reducer is retained as the instant-revert fallback.
+      const pre = currentLayoutSnapshot(get());
       const { activePanelId } = get();
-      if (!activePanelId) return applyLocal();
-      void runLayoutIntent(
-        "layout.split",
-        { panelId: activePanelId, direction: direction ?? "horizontal", position: "after" },
-        currentLayoutSnapshot(get())
-      )
-        .then((res) => set(res))
-        .catch((err) => {
-          logBridgeFallback("layout.split", err);
-          applyLocal();
-        });
+      applyLocal();
+      if (layoutIntentsEnabled() && activePanelId) {
+        mirrorLayoutIntent(
+          "layout.split",
+          { panelId: activePanelId, direction: direction ?? "horizontal", position: "after" },
+          pre,
+          currentLayoutSnapshot(get())
+        );
+      }
     },
 
     removePanel: (panelId) => {
@@ -4679,20 +4841,17 @@ export const useAppStore = create<AppState>((set, get, store) => {
           return { rootPanel, activePanelId };
         });
 
-      // Structural remove cut (#2188): route through `layout.removePanel` — a
-      // dedicated transform, since `merge` preserves the tabs and
-      // `closeTabStructure` is per-tab, so neither models "discard the whole
-      // panel". The sole-leaf case is a no-op both here and in the store. Any
-      // failure falls back to the local reducer.
-      if (!layoutIntentsEnabled()) return applyLocal();
-      const { rootPanel } = get();
-      if (getAllLeaves(rootPanel).length <= 1) return;
-      void runLayoutIntent("layout.removePanel", { panelId }, currentLayoutSnapshot(get()))
-        .then((res) => set(res))
-        .catch((err) => {
-          logBridgeFallback("layout.removePanel", err);
-          applyLocal();
-        });
+      // Optimistic-fold overlay (#2283 slice D'): the sole-leaf case is a no-op
+      // both here and in the store, so skip it. Otherwise apply the authoritative
+      // local remove synchronously, then mirror it into the region via
+      // `layout.removePanel`. appStore stays authoritative; the local reducer is
+      // the retained instant-revert fallback.
+      if (getAllLeaves(get().rootPanel).length <= 1) return;
+      const pre = currentLayoutSnapshot(get());
+      applyLocal();
+      if (layoutIntentsEnabled()) {
+        mirrorLayoutIntent("layout.removePanel", { panelId }, pre, currentLayoutSnapshot(get()));
+      }
     },
 
     setActivePanel: (panelId) => {
@@ -4710,19 +4869,15 @@ export const useAppStore = create<AppState>((set, get, store) => {
           return { activePanelId: panelId, zoomedTabId: newZoomedTabId };
         });
 
-      // Focus is projection state (`activePanelId`), so fold it into the layout
-      // region (#2188): apply locally for instant UX, then best-effort push the
-      // focus through `layout.setActivePanel` so the backend stays authoritative
-      // and the render-from-projection mirror keeps matching. The reconciled
-      // result is ignored — the local set already landed — and a failure is just
-      // logged (the projection catches up on the next seed).
+      // Focus is projection state (`activePanelId`): apply locally for instant UX
+      // (authoritative), then mirror it into the region via `layout.setActivePanel`
+      // (#2283 slice D') so the projection stays in step synchronously. A failure
+      // is logged; the local set already landed.
+      const pre = currentLayoutSnapshot(get());
       applyLocal();
-      if (!layoutIntentsEnabled()) return;
-      void runLayoutIntent(
-        "layout.setActivePanel",
-        { panelId },
-        currentLayoutSnapshot(get())
-      ).catch((err) => logBridgeFallback("layout.setActivePanel", err));
+      if (layoutIntentsEnabled()) {
+        mirrorLayoutIntent("layout.setActivePanel", { panelId }, pre, currentLayoutSnapshot(get()));
+      }
     },
 
     setPanelSizes: (splitId, sizes) => {
@@ -4732,16 +4887,14 @@ export const useAppStore = create<AppState>((set, get, store) => {
       const applyLocal = () =>
         set((state) => ({ rootPanel: setSplitSizesInTree(state.rootPanel, splitId, sizes) }));
 
-      // Resize cut (#2188): route through `layout.resize`; the backend persists
-      // the normalized sizes and reconcileNode writes the reconciled tree. Only
-      // `rootPanel` changes. Any failure falls back to the local reducer.
-      if (!layoutIntentsEnabled()) return applyLocal();
-      void runLayoutIntent("layout.resize", { splitId, sizes }, currentLayoutSnapshot(get()))
-        .then((res) => set({ rootPanel: res.rootPanel }))
-        .catch((err) => {
-          logBridgeFallback("layout.resize", err);
-          applyLocal();
-        });
+      // Optimistic-fold overlay (#2283 slice D'): apply the authoritative local
+      // resize synchronously, then mirror it into the region via `layout.resize`.
+      // appStore stays authoritative; the local reducer is the retained fallback.
+      const pre = currentLayoutSnapshot(get());
+      applyLocal();
+      if (layoutIntentsEnabled()) {
+        mirrorLayoutIntent("layout.resize", { splitId, sizes }, pre, currentLayoutSnapshot(get()));
+      }
     },
 
     splitPanelWithTab: (tabId, fromPanelId, targetPanelId, edge) => {
@@ -4820,30 +4973,22 @@ export const useAppStore = create<AppState>((set, get, store) => {
           return { rootPanel, activePanelId: newLeaf.id };
         });
 
-      // Tab-carrying drop cut (#2151 step 2, default-on since #2184): maps to
-      // `layout.moveTab` (center = merge into the target stack, edge = split the
-      // target). The backend collapses an emptied self-drop source but the local
-      // reducer keeps it, so the single-tab self-edge-drop corner stays on the
-      // local path to preserve exact parity; everything else routes through the
-      // store, with reconcileNode as the authoritative writer.
-      if (!layoutIntentsEnabled()) return applyLocal();
-      const { rootPanel } = get();
-      const sourceLeaf = findLeaf(rootPanel, fromPanelId);
-      const selfEdgeSingleTab =
-        edge !== "center" && fromPanelId === targetPanelId && (sourceLeaf?.tabs.length ?? 0) <= 1;
-      if (!sourceLeaf || selfEdgeSingleTab) return applyLocal();
-
-      void runLayoutIntent(
-        "layout.moveTab",
-        moveTabPayload(tabId, targetPanelId, edge),
-        currentLayoutSnapshot(get()),
-        tabId
-      )
-        .then((res) => set(res))
-        .catch((err) => {
-          logBridgeFallback("layout.moveTab", err);
-          applyLocal();
-        });
+      // Optimistic-fold overlay (#2283 slice D'): apply the authoritative local
+      // move synchronously (it keeps an emptied self-drop source that the backend
+      // would collapse — appStore stays authoritative, so its result wins), then
+      // mirror it into the region via `layout.moveTab` (center = merge into the
+      // target stack, edge = split the target). The overlay installs appStore's
+      // result, so any backend divergence self-heals on the next seed.
+      const pre = currentLayoutSnapshot(get());
+      applyLocal();
+      if (layoutIntentsEnabled()) {
+        mirrorLayoutIntent(
+          "layout.moveTab",
+          moveTabPayload(tabId, targetPanelId, edge),
+          pre,
+          currentLayoutSnapshot(get())
+        );
+      }
     },
 
     // Connections — the saved-connection / folder tree is region-authoritative
@@ -6551,10 +6696,18 @@ export const useAppStore = create<AppState>((set, get, store) => {
         return { ...panel, tabs: updatedTabs };
       };
 
-      set((s) => ({
-        rootPanel: convertPanel(s.rootPanel),
-        tabGroups: s.tabGroups.map((g) => ({ ...g, rootPanel: convertPanel(g.rootPanel) })),
-      }));
+      set((s) => {
+        const rootPanel = convertPanel(s.rootPanel);
+        const tabGroups = s.tabGroups.map((g) => ({ ...g, rootPanel: convertPanel(g.rootPanel) }));
+        return {
+          rootPanel,
+          tabGroups,
+          // Instrument the agent-error → terminal conversion so the by-id content
+          // map never goes stale (#2539): re-track every tab from the converted
+          // trees, so a resolved tab now resolves as a `terminal` from `tabContent`.
+          tabContent: tabContentFromGroups(tabGroups, s.activeTabGroupId, rootPanel),
+        };
+      });
     },
 
     // File browser — the view is owned by the authoritative `file-browser` region
@@ -7635,6 +7788,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
           rootPanel: firstGroup.rootPanel,
           activePanelId: firstGroup.activePanelId,
           activeWorkspaceName: definition.name,
+          // Track every restored tab — including `agent-error` — in the by-id
+          // content map so it resolves from `tabContent` (#2539).
+          tabContent: tabContentFromGroups(builtGroups),
         });
         // GAP G4 (#1146): register the placed tabs as a cohort so a single
         // summary toast fires once every tab has connected or failed.
@@ -7840,6 +7996,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
           activeTabGroupId: activeGroup.id,
           rootPanel: activeGroup.rootPanel,
           activePanelId: activeGroup.activePanelId,
+          // Track every restored tab — including `agent-error` — in the by-id
+          // content map so it resolves from `tabContent` (#2539).
+          tabContent: tabContentFromGroups(builtGroups),
         });
         // GAP G4 (#1146): register the placed tabs as a cohort so a single
         // summary toast fires once every tab has connected or failed.

--- a/src/store/layoutBridge.ts
+++ b/src/store/layoutBridge.ts
@@ -51,6 +51,7 @@ import {
   newClientId,
   newIntentId,
   ProjectionClient,
+  type Intent,
   type IntentAck,
   type Transport,
 } from "@/services/transport";
@@ -64,13 +65,6 @@ import type {
   TerminalTab,
 } from "@/types/terminal";
 import { frontendLog } from "@/utils/frontendLog";
-import { findLeafByTab } from "@/utils/panelTree";
-
-/** The structural result the bridge hands back to `appStore`. */
-export interface LayoutStructuralResult {
-  rootPanel: PanelNode;
-  activePanelId: string | null;
-}
 
 // ── Minimal projected shapes (twins of the Rust `layout` view model) ──────────
 
@@ -274,7 +268,7 @@ export function layoutRenderFromProjectionEnabled(): boolean {
   return readFlag(renderFlagOverride, "__TERMIHUB_LAYOUT_RENDER__", "termihub.layoutRender", true);
 }
 
-// ── Transport + region client (lazy, mirrors the tunnel slice) ─────────────────
+// ── Transport + region client (sync-create, mirrors the file-browsers slice) ───
 
 // A stable per-session client identity. The client-scoped region is
 // `layout@<clientId>`, and dispatched intents carry the same id, so this
@@ -283,8 +277,23 @@ const clientId = newClientId();
 const region = `layout@${clientId}`;
 
 let transportInstance: Transport | null = null;
+/** The region client once its subscription has started (its snapshot adopted). */
 let regionClient: ProjectionClient | null = null;
+/** The region client the moment it is created — before `start()` resolves — so an
+ * optimistic dispatch can overlay on it synchronously ({@link mirrorLayoutIntent}).
+ * Same object as {@link regionClient} once started. */
+let creatingClient: ProjectionClient | null = null;
 let startPromise: Promise<ProjectionClient> | null = null;
+
+/** Inject a transport for tests; `null` restores the lazily-created real one and
+ * drops any active subscription. */
+export function setLayoutTransportForTest(t: Transport | null): void {
+  (regionClient ?? creatingClient)?.stop();
+  regionClient = null;
+  creatingClient = null;
+  startPromise = null;
+  transportInstance = t;
+}
 
 function transport(): Transport {
   if (!transportInstance) {
@@ -294,13 +303,28 @@ function transport(): Transport {
 }
 
 /**
+ * The region client instance, created **synchronously** on first use — before its
+ * subscription has started — so an optimistic dispatch can overlay on it at once
+ * (mirrors `fileBrowsersRegionClient`). Returns the started {@link regionClient}
+ * once available, else the {@link creatingClient}. Throws only if the transport
+ * itself cannot be built (non-Tauri without a socket).
+ */
+function layoutRegionClient(): ProjectionClient {
+  if (regionClient) return regionClient;
+  if (!creatingClient) {
+    creatingClient = new ProjectionClient(transport(), region);
+  }
+  return creatingClient;
+}
+
+/**
  * Ensure the `layout@<clientId>` region client is subscribed, so intent diffs
  * are received. Idempotent and de-duplicated across concurrent callers.
  */
 function ensureSubscribed(): Promise<ProjectionClient> {
   if (regionClient) return Promise.resolve(regionClient);
   if (!startPromise) {
-    const client = new ProjectionClient(transport(), region);
+    const client = layoutRegionClient();
     startPromise = client
       .start()
       .then(() => {
@@ -313,6 +337,23 @@ function ensureSubscribed(): Promise<ProjectionClient> {
       });
   }
   return startPromise;
+}
+
+/** Drop the region subscription (tests / re-init). */
+export function stopLayoutSubscription(): void {
+  (regionClient ?? creatingClient)?.stop();
+  regionClient = null;
+  creatingClient = null;
+  startPromise = null;
+}
+
+/**
+ * The layout region's current effective (optimistically-overlaid) view — for
+ * synchronous test assertions on the projection. `undefined` before the client
+ * exists / its first snapshot.
+ */
+export function currentLayoutView(): LayoutView | undefined {
+  return (regionClient ?? creatingClient)?.state.view as LayoutView | undefined;
 }
 
 async function dispatch(kind: string, payload: unknown): Promise<IntentAck> {
@@ -418,93 +459,83 @@ export function reconcileNode(
   return split;
 }
 
-// ── Await a region version, then read the reconciled tree ─────────────────────
-
-/** Resolve once the region client has caught up to (at least) `version`. */
-function awaitVersion(client: ProjectionClient, version: number, timeoutMs = 4000): Promise<void> {
-  if (client.state.version >= version) return Promise.resolve();
-  return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      unsubscribe();
-      reject(new Error(`layout region did not reach version ${version} in time`));
-    }, timeoutMs);
-    const unsubscribe = client.onChange((state) => {
-      if (state.version >= version) {
-        clearTimeout(timer);
-        unsubscribe();
-        resolve();
-      }
-    });
-  });
-}
+// ── Optimistic mirror: synchronous fold overlay + granular intent dispatch ─────
 
 /**
- * Run a structural layout mutation through the store: seed the store with the
- * current tree, dispatch `kind`, await the resulting diff, and reconcile it back
- * into `appStore`'s rich panel-tree shape.
+ * Optimistically mirror a layout mutation into the client's `layout@<clientId>`
+ * region (#2283 slice D', the un-gated timing win).
  *
- * The backend `move_tab` transform does not repoint the focused panel, but the
- * old local move/split-with-tab reducers all focus the tab's destination. So
- * when `focusTabId` is given, the reconciled `activePanelId` is re-derived as
- * the panel that now holds that tab — reproducing the old focus behaviour.
+ * The `appStore` reducer has **already** applied the mutation to its
+ * authoritative `rootPanel`/`tabGroups` — the retained instant-revert path that
+ * this slice deliberately keeps (the #2283 fallback removal stays gated). This
+ * function pushes the same transition into the projection region **without** the
+ * old `seed→await→reconcile` round-trip:
  *
- * # Group-aware seed (#2283 slice C)
+ * - it overlays `postSnapshot` — `appStore`'s already-transformed tree, so the
+ *   region matches `appStore`'s ids exactly — onto the region **synchronously**
+ *   via {@link ProjectionClient.dispatchOptimistic}, so the render path reflects
+ *   the mutation at once (no fallback flicker while a backend round-trip lands);
+ * - it seeds the backend to `preSnapshot` (fire-and-forget; the transport
+ *   preserves order) so the authoritative store applies the granular `kind`
+ *   intent to the correct pre-transform tree and converges to the same view,
+ *   at which point the optimistic overlay is pruned.
  *
- * Seed-before-mutate installs **every** tab group via `layout.replaceGroups`
- * (not just the active tree), so the region is a faithful multi-group mirror
- * before the transform runs. The structural intent still operates on the active
- * group (its `groupId` is omitted → the store's active group), and the active
- * group is read back out of the full view for reconcile.
- *
- * @param kind        the `layout.*` intent kind
- * @param payload     the intent payload
- * @param snapshot    `appStore`'s current multi-group snapshot (authority)
- * @param focusTabId  when set, focus the panel this tab landed in
- * @returns the reconciled `{ rootPanel, activePanelId }` for the **active** group
- * @throws  on a rejected/failed intent or an unreconcilable diff (caller falls
- *          back to the local mutation)
+ * Never throws (resilience): a transport-construction failure (non-Tauri without
+ * a socket) or a rejected/failed dispatch is caught and logged. `appStore`
+ * stays authoritative, so the render path's faithful-mirror gate simply keeps
+ * rendering `appStore.rootPanel` and {@link seedLayoutRegion} re-syncs the region
+ * — nothing is lost. A rejected optimistic dispatch rolls its overlay back at
+ * once ({@link ProjectionClient.dispatchOptimistic}), leaving the region on the
+ * backend's view while `appStore` holds the local result.
  */
-export async function runLayoutIntent(
+export function mirrorLayoutIntent(
   kind: string,
   payload: Record<string, unknown>,
-  snapshot: LayoutSnapshot,
-  focusTabId?: string
-): Promise<LayoutStructuralResult> {
-  const client = await ensureSubscribed();
-  const activeGroup =
-    snapshot.groups.find((g) => g.id === snapshot.activeGroupId) ?? snapshot.groups[0];
-  if (!activeGroup) {
-    throw new Error("layout snapshot has no active group");
-  }
-  const tabsById = collectTabs(activeGroup.root);
-
-  // Seed the store with appStore's authoritative multi-group layout, then
-  // transform the active group.
-  throwIfRejected(
-    await dispatch("layout.replaceGroups", {
-      groups: snapshot.groups.map(toMinimalGroup),
-      activeGroupId: snapshot.activeGroupId,
-    }),
-    "replaceGroups"
-  );
-  const ack = await dispatch(kind, payload);
-  throwIfRejected(ack, kind);
-
-  const produced = ack.produced?.find((p) => p.region === region);
-  if (produced) {
-    await awaitVersion(client, produced.version);
+  preSnapshot: LayoutSnapshot,
+  postSnapshot: LayoutSnapshot
+): void {
+  let client: ProjectionClient;
+  try {
+    client = layoutRegionClient();
+  } catch (err) {
+    // No transport (e.g. non-Tauri without a socket): appStore already holds the
+    // authoritative result, so a failed mirror is a resilience event, not a crash.
+    logBridgeFallback(kind, err);
+    return;
   }
 
-  const view = client.state.view as LayoutView | undefined;
-  const projectedGroup = view ? activeGroupOf(view) : undefined;
-  if (!projectedGroup || !projectedGroup.root) {
-    throw new Error("layout region has no active group after intent");
-  }
-  const rootPanel = reconcileNode(projectedGroup.root, tabsById);
-  const activePanelId = focusTabId
-    ? (findLeafByTab(rootPanel, focusTabId)?.id ?? projectedGroup.activePanelId)
-    : projectedGroup.activePanelId;
-  return { rootPanel, activePanelId };
+  // Ensure the region is subscribed so the authoritative diff arrives to prune the
+  // overlay; a subscribe failure is logged and does not strand it.
+  void ensureSubscribed().catch((err) => logBridgeFallback("subscribe", err));
+
+  const postView: LayoutView = {
+    groups: postSnapshot.groups.map(toMinimalGroup),
+    activeGroupId: postSnapshot.activeGroupId,
+  };
+
+  // Seed the authoritative backend to the pre-transform layout so the granular
+  // intent it then applies produces the same tree (fire-and-forget, ordered
+  // before the intent by the transport's FIFO delivery).
+  void dispatch("layout.replaceGroups", {
+    groups: preSnapshot.groups.map(toMinimalGroup),
+    activeGroupId: preSnapshot.activeGroupId,
+  })
+    .then((ack) => throwIfRejected(ack, "replaceGroups"))
+    .catch((err) => logBridgeFallback("replaceGroups", err));
+
+  // Dispatch the granular intent under a synchronous optimistic overlay that
+  // installs `postView` at once. The overlay is a last-writer constant (it
+  // ignores the baseline), so the region reflects the mutation even before the
+  // seed diff lands, and is pruned when the intent's version confirms.
+  const intent: Intent = { intentId: newIntentId(), kind, payload, clientId };
+  void client
+    .dispatchOptimistic(intent, () => postView)
+    .then((ack) => {
+      if (ack.status === "rejected") {
+        logBridgeFallback(kind, new Error(ack.error?.message ?? "rejected"));
+      }
+    })
+    .catch((err) => logBridgeFallback(kind, err));
 }
 
 /** Map a {@link DropEdge} to a `layout.moveTab` payload for a split-with-tab drop. */

--- a/src/test/layoutRegionTestHarness.ts
+++ b/src/test/layoutRegionTestHarness.ts
@@ -1,0 +1,452 @@
+/**
+ * Test harness for the client-scoped `layout@<clientId>` projection region
+ * (#2151 / #2283 slice D').
+ *
+ * {@link FakeLayoutTransport} is an in-memory twin of the Rust `LayoutStore`: it
+ * folds the granular `layout.*` intents exactly as the backend routes them
+ * (mirroring `src-tauri/src/layout/store.rs`) over a multi-group view
+ * `{ groups, activeGroupId }`, and fans a fresh snapshot to every subscriber. It
+ * lets a test drive `appStore`'s layout reducers through the **real**
+ * {@link import("@/store/layoutBridge").mirrorLayoutIntent} path — the optimistic
+ * overlay applies synchronously, and this fake backend supplies the authoritative
+ * diff that reconciles (prunes) it.
+ *
+ * Because the reducers stay authoritative for `appStore.rootPanel` under slice D'
+ * (the fallback removal is still gated on #2283), tests assert two things: the
+ * local tree lands in `appStore.rootPanel` synchronously, and the projected region
+ * view (via {@link import("@/store/layoutBridge").currentLayoutView}) tracks it.
+ */
+
+import type {
+  FrameHandler,
+  Intent,
+  IntentAck,
+  SnapshotFrame,
+  Subscription,
+  Transport,
+} from "@/services/transport";
+import {
+  createLeafPanel,
+  edgeToSplit,
+  findLeaf,
+  findLeafByTab,
+  generatePanelId,
+  getAllLeaves,
+  normalizeSizes,
+  removeLeaf,
+  simplifyTree,
+  splitLeaf,
+  updateLeaf,
+} from "@/utils/panelTree";
+import type { DropEdge, LeafPanel, PanelNode } from "@/types/terminal";
+
+import { setLayoutTransportForTest, stopLayoutSubscription } from "@/store/layoutBridge";
+
+/** A minimal projected tab (twin of the Rust `Tab`). */
+export interface MinimalTab {
+  id: string;
+  sessionId?: string | null;
+  contentType: string;
+}
+
+/** One projected tab group (twin of the Rust `GroupLayout`). */
+export interface GroupView {
+  id: string;
+  name: string;
+  color?: string;
+  root: PanelNode;
+  activePanelId: string | null;
+}
+
+/** The full multi-group region view (twin of the Rust `ClientLayout`). */
+export interface FullLayoutView {
+  groups: GroupView[];
+  activeGroupId: string;
+}
+
+let fakeGroupCounter = 0;
+
+/** A minimal-view tab removal with the positional active fallback (Rust parity). */
+function removeTabMinimal(leaf: LeafPanel, tabId: string): LeafPanel {
+  const idx = leaf.tabs.findIndex((t) => t.id === tabId);
+  if (idx === -1) return leaf;
+  const tabs = leaf.tabs.filter((t) => t.id !== tabId);
+  let activeTabId = leaf.activeTabId;
+  if (activeTabId === tabId) {
+    activeTabId = tabs.length ? tabs[Math.min(idx, tabs.length - 1)].id : null;
+  }
+  return { ...leaf, tabs, activeTabId };
+}
+
+/** Repoint a group's focus at an existing leaf when the current one is gone. */
+function fixActive(group: GroupView): GroupView {
+  const present = group.activePanelId && findLeaf(group.root, group.activePanelId);
+  if (present) return group;
+  return { ...group, activePanelId: getAllLeaves(group.root)[0]?.id ?? null };
+}
+
+/**
+ * An in-memory substrate double for the `layout@<clientId>` region: holds one
+ * multi-group view, folds the granular `layout.*` intents like the Rust store, and
+ * fans a snapshot to every subscriber.
+ */
+export class FakeLayoutTransport implements Transport {
+  dispatched: Intent[] = [];
+  /** When `true`, every dispatch is rejected — drives the rollback path. */
+  reject = false;
+
+  private view: FullLayoutView = {
+    groups: [{ id: "g-seed", name: "Main", root: createLeafPanel(), activePanelId: null }],
+    activeGroupId: "g-seed",
+  };
+  private version = 0;
+  private handlers = new Set<FrameHandler>();
+  private region = "";
+
+  /** Intent kinds dispatched, in order (assertion helper). */
+  kinds(): string[] {
+    return this.dispatched.map((i) => i.kind);
+  }
+
+  /** The current projected multi-group view (assertion helper). */
+  regionView(): FullLayoutView {
+    return structuredClone(this.view);
+  }
+
+  /** The active group of the current view (assertion helper). */
+  activeGroup(): GroupView {
+    return this.view.groups.find((g) => g.id === this.view.activeGroupId) ?? this.view.groups[0];
+  }
+
+  /** Seed the region view directly (test setup), fanning a snapshot. */
+  seed(view: FullLayoutView): void {
+    this.view = structuredClone(view);
+    this.bump();
+  }
+
+  private groupFor(groupId: string | undefined): GroupView {
+    if (groupId) return this.view.groups.find((g) => g.id === groupId) ?? this.activeGroup();
+    return this.activeGroup();
+  }
+
+  private setGroup(next: GroupView): void {
+    this.view.groups = this.view.groups.map((g) => (g.id === next.id ? next : g));
+  }
+
+  private setRoot(group: GroupView, root: PanelNode, activePanelId: string | null): void {
+    this.setGroup(fixActive({ ...group, root, activePanelId }));
+  }
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    this.dispatched.push(intent);
+    if (this.reject) {
+      return {
+        intentId: intent.intentId,
+        status: "rejected",
+        error: { code: "x", message: "nope" },
+      };
+    }
+    const p = intent.payload as Record<string, unknown>;
+    const gid = p.groupId as string | undefined;
+    switch (intent.kind) {
+      case "layout.replaceGroups":
+        this.view = {
+          groups: structuredClone(p.groups as GroupView[]),
+          activeGroupId: p.activeGroupId as string,
+        };
+        break;
+      case "layout.split": {
+        const g = this.groupFor(gid);
+        const newLeaf = createLeafPanel();
+        let root = splitLeaf(
+          g.root,
+          p.panelId as string,
+          newLeaf,
+          p.direction as "horizontal" | "vertical",
+          p.position as "before" | "after"
+        );
+        root = simplifyTree(root);
+        this.setRoot(g, root, newLeaf.id);
+        break;
+      }
+      case "layout.moveTab": {
+        const g = this.groupFor(gid);
+        const tabId = p.tabId as string;
+        const target = p.targetPanelId as string;
+        const src = findLeafByTab(g.root, tabId);
+        if (!src) return this.rejectAck(intent, "tab_not_found");
+        const theTab = src.tabs.find((t) => t.id === tabId);
+        if (!theTab) return this.rejectAck(intent, "tab_not_found");
+        let root = updateLeaf(g.root, src.id, (leaf) => removeTabMinimal(leaf, tabId));
+        const splitInfo = edgeToSplit(p.edge as DropEdge);
+        if (!splitInfo) {
+          root = updateLeaf(root, target, (leaf) => ({
+            ...leaf,
+            tabs: [...leaf.tabs, { ...theTab }],
+            activeTabId: tabId,
+          }));
+        } else {
+          const newLeaf: LeafPanel = {
+            type: "leaf",
+            id: generatePanelId(),
+            tabs: [{ ...theTab }],
+            activeTabId: tabId,
+          };
+          root = splitLeaf(root, target, newLeaf, splitInfo.direction, splitInfo.position);
+        }
+        const src2 = findLeaf(root, src.id);
+        if (src2 && src2.tabs.length === 0) {
+          const removed = removeLeaf(root, src.id);
+          root = removed ? simplifyTree(removed) : simplifyTree(root);
+        } else {
+          root = simplifyTree(root);
+        }
+        this.setRoot(g, root, g.activePanelId);
+        break;
+      }
+      case "layout.removePanel": {
+        const g = this.groupFor(gid);
+        if (getAllLeaves(g.root).length <= 1) break;
+        const removed = removeLeaf(g.root, p.panelId as string);
+        this.setRoot(g, removed ? simplifyTree(removed) : g.root, g.activePanelId);
+        break;
+      }
+      case "layout.reorderTabs": {
+        const g = this.groupFor(gid);
+        const root = updateLeaf(g.root, p.panelId as string, (leaf) => {
+          const tabs = [...leaf.tabs];
+          const [moved] = tabs.splice(p.oldIndex as number, 1);
+          tabs.splice(p.newIndex as number, 0, moved);
+          return { ...leaf, tabs };
+        });
+        this.setRoot(g, root, g.activePanelId);
+        break;
+      }
+      case "layout.setActivePanel": {
+        const g = this.groupFor(gid);
+        if (!findLeaf(g.root, p.panelId as string))
+          return this.rejectAck(intent, "panel_not_found");
+        this.setRoot(g, g.root, p.panelId as string);
+        break;
+      }
+      case "layout.setActiveTab": {
+        const g = this.groupFor(gid);
+        const tabId = p.tabId as string;
+        const leaf = findLeafByTab(g.root, tabId);
+        if (!leaf) return this.rejectAck(intent, "tab_not_found");
+        const root = updateLeaf(g.root, leaf.id, (l) => ({
+          ...l,
+          tabs: l.tabs.map((t) => ({ ...t, isActive: t.id === tabId })),
+          activeTabId: tabId,
+        }));
+        this.setRoot(g, root, leaf.id);
+        break;
+      }
+      case "layout.resize": {
+        const g = this.groupFor(gid);
+        const splitId = p.splitId as string;
+        const sizes = normalizeSizes(p.sizes as number[]);
+        const apply = (n: PanelNode): PanelNode => {
+          if (n.type === "leaf") return n;
+          const children = n.children.map(apply);
+          return n.id === splitId ? { ...n, children, sizes } : { ...n, children };
+        };
+        this.setRoot(g, apply(g.root), g.activePanelId);
+        break;
+      }
+      case "layout.addTab": {
+        const g = this.groupFor(gid);
+        const tab = p.tab as MinimalTab;
+        const panelId = p.panelId as string;
+        if (!findLeaf(g.root, panelId)) return this.rejectAck(intent, "panel_not_found");
+        const root = updateLeaf(g.root, panelId, (leaf) => ({
+          ...leaf,
+          tabs: [...leaf.tabs, tab as unknown as LeafPanel["tabs"][number]],
+          activeTabId: tab.id,
+        }));
+        this.setRoot(g, root, panelId);
+        break;
+      }
+      case "layout.closeTabStructure": {
+        const g = this.groupFor(gid);
+        const tabId = p.tabId as string;
+        const leaf = findLeafByTab(g.root, tabId);
+        if (!leaf) return this.rejectAck(intent, "tab_not_found");
+        let root = updateLeaf(g.root, leaf.id, (l) => removeTabMinimal(l, tabId));
+        const after = findLeaf(root, leaf.id);
+        if (after && after.tabs.length === 0 && getAllLeaves(root).length > 1) {
+          const removed = removeLeaf(root, leaf.id);
+          root = removed ? simplifyTree(removed) : root;
+        }
+        this.setRoot(g, root, g.activePanelId);
+        break;
+      }
+      case "layout.addGroup": {
+        const leaf = createLeafPanel();
+        const id = `g-fake-${(fakeGroupCounter += 1)}`;
+        this.view.groups.push({
+          id,
+          name: (p.name as string) ?? `Group ${this.view.groups.length + 1}`,
+          root: leaf,
+          activePanelId: leaf.id,
+        });
+        this.view.activeGroupId = id;
+        break;
+      }
+      case "layout.closeGroup": {
+        const groupId = p.groupId as string;
+        if (this.view.groups.length <= 1) return this.rejectAck(intent, "last_group");
+        const idx = this.view.groups.findIndex((g) => g.id === groupId);
+        if (idx === -1) return this.rejectAck(intent, "group_not_found");
+        const wasActive = this.view.activeGroupId === groupId;
+        this.view.groups.splice(idx, 1);
+        if (wasActive) {
+          const newIdx = Math.min(Math.max(0, idx - 1), this.view.groups.length - 1);
+          this.view.activeGroupId = this.view.groups[newIdx].id;
+        }
+        break;
+      }
+      case "layout.renameGroup": {
+        const g = this.view.groups.find((x) => x.id === (p.groupId as string));
+        if (!g) return this.rejectAck(intent, "group_not_found");
+        this.setGroup({ ...g, name: p.name as string });
+        break;
+      }
+      case "layout.setGroupColor": {
+        const g = this.view.groups.find((x) => x.id === (p.groupId as string));
+        if (!g) return this.rejectAck(intent, "group_not_found");
+        const color = p.color as string | undefined;
+        const next: GroupView = { ...g };
+        if (color != null) next.color = color;
+        else delete next.color;
+        this.setGroup(next);
+        break;
+      }
+      case "layout.setActiveGroup": {
+        const groupId = p.groupId as string;
+        if (!this.view.groups.some((g) => g.id === groupId)) {
+          return this.rejectAck(intent, "group_not_found");
+        }
+        this.view.activeGroupId = groupId;
+        break;
+      }
+      case "layout.reorderGroups": {
+        const groups = [...this.view.groups];
+        const [moved] = groups.splice(p.fromIndex as number, 1);
+        groups.splice(p.toIndex as number, 0, moved);
+        this.view.groups = groups;
+        break;
+      }
+      case "layout.moveTabToGroup": {
+        const targetGroupId = p.targetGroupId as string;
+        if (targetGroupId === this.view.activeGroupId) break;
+        const target = this.view.groups.find((g) => g.id === targetGroupId);
+        if (!target) return this.rejectAck(intent, "group_not_found");
+        const active = this.activeGroup();
+        const tabId = p.tabId as string;
+        const from = p.fromPanelId as string;
+        const src = findLeaf(active.root, from);
+        const theTab = src?.tabs.find((t) => t.id === tabId);
+        if (!theTab) return this.rejectAck(intent, "tab_not_found");
+        let root = updateLeaf(active.root, from, (leaf) => removeTabMinimal(leaf, tabId));
+        const after = findLeaf(root, from);
+        if (after && after.tabs.length === 0 && getAllLeaves(root).length > 1) {
+          const removed = removeLeaf(root, from);
+          root = removed ? simplifyTree(removed) : root;
+        }
+        this.setGroup(fixActive({ ...active, root }));
+        const firstLeaf = getAllLeaves(target.root)[0];
+        const targetRoot = updateLeaf(target.root, firstLeaf.id, (leaf) => ({
+          ...leaf,
+          tabs: [...leaf.tabs, { ...theTab }],
+          activeTabId: theTab.id,
+        }));
+        this.setGroup({ ...target, root: targetRoot });
+        break;
+      }
+      case "layout.addGroupWithTab": {
+        const active = this.activeGroup();
+        const tabId = p.tabId as string;
+        const from = p.fromPanelId as string;
+        const src = findLeaf(active.root, from);
+        const theTab = src?.tabs.find((t) => t.id === tabId);
+        if (!theTab) return this.rejectAck(intent, "tab_not_found");
+        let root = updateLeaf(active.root, from, (leaf) => removeTabMinimal(leaf, tabId));
+        const after = findLeaf(root, from);
+        if (after && after.tabs.length === 0 && getAllLeaves(root).length > 1) {
+          const removed = removeLeaf(root, from);
+          root = removed ? simplifyTree(removed) : root;
+        }
+        this.setGroup(fixActive({ ...active, root }));
+        const leaf = createLeafPanel();
+        leaf.tabs = [{ ...theTab }];
+        leaf.activeTabId = theTab.id;
+        const id = `g-fake-${(fakeGroupCounter += 1)}`;
+        this.view.groups.push({
+          id,
+          name: `Group ${this.view.groups.length + 1}`,
+          root: leaf,
+          activePanelId: leaf.id,
+        });
+        this.view.activeGroupId = id;
+        break;
+      }
+      default:
+        // Unknown intent: accept without a fold (no region change).
+        return { intentId: intent.intentId, status: "accepted", produced: [] };
+    }
+    this.bump();
+    return {
+      intentId: intent.intentId,
+      status: "accepted",
+      produced: [{ region: this.region, version: this.version }],
+    };
+  }
+
+  private rejectAck(intent: Intent, code: string): IntentAck {
+    return { intentId: intent.intentId, status: "rejected", error: { code, message: code } };
+  }
+
+  async subscribe(region: string, onFrame: FrameHandler): Promise<Subscription> {
+    this.region = region;
+    this.handlers.add(onFrame);
+    return {
+      snapshot: this.snapshot(region),
+      unsubscribe: () => this.handlers.delete(onFrame),
+    };
+  }
+
+  async resync(): Promise<SnapshotFrame | null> {
+    return null;
+  }
+
+  private snapshot(region: string): SnapshotFrame {
+    return { kind: "snapshot", region, version: this.version, view: structuredClone(this.view) };
+  }
+
+  private bump(): void {
+    this.version += 1;
+    const frame = this.snapshot(this.region);
+    for (const h of this.handlers) h(frame);
+  }
+}
+
+/**
+ * Install a {@link FakeLayoutTransport} as the layout bridge's transport. Returns
+ * the transport plus a `teardown` that drops the subscription and restores the
+ * real transport — call it in `afterEach`.
+ */
+export function installLayoutHarness(): {
+  transport: FakeLayoutTransport;
+  teardown: () => void;
+} {
+  const transport = new FakeLayoutTransport();
+  setLayoutTransportForTest(transport);
+  return {
+    transport,
+    teardown: () => {
+      stopLayoutSubscription();
+      setLayoutTransportForTest(null);
+    },
+  };
+}


### PR DESCRIPTION
## What

Slice **D'** of the layout data-flow inversion (Part of \`#2283\`) — the **un-gated timing win**. It replaces the old `seed → await → reconcile` (`runLayoutIntent`) path with a **synchronous optimistic overlay** and adds the missing tab-activation intent, **without** removing any reducer or fallback (the #2283 reducer/fallback removal stays gated on the maintainer opening the extended-testing period).

### The shape
- **The local reducer stays authoritative and synchronous.** `appStore.rootPanel`/`tabGroups` update at once — no async round-trip before the tree changes — and remain the retained **instant-revert fallback**.
- **The same transition is mirrored into the `layout@<clientId>` region synchronously** via `mirrorLayoutIntent` on `ProjectionClient.dispatchOptimistic`: it seeds the backend to the pre-transform tree, dispatches the **granular** intent, and overlays appStore's post-transform tree at once so the projection tracks it with no seed→await→reconcile latency. The backend's diff then prunes the overlay.
- **A rejected dispatch rolls the overlay back** while appStore keeps the local result — the fallback genuinely covers the failure.

### New backend primitive
- `layout.setActiveTab` (store reducer + projection route + store/route-parity tests). Activating a tab within its leaf previously had **no** `layout.*` intent — it's the prerequisite for routing `setActiveTab` (the hottest layout interaction) through the region.

### Ops routed (each via its granular intent)
`split`, `removePanel`, `setActivePanel`, `setPanelSizes` (`resize`), `reorderTabs`, `splitPanelWithTab` (`moveTab`), `setActiveTab`, `addTab`, `closeTab` (`closeTabStructure`), and the group ops `addGroup`/`closeGroup`/`renameGroup`/`setGroupColor`/`setActiveGroup`/`reorderGroups`/`moveTabToGroup`/`addGroupWithTab`.

### Closes #2539 (folded in)
Agent-error tabs are now tracked in the by-id `tabContent` map at their creation site (workspace restore) and through the in-place **agent-error → terminal conversion**, so every rendered tab type resolves from the map and the in-tree fallback is pure belt-and-suspenders.

## Invariant
Tab/panel **ids are preserved** across split / move / group-switch / tab-activation — `addTab` passes the frontend-generated tab id to the backend — so the live xterm DOM (keyed by tab id) is **reparented, never remounted**.

## Tests
- New `FakeLayoutTransport` region harness (faithful twin of the Rust `LayoutStore`).
- Rewritten `appStore.layoutBridge.test.ts`: synchronous local authority, synchronous overlay feedback, backend reconcile, rejected-dispatch **rollback-to-fallback**, granular-intent routing for every op, and explicit tab-id preservation across split/move/group-switch/tab-activation.
- New `appStore.agentErrorTabContent.test.ts` (#2539): map comprehensiveness, conversion sync, close-prune, render parity.
- New Rust `set_active_tab` store + route-parity tests.

## Verification
- Full frontend suite green (**5001** tests, 555 files); `tsc` clean; `prettier --check` clean; eslint clean.
- `cargo test -p termihub layout::` (80 pass); `cargo fmt --check` clean; `cargo clippy --all-targets --all-features -D warnings` clean.

Part of \`#2283\` (does not close the umbrella). Closes #2539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)