### PR TITLE
refactor(layout): finalize the layout data-flow inversion — remove appStore reducers (Part of #2283)

### DIFF
--- a/src/components/Terminal/ConfirmSessionCloseDialog.test.tsx
+++ b/src/components/Terminal/ConfirmSessionCloseDialog.test.tsx
@@ -3,7 +3,6 @@ import { act } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { useAppStore } from "@/store/appStore";
 import { getAllLeaves } from "@/utils/panelTree";
-import { setLayoutIntentsEnabled } from "@/store/layoutBridge";
 import { ConfirmSessionCloseDialog } from "./ConfirmSessionCloseDialog";
 
 const toastSuccess = vi.fn();
@@ -30,7 +29,6 @@ describe("ConfirmSessionCloseDialog", () => {
     // The panel-kind spec splits synchronously before rendering; pin to the local
     // reducer (retained resilience fallback) since the mutation cut (#2184) makes
     // the intent path async by default.
-    setLayoutIntentsEnabled(false);
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -41,7 +39,6 @@ describe("ConfirmSessionCloseDialog", () => {
     act(() => root.unmount());
     container.remove();
     vi.clearAllMocks();
-    setLayoutIntentsEnabled(null);
   });
 
   it("renders nothing when no request is pending", () => {

--- a/src/hooks/useKeyboardShortcuts.test.ts
+++ b/src/hooks/useKeyboardShortcuts.test.ts
@@ -60,7 +60,6 @@ import {
 import { matchHotkeyWorkflow } from "@/services/workflowTriggers";
 import { useAppStore } from "@/store/appStore";
 import { getAllLeaves } from "@/utils/panelTree";
-import { setLayoutIntentsEnabled } from "@/store/layoutBridge";
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
 import { setupSettingsRegion, seedSettings } from "@/test/settingsRegionTestHarness";
 
@@ -99,7 +98,6 @@ describe("useKeyboardShortcuts", () => {
     // split-right/-down assert the split synchronously; pin to the local reducer
     // (the retained resilience fallback) since the mutation cut (#2184) makes the
     // intent path async by default. Intent path covered in appStore.layoutBridge.test.ts.
-    setLayoutIntentsEnabled(false);
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -108,7 +106,6 @@ describe("useKeyboardShortcuts", () => {
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
-    setLayoutIntentsEnabled(null);
   });
 
   describe("lifecycle", () => {

--- a/src/services/contextCommands.test.ts
+++ b/src/services/contextCommands.test.ts
@@ -10,7 +10,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { CONTEXT_COMMANDS } from "./contextCommands";
 import { useAppStore, getActiveTab } from "@/store/appStore";
 import { getAllLeaves } from "@/utils/panelTree";
-import { setLayoutIntentsEnabled } from "@/store/layoutBridge";
 import { setupSettingsRegion, seedSettings } from "@/test/settingsRegionTestHarness";
 
 /** Add a tab of the given content type and make it the active tab/panel. */
@@ -37,12 +36,9 @@ beforeEach(() => {
   // focus-panel sets up panels via a synchronous splitPanel; pin to the local
   // reducer (retained resilience fallback) since the mutation cut (#2184) makes
   // the intent path async by default.
-  setLayoutIntentsEnabled(false);
 });
 
-afterEach(() => {
-  setLayoutIntentsEnabled(null);
-});
+afterEach(() => {});
 
 describe("CONTEXT_COMMANDS registry", () => {
   it("registers exactly the context-bound actions from the issue", () => {

--- a/src/store/appStore.layoutBridge.test.ts
+++ b/src/store/appStore.layoutBridge.test.ts
@@ -1,18 +1,19 @@
 /**
- * appStore ↔ layout projection bridge wiring (#2283 slice D' — the un-gated
- * optimistic-fold overlay).
+ * appStore ↔ layout projection bridge wiring (#2283 slice E2 — the region as the
+ * sole writer of `appStore`'s layout).
  *
- * Drives the layout reducers through the **real**
+ * Drives the layout ops through the **real**
  * {@link import("./layoutBridge").mirrorLayoutIntent} path against an in-memory
  * backend double ({@link FakeLayoutTransport}) that folds the granular `layout.*`
  * intents like the Rust store. It pins the slice's contract:
  *
- * - the local reducer stays authoritative and **synchronous** — `appStore.rootPanel`
- *   updates at once (the timing win: no seed→await→reconcile round-trip);
- * - the same transition is mirrored into the region **synchronously** via an
- *   optimistic overlay, then reconciled when the backend's diff lands;
- * - a rejected dispatch rolls the overlay back while `appStore` keeps the local
- *   result — the retained instant-revert fallback (#2283 removal stays gated);
+ * - the local reducers are gone — `appStore.rootPanel` is composed by the
+ *   region→appStore mirror, synchronously via the optimistic overlay (the timing
+ *   win survives: no seed→await→reconcile round-trip before the tree updates);
+ * - each op dispatches its granular `layout.*` intent, and `appStore` converges to
+ *   the backend's authoritative folded view when the diff lands;
+ * - a rejected dispatch leaves `appStore` on the region's (unchanged) view — there
+ *   is no local fallback any more;
  * - tab **ids are preserved** across split / move / group-switch / tab-activation,
  *   so the live xterm DOM (keyed by tab id) is never remounted.
  */
@@ -43,9 +44,10 @@ vi.mock("@/components/ui", async () => {
 
 import { useAppStore } from "./appStore";
 import {
+  buildLayoutSnapshot,
   currentLayoutView,
   ensureLayoutRegionClient,
-  setLayoutIntentsEnabled,
+  reseedLayoutRegion,
 } from "./layoutBridge";
 
 function tab(id: string): TerminalTab {
@@ -103,49 +105,44 @@ let teardown: () => void;
 async function resetStore(root: PanelNode = seedTree(), activePanelId = "a"): Promise<void> {
   useAppStore.setState(useAppStore.getInitialState());
   useAppStore.setState({ rootPanel: root, activePanelId });
+  // Under E2 `appStore`'s layout is derived solely from the region, so seed the
+  // region to this tree (the mirror composes it back) rather than leaving the
+  // backend twin on its default view, which the mirror would otherwise compose
+  // over `appStore`.
+  const s = useAppStore.getState();
+  reseedLayoutRegion(buildLayoutSnapshot(s.tabGroups, s.activeTabGroupId, root, activePanelId));
+  await flush();
 }
 
 beforeEach(async () => {
   ({ transport, teardown } = installLayoutHarness());
-  setLayoutIntentsEnabled(null);
-  await resetStore();
-  // Pre-subscribe so the region's initial snapshot is adopted before any reducer
-  // dispatch — the fake fans snapshots synchronously, so subscribing first keeps
-  // versions monotonic (production's real transport is naturally ordered).
+  // Pre-subscribe so the region's initial snapshot is adopted before any dispatch —
+  // the fake fans snapshots synchronously, so subscribing first keeps versions
+  // monotonic (production's real transport is naturally ordered).
   await ensureLayoutRegionClient();
+  await resetStore();
 });
 
 afterEach(() => {
-  setLayoutIntentsEnabled(null);
   teardown();
 });
 
-describe("slice D' — synchronous local authority + optimistic region overlay", () => {
-  it("flag off: splitPanel mutates locally and dispatches nothing", () => {
-    setLayoutIntentsEnabled(false);
+describe("E2 — region is the sole writer of appStore's layout", () => {
+  it("splitPanel applies to rootPanel synchronously via the optimistic overlay", () => {
     useAppStore.getState().splitPanel("vertical");
-
-    expect(transport.kinds()).toHaveLength(0);
+    // No flush: the mirror composes the optimistic overlay synchronously, so
+    // `appStore.rootPanel` reflects the split at once (no local reducer any more).
     expect(getAllLeaves(useAppStore.getState().rootPanel)).toHaveLength(3);
   });
 
-  it("flag on: splitPanel applies to rootPanel SYNCHRONOUSLY (no await)", () => {
-    setLayoutIntentsEnabled(true);
+  it("the region overlay reflects the split synchronously, before any ack", () => {
     useAppStore.getState().splitPanel("vertical");
-    // No flush: the local reducer is the authoritative, synchronous writer.
-    expect(getAllLeaves(useAppStore.getState().rootPanel)).toHaveLength(3);
-  });
-
-  it("flag on: the region overlay reflects the split SYNCHRONOUSLY, before any ack", () => {
-    setLayoutIntentsEnabled(true);
-    useAppStore.getState().splitPanel("vertical");
-    // The optimistic overlay installs appStore's post-split tree at once.
     const root = regionActiveRoot(currentLayoutView());
     expect(root && getAllLeaves(root)).toHaveLength(3);
   });
 
-  it("flag on: dispatches replaceGroups (seed) then the granular layout.split", async () => {
-    setLayoutIntentsEnabled(true);
+  it("dispatches replaceGroups (seed) then the granular layout.split", async () => {
+    transport.dispatched.length = 0;
     useAppStore.getState().splitPanel("vertical");
     await flush();
     expect(transport.kinds()).toEqual(["layout.replaceGroups", "layout.split"]);
@@ -156,35 +153,30 @@ describe("slice D' — synchronous local authority + optimistic region overlay",
     });
   });
 
-  it("reconcile: the backend converges to the same tab layout after the diff lands", async () => {
-    setLayoutIntentsEnabled(true);
+  it("appStore converges to the backend's authoritative view after the diff lands", async () => {
     useAppStore.getState().reorderTabs("a", 0, 1);
     await flush();
-    // Non-id-generating op: the backend's authoritative view matches appStore.
+    // appStore's tree equals the backend's folded view — the mirror is deriving it.
     const backendRoot = regionActiveRoot(transport.regionView())!;
     expect(tabIds(backendRoot)).toEqual(tabIds(useAppStore.getState().rootPanel));
-    // …and the client's effective view reconciled to it (overlay pruned).
     expect(tabIds(regionActiveRoot(currentLayoutView())!)).toEqual(
       tabIds(useAppStore.getState().rootPanel)
     );
   });
 
-  it("rejected dispatch: overlay rolls back, appStore keeps the local result (fallback retained)", async () => {
-    setLayoutIntentsEnabled(true);
+  it("a rejected dispatch leaves appStore on the backend's (unchanged) view", async () => {
     transport.reject = true;
     useAppStore.getState().splitPanel("vertical");
-    // Local reducer already applied the split (authoritative + instant).
-    expect(getAllLeaves(useAppStore.getState().rootPanel)).toHaveLength(3);
     await flush();
-    // Still split locally — the retained fallback held through the rejection.
-    expect(getAllLeaves(useAppStore.getState().rootPanel)).toHaveLength(3);
-    // The optimistic overlay was rolled back (region did not adopt the change).
+    // No local reducer fallback any more: with the region rejecting the split, the
+    // authoritative view never adopted it, so appStore follows the region back.
+    expect(getAllLeaves(useAppStore.getState().rootPanel).length).toBeLessThan(3);
     const root = regionActiveRoot(currentLayoutView());
     expect(root && getAllLeaves(root).length).toBeLessThan(3);
   });
 });
 
-describe("slice D' — every listed op routes its granular intent", () => {
+describe("E2 — every listed op routes its granular intent", () => {
   const cases: { name: string; run: () => void; kind: string }[] = [
     {
       name: "splitPanel",
@@ -246,7 +238,6 @@ describe("slice D' — every listed op routes its granular intent", () => {
 
   for (const c of cases) {
     it(`${c.name} dispatches ${c.kind}`, async () => {
-      setLayoutIntentsEnabled(true);
       c.run();
       await flush();
       expect(transport.kinds()).toContain(c.kind);
@@ -254,7 +245,6 @@ describe("slice D' — every listed op routes its granular intent", () => {
   }
 
   it("addTab dispatches layout.addTab carrying the frontend-generated tab id", async () => {
-    setLayoutIntentsEnabled(true);
     const id = useAppStore.getState().addTab("New", "local", { type: "local", config: {} });
     await flush();
     const add = transport.dispatched.find((d) => d.kind === "layout.addTab");
@@ -263,14 +253,12 @@ describe("slice D' — every listed op routes its granular intent", () => {
   });
 
   it("closeTab dispatches layout.closeTabStructure", async () => {
-    setLayoutIntentsEnabled(true);
     useAppStore.getState().closeTab("t2", "a");
     await flush();
     expect(transport.kinds()).toContain("layout.closeTabStructure");
   });
 
   it("setActiveTab activates the tab in both appStore and the region", async () => {
-    setLayoutIntentsEnabled(true);
     useAppStore.getState().setActiveTab("t2", "a");
     await flush();
     expect(findLeaf(useAppStore.getState().rootPanel, "a")!.activeTabId).toBe("t2");
@@ -279,23 +267,20 @@ describe("slice D' — every listed op routes its granular intent", () => {
   });
 });
 
-describe("slice D' — tab id preservation (no live-terminal remount)", () => {
+describe("E2 — tab id preservation (no live-terminal remount)", () => {
   it("split preserves every existing tab id", () => {
-    setLayoutIntentsEnabled(true);
     const before = tabIds(useAppStore.getState().rootPanel);
     useAppStore.getState().splitPanel("vertical");
     expect(tabIds(useAppStore.getState().rootPanel)).toEqual(before);
   });
 
   it("drag-move (center) preserves the moved tab id and its stack neighbours", () => {
-    setLayoutIntentsEnabled(true);
     useAppStore.getState().splitPanelWithTab("t1", "a", "b", "center");
     const ids = tabIds(useAppStore.getState().rootPanel).sort();
     expect(ids).toEqual(["t1", "t2", "t3"]);
   });
 
   it("group switch keeps each group's tab ids intact", async () => {
-    setLayoutIntentsEnabled(true);
     // The seed tree lives in the first group. Add a fresh (empty) group — which
     // becomes active — then switch back to the first and assert its tabs survived.
     useAppStore.getState().addTabGroup("G2");
@@ -307,7 +292,6 @@ describe("slice D' — tab id preservation (no live-terminal remount)", () => {
   });
 
   it("tab activation never changes tab ids, only the active flag", () => {
-    setLayoutIntentsEnabled(true);
     const before = tabIds(useAppStore.getState().rootPanel);
     useAppStore.getState().setActiveTab("t2", "a");
     expect(tabIds(useAppStore.getState().rootPanel)).toEqual(before);

--- a/src/store/appStore.tabContent.test.ts
+++ b/src/store/appStore.tabContent.test.ts
@@ -384,4 +384,33 @@ describe("appStore — region→appStore layout mirror (#2283 slice E1)", () => 
     // The settings tab is present in appStore's live tree.
     expect(allTabs().some((t) => t.contentType === "settings")).toBe(true);
   });
+
+  it("preserves directional lastActiveLeafId marks across mirror recompositions (#448)", () => {
+    const s = useAppStore.getState();
+    s.addTab("Shell", "local", LOCAL_CONFIG);
+    s.splitPanel("horizontal");
+    const root0 = useAppStore.getState().rootPanel as PanelNode & { id: string };
+    expect(root0.type).toBe("split");
+    const leaves = getAllLeaves(useAppStore.getState().rootPanel).map((l) => l.id);
+    expect(leaves).toHaveLength(2);
+    const [p1] = leaves;
+
+    // Focus a panel — the #448 subscription marks the root split's last-focused
+    // child. The mark lives only in appStore (the backend does not mark), so the
+    // mirror must re-apply it on every recompose.
+    s.setActivePanel(p1);
+    const markedRoot = useAppStore.getState().rootPanel as PanelNode & {
+      lastActiveLeafId?: string;
+    };
+    expect(markedRoot.lastActiveLeafId).toBe(p1);
+
+    // A subsequent mirror-firing op (a resize — no focus change) must not drop it.
+    s.setPanelSizes(root0.id, [70, 30]);
+    const afterRoot = useAppStore.getState().rootPanel as PanelNode & {
+      lastActiveLeafId?: string;
+      sizes?: number[];
+    };
+    expect(afterRoot.lastActiveLeafId).toBe(p1);
+    expect(afterRoot.sizes).toEqual([70, 30]);
+  });
 });

--- a/src/store/appStore.test.ts
+++ b/src/store/appStore.test.ts
@@ -36,7 +36,6 @@ vi.mock("@/services/api", () => ({
 import { useAppStore } from "./appStore";
 import { currentConnectionsView } from "@/store/connectionsBridge";
 import { setupConnectionsRegion } from "@/test/connectionsHarness";
-import { setLayoutIntentsEnabled } from "./layoutBridge";
 import type { LeafPanel } from "@/types/terminal";
 import { findLeaf, getAllLeaves } from "@/utils/panelTree";
 import * as api from "@/services/api";
@@ -52,12 +51,9 @@ describe("appStore", () => {
     // cut (#2184) makes split/move async intent round-trips by default; here we
     // exercise the retained local reducer (the resilience fallback) directly.
     // The intent-routed path has its own coverage in appStore.layoutBridge.test.ts.
-    setLayoutIntentsEnabled(false);
   });
 
-  afterEach(() => {
-    setLayoutIntentsEnabled(null);
-  });
+  afterEach(() => {});
 
   describe("addTab", () => {
     it("adds a tab to the active panel", () => {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -251,8 +251,8 @@ import {
   layoutIntentsEnabled,
   mirrorLayoutIntent,
   moveTabPayload,
+  reseedLayoutRegion,
   subscribeLayoutRegion,
-  viewMatchesTree,
 } from "@/store/layoutBridge";
 import {
   ensureSessionSubscribed,
@@ -8217,32 +8217,38 @@ useAppStore.subscribe((state, prev) => {
   }
 });
 
-// Region→appStore layout mirror (#2283 slice E1). Derive `appStore`'s layout
-// fields from the `layout@<clientId>` projection whenever the region view is a
-// faithful structural mirror of the current tree. Every structural op already
-// pushes its result into the region via `mirrorLayoutIntent` (an optimistic
-// overlay that emits synchronously), so this composes that view straight back —
-// the region becoming the producer of the layout `appStore` renders from.
+// Region→appStore layout mirror (#2283 slice E2). `appStore`'s layout fields
+// (`rootPanel`/`activePanelId`/`tabGroups`/`activeTabGroupId`) are now derived
+// **solely** from the `layout@<clientId>` projection: every structural op
+// dispatches only its region intent (an optimistic overlay that emits
+// synchronously), the non-intent writers reseed the region, and this mirror
+// composes that view back into `appStore` — the region is the sole authority for
+// the layout the UI renders (the local reducers were removed in this slice).
 //
-// In E1 this is a *pure addition*: the local reducers still run and write the
-// same result first, so the mirror is idempotent (it re-derives an identical
-// tree). The `viewMatchesTree` gate keeps it that way — it applies only when the
-// view already mirrors `appStore` (so the composed state equals the reducer's),
-// and skips a non-mirroring view such as the initial backend-default snapshot
-// before the region is seeded from `appStore`. E2 removes the local reducers,
-// at which point this mirror becomes the sole writer.
+// Unconditional (E1's `viewMatchesTree` gate is gone): the mirror composes on
+// every change. `composeLayoutState` guards against the transient cases — it
+// returns `null` for an empty/absent view (the initial backend-default snapshot
+// before the seed below lands) or a view that references a tab absent from both
+// the content map and the current tree — leaving `appStore` on its last-good
+// tree. Directional `lastActiveLeafId` marks are applied on top by the `#448`
+// subscription above and reseeded into the region so they survive convergence.
 subscribeLayoutRegion((view) => {
   const state = useAppStore.getState();
-  const snapshot = buildLayoutSnapshot(
-    state.tabGroups,
-    state.activeTabGroupId,
-    state.rootPanel,
-    state.activePanelId
-  );
-  if (!viewMatchesTree(view, snapshot)) return;
   const composed = composeLayoutState(view, state.rootPanel, state.tabGroups, state.tabContent);
   if (composed) useAppStore.setState(composed);
 });
+
+// Seed the region from `appStore`'s initial layout at startup so the mirror's
+// first composition reproduces the initial tree (rather than composing a
+// backend-default snapshot over it). Optimistic, so it lands synchronously.
+reseedLayoutRegion(
+  buildLayoutSnapshot(
+    useAppStore.getState().tabGroups,
+    useAppStore.getState().activeTabGroupId,
+    useAppStore.getState().rootPanel,
+    useAppStore.getState().activePanelId
+  )
+);
 
 /**
  * Render a settled restore/launch cohort's aggregate summary toast from the

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -2914,6 +2914,21 @@ export const useAppStore = create<AppState>((set, get, store) => {
    * the non-intent structural writers (openers, handoff, restore, conversion). */
   const reseedLayout = (): void => reseedLayoutRegion(currentLayoutSnapshot(get()));
 
+  /**
+   * `set` for a **non-intent** structural writer (#2283 slice E2): it writes the
+   * layout locally (there is no granular `layout.*` intent for it — the singleton
+   * tab openers, cross-window handoff, restore, the agent-error→terminal
+   * conversion) and then reseeds the region so it never lags. Without the reseed
+   * the unconditional mirror would recompose an older region view over the
+   * just-written tab on the next convergence diff and strand it.
+   */
+  const setAndReseed = (
+    partial: Partial<AppState> | ((state: AppState) => Partial<AppState>)
+  ): void => {
+    set(partial as Parameters<typeof set>[0]);
+    reseedLayout();
+  };
+
   return {
     // Domain slices (#2077) — extracted from this monolith, spread in first so
     // the root store keeps the same public shape and behavior.
@@ -3354,10 +3369,13 @@ export const useAppStore = create<AppState>((set, get, store) => {
           ...transferMoved,
         };
       });
+      // Non-intent structural writer (#2283 slice E2): reseed the region after the
+      // local tree removal so it does not lag.
+      reseedLayout();
     },
 
     hydrateHandoffTab: (record) =>
-      set((state) => {
+      setAndReseed((state) => {
         const h = record.tab;
         const targetLeaf = getAllLeaves(state.rootPanel)[0];
         if (!targetLeaf) return state;
@@ -3472,7 +3490,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // GAP G5 (#1146): raise the guard before placing the layout so this
       // window's auto-report subscription does not report a mid-hydrate tree.
       beginRestoreGuard(set);
-      set({
+      setAndReseed({
         tabGroups: builtGroups,
         activeTabGroupId: firstGroup.id,
         rootPanel: firstGroup.rootPanel,
@@ -4222,7 +4240,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
     pendingSettingsPluginId: null,
 
     openSettingsTab: (target) =>
-      set((state) => {
+      setAndReseed((state) => {
         // Deep-link target (#2000): a null category leaves the panel's current
         // category alone, so a plain open never resets it to General.
         const nav = {
@@ -4266,7 +4284,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
       }),
 
     openLogViewerTab: () =>
-      set((state) => {
+      setAndReseed((state) => {
         const allLeaves = getAllLeaves(state.rootPanel);
 
         // Look for an existing log-viewer tab
@@ -4302,7 +4320,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
       }),
 
     openNetworkDiagnosticTab: (tool, prefillHost, connectionId) =>
-      set((state) => {
+      setAndReseed((state) => {
         const allLeaves = getAllLeaves(state.rootPanel);
         const targetPanelId = state.activePanelId ?? allLeaves[0]?.id;
         if (!targetPanelId) return state;
@@ -4339,7 +4357,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
       }),
 
     openEditorTab: (filePath, isRemote, permissions, sessionBrowser) =>
-      set((state) => {
+      setAndReseed((state) => {
         const allLeaves = getAllLeaves(state.rootPanel);
 
         // Stable identity of the backing session, so the same path opened from
@@ -4416,7 +4434,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
       }),
 
     openScratchEditorTab: (title, fileName, content) =>
-      set((state) => {
+      setAndReseed((state) => {
         const allLeaves = getAllLeaves(state.rootPanel);
         const targetPanelId = state.activePanelId ?? allLeaves[0]?.id;
         if (!targetPanelId) return state;
@@ -4445,7 +4463,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
       }),
 
     openConnectionEditorTab: (connectionId, folderId) =>
-      set((state) => {
+      setAndReseed((state) => {
         const allLeaves = getAllLeaves(state.rootPanel);
 
         // Look for an existing connection-editor tab for this connection
@@ -4502,7 +4520,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
       }),
 
     openAgentDefinitionEditorTab: (agentId, definitionId, folderId) =>
-      set((state) => {
+      setAndReseed((state) => {
         const allLeaves = getAllLeaves(state.rootPanel);
 
         // Look for an existing editor tab for this agent definition
@@ -6707,7 +6725,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
         return { ...panel, tabs: updatedTabs };
       };
 
-      set((s) => {
+      setAndReseed((s) => {
         const rootPanel = convertPanel(s.rootPanel);
         const tabGroups = s.tabGroups.map((g) => ({ ...g, rootPanel: convertPanel(g.rootPanel) }));
         return {
@@ -6973,7 +6991,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
     },
 
     openTunnelEditorTab: (tunnelId) =>
-      set((state) => {
+      setAndReseed((state) => {
         const allLeaves = getAllLeaves(state.rootPanel);
 
         // Look for an existing tunnel-editor tab for this tunnel
@@ -7568,7 +7586,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
     },
 
     openWorkspaceEditorTab: (workspaceId) =>
-      set((state) => {
+      setAndReseed((state) => {
         const allLeaves = getAllLeaves(state.rootPanel);
 
         // Look for an existing workspace-editor tab for this workspace
@@ -7793,7 +7811,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
         // connects that follow — do not persist a mid-launch snapshot over the
         // previously-good session.
         beginRestoreGuard(set);
-        set({
+        setAndReseed({
           tabGroups: builtGroups,
           activeTabGroupId: firstGroup.id,
           rootPanel: firstGroup.rootPanel,
@@ -8002,7 +8020,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
         // auto-save subscription that fires from this very `set` — and the
         // per-tab connects that follow — are skipped until the cohort settles.
         beginRestoreGuard(set);
-        set({
+        setAndReseed({
           tabGroups: builtGroups,
           activeTabGroupId: activeGroup.id,
           rootPanel: activeGroup.rootPanel,

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -248,7 +248,6 @@ import {
   buildLayoutSnapshot,
   composeLayoutState,
   type LayoutSnapshot,
-  layoutIntentsEnabled,
   mirrorLayoutIntent,
   moveTabPayload,
   reseedLayoutRegion,
@@ -2630,6 +2629,42 @@ function currentLayoutSnapshot(state: {
 }
 
 /**
+ * The four layout fields the region→appStore mirror owns (#2283 slice E2). A
+ * structural op's reducer no longer writes these to `appStore`; it computes them
+ * so the `post` snapshot can be dispatched, and the mirror composes them back.
+ */
+const MIRROR_LAYOUT_KEYS = new Set<keyof AppState>([
+  "rootPanel",
+  "activePanelId",
+  "tabGroups",
+  "activeTabGroupId",
+]);
+
+/** The **non-layout** portion of a reducer result — everything the mirror does
+ * NOT own (e.g. `zoomedTabId`, `tabContent`, the per-tab maps). Set locally; the
+ * mirror sets the layout fields from the dispatched region view. */
+function nonLayoutPartial(next: Partial<AppState>): Partial<AppState> {
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(next)) {
+    if (!MIRROR_LAYOUT_KEYS.has(key as keyof AppState)) {
+      out[key] = (next as Record<string, unknown>)[key];
+    }
+  }
+  return out as Partial<AppState>;
+}
+
+/** The `post` layout snapshot a reducer result implies, merged over the prior
+ * state — the overlay the region mirror composes back (#2283 slice E2). */
+function postLayoutSnapshot(prev: AppState, next: Partial<AppState>): LayoutSnapshot {
+  return currentLayoutSnapshot({
+    tabGroups: next.tabGroups ?? prev.tabGroups,
+    activeTabGroupId: next.activeTabGroupId ?? prev.activeTabGroupId,
+    rootPanel: next.rootPanel ?? prev.rootPanel,
+    activePanelId: "activePanelId" in next ? (next.activePanelId ?? null) : prev.activePanelId,
+  });
+}
+
+/**
  * Serialize a tab into the view-model carried across a native-window boundary
  * (#1900). Placement (`panelId`/`isActive`) is dropped — the destination window
  * re-assigns it on hydrate — while `sessionId` anchors the re-attach to the same
@@ -2856,6 +2891,29 @@ export const useAppStore = create<AppState>((set, get, store) => {
     activePanelId: initialPanel.id,
   };
 
+  /**
+   * Run a layout reducer as a region-authoritative op (#2283 slice E2). The
+   * reducer computes the transform (and any side effects) exactly as before, but
+   * only its **non-layout** fields are written to `appStore` here — the four
+   * layout fields are dispatched as `post` and the region→appStore mirror writes
+   * them back, so the region is their sole writer. Returns the reducer result so
+   * callers can read the computed layout / ids. A no-op reducer (`return state`)
+   * writes nothing.
+   */
+  const setLayoutLocal = (reducer: (state: AppState) => Partial<AppState>): Partial<AppState> => {
+    const s0 = get();
+    const next = reducer(s0);
+    if (next !== s0) {
+      const rest = nonLayoutPartial(next);
+      if (Object.keys(rest).length > 0) set(rest);
+    }
+    return next;
+  };
+
+  /** Reseed the region to `appStore`'s current layout — the retained safety for
+   * the non-intent structural writers (openers, handoff, restore, conversion). */
+  const reseedLayout = (): void => reseedLayoutRegion(currentLayoutSnapshot(get()));
+
   return {
     // Domain slices (#2077) — extracted from this monolith, spread in first so
     // the root store keeps the same public shape and behavior.
@@ -2910,9 +2968,10 @@ export const useAppStore = create<AppState>((set, get, store) => {
     addTabGroup: (name) => {
       const newGroupId = generateGroupId();
       const newPanel = createLeafPanel();
-      const pre = currentLayoutSnapshot(get());
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
       let assignedName = name ?? "";
-      set((state) => {
+      const next = setLayoutLocal((state) => {
         const groupCount = state.tabGroups.length + 1;
         assignedName = name ?? `Group ${groupCount}`;
         const newGroup: TabGroup = {
@@ -2934,24 +2993,23 @@ export const useAppStore = create<AppState>((set, get, store) => {
           activePanelId: newPanel.id,
         };
       });
-      // Optimistic-fold overlay (#2283 slice D'): mirror the new group into the
-      // region via `layout.addGroup`. The backend assigns its own group id; the
-      // overlay carries appStore's, so the region matches until the next reseed.
-      if (layoutIntentsEnabled()) {
-        mirrorLayoutIntent(
-          "layout.addGroup",
-          { name: assignedName },
-          pre,
-          currentLayoutSnapshot(get())
-        );
-      }
+      // Dispatch the new group to the region via `layout.addGroup`; the mirror
+      // composes the result back (#2283 slice E2). The backend assigns its own
+      // group id; the overlay carries appStore's until the next reseed.
+      mirrorLayoutIntent(
+        "layout.addGroup",
+        { name: assignedName },
+        pre,
+        postLayoutSnapshot(prev, next)
+      );
       return newGroupId;
     },
 
     closeTabGroup: (groupId) => {
       if (get().tabGroups.length <= 1) return; // sole group: no-op (backend rejects too)
-      const pre = currentLayoutSnapshot(get());
-      set((state) => {
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
+      const next = setLayoutLocal((state) => {
         const newGroups = state.tabGroups.filter((g) => g.id !== groupId);
 
         if (groupId !== state.activeTabGroupId) {
@@ -2970,51 +3028,48 @@ export const useAppStore = create<AppState>((set, get, store) => {
           activePanelId: newActiveGroup.activePanelId,
         };
       });
-      // Optimistic-fold overlay (#2283 slice D'): mirror the close into the region.
-      if (layoutIntentsEnabled()) {
-        mirrorLayoutIntent("layout.closeGroup", { groupId }, pre, currentLayoutSnapshot(get()));
-      }
+      // Dispatch the close to the region; the mirror composes it back (E2).
+      mirrorLayoutIntent("layout.closeGroup", { groupId }, pre, postLayoutSnapshot(prev, next));
     },
 
     renameTabGroup: (groupId, name) => {
-      const pre = currentLayoutSnapshot(get());
-      set((state) => ({
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
+      const next = setLayoutLocal((state) => ({
         tabGroups: state.tabGroups.map((g) => (g.id === groupId ? { ...g, name } : g)),
       }));
-      if (layoutIntentsEnabled()) {
-        mirrorLayoutIntent(
-          "layout.renameGroup",
-          { groupId, name },
-          pre,
-          currentLayoutSnapshot(get())
-        );
-      }
+      mirrorLayoutIntent(
+        "layout.renameGroup",
+        { groupId, name },
+        pre,
+        postLayoutSnapshot(prev, next)
+      );
     },
 
     setTabGroupColor: (groupId, color) => {
-      const pre = currentLayoutSnapshot(get());
-      set((state) => ({
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
+      const next = setLayoutLocal((state) => ({
         tabGroups: state.tabGroups.map((g) =>
           g.id === groupId ? { ...g, color: color ?? undefined } : g
         ),
       }));
       // Omit `color` when clearing so the backend's `optional_str` resolves to
       // `None` and drops the accent (matching the local `color ?? undefined`).
-      if (layoutIntentsEnabled()) {
-        mirrorLayoutIntent(
-          "layout.setGroupColor",
-          color != null ? { groupId, color } : { groupId },
-          pre,
-          currentLayoutSnapshot(get())
-        );
-      }
+      mirrorLayoutIntent(
+        "layout.setGroupColor",
+        color != null ? { groupId, color } : { groupId },
+        pre,
+        postLayoutSnapshot(prev, next)
+      );
     },
 
     setActiveTabGroup: (groupId) => {
       if (groupId === get().activeTabGroupId) return; // no-op
       if (!get().tabGroups.some((g) => g.id === groupId)) return; // unknown group
-      const pre = currentLayoutSnapshot(get());
-      set((state) => {
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
+      const next = setLayoutLocal((state) => {
         const targetGroup = state.tabGroups.find((g) => g.id === groupId);
         if (!targetGroup) return state;
         // Save current live state into the currently active group
@@ -3039,34 +3094,31 @@ export const useAppStore = create<AppState>((set, get, store) => {
           zoomedTabId: newZoomedTabId,
         };
       });
-      // Optimistic-fold overlay (#2283 slice D'): mirror the group switch into the
-      // region via `layout.setActiveGroup`.
-      if (layoutIntentsEnabled()) {
-        mirrorLayoutIntent("layout.setActiveGroup", { groupId }, pre, currentLayoutSnapshot(get()));
-      }
+      // Dispatch the group switch to the region; the mirror composes it back (E2).
+      mirrorLayoutIntent("layout.setActiveGroup", { groupId }, pre, postLayoutSnapshot(prev, next));
     },
 
     reorderTabGroups: (fromIndex, toIndex) => {
-      const pre = currentLayoutSnapshot(get());
-      set((state) => {
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
+      const next = setLayoutLocal((state) => {
         const groups = [...state.tabGroups];
         const [moved] = groups.splice(fromIndex, 1);
         groups.splice(toIndex, 0, moved);
         return { tabGroups: groups };
       });
-      if (layoutIntentsEnabled()) {
-        mirrorLayoutIntent(
-          "layout.reorderGroups",
-          { fromIndex, toIndex },
-          pre,
-          currentLayoutSnapshot(get())
-        );
-      }
+      mirrorLayoutIntent(
+        "layout.reorderGroups",
+        { fromIndex, toIndex },
+        pre,
+        postLayoutSnapshot(prev, next)
+      );
     },
 
     moveTabToGroup: (tabId, fromPanelId, targetGroupId) => {
-      const pre = currentLayoutSnapshot(get());
-      set((state) => {
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
+      const next = setLayoutLocal((state) => {
         if (targetGroupId === state.activeTabGroupId) return state;
 
         // Find the tab in the active group's live rootPanel
@@ -3119,16 +3171,13 @@ export const useAppStore = create<AppState>((set, get, store) => {
           activePanelId: newActivePanelId,
         };
       });
-      // Optimistic-fold overlay (#2283 slice D'): mirror the cross-group move into
-      // the region via `layout.moveTabToGroup`.
-      if (layoutIntentsEnabled()) {
-        mirrorLayoutIntent(
-          "layout.moveTabToGroup",
-          { tabId, fromPanelId, targetGroupId },
-          pre,
-          currentLayoutSnapshot(get())
-        );
-      }
+      // Dispatch the cross-group move to the region; the mirror composes it (E2).
+      mirrorLayoutIntent(
+        "layout.moveTabToGroup",
+        { tabId, fromPanelId, targetGroupId },
+        pre,
+        postLayoutSnapshot(prev, next)
+      );
       // Moving a tab across groups changes broadcast membership when the source
       // or a target crosses the group boundary (#1980) — re-resolve so an
       // "all"/"panel" scope drops/adds it in the source's own group.
@@ -3136,8 +3185,9 @@ export const useAppStore = create<AppState>((set, get, store) => {
     },
 
     addTabGroupWithTab: (tabId, fromPanelId) => {
-      const pre = currentLayoutSnapshot(get());
-      set((state) => {
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
+      const next = setLayoutLocal((state) => {
         // Find the tab in the active group's live rootPanel
         const sourceLeaf = getAllLeaves(state.rootPanel).find((l) => l.id === fromPanelId);
         if (!sourceLeaf) return state;
@@ -3194,17 +3244,15 @@ export const useAppStore = create<AppState>((set, get, store) => {
           activePanelId: newPanel.id,
         };
       });
-      // Optimistic-fold overlay (#2283 slice D'): mirror the "tab to new group"
-      // move into the region via `layout.addGroupWithTab`. The backend assigns its
-      // own group id; the overlay carries appStore's until the next reseed.
-      if (layoutIntentsEnabled()) {
-        mirrorLayoutIntent(
-          "layout.addGroupWithTab",
-          { tabId, fromPanelId },
-          pre,
-          currentLayoutSnapshot(get())
-        );
-      }
+      // Dispatch the "tab to new group" move to the region; the mirror composes it
+      // back (E2). The backend assigns its own group id; the overlay carries
+      // appStore's until the next reseed.
+      mirrorLayoutIntent(
+        "layout.addGroupWithTab",
+        { tabId, fromPanelId },
+        pre,
+        postLayoutSnapshot(prev, next)
+      );
     },
 
     // ── Multi-window foundation (#1900) ──
@@ -4047,12 +4095,13 @@ export const useAppStore = create<AppState>((set, get, store) => {
         spawned,
         initialCommand,
       } = options ?? {};
-      const pre = currentLayoutSnapshot(get());
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
       let createdTabId = "";
       let addedPanelId = "";
       let addedContentType = "terminal";
       let addedSessionId: string | null = null;
-      set((state) => {
+      const next = setLayoutLocal((state) => {
         const allLeaves = getAllLeaves(state.rootPanel);
         const targetPanelId = panelId ?? state.activePanelId ?? allLeaves[0]?.id;
         if (!targetPanelId) return state;
@@ -4114,7 +4163,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // tab id, is never remounted). The tab's rich content stays in appStore's
       // `tabContent` map / tree; the region carries only `{ id, sessionId,
       // contentType }`.
-      if (layoutIntentsEnabled() && createdTabId && addedPanelId) {
+      if (createdTabId && addedPanelId) {
         mirrorLayoutIntent(
           "layout.addTab",
           {
@@ -4122,7 +4171,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
             tab: { id: createdTabId, sessionId: addedSessionId, contentType: addedContentType },
           },
           pre,
-          currentLayoutSnapshot(get())
+          postLayoutSnapshot(prev, next)
         );
       }
       // Record real terminal connections in the session history (#1883). Only
@@ -4525,7 +4574,8 @@ export const useAppStore = create<AppState>((set, get, store) => {
 
     closeTab: (tabId, panelId) => {
       // Snapshot the pre-close layout for the region seed (#2283 slice D').
-      const preLayout = currentLayoutSnapshot(get());
+      const prevLayout = get();
+      const preLayout = currentLayoutSnapshot(prevLayout);
 
       // Session-intents cut (#2203): the tab is gone — drop its lifecycle record
       // from the shared region so the store does not leak a dead session. Any
@@ -4545,7 +4595,7 @@ export const useAppStore = create<AppState>((set, get, store) => {
         bestEffortOwnership(() => releaseSession(closingSessionId));
       }
 
-      set((state) => {
+      const closeNext = setLayoutLocal((state) => {
         // Clean up per-tab state for the closed tab
         const remainingCwds = omitKey(state.tabCwds, tabId);
         const remainingHs = omitKey(state.tabHorizontalScrolling, tabId);
@@ -4675,56 +4725,53 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // the region via `layout.closeTabStructure` (the structural half only —
       // session teardown stayed above). appStore is authoritative; the overlay
       // installs the post-close tree.
-      if (layoutIntentsEnabled()) {
-        mirrorLayoutIntent(
-          "layout.closeTabStructure",
-          { tabId },
-          preLayout,
-          currentLayoutSnapshot(get())
-        );
-      }
+      mirrorLayoutIntent(
+        "layout.closeTabStructure",
+        { tabId },
+        preLayout,
+        postLayoutSnapshot(prevLayout, closeNext)
+      );
     },
 
     setActiveTab: (tabId, panelId) => {
-      // Local reducer — the authoritative, synchronous writer and the retained
-      // instant-revert fallback. Focuses `tabId` within its leaf and repoints the
-      // active panel, following the zoom overlay when it shows a tab of that leaf.
-      const applyLocal = () =>
-        set((state) => {
-          const newRootPanel = updateLeaf(state.rootPanel, panelId, (leaf) => ({
-            ...leaf,
-            tabs: leaf.tabs.map((t) => ({ ...t, isActive: t.id === tabId })),
-            activeTabId: tabId,
-          }));
+      // Region-authoritative op (#2283 slice E2): the reducer computes the focus
+      // change (and any zoom-follow); its non-layout `zoomedTabId` is written
+      // locally, the region mirror composes the layout fields back. Focuses
+      // `tabId` within its leaf and repoints the active panel, following the zoom
+      // overlay when it shows a tab of that leaf.
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
+      const next = setLayoutLocal((state) => {
+        const newRootPanel = updateLeaf(state.rootPanel, panelId, (leaf) => ({
+          ...leaf,
+          tabs: leaf.tabs.map((t) => ({ ...t, isActive: t.id === tabId })),
+          activeTabId: tabId,
+        }));
 
-          // If the zoom overlay is showing a tab from the same panel, follow the switch
-          let newZoomedTabId = state.zoomedTabId;
-          if (state.zoomedTabId !== null) {
-            const panelLeaf = findLeaf(state.rootPanel, panelId);
-            if (panelLeaf?.tabs.some((t) => t.id === state.zoomedTabId)) {
-              newZoomedTabId = tabId;
-            }
+        // If the zoom overlay is showing a tab from the same panel, follow the switch
+        let newZoomedTabId = state.zoomedTabId;
+        if (state.zoomedTabId !== null) {
+          const panelLeaf = findLeaf(state.rootPanel, panelId);
+          if (panelLeaf?.tabs.some((t) => t.id === state.zoomedTabId)) {
+            newZoomedTabId = tabId;
           }
+        }
 
-          return {
-            rootPanel: newRootPanel,
-            activePanelId: panelId,
-            zoomedTabId: newZoomedTabId,
-          };
-        });
+        return {
+          rootPanel: newRootPanel,
+          activePanelId: panelId,
+          zoomedTabId: newZoomedTabId,
+        };
+      });
 
-      // Optimistic-fold overlay (#2283 slice D'): apply locally (authoritative),
-      // then mirror the tab focus into the region via `layout.setActiveTab` — the
-      // structural "focus a tab within its leaf" primitive added for this slice.
-      // The backend derives the leaf from the tab id and repoints its active panel.
-      const pre = currentLayoutSnapshot(get());
-      applyLocal();
-      if (layoutIntentsEnabled()) {
-        mirrorLayoutIntent("layout.setActiveTab", { tabId }, pre, currentLayoutSnapshot(get()));
-      }
+      // Dispatch the tab focus to the region via `layout.setActiveTab`; the mirror
+      // composes it back (E2). The backend derives the leaf from the tab id.
+      mirrorLayoutIntent("layout.setActiveTab", { tabId }, pre, postLayoutSnapshot(prev, next));
     },
 
-    moveTab: (tabId, fromPanelId, toPanelId, newIndex) =>
+    moveTab: (tabId, fromPanelId, toPanelId, newIndex) => {
+      // A non-intent structural writer (no `layout.moveTab*` dispatch of its own):
+      // keep the local write and reseed the region after so it does not lag (E2).
       set((state) => {
         if (fromPanelId === toPanelId) return state;
 
@@ -4758,70 +4805,57 @@ export const useAppStore = create<AppState>((set, get, store) => {
         }
 
         return { rootPanel, activePanelId: toPanelId };
-      }),
+      });
+      reseedLayout();
+    },
 
     reorderTabs: (panelId, oldIndex, newIndex) => {
-      // Local reducer — the authoritative, synchronous writer and the retained
-      // instant-revert fallback (see `splitPanel`). Reorders a tab within its
-      // leaf, leaving focus untouched.
-      const applyLocal = () =>
-        set((state) => ({
-          rootPanel: updateLeaf(state.rootPanel, panelId, (leaf) => {
-            const tabs = [...leaf.tabs];
-            const [moved] = tabs.splice(oldIndex, 1);
-            tabs.splice(newIndex, 0, moved);
-            return { ...leaf, tabs };
-          }),
-        }));
-
-      // Optimistic-fold overlay (#2283 slice D'): apply the authoritative local
-      // reorder synchronously, then mirror the same transition into the region
-      // via `layout.reorderTabs` so the projection stays in step without a
-      // seed→await round-trip. appStore stays authoritative and the fallback is
-      // retained (the #2283 reducer removal remains gated).
-      const pre = currentLayoutSnapshot(get());
-      applyLocal();
-      if (layoutIntentsEnabled()) {
-        mirrorLayoutIntent(
-          "layout.reorderTabs",
-          { panelId, oldIndex, newIndex },
-          pre,
-          currentLayoutSnapshot(get())
-        );
-      }
+      // Region-authoritative op (#2283 slice E2): reorder a tab within its leaf,
+      // leaving focus untouched; the region mirror composes the result back.
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
+      const next = setLayoutLocal((state) => ({
+        rootPanel: updateLeaf(state.rootPanel, panelId, (leaf) => {
+          const tabs = [...leaf.tabs];
+          const [moved] = tabs.splice(oldIndex, 1);
+          tabs.splice(newIndex, 0, moved);
+          return { ...leaf, tabs };
+        }),
+      }));
+      mirrorLayoutIntent(
+        "layout.reorderTabs",
+        { panelId, oldIndex, newIndex },
+        pre,
+        postLayoutSnapshot(prev, next)
+      );
     },
 
     splitPanel: (direction) => {
-      // Local reducer — the authoritative, synchronous writer, and the retained
-      // instant-revert fallback (the #2283 reducer removal stays gated). It
-      // orchestrates the shared `@/utils/panelTree` helpers (the same seam the
-      // Rust store ports), so it never drifts from the region's `layout.split`.
-      const applyLocal = () =>
-        set((state) => {
-          const dir = direction ?? "horizontal";
-          const targetId = state.activePanelId;
-          if (!targetId) return state;
+      // Region-authoritative op (#2283 slice E2): orchestrates the shared
+      // `@/utils/panelTree` helpers (the same seam the Rust store ports), so it
+      // never drifts from the region's `layout.split`; the mirror composes it back.
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
+      const { activePanelId } = prev;
+      const next = setLayoutLocal((state) => {
+        const dir = direction ?? "horizontal";
+        const targetId = state.activePanelId;
+        if (!targetId) return state;
 
-          const newLeaf = createLeafPanel();
-          let rootPanel = splitLeaf(state.rootPanel, targetId, newLeaf, dir, "after");
-          rootPanel = simplifyTree(rootPanel);
-          return { rootPanel, activePanelId: newLeaf.id };
-        });
+        const newLeaf = createLeafPanel();
+        let rootPanel = splitLeaf(state.rootPanel, targetId, newLeaf, dir, "after");
+        rootPanel = simplifyTree(rootPanel);
+        return { rootPanel, activePanelId: newLeaf.id };
+      });
 
-      // Optimistic-fold overlay (#2283 slice D'): apply the authoritative local
-      // split synchronously, then mirror it into the region via `layout.split`.
-      // The split targets the pre-split active panel; the backend focuses its
-      // new leaf, matching the local reducer. appStore stays authoritative and
-      // the local reducer is retained as the instant-revert fallback.
-      const pre = currentLayoutSnapshot(get());
-      const { activePanelId } = get();
-      applyLocal();
-      if (layoutIntentsEnabled() && activePanelId) {
+      // The split targets the pre-split active panel; the backend focuses its new
+      // leaf, matching the reducer.
+      if (activePanelId) {
         mirrorLayoutIntent(
           "layout.split",
           { panelId: activePanelId, direction: direction ?? "horizontal", position: "after" },
           pre,
-          currentLayoutSnapshot(get())
+          postLayoutSnapshot(prev, next)
         );
       }
     },
@@ -4830,168 +4864,142 @@ export const useAppStore = create<AppState>((set, get, store) => {
       // Local reducer — the retained rollback/resilience fallback. Drops a whole
       // leaf panel and simplifies; repoints focus onto the first survivor when
       // the removed panel held it.
-      const applyLocal = () =>
-        set((state) => {
-          const allLeaves = getAllLeaves(state.rootPanel);
-          if (allLeaves.length <= 1) return state;
-
-          const removed = removeLeaf(state.rootPanel, panelId);
-          if (!removed) return state;
-          const rootPanel = simplifyTree(removed);
-          const newLeaves = getAllLeaves(rootPanel);
-          const activePanelId =
-            state.activePanelId === panelId ? (newLeaves[0]?.id ?? null) : state.activePanelId;
-          return { rootPanel, activePanelId };
-        });
-
-      // Optimistic-fold overlay (#2283 slice D'): the sole-leaf case is a no-op
-      // both here and in the store, so skip it. Otherwise apply the authoritative
-      // local remove synchronously, then mirror it into the region via
-      // `layout.removePanel`. appStore stays authoritative; the local reducer is
-      // the retained instant-revert fallback.
+      // The sole-leaf case is a no-op both here and in the store, so skip it.
       if (getAllLeaves(get().rootPanel).length <= 1) return;
-      const pre = currentLayoutSnapshot(get());
-      applyLocal();
-      if (layoutIntentsEnabled()) {
-        mirrorLayoutIntent("layout.removePanel", { panelId }, pre, currentLayoutSnapshot(get()));
-      }
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
+      const next = setLayoutLocal((state) => {
+        const allLeaves = getAllLeaves(state.rootPanel);
+        if (allLeaves.length <= 1) return state;
+
+        const removed = removeLeaf(state.rootPanel, panelId);
+        if (!removed) return state;
+        const rootPanel = simplifyTree(removed);
+        const newLeaves = getAllLeaves(rootPanel);
+        const activePanelId =
+          state.activePanelId === panelId ? (newLeaves[0]?.id ?? null) : state.activePanelId;
+        return { rootPanel, activePanelId };
+      });
+
+      // Region-authoritative op (#2283 slice E2): the mirror composes it back.
+      mirrorLayoutIntent("layout.removePanel", { panelId }, pre, postLayoutSnapshot(prev, next));
     },
 
     setActivePanel: (panelId) => {
-      // Local reducer — applied synchronously in every mode so focus stays
-      // instant (this is a hot path: every panel click and keyboard-nav step).
-      // Zoom-follow: when the zoom overlay shows a tab from the newly-focused
+      // Region-authoritative op (#2283 slice E2) on a hot path (every panel click
+      // and keyboard-nav step): the region mirror composes the focus change back,
+      // synchronously via the optimistic overlay. Zoom-follow (a non-layout field
+      // set locally): when the zoom overlay shows a tab from the newly-focused
       // panel, follow the switch to that panel's active tab.
-      const applyLocal = () =>
-        set((state) => {
-          let newZoomedTabId = state.zoomedTabId;
-          if (state.zoomedTabId !== null) {
-            const newPanel = findLeaf(state.rootPanel, panelId);
-            newZoomedTabId = newPanel?.activeTabId ?? null;
-          }
-          return { activePanelId: panelId, zoomedTabId: newZoomedTabId };
-        });
-
-      // Focus is projection state (`activePanelId`): apply locally for instant UX
-      // (authoritative), then mirror it into the region via `layout.setActivePanel`
-      // (#2283 slice D') so the projection stays in step synchronously. A failure
-      // is logged; the local set already landed.
-      const pre = currentLayoutSnapshot(get());
-      applyLocal();
-      if (layoutIntentsEnabled()) {
-        mirrorLayoutIntent("layout.setActivePanel", { panelId }, pre, currentLayoutSnapshot(get()));
-      }
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
+      const next = setLayoutLocal((state) => {
+        let newZoomedTabId = state.zoomedTabId;
+        if (state.zoomedTabId !== null) {
+          const newPanel = findLeaf(state.rootPanel, panelId);
+          newZoomedTabId = newPanel?.activeTabId ?? null;
+        }
+        return { activePanelId: panelId, zoomedTabId: newZoomedTabId };
+      });
+      mirrorLayoutIntent("layout.setActivePanel", { panelId }, pre, postLayoutSnapshot(prev, next));
     },
 
     setPanelSizes: (splitId, sizes) => {
-      // Local reducer — the retained rollback/resilience fallback. Persists a
-      // split's child percentage sizes so a resize-handle drag survives remounts
-      // and workspace save/restore.
-      const applyLocal = () =>
-        set((state) => ({ rootPanel: setSplitSizesInTree(state.rootPanel, splitId, sizes) }));
-
-      // Optimistic-fold overlay (#2283 slice D'): apply the authoritative local
-      // resize synchronously, then mirror it into the region via `layout.resize`.
-      // appStore stays authoritative; the local reducer is the retained fallback.
-      const pre = currentLayoutSnapshot(get());
-      applyLocal();
-      if (layoutIntentsEnabled()) {
-        mirrorLayoutIntent("layout.resize", { splitId, sizes }, pre, currentLayoutSnapshot(get()));
-      }
+      // Region-authoritative op (#2283 slice E2): persists a split's child
+      // percentage sizes so a resize-handle drag survives remounts and workspace
+      // save/restore; the mirror composes it back.
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
+      const next = setLayoutLocal((state) => ({
+        rootPanel: setSplitSizesInTree(state.rootPanel, splitId, sizes),
+      }));
+      mirrorLayoutIntent("layout.resize", { splitId, sizes }, pre, postLayoutSnapshot(prev, next));
     },
 
     splitPanelWithTab: (tabId, fromPanelId, targetPanelId, edge) => {
-      // Local reducer. As with splitPanel, since #2184 this is the retained
-      // resilience/rollback fallback (flag off, or an intent failure) rather than
-      // the default path — kept as a safety net over the shared panelTree algebra.
-      const applyLocal = () =>
-        set((state) => {
-          const splitInfo = edgeToSplit(edge);
+      // Region-authoritative op (#2283 slice E2) over the shared panelTree algebra;
+      // the mirror composes the result back.
+      const prev = get();
+      const pre = currentLayoutSnapshot(prev);
+      const next = setLayoutLocal((state) => {
+        const splitInfo = edgeToSplit(edge);
 
-          // Center drop: move tab to existing panel
-          if (!splitInfo) {
-            const sourceLeaf = findLeaf(state.rootPanel, fromPanelId);
-            if (!sourceLeaf) return state;
-            const tab = sourceLeaf.tabs.find((t) => t.id === tabId);
-            if (!tab) return state;
-
-            const movedTab: TerminalTab = { ...tab, panelId: targetPanelId, isActive: true };
-
-            let rootPanel = updateLeaf(state.rootPanel, fromPanelId, (leaf) =>
-              removeTabFromLeaf(leaf, tabId)
-            );
-            rootPanel = updateLeaf(rootPanel, targetPanelId, (leaf) => ({
-              ...leaf,
-              tabs: [...leaf.tabs.map((t) => ({ ...t, isActive: false })), movedTab],
-              activeTabId: movedTab.id,
-            }));
-
-            // Clean up empty source
-            const updatedSource = findLeaf(rootPanel, fromPanelId);
-            const allLeaves = getAllLeaves(rootPanel);
-            if (updatedSource && updatedSource.tabs.length === 0 && allLeaves.length > 1) {
-              const removed = removeLeaf(rootPanel, fromPanelId);
-              rootPanel = removed ? simplifyTree(removed) : rootPanel;
-            }
-
-            return { rootPanel, activePanelId: targetPanelId };
-          }
-
-          // Edge drop: create new panel via split
+        // Center drop: move tab to existing panel
+        if (!splitInfo) {
           const sourceLeaf = findLeaf(state.rootPanel, fromPanelId);
           if (!sourceLeaf) return state;
           const tab = sourceLeaf.tabs.find((t) => t.id === tabId);
           if (!tab) return state;
 
-          const newLeaf = createLeafPanel();
-          const movedTab: TerminalTab = { ...tab, panelId: newLeaf.id, isActive: true };
-          newLeaf.tabs = [movedTab];
-          newLeaf.activeTabId = movedTab.id;
+          const movedTab: TerminalTab = { ...tab, panelId: targetPanelId, isActive: true };
 
-          // Remove tab from source
           let rootPanel = updateLeaf(state.rootPanel, fromPanelId, (leaf) =>
             removeTabFromLeaf(leaf, tabId)
           );
+          rootPanel = updateLeaf(rootPanel, targetPanelId, (leaf) => ({
+            ...leaf,
+            tabs: [...leaf.tabs.map((t) => ({ ...t, isActive: false })), movedTab],
+            activeTabId: movedTab.id,
+          }));
 
-          // Clean up empty source before splitting (unless source IS the target)
-          if (fromPanelId !== targetPanelId) {
-            const updatedSource = findLeaf(rootPanel, fromPanelId);
-            const allLeaves = getAllLeaves(rootPanel);
-            if (updatedSource && updatedSource.tabs.length === 0 && allLeaves.length > 1) {
-              const removed = removeLeaf(rootPanel, fromPanelId);
-              rootPanel = removed ? simplifyTree(removed) : rootPanel;
-            }
+          // Clean up empty source
+          const updatedSource = findLeaf(rootPanel, fromPanelId);
+          const allLeaves = getAllLeaves(rootPanel);
+          if (updatedSource && updatedSource.tabs.length === 0 && allLeaves.length > 1) {
+            const removed = removeLeaf(rootPanel, fromPanelId);
+            rootPanel = removed ? simplifyTree(removed) : rootPanel;
           }
 
-          // Split the target
-          rootPanel = splitLeaf(
-            rootPanel,
-            targetPanelId,
-            newLeaf,
-            splitInfo.direction,
-            splitInfo.position
-          );
-          rootPanel = simplifyTree(rootPanel);
+          return { rootPanel, activePanelId: targetPanelId };
+        }
 
-          return { rootPanel, activePanelId: newLeaf.id };
-        });
+        // Edge drop: create new panel via split
+        const sourceLeaf = findLeaf(state.rootPanel, fromPanelId);
+        if (!sourceLeaf) return state;
+        const tab = sourceLeaf.tabs.find((t) => t.id === tabId);
+        if (!tab) return state;
 
-      // Optimistic-fold overlay (#2283 slice D'): apply the authoritative local
-      // move synchronously (it keeps an emptied self-drop source that the backend
-      // would collapse — appStore stays authoritative, so its result wins), then
-      // mirror it into the region via `layout.moveTab` (center = merge into the
-      // target stack, edge = split the target). The overlay installs appStore's
-      // result, so any backend divergence self-heals on the next seed.
-      const pre = currentLayoutSnapshot(get());
-      applyLocal();
-      if (layoutIntentsEnabled()) {
-        mirrorLayoutIntent(
-          "layout.moveTab",
-          moveTabPayload(tabId, targetPanelId, edge),
-          pre,
-          currentLayoutSnapshot(get())
+        const newLeaf = createLeafPanel();
+        const movedTab: TerminalTab = { ...tab, panelId: newLeaf.id, isActive: true };
+        newLeaf.tabs = [movedTab];
+        newLeaf.activeTabId = movedTab.id;
+
+        // Remove tab from source
+        let rootPanel = updateLeaf(state.rootPanel, fromPanelId, (leaf) =>
+          removeTabFromLeaf(leaf, tabId)
         );
-      }
+
+        // Clean up empty source before splitting (unless source IS the target)
+        if (fromPanelId !== targetPanelId) {
+          const updatedSource = findLeaf(rootPanel, fromPanelId);
+          const allLeaves = getAllLeaves(rootPanel);
+          if (updatedSource && updatedSource.tabs.length === 0 && allLeaves.length > 1) {
+            const removed = removeLeaf(rootPanel, fromPanelId);
+            rootPanel = removed ? simplifyTree(removed) : rootPanel;
+          }
+        }
+
+        // Split the target
+        rootPanel = splitLeaf(
+          rootPanel,
+          targetPanelId,
+          newLeaf,
+          splitInfo.direction,
+          splitInfo.position
+        );
+        rootPanel = simplifyTree(rootPanel);
+
+        return { rootPanel, activePanelId: newLeaf.id };
+      });
+
+      // Dispatch the move to the region via `layout.moveTab` (center = merge into
+      // the target stack, edge = split the target); the mirror composes it back.
+      mirrorLayoutIntent(
+        "layout.moveTab",
+        moveTabPayload(tabId, targetPanelId, edge),
+        pre,
+        postLayoutSnapshot(prev, next)
+      );
     },
 
     // Connections — the saved-connection / folder tree is region-authoritative

--- a/src/store/layoutBridge.test.ts
+++ b/src/store/layoutBridge.test.ts
@@ -1,10 +1,11 @@
 /**
- * Unit tests for the layout projection bridge (#2151 step 2): the rich⇄minimal
+ * Unit tests for the layout projection bridge (#2151 / #2283): the rich⇄minimal
  * tree mapping, the reconcile that re-hydrates minimal-tab diffs into rich
- * `TerminalTab`s by id, and the feature flag. The dispatch/subscribe round-trip
- * is exercised at the appStore level in `appStore.layoutBridge.test.ts`.
+ * `TerminalTab`s by id, and `composeLayoutState` (the region→appStore mirror's
+ * core). The dispatch/subscribe round-trip is exercised at the appStore level in
+ * `appStore.layoutBridge.test.ts`.
  */
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 
 import type { PanelNode, TabContent, TerminalTab } from "@/types/terminal";
 
@@ -13,17 +14,11 @@ import {
   collectTabs,
   composeLayoutState,
   composeRenderTree,
-  type LayoutSnapshot,
   type LayoutView,
-  layoutIntentsEnabled,
-  layoutRenderFromProjectionEnabled,
   minimalNodesEqual,
   reconcileNode,
-  setLayoutIntentsEnabled,
-  setLayoutRenderFromProjectionEnabled,
   toMinimalGroup,
   toMinimalNode,
-  viewMatchesTree,
 } from "./layoutBridge";
 import type { TabGroup } from "@/types/terminal";
 
@@ -156,12 +151,6 @@ describe("layoutBridge — render-from-projection helpers (#2151 step 3)", () =>
     };
   }
 
-  /** A single-group `appStore` snapshot mirroring `view()`. */
-  function snapshot(root: PanelNode = tree(), activePanelId: string | null = "a"): LayoutSnapshot {
-    const groups: TabGroup[] = [{ id: "g1", name: "Main", rootPanel: root, activePanelId }];
-    return buildLayoutSnapshot(groups, "g1", root, activePanelId);
-  }
-
   it("minimalNodesEqual: a tree equals its own minimal projection", () => {
     expect(minimalNodesEqual(toMinimalNode(tree()), toMinimalNode(tree()))).toBe(true);
   });
@@ -191,79 +180,6 @@ describe("layoutBridge — render-from-projection helpers (#2151 step 3)", () =>
       ],
     });
     expect(minimalNodesEqual(base, otherActive)).toBe(false);
-  });
-
-  it("viewMatchesTree: true only when structure AND active panel align", () => {
-    expect(viewMatchesTree(view(), snapshot())).toBe(true);
-    // Active panel differs.
-    expect(viewMatchesTree(view(), snapshot(tree(), "b"))).toBe(false);
-    // A view missing a tab appStore still has (local add not yet in the region).
-    const stale: LayoutView = {
-      groups: [
-        {
-          id: "g1",
-          name: "Main",
-          root: toMinimalNode({
-            type: "split",
-            id: "root",
-            direction: "horizontal",
-            sizes: [50, 50],
-            children: [
-              { type: "leaf", id: "a", tabs: [tab("t1")], activeTabId: "t1" },
-              { type: "leaf", id: "b", tabs: [tab("t3")], activeTabId: "t3" },
-            ],
-          }),
-          activePanelId: "a",
-        },
-      ],
-      activeGroupId: "g1",
-    };
-    expect(viewMatchesTree(stale, snapshot())).toBe(false);
-    expect(viewMatchesTree(null, snapshot())).toBe(false);
-  });
-
-  it("viewMatchesTree (multi-group): all groups must match, in order (#2283)", () => {
-    // Two groups: g1 active holding the tree, g2 a single leaf.
-    const g2Root: PanelNode = { type: "leaf", id: "z", tabs: [tab("t9")], activeTabId: "t9" };
-    const groups: TabGroup[] = [
-      { id: "g1", name: "Main", rootPanel: tree(), activePanelId: "a" },
-      { id: "g2", name: "Second", rootPanel: g2Root, activePanelId: "z" },
-    ];
-    const snap = buildLayoutSnapshot(groups, "g1", tree(), "a");
-    const mirror: LayoutView = {
-      groups: [
-        { id: "g1", name: "Main", root: toMinimalNode(tree()), activePanelId: "a" },
-        { id: "g2", name: "Second", root: toMinimalNode(g2Root), activePanelId: "z" },
-      ],
-      activeGroupId: "g1",
-    };
-    expect(viewMatchesTree(mirror, snap)).toBe(true);
-
-    // A non-active group's tree drifts → the whole gate fails (forces a reseed).
-    const drifted: LayoutView = {
-      ...mirror,
-      groups: [
-        mirror.groups[0],
-        { id: "g2", name: "Second", root: toMinimalNode(tree()), activePanelId: "a" },
-      ],
-    };
-    expect(viewMatchesTree(drifted, snap)).toBe(false);
-
-    // Group metadata (name) drifts → fails.
-    const renamed: LayoutView = {
-      ...mirror,
-      groups: [{ ...mirror.groups[0], name: "Renamed" }, mirror.groups[1]],
-    };
-    expect(viewMatchesTree(renamed, snap)).toBe(false);
-
-    // activeGroupId differs → fails.
-    expect(viewMatchesTree({ ...mirror, activeGroupId: "g2" }, snap)).toBe(false);
-
-    // Group order / count differs → fails.
-    expect(viewMatchesTree({ ...mirror, groups: [mirror.groups[1], mirror.groups[0]] }, snap)).toBe(
-      false
-    );
-    expect(viewMatchesTree({ ...mirror, groups: [mirror.groups[0]] }, snap)).toBe(false);
   });
 
   it("composeRenderTree (multi-group): composes the active group whichever it is (#2283)", () => {
@@ -359,35 +275,6 @@ describe("layoutBridge — render-from-projection helpers (#2151 step 3)", () =>
     expect((viaMap as Extract<PanelNode, { type: "leaf" }>).tabs[0].title).toBe("Tab ghost");
     // Absent from both an empty tree index and an empty map → throws.
     expect(() => reconcileNode(projected, new Map(), {})).toThrow(/unknown tab ghost/);
-  });
-});
-
-describe("layoutBridge — feature flags", () => {
-  afterEach(() => {
-    setLayoutIntentsEnabled(null);
-    setLayoutRenderFromProjectionEnabled(null);
-  });
-
-  it("mutation cut is on by default (#2184: GUI-verified parity-clean)", () => {
-    setLayoutIntentsEnabled(null);
-    expect(layoutIntentsEnabled()).toBe(true);
-  });
-
-  it("render cut is on by default (step 3: parity-safe by construction)", () => {
-    setLayoutRenderFromProjectionEnabled(null);
-    expect(layoutRenderFromProjectionEnabled()).toBe(true);
-  });
-
-  it("honours programmatic overrides on each flag independently", () => {
-    setLayoutIntentsEnabled(true);
-    expect(layoutIntentsEnabled()).toBe(true);
-    setLayoutIntentsEnabled(false);
-    expect(layoutIntentsEnabled()).toBe(false);
-
-    setLayoutRenderFromProjectionEnabled(false);
-    expect(layoutRenderFromProjectionEnabled()).toBe(false);
-    setLayoutRenderFromProjectionEnabled(true);
-    expect(layoutRenderFromProjectionEnabled()).toBe(true);
   });
 });
 

--- a/src/store/layoutBridge.ts
+++ b/src/store/layoutBridge.ts
@@ -724,6 +724,31 @@ export interface ComposedLayoutState {
  * before the region is seeded from `appStore`). Callers gate with
  * {@link viewMatchesTree} first, so on the happy path this composes cleanly.
  */
+/** Index a tree's directional `lastActiveLeafId` marks by split-container id. */
+function collectSplitMarks(node: PanelNode, into: Map<string, string>): void {
+  if (node.type === "split") {
+    if (node.lastActiveLeafId) into.set(node.id, node.lastActiveLeafId);
+    node.children.forEach((c) => collectSplitMarks(c, into));
+  }
+}
+
+/**
+ * Re-apply directional `lastActiveLeafId` marks (#448) from `prior` onto a freshly
+ * composed tree, by split-container id. The marks are a **frontend-only** derivation
+ * (the backend `set_active_panel` does not mark), so the region does not carry them;
+ * without this the region→appStore mirror would drop a split's last-focused-child
+ * memory every time it recomposes. A split absent from `prior` keeps whatever mark
+ * the composed tree already has.
+ */
+function preserveSplitMarks(node: PanelNode, marks: Map<string, string>): PanelNode {
+  if (node.type !== "split") return node;
+  const children = node.children.map((c) => preserveSplitMarks(c, marks));
+  const next: SplitContainer = { ...node, children };
+  const mark = marks.get(node.id);
+  if (mark !== undefined) next.lastActiveLeafId = mark;
+  return next;
+}
+
 export function composeLayoutState(
   view: LayoutView | null | undefined,
   curRootPanel: PanelNode,
@@ -742,6 +767,16 @@ export function composeLayoutState(
   }
   for (const [id, tab] of collectTabs(curRootPanel)) fallback.set(id, tab);
 
+  // Directional marks by group id, from the prior `appStore` trees (active group's
+  // live tree overriding its stale `tabGroups` entry) — re-applied onto each
+  // freshly composed tree so the mirror never drops a split's last-focused memory.
+  const marksByGroup = new Map<string, Map<string, string>>();
+  for (const g of curTabGroups) {
+    const m = new Map<string, string>();
+    collectSplitMarks(g.id === view.activeGroupId ? curRootPanel : g.rootPanel, m);
+    marksByGroup.set(g.id, m);
+  }
+
   try {
     const activeGroupId = view.activeGroupId;
     const activeView = activeGroupOf(view);
@@ -757,7 +792,10 @@ export function composeLayoutState(
       const entry: TabGroup = {
         id: vg.id,
         name: vg.name,
-        rootPanel: reconcileNode(vg.root, fallback, tabContent),
+        rootPanel: preserveSplitMarks(
+          reconcileNode(vg.root, fallback, tabContent),
+          marksByGroup.get(vg.id) ?? new Map()
+        ),
         activePanelId: vg.activePanelId,
       };
       if (vg.color != null) entry.color = vg.color;
@@ -765,7 +803,10 @@ export function composeLayoutState(
     });
 
     return {
-      rootPanel: reconcileNode(activeView.root, fallback, tabContent),
+      rootPanel: preserveSplitMarks(
+        reconcileNode(activeView.root, fallback, tabContent),
+        marksByGroup.get(activeGroupId) ?? new Map()
+      ),
       activePanelId: activeView.activePanelId,
       tabGroups,
       activeTabGroupId: activeGroupId,
@@ -790,6 +831,53 @@ export function subscribeLayoutRegion(handler: (view: LayoutView | undefined) =>
   const off = client.onChange((state) => handler(state.view as LayoutView | undefined));
   void ensureSubscribed().catch((err) => logRenderFallback(err));
   return off;
+}
+
+/**
+ * Reseed the layout region to `snapshot` **synchronously and optimistically**
+ * (#2283 slice E2). Installs `snapshot`'s view as the region's effective view at
+ * once via {@link ProjectionClient.dispatchOptimistic} — so the region→appStore
+ * mirror composes it immediately — and replaces the backend's layout via
+ * `layout.replaceGroups` so the authoritative store converges to the same view.
+ *
+ * This is the retained reseed-safety, relocated from the render-side gate to the
+ * write sites: the region has no granular intent for the ~15 **non-intent**
+ * structural writers (the tab openers, cross-window handoff, workspace restore,
+ * the agent-error→terminal conversion) or for the directional `lastActiveLeafId`
+ * marking, so each keeps its local `appStore` write and reseeds the region after,
+ * keeping the region a faithful mirror rather than letting it lag (which, with the
+ * unconditional mirror, would strand the just-written tab on the next diff).
+ *
+ * Never throws (resilience): a missing transport or a rejected dispatch is logged;
+ * `appStore` keeps its local write, and the next reseed re-syncs the region.
+ */
+export function reseedLayoutRegion(snapshot: LayoutSnapshot): void {
+  const view: LayoutView = {
+    groups: snapshot.groups.map(toMinimalGroup),
+    activeGroupId: snapshot.activeGroupId,
+  };
+  try {
+    const client = layoutRegionClient();
+    void ensureSubscribed().catch((err) => logBridgeFallback("subscribe", err));
+    const intent: Intent = {
+      intentId: newIntentId(),
+      kind: "layout.replaceGroups",
+      payload: { groups: view.groups, activeGroupId: view.activeGroupId },
+      clientId,
+    };
+    void client
+      .dispatchOptimistic(intent, () => view)
+      .then((ack) => {
+        if (ack.status === "rejected") {
+          logBridgeFallback("reseed", new Error(ack.error?.message ?? "rejected"));
+        }
+      })
+      .catch((err) => logBridgeFallback("reseed", err));
+  } catch (err) {
+    // No transport, or an incomplete client (e.g. a partial test stub): the local
+    // `appStore` write already landed, and the next reseed re-syncs the region.
+    logBridgeFallback("reseed", err);
+  }
 }
 
 /**

--- a/src/store/layoutBridge.ts
+++ b/src/store/layoutBridge.ts
@@ -178,97 +178,6 @@ export function activeGroupOf(view: LayoutView): MinimalGroup | undefined {
   return view.groups.find((g) => g.id === view.activeGroupId) ?? view.groups[0];
 }
 
-// ── Feature flag (runtime-flippable so a dev build can verify the ON path) ─────
-
-interface LayoutFlagWindow {
-  __TERMIHUB_LAYOUT_INTENTS__?: boolean;
-  __TERMIHUB_LAYOUT_RENDER__?: boolean;
-  localStorage?: Storage;
-}
-
-let flagOverride: boolean | null = null;
-let renderFlagOverride: boolean | null = null;
-
-/**
- * Programmatic override for the layout-intents (mutation) flag (tests, and a
- * runtime toggle). `null` clears the override and falls back to the
- * window/localStorage signal, then to the default.
- */
-export function setLayoutIntentsEnabled(value: boolean | null): void {
-  flagOverride = value;
-}
-
-/**
- * Programmatic override for the render-from-projection flag (tests, runtime
- * toggle). `null` clears it and falls back to the window/localStorage signal,
- * then to the default.
- */
-export function setLayoutRenderFromProjectionEnabled(value: boolean | null): void {
-  renderFlagOverride = value;
-}
-
-/** Read a boolean feature signal from `window`/`localStorage`, else `dflt`. */
-function readFlag(
-  override: boolean | null,
-  windowKey: keyof LayoutFlagWindow,
-  storageKey: string,
-  dflt: boolean
-): boolean {
-  if (override !== null) return override;
-  try {
-    if (typeof window !== "undefined") {
-      const w = window as unknown as LayoutFlagWindow;
-      const wv = w[windowKey];
-      if (typeof wv === "boolean") return wv;
-      const ls = w.localStorage?.getItem(storageKey);
-      if (ls === "true") return true;
-      if (ls === "false") return false;
-    }
-  } catch {
-    // A missing/blocked window or storage just means "use the default".
-  }
-  return dflt;
-}
-
-/**
- * Whether structural layout **mutations** route through `layout.*` intents
- * (step 2) instead of editing `appStore.rootPanel` locally.
- *
- * **On by default** (#2184). The backend `LayoutStore` is authoritative for
- * mutations: split/move/merge run as asynchronous backend round-trips, with the
- * projected diff reconciled back into `appStore` by {@link reconcileNode}. The
- * behavioural (timing) change was verified parity-clean in a live GUI run before
- * flipping — split, drag-to-edge, drag-to-center, tab-move across panels, and
- * merge, with live-terminal scrollback surviving every op. Any dispatch/reconcile
- * failure still falls back to the local reducer, so a backend hiccup can never
- * break layout. Overridable at runtime for rollback / tests via
- * `window.__TERMIHUB_LAYOUT_INTENTS__` or `localStorage["termihub.layoutIntents"]`
- * (set `"false"` to restore the pre-cut local-mutation path).
- */
-export function layoutIntentsEnabled(): boolean {
-  return readFlag(flagOverride, "__TERMIHUB_LAYOUT_INTENTS__", "termihub.layoutIntents", true);
-}
-
-/**
- * Whether the **renderer** sources its panel/tab structure from the projected
- * `layout@<clientId>` render-list (step 3,
- * {@link import("./useLayoutRenderTree").useLayoutRenderTree}) rather than from
- * `appStore.rootPanel` directly.
- *
- * **On by default.** Parity-safe by construction: the renderer composes from the
- * projection only when its view structurally mirrors `appStore`'s tree, and
- * otherwise falls back to that tree verbatim — so the rendered output is always
- * identical to the pre-cut renderer, and live xterm DOM is reparented (never
- * remounted) because tab/panel ids are preserved. Independent of the mutation
- * cut: the region is seeded from `appStore` whether mutations are local or
- * intent-routed. Overridable for rollback / an A-B check (the renderer reads it
- * at mount, so a flip takes effect on reload) via
- * `window.__TERMIHUB_LAYOUT_RENDER__` or `localStorage["termihub.layoutRender"]`.
- */
-export function layoutRenderFromProjectionEnabled(): boolean {
-  return readFlag(renderFlagOverride, "__TERMIHUB_LAYOUT_RENDER__", "termihub.layoutRender", true);
-}
-
 // ── Transport + region client (sync-create, mirrors the file-browsers slice) ───
 
 // A stable per-session client identity. The client-scoped region is
@@ -652,38 +561,6 @@ function sizesEqual(a: number[] | undefined, b: number[] | undefined): boolean {
 }
 
 /**
- * Whether one projected {@link MinimalGroup} faithfully mirrors a rich
- * {@link GroupSnapshot} — same id, metadata, focused panel, and panel tree.
- */
-function minimalGroupMatches(view: MinimalGroup, snap: GroupSnapshot): boolean {
-  return (
-    view.id === snap.id &&
-    view.name === snap.name &&
-    (view.color ?? null) === (snap.color ?? null) &&
-    (view.activePanelId ?? null) === (snap.activePanelId ?? null) &&
-    minimalNodesEqual(toMinimalNode(snap.root), view.root)
-  );
-}
-
-/**
- * Whether a projected `view` is a faithful structural mirror of the whole
- * `snapshot` — **every** group matches in order (id, metadata, focused panel and
- * tree) and the active group id agrees (#2283 slice C). This is the gate that
- * decides if the renderer may source structure from the projection (true) or
- * must fall back to `appStore` (false). Widened from the single active tree so a
- * group add/close/rename/color/reorder (still local) reseeds the region.
- */
-export function viewMatchesTree(
-  view: LayoutView | null | undefined,
-  snapshot: LayoutSnapshot
-): boolean {
-  if (!view || !Array.isArray(view.groups)) return false;
-  if ((view.activeGroupId ?? null) !== (snapshot.activeGroupId ?? null)) return false;
-  if (view.groups.length !== snapshot.groups.length) return false;
-  return view.groups.every((vg, i) => minimalGroupMatches(vg, snapshot.groups[i]));
-}
-
-/**
  * Compose the rich render tree for the **active** group of a projected view:
  * **structure** from the active group's `root`, **content** re-attached by tab
  * id — preferring the flat `contentById` {@link TabContent} map (part of #2283),
@@ -918,23 +795,6 @@ export function reseedLayoutRegion(snapshot: LayoutSnapshot): void {
     // `appStore` write already landed, and the next reseed re-syncs the region.
     logBridgeFallback("reseed", err);
   }
-}
-
-/**
- * Seed the layout region with the whole multi-group layout so the projection
- * tracks `appStore`'s current structure (the render-side counterpart to the
- * mutation bridge's seed-before-mutate). Installs every group via
- * `layout.replaceGroups` (#2283 slice C). Idempotent server-side: replacing with
- * the same layout yields no diff.
- */
-export async function seedLayoutRegion(snapshot: LayoutSnapshot): Promise<void> {
-  throwIfRejected(
-    await dispatch("layout.replaceGroups", {
-      groups: snapshot.groups.map(toMinimalGroup),
-      activeGroupId: snapshot.activeGroupId,
-    }),
-    "replaceGroups"
-  );
 }
 
 /** Structural equality over two rich {@link LayoutSnapshot}s — used to de-dupe

--- a/src/store/layoutBridge.ts
+++ b/src/store/layoutBridge.ts
@@ -286,8 +286,25 @@ let regionClient: ProjectionClient | null = null;
 let creatingClient: ProjectionClient | null = null;
 let startPromise: Promise<ProjectionClient> | null = null;
 
+/**
+ * Registered region→appStore mirror handlers (#2283 slice E2). Kept in a set so
+ * they are **re-attached** whenever the client is (re)created — a transport swap
+ * ({@link setLayoutTransportForTest}) or {@link stopLayoutSubscription} drops the
+ * old client and its listeners, and with the local reducers gone the mirror is
+ * the *sole* writer of `appStore`'s layout, so it must not be orphaned by a reset.
+ */
+const layoutMirrorHandlers = new Set<(view: LayoutView | undefined) => void>();
+
+/** Attach every registered mirror handler's `onChange` to a freshly-made client. */
+function attachLayoutMirrorHandlers(client: ProjectionClient): void {
+  for (const handler of layoutMirrorHandlers) {
+    client.onChange((state) => handler(state.view as LayoutView | undefined));
+  }
+}
+
 /** Inject a transport for tests; `null` restores the lazily-created real one and
- * drops any active subscription. */
+ * drops any active subscription. Registered mirror handlers survive and re-attach
+ * to the next client. */
 export function setLayoutTransportForTest(t: Transport | null): void {
   (regionClient ?? creatingClient)?.stop();
   regionClient = null;
@@ -324,6 +341,9 @@ function layoutRegionClient(): ProjectionClient {
   if (regionClient) return regionClient;
   if (!creatingClient) {
     creatingClient = new ProjectionClient(transport(), region);
+    // Re-bind the region→appStore mirror to the new client (E2): a transport swap
+    // or subscription reset drops the previous client and its listeners.
+    attachLayoutMirrorHandlers(creatingClient);
   }
   return creatingClient;
 }
@@ -785,9 +805,16 @@ export function composeLayoutState(
     const tabGroups: TabGroup[] = view.groups.map((vg) => {
       if (vg.id === activeGroupId) {
         const cur = curTabGroups.find((g) => g.id === vg.id);
-        // Keep the active group's `appStore` entry verbatim (see doc): the live
-        // tree is the top-level `rootPanel`, not this entry.
-        if (cur) return { ...cur };
+        // Keep the active group's `appStore` entry's tree/activePanelId (the live
+        // tree is the top-level `rootPanel`, so this entry is intentionally stale),
+        // but track its metadata (name/color) from the region view — a rename or
+        // recolor of the active group changes only that.
+        if (cur) {
+          const entry: TabGroup = { ...cur, name: vg.name };
+          if (vg.color != null) entry.color = vg.color;
+          else delete entry.color;
+          return entry;
+        }
       }
       const entry: TabGroup = {
         id: vg.id,
@@ -827,10 +854,23 @@ export function composeLayoutState(
  * (idempotent) so the stream is live. Returns an unsubscribe.
  */
 export function subscribeLayoutRegion(handler: (view: LayoutView | undefined) => void): () => void {
+  const alreadyRegistered = layoutMirrorHandlers.has(handler);
+  layoutMirrorHandlers.add(handler);
+  // Attach to the current client now. If the client did not yet exist,
+  // `layoutRegionClient()` creates it and `attachLayoutMirrorHandlers` binds every
+  // registered handler (including this one) — so only bind here when the client was
+  // already live and would not have picked this handler up on creation.
+  const hadClient = regionClient !== null || creatingClient !== null;
   const client = layoutRegionClient();
-  const off = client.onChange((state) => handler(state.view as LayoutView | undefined));
+  let off = (): void => {};
+  if (hadClient && !alreadyRegistered) {
+    off = client.onChange((state) => handler(state.view as LayoutView | undefined));
+  }
   void ensureSubscribed().catch((err) => logRenderFallback(err));
-  return off;
+  return () => {
+    layoutMirrorHandlers.delete(handler);
+    off();
+  };
 }
 
 /**

--- a/src/store/useLayoutRenderTree.test.tsx
+++ b/src/store/useLayoutRenderTree.test.tsx
@@ -1,47 +1,16 @@
 /**
- * `useLayoutRenderTree` — the renderer's cut to the projected layout render-list
- * (#2151 step 3). Drives the hook against a simulated `layout@<clientId>` region
- * and asserts: flag-off returns the appStore tree untouched and dispatches
- * nothing; flag-on seeds the region and then composes the render tree from the
- * projection (structure) + appStore (content), structurally identical to the
- * appStore tree; and a region that has not caught up falls back to the appStore
- * tree rather than render a stale structure.
+ * `useLayoutRenderTree` (#2283 slice E2) — after the layout data-flow inversion
+ * completed, the hook is a thin read of the region-derived `appStore.rootPanel`
+ * (the mirror composes it from the `layout@<clientId>` projection). The earlier
+ * strangler machinery — a render flag, a faithful-mirror gate, and a
+ * seed-on-drift effect — is gone, so this just pins that the hook returns the
+ * current tree and re-renders when it changes.
  */
 import { act } from "react";
-import { flushMacrotask } from "@/test/flushAsync";
 import { createRoot, type Root } from "react-dom/client";
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { LeafPanel, PanelNode, TerminalTab } from "@/types/terminal";
-
-interface RegionState {
-  version: number;
-  view: unknown;
-}
-
-const { backend, dispatched } = vi.hoisted(() => ({
-  backend: {
-    version: -1,
-    view: undefined as unknown,
-    listeners: new Set<(s: RegionState) => void>(),
-    /** When false, `layout.replace` is accepted but does NOT advance the region
-     * (simulates a region that has not caught up to appStore). */
-    applyReplace: true,
-    push(view: unknown) {
-      this.version += 1;
-      this.view = view;
-      const snapshot = { version: this.version, view: this.view };
-      this.listeners.forEach((l) => l(snapshot));
-    },
-    reset() {
-      this.version = -1;
-      this.view = undefined;
-      this.listeners.clear();
-      this.applyReplace = true;
-    },
-  },
-  dispatched: [] as { kind: string; payload: Record<string, unknown> }[],
-}));
+import type { PanelNode } from "@/types/terminal";
 
 vi.mock("@/services/storage", () => ({
   loadConnections: vi.fn(() =>
@@ -56,200 +25,48 @@ vi.mock("@/services/storage", () => ({
 
 vi.mock("@/themes", () => ({ applyTheme: vi.fn(), onThemeChange: vi.fn(() => vi.fn()) }));
 
-vi.mock("@/services/transport", () => ({
-  newClientId: () => "client-test",
-  newIntentId: () => "intent-test",
-  createTransport: () => ({
-    async dispatch(intent: { kind: string; payload: Record<string, unknown> }) {
-      dispatched.push({ kind: intent.kind, payload: intent.payload });
-      if (intent.kind === "layout.replaceGroups" && backend.applyReplace) {
-        backend.push({
-          groups: intent.payload.groups,
-          activeGroupId: intent.payload.activeGroupId,
-        });
-      }
-      return {
-        intentId: "intent-test",
-        status: "accepted",
-        produced: [{ region: "layout@client-test", version: backend.version }],
-      };
-    },
-    subscribe: vi.fn(),
-    resync: vi.fn(),
-  }),
-  ProjectionClient: class {
-    constructor(
-      _transport: unknown,
-      public readonly region: string
-    ) {}
-    get state(): RegionState {
-      return { version: backend.version, view: backend.view };
-    }
-    onChange(listener: (s: RegionState) => void) {
-      backend.listeners.add(listener);
-      return () => backend.listeners.delete(listener);
-    }
-    async start() {
-      // The store seeds an unknown client's region to a single "Main" group with
-      // one empty leaf (the full multi-group view — #2283 slice C).
-      backend.push({
-        groups: [
-          {
-            id: "seed-group",
-            name: "Main",
-            root: { type: "leaf", id: "seed", tabs: [], activeTabId: null },
-            activePanelId: "seed",
-          },
-        ],
-        activeGroupId: "seed-group",
-      });
-    }
-    stop() {}
-  },
-}));
-
-vi.mock("@/components/ui", async () => {
-  const actual = await vi.importActual<typeof import("@/components/ui")>("@/components/ui");
-  return { ...actual, toast: { loading: vi.fn(), success: vi.fn(), error: vi.fn() } };
-});
-
 import { useAppStore } from "./appStore";
-import { setLayoutRenderFromProjectionEnabled, toMinimalNode } from "./layoutBridge";
 import { useLayoutRenderTree } from "./useLayoutRenderTree";
 
-function tab(id: string): TerminalTab {
-  return {
-    id,
-    sessionId: `sess-${id}`,
-    title: `Tab ${id}`,
-    connectionType: "local",
-    contentType: "terminal",
-    config: {} as TerminalTab["config"],
-    panelId: "a",
-    isActive: id === "t1",
-  } as TerminalTab;
+/** Render the hook into a throwaway component, exposing the latest return value. */
+function renderHook(): { get: () => PanelNode; unmount: () => void } {
+  const container = document.createElement("div");
+  const root: Root = createRoot(container);
+  let latest: PanelNode = useAppStore.getState().rootPanel;
+
+  function Probe() {
+    latest = useLayoutRenderTree();
+    return null;
+  }
+
+  act(() => root.render(<Probe />));
+  return { get: () => latest, unmount: () => act(() => root.unmount()) };
 }
 
-function seedTree(): PanelNode {
-  return {
-    type: "split",
-    id: "root",
-    direction: "horizontal",
-    sizes: [50, 50],
-    children: [
-      { type: "leaf", id: "a", tabs: [tab("t1"), tab("t2")], activeTabId: "t1" },
-      { type: "leaf", id: "b", tabs: [tab("t3")], activeTabId: "t3" },
-    ] as LeafPanel[],
-  };
+function leaf(id: string): PanelNode {
+  return { type: "leaf", id, tabs: [], activeTabId: null };
 }
 
-let container: HTMLDivElement;
-let root: Root;
-let latest: PanelNode | null = null;
-
-function Probe() {
-  latest = useLayoutRenderTree();
-  return null;
-}
-
-async function mount() {
-  await act(async () => {
-    root.render(<Probe />);
-  });
-  // Let the async subscribe + seed + onChange settle.
-  await act(async () => {
-    await flushMacrotask();
-    await flushMacrotask();
-  });
-}
-
-describe("useLayoutRenderTree (#2151 step 3)", () => {
+describe("useLayoutRenderTree", () => {
   beforeEach(() => {
-    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-    container = document.createElement("div");
-    document.body.appendChild(container);
-    root = createRoot(container);
     useAppStore.setState(useAppStore.getInitialState());
-    useAppStore.setState({ rootPanel: seedTree(), activePanelId: "a" });
-    backend.reset();
-    dispatched.length = 0;
-    latest = null;
-    setLayoutRenderFromProjectionEnabled(null);
   });
 
-  afterEach(() => {
-    act(() => root.unmount());
-    container.remove();
-    setLayoutRenderFromProjectionEnabled(null);
-    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  it("returns the current region-derived rootPanel", () => {
+    const root = leaf("only");
+    useAppStore.setState({ rootPanel: root, activePanelId: "only" });
+    const hook = renderHook();
+    expect(hook.get()).toBe(root);
+    hook.unmount();
   });
 
-  it("flag off: returns the appStore tree verbatim and dispatches nothing", async () => {
-    setLayoutRenderFromProjectionEnabled(false);
-    await mount();
-    expect(dispatched).toHaveLength(0);
-    expect(latest).toBe(useAppStore.getState().rootPanel);
-  });
-
-  it("flag on: seeds the region, then composes structure⊕content matching appStore", async () => {
-    setLayoutRenderFromProjectionEnabled(true);
-    await mount();
-
-    // The initial snapshot was a single empty leaf (not a mirror) → the hook
-    // seeded the region with appStore's tree.
-    expect(dispatched.map((d) => d.kind)).toContain("layout.replaceGroups");
-
-    // Composed from the projection: structurally identical to appStore's tree.
-    const store = useAppStore.getState().rootPanel;
-    expect(latest).not.toBeNull();
-    expect(toMinimalNode(latest!)).toEqual(toMinimalNode(store));
-
-    const split = latest as Extract<PanelNode, { type: "split" }>;
-    const leafA = split.children[0] as LeafPanel;
-    // Rich content re-hydrated by id.
-    expect(leafA.tabs.map((t) => t.id)).toEqual(["t1", "t2"]);
-    expect(leafA.tabs[0].title).toBe("Tab t1");
-    expect(leafA.tabs[0].sessionId).toBe("sess-t1");
-  });
-
-  it("flag on but region never catches up: falls back to the appStore tree", async () => {
-    setLayoutRenderFromProjectionEnabled(true);
-    backend.applyReplace = false; // region stays on the initial single-leaf snapshot
-    await mount();
-
-    // Seed was attempted, but the region did not advance to a mirror.
-    expect(dispatched.map((d) => d.kind)).toContain("layout.replaceGroups");
-    // Renderer fell back to appStore's tree rather than showing the stale leaf.
-    expect(latest).toBe(useAppStore.getState().rootPanel);
-  });
-
-  it("multi-group: seeds every group and composes the active one (#2283)", async () => {
-    // Two groups: the active one holds seedTree(), a second holds a single leaf.
-    const secondRoot: PanelNode = {
-      type: "leaf",
-      id: "z",
-      tabs: [tab("t9")],
-      activeTabId: "t9",
-    };
-    const groups = useAppStore.getState().tabGroups;
-    const activeId = useAppStore.getState().activeTabGroupId;
-    useAppStore.setState({
-      tabGroups: [
-        { ...groups[0] },
-        { id: "group-2", name: "Second", rootPanel: secondRoot, activePanelId: "z" },
-      ],
-      activeTabGroupId: activeId,
+  it("re-renders when the rootPanel changes", () => {
+    const hook = renderHook();
+    const next = leaf("next");
+    act(() => {
+      useAppStore.setState({ rootPanel: next, activePanelId: "next" });
     });
-    setLayoutRenderFromProjectionEnabled(true);
-    await mount();
-
-    // The seed installs BOTH groups via replaceGroups.
-    const seed = dispatched.find((d) => d.kind === "layout.replaceGroups");
-    expect(seed).toBeDefined();
-    expect((seed!.payload.groups as unknown[]).length).toBe(2);
-
-    // The renderer composes the ACTIVE group's tree (seedTree), not the second.
-    expect(latest).not.toBeNull();
-    expect(toMinimalNode(latest!)).toEqual(toMinimalNode(useAppStore.getState().rootPanel));
+    expect(hook.get()).toBe(next);
+    hook.unmount();
   });
 });

--- a/src/store/useLayoutRenderTree.ts
+++ b/src/store/useLayoutRenderTree.ts
@@ -1,142 +1,22 @@
 /**
- * `useLayoutRenderTree` — the renderer's cut to the projected layout render-list
- * (#2151 step 3, part of #2139).
+ * `useLayoutRenderTree` — the renderer's handle on the active tab group's panel
+ * tree (#2151, part of #2139; finalized in #2283 slice E2).
  *
- * `SplitView` renders the active tab group's panel tree. Through step 2 that
- * tree came straight from `appStore.rootPanel` (a mirror the mutation bridge
- * reconciled from the `layout@<clientId>` projection). Step 3 makes the
- * **renderer** source its structure from the projection directly and overlay
- * per-tab content from `appStore` — the partial-projection seam (Decision #2:
- * the layout region carries only panel structure + minimal tab identity; title,
- * colour, session status, broadcast and zoom stay in `appStore`).
- *
- * The hook returns a rich {@link PanelNode} — structure from the projection,
- * content re-attached by tab id from `appStore`'s current tree — so `SplitView`
- * consumes it exactly where it used to read `appStore.rootPanel` (one call
- * site). Because the composed tree preserves every `tab.id`/`panel.id`, the live
- * xterm DOM is reparented, never remounted (see {@link composeRenderTree}).
- *
- * # Safety (strangler)
- *
- * - **Gated** by {@link layoutRenderFromProjectionEnabled}. Flag off → the hook
- *   returns `appStore.rootPanel` verbatim, so the renderer is byte-for-byte
- *   unchanged.
- * - **Faithful-mirror gate.** The projection drives the render only when its
- *   view is a structural mirror of `appStore`'s tree ({@link viewMatchesTree}).
- *   Tab create/close/reorder/activate are not yet layout intents, so they edit
- *   `appStore` locally and momentarily desync the region; while desynced the
- *   hook falls back to `appStore.rootPanel` (never a stale tree) and
- *   {@link seedLayoutRegion} catches the region up so composing resumes. The
- *   gate guarantees the composed tree is structurally identical to
- *   `appStore.rootPanel`, so rendering can never diverge from the pre-cut output.
+ * `SplitView` renders the active group's tree. Since the layout data-flow
+ * inversion completed (#2283 slice E2), `appStore.rootPanel` is **no longer an
+ * independent authoritative store** — it is composed by the region→appStore
+ * mirror from the `layout@<clientId>` projection (structure) plus `appStore`'s
+ * by-id tab content. So the renderer simply reads that region-derived tree; the
+ * earlier strangler machinery (a runtime flag, a faithful-mirror gate, and a
+ * seed-on-drift effect that let the renderer source structure straight from the
+ * projection while `appStore` was still authoritative) is gone.
  */
-
-import { useEffect, useMemo, useRef, useState } from "react";
 
 import { useAppStore } from "@/store/appStore";
-import {
-  buildLayoutSnapshot,
-  composeRenderTree,
-  ensureLayoutRegionClient,
-  type LayoutSnapshot,
-  type LayoutView,
-  layoutRenderFromProjectionEnabled,
-  layoutSnapshotsEqual,
-  logRenderFallback,
-  seedLayoutRegion,
-  viewMatchesTree,
-} from "@/store/layoutBridge";
-import type { ProjectionCacheState, ProjectionClient } from "@/services/transport";
 import type { PanelNode } from "@/types/terminal";
 
-/**
- * The active tab group's panel tree for rendering: structure sourced from the
- * projected layout region when it faithfully mirrors `appStore`, otherwise
- * `appStore.rootPanel` verbatim (flag off, region not yet caught up, or a
- * transport that cannot subscribe).
- */
+/** The active tab group's panel tree for rendering — the region-derived
+ * `appStore.rootPanel` (composed by the layout mirror). */
 export function useLayoutRenderTree(): PanelNode {
-  const storeRoot = useAppStore((s) => s.rootPanel);
-  const storeActivePanelId = useAppStore((s) => s.activePanelId);
-  // The full group model: `tabGroups` + the active group id, with the active
-  // group's live tree carried at top-level `rootPanel`/`activePanelId` (#2283
-  // slice C). The region mirrors all groups; the renderer composes the active
-  // one.
-  const tabGroups = useAppStore((s) => s.tabGroups);
-  const activeTabGroupId = useAppStore((s) => s.activeTabGroupId);
-  // The authoritative by-id tab-content map (part of #2283). Render composition
-  // sources each tab's content from here, falling back to the in-tree tab for
-  // any id the map does not yet hold (editor/settings/etc.). Behaviour-preserving
-  // while the tree still carries the full tab.
-  const tabContent = useAppStore((s) => s.tabContent);
-
-  // Read the flag once at mount: it flips only via dev tooling, and the
-  // subscription lifecycle is keyed off it below.
-  const [enabled] = useState(() => layoutRenderFromProjectionEnabled());
-
-  const [regionState, setRegionState] = useState<ProjectionCacheState | null>(null);
-  const clientRef = useRef<ProjectionClient | null>(null);
-  const lastSeeded = useRef<LayoutSnapshot | null>(null);
-
-  // The rich multi-group snapshot appStore is authoritative for — the seed
-  // payload and the faithful-mirror gate's reference.
-  const snapshot = useMemo<LayoutSnapshot>(
-    () => buildLayoutSnapshot(tabGroups, activeTabGroupId, storeRoot, storeActivePanelId),
-    [tabGroups, activeTabGroupId, storeRoot, storeActivePanelId]
-  );
-
-  // Subscribe to the layout region while enabled; a transport that cannot
-  // subscribe (non-Tauri without a socket) just leaves the renderer on the
-  // appStore fallback.
-  useEffect(() => {
-    if (!enabled) return;
-    let cancelled = false;
-    let unsubscribe = (): void => {};
-    ensureLayoutRegionClient()
-      .then((client) => {
-        if (cancelled) return;
-        clientRef.current = client;
-        setRegionState(client.state);
-        unsubscribe = client.onChange((state) => setRegionState(state));
-      })
-      .catch((err) => logRenderFallback(err));
-    return () => {
-      cancelled = true;
-      unsubscribe();
-      clientRef.current = null;
-    };
-  }, [enabled]);
-
-  const view = regionState?.view as LayoutView | undefined;
-  const matches = enabled && viewMatchesTree(view, snapshot);
-
-  // Keep the region a faithful mirror of appStore's multi-group structure. When
-  // the view is not a mirror (initial single-leaf snapshot, or a local non-intent
-  // edit — including a group add/close/rename/color/reorder), seed the whole
-  // layout so composing can resume. De-duped so a settled layout is not reseeded
-  // on every render.
-  useEffect(() => {
-    if (!enabled || !clientRef.current || matches) return;
-    const prev = lastSeeded.current;
-    if (prev && layoutSnapshotsEqual(prev, snapshot)) return;
-    lastSeeded.current = snapshot;
-    seedLayoutRegion(snapshot).catch((err) => logRenderFallback(err));
-    // `regionState` is a dep so the seed re-evaluates once the region snapshot
-    // first arrives (which sets `clientRef` but may leave `matches` false).
-  }, [enabled, matches, snapshot, regionState]);
-
-  return useMemo(() => {
-    if (matches && view) {
-      try {
-        // Content fallback comes from the active group's rich tree (`storeRoot`).
-        return composeRenderTree(view, storeRoot, tabContent);
-      } catch (err) {
-        // A tab referenced by the view but absent from appStore — treat as a
-        // desync and fall back rather than throw in render.
-        logRenderFallback(err);
-        return storeRoot;
-      }
-    }
-    return storeRoot;
-  }, [matches, view, storeRoot, tabContent]);
+  return useAppStore((s) => s.rootPanel);
 }


### PR DESCRIPTION
## Summary

Slice **E2** of the layout data-flow inversion (Part of `#2283`) — the **gate-authorized** reducer removal (the extended-testing gate is open). Builds on E1 (#2543, the always-on mirror proven byte-identical): the local authoritative layout reducers are **deleted**, and the `layout@<clientId>` projection becomes the **sole authority** for the layout `appStore` renders from. `rootPanel`/`tabGroups`/`activePanelId`/`activeTabGroupId` are **kept** as the region-derived mirror (field deletion stays deferred to #2077), so all ~300 reader sites work unchanged.

## What changed

- **17 structural/group ops are dispatch-only.** Each computes its transform and writes only its **non-layout** output (`zoomedTabId`, `tabContent`, per-tab maps) via a new `setLayoutLocal`; it dispatches its `layout.*` intent, and the region→appStore mirror composes the four layout fields back — synchronously, via the optimistic overlay (no flicker). `composeLayoutState` now tracks the active group's name/color from the region view (its stale `tabGroups` entry no longer carries them) and **preserves directional `lastActiveLeafId` marks** (#448, a frontend-only derivation the backend doesn't carry) across every recompose.
- **The mirror is unconditional and the sole writer.** The E1 `viewMatchesTree` gate is gone; `composeLayoutState` guards the transient cases (empty view, unknown tab). The mirror **re-binds** on client (re)creation so a transport swap / subscription reset never orphans it. The region is seeded from `appStore`'s initial layout at startup.
- **Reseed-safety for the ~15 non-intent structural writers** (the singleton tab openers, cross-window handoff/hydrate, workspace restore, the agent-error→terminal conversion): they keep their local write but reseed the region (`setAndReseed` / `reseedLayout`) so a stale convergence diff can't strand a just-opened tab now that the gate is gone.
- **Removed the strangler scaffolding:** the `layoutIntentsEnabled` / `layoutRenderFromProjectionEnabled` flags + setters + flag machinery, `viewMatchesTree` / `minimalGroupMatches`, and the render-cut `seedLayoutRegion`. `useLayoutRenderTree` is now a thin read of the region-derived `rootPanel`.

## Verification

- Full frontend suite green: **5009 tests / 556 files**; `tsc --noEmit`, `eslint src/`, `prettier --check src/**` all clean. No backend changes.
- The ~130 existing layout assertions (tabGroups/tabContent/multiWindow/layout) + E1's per-op parity now pass **sourced purely from the mirror** (no `applyLocal`, no gate).
- New/updated E2 specs: `appStore.layoutBridge.test.ts` rewritten for region-sole-writer (granular dispatch, synchronous overlay, backend convergence, id preservation, no fallback); the open-a-tab-without-a-layout-intent no-strand round-trip; **directional `lastActiveLeafId` marks survive mirror recomposition**; `useLayoutRenderTree` reduced to its region-derived read.

Residual (not blocking): the `#2184` manual GUI-smoke matrix (split / drag-to-edge / drag-to-center / cross-panel move / merge / tab-move-across-groups / group-switch, each asserting live-terminal scrollback survives) remains the recommended final human check for the maintainer — the automated `tests/system/` harness covers structural round-trips.

Part of `#2283` (the umbrella also needs session `#2205`, so this does not close it).