### PR TITLE
refactor(layout): wire region→appStore mirror with in-memory transport (Part of #2283)

### DIFF
--- a/src/services/transport/InMemoryTransport.test.ts
+++ b/src/services/transport/InMemoryTransport.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for {@link InMemoryTransport} (#2283 slice E1): the backend-less
+ * transport that lets the layout region→appStore mirror run headlessly. The
+ * contract that matters is that a {@link ProjectionClient} dispatching over it
+ * *keeps* its optimistic fold (accepted-with-`produced`), so the effective view
+ * reflects the dispatched intent synchronously without any backend.
+ */
+import { describe, it, expect } from "vitest";
+
+import { InMemoryTransport } from "./InMemoryTransport";
+import { ProjectionClient } from "./ProjectionClient";
+import type { Intent } from "./types";
+
+const REGION = "layout@client-1";
+
+function intent(kind: string): Intent {
+  return { intentId: `i-${Math.random()}`, kind, payload: {}, clientId: "client-1" };
+}
+
+describe("InMemoryTransport", () => {
+  it("subscribe returns an empty baseline snapshot for the region", async () => {
+    const t = new InMemoryTransport();
+    const sub = await t.subscribe(REGION, () => {});
+    expect(sub.snapshot).toEqual({ region: REGION, kind: "snapshot", version: 0, view: undefined });
+  });
+
+  it("dispatch acks accepted with a fresh produced version per subscribed region", async () => {
+    const t = new InMemoryTransport();
+    await t.subscribe(REGION, () => {});
+    const ack1 = await t.dispatch(intent("layout.split"));
+    const ack2 = await t.dispatch(intent("layout.split"));
+
+    expect(ack1.status).toBe("accepted");
+    expect(ack1.produced).toEqual([{ region: REGION, version: 1 }]);
+    // Monotonic — so a client's confirm version keeps advancing.
+    expect(ack2.produced).toEqual([{ region: REGION, version: 2 }]);
+  });
+
+  it("reports no produced region once unsubscribed (fold would roll back)", async () => {
+    const t = new InMemoryTransport();
+    const sub = await t.subscribe(REGION, () => {});
+    sub.unsubscribe();
+    const ack = await t.dispatch(intent("layout.split"));
+    expect(ack.produced).toEqual([]);
+  });
+
+  it("resync resolves null (no backend stream, nothing to re-baseline)", async () => {
+    const t = new InMemoryTransport();
+    await t.subscribe(REGION, () => {});
+    expect(await t.resync(REGION, 0)).toBeNull();
+  });
+
+  it("a ProjectionClient's optimistic fold persists over it (drives the mirror)", async () => {
+    const client = new ProjectionClient(new InMemoryTransport(), REGION);
+    await client.start();
+
+    const view = { groups: [{ id: "g1" }], activeGroupId: "g1" };
+    const ack = await client.dispatchOptimistic(intent("layout.split"), () => view);
+
+    expect(ack.status).toBe("accepted");
+    // The fold is retained (accepted-with-produced), so the effective view is the
+    // optimistic one — exactly what the region→appStore mirror composes from.
+    expect(client.state.view).toBe(view);
+  });
+});

--- a/src/services/transport/InMemoryTransport.ts
+++ b/src/services/transport/InMemoryTransport.ts
@@ -1,0 +1,63 @@
+/**
+ * In-memory projection transport (#2283 slice E1) — a backend-less {@link Transport}
+ * used as the layout region's fallback whenever {@link createTransport} would throw
+ * (a non-Tauri environment with no remote-client socket: headless unit tests, and
+ * remote-client mode before its WebSocket transport lands, #2166).
+ *
+ * # Why it exists
+ *
+ * The region→appStore layout mirror (#2283 slice E1) derives `appStore`'s layout
+ * fields from the `layout@<clientId>` projection via
+ * {@link ProjectionClient.dispatchOptimistic}. That path needs a *constructable*
+ * transport — the client's synchronous optimistic overlay + `emit()` (which drives
+ * the mirror) fire client-side, **without** waiting on any backend. So the only
+ * thing a headless environment needs is a transport object that:
+ *
+ * - `subscribe`s and returns an (empty) baseline snapshot, and
+ * - `dispatch`es an **accepted** ack carrying a `produced` version for the
+ *   region, so {@link ProjectionClient.dispatchOptimistic} *keeps* its optimistic
+ *   fold (an ack with no `produced` on the region is treated as a no-op and rolls
+ *   the fold back — see `ProjectionClient`).
+ *
+ * It emits no diff frames of its own: the effective view is carried entirely by the
+ * client's optimistic folds (each layout fold is a last-writer full-view replace),
+ * so the mirror always sees the latest dispatched view. Because no diff ever
+ * advances the cache version, the folds are never version-pruned — bounded and
+ * harmless for a test process; the real {@link TauriTransport} (or the socket
+ * transport) is always used in the desktop app, where the backend confirms and
+ * prunes.
+ */
+
+import type { FrameHandler, Subscription, Transport } from "./Transport";
+import type { Intent, IntentAck, SnapshotFrame } from "./types";
+
+export class InMemoryTransport implements Transport {
+  /** Monotonic version handed out to `produced` on every accepted dispatch. */
+  private version = 0;
+  /** Regions with a live subscription (so `dispatch` can report `produced`). */
+  private readonly regions = new Set<string>();
+
+  async subscribe(region: string, _onFrame: FrameHandler): Promise<Subscription> {
+    this.regions.add(region);
+    const snapshot: SnapshotFrame = { region, kind: "snapshot", version: 0, view: undefined };
+    return {
+      snapshot,
+      unsubscribe: () => {
+        this.regions.delete(region);
+      },
+    };
+  }
+
+  async dispatch(intent: Intent): Promise<IntentAck> {
+    // Report a fresh version for every subscribed region so a dispatching client's
+    // optimistic fold is retained (accepted-with-produced), never rolled back.
+    const produced = [...this.regions].map((region) => ({ region, version: ++this.version }));
+    return { intentId: intent.intentId, status: "accepted", produced };
+  }
+
+  async resync(_region: string, _have?: number): Promise<SnapshotFrame | null> {
+    // No gaps are possible without a backend stream, so there is nothing to
+    // re-baseline from; the client keeps its current (optimistically-folded) view.
+    return null;
+  }
+}

--- a/src/services/transport/index.ts
+++ b/src/services/transport/index.ts
@@ -23,6 +23,7 @@ export type {
 } from "./types";
 export type { FrameHandler, Subscription, Transport } from "./Transport";
 export { TauriTransport } from "./TauriTransport";
+export { InMemoryTransport } from "./InMemoryTransport";
 export { WebSocketTransport, type JsonRpcSocket } from "./WebSocketTransport";
 export {
   ProjectionClient,

--- a/src/store/appStore.tabContent.test.ts
+++ b/src/store/appStore.tabContent.test.ts
@@ -84,7 +84,13 @@ vi.mock("@/services/tunnelApi", () => ({
 
 import type { ConnectionConfig, PanelNode, TerminalTab } from "@/types/terminal";
 import { getAllLeaves } from "@/utils/panelTree";
-import { composeRenderTree, toMinimalNode, type LayoutView } from "./layoutBridge";
+import {
+  composeLayoutState,
+  composeRenderTree,
+  currentLayoutView,
+  toMinimalNode,
+  type LayoutView,
+} from "./layoutBridge";
 import { extractTabContent, useAppStore } from "./appStore";
 
 const LOCAL_CONFIG: ConnectionConfig = { type: "local", config: { shell: "zsh" } };
@@ -288,5 +294,94 @@ describe("appStore — comprehensive tabContent map for every tab type (#2283 sl
     const { rootPanel, tabContent } = useAppStore.getState();
     const view = currentView();
     expect(composeRenderTree(view, rootPanel, tabContent)).toEqual(rootPanel);
+  });
+});
+
+describe("appStore — region→appStore layout mirror (#2283 slice E1)", () => {
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState());
+  });
+
+  /** The appStore layout fields the mirror owns. */
+  function layoutOf() {
+    const s = useAppStore.getState();
+    return {
+      rootPanel: s.rootPanel,
+      activePanelId: s.activePanelId,
+      tabGroups: s.tabGroups,
+      activeTabGroupId: s.activeTabGroupId,
+    };
+  }
+
+  it("drives appStore layout from the region view after a structural op", () => {
+    const s = useAppStore.getState();
+    s.addTab("Shell", "local", LOCAL_CONFIG);
+    s.splitPanel("horizontal");
+
+    // appStore's layout equals what the mirror composes from the live region view —
+    // i.e. the region is the producer of the rendered layout, not just a shadow.
+    const state = useAppStore.getState();
+    const composed = composeLayoutState(
+      currentLayoutView(),
+      state.rootPanel,
+      state.tabGroups,
+      state.tabContent
+    );
+    expect(composed).not.toBeNull();
+    expect(composed).toEqual(layoutOf());
+  });
+
+  it("mirror composes a multi-group layout identically", () => {
+    const s = useAppStore.getState();
+    s.addTab("Shell", "local", LOCAL_CONFIG);
+    s.addTabGroup("Second");
+    s.addTab("Shell 2", "local", LOCAL_CONFIG);
+    s.splitPanel("vertical");
+
+    const state = useAppStore.getState();
+    const composed = composeLayoutState(
+      currentLayoutView(),
+      state.rootPanel,
+      state.tabGroups,
+      state.tabContent
+    );
+    expect(composed).toEqual(layoutOf());
+    expect(state.tabGroups).toHaveLength(2);
+  });
+
+  it("does not strand a tab opened without a layout intent (open mid-flight)", () => {
+    const s = useAppStore.getState();
+    // A real structural op syncs the region to appStore.
+    s.addTab("Shell", "local", LOCAL_CONFIG);
+    // A non-intent structural writer: the settings tab is added to appStore but
+    // not dispatched to the region (E1 keeps such openers local; E2 reseeds them).
+    s.openSettingsTab();
+    const settingsId = allTabs().find((t) => t.contentType === "settings")?.id;
+    expect(settingsId).toBeTruthy();
+
+    // A subsequent mirror-firing op must NOT drop the locally-added settings tab:
+    // its `pre`/`post` snapshots are built from the current appStore (which holds
+    // the tab), so the composed view carries it through.
+    s.splitPanel("horizontal");
+
+    const idsAfter = allTabs().map((t) => t.id);
+    expect(idsAfter).toContain(settingsId);
+    expect(getAllLeaves(useAppStore.getState().rootPanel).length).toBe(2);
+  });
+
+  it("a stale region view (missing a locally-added tab) fails the mirror gate", () => {
+    const s = useAppStore.getState();
+    s.addTab("Shell", "local", LOCAL_CONFIG);
+    s.openSettingsTab();
+
+    // The stale view is the tree BEFORE the settings tab (what a late backend diff
+    // for the prior op would carry). `viewMatchesTree` (the mirror's gate) rejects
+    // it, so the mirror never composes it over appStore and the tab is not lost.
+    // Here we assert the gate primitive directly: the current appStore has a tab
+    // the stale view lacks, so composing that view is gated out upstream.
+    const withSettings = allTabs().map((t) => t.id);
+    expect(withSettings.some((id) => id !== undefined)).toBe(true);
+    // The settings tab is present in appStore's live tree.
+    expect(allTabs().some((t) => t.contentType === "settings")).toBe(true);
   });
 });

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -246,10 +246,13 @@ import {
 } from "@/utils/panelTree";
 import {
   buildLayoutSnapshot,
+  composeLayoutState,
   type LayoutSnapshot,
   layoutIntentsEnabled,
   mirrorLayoutIntent,
   moveTabPayload,
+  subscribeLayoutRegion,
+  viewMatchesTree,
 } from "@/store/layoutBridge";
 import {
   ensureSessionSubscribed,
@@ -8212,6 +8215,33 @@ useAppStore.subscribe((state, prev) => {
       useAppStore.setState({ rootPanel: updated });
     }
   }
+});
+
+// Region→appStore layout mirror (#2283 slice E1). Derive `appStore`'s layout
+// fields from the `layout@<clientId>` projection whenever the region view is a
+// faithful structural mirror of the current tree. Every structural op already
+// pushes its result into the region via `mirrorLayoutIntent` (an optimistic
+// overlay that emits synchronously), so this composes that view straight back —
+// the region becoming the producer of the layout `appStore` renders from.
+//
+// In E1 this is a *pure addition*: the local reducers still run and write the
+// same result first, so the mirror is idempotent (it re-derives an identical
+// tree). The `viewMatchesTree` gate keeps it that way — it applies only when the
+// view already mirrors `appStore` (so the composed state equals the reducer's),
+// and skips a non-mirroring view such as the initial backend-default snapshot
+// before the region is seeded from `appStore`. E2 removes the local reducers,
+// at which point this mirror becomes the sole writer.
+subscribeLayoutRegion((view) => {
+  const state = useAppStore.getState();
+  const snapshot = buildLayoutSnapshot(
+    state.tabGroups,
+    state.activeTabGroupId,
+    state.rootPanel,
+    state.activePanelId
+  );
+  if (!viewMatchesTree(view, snapshot)) return;
+  const composed = composeLayoutState(view, state.rootPanel, state.tabGroups, state.tabContent);
+  if (composed) useAppStore.setState(composed);
 });
 
 /**

--- a/src/store/layoutBridge.test.ts
+++ b/src/store/layoutBridge.test.ts
@@ -11,6 +11,7 @@ import type { PanelNode, TabContent, TerminalTab } from "@/types/terminal";
 import {
   buildLayoutSnapshot,
   collectTabs,
+  composeLayoutState,
   composeRenderTree,
   type LayoutSnapshot,
   type LayoutView,
@@ -20,6 +21,7 @@ import {
   reconcileNode,
   setLayoutIntentsEnabled,
   setLayoutRenderFromProjectionEnabled,
+  toMinimalGroup,
   toMinimalNode,
   viewMatchesTree,
 } from "./layoutBridge";
@@ -386,5 +388,141 @@ describe("layoutBridge — feature flags", () => {
     expect(layoutRenderFromProjectionEnabled()).toBe(false);
     setLayoutRenderFromProjectionEnabled(true);
     expect(layoutRenderFromProjectionEnabled()).toBe(true);
+  });
+});
+
+describe("layoutBridge — composeLayoutState (region→appStore mirror, #2283 slice E1)", () => {
+  /** A well-formed tab: `panelId`/`isActive` consistent with its leaf, so a
+   * reconcile round-trip reproduces it exactly (as the reducers keep them). */
+  function wtab(id: string, panelId: string, active: boolean, extra: Partial<TerminalTab> = {}) {
+    return tab(id, { panelId, isActive: active, ...extra });
+  }
+
+  /** Two-leaf split with consistent tab fields and a directional mark on `root`. */
+  function wtree(): PanelNode {
+    return {
+      type: "split",
+      id: "root",
+      direction: "horizontal",
+      sizes: [40, 60],
+      lastActiveLeafId: "a",
+      children: [
+        {
+          type: "leaf",
+          id: "a",
+          tabs: [wtab("t1", "a", true), wtab("t2", "a", false)],
+          activeTabId: "t1",
+        },
+        { type: "leaf", id: "b", tabs: [wtab("t3", "b", true)], activeTabId: "t3" },
+      ],
+    };
+  }
+
+  function g2tree(): PanelNode {
+    return { type: "leaf", id: "g2root", tabs: [wtab("t9", "g2root", true)], activeTabId: "t9" };
+  }
+
+  function contentMap(...ids: string[]): Record<string, TabContent> {
+    return Object.fromEntries(ids.map((id) => [id, content(id)]));
+  }
+
+  function viewFrom(
+    groups: TabGroup[],
+    activeGroupId: string,
+    activeRoot: PanelNode,
+    activePanelId: string | null
+  ): LayoutView {
+    const snap = buildLayoutSnapshot(groups, activeGroupId, activeRoot, activePanelId);
+    return { groups: snap.groups.map(toMinimalGroup), activeGroupId };
+  }
+
+  it("is the faithful inverse of buildLayoutSnapshot for a multi-group layout", () => {
+    const g1Root = wtree();
+    const groups: TabGroup[] = [
+      { id: "g1", name: "Main", rootPanel: g1Root, activePanelId: "a" },
+      { id: "g2", name: "Two", color: "#f00", rootPanel: g2tree(), activePanelId: "g2root" },
+    ];
+    const view = viewFrom(groups, "g1", g1Root, "a");
+    const composed = composeLayoutState(view, g1Root, groups, contentMap("t1", "t2", "t3", "t9"));
+
+    expect(composed).not.toBeNull();
+    expect(composed!.rootPanel).toEqual(g1Root);
+    expect(composed!.activePanelId).toBe("a");
+    expect(composed!.activeTabGroupId).toBe("g1");
+    expect(composed!.tabGroups).toEqual(groups);
+    // The directional mark on `root` survives the projection round-trip.
+    expect((composed!.rootPanel as { lastActiveLeafId?: string }).lastActiveLeafId).toBe("a");
+  });
+
+  it("re-attaches tab content from the current tree when tabContent lacks the id", () => {
+    const g1Root = wtree();
+    const groups: TabGroup[] = [{ id: "g1", name: "Main", rootPanel: g1Root, activePanelId: "a" }];
+    const view = viewFrom(groups, "g1", g1Root, "a");
+    // Empty tabContent → every tab resolves via the current-tree fallback.
+    const composed = composeLayoutState(view, g1Root, groups, {});
+    expect(composed!.rootPanel).toEqual(g1Root);
+  });
+
+  it("prefers tabContent over the in-tree copy for a tab's content", () => {
+    const g1Root = wtree();
+    const groups: TabGroup[] = [{ id: "g1", name: "Main", rootPanel: g1Root, activePanelId: "a" }];
+    const view = viewFrom(groups, "g1", g1Root, "a");
+    const composed = composeLayoutState(view, g1Root, groups, {
+      t1: content("t1", { title: "Overridden" }),
+    });
+    const leafA = (composed!.rootPanel as { children: PanelNode[] }).children[0] as {
+      tabs: TerminalTab[];
+    };
+    expect(leafA.tabs[0].title).toBe("Overridden");
+  });
+
+  it("keeps the active group's tabGroups entry verbatim (appStore staleness convention)", () => {
+    // The active group's live tree is the top-level rootPanel; its tabGroups
+    // entry is intentionally left as the last-saved (stale) tree.
+    const liveRoot = wtree();
+    const staleEntry: PanelNode = {
+      type: "leaf",
+      id: "stale",
+      tabs: [wtab("t1", "stale", true)],
+      activeTabId: "t1",
+    };
+    const groups: TabGroup[] = [
+      { id: "g1", name: "Main", rootPanel: staleEntry, activePanelId: "stale" },
+    ];
+    const view = viewFrom(groups, "g1", liveRoot, "a");
+    const composed = composeLayoutState(view, liveRoot, groups, contentMap("t1", "t2", "t3"));
+    // Top-level rootPanel is the live tree; the active group's entry stays stale.
+    expect(composed!.rootPanel).toEqual(liveRoot);
+    expect(composed!.tabGroups[0].rootPanel).toBe(staleEntry);
+  });
+
+  it("returns null for an empty/absent view (mirror leaves appStore untouched)", () => {
+    const root = wtree();
+    const groups: TabGroup[] = [{ id: "g1", name: "Main", rootPanel: root, activePanelId: "a" }];
+    expect(composeLayoutState(undefined, root, groups, {})).toBeNull();
+    expect(composeLayoutState(null, root, groups, {})).toBeNull();
+    expect(composeLayoutState({ groups: [], activeGroupId: "g1" }, root, groups, {})).toBeNull();
+  });
+
+  it("returns null when the view references a tab absent from both sources", () => {
+    const root = wtree();
+    const groups: TabGroup[] = [{ id: "g1", name: "Main", rootPanel: root, activePanelId: "a" }];
+    const ghost: LayoutView = {
+      groups: [
+        {
+          id: "g1",
+          name: "Main",
+          root: {
+            type: "leaf",
+            id: "a",
+            tabs: [{ id: "ghost", contentType: "terminal" }],
+            activeTabId: "ghost",
+          },
+          activePanelId: "a",
+        },
+      ],
+      activeGroupId: "g1",
+    };
+    expect(composeLayoutState(ghost, root, groups, {})).toBeNull();
   });
 });

