### PR TITLE
feat(terminal): default sessionBackendReattach on — backend is sole reconnect authority (Part of #2205)

### DIFF
--- a/src/components/Terminal/Terminal.inflight-per-attempt.test.tsx
+++ b/src/components/Terminal/Terminal.inflight-per-attempt.test.tsx
@@ -28,6 +28,7 @@ import { createRoot, Root } from "react-dom/client";
 import { Terminal } from "./Terminal";
 import { TerminalPortalProvider } from "./TerminalRegistry";
 import { useAppStore } from "@/store/appStore";
+import { setSessionBackendReattachEnabled } from "@/store/sessionBridge";
 
 // --- Mocks ---
 
@@ -152,6 +153,11 @@ let root: Root;
 
 beforeEach(() => {
   useAppStore.setState(useAppStore.getInitialState());
+  // This suite exercises the client-redrive fallback (per-attempt
+  // `create_connection` in-flight tracking). Since #2205 PR-B flipped
+  // `sessionBackendReattach` on by default, pin it OFF so the retained
+  // instant-revert fallback path is what is under test here.
+  setSessionBackendReattachEnabled(false);
   pendingConnects.length = 0;
   mockCreateTerminal.mockClear();
   mockCancelConnecting.mockClear();
@@ -163,6 +169,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount());
   container.remove();
+  setSessionBackendReattachEnabled(null);
 });
 
 // Direct (non-agent) local shell connection so setupTerminal takes the

--- a/src/components/Terminal/Terminal.overlapping-connect.test.tsx
+++ b/src/components/Terminal/Terminal.overlapping-connect.test.tsx
@@ -22,6 +22,7 @@ import { createRoot, Root } from "react-dom/client";
 import { Terminal } from "./Terminal";
 import { TerminalPortalProvider } from "./TerminalRegistry";
 import { useAppStore } from "@/store/appStore";
+import { setSessionBackendReattachEnabled } from "@/store/sessionBridge";
 
 // --- Mocks ---
 
@@ -142,6 +143,11 @@ let root: Root;
 
 beforeEach(() => {
   useAppStore.setState(useAppStore.getInitialState());
+  // This suite exercises the client-redrive fallback (a reconnect calling
+  // `create_connection` with a fresh connect id). Since #2205 PR-B flipped
+  // `sessionBackendReattach` on by default, pin it OFF so the retained
+  // instant-revert fallback path is what is under test here.
+  setSessionBackendReattachEnabled(false);
   createTerminalConnectIds.length = 0;
   mockCreateTerminal.mockClear();
   mockCancelConnecting.mockClear();
@@ -153,6 +159,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount());
   container.remove();
+  setSessionBackendReattachEnabled(null);
 });
 
 // Direct (non-agent) local shell connection so setupTerminal takes the

--- a/src/components/Terminal/Terminal.reconnect-fresh.test.tsx
+++ b/src/components/Terminal/Terminal.reconnect-fresh.test.tsx
@@ -17,6 +17,7 @@ import { createRoot, Root } from "react-dom/client";
 import { Terminal } from "./Terminal";
 import { TerminalPortalProvider } from "./TerminalRegistry";
 import { useAppStore } from "@/store/appStore";
+import { setSessionBackendReattachEnabled } from "@/store/sessionBridge";
 import { setupAgentsRegion, seedAgentsRegion } from "@/test/agentsRegionTestHarness";
 
 // --- Mocks ---
@@ -125,6 +126,11 @@ let root: Root;
 
 beforeEach(() => {
   useAppStore.setState(useAppStore.getInitialState());
+  // This suite exercises the client-redrive fallback (a reconnect calling
+  // `create_connection` to mint a fresh session). Since #2205 PR-B flipped
+  // `sessionBackendReattach` on by default, pin it OFF so the retained
+  // instant-revert fallback path is what is under test here.
+  setSessionBackendReattachEnabled(false);
   mockCreateTerminal.mockClear();
   mockCreateTerminal.mockResolvedValue("fresh-session");
   mockGetAgentSessionBuffer.mockClear();
@@ -136,6 +142,7 @@ beforeEach(() => {
 afterEach(() => {
   act(() => root.unmount());
   container.remove();
+  setSessionBackendReattachEnabled(null);
 });
 
 const AGENT_CONFIG = {

--- a/src/store/sessionBridge.backendReattach.test.ts
+++ b/src/store/sessionBridge.backendReattach.test.ts
@@ -3,9 +3,10 @@
  * server-side reconnect redrive #2454 / umbrella #2446).
  *
  * Covers the two new pieces this issue adds to `sessionBridge`:
- *  - {@link sessionBackendReattachEnabled} — the NEW default-off flag that switches
- *    a direct-connection reconnect from the client redrive to the attach-to-given-
- *    session path. Default off ⇒ behavior identical to `develop`.
+ *  - {@link sessionBackendReattachEnabled} — the flag that switches a
+ *    direct-connection reconnect from the client redrive to the attach-to-given-
+ *    session path. Default **on** (#2205 PR-B); the `"false"` override forces the
+ *    client-redrive fallback for an instant revert.
  *  - {@link waitForBackendReattachSessionId} — resolves the backend session id the
  *    server-side redrive publishes to the `session-lifecycle` region (keyed by tab
  *    id), so the terminal can re-attach I/O without calling `create_connection`.
@@ -100,15 +101,17 @@ afterEach(() => {
 });
 
 describe("sessionBackendReattachEnabled flag", () => {
-  it("defaults OFF and honours the programmatic override", () => {
-    // Default off ⇒ the client redrive path is unchanged (develop behavior).
-    expect(sessionBackendReattachEnabled()).toBe(false);
-    setSessionBackendReattachEnabled(true);
+  it("defaults ON and honours the programmatic override", () => {
+    // Default on (#2205 PR-B) ⇒ the backend is the sole reconnect authority.
+    // The `"false"` override still forces the client-redrive fallback for an
+    // instant revert.
     expect(sessionBackendReattachEnabled()).toBe(true);
     setSessionBackendReattachEnabled(false);
     expect(sessionBackendReattachEnabled()).toBe(false);
+    setSessionBackendReattachEnabled(true);
+    expect(sessionBackendReattachEnabled()).toBe(true);
     setSessionBackendReattachEnabled(null);
-    expect(sessionBackendReattachEnabled()).toBe(false);
+    expect(sessionBackendReattachEnabled()).toBe(true);
   });
 });
 

--- a/src/store/sessionBridge.ts
+++ b/src/store/sessionBridge.ts
@@ -253,18 +253,21 @@ export function setSessionBackendReattachEnabled(value: boolean | null): void {
  * re-attaches terminal I/O to a backend-chosen session id instead of driving the
  * reconnect itself via `create_connection` (#2457).
  *
- * **Off by default.** When on, a direct-connection reconnect no longer calls
- * `create_connection`; instead {@link waitForBackendReattachSessionId} reads the
- * new backend session id the server-side redrive publishes to the
- * `session-lifecycle` region and the terminal re-attaches to it. When off (the
- * default) the client redrive runs exactly as on `develop` — the terminal calls
- * `create_connection` on every reconnect — so behavior is byte-identical.
+ * **On by default (#2205 PR-B).** When on, a direct-connection reconnect no
+ * longer calls `create_connection`; instead {@link waitForBackendReattachSessionId}
+ * reads the new backend session id the server-side redrive publishes to the
+ * `session-lifecycle` region and the terminal re-attaches to it. The backend is
+ * the sole reconnect authority for both agent and direct-SSH tabs: the
+ * source-side drop fold arms the backend reconnect timer (#2476) and the redrive
+ * (#2454/#2512) re-establishes the transport itself, so no client
+ * `create_connection` redrive runs.
  *
- * This is the same flag the backend redrive wiring (#2454's remainder) gates on:
- * turning it on without both halves present would strand the reconnect, so it
- * stays off until that lands. Overridable at runtime for rollout / tests via
- * `window.__TERMIHUB_SESSION_BACKEND_REATTACH__` or
- * `localStorage["termihub.sessionBackendReattach"]` (`"true"` to force on).
+ * Both halves — the backend redrive (#2454/#2512) and the frontend re-attach
+ * (#2457) — are present, so the default flipped on once the extended-testing gate
+ * (#2283) opened. It remains overridable at runtime for an instant revert /
+ * rollout via `window.__TERMIHUB_SESSION_BACKEND_REATTACH__` or
+ * `localStorage["termihub.sessionBackendReattach"]` (`"false"` to force off,
+ * `"true"` to force on).
  */
 export function sessionBackendReattachEnabled(): boolean {
   if (backendReattachFlagOverride !== null) return backendReattachFlagOverride;
@@ -281,7 +284,7 @@ export function sessionBackendReattachEnabled(): boolean {
   } catch {
     // A missing/blocked window or storage just means "use the default".
   }
-  return false;
+  return true;
 }
 
 // ── Transport + region client (lazy, mirrors the tunnel slice) ─────────────────


### PR DESCRIPTION
## Summary

Flips the `sessionBackendReattach` flag **on by default**, making the backend the
sole reconnect authority for both **agent** and **direct-SSH** tabs. This is the
**activation half** of #2205 PR-B. It deliberately does **not** delete the client
reconnect engine — see *Why not the full deletion yet* below — so it does not
`Closes #2205`.

Under the new default:
- a genuine drop of a resilient tab is folded server-side (`DropFold::Reconnect`
  → `store.reconnect`, `src-tauri/src/session/manager.rs`), which **arms the
  backend reconnect timer itself** (#2476) rather than depending on the client
  `session.reconnect` mirror;
- the backend redrive (`src-tauri/src/session_projection/redrive.rs`)
  re-establishes the transport for **direct** (#2454) and **agent** (#2512) tabs,
  mints/​re-attaches the session, and publishes the new backend session id to the
  `session-lifecycle` region;
- the frontend re-attaches terminal I/O to that id (#2457) — agent tabs via the
  give-up-aware wait (no client fall-through), direct tabs via
  `waitForBackendReattachSessionId`.

Instant revert is preserved: `window.__TERMIHUB_SESSION_BACKEND_REATTACH__ = false`
or `localStorage["termihub.sessionBackendReattach"] = "false"` forces the client
redrive engine back on.

## Verification
- Backend genuinely drives **direct-SSH** reconnect end-to-end (source-side drop
  fold arms the timer; redrive re-establishes the direct transport with
  `agent_id = None` and folds the outcome) — verified in code + covered by
  `redrive_resume_tests.rs`. No stranded-reconnect gap.
- Full frontend suite green (5001 tests); `pnpm build` (tsc) clean; prettier clean.
- Four suites adjusted: `sessionBridge.backendReattach.test.ts` now asserts the
  default-on; the three client-redrive suites
  (`Terminal.{reconnect-fresh,overlapping-connect,inflight-per-attempt}`) are
  pinned flag-off so they keep exercising the retained instant-revert fallback.

## Why not the full deletion (client engine) yet
#2205 PR-B as written also deletes the appStore reconnect engine
(`driveAutoReconnect` + `terminalConnecting` / `terminalReconnectingTabs` /
`terminalReconnectTriggerErrors` / `terminalAutoReconnect` + timers). Deleting it
**removes the instant-revert fallback** — once the engine is gone, `flag = false`
has nothing to revert to. On the ventilator-grade reconnect hot path the
established discipline is to keep the instant-revert fallback until **after** the
extended-testing period, and the live prolonged-drop grade below has not yet run.
So the engine deletion is deferred to the Phase-6 removal (#2283), to land once
the live grade passes.

## Manual gate (final verification — needs a foreground display)
The live prolonged agent-drop / direct-SSH-drop reconnect grade must be run on a
real foreground display (headless WKWebView occlusion-throttles the long connect):
`scripts/internal/verify-agent-reconnect.sh` (flag is now the default, so no
override needed) plus `scripts/internal/agent-reconnect-transport.sh drop|restore`.
This is the extended-testing step that must pass before the client engine is
deleted under #2283.

Part of #2205. Prerequisite verification for #2283.