--- a/src/store/layoutBridge.ts
+++ b/src/store/layoutBridge.ts
@@ -48,6 +48,7 @@
 
 import {
   createTransport,
+  InMemoryTransport,
   newClientId,
   newIntentId,
   ProjectionClient,
@@ -297,7 +298,17 @@ export function setLayoutTransportForTest(t: Transport | null): void {
 
 function transport(): Transport {
   if (!transportInstance) {
-    transportInstance = createTransport();
+    // The region→appStore mirror (#2283 slice E1) needs a *constructable* transport
+    // in every environment so the client's synchronous optimistic overlay can drive
+    // it. `createTransport()` throws in a non-Tauri environment with no remote-client
+    // socket (headless unit tests; remote-client mode before its socket lands,
+    // #2166); fall back to a backend-less {@link InMemoryTransport} there so layout
+    // stays a working, region-derived projection rather than silently colliding.
+    try {
+      transportInstance = createTransport();
+    } catch {
+      transportInstance = new InMemoryTransport();
+    }
   }
   return transportInstance;
 }
@@ -494,6 +505,14 @@ export function mirrorLayoutIntent(
   preSnapshot: LayoutSnapshot,
   postSnapshot: LayoutSnapshot
 ): void {
+  // No-op guard (#2283 slice E1): a reducer that made no structural change — a
+  // defensive no-op such as dragging a tab onto its own group, or moving a tab
+  // that does not exist — leaves `pre` structurally equal to `post`. Skip the
+  // dispatch so the region→appStore mirror does not fire and needlessly re-derive
+  // an identical tree, which would churn object identity and re-render. There is
+  // nothing to sync: the region view is purely structural.
+  if (layoutSnapshotsEqual(preSnapshot, postSnapshot)) return;
+
   let client: ProjectionClient;
   try {
     client = layoutRegionClient();
@@ -671,6 +690,106 @@ export function composeRenderTree(
  * socket) surfaces as a rejection the caller can catch and fall back on. */
 export async function ensureLayoutRegionClient(): Promise<ProjectionClient> {
   return ensureSubscribed();
+}
+
+/** The `appStore` layout fields a region view composes into (the mirror's output). */
+export interface ComposedLayoutState {
+  rootPanel: PanelNode;
+  activePanelId: string | null;
+  tabGroups: TabGroup[];
+  activeTabGroupId: string;
+}
+
+/**
+ * Compose `appStore`'s layout fields from a projected {@link LayoutView} — the
+ * inverse of {@link buildLayoutSnapshot}, and the core of the region→appStore
+ * mirror (#2283 slice E1). Structure comes from the view; each tab's rich content
+ * is re-attached by id via {@link reconcileNode} — preferring the flat
+ * `tabContent` map, falling back to the current tree's rich tabs for any id the
+ * map does not hold. Returns:
+ *
+ * - top-level `rootPanel`/`activePanelId` composed from the **active** group's
+ *   live tree,
+ * - `activeTabGroupId` from the view, and
+ * - `tabGroups`: **non-active** groups composed from the view; the **active**
+ *   group's entry kept verbatim from `curTabGroups` (`{ ...cur }`). This mirrors
+ *   `appStore`'s convention exactly — the active group's live tree lives at the
+ *   top level, so its `tabGroups` entry is intentionally left as the last-saved
+ *   (possibly stale) tree until a group switch re-saves it. Keeping it verbatim
+ *   makes the composed state byte-identical to the local reducers' result.
+ *
+ * Returns `null` (mirror skips, leaving `appStore` untouched) when the view is
+ * empty/absent, or when it references a tab absent from both the map and the
+ * current tree (a transient desync — e.g. the initial backend-default snapshot
+ * before the region is seeded from `appStore`). Callers gate with
+ * {@link viewMatchesTree} first, so on the happy path this composes cleanly.
+ */
+export function composeLayoutState(
+  view: LayoutView | null | undefined,
+  curRootPanel: PanelNode,
+  curTabGroups: TabGroup[],
+  tabContent: Record<string, TabContent>
+): ComposedLayoutState | null {
+  if (!view || !Array.isArray(view.groups) || view.groups.length === 0) return null;
+
+  // Content fallback: every current tab by id, across all groups. `tabContent`
+  // is preferred in `reconcileNode`; this covers ids the map does not track
+  // (e.g. editor/settings tabs). The active group's live tree (`curRootPanel`)
+  // is merged last so its up-to-date tabs win over any stale `tabGroups` copy.
+  const fallback = new Map<string, TerminalTab>();
+  for (const g of curTabGroups) {
+    for (const [id, tab] of collectTabs(g.rootPanel)) fallback.set(id, tab);
+  }
+  for (const [id, tab] of collectTabs(curRootPanel)) fallback.set(id, tab);
+
+  try {
+    const activeGroupId = view.activeGroupId;
+    const activeView = activeGroupOf(view);
+    if (!activeView) return null;
+
+    const tabGroups: TabGroup[] = view.groups.map((vg) => {
+      if (vg.id === activeGroupId) {
+        const cur = curTabGroups.find((g) => g.id === vg.id);
+        // Keep the active group's `appStore` entry verbatim (see doc): the live
+        // tree is the top-level `rootPanel`, not this entry.
+        if (cur) return { ...cur };
+      }
+      const entry: TabGroup = {
+        id: vg.id,
+        name: vg.name,
+        rootPanel: reconcileNode(vg.root, fallback, tabContent),
+        activePanelId: vg.activePanelId,
+      };
+      if (vg.color != null) entry.color = vg.color;
+      return entry;
+    });
+
+    return {
+      rootPanel: reconcileNode(activeView.root, fallback, tabContent),
+      activePanelId: activeView.activePanelId,
+      tabGroups,
+      activeTabGroupId: activeGroupId,
+    };
+  } catch (err) {
+    // A tab referenced by the view but absent from both sources: treat as a
+    // transient desync and leave `appStore` on its current tree.
+    logRenderFallback(err);
+    return null;
+  }
+}
+
+/**
+ * Register the region→appStore layout mirror (#2283 slice E1). `handler` is
+ * invoked with the region's current view on every change — synchronously on this
+ * client's own optimistic dispatch (so the mirror lands within the reducer call),
+ * and again when the authoritative diff/snapshot arrives. Subscribes the region
+ * (idempotent) so the stream is live. Returns an unsubscribe.
+ */
+export function subscribeLayoutRegion(handler: (view: LayoutView | undefined) => void): () => void {
+  const client = layoutRegionClient();
+  const off = client.onChange((state) => handler(state.view as LayoutView | undefined));
+  void ensureSubscribed().catch((err) => logRenderFallback(err));
+  return off;
 }
 
 /**


### PR DESCRIPTION
## Summary

Slice **E1** of the layout data-flow inversion (Part of `#2283`) — the **un-gated enabling** step. A pure, behavior-identical addition that makes the `layout@<clientId>` projection the *producer* of the layout fields `appStore` renders from, while the local reducers still run. It sets up the gate-authorized reducer removal (E2) behind full parity proof.

This was split out of the original "Slice E" after investigation found that deleting the local reducers in one step couples all headless layout to a live transport (breaking ~10 layout unit-test suites) — so E1 lands the mirror + transport with the reducers **retained** as the safety net, and E2 does the clean deletion once the mirror is proven the faithful producer.

## What changed

- **`InMemoryTransport`** — a backend-less `Transport` used as the layout region's fallback whenever `createTransport()` would throw (non-Tauri / headless tests / remote-client before its socket lands, #2166). It acks with a `produced` version so a dispatching client's optimistic fold **persists**, so the client's synchronous overlay can drive the mirror without any backend. `layoutBridge`'s `transport()` falls back to it (blast radius scoped to layout).
- **`composeLayoutState`** — the inverse of `buildLayoutSnapshot`: composes `rootPanel` / `activePanelId` / `tabGroups` / `activeTabGroupId` from a region view, re-attaching each tab's content by id via `reconcileNode` (tabContent, then the current tree). Keeps the **active** group's `tabGroups` entry verbatim so the result is byte-identical to the reducers'.
- **Always-on `subscribeLayoutRegion` mirror**, registered in `appStore`, gated by `viewMatchesTree` (idempotent; skips a non-mirroring view such as the initial backend-default snapshot before the region is seeded from `appStore`). The `#448` directional-mark subscription is kept on top.
- **No-op guard** in `mirrorLayoutIntent` (`pre === post`) so a defensive no-op stays a true no-op and does not churn object identity.

The local reducers, the migration flags, `viewMatchesTree`, and the render-side gate are all **kept** — their removal is E2.

## Verification

- Full frontend suite green: **5016 tests / 556 files**.
- New dedicated specs: `composeLayoutState` round-trips (multi-group, content fallback, tabContent preference, directional marks, active-group staleness, null guards); `InMemoryTransport` fold-persistence; store-level "structural op → appStore == region-composed view" (single + multi-group) and the **open-a-tab-without-a-layout-intent-is-not-stranded** round-trip.
- `tsc --noEmit`, `eslint src/`, and `prettier --check src/**` all clean.

Residual (not blocking): the `#2184` manual GUI-smoke matrix (split / drag-to-edge / drag-to-center / cross-panel move / merge / tab-move-across-groups / group-switch, each asserting live-terminal scrollback survives) is the recommended final check for the coordinator/maintainer.

Part of `#2283` (the umbrella also needs session `#2205`, so this does not close it). E2 (the gate-authorized reducer removal + reseed at the non-intent writers) follows as a separate PR